### PR TITLE
Cayenne deletion vector caching support

### DIFF
--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -86,6 +86,13 @@ pub enum CatalogError {
         /// The underlying IO error  
         source: std::io::Error,
     },
+
+    /// Lock poisoning error
+    #[snafu(display("Lock poisoned during {operation}: a thread panicked while holding this lock. This indicates an internal error that requires restarting the runtime."))]
+    LockPoisoned {
+        /// The operation that failed due to lock poisoning
+        operation: String,
+    },
 }
 
 /// Result type for catalog operations.

--- a/crates/cayenne/src/provider.rs
+++ b/crates/cayenne/src/provider.rs
@@ -309,6 +309,10 @@ pub struct CayenneTableProvider {
     listing_table: Arc<RwLock<Arc<ListingTable>>>,
     /// Optional retention filters that should be applied immediately after writes.
     retention_filters: Vec<Expr>,
+    /// Cached deletion vectors (deleted row IDs) to avoid repeated metastore queries on every scan.
+    /// This is loaded once during table provider initialization and invalidated when delete files change.
+    /// Using `RwLock` for concurrent reads during scans with occasional writes on updates.
+    cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
 }
 
 impl std::fmt::Debug for CayenneTableProvider {
@@ -440,11 +444,17 @@ impl CayenneTableProvider {
             Arc::<arrow_schema::Schema>::clone(&table_metadata.schema),
         )?;
 
+        // Load deletion vectors once at initialization to avoid repeated SQLite queries on every scan
+        let table_id = table_metadata.table_id;
+        let catalog_for_load = Arc::clone(&catalog);
+        let deleted_row_ids = Self::load_deletion_vectors(table_id, catalog_for_load).await?;
+
         Ok(Self {
             table_metadata,
             catalog,
             listing_table: Arc::new(RwLock::new(listing_table)),
             retention_filters,
+            cached_deleted_row_ids: Arc::new(RwLock::new(deleted_row_ids)),
         })
     }
 
@@ -729,13 +739,55 @@ impl CayenneTableProvider {
             Arc::clone(&self.listing_table),
             Arc::clone(&self.table_metadata.schema),
             &filters,
+            Arc::clone(&self.cached_deleted_row_ids),
         );
 
-        sink.delete_from()
-            .await
-            .map_err(|err| CatalogError::InvalidOperation {
-                message: format!("Failed to execute retention filters: {err}"),
-            })
+        let deleted_count =
+            sink.delete_from()
+                .await
+                .map_err(|err| CatalogError::InvalidOperation {
+                    message: format!("Failed to execute retention filters: {err}"),
+                })?;
+
+        // Refresh deletion cache after applying retention filters
+        if deleted_count > 0 {
+            self.refresh_deletion_cache().await?;
+        }
+
+        Ok(deleted_count)
+    }
+
+    /// Refresh the cached deletion vectors by reloading from the catalog.
+    ///
+    /// This should be called after operations that modify deletion vectors:
+    /// - After applying retention filters
+    /// - After manual delete operations
+    /// - After compaction that removes deleted rows
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deletion vectors cannot be loaded from the catalog.
+    async fn refresh_deletion_cache(&self) -> CatalogResult<()> {
+        let deleted_row_ids =
+            Self::load_deletion_vectors(self.table_metadata.table_id, Arc::clone(&self.catalog))
+                .await?;
+
+        let mut guard =
+            self.cached_deleted_row_ids
+                .write()
+                .map_err(|e| CatalogError::InvalidOperation {
+                    message: format!("Failed to acquire write lock on deletion cache: {e}"),
+                })?;
+
+        *guard = deleted_row_ids;
+
+        tracing::debug!(
+            "Refreshed deletion cache for table {} ({} deleted rows)",
+            self.table_metadata.table_name,
+            guard.len()
+        );
+
+        Ok(())
     }
 
     /// Delete rows matching the given primary key values.
@@ -811,6 +863,59 @@ impl CayenneTableProvider {
         );
 
         Ok(())
