### PR TITLE
Fix financebench, configure s3vectors for appropriate snapshotting

### DIFF
--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -25,6 +25,7 @@ on:
           - 'embedding'
           - 'hybrid'
           - 'full_text'
+          - 's3_vectors'
         default: 'embedding'
   schedule:
     - cron: '0 4 * * 2,5' # Every Monday and Thursday at 8pm PST (4am UTC next day)
@@ -46,7 +47,8 @@ jobs:
         with:
           install_to_system_path: 'false'
           upload_artifact: 'true'
-
+          force_rebuild: 'true'
+          download_from_minio: 'false'
   build-spiced:
     name: Build spiced
     runs-on: 'spiceai-macos'
@@ -132,8 +134,13 @@ jobs:
                     return m;
                 });
               }
+              if (search_option === 's3vectors') {
+                filtered = filtered.map((m) => {
+                    m.spicepod = "./test/spicepods/financebench/embedding[s3vector].yaml";
+                    return m;
+                });
+              }
             }
-
             return filtered;
 
   run-testoperator:
@@ -171,6 +178,9 @@ jobs:
           SPICEAI_FINANCEBENCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_FINANCEBENCH_API_KEY}}
           OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_VECTORS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_VECTORS_SECRET }}
+          AWS_REGION: 'us-east-1'
         run: |
           ./testoperator run evals \
             -s $GITHUB_WORKSPACE/spiced \

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -145,7 +145,9 @@ impl AppBuilder {
         self.secrets.extend(spicepod.secrets.clone());
         self.extensions.extend(spicepod.extensions.clone());
         self.management.clone_from(&spicepod.management);
-        self.snapshots.clone_from(&spicepod.snapshots);
+        if let Some(ref snapshot) = spicepod.snapshots {
+            self.snapshots = Some(snapshot.clone());
+        }
         self.catalogs.extend(spicepod.catalogs.clone());
         self.datasets.extend(spicepod.datasets.clone());
         self.views.extend(spicepod.views.clone());

--- a/crates/runtime/src/dataaccelerator/snapshots.rs
+++ b/crates/runtime/src/dataaccelerator/snapshots.rs
@@ -40,7 +40,7 @@ pub(super) async fn download_snapshot_if_needed(
     }
 
     if path.exists() {
-        tracing::debug!(
+        tracing::info!(
             "Acceleration already exists at {}, skipping snapshot download",
             path.display()
         );

--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -11,13 +11,13 @@ dependencies:
   - evals
 
 snapshots:
-  enabled: false
+  enabled: true
   location: s3://spiceai-public-datasets/financebench/indexes
   bootstrap_on_failure_behavior: warn
 
 datasets:
   - from: s3://spiceai-public-datasets/financebench/txt/
-    name: data
+    name: financebench.data
     description: Financial information
     # We use `refresh_mode: append` based on `last_modified` so that if we have `duckdb_file` present, we don't reindex (or rewrite into S3vectors).
     # With snapshotting soon™, we will be able to automatically load this `duckdb_file` whereever we run this spicepod.
@@ -25,13 +25,16 @@ datasets:
     time_format: timestamptz
     metadata:
       last_modified: enabled
+      size: enabled
     params:
       file_format: txt
     acceleration:
       enabled: true
       engine: duckdb
-      snapshots: disabled
+      snapshots: bootstrap_only
       mode: file
+      on_conflict:
+        location: upsert
       primary_key: location
       refresh_mode: append
       params:
@@ -50,4 +53,5 @@ datasets:
       engine: s3_vectors
       params:
         s3_vectors_bucket: spiceai-financebench-s3-data
+        s3_vectors_index: financebench-openai-small-1000-200
         s3_vectors_aws_region: us-east-1


### PR DESCRIPTION
## 📝 Summary
 - Changes to Minio in `./.github/actions/build-testoperator` broke financebench CI. 
 - Also add changed parameters for s3vector variant needed to enable snapshot bootstrapping. 

## 🔗 Related
- Updated version of #7517