### PR TITLE
Optimize macOS and Windows builds

### DIFF
--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -27,7 +27,7 @@ runs:
       if: inputs.os == 'darwin'
       shell: bash
       run: |
-        # macos-14 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
+        # macos-15 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
         brew update
         brew install postgresql
         brew services start postgresql

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -61,6 +61,23 @@ jobs:
         id: setup-matrix
         with:
           script: |
+            // Check if this is a tagged release
+            const isTaggedRelease = context.ref.startsWith('refs/tags/v');
+            
+            // Check if this is trunk or a release branch
+            const isTrunkOrRelease = context.ref === 'refs/heads/trunk' || 
+                                      context.ref.startsWith('refs/heads/release-') ||
+                                      context.ref.startsWith('refs/heads/release/');
+            
+            // Check if this is a manual workflow dispatch
+            const isManualDispatch = context.eventName === 'workflow_dispatch';
+            
+            // Include Windows only for trunk, release branches, tagged releases, or manual dispatch
+            const includeWindows = isTaggedRelease || isTrunkOrRelease || isManualDispatch;
+            
+            // Use hosted macOS runners only for tagged releases, otherwise use self-hosted
+            const macosRunner = isTaggedRelease ? "macos-14" : "spiceai-macos";
+            
             const matrix = [
               {
                 name: "Linux x64",
@@ -78,23 +95,28 @@ jobs:
                 tags: ["default", "models"],
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
-                runner: "macos-14",
+                runner: macosRunner,
                 target_os: "darwin",
                 target_arch: "aarch64",
                 target_arch_go: "arm64",
                 tags: ["default", "models", "metal"],
-              }, {
+              }
+            ];
+            
+            // Add Windows only for trunk, release branches, tagged releases, or manual dispatch
+            if (includeWindows) {
+              matrix.push({
                 name: "Windows x64",
                 runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64",
                 target_arch_go: "amd64",
                 tags: ["default", "models"],
-              }
-            ];
+              });
+            }
 
             // If running via workflow_dispatch, filter based on input
-            if (context.eventName === 'workflow_dispatch') {
+            if (isManualDispatch) {
               const platform_option = context.payload.inputs.platform_option;
 
               if (platform_option === 'all') {

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -76,7 +76,7 @@ jobs:
             const includeWindows = isTaggedRelease || isTrunkOrRelease || isManualDispatch;
             
             // Use hosted macOS runners only for tagged releases, otherwise use self-hosted
-            const macosRunner = isTaggedRelease ? "macos-14" : "spiceai-macos";
+            const macosRunner = isTaggedRelease ? "macos-15" : "spiceai-macos";
             
             const matrix = [
               {

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -78,7 +78,7 @@ jobs:
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
                 builder: "spiceai-macos",
-                runner: "macos-14",
+                runner: "macos-15",
                 target_os: "darwin",
                 target_arch: "aarch64",
                 target_arch_go: "arm64"
@@ -723,7 +723,7 @@ jobs:
       - name: Install MySQL (MacOS)
         if: matrix.target.target_os == 'darwin'
         run: |
-          # macos-14 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
+          # macos-15 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
           brew update
           brew install mysql@8.4
           brew link mysql@8.4 --force --overwrite

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -20,7 +20,7 @@ jobs:
             target_os: linux
             target_arch: aarch64
           - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
+            runner: macos-15
             target_os: darwin
             target_arch: aarch64
           - name: Windows x64

--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -44,7 +44,7 @@ jobs:
               },
               {
                 name: "macOS aarch64",
-                runner: "macos-14",
+                runner: "macos-15",
                 target_os: "darwin",
                 target_arch: "aarch64",
                 tags: []

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -33,7 +33,7 @@ jobs:
                 target_arch_go: "amd64",
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
-                runner: "macos-14",
+                runner: "macos-15",
                 target_os: "darwin",
                 target_arch: "aarch64",
                 target_arch_go: "arm64",
@@ -454,7 +454,7 @@ jobs:
       matrix:
         target:
           - name: 'macOS aarch64 (Apple Silicon)'
-            runner: 'macos-14'
+            runner: 'macos-15'
             target_os: 'darwin'
             target_arch: 'aarch64'
             target_arch_go: 'arm64'
@@ -502,7 +502,7 @@ jobs:
       matrix:
         target:
           - name: 'macOS aarch64 (Apple Silicon)'
-            runner: 'macos-14'
+            runner: 'macos-15'
             target_os: 'darwin'
             target_arch: 'aarch64'
             target_arch_go: 'arm64'


### PR DESCRIPTION
This pull request updates the build matrix logic in the `.github/workflows/build_and_release.yml` workflow to make platform selection more dynamic and context-aware. The changes ensure that Windows builds are only included for certain branches or events, and that the macOS runner type is selected based on whether the workflow is running for a tagged release.

**Build matrix and runner selection improvements:**

* Added logic to include Windows builds only for trunk, release branches, tagged releases, or manual workflow dispatches, reducing unnecessary Windows builds on other branches. [[1]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R64-R80) [[2]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L81-R119)
* Updated macOS build configuration to use the hosted `macos-14` runner only for tagged releases, and a self-hosted runner (`spiceai-macos`) otherwise, optimizing runner usage and potentially reducing costs. [[1]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R64-R80) [[2]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L81-R119)