+    }
+
+    /// Load deletion vectors from the catalog and return a set of deleted row IDs.
+    ///
+    /// This method queries the catalog for delete files and loads all deletion vectors
+    /// into memory. It should be called once during table provider initialization and
+    /// whenever delete files are added/updated.
+    ///
+    /// # Performance Notes
+    ///
+    /// - Queries metastore once via catalog
+    /// - Reads deletion vector files in a blocking task
+    /// - Result is cached in the table provider to avoid repeated queries on every scan
+    async fn load_deletion_vectors(
+        table_id: i64,
+        catalog: Arc<dyn MetadataCatalog>,
+    ) -> CatalogResult<std::collections::HashSet<i64>> {
+        // Query catalog for delete files (this spawns a blocking task internally)
+        let delete_files = catalog
+            .get_table_delete_files(table_id)
+            .await
+            .map_err(|e| super::catalog::CatalogError::InvalidOperation {
+                message: format!("Failed to load deletion vectors from catalog: {e}"),
+            })?;
+
+        if delete_files.is_empty() {
+            return Ok(std::collections::HashSet::new());
+        }
+
+        // Read deletion vector files in a blocking task
+        let delete_files_for_read = delete_files.clone();
+        let deleted_row_ids =
+            task::spawn_blocking(move || Self::read_deletion_vectors(delete_files_for_read))
+                .await
+                .map_err(|err| super::catalog::CatalogError::InvalidOperation {
+                    message: format!(
+                        "Deletion vector reader task panicked or was cancelled: {err}"
+                    ),
+                })
+                .and_then(|result| {
+                    result.map_err(|err| super::catalog::CatalogError::InvalidOperation {
+                        message: format!("Failed to read deletion vectors: {err}"),
+                    })
+                })?;
+
+        tracing::debug!(
+            "Cached {} deletion vectors ({} deleted rows) for table_id {}",
+            delete_files.len(),
+            deleted_row_ids.len(),
+            table_id
+        );
+
+        Ok(deleted_row_ids)
     }
 
     /// Read deletion vectors from files and return a set of deleted row IDs.
@@ -934,49 +1039,26 @@ impl TableProvider for CayenneTableProvider {
             .scan(state, projection, filters, limit)
             .await?;
 
-        // Load deletion vectors from catalog
-        let delete_files = self
-            .catalog
-            .get_table_delete_files(self.table_metadata.table_id)
-            .await
-            .map_err(|e| {
+        // Use cached deletion vectors instead of querying the catalog on every scan.
+        // This dramatically improves concurrent query performance by avoiding repeated
+        // SQLite queries and spawn_blocking tasks.
+        let deleted_row_ids = {
+            let guard = self.cached_deleted_row_ids.read().map_err(|e| {
                 datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to load deletion vectors: {e}"
+                    "Failed to acquire read lock on deletion cache: {e}"
                 ))
             })?;
+            guard.clone()
+        };
 
-        // If there are any deletion vectors, load and apply filtering
-        if !delete_files.is_empty() {
-            let total_deleted = delete_files.iter().map(|df| df.delete_count).sum::<i64>();
+        // If there are any deleted rows, apply filtering
+        if !deleted_row_ids.is_empty() {
             tracing::debug!(
-                "Applying {} deletion vectors ({} deleted rows) to scan of table {}",
-                delete_files.len(),
-                total_deleted,
+                "Applying cached deletion filter ({} deleted rows) to scan of table {}",
+                deleted_row_ids.len(),
                 self.table_metadata.table_name
             );
-
-            // Read all deletion vectors and build a set of deleted row IDs
-            let delete_files_for_read = delete_files.clone();
-            let deleted_row_ids =
-                task::spawn_blocking(move || Self::read_deletion_vectors(delete_files_for_read))
-                    .await
-                    .map_err(|err| {
-                        datafusion_common::DataFusionError::Execution(format!(
-                            "Deletion vector reader task panicked or was cancelled: {err}"
-                        ))
-                    })
-                    .and_then(|result| {
-                        result.map_err(|err| {
-                            datafusion_common::DataFusionError::Execution(format!(
-                                "Failed to read deletion vectors: {err}"
-                            ))
-                        })
-                    })?;
-
-            if !deleted_row_ids.is_empty() {
-                // Wrap the plan with our deletion filter
-                return Ok(Arc::new(DeletionFilterExec::new(plan, deleted_row_ids)));
-            }
+            return Ok(Arc::new(DeletionFilterExec::new(plan, deleted_row_ids)));
         }
 
         Ok(plan)
@@ -1139,6 +1221,7 @@ impl DeletionTableProvider for CayenneTableProvider {
                 Arc::clone(&self.listing_table),
                 Arc::clone(&self.table_metadata.schema),
                 filters,
+                Arc::clone(&self.cached_deleted_row_ids),
             )),
             &self.table_metadata.schema,
         )))
