### PR TITLE
fix: Kafka message delivery failed

### DIFF
--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -138,7 +138,7 @@ pub async fn send_messages_to_kafka<T>(
 where
     T: serde::Serialize,
 {
-    const QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+    const QUEUE_TIMEOUT: Duration = Duration::from_secs(10);
     for message in messages {
         let message_str = serde_json::to_string(message)?;
         producer

--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -138,12 +138,13 @@ pub async fn send_messages_to_kafka<T>(
 where
     T: serde::Serialize,
 {
+    const QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
     for message in messages {
         let message_str = serde_json::to_string(message)?;
         producer
             .send(
                 FutureRecord::<String, String>::to(topic).payload(&message_str),
-                Duration::from_secs(2),
+                QUEUE_TIMEOUT,
             )
             .await
             .map_err(|(e, _)| anyhow::Error::msg(format!("Kafka message delivery failed: {e}")))?;

--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -138,16 +138,46 @@ pub async fn send_messages_to_kafka<T>(
 where
     T: serde::Serialize,
 {
-    const QUEUE_TIMEOUT: Duration = Duration::from_secs(10);
+    const MAX_RETRIES: u32 = 5;
+    const DELAY_S: u64 = 1;
+    const QUEUE_TIMEOUT: Duration = Duration::from_secs(2);
+
     for message in messages {
         let message_str = serde_json::to_string(message)?;
-        producer
-            .send(
-                FutureRecord::<String, String>::to(topic).payload(&message_str),
-                QUEUE_TIMEOUT,
-            )
-            .await
-            .map_err(|(e, _)| anyhow::Error::msg(format!("Kafka message delivery failed: {e}")))?;
+
+        let mut last_error = None;
+        for attempt in 0..=MAX_RETRIES {
+            let record = FutureRecord::<String, String>::to(topic).payload(&message_str);
+
+            match producer.send(record, QUEUE_TIMEOUT).await {
+                Ok(_) => {
+                    if attempt > 0 {
+                        tracing::debug!("Message sent successfully after {attempt} retries");
+                    }
+                    last_error = None;
+                    break;
+                }
+                Err((e, _)) if attempt < MAX_RETRIES => {
+                    tracing::debug!(
+                        "Kafka send failed (attempt {}/{}): {e}. Retrying in {DELAY_S} seconds",
+                        attempt + 1,
+                        MAX_RETRIES + 1,
+                    );
+                    last_error = Some(e);
+                    tokio::time::sleep(Duration::from_secs(DELAY_S)).await;
+                }
+                Err((e, _)) => {
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        if let Some(e) = last_error {
+            return Err(anyhow::Error::msg(format!(
+                "Kafka message delivery failed after {} attempts: {e}",
+                MAX_RETRIES + 1,
+            )));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

Some [integration test runs](https://github.com/spiceai/spiceai/actions/runs/19030147305/job/54387712044?pr=7869#step:6:133) fail due to:

```
Error: Kafka message delivery failed: Message production error: MessageTimedOut (Local: Message timed out)
```

This PR increases the send timeout to wait longer for the Kafka broker to setup and be ready for accepting messages.

Rerunning the test has fixed the issue at times, supporting the idea that it's simply a race condition.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
