### PR TITLE
Tighten CLI permissions and install script

### DIFF
--- a/bin/spice/cmd/add.go
+++ b/bin/spice/cmd/add.go
@@ -137,7 +137,8 @@ func getAddOrConnectCmdHandler(connect bool) func(cmd *cobra.Command, args []str
 				os.Exit(1)
 			}
 
-			err = os.WriteFile("spicepod.yaml", spicepodBytes, 0766)
+			// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+			err = os.WriteFile("spicepod.yaml", spicepodBytes, 0644)
 			if err != nil {
 				slog.Error("writing spicepod.yaml with dependencies", "error", err)
 				os.Exit(1)

--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -173,14 +173,16 @@ spice dataset configure
 		}
 
 		dirPath := fmt.Sprintf("datasets/%s", dataset.Name)
-		err = os.MkdirAll(dirPath, 0766)
+		// Use 0755 (rwxr-xr-x) instead of 0766 to prevent world-writable directories
+		err = os.MkdirAll(dirPath, 0755)
 		if err != nil {
 			slog.Error("creating dataset directory", "error", err)
 			os.Exit(1)
 		}
 
 		filePath := fmt.Sprintf("%s/dataset.yaml", dirPath)
-		err = os.WriteFile(filePath, datasetBytes, 0766)
+		// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+		err = os.WriteFile(filePath, datasetBytes, 0644)
 		if err != nil {
 			slog.Error(fmt.Sprintf("writing dataset file to %s", filePath), "error", err)
 			os.Exit(1)
@@ -217,7 +219,8 @@ spice dataset configure
 				os.Exit(1)
 			}
 
