### PR TITLE
bump async-openai commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.29.1"
-source = "git+https://github.com/spiceai/async-openai?rev=ec48de2d31ecc021a1962c629199ca11cf645fab#ec48de2d31ecc021a1962c629199ca11cf645fab"
+source = "git+https://github.com/spiceai/async-openai?rev=afaaba87a10e48853e59c809bf296aefbb08c9bd#afaaba87a10e48853e59c809bf296aefbb08c9bd"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/async-openai?rev=ec48de2d31ecc021a1962c629199ca11cf645fab#ec48de2d31ecc021a1962c629199ca11cf645fab"
+source = "git+https://github.com/spiceai/async-openai?rev=afaaba87a10e48853e59c809bf296aefbb08c9bd#afaaba87a10e48853e59c809bf296aefbb08c9bd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ arrow-ipc = "56.0.0"
 arrow-json = "56.0.0"
 arrow-odbc = "18"
 arrow-schema = "56.0.0"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "ec48de2d31ecc021a1962c629199ca11cf645fab", features = [
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "afaaba87a10e48853e59c809bf296aefbb08c9bd", features = [
     "byot",
 ] }
 async-stream = "0.3.5"


### PR DESCRIPTION
## 📝 Summary

Includes this PR:

https://github.com/spiceai/async-openai/pull/28

Which uses the actual Retry-After value from the response header in backoff.

## 🔗 Related

Part of: #7511 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
