### PR TITLE
Fix Bug: DuckDB INTERNAL Error: Failed to load metadata pointer

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -127,7 +127,7 @@ impl DuckDBAccelerator {
 
     /// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` accelerator from this dataset
     pub fn duckdb_file_path(&self, source: &dyn AccelerationSource) -> Result<String> {
-        duckdb_file_path(&self.duckdb_factory, source)
+        duckdb_file_path(&self.duckdb_factory, source, "accelerated_duckdb")
     }
 
     /// Returns an existing `DuckDB` connection pool for the given dataset, or creates a new one if it doesn't exist.
@@ -135,7 +135,7 @@ impl DuckDBAccelerator {
         &self,
         source: &dyn AccelerationSource,
     ) -> Result<DuckDbConnectionPool> {
-        let duckdb_file = duckdb_file_path(&self.duckdb_factory, source);
+        let duckdb_file = self.duckdb_file_path(source);
 
         let acceleration = source.acceleration().context(AccelerationNotEnabledSnafu {
             dataset: source.name().to_string(),
@@ -229,10 +229,17 @@ impl DuckDBAccelerator {
     }
 }
 
-/// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` accelerator from this dataset
+/// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` acceleration for this acceleration source
+///
+/// # Parameters
+///
+/// * `duckdb_factory` - The `DuckDB` table provider factory used to generate the file path
+/// * `source` - The acceleration source (dataset or view) containing acceleration configuration
+/// * `default_db_name` - Default database file name to use if the `duckdb_file` parameter is not specified
 pub fn duckdb_file_path(
     duckdb_factory: &DuckDBTableProviderFactory,
     source: &dyn AccelerationSource,
+    default_db_name: &str,
 ) -> Result<String> {
     if !source.is_file_accelerated() {
         Err(Error::InvalidConfiguration {
@@ -260,7 +267,7 @@ pub fn duckdb_file_path(
         }
 
         duckdb_factory
-            .duckdb_file_path("accelerated_duckdb", &mut params)
+            .duckdb_file_path(default_db_name, &mut params)
             .map_err(|err| Error::InvalidConfiguration {
                 detail: Arc::from(err.to_string()),
             })

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -131,9 +131,11 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
     }
 
     fn file_path(&self, source: &dyn AccelerationSource) -> Result<String, FilePathError> {
-        duckdb_file_path(&self.duckdb_factory, source).map_err(|e| FilePathError::External {
-            engine: Engine::DuckDB,
-            source: e.into(),
+        duckdb_file_path(&self.duckdb_factory, source, &source.name().to_string()).map_err(|e| {
+            FilePathError::External {
+                engine: Engine::DuckDB,
+                source: e.into(),
+            }
         })
     }
 

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -190,7 +190,7 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
         let source = source.context(ExpectedAccelerationSourceSnafu)?;
 
         if !cmd.options.contains_key("open") {
-            let duckdb_file = duckdb_file_path(&self.duckdb_factory, source)?;
+            let duckdb_file = self.file_path(source)?;
             cmd.options.insert("open".to_string(), duckdb_file);
         }
 
@@ -201,6 +201,7 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
                 cmd.clone(),
                 partition_by_first,
                 Arc::clone(&schema),
+                &self.duckdb_factory,
             )
             .await?,
         );
@@ -253,12 +254,11 @@ impl DuckDBPartitionCreator {
         cmd: CreateExternalTable,
         partition_by: PartitionedBy,
         schema: SchemaRef,
+        duckdb_factory: &DuckDBTableProviderFactory,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let duckdb_factory = create_factory();
-
         // We use the DuckDB factory to create a table provider in order to extract
         // target table definition and on_conflict settings that will be used directly for each partition.
-        let table_provider = create_table_provider(&duckdb_factory, &cmd, None)
+        let table_provider = create_table_provider(duckdb_factory, &cmd, None)
             .await
             .map_err(|e| format!("Failed to create table provider: {e}"))?;
 


### PR DESCRIPTION
## 📝 Summary

PR improves `TablesModePartitionedDuckDBAccelerator` to eliminate duplicate writers with `DuckDBAccelerator`
- Both `DuckDBAccelerator` and `TablesModePartitionedDuckDBAccelerator` maintain their own `DuckDBTableProviderFactory` instances, each tracking separate connection pools. This could result in multiple pools (including writers) targeting the same default database file (`.spice/data/accelerated_duckdb.db`) when both non-partitioned and table-based partitioned `duckdb` tables were present resulting in corrupted duckdb state.
- Since `TablesModePartitionedDuckDBAccelerator` does **not** support federation, there is no good reason to default to the shared `.spice/data/accelerated_duckdb.db`. Instead, it now defaults to a per-table database file named after the table itself—consistent with DuckDB’s default behavior when federation is disabled.
- PR also removes redundant creation of `DuckDBTableProviderFactory` within `TablesModePartitionedDuckDBAccelerator`

This fixes 
- https://github.com/spiceai/spiceai/issues/7838

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/7838

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
