### PR TITLE
Revert FlightIPC issues

### DIFF
--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -230,7 +230,7 @@ impl Service {
 
         // Pre-compute schema flight data once
         let mut dict_tracker = DictionaryTracker::new(true); // Set to true to handle dictionaries
-        let mut encoder = IpcDataGenerator::default();
+        let encoder = IpcDataGenerator::default();
         let data = IpcMessage(
             encoder
                 .schema_to_bytes_with_dictionary_tracker(

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -230,8 +230,21 @@ impl Service {
 
         // Pre-compute schema flight data once
         let mut dict_tracker = DictionaryTracker::new(true); // Set to true to handle dictionaries
-        let encoder = IpcDataGenerator::default();
-        let schema_flight_data = FlightData::from(SchemaAsIpc::new(schema.as_ref(), &options));
+        let mut encoder = IpcDataGenerator::default();
+        let data = IpcMessage(
+            encoder
+                .schema_to_bytes_with_dictionary_tracker(
+                    schema.as_ref(),
+                    &mut dict_tracker,
+                    &options,
+                )
+                .ipc_message
+                .into(),
+        );
+        let schema_flight_data = FlightData {
+            data_header: data.0,
+            ..Default::default()
+        };
 
         let data_stream = query_result.data;
         let cache_status = query_result.cache_status;


### PR DESCRIPTION
## 📝 Summary
 - Revert bad changes to Flight IPC handling. Broke integration [tests](https://github.com/spiceai/spiceai/actions/runs/19020960237/job/54316969430) in trunk

  ```
  Error: Tonic error: status: Internal, message: "Ipc error: no dict id for field col1", details: [], metadata: MetadataMap { headers: {} }
  ```

## 🔗 Related
- Bad code added in #7859
