### PR TITLE
Cleanup old snapshots after full refresh

### DIFF
--- a/crates/cayenne/src/provider.rs
+++ b/crates/cayenne/src/provider.rs
@@ -405,6 +405,9 @@ impl CayenneTableProvider {
     /// For full refresh mode, after the new snapshot is written and the catalog is updated,
     /// old snapshot directories are no longer needed and can be physically deleted.
     ///
+    /// This function performs blocking filesystem I/O and should be called from within
+    /// `tokio::task::spawn_blocking` to avoid blocking the async runtime thread pool.
+    ///
     /// # Arguments
     ///
     /// * `table_path` - Base path for the table
@@ -414,7 +417,12 @@ impl CayenneTableProvider {
     /// # Errors
     ///
     /// Returns an error if snapshot directories cannot be listed or deleted.
-    async fn cleanup_old_snapshots(
+    ///
+    /// # Blocking I/O Warning
+    ///
+    /// This function uses `std::fs` for filesystem operations and will block the calling thread.
+    /// It must be called from within `tokio::task::spawn_blocking`.
+    fn cleanup_old_snapshots_blocking(
         table_path: &str,
         table_id: i64,
         current_snapshot_id: &str,
@@ -432,17 +440,13 @@ impl CayenneTableProvider {
             current_snapshot_id
         );
 
-        // Read all entries in the table directory
-        let mut entries = tokio::fs::read_dir(&table_dir)
-            .await
-            .map_err(|source| CatalogError::IoError { source })?;
+        // Read all entries in the table directory using blocking I/O
+        let entries =
+            std::fs::read_dir(&table_dir).map_err(|source| CatalogError::IoError { source })?;
 
         let mut deleted_count = 0;
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .map_err(|source| CatalogError::IoError { source })?
-        {
+        for entry_result in entries {
+            let entry = entry_result.map_err(|source| CatalogError::IoError { source })?;
             let path = entry.path();
 
             // Only process directories (snapshots)
@@ -461,16 +465,14 @@ impl CayenneTableProvider {
                 continue;
             }
 
-            // Delete the old snapshot directory
+            // Delete the old snapshot directory using blocking I/O
             tracing::info!(
                 "Deleting old snapshot directory for table {}: {}",
                 table_id,
                 snapshot_id
             );
 
-            tokio::fs::remove_dir_all(&path)
-                .await
-                .map_err(|source| CatalogError::IoError { source })?;
+            std::fs::remove_dir_all(&path).map_err(|source| CatalogError::IoError { source })?;
 
             deleted_count += 1;
         }
@@ -1175,13 +1177,13 @@ impl TableProvider for CayenneTableProvider {
             *listing_table_guard = new_listing_table;
 
             // Trigger cleanup of old snapshot directories after successful full refresh
-            // This is fire-and-forget to avoid blocking the refresh operation
+            // This is fire-and-forget using spawn_blocking to avoid blocking the async runtime
             let table_path = self.table_metadata.path.clone();
             let table_id = self.table_metadata.table_id;
             let current_snapshot = new_snapshot_id.clone();
-            tokio::spawn(async move {
+            tokio::task::spawn_blocking(move || {
                 if let Err(e) =
-                    Self::cleanup_old_snapshots(&table_path, table_id, &current_snapshot).await
+                    Self::cleanup_old_snapshots_blocking(&table_path, table_id, &current_snapshot)
                 {
                     tracing::warn!(
                         "Failed to cleanup old snapshots for table {}: {e}",

--- a/crates/cayenne/src/provider.rs
+++ b/crates/cayenne/src/provider.rs
@@ -400,6 +400,94 @@ impl CayenneTableProvider {
         Ok(())
     }
 
+    /// Cleanup old snapshot directories after a full refresh.
+    ///
+    /// For full refresh mode, after the new snapshot is written and the catalog is updated,
+    /// old snapshot directories are no longer needed and can be physically deleted.
+    ///
+    /// # Arguments
+    ///
+    /// * `table_path` - Base path for the table
+    /// * `table_id` - Table identifier
+    /// * `current_snapshot_id` - The current (active) snapshot ID that should be kept
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if snapshot directories cannot be listed or deleted.
+    async fn cleanup_old_snapshots(
+        table_path: &str,
+        table_id: i64,
+        current_snapshot_id: &str,
+    ) -> CatalogResult<()> {
+        let table_dir = std::path::PathBuf::from(table_path).join(table_id.to_string());
+
+        // Check if table directory exists
+        if !table_dir.exists() {
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "Cleaning up old snapshots for table {} (keeping {})",
+            table_id,
+            current_snapshot_id
+        );
+
+        // Read all entries in the table directory
+        let mut entries = tokio::fs::read_dir(&table_dir)
+            .await
+            .map_err(|source| CatalogError::IoError { source })?;
+
+        let mut deleted_count = 0;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|source| CatalogError::IoError { source })?
+        {
+            let path = entry.path();
+
+            // Only process directories (snapshots)
+            if !path.is_dir() {
+                continue;
+            }
+
+            // Get the snapshot ID (directory name)
+            let Some(snapshot_id) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+
+            // Skip the current snapshot
+            if snapshot_id == current_snapshot_id {
+                tracing::debug!("Keeping current snapshot: {}", snapshot_id);
+                continue;
+            }
+
+            // Delete the old snapshot directory
+            tracing::info!(
+                "Deleting old snapshot directory for table {}: {}",
+                table_id,
+                snapshot_id
+            );
+
+            tokio::fs::remove_dir_all(&path)
+                .await
+                .map_err(|source| CatalogError::IoError { source })?;
+
+            deleted_count += 1;
+        }
+
+        if deleted_count > 0 {
+            tracing::info!(
+                "Cleaned up {} old snapshot(s) for table {}",
+                deleted_count,
+                table_id
+            );
+        } else {
+            tracing::debug!("No old snapshots to cleanup for table {}", table_id);
+        }
+
+        Ok(())
+    }
+
     /// Create a new Cayenne table provider.
     ///
     /// # Errors
@@ -1085,6 +1173,22 @@ impl TableProvider for CayenneTableProvider {
                 ))
             })?;
             *listing_table_guard = new_listing_table;
+
+            // Trigger cleanup of old snapshot directories after successful full refresh
+            // This is fire-and-forget to avoid blocking the refresh operation
+            let table_path = self.table_metadata.path.clone();
+            let table_id = self.table_metadata.table_id;
+            let current_snapshot = new_snapshot_id.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    Self::cleanup_old_snapshots(&table_path, table_id, &current_snapshot).await
+                {
+                    tracing::warn!(
+                        "Failed to cleanup old snapshots for table {}: {e}",
+                        table_id
+                    );
+                }
+            });
 
             return Ok(result);
         }

--- a/crates/cayenne/tests/overwrite_test.rs
+++ b/crates/cayenne/tests/overwrite_test.rs
@@ -97,19 +97,24 @@ async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     println!("✓ INSERT OVERWRITE completed (2 new rows)");
 
-    // 7. Check that a new snapshot subdirectory was created
+    // Wait for async cleanup to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // 7. Check snapshot count after overwrite and cleanup
     let snapshots_after: Vec<_> = std::fs::read_dir(&table_dir)?
         .filter_map(std::result::Result::ok)
         .filter(|e| e.path().is_dir())
         .collect();
     println!("✓ Snapshots after overwrite: {}", snapshots_after.len());
 
-    // We should have at least one more snapshot directory (the overwrite snapshot)
-    assert!(
-        snapshots_after.len() > snapshots_before.len(),
-        "Expected new snapshot subdirectory to be created for overwrite"
+    // After full refresh, old snapshots should be automatically cleaned up
+    // Only the current snapshot should remain
+    assert_eq!(
+        snapshots_after.len(),
+        1,
+        "Expected only 1 snapshot after overwrite (old snapshot cleaned up)"
     );
-    println!("✓ New snapshot subdirectory created for overwrite");
+    println!("✓ Old snapshot automatically cleaned up after overwrite");
 
     // 8. Verify overwrite replaced the data
     // After overwrite, the provider's listing_table should now point to the new
@@ -142,18 +147,19 @@ async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!("✓ New overwrite data is accessible");
 
-    // 9. Verify snapshot directories use UUIDv7 naming
+    // 9. Verify snapshot directory uses UUIDv7 naming
     let snapshot_dirs: Vec<_> = std::fs::read_dir(&table_dir)?
         .filter_map(std::result::Result::ok)
         .filter(|e| e.path().is_dir())
         .collect();
-    assert!(
-        snapshot_dirs.len() >= 2,
-        "Expected at least 2 snapshot directories (initial + overwrite)"
+    assert_eq!(
+        snapshot_dirs.len(),
+        1,
+        "Expected 1 snapshot directory (current snapshot)"
     );
-    println!("✓ Snapshot directories use UUIDv7 naming");
+    println!("✓ Snapshot directory uses UUIDv7 naming");
 
-    // Verify that the snapshot directory names are valid UUIDs
+    // Verify that the snapshot directory name is a valid UUID
     for entry in &snapshot_dirs {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -163,9 +169,136 @@ async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
             "Snapshot directory name should be a UUID: {name_str}"
         );
     }
-    println!("✓ All snapshot directories have valid UUID names");
+    println!("✓ Snapshot directory has valid UUID name");
 
     println!("\n✅ INSERT OVERWRITE test passed!");
     println!("✅ Snapshot-based overwrite semantics working correctly");
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_insert_overwrite_cleanup_old_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n🧪 Testing INSERT OVERWRITE cleanup of old snapshots...");
+
+    // 1. Setup test environment
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().join("overwrite_cleanup_test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+
+    // 2. Create catalog and table
+    let catalog: Arc<dyn MetadataCatalog> = Arc::new(CayenneCatalog::new(format!(
+        "sqlite://{}",
+        db_path.to_string_lossy()
+    ))?);
+    catalog.init().await?;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Utf8, false),
+    ]));
+
+    let table_options = CreateTableOptions {
+        table_name: "test_cleanup".to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec![],
+        base_path: data_path.to_string_lossy().to_string(),
+        partition_column: None,
+    };
+
+    let table = CayenneTableProvider::create_table(Arc::clone(&catalog), table_options).await?;
+    println!("✓ Table created");
+
+    // 3. Register with DataFusion context
+    let ctx = SessionContext::new();
+    ctx.register_table("test_cleanup", Arc::new(table))?;
+    println!("✓ Table registered with DataFusion");
+
+    // 4. Initial insert - creates first snapshot
+    ctx.sql("INSERT INTO test_cleanup VALUES (1, 'first'), (2, 'second')")
+        .await?
+        .collect()
+        .await?;
+    println!("✓ Initial data inserted (2 rows)");
+
+    // 5. Get initial snapshot count
+    let table_dir = data_path.join("1"); // table_id = 1
+    let snapshots_after_insert: Vec<_> = std::fs::read_dir(&table_dir)?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().is_dir())
+        .collect();
+    println!(
+        "✓ Snapshots after initial insert: {}",
+        snapshots_after_insert.len()
+    );
+    assert_eq!(
+        snapshots_after_insert.len(),
+        1,
+        "Expected 1 snapshot after initial insert"
+    );
+
+    // 6. Perform first INSERT OVERWRITE - creates second snapshot
+    ctx.sql("INSERT OVERWRITE test_cleanup VALUES (10, 'new_data')")
+        .await?
+        .collect()
+        .await?;
+    println!("✓ First INSERT OVERWRITE completed");
+
+    // Wait a bit for async cleanup to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // 7. Check that old snapshot was cleaned up
+    let snapshots_after_first_overwrite: Vec<_> = std::fs::read_dir(&table_dir)?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().is_dir())
+        .collect();
+    println!(
+        "✓ Snapshots after first overwrite: {}",
+        snapshots_after_first_overwrite.len()
+    );
+    assert_eq!(
+        snapshots_after_first_overwrite.len(),
+        1,
+        "Expected only 1 snapshot after cleanup (old snapshot should be deleted)"
+    );
+
+    // 8. Perform second INSERT OVERWRITE - creates third snapshot
+    ctx.sql("INSERT OVERWRITE test_cleanup VALUES (20, 'newer_data')")
+        .await?
+        .collect()
+        .await?;
+    println!("✓ Second INSERT OVERWRITE completed");
+
+    // Wait for cleanup
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // 9. Check that second old snapshot was also cleaned up
+    let snapshots_after_second_overwrite: Vec<_> = std::fs::read_dir(&table_dir)?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().is_dir())
+        .collect();
+    println!(
+        "✓ Snapshots after second overwrite: {}",
+        snapshots_after_second_overwrite.len()
+    );
+    assert_eq!(
+        snapshots_after_second_overwrite.len(),
+        1,
+        "Expected only 1 snapshot after second cleanup"
+    );
+
+    // 10. Verify we can still query the current data
+    let df = ctx.sql("SELECT * FROM test_cleanup").await?;
+    let results = df.collect().await?;
+    let total_rows: usize = results
+        .iter()
+        .map(arrow::array::RecordBatch::num_rows)
+        .sum();
+    assert_eq!(total_rows, 1, "Expected 1 row in current snapshot");
+    println!("✓ Current data is still accessible after cleanup");
+
+    println!("\n✅ INSERT OVERWRITE cleanup test passed!");
+    println!("✅ Old snapshot directories are automatically deleted after full refresh");
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces automatic cleanup of old snapshot directories after a full refresh (such as an `INSERT OVERWRITE`) in the Cayenne table provider. Now, after a successful overwrite, only the latest snapshot is retained on disk, ensuring efficient storage usage. The changes include the implementation of the cleanup logic, integration into the table provider workflow, and comprehensive tests to verify correct behavior.

**Snapshot cleanup logic:**

* Added a new async method `cleanup_old_snapshots` to `CayenneTableProvider` that deletes all but the current snapshot directory after a full refresh. This method is robust to errors and logs its progress and any issues encountered.

* Integrated the snapshot cleanup so that after a successful full refresh (e.g., `INSERT OVERWRITE`), the cleanup runs asynchronously in the background, ensuring the operation does not block user queries.

**Testing and verification:**

* Updated the `test_insert_overwrite` integration test to assert that only one snapshot directory remains after an overwrite (i.e., old snapshots are cleaned up), and improved assertions and output for clarity. [[1]](diffhunk://#diff-9610af9567312cf9f359f01046a554d16855e955769465468b893e6c3cb44b26L100-R117) [[2]](diffhunk://#diff-9610af9567312cf9f359f01046a554d16855e955769465468b893e6c3cb44b26L145-R162) [[3]](diffhunk://#diff-9610af9567312cf9f359f01046a554d16855e955769465468b893e6c3cb44b26L166-R304)

* Added a new test, `test_insert_overwrite_cleanup_old_snapshots`, which verifies that after multiple `INSERT OVERWRITE` operations, only the most recent snapshot directory remains and that the table remains queryable.