### PR TITLE
[DynamoDB] Support parallelization for `Scan` request

### DIFF
--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -69,6 +69,8 @@ pub struct DynamoDBTableProvider {
 type DynamoDBItemStream =
     dyn Stream<Item = DataFusionResult<HashMap<String, AttributeValue>>> + Send + 'static;
 
+const DEFAULT_SEGMENTS: usize = 8;
+
 impl DynamoDBTableProvider {
     pub async fn try_new(
         client: Arc<Client>,
@@ -183,7 +185,7 @@ impl DynamoDBTableProvider {
 
     fn get_partitions_from_table_size(&self) -> usize {
         match self.table_total_item_count {
-            None => 8,
+            None => DEFAULT_SEGMENTS,
             Some(row_count) => match row_count {
                 0..1_000 => 1,
                 1_000..10_000 => 2,

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -368,11 +368,21 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
             Partitioning::UnknownPartitioning(partitions) => partitions,
         };
 
+        let segment: i32 = i32::try_from(partition).map_err(|_| {
+            DataFusionError::Execution(
+                format!("Partition number too large for DynamoDB segment: {partition}").to_string(),
+            )
+        })?;
+
+        let total_segments: i32 = i32::try_from(total_partitions).map_err(|_| DataFusionError::Execution(
+            format!("Total partitions number too large for DynamoDB total_segments: {total_partitions}").to_string()
+        ))?;
+
         builder.spawn(async move {
             const CHUNK_SIZE: usize = 4_000;
 
             let item_stream =
-                build_stream_from_plan(&client, request_plan, partition, total_partitions);
+                build_stream_from_plan(&client, request_plan, segment, total_segments);
             let chunked_stream = item_stream.chunks(CHUNK_SIZE);
             pin_mut!(chunked_stream);
 
@@ -404,8 +414,8 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
 fn build_stream_from_plan(
     client: &Arc<Client>,
     request: DynamoDBRequestPlan,
-    partition: usize,
-    total_partitions: usize,
+    segment: i32,
+    total_segments: i32,
 ) -> Pin<Box<DynamoDBItemStream>> {
     match request {
         DynamoDBRequestPlan::Query(QueryParams {
@@ -456,10 +466,8 @@ fn build_stream_from_plan(
                 .set_projection_expression(projection_expression)
                 .set_limit(limit);
 
-            if total_partitions > 1 {
-                request = request
-                    .segment(partition as i32)
-                    .total_segments(total_partitions as i32);
+            if total_segments > 1 {
+                request = request.segment(segment).total_segments(total_segments);
             }
 
             let pagination_stream = TryFlatMap::new(request.into_paginator().send())

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -62,6 +62,8 @@ pub struct DynamoDBTableProvider {
     table_schema: DynamoDBTableSchema,
     request_plan_builder: DynamoDBRequestPlanBuilder,
     unnest_depth: Option<usize>,
+    config_partitions: Option<usize>,
+    table_total_item_count: Option<i64>,
 }
 
 type DynamoDBItemStream =
@@ -73,14 +75,16 @@ impl DynamoDBTableProvider {
         table_name: Arc<str>,
         unnest_depth: Option<usize>,
         schema_infer_max_records: i32,
+        config_partitions: Option<usize>,
     ) -> Result<Self, Error> {
-        let (table_schema, partition_key, sort_key, flattened_fields) = Self::fetch_table_metadata(
-            Arc::clone(&client),
-            &table_name,
-            unnest_depth,
-            schema_infer_max_records,
-        )
-        .await?;
+        let (table_schema, partition_key, sort_key, flattened_fields, table_total_item_count) =
+            Self::fetch_table_metadata(
+                Arc::clone(&client),
+                &table_name,
+                unnest_depth,
+                schema_infer_max_records,
+            )
+            .await?;
 
         let table_schema = DynamoDBTableSchema::new(
             table_name,
@@ -94,6 +98,8 @@ impl DynamoDBTableProvider {
             table_schema: table_schema.clone(),
             request_plan_builder: DynamoDBRequestPlanBuilder::new(table_schema),
             unnest_depth,
+            config_partitions,
+            table_total_item_count,
         })
     }
 
@@ -102,7 +108,13 @@ impl DynamoDBTableProvider {
         table_name: &str,
         unnest_depth: Option<usize>,
         schema_infer_max_records: i32,
-    ) -> Result<(SchemaRef, String, Option<String>, HashSet<String>)> {
+    ) -> Result<(
+        SchemaRef,
+        String,
+        Option<String>,
+        HashSet<String>,
+        Option<i64>,
+    )> {
         let response = client
             .describe_table()
             .table_name(table_name)
@@ -165,7 +177,22 @@ impl DynamoDBTableProvider {
             partition_key,
             sort_key,
             flattened_fields,
+            table.item_count,
         ))
+    }
+
+    fn get_partitions_from_table_size(&self) -> usize {
+        match self.table_total_item_count {
+            None => 8,
+            Some(row_count) => match row_count {
+                0..1_000 => 1,
+                1_000..10_000 => 2,
+                10_000..100_000 => 4,
+                100_000..1_000_000 => 8,
+                1_000_000..10_000_000 => 16,
+                _ => 32,
+            },
+        }
     }
 }
 
@@ -192,6 +219,14 @@ impl TableProvider for DynamoDBTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut projected_schema = project_schema(self.table_schema.schema(), projection)?;
 
+        tracing::debug!(
+            "Table {:?}, projection: {:?}, filters: {:?}, limit: {:?}",
+            self.table_schema.table_name(),
+            projection,
+            filters,
+            limit
+        );
+
         // If no columns are specified, use partition_key - otherwise DynamoDB returns an error
         if projected_schema.fields.is_empty() {
             let idx = self
@@ -205,11 +240,29 @@ impl TableProvider for DynamoDBTableProvider {
             self.request_plan_builder
                 .build_request_plan(filters, &projected_schema, limit)?;
 
+        tracing::debug!(
+            "Table {:?}, request_plan: {:?}",
+            self.table_schema.table_name(),
+            request_plan
+        );
+
+        // If `config_partitions` is empty (i.e. it was set to 'auto' in the config), use table size as a heuristic.
+        let total_partitions = self
+            .config_partitions
+            .unwrap_or_else(|| self.get_partitions_from_table_size());
+
+        tracing::debug!(
+            "Table {:?}, total_partitions: {:?}",
+            self.table_schema.table_name(),
+            total_partitions
+        );
+
         Ok(Arc::new(DynamoDBTableProviderExec::new(
             Arc::clone(&self.client),
             request_plan,
             self.unnest_depth,
             projected_schema,
+            total_partitions,
         )))
     }
 
@@ -236,6 +289,7 @@ impl DynamoDBTableProviderExec {
         request_plan: DynamoDBRequestPlan,
         unnest_depth: Option<usize>,
         projected_schema: SchemaRef,
+        partitions: usize,
     ) -> Self {
         Self {
             client,
@@ -244,7 +298,7 @@ impl DynamoDBTableProviderExec {
             unnest_depth,
             properties: PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
-                Partitioning::UnknownPartitioning(1),
+                Partitioning::UnknownPartitioning(partitions),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             ),
@@ -254,13 +308,17 @@ impl DynamoDBTableProviderExec {
 
 impl std::fmt::Debug for DynamoDBTableProviderExec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "DynamoDBTableProviderExec")
+        f.debug_struct("DynamoDBTableProviderExec")
+            .field("request_plan", &self.request_plan)
+            .finish_non_exhaustive()
     }
 }
 
 impl DisplayAs for DynamoDBTableProviderExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "DynamoDBTableProviderExec")
+        f.debug_struct("DynamoDBTableProviderExec")
+            .field("request_plan", &self.request_plan)
+            .finish_non_exhaustive()
     }
 }
 
@@ -294,7 +352,7 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let mut builder = RecordBatchReceiverStream::builder(Arc::clone(&self.projected_schema), 2);
@@ -305,10 +363,16 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
         let request_plan = self.request_plan.clone();
         let unnest_depth = self.unnest_depth;
 
+        let total_partitions = match self.properties.partitioning {
+            Partitioning::RoundRobinBatch(_) | Partitioning::Hash(_, _) => 1,
+            Partitioning::UnknownPartitioning(partitions) => partitions,
+        };
+
         builder.spawn(async move {
             const CHUNK_SIZE: usize = 4_000;
 
-            let item_stream = build_stream_from_plan(&client, request_plan);
+            let item_stream =
+                build_stream_from_plan(&client, request_plan, partition, total_partitions);
             let chunked_stream = item_stream.chunks(CHUNK_SIZE);
             pin_mut!(chunked_stream);
 
@@ -340,6 +404,8 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
 fn build_stream_from_plan(
     client: &Arc<Client>,
     request: DynamoDBRequestPlan,
+    partition: usize,
+    total_partitions: usize,
 ) -> Pin<Box<DynamoDBItemStream>> {
     match request {
         DynamoDBRequestPlan::Query(QueryParams {
@@ -381,7 +447,7 @@ fn build_stream_from_plan(
             projection_expression,
             limit,
         }) => {
-            let request = client
+            let mut request = client
                 .scan()
                 .table_name(table_name)
                 .set_filter_expression(filter_expression)
@@ -389,6 +455,12 @@ fn build_stream_from_plan(
                 .set_expression_attribute_names(expression_attribute_names)
                 .set_projection_expression(projection_expression)
                 .set_limit(limit);
+
+            if total_partitions > 1 {
+                request = request
+                    .segment(partition as i32)
+                    .total_segments(total_partitions as i32);
+            }
 
             let pagination_stream = TryFlatMap::new(request.into_paginator().send())
                 .flat_map(|output| output.items().to_vec());

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -69,7 +69,7 @@ pub struct DynamoDBTableProvider {
 type DynamoDBItemStream =
     dyn Stream<Item = DataFusionResult<HashMap<String, AttributeValue>>> + Send + 'static;
 
-const DEFAULT_SEGMENTS: usize = 8;
+const DEFAULT_PARTITIONS: usize = 8;
 
 impl DynamoDBTableProvider {
     pub async fn try_new(
@@ -185,7 +185,7 @@ impl DynamoDBTableProvider {
 
     fn get_partitions_from_table_size(&self) -> usize {
         match self.table_total_item_count {
-            None => DEFAULT_SEGMENTS,
+            None => DEFAULT_PARTITIONS,
             Some(row_count) => match row_count {
                 0..1_000 => 1,
                 1_000..10_000 => 2,

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -49,6 +49,7 @@ impl DynamoDBFactory {
 }
 
 const DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR: &str = "10";
+const PARTITIONS_AUTO_STR: &str = "auto";
 
 const PARAMETERS: &[ParameterSpec] = &[
     // Connector parameters
@@ -70,6 +71,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("schema_infer_max_records")
         .description("Number of documents to use to infer the schema. Defaults to 10.")
         .default(DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR),
+    ParameterSpec::runtime("scan_partitions")
+        .description("Number of partitions. 'auto' by default.")
+        .default(PARTITIONS_AUTO_STR),
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {
@@ -151,11 +155,27 @@ impl DataConnector for DynamoDB {
             ExposedParamLookup::Absent(_) => None,
         };
 
+        let config_partitions_str = match self.params.get("scan_partitions").expose() {
+            ExposedParamLookup::Present(partitions_str) => partitions_str,
+            ExposedParamLookup::Absent(_) => PARTITIONS_AUTO_STR,
+        };
+
+        let config_partitions = match config_partitions_str.to_lowercase().as_str() {
+            PARTITIONS_AUTO_STR => None,
+            _ => Some(usize::from_str(config_partitions_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+                dataconnector: "dynamodb".to_string(),
+                message: format!(
+                    "DynamoDB parameter 'scan_partitions' must be either an integer or 'auto', not {config_partitions_str}"),
+                connector_component: ConnectorComponent::from(dataset)
+            })?)
+        };
+
         let provider = DynamoDBTableProvider::try_new(
             Arc::new(client),
             Arc::from(table_name),
             unnest_depth,
             schema_infer_max_records,
+            config_partitions,
         )
         .await
         .map_err(|e| DataConnectorError::UnableToGetReadProvider {

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -49,7 +49,7 @@ impl DynamoDBFactory {
 }
 
 const DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR: &str = "10";
-const PARTITIONS_AUTO_STR: &str = "auto";
+const SEGMENTS_AUTO_STR: &str = "auto";
 
 const PARAMETERS: &[ParameterSpec] = &[
     // Connector parameters
@@ -71,9 +71,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("schema_infer_max_records")
         .description("Number of documents to use to infer the schema. Defaults to 10.")
         .default(DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR),
-    ParameterSpec::runtime("scan_partitions")
-        .description("Number of partitions. 'auto' by default.")
-        .default(PARTITIONS_AUTO_STR),
+    ParameterSpec::runtime("scan_segments")
+        .description("Number of segments. 'auto' by default.")
+        .default(SEGMENTS_AUTO_STR),
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {
@@ -155,19 +155,35 @@ impl DataConnector for DynamoDB {
             ExposedParamLookup::Absent(_) => None,
         };
 
-        let config_partitions_str = match self.params.get("scan_partitions").expose() {
-            ExposedParamLookup::Present(partitions_str) => partitions_str,
-            ExposedParamLookup::Absent(_) => PARTITIONS_AUTO_STR,
-        };
+        let config_segments = match self
+            .params
+            .get("scan_segments")
+            .expose()
+            .unwrap_or_else(|_| SEGMENTS_AUTO_STR)
+            .to_lowercase()
+            .as_str()
+        {
+            SEGMENTS_AUTO_STR => None,
+            config_segments_str => {
+                let config_segments = usize::from_str(config_segments_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+                    dataconnector: "dynamodb".to_string(),
+                    message: format!(
+                        "DynamoDB parameter 'scan_segments' must be either an integer > 0 or 'auto', not {config_segments_str}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                })?;
 
-        let config_partitions = match config_partitions_str.to_lowercase().as_str() {
-            PARTITIONS_AUTO_STR => None,
-            _ => Some(usize::from_str(config_partitions_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
-                dataconnector: "dynamodb".to_string(),
-                message: format!(
-                    "DynamoDB parameter 'scan_partitions' must be either an integer or 'auto', not {config_partitions_str}"),
-                connector_component: ConnectorComponent::from(dataset)
-            })?)
+                if config_segments == 0 {
+                    return Err(DataConnectorError::InvalidConfigurationNoSource {
+                        dataconnector: "dynamodb".to_string(),
+                        message: format!(
+                            "DynamoDB parameter 'scan_segments' must be either an integer > 0 or 'auto', not {config_segments_str}"
+                        ),
+                        connector_component: ConnectorComponent::from(dataset),
+                    });
+                }
+
+                Some(config_segments)
+            }
         };
 
         let provider = DynamoDBTableProvider::try_new(
@@ -175,7 +191,7 @@ impl DataConnector for DynamoDB {
             Arc::from(table_name),
             unnest_depth,
             schema_infer_max_records,
-            config_partitions,
+            config_segments,
         )
         .await
         .map_err(|e| DataConnectorError::UnableToGetReadProvider {


### PR DESCRIPTION
## 📝 Summary

`Scan` requests in DynamoDB support optional parallelization which is configuration using two paramteres:
* `total_segments`
* `segment`

This PR adds following configuration for dynamodb datasets: `scan_segments` which is `auto` by default.

The logic to calculate number of segments for a given request is:
* If `scan_segments` is integer -> use it as number of segments
* If `scan_segments` is `auto`, use following mapping based on table size:
  *  <1k rows: 1 segment
  * \>10k: 2 segments
  * \>100k: 4 segments
  * \>100k: 8 segments
  * \>1m: 16 segments
  * \>10m: 32 segments

## 🔗 Related

https://github.com/spiceai/spiceai/pull/7715

## 📚 Docs

Will be done in https://github.com/spiceai/spiceai/issues/7755