### PR TITLE
Upgrade to Turso v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16756,8 +16756,7 @@ dependencies = [
 [[package]]
 name = "turso"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e46b08d3c1f5d6d604a8a367bde08d6884762cef99bd73ee4e5f514c8f0559"
+source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
 dependencies = [
  "mimalloc",
  "thiserror 2.0.17",
@@ -16769,8 +16768,7 @@ dependencies = [
 [[package]]
 name = "turso_core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b48939c21f420d33a5f222c4723cb37ebafe3dfa6488acdce0ceb99b136b002"
+source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
 dependencies = [
  "aegis",
  "aes",
@@ -16818,8 +16816,7 @@ dependencies = [
 [[package]]
 name = "turso_ext"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb31d1e0dcdcf596406b83dd6cacbda726195d03063f237de49db0a5eddba157"
+source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -16829,8 +16826,7 @@ dependencies = [
 [[package]]
 name = "turso_macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f64cfc56b1c550a347b6679bf50686d9ff34c04e0c1a007fc6f8538dc74664"
+source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16840,8 +16836,7 @@ dependencies = [
 [[package]]
 name = "turso_parser"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821b2223adfd988771afc9c7fb743a6acf5cd20f1d4386614b2e2ac413844c16"
+source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
 dependencies = [
  "bitflags 2.10.0",
  "miette",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5124,7 +5124,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5479,7 +5479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7314,7 +7314,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7875,7 +7875,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9824,7 +9824,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11673,7 +11673,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -13447,7 +13447,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14418,7 +14418,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -15474,7 +15474,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16755,9 +16755,11 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.3.0-pre.4"
-source = "git+https://github.com/tursodatabase/turso?rev=ae60b78d828dc08c6bcdc070d7ec71c4d61bd007#ae60b78d828dc08c6bcdc070d7ec71c4d61bd007"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e46b08d3c1f5d6d604a8a367bde08d6884762cef99bd73ee4e5f514c8f0559"
 dependencies = [
+ "mimalloc",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
@@ -16766,12 +16768,14 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.3.0-pre.4"
-source = "git+https://github.com/tursodatabase/turso?rev=ae60b78d828dc08c6bcdc070d7ec71c4d61bd007#ae60b78d828dc08c6bcdc070d7ec71c4d61bd007"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b48939c21f420d33a5f222c4723cb37ebafe3dfa6488acdce0ceb99b136b002"
 dependencies = [
  "aegis",
  "aes",
  "aes-gcm",
+ "arc-swap",
  "bitflags 2.10.0",
  "built",
  "bytemuck",
@@ -16794,6 +16798,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "roaring 0.11.2",
+ "rustc-hash 2.1.1",
  "rustix 1.1.2",
  "ryu",
  "simsimd",
@@ -16812,8 +16817,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.3.0-pre.4"
-source = "git+https://github.com/tursodatabase/turso?rev=ae60b78d828dc08c6bcdc070d7ec71c4d61bd007#ae60b78d828dc08c6bcdc070d7ec71c4d61bd007"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb31d1e0dcdcf596406b83dd6cacbda726195d03063f237de49db0a5eddba157"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -16822,8 +16828,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.3.0-pre.4"
-source = "git+https://github.com/tursodatabase/turso?rev=ae60b78d828dc08c6bcdc070d7ec71c4d61bd007#ae60b78d828dc08c6bcdc070d7ec71c4d61bd007"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f64cfc56b1c550a347b6679bf50686d9ff34c04e0c1a007fc6f8538dc74664"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16832,8 +16839,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.3.0-pre.4"
-source = "git+https://github.com/tursodatabase/turso?rev=ae60b78d828dc08c6bcdc070d7ec71c4d61bd007#ae60b78d828dc08c6bcdc070d7ec71c4d61bd007"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821b2223adfd988771afc9c7fb743a6acf5cd20f1d4386614b2e2ac413844c16"
 dependencies = [
  "bitflags 2.10.0",
  "miette",
@@ -18325,7 +18333,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -18393,21 +18401,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -18472,8 +18467,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -18486,30 +18481,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,3 +352,7 @@ aws-smithy-runtime = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "8
 aws-smithy-runtime-api = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-runtime-api" }                   # pinned from release-2025-10-08
 aws-smithy-types = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-types" }                               # pinned from release-2025-10-08
 
+# Note: Turso's bindings/rust/src/lib.rs defines #[global_allocator] which conflicts with spiced's allocator
+# We need to fork and remove the global allocator or patch it out
+turso = { git = "https://github.com/spiceai/turso", rev = "5c4d14d298869fe5ea296163b3241d6963a2e87d" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,7 @@ tracing = "0.1.41"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-turso = "0.3.0-pre.4"
+turso = "0.3.0"
 twox-hash = "2.1.2"
 url = "2.5"
 uuid = "1"
@@ -351,7 +351,4 @@ aws-sigv4 = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58f
 aws-smithy-runtime = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-runtime" }                           # pinned from release-2025-10-08
 aws-smithy-runtime-api = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-runtime-api" }                   # pinned from release-2025-10-08
 aws-smithy-types = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-types" }                               # pinned from release-2025-10-08
-
-# Required until Turso releases 0.23 without the GPL dependency
-turso = { git = "https://github.com/tursodatabase/turso", rev = "ae60b78d828dc08c6bcdc070d7ec71c4d61bd007" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -81,5 +81,5 @@ license-files = []
 name = "cfg_block"
 version = "0.1.1"
 expression = "Apache-2.0"
-license-files = ['https://github.com/pluots/cfg_block/blob/main/LICENSE']
+license-files = []
 

--- a/deny.toml
+++ b/deny.toml
@@ -77,3 +77,9 @@ version = "0.1.3"
 expression = "MIT"
 license-files = []
 
+[[licenses.clarify]]
+name = "cfg_block"
+version = "0.1.1"
+expression = "Apache-2.0"
+license-files = ['https://github.com/pluots/cfg_block/blob/main/LICENSE']
+


### PR DESCRIPTION
This pull request updates the `turso` dependency in the `Cargo.toml` file, switching from a pre-release or git-based version to the stable `0.3.0` release. This simplifies dependency management and removes the need for a custom git reference.

Dependency updates:

* Updated the `turso` crate from version `0.3.0-pre.4` to the stable `0.3.0` in `Cargo.toml`.
* Removed the git-based `turso` dependency and its associated comment from `Cargo.toml`, now that the stable release is available and no longer requires a workaround for GPL dependencies.