### PR TITLE
deps: Upgrade to Rust 1.90

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,12 +36,12 @@ runs:
       if: inputs.os != 'windows'
       shell: bash
       run: |
-        rustup toolchain install 1.89
-        rustup default 1.89
+        rustup toolchain install 1.90
+        rustup default 1.90
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
-        rustup toolchain install 1.89
-        rustup default 1.89
+        rustup toolchain install 1.90
+        rustup default 1.90

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ exclude = [".github/"]
 homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.89"
+rust-version = "1.90"
 version = "1.9.0-unstable"
 
 [workspace.dependencies]
@@ -96,10 +96,10 @@ aws-sdk-s3 = "1.108.0"
 aws-sdk-s3vectors = "1.11"
 aws-sdk-secretsmanager = "1.90.0"
 aws-sdk-sts = "1.88.0"
+aws-smithy-async = "1.2.5"
 aws-smithy-runtime = "1.9.3"
 aws-smithy-runtime-api = "1.9.1"
 aws-smithy-types = "1.3.3"
-aws-smithy-async = "1.2.5"
 axum = { version = "0.8", features = ["macros"] }
 ballista = "50.0.0"
 ballista-core = "50.0.0"
@@ -350,13 +350,12 @@ aws-sdk-s3vectors = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "88
 aws-sdk-secretsmanager = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-sdk-secretsmanager" }                   # pinned from release-2025-10-08
 aws-sdk-sts = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-sdk-sts" }                                         # pinned from release-2025-10-08
 aws-sigv4 = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-sigv4" }                                             # pinned from release-2025-10-08
+aws-smithy-async = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-async" }                               # pinned from release-2025-10-08
 aws-smithy-runtime = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-runtime" }                           # pinned from release-2025-10-08
 aws-smithy-runtime-api = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-runtime-api" }                   # pinned from release-2025-10-08
 aws-smithy-types = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-types" }                               # pinned from release-2025-10-08
-aws-smithy-async = { git = "https://github.com/spiceai/aws-sdk-rust", rev = "887b71e58fe61d939c7999cb32ec99069d8b1ed0", package = "aws-smithy-async" }                               # pinned from release-2025-10-08
 
 
 # Note: Turso's bindings/rust/src/lib.rs defines #[global_allocator] which conflicts with spiced's allocator
 # We need to fork and remove the global allocator or patch it out
 turso = { git = "https://github.com/spiceai/turso", rev = "5c4d14d298869fe5ea296163b3241d6963a2e87d" }
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.89
+ARG RUST_VERSION=1.90
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.89
+ARG RUST_VERSION=1.90
 
 FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS build
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
-components = ["rustc", "cargo", "rustfmt", "clippy"] 
+channel = "1.90.0"
+components = ["rustc", "cargo", "rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Rust 1.91 was [announced](https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/), so we upgrade to Rust 1.90.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