@@ -1152,6 +1235,8 @@ struct CayenneDeletionSink {
     listing_table: Arc<RwLock<Arc<ListingTable>>>,
     schema: SchemaRef,
     filters: Vec<Expr>,
+    /// Reference to the cached deletion vectors to invalidate after writing new deletions
+    cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
 }
 
 impl CayenneDeletionSink {
@@ -1161,6 +1246,7 @@ impl CayenneDeletionSink {
         listing_table: Arc<RwLock<Arc<ListingTable>>>,
         schema: SchemaRef,
         filters: &[Expr],
+        cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
     ) -> Self {
         Self {
             table_metadata,
@@ -1168,6 +1254,7 @@ impl CayenneDeletionSink {
             listing_table,
             schema,
             filters: filters.to_vec(),
+            cached_deleted_row_ids,
         }
     }
 
@@ -1292,10 +1379,22 @@ impl CayenneDeletionSink {
             .await
             .map_err(catalog_error_to_box)?;
 
+        // Update the cached deletion vectors with the newly deleted row IDs
+        // This avoids needing to reload from SQLite on the next scan
+        {
+            let mut guard = self
+                .cached_deleted_row_ids
+                .write()
+                .map_err(|e| format!("Failed to acquire write lock on deletion cache: {e}"))?;
+            for row_id in &result.row_ids {
+                guard.insert(*row_id);
+            }
+        }
+
         let deleted_count = convert_to_u64_box(result.row_ids.len(), "deleted row count")?;
 
         tracing::debug!(
-            "Deletion vector written: {} row(s) at {:?}",
+            "Deletion vector written and cache updated: {} row(s) at {:?}",
             deleted_count,
             result.path
         );

--- a/crates/cayenne/src/provider.rs
+++ b/crates/cayenne/src/provider.rs
@@ -69,14 +69,23 @@ const DEFAULT_DATA_FILE_ID: i64 = 0;
 ///
 /// This wraps another execution plan and removes rows whose positions
 /// match the deleted row IDs loaded from deletion vector files.
+///
+/// # Zero-Copy Design
+///
+/// The deleted row IDs are wrapped in `Arc` to enable zero-copy sharing across
+/// concurrent scans. This avoids cloning potentially large `HashSet`s on every scan,
+/// aligning with the project's zero-copy principles for Arrow data.
 struct DeletionFilterExec {
     input: Arc<dyn ExecutionPlan>,
-    deleted_row_ids: std::collections::HashSet<i64>,
+    deleted_row_ids: Arc<std::collections::HashSet<i64>>,
     properties: datafusion_physical_plan::PlanProperties,
 }
 
 impl DeletionFilterExec {
-    fn new(input: Arc<dyn ExecutionPlan>, deleted_row_ids: std::collections::HashSet<i64>) -> Self {
+    fn new(
+        input: Arc<dyn ExecutionPlan>,
+        deleted_row_ids: Arc<std::collections::HashSet<i64>>,
+    ) -> Self {
         let properties = input.properties().clone();
         Self {
             input,
@@ -130,7 +139,7 @@ impl ExecutionPlan for DeletionFilterExec {
         }
         Ok(Arc::new(Self::new(
             Arc::clone(&children[0]),
-            self.deleted_row_ids.clone(),
+            Arc::clone(&self.deleted_row_ids),
         )))
     }
 
@@ -140,7 +149,8 @@ impl ExecutionPlan for DeletionFilterExec {
         context: Arc<datafusion_execution::TaskContext>,
     ) -> datafusion_common::Result<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
-        let deleted_row_ids = self.deleted_row_ids.clone();
+        // Zero-copy Arc clone - just increments reference count
+        let deleted_row_ids = Arc::clone(&self.deleted_row_ids);
         let schema = input_stream.schema();
 
         Ok(Box::pin(DeletionFilterStream {
@@ -155,7 +165,7 @@ impl ExecutionPlan for DeletionFilterExec {
 /// Stream that filters out deleted rows from an input stream.
 struct DeletionFilterStream {
     input: SendableRecordBatchStream,
-    deleted_row_ids: std::collections::HashSet<i64>,
+    deleted_row_ids: Arc<std::collections::HashSet<i64>>,
     schema: arrow_schema::SchemaRef,
     global_row_offset: i64,
 }
@@ -312,7 +322,9 @@ pub struct CayenneTableProvider {
     /// Cached deletion vectors (deleted row IDs) to avoid repeated metastore queries on every scan.
     /// This is loaded once during table provider initialization and invalidated when delete files change.
     /// Using `RwLock` for concurrent reads during scans with occasional writes on updates.
-    cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
+    /// The inner `Arc<HashSet<i64>>` enables zero-copy sharing: scans clone the Arc (cheap ref count
+    /// increment) rather than cloning the entire `HashSet`, aligning with zero-copy principles.
+    cached_deleted_row_ids: Arc<RwLock<Arc<std::collections::HashSet<i64>>>>,
 }
 
 impl std::fmt::Debug for CayenneTableProvider {
@@ -454,7 +466,8 @@ impl CayenneTableProvider {
             catalog,
             listing_table: Arc::new(RwLock::new(listing_table)),
             retention_filters,
-            cached_deleted_row_ids: Arc::new(RwLock::new(deleted_row_ids)),
+            // Wrap in Arc for zero-copy sharing across concurrent scans
+            cached_deleted_row_ids: Arc::new(RwLock::new(Arc::new(deleted_row_ids))),
         })
     }
 
@@ -641,9 +654,9 @@ impl CayenneTableProvider {
         // Delegate to ListingTable's insert_into to write Vortex files
         // Clone the Arc and drop the lock before awaiting
         let listing_table = {
-            let guard = self.listing_table.read().map_err(|e| {
-                super::catalog::CatalogError::InvalidOperation {
-                    message: format!("Failed to acquire read lock on listing table: {e}"),
+            let guard = self.listing_table.read().map_err(|_| {
+                super::catalog::CatalogError::LockPoisoned {
+                    operation: "insert (read listing table)".to_string(),
                 }
             })?;
             Arc::clone(&guard)
@@ -775,11 +788,12 @@ impl CayenneTableProvider {
         let mut guard =
             self.cached_deleted_row_ids
                 .write()
-                .map_err(|e| CatalogError::InvalidOperation {
-                    message: format!("Failed to acquire write lock on deletion cache: {e}"),
+                .map_err(|_| CatalogError::LockPoisoned {
+                    operation: "refresh deletion cache (write)".to_string(),
                 })?;
 
-        *guard = deleted_row_ids;
+        // Replace with new Arc-wrapped HashSet for zero-copy sharing
+        *guard = Arc::new(deleted_row_ids);
 
         tracing::debug!(
             "Refreshed deletion cache for table {} ({} deleted rows)",
@@ -850,11 +864,12 @@ impl CayenneTableProvider {
         )?;
 
         // Update the listing table with write lock
-        let mut guard = self.listing_table.write().map_err(|e| {
-            super::catalog::CatalogError::InvalidOperation {
-                message: format!("Failed to acquire write lock for listing table refresh: {e}"),
-            }
-        })?;
+        let mut guard =
+            self.listing_table
+                .write()
+                .map_err(|_| super::catalog::CatalogError::LockPoisoned {
+                    operation: "refresh listing table (write)".to_string(),
+                })?;
         *guard = new_listing_table;
 
         tracing::debug!(
@@ -1028,10 +1043,12 @@ impl TableProvider for CayenneTableProvider {
         // Delegate to the underlying listing table first
         // Clone the Arc and drop the lock before awaiting to avoid holding locks across await points
         let listing_table = {
-            let guard = self.listing_table.read().map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to acquire read lock on listing table: {e}"
-                ))
+            let guard = self.listing_table.read().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
+                    This indicates an internal error that requires restarting the runtime."
+                        .to_string(),
+                )
             })?;
             Arc::clone(&guard)
         };
@@ -1042,13 +1059,16 @@ impl TableProvider for CayenneTableProvider {
         // Use cached deletion vectors instead of querying the catalog on every scan.
         // This dramatically improves concurrent query performance by avoiding repeated
         // SQLite queries and spawn_blocking tasks.
+        // Zero-copy Arc clone: just increments reference count, no HashSet allocation.
         let deleted_row_ids = {
-            let guard = self.cached_deleted_row_ids.read().map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to acquire read lock on deletion cache: {e}"
-                ))
+            let guard = self.cached_deleted_row_ids.read().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Lock poisoned on deletion cache: a thread panicked while holding this lock. \
+                    This indicates an internal error that requires restarting the runtime."
+                        .to_string(),
+                )
             })?;
-            guard.clone()
+            Arc::clone(&guard)
         };
 
         // If there are any deleted rows, apply filtering
@@ -1070,10 +1090,12 @@ impl TableProvider for CayenneTableProvider {
     ) -> datafusion_common::Result<Vec<TableProviderFilterPushDown>> {
         // Synchronous method - clone Arc quickly and release lock immediately
         let listing_table = {
-            let guard = self.listing_table.read().map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to acquire read lock on listing table: {e}"
-                ))
+            let guard = self.listing_table.read().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
+                    This indicates an internal error that requires restarting the runtime."
+                        .to_string(),
+                )
             })?;
             Arc::clone(&guard)
         };
@@ -1161,10 +1183,12 @@ impl TableProvider for CayenneTableProvider {
 
             // Update the provider's listing table to point to the new snapshot
             // This ensures subsequent queries in the same context will read from the new data
-            let mut listing_table_guard = self.listing_table.write().map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to acquire write lock on listing table: {e}"
-                ))
+            let mut listing_table_guard = self.listing_table.write().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
+                    This indicates an internal error that requires restarting the runtime."
+                        .to_string(),
+                )
             })?;
             *listing_table_guard = new_listing_table;
 
@@ -1183,10 +1207,12 @@ impl TableProvider for CayenneTableProvider {
 
         // Clone the Arc and drop the lock before awaiting
         let listing_table = {
-            let guard = self.listing_table.read().map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to acquire read lock on listing table: {e}"
-                ))
+            let guard = self.listing_table.read().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
+                    This indicates an internal error that requires restarting the runtime."
+                        .to_string(),
+                )
             })?;
             Arc::clone(&guard)
         };