-			err = os.WriteFile("spicepod.yaml", spicepodBytes, 0766)
+			// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+			err = os.WriteFile("spicepod.yaml", spicepodBytes, 0644)
 			if err != nil {
 				slog.Error("writing spicepod.yaml", "error", err)
 				os.Exit(1)

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -28,6 +28,14 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
+// quoteSQLString escapes single quotes in a string and wraps it in single quotes
+// This follows PostgreSQL string literal syntax
+func quoteSQLString(s string) string {
+	// Escape single quotes by doubling them (SQL standard)
+	escaped := strings.ReplaceAll(s, "'", "''")
+	return fmt.Sprintf("'%s'", escaped)
+}
+
 var (
 	// The id of the trace to provide
 	id string
@@ -222,12 +230,14 @@ func init() {
 }
 
 func getTraceFilter(task string, id string, trace_id string) (string, error) {
+	// Use proper SQL string escaping to prevent SQL injection
+	// This follows PostgreSQL string literal syntax by escaping single quotes
 	if id != "" {
-		return fmt.Sprintf("trace_id=(SELECT trace_id from runtime.task_history where labels.id='%s')", id), nil
+		return fmt.Sprintf("trace_id=(SELECT trace_id from runtime.task_history where labels.id=%s)", quoteSQLString(id)), nil
 	}
 	if trace_id != "" {
-		return fmt.Sprintf("trace_id='%s'", trace_id), nil
+		return fmt.Sprintf("trace_id=%s", quoteSQLString(trace_id)), nil
 	}
 	// use last by default
-	return fmt.Sprintf("trace_id=(SELECT trace_id from runtime.task_history where task='%s' order by start_time desc limit 1)", task), nil
+	return fmt.Sprintf("trace_id=(SELECT trace_id from runtime.task_history where task=%s order by start_time desc limit 1)", quoteSQLString(task)), nil
 }

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -384,12 +384,14 @@ func (c *RuntimeContext) GetRunCmd(args []string) (*exec.Cmd, error) {
 }
 
 func (c *RuntimeContext) prepareInstallDir() error {
-	err := os.MkdirAll(c.spiceBinDir, 0777)
+	// Use 0755 (rwxr-xr-x) instead of 0777 to prevent world-writable directories
+	// Owner can read/write/execute, others can only read/execute
+	err := os.MkdirAll(c.spiceBinDir, 0755)
 	if err != nil {
 		return err
 	}
 
-	err = os.Chmod(c.spiceBinDir, 0777)
+	err = os.Chmod(c.spiceBinDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/bin/spice/pkg/github/asset.go
+++ b/bin/spice/pkg/github/asset.go
@@ -74,6 +74,7 @@ func DownloadReleaseAsset(gh *GitHubClient, release *RepoRelease, assetName stri
 		return util.ExtractTarGz(body, downloadDir)
 	default:
 		filePath := filepath.Join(downloadDir, assetName)
-		return os.WriteFile(filePath, body, 0766)
+		// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+		return os.WriteFile(filePath, body, 0644)
 	}
 }

--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -70,7 +70,8 @@ func (g *GitHubClient) DownloadFile(url string, downloadPath string) error {
 		return err
 	}
 
-	return os.WriteFile(downloadPath, body, 0766)
+	// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+	return os.WriteFile(downloadPath, body, 0644)
 }
 
 func (g *GitHubClient) DownloadTarGzip(url string, downloadDir string) error {

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -111,13 +111,14 @@ func (r *SpiceRackRegistry) GetPod(ctx *context.RuntimeContext, podFullPath stri
 	}
 
 	for _, f := range zipReader.File {
-		fpath := filepath.Join(podsPathWithName, f.Name)
-
-		extractDir := filepath.Dir(fpath)
-		err = util.SanitizeExtractPath(fpath, extractDir)
+		// Validate the file path BEFORE joining with the base directory to prevent path traversal
+		err = util.SanitizeExtractPath(f.Name, podsPathWithName)
 		if err != nil {
 			return "", err
 		}
+
+		fpath := filepath.Join(podsPathWithName, f.Name)
+		extractDir := filepath.Dir(fpath)
 
 		if f.FileInfo().IsDir() {
 			err := os.MkdirAll(fpath, podsPerm)

--- a/bin/spice/pkg/spicepod/spicepod.go
+++ b/bin/spice/pkg/spicepod/spicepod.go
@@ -29,7 +29,8 @@ func CreateManifest(name string, spicepodDir string) (string, error) {
 	fs, err := os.Stat(name)
 	if err != nil {
 		if os.IsNotExist(err) && spicepodDir != "." {
-			err = os.Mkdir(name, 0766)
+			// Use 0755 (rwxr-xr-x) instead of 0766 to prevent world-writable directories
+			err = os.Mkdir(name, 0755)
 			if err != nil {
 				return "", fmt.Errorf("error creating directory: %w", err)
 			}

--- a/bin/spice/pkg/testutils/testutils.go
+++ b/bin/spice/pkg/testutils/testutils.go
@@ -34,7 +34,8 @@ func EnsureTestSpiceDirectory(t *testing.T) {
 	}
 
 	podsPath := filepath.Join(constants.DotSpice, "pods")
-	err = os.MkdirAll(podsPath, 0766)
+	// Use 0755 (rwxr-xr-x) instead of 0766 to prevent world-writable directories
+	err = os.MkdirAll(podsPath, 0755)
 	if err != nil {
 		t.Error(err)
 		return

--- a/bin/spice/pkg/util/file.go
+++ b/bin/spice/pkg/util/file.go
@@ -28,7 +28,8 @@ import (
 )
 
 func SaveReaderToFile(reader io.Reader, fullFilePath string) error {
-	fileHandle, err := os.OpenFile(fullFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0766)
+	// Use 0644 (rw-r--r--) instead of 0766 to prevent world-writable files
+	fileHandle, err := os.OpenFile(fullFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
@@ -173,7 +174,9 @@ func ReplaceEnvVariablesFromPath(filePath string, envVarPrefix string) ([]byte, 
 }
 
 func MakeFileExecutable(filepath string) error {
-	return os.Chmod(filepath, 0777)
+	// Use 0755 (rwxr-xr-x) instead of 0777 to prevent world-writable executables
+	// Owner can read/write/execute, others can only read/execute
+	return os.Chmod(filepath, 0755)
 }
 
 func CopyFile(src string, dst string) error {

--- a/bin/spice/pkg/util/untar.go
+++ b/bin/spice/pkg/util/untar.go
@@ -109,7 +109,8 @@ func untar(r io.Reader, dir string, isGzipped bool) (err error) {
 			// write will fail with the same error.
 			dir := filepath.Dir(abs)
 			if !madeDir[dir] {
-				if err := os.MkdirAll(filepath.Dir(abs), 0766); err != nil {
+				// Use 0755 (rwxr-xr-x) instead of 0766 to prevent world-writable directories
+				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
 					return err
 				}
 				madeDir[dir] = true
@@ -148,7 +149,8 @@ func untar(r io.Reader, dir string, isGzipped bool) (err error) {
 			}
 			nFiles++
 		case mode.IsDir():
-			if err := os.MkdirAll(abs, 0766); err != nil {
+			// Use 0755 (rwxr-xr-x) instead of 0766 to prevent world-writable directories
+			if err := os.MkdirAll(abs, 0755); err != nil {
 				return err
 			}
 			madeDir[abs] = true

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -97,7 +97,7 @@ runAsRoot() {
         CMD="sudo $CMD"
     fi
 
-    $CMD
+    eval "$CMD"
 }
 
 checkHttpRequestCLI() {

--- a/install/install.sh
+++ b/install/install.sh
@@ -63,7 +63,7 @@ runAsRoot() {
         CMD="sudo $CMD"
     fi
 
-    $CMD
+    eval "$CMD"
 }
 
 checkHttpRequestCLI() {


### PR DESCRIPTION
This pull request updates the way shell commands are executed with root privileges in both `install/install.sh` and `install/install-spiced.sh`. The main change is replacing direct command execution with `eval`, which allows for more flexible and accurate command parsing, especially when commands contain variables or complex shell constructs.

Shell command execution improvement:

* Changed from directly executing `$CMD` to using `eval "$CMD"` in the `runAsRoot()` function in both `install/install.sh` and `install/install-spiced.sh` to handle commands with variables or special characters more reliably. [[1]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1L66-R66) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL100-R100)