### PR TITLE
Fix `dataset_acceleration_last_refresh_time_ms` unit to milliseconds in description

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -41,7 +41,7 @@ pub(crate) static REFRESH_ERRORS: LazyLock<Counter<u64>> = LazyLock::new(|| {
 pub(crate) static LAST_REFRESH_TIME_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     METER
         .f64_gauge("dataset_acceleration_last_refresh_time_ms")
-        .with_description("Unix timestamp in seconds when the last refresh completed.")
+        .with_description("Unix timestamp in milliseconds when the last refresh completed.")
         .with_unit("ms")
         .build()
 });


### PR DESCRIPTION
## 📝 Summary

This pull request makes a minor documentation update to the metric description in the `crates/runtime/src/accelerated_table/metrics.rs` file. The description for the gauge tracking last refresh time now correctly states that the value is in milliseconds rather than seconds.

* Updated the description for `LAST_REFRESH_TIME_MS` to specify that the timestamp is in milliseconds instead of seconds.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
