### PR TITLE
Update test-framework workers to use dedicated Flight client

### DIFF
--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -182,39 +182,37 @@ impl SpiceTest<NotStarted> {
             None
         };
 
-        let spice_client = self
-            .get_spiced()?
-            .spice_client(self.api_key.clone(), self.state.disable_caching)
-            .await?;
-
         let http_client = self.get_spiced()?.http_client()?;
 
-        let query_workers = (0..self.state.parallel_count)
-            .map(|id| {
-                let mut worker = SpiceTestQueryWorker::new(
-                    id,
-                    self.state.query_set.clone(),
-                    self.state.end_condition,
-                    spice_client.clone(),
-                    self.name.clone(),
-                )
-                .with_explain_plan_snapshot(self.explain_plan_snapshot)
-                .with_results_snapshot(self.results_snapshot_predicate)
-                .with_validate(self.state.validate)
-                .with_scale_factor(self.state.scale_factor);
+        let mut query_workers = Vec::new();
+        for id in 0..self.state.parallel_count {
+            let spice_client = self
+                .get_spiced()?
+                .spice_client(self.api_key.clone(), self.state.disable_caching)
+                .await?;
 
-                if let Some(multi) = &multi {
-                    worker = worker.with_progress_bar(multi.add(self.get_new_progress_bar()));
-                }
+            let mut worker = SpiceTestQueryWorker::new(
+                id,
+                self.state.query_set.clone(),
+                self.state.end_condition,
+                spice_client,
+                self.name.clone(),
+            )
+            .with_explain_plan_snapshot(self.explain_plan_snapshot)
+            .with_results_snapshot(self.results_snapshot_predicate)
+            .with_validate(self.state.validate)
+            .with_scale_factor(self.state.scale_factor);
 
-                if self.state.http_client {
-                    worker = worker.with_http_client(http_client.clone());
-                }
+            if let Some(multi) = &multi {
+                worker = worker.with_progress_bar(multi.add(self.get_new_progress_bar()));
+            }
 
-                worker
-            })
-            .map(SpiceTestQueryWorker::start)
-            .collect();
+            if self.state.http_client {
+                worker = worker.with_http_client(http_client.clone());
+            }
+
+            query_workers.push(worker.start());
+        }
 
         Ok(SpiceTest {
             name: self.name,


### PR DESCRIPTION
## 📝 Summary

Fix high-concurrency load testing by giving each worker its own Flight client

Previously, all workers shared a single FlightClient/gRPC connection, causing HTTP/2 stream exhaustion and ENHANCE_YOUR_CALM errors with high concurrency:
>2025-11-03 16:37:43.154810850 UTC FAIL - Worker 87 - Query 'q1' failed: Query execution failed: Ipc error: Status { code: ResourceExhausted, message: "h2 protocol error: http2 error", source: Some(tonic::transport::Error(Transport, hyper::Error(Http2, Error { kind: GoAway(b"too_many_internal_resets", ENHANCE_YOUR_CALM, Library) }))) }

Changes:

1. Each worker now creates its own Spice client with dedicated gRPC connection
1. Makes load testing more realistic (simulates real-world client behavior)
1. Fixes `too_many_internal_resets` /  `ENHANCE_YOUR_CALM` issue

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
