### PR TITLE
Make preview warnings consistent

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -467,8 +467,7 @@ impl DataAccelerator for CayenneAccelerator {
         source: &dyn AccelerationSource,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         tracing::warn!(
-            "Cayenne data accelerator (Alpha) is in preview and should not be used in production. \
-             Data format and API may change without notice."
+            "Cayenne data accelerator (Alpha) is in preview and should not be used in production."
         );
 
         if !source.is_file_accelerated() {

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -467,8 +467,7 @@ impl DataAccelerator for CayenneAccelerator {
         source: &dyn AccelerationSource,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         tracing::warn!(
-            "Cayenne data accelerator (Alpha) is in preview and should not be used in production."
-        );
+            "Cayenne data accelerator (Alpha) is in preview and should not be used in production.");
 
         if !source.is_file_accelerated() {
             return Err(Box::new(Error::InvalidConfiguration {

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -466,8 +466,8 @@ impl DataAccelerator for CayenneAccelerator {
         &self,
         source: &dyn AccelerationSource,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        tracing::info!(
-            "⚠️  Cayenne data accelerator is in ALPHA stage and should NOT be used in production. \
+        tracing::warn!(
+            "Cayenne data accelerator (Alpha) is in preview and should not be used in production. \
              Data format and API may change without notice."
         );
 

--- a/crates/runtime/src/datafusion/cluster/mod.rs
+++ b/crates/runtime/src/datafusion/cluster/mod.rs
@@ -42,6 +42,8 @@ pub mod physical_plan;
 
 /// Creates & binds a Ballista scheduler to the Runtime handle, then updates status
 pub async fn initialize_cluster_scheduler(rt: &Arc<Runtime>) -> crate::Result<()> {
+    tracing::warn!("Distributed Query (Alpha) is in preview and should not be used in production.");
+
     let scheduler = create_scheduler_server(rt).await?;
 
     rt.df
@@ -61,6 +63,8 @@ pub async fn initialize_cluster_scheduler(rt: &Arc<Runtime>) -> crate::Result<()
 pub async fn initialize_cluster_executor(
     rt: Arc<Runtime>,
 ) -> crate::Result<impl Future<Output = crate::Result<()>>> {
+    tracing::warn!("Distributed Query (Alpha) is in preview and should not be used in production.");
+
     executor_bind_app(&rt, rt.config.cluster.scheduler_url.to_string()).await?;
 
     let runtime_handle = Arc::clone(&rt);

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -706,7 +706,7 @@ impl Runtime {
         // Warn if Turso engine is being used
         if accelerator_engine == crate::component::dataset::acceleration::Engine::Turso {
             tracing::warn!(
-                "The Turso data accelerator (engine: turso) is in preview and should not be used in production."
+                "Turso data accelerator (Alpha) is in preview and should not be used in production."
             );
         }
 


### PR DESCRIPTION
This pull request updates warning messages across several modules to clearly indicate that certain features are in "Alpha" and are not recommended for production use. The changes improve consistency and clarity in user-facing logs related to experimental components.

**Warning Message Updates**

* Updated the warning message in `CayenneAccelerator` to clarify that the Cayenne data accelerator is in Alpha, in preview, and should not be used in production (`crates/runtime/src/dataaccelerator/cayenne.rs`).
* Updated the warning message for Turso data accelerator to specify its Alpha status and preview nature (`crates/runtime/src/init/dataset.rs`).

**Distributed Query Feature Warnings**

* Added a warning in `initialize_cluster_scheduler` to inform users that Distributed Query is in Alpha and not for production (`crates/runtime/src/datafusion/cluster/mod.rs`).
* Added a similar warning in `initialize_cluster_executor` for the same feature and status (`crates/runtime/src/datafusion/cluster/mod.rs`).