### PR TITLE
Revert "Use GitHub-hosted macOS runner only for tag releases"

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -61,10 +61,6 @@ jobs:
         id: setup-matrix
         with:
           script: |
-            // Use GitHub-hosted macOS runner only for tag releases
-            const isTagRelease = context.ref && context.ref.startsWith('refs/tags/v');
-            const macosRunner = isTagRelease ? "macos-14" : "spiceai-macos";
-
             const matrix = [
               {
                 name: "Linux x64",
@@ -82,7 +78,7 @@ jobs:
                 tags: ["default", "models"],
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
-                runner: macosRunner,
+                runner: "macos-14",
                 target_os: "darwin",
                 target_arch: "aarch64",
                 target_arch_go: "arm64",


### PR DESCRIPTION
Reverts spiceai/spiceai#7836

Untill we fix the macs.