@@ -1235,8 +1261,9 @@ struct CayenneDeletionSink {
     listing_table: Arc<RwLock<Arc<ListingTable>>>,
     schema: SchemaRef,
     filters: Vec<Expr>,
-    /// Reference to the cached deletion vectors to invalidate after writing new deletions
-    cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
+    /// Reference to the cached deletion vectors to invalidate after writing new deletions.
+    /// Uses Arc-wrapped `HashSet` for zero-copy sharing across concurrent operations.
+    cached_deleted_row_ids: Arc<RwLock<Arc<std::collections::HashSet<i64>>>>,
 }
 
 impl CayenneDeletionSink {
@@ -1246,7 +1273,7 @@ impl CayenneDeletionSink {
         listing_table: Arc<RwLock<Arc<ListingTable>>>,
         schema: SchemaRef,
         filters: &[Expr],
-        cached_deleted_row_ids: Arc<RwLock<std::collections::HashSet<i64>>>,
+        cached_deleted_row_ids: Arc<RwLock<Arc<std::collections::HashSet<i64>>>>,
     ) -> Self {
         Self {
             table_metadata,
@@ -1380,15 +1407,24 @@ impl CayenneDeletionSink {
             .map_err(catalog_error_to_box)?;
 
         // Update the cached deletion vectors with the newly deleted row IDs
-        // This avoids needing to reload from SQLite on the next scan
+        // This avoids needing to reload from SQLite on the next scan.
+        // We create a new Arc with the updated HashSet to maintain zero-copy semantics
+        // for concurrent readers who still hold references to the old Arc.
         {
-            let mut guard = self
-                .cached_deleted_row_ids
-                .write()
-                .map_err(|e| format!("Failed to acquire write lock on deletion cache: {e}"))?;
+            let mut guard = self.cached_deleted_row_ids.write().map_err(|_| {
+                "Lock poisoned on deletion cache: a thread panicked while holding this lock. \
+                This indicates an internal error that requires restarting the runtime."
+                    .to_string()
+            })?;
+
+            // Clone the current HashSet and add new deletions
+            let mut updated_set = (**guard).clone();
             for row_id in &result.row_ids {
-                guard.insert(*row_id);
+                updated_set.insert(*row_id);
             }
+
+            // Replace with new Arc - concurrent readers still have old Arc
+            *guard = Arc::new(updated_set);
         }
 
         let deleted_count = convert_to_u64_box(result.row_ids.len(), "deleted row count")?;
@@ -1449,10 +1485,11 @@ impl DeletionSink for CayenneDeletionSink {
         let ctx = SessionContext::new();
 
         let listing_table = {
-            let guard = self
-                .listing_table
-                .read()
-                .map_err(|e| format!("Failed to acquire read lock on listing table: {e}"))?;
+            let guard = self.listing_table.read().map_err(|_| {
+                "Lock poisoned on listing table: a thread panicked while holding this lock. \
+                This indicates an internal error that requires restarting the runtime."
+                    .to_string()
+            })?;
             Arc::clone(&guard)
         };
 

--- a/crates/cayenne/src/provider.rs
+++ b/crates/cayenne/src/provider.rs
@@ -65,6 +65,22 @@ use vortex_datafusion::VortexFormat;
 
 const DEFAULT_DATA_FILE_ID: i64 = 0;
 
+/// Error message for poisoned `RwLock` on the listing table.
+///
+/// Lock poisoning occurs when a thread panics while holding the lock, leaving it in an
+/// inconsistent state. This is a critical error that typically requires restarting the runtime.
+const LISTING_TABLE_LOCK_POISONED: &str =
+    "Lock poisoned on listing table: a thread panicked while holding this lock. \
+    This indicates an internal error that requires restarting the runtime.";
+
+/// Error message for poisoned `RwLock` on the deletion cache.
+///
+/// Lock poisoning occurs when a thread panics while holding the lock, leaving it in an
+/// inconsistent state. This is a critical error that typically requires restarting the runtime.
+const DELETION_CACHE_LOCK_POISONED: &str =
+    "Lock poisoned on deletion cache: a thread panicked while holding this lock. \
+    This indicates an internal error that requires restarting the runtime.";
+
 /// Execution plan that filters out deleted rows based on deletion vectors.
 ///
 /// This wraps another execution plan and removes rows whose positions
@@ -998,9 +1014,8 @@ impl CayenneTableProvider {
         }
 
         // Read deletion vector files in a blocking task
-        let delete_files_for_read = delete_files.clone();
         let deleted_row_ids =
-            task::spawn_blocking(move || Self::read_deletion_vectors(delete_files_for_read))
+            task::spawn_blocking(move || Self::read_deletion_vectors(delete_files))
                 .await
                 .map_err(|err| super::catalog::CatalogError::InvalidOperation {
                     message: format!(
@@ -1015,7 +1030,7 @@ impl CayenneTableProvider {
 
         tracing::debug!(
             "Cached {} deletion vectors ({} deleted rows) for table_id {}",
-            delete_files.len(),
+            deleted_row_ids.len(),
             deleted_row_ids.len(),
             table_id
         );
@@ -1135,9 +1150,7 @@ impl TableProvider for CayenneTableProvider {
         let listing_table = {
             let guard = self.listing_table.read().map_err(|_| {
                 datafusion_common::DataFusionError::Execution(
-                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
-                    This indicates an internal error that requires restarting the runtime."
-                        .to_string(),
+                    LISTING_TABLE_LOCK_POISONED.to_string(),
                 )
             })?;
             Arc::clone(&guard)
@@ -1153,9 +1166,7 @@ impl TableProvider for CayenneTableProvider {
         let deleted_row_ids = {
             let guard = self.cached_deleted_row_ids.read().map_err(|_| {
                 datafusion_common::DataFusionError::Execution(
-                    "Lock poisoned on deletion cache: a thread panicked while holding this lock. \
-                    This indicates an internal error that requires restarting the runtime."
-                        .to_string(),
+                    DELETION_CACHE_LOCK_POISONED.to_string(),
                 )
             })?;
             Arc::clone(&guard)
@@ -1182,9 +1193,7 @@ impl TableProvider for CayenneTableProvider {
         let listing_table = {
             let guard = self.listing_table.read().map_err(|_| {
                 datafusion_common::DataFusionError::Execution(
-                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
-                    This indicates an internal error that requires restarting the runtime."
-                        .to_string(),
+                    LISTING_TABLE_LOCK_POISONED.to_string(),
                 )
             })?;
             Arc::clone(&guard)
@@ -1275,9 +1284,7 @@ impl TableProvider for CayenneTableProvider {
             // This ensures subsequent queries in the same context will read from the new data
             let mut listing_table_guard = self.listing_table.write().map_err(|_| {
                 datafusion_common::DataFusionError::Execution(
-                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
-                    This indicates an internal error that requires restarting the runtime."
-                        .to_string(),
+                    LISTING_TABLE_LOCK_POISONED.to_string(),
                 )
             })?;
             *listing_table_guard = new_listing_table;
@@ -1315,9 +1322,7 @@ impl TableProvider for CayenneTableProvider {
         let listing_table = {
             let guard = self.listing_table.read().map_err(|_| {
                 datafusion_common::DataFusionError::Execution(
-                    "Lock poisoned on listing table: a thread panicked while holding this lock. \
-                    This indicates an internal error that requires restarting the runtime."
-                        .to_string(),
+                    LISTING_TABLE_LOCK_POISONED.to_string(),
                 )
             })?;
             Arc::clone(&guard)
@@ -1514,20 +1519,31 @@ impl CayenneDeletionSink {
 
         // Update the cached deletion vectors with the newly deleted row IDs
         // This avoids needing to reload from SQLite on the next scan.
+        //
         // We create a new Arc with the updated HashSet to maintain zero-copy semantics
-        // for concurrent readers who still hold references to the old Arc.
+        // for concurrent readers who still hold references to the old Arc. This requires
+        // cloning the entire HashSet, which is acceptable because:
+        //
+        // 1. **Write infrequency**: Deletions happen much less frequently than reads
+        // 2. **Concurrent reader safety**: Cloning prevents disrupting ongoing scans that
+        //    hold Arc references to the old deletion set
+        // 3. **Cache coherence**: The alternative (in-place mutation) would require either:
+        //    - Taking write locks during scans (blocks all concurrent queries)
+        //    - Complex lock-free data structures (higher complexity, potential performance issues)
+        //
+        // For tables with very large deletion sets (millions of deleted rows), consider
+        // running compaction to physically remove deleted rows and reset the deletion vectors.
         {
-            let mut guard = self.cached_deleted_row_ids.write().map_err(|_| {
-                "Lock poisoned on deletion cache: a thread panicked while holding this lock. \
-                This indicates an internal error that requires restarting the runtime."
-                    .to_string()
-            })?;
+            let mut guard = self
+                .cached_deleted_row_ids
+                .write()
+                .map_err(|_| DELETION_CACHE_LOCK_POISONED.to_string())?;
 
-            // Clone the current HashSet and add new deletions
+            // Clone the entire HashSet and add new deletions.
+            // Cost: O(n) where n = existing deleted rows, but this is write path (infrequent).
+            // Benefit: Zero-copy Arc clones for concurrent readers (frequent).
             let mut updated_set = (**guard).clone();
-            for row_id in &result.row_ids {
-                updated_set.insert(*row_id);
-            }
+            updated_set.extend(result.row_ids.iter().copied());
 
             // Replace with new Arc - concurrent readers still have old Arc
             *guard = Arc::new(updated_set);
@@ -1591,11 +1607,10 @@ impl DeletionSink for CayenneDeletionSink {
         let ctx = SessionContext::new();
 
         let listing_table = {
-            let guard = self.listing_table.read().map_err(|_| {
-                "Lock poisoned on listing table: a thread panicked while holding this lock. \
-                This indicates an internal error that requires restarting the runtime."
-                    .to_string()
-            })?;
+            let guard = self
+                .listing_table
+                .read()
+                .map_err(|_| LISTING_TABLE_LOCK_POISONED.to_string())?;
             Arc::clone(&guard)
         };
 

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -147,12 +147,13 @@ mod tests {
             ),
         ];
 
-        for (input, expected) in test_cases {
-            let path_regex = regex::Regex::new(super::CAYENNE_PATH_FILTER_PATTERN)
-                .map_err(|e| format!("{e}"))?;
-            let range_regex = regex::Regex::new(super::VORTEX_RANGE_FILTER_PATTERN)
-                .map_err(|e| format!("{e}"))?;
+        // Compile regexes once outside the loop to avoid repeated compilation overhead
+        let path_regex =
+            regex::Regex::new(super::CAYENNE_PATH_FILTER_PATTERN).map_err(|e| format!("{e}"))?;
+        let range_regex =
+            regex::Regex::new(super::VORTEX_RANGE_FILTER_PATTERN).map_err(|e| format!("{e}"))?;
 
+        for (input, expected) in test_cases {
             let path_redacted =
                 path_regex.replace_all(input, super::CAYENNE_PATH_FILTER_REPLACEMENT);
             let fully_redacted = range_regex


### PR DESCRIPTION
This pull request introduces a caching mechanism for deletion vectors (deleted row IDs) in the `CayenneTableProvider` to significantly improve scan performance and concurrency. Instead of querying the metastore and reading deletion vector files on every scan, deleted row IDs are now loaded once at initialization and cached in memory, with the cache being updated or invalidated as necessary after relevant operations. This reduces redundant SQLite queries and blocking tasks, especially under concurrent workloads.

Key changes:

**Caching and Cache Management**
- Added a `cached_deleted_row_ids` field (protected by an `RwLock`) to `CayenneTableProvider` for storing deleted row IDs, initialized once and updated as needed.
- Implemented a `refresh_deletion_cache` async method to reload deletion vectors from the catalog after operations that may change the set of deleted rows (e.g., after applying retention filters or manual deletes).
- Updated the initialization and deletion logic to load and update the cache appropriately, ensuring consistency between the cache and the actual state of deletions. [[1]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R447-R457) [[2]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R868-R920)

**Scan and Deletion Logic Updates**
- Modified the table scan implementation to use the cached deletion vectors instead of querying the catalog and reading files on every scan, greatly improving performance and concurrency.
- Updated deletion sinks to update the cached deletion vectors immediately after writing new deletions, so the cache remains up-to-date without needing to reload from the metastore. [[1]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R1224) [[2]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R1238-R1239) [[3]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R1249-R1257) [[4]](diffhunk://#diff-7ccca5b658cf78372be7d7bd6b882f112abcc8fe1234bc251b1b99939bd8ddf1R1382-R1397)

**Supporting Methods**
- Added a `load_deletion_vectors` method to load and aggregate deletion vectors from the catalog and files, used during initialization and cache refresh.

These changes collectively ensure that deletion information is efficiently and safely managed, reducing latency and resource usage for scans and concurrent queries.