### PR TITLE
fix: cannot determine vector dimension for partitioned indexes

### DIFF
--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -194,9 +194,13 @@ async fn process_single_batch(
     }
 
     // Update the embedding column in the batch with computed embeddings
-    let updated_record =
-        update_embedding_column_in_batch(&record, &index.embedded_column, &embedding_vectors)
-            .map_err(|e| *e)?;
+    let updated_record = update_embedding_column_in_batch(
+        &record,
+        &index.embedded_column,
+        &embedding_vectors,
+        i32::try_from(table.dimension).unwrap_or_default(),
+    )
+    .map_err(|e| *e)?;
 
     // Filter out zero vectors to prevent cosine similarity calculation errors
     let (filtered_embeddings, filtered_primary_key, filtered_metadata) =
@@ -413,6 +417,7 @@ fn update_embedding_column_in_batch(
     record: &RecordBatch,
     embedded_column_name: &str,
     embedding_vectors: &[Option<Vec<f32>>],
+    dimension: i32,
 ) -> Result<RecordBatch, Box<Error>> {
     let embedding_column_name = embedding_col(embedded_column_name);
 
@@ -420,7 +425,7 @@ fn update_embedding_column_in_batch(
     let mut columns = record.columns().to_vec();
 
     // Create new embedding array that will replace the existing column or be added as a new column
-    let embedding_array = create_embedding_array(embedding_vectors)?;
+    let embedding_array = create_embedding_array(embedding_vectors, dimension)?;
 
     // Check if the embedding column already exists
     let target_schema = if let Some((idx, _)) = schema.column_with_name(&embedding_column_name) {
@@ -449,21 +454,24 @@ fn update_embedding_column_in_batch(
 #[allow(clippy::cast_sign_loss)]
 fn create_embedding_array(
     embedding_vectors: &[Option<Vec<f32>>],
+    dimension: i32,
 ) -> Result<Arc<dyn Array>, Box<Error>> {
-    // Determine embedding dimension from first non-null embedding
-    let dimension = i32::try_from(
-        embedding_vectors
-            .iter()
-            .find_map(|opt| opt.as_ref().map(Vec::len))
-            .unwrap_or(0),
-    )
-    .context(EmbeddingDimensionTooLargeSnafu)
-    .map_err(Box::from)?;
-
+    let mut dimension = dimension;
     if dimension <= 0 {
-        CannotDetermineEmbeddingDimensionSnafu {}
-            .fail()
-            .map_err(Box::from)?;
+        // Fallback: determine embedding dimension from first non-null embedding
+        dimension = i32::try_from(
+            embedding_vectors
+                .iter()
+                .find_map(|opt| opt.as_ref().map(Vec::len))
+                .unwrap_or(0),
+        )
+        .context(EmbeddingDimensionTooLargeSnafu)
+        .map_err(Box::from)?;
+        if dimension <= 0 {
+            CannotDetermineEmbeddingDimensionSnafu {}
+                .fail()
+                .map_err(Box::from)?;
+        }
     }
 
     let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dimension);
@@ -587,7 +595,8 @@ mod tests {
     fn test_create_embedding_array_valid_embeddings() {
         let embeddings = vec![Some(vec![0.1, 0.2, 0.3]), None, Some(vec![0.7, 0.8, 0.9])];
 
-        let result = create_embedding_array(&embeddings).expect("Failed to create embedding array");
+        let result =
+            create_embedding_array(&embeddings, 3).expect("Failed to create embedding array");
 
         let list_array = result
             .as_any()
@@ -614,7 +623,7 @@ mod tests {
     fn test_create_embedding_array_empty_embeddings() {
         let embeddings: Vec<Option<Vec<f32>>> = vec![None, None];
 
-        let result = create_embedding_array(&embeddings);
+        let result = create_embedding_array(&embeddings, 0);
 
         // Should fail because no valid embeddings to determine dimension
         assert!(result.is_err());
@@ -635,7 +644,7 @@ mod tests {
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
 
-        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings)
+        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings, 3)
             .expect("Failed to update embedding column");
 
         // Verify the updated batch has the new embeddings
@@ -665,7 +674,7 @@ mod tests {
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
 
-        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings)
+        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings, 3)
             .expect("Failed to handle missing embedding column");
 
         // Should append the embedding column with the correct name


### PR DESCRIPTION
## 📝 Summary

When using partitioning with S3 vectors, the `CannotDetermineEmbeddingDimension` error occurs during dataset updates/appends. This happens because the write function splits records into chunks, and if a chunk contains no valid embeddable data (all null/empty strings), the dimension inference fails. The `create_embedding_array` function determines embedding dimension by finding the first non-null embedding vector in each batch. With partitioning, some chunks may have no valid embeddings, causing dimension = 0 and triggering the error.

Fixed by using the stored `dimension` in `S3VectorsTable`

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
