### PR TITLE
AWS SDK Auth max retries & max duration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,14 +110,26 @@ mod tests {
 
 - **Use `tracing::` for logging**: Use `tracing::info!`, `tracing::error!`, `tracing::debug!`, etc.
 - **DO NOT use `log::`**: The project uses `tracing` crate, not `log` crate
+- **DO NOT add newlines in log messages or error strings**: Keep all log/error messages on a single line
 
 ```rust
 // GOOD
 tracing::info!("Starting runtime");
 tracing::error!("Failed to connect: {}", error);
+tracing::warn!(attempt = 1, "Failed to initialize credentials; retrying");
+
+// GOOD - long messages on single line
+tracing::debug!("AWS credential provider initialized without credentials. Proceeding without authentication.");
 
 // BAD - don't use log crate
 log::info!("Starting runtime");
+
+// BAD - don't add newlines in messages
+tracing::error!(
+    "Failed to connect: {}. \
+     Please check your configuration.",
+    error
+);
 ```
 
 ### Async/Blocking Patterns (CRITICAL)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13344,6 +13344,7 @@ version = "1.9.0-unstable"
 dependencies = [
  "async-trait",
  "aws-config",
+ "aws-sdk-credential-bridge",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8630,6 +8630,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-bedrockruntime",
+ "aws-sdk-credential-bridge",
  "aws-smithy-types",
  "bytes",
  "cache",

--- a/crates/aws-sdk-credential-bridge/src/credential_provider.rs
+++ b/crates/aws-sdk-credential-bridge/src/credential_provider.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use aws_config::{BehaviorVersion, SdkConfig};
+use aws_config::SdkConfig;
 
 use aws_credential_types::Credentials;
 use aws_runtime::auth::sigv4::SigV4AuthScheme;
@@ -59,7 +59,7 @@ impl S3CredentialProvider {
     ///
     /// Returns an error if the credentials cannot be loaded from the environment.
     pub async fn from_env() -> Result<(Self, SdkConfig)> {
-        let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+        let config = super::default_aws_config().load().await;
 
         Ok((Self::from_config(&config)?, config))
     }
@@ -128,11 +128,18 @@ impl AwsCredentialLoad for S3CredentialProvider {
                 &ConfigBag::base(),
             )
             .await
+            .inspect_err(|err| {
+                tracing::error!(
+                    error = %err,
+                    "Failed to resolve AWS credentials from identity cache for Iceberg"
+                );
+            })
             .context(FailedToResolveIcebergCredentialsSnafu)?;
 
         let credentials = wrapped_credentials.data::<Credentials>().ok_or_else(|| {
+            tracing::error!("Resolved identity does not contain AWS credentials for Iceberg");
             Error::FailedToResolveIcebergCredentials {
-                source: "No valid credentials found".into(),
+                source: "No valid credentials found in resolved identity".into(),
             }
         })?;
 
@@ -160,15 +167,29 @@ impl CredentialProvider for S3CredentialProvider {
                 &ConfigBag::base(),
             )
             .await
-            .map_err(|_| object_store::Error::Generic {
-                store: "S3",
-                source: "Failed to find valid credentials from the AWS credential provider chain for the S3 connection. Ensure that valid AWS credentials are provided in the environment. Details: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html#credproviders-default-credentials-provider-chain".into(),
+            .map_err(|err| {
+                tracing::error!(
+                    error = %err,
+                    "Failed to resolve AWS credentials from identity cache"
+                );
+                object_store::Error::Generic {
+                    store: "S3",
+                    source: format!(
+                        "Failed to find valid credentials from the AWS credential provider chain for the S3 connection: {err}. \
+                         Ensure that valid AWS credentials are provided in the environment. \
+                         Details: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html#credproviders-default-credentials-provider-chain"
+                    ).into(),
+                }
             })?;
 
         let credentials = wrapped_credentials.data::<Credentials>().ok_or_else(|| {
+            tracing::error!("Resolved identity does not contain AWS credentials");
             object_store::Error::Generic {
                 store: "S3",
-                source: "Failed to find valid credentials from the AWS credential provider chain for the S3 connection. Ensure that valid AWS credentials are provided in the environment. Details: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html#credproviders-default-credentials-provider-chain".into(),
+                source: "Failed to find valid credentials from the AWS credential provider chain for the S3 connection. \
+                         The resolved identity does not contain credential data. \
+                         Ensure that valid AWS credentials are provided in the environment. \
+                         Details: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html#credproviders-default-credentials-provider-chain".into(),
             }
         })?;
 

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -70,6 +70,15 @@ pub enum LoadError {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Returns a default AWS SDK configuration with the latest behavior version.
+///
+/// This is a convenience function to ensure all AWS SDK configuration uses
+/// the same behavior version consistently across the codebase.
+#[must_use]
+pub fn default_aws_config() -> aws_config::ConfigLoader {
+    aws_config::defaults(BehaviorVersion::v2025_08_07())
+}
+
 static SDK_CONFIG: OnceCell<Option<Arc<SdkConfig>>> = OnceCell::const_new();
 
 /// Returns the global SDK configuration, initializing it if necessary.
@@ -81,14 +90,32 @@ static SDK_CONFIG: OnceCell<Option<Arc<SdkConfig>>> = OnceCell::const_new();
 ///
 /// Returns a [`LoadError`] if credential initialization continues to fail due to unrecoverable
 /// issues when communicating with the AWS credential provider.
+///
+/// # Note on Concurrent Calls
+///
+/// Multiple concurrent calls to this function are safe but if initialization fails,
+/// subsequent calls will retry from scratch. This is intentional to allow recovery
+/// from transient failures.
 pub async fn get_or_init_sdk_config() -> std::result::Result<Option<Arc<SdkConfig>>, LoadError> {
     if let Some(cached) = SDK_CONFIG.get() {
         return Ok(cached.clone());
     }
 
+    tracing::debug!("Initializing AWS SDK configuration from environment");
+
     let value = SDK_CONFIG
         .get_or_try_init(|| async move { retry_with_backoff(load_sdk_config_from_env).await })
-        .await?;
+        .await
+        .inspect(|config| {
+            if config.is_some() {
+                tracing::info!("Successfully initialized AWS SDK configuration");
+            } else {
+                tracing::info!("AWS SDK initialized without credentials (unauthenticated mode)");
+            }
+        })
+        .inspect_err(|err| {
+            tracing::error!(error = %err, "Failed to initialize AWS SDK configuration after all retry attempts");
+        })?;
 
     Ok(value.clone())
 }
@@ -109,6 +136,25 @@ const MAX_CREDENTIAL_RETRIES: usize = 300;
 /// 600 seconds (10 minutes) caps the backoff interval between retry attempts.
 const MAX_RETRY_DURATION_SECS: u64 = 600;
 
+/// Retry a credential loading operation with Fibonacci backoff.
+///
+/// This function implements a resilient retry strategy for AWS credential initialization:
+/// - Uses Fibonacci backoff sequence: 1s, 1s, 2s, 3s, 5s, 8s, 13s, 21s, 34s, 55s, 89s, 144s...
+/// - Caps individual retry intervals at 10 minutes to prevent excessive delays
+/// - Allows up to 300 retry attempts, providing ~48 hours of total retry time
+/// - Returns immediately on success or when no credentials are needed (Ok(None))
+/// - Logs warnings for each failed attempt with retry timing information
+///
+/// This generous retry policy accommodates:
+/// - Extended AWS service outages (up to ~2 days)
+/// - Slow metadata service responses (IMDS)
+/// - Transient network issues
+/// - IAM credential propagation delays
+///
+/// # Returns
+/// - `Ok(Some(T))` - Successfully loaded credentials
+/// - `Ok(None)` - No credentials configured (unauthenticated mode)
+/// - `Err(LoadError)` - All retry attempts exhausted with persistent failure
 async fn retry_with_backoff<F, Fut, T>(mut attempt: F) -> std::result::Result<Option<T>, LoadError>
 where
     F: FnMut() -> Fut,
@@ -126,26 +172,36 @@ where
         attempt_num += 1;
 
         match attempt().await {
-            Ok(result @ Some(_)) => return Ok(result),
+            Ok(result @ Some(_)) => {
+                if attempt_num > 1 {
+                    tracing::info!(
+                        attempts = attempt_num,
+                        "Successfully initialized AWS SDK credentials after retries"
+                    );
+                }
+                return Ok(result);
+            }
             Ok(None) => return Ok(None),
             Err(err) => {
                 let Some(delay) = backoff.next_duration() else {
-                    // Exhausted retries
-                    return Err(last_err.unwrap_or(LoadError::Other {
+                    // Exhausted retries - return the last error with context
+                    let final_error = last_err.unwrap_or_else(|| LoadError::Other {
                         message: format!(
-                            "Failed to initialize AWS SDK credentials after {} attempts",
+                            "Failed to initialize AWS SDK credentials after {} attempts. This may indicate a persistent AWS service outage or misconfigured credentials.",
                             attempt_num - 1
                         ),
-                    }));
+                    });
+
+                    tracing::error!(
+                        attempts = attempt_num - 1,
+                        max_retries = MAX_CREDENTIAL_RETRIES,
+                        "Exhausted all retry attempts for AWS SDK credential initialization"
+                    );
+
+                    return Err(final_error);
                 };
 
-                tracing::warn!(
-                    attempt = attempt_num,
-                    max_retries = MAX_CREDENTIAL_RETRIES,
-                    next_retry_in = ?delay,
-                    error = %err,
-                    "Failed to initialize AWS SDK credentials; retrying"
-                );
+                tracing::warn!(attempt = attempt_num, max_retries = MAX_CREDENTIAL_RETRIES, next_retry_in = ?delay, error = %err, "Failed to initialize AWS SDK credentials; retrying");
 
                 last_err = Some(err);
                 sleep(delay).await;
@@ -155,15 +211,14 @@ where
 }
 
 async fn load_sdk_config_from_env() -> std::result::Result<Option<Arc<SdkConfig>>, LoadError> {
-    let sdk_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let sdk_config = default_aws_config().load().await;
 
     if let Some(creds_provider) = sdk_config.credentials_provider() {
         match creds_provider.provide_credentials().await {
             Ok(_) => Ok(Some(Arc::new(sdk_config))),
             Err(err @ CredentialsError::CredentialsNotLoaded(_)) => {
                 tracing::debug!(
-                    "AWS credential provider initialized without credentials: {err}. \
-                     Proceeding without authentication."
+                    "AWS credential provider initialized without credentials: {err}. Proceeding without authentication."
                 );
                 Ok(None)
             }
@@ -171,8 +226,7 @@ async fn load_sdk_config_from_env() -> std::result::Result<Option<Arc<SdkConfig>
         }
     } else {
         tracing::debug!(
-            "No AWS credential provider detected in the default configuration. \
-             Assuming unauthenticated access."
+            "No AWS credential provider detected in the default configuration. Assuming unauthenticated access."
         );
         Ok(None)
     }

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn get_or_init_sdk_config() -> std::result::Result<Option<Arc<SdkConfi
     }
 
     let value = SDK_CONFIG
-        .get_or_try_init(initialize_sdk_config_with_retry)
+        .get_or_try_init(|| async move { retry_with_backoff(load_sdk_config_from_env).await })
         .await?;
 
     Ok(value.clone())
@@ -100,29 +100,54 @@ pub fn get_sdk_config() -> Option<Arc<SdkConfig>> {
         .and_then(|value| value.as_ref().map(Arc::clone))
 }
 
-async fn initialize_sdk_config_with_retry() -> std::result::Result<Option<Arc<SdkConfig>>, LoadError>
-{
-    retry_with_backoff(load_sdk_config_from_env).await
-}
+/// Maximum number of retry attempts for AWS credential initialization.
+/// 300 attempts with Fibonacci backoff (capped at 10 minutes) provides approximately 48 hours of AWS downtime
+/// retry time, accommodating extended AWS service outages while eventually failing for permanent issues.
+const MAX_CREDENTIAL_RETRIES: usize = 300;
+
+/// Maximum duration for a single retry interval in seconds.
+/// 600 seconds (10 minutes) caps the backoff interval between retry attempts.
+const MAX_RETRY_DURATION_SECS: u64 = 600;
 
 async fn retry_with_backoff<F, Fut, T>(mut attempt: F) -> std::result::Result<Option<T>, LoadError>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = std::result::Result<Option<T>, LoadError>>,
 {
-    let mut backoff = FibonacciBackoffBuilder::new().build();
+    let mut backoff = FibonacciBackoffBuilder::new()
+        .max_retries(Some(MAX_CREDENTIAL_RETRIES))
+        .max_duration(Some(Duration::from_secs(MAX_RETRY_DURATION_SECS)))
+        .build();
+
+    let mut last_err = None;
+    let mut attempt_num = 0;
 
     loop {
+        attempt_num += 1;
+
         match attempt().await {
             Ok(result @ Some(_)) => return Ok(result),
             Ok(None) => return Ok(None),
             Err(err) => {
-                let delay = backoff
-                    .next_duration()
-                    .unwrap_or_else(|| Duration::from_secs(1));
+                let Some(delay) = backoff.next_duration() else {
+                    // Exhausted retries
+                    return Err(last_err.unwrap_or(LoadError::Other {
+                        message: format!(
+                            "Failed to initialize AWS SDK credentials after {} attempts",
+                            attempt_num - 1
+                        ),
+                    }));
+                };
+
                 tracing::warn!(
-                    "Failed to initialize AWS SDK credentials (retrying in {delay:?}): {err}"
+                    attempt = attempt_num,
+                    max_retries = MAX_CREDENTIAL_RETRIES,
+                    next_retry_in = ?delay,
+                    error = %err,
+                    "Failed to initialize AWS SDK credentials; retrying"
                 );
+
+                last_err = Some(err);
                 sleep(delay).await;
             }
         }
@@ -295,6 +320,27 @@ mod tests {
 
         assert!(result.is_none());
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_with_backoff_exhausts_retries() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let attempts_clone = Arc::clone(&attempts);
+        let result: std::result::Result<Option<()>, LoadError> = retry_with_backoff(|| {
+            let attempts = Arc::clone(&attempts_clone);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(LoadError::Other {
+                    message: "persistent failure".to_string(),
+                })
+            }
+        })
+        .await;
+
+        assert!(result.is_err(), "Expected error after exhausting retries");
+        // Should attempt initial + MAX_CREDENTIAL_RETRIES
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_CREDENTIAL_RETRIES + 1);
     }
 
     #[test]

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -67,6 +67,7 @@ model2vec-rs = { git = "https://github.com/spiceai/model2vec-rs.git", rev = "dd0
 [dev-dependencies]
 anyhow = "1.0.99"
 aws-credential-types.workspace = true
+aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge" }
 dotenvy.workspace = true
 insta.workspace = true
 jsonpath-rust = "0.7.3"

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -16,8 +16,9 @@ limitations under the License.
 
 use anyhow::Context;
 use async_openai::error::OpenAIError;
-use aws_config::{BehaviorVersion, Region, defaults};
+use aws_config::Region;
 use aws_credential_types::Credentials;
+use aws_sdk_credential_bridge::default_aws_config;
 use hf_hub::{Repo, RepoType, api::sync::ApiBuilder};
 use llms::{
     anthropic::Anthropic,
@@ -38,7 +39,7 @@ use std::{
 };
 
 pub(crate) async fn create_bedrock(model_id: &str) -> Result<Arc<dyn Chat>, anyhow::Error> {
-    let mut config_builder = defaults(BehaviorVersion::latest());
+    let mut config_builder = default_aws_config();
 
     if let Ok(region) = std::env::var("SPICE_BEDROCK_REGION") {
         config_builder = config_builder.region(Region::new(region.clone()));
@@ -70,7 +71,7 @@ pub(crate) async fn create_bedrock(model_id: &str) -> Result<Arc<dyn Chat>, anyh
         }
     }
 
-    let config = config_builder.load().await;
+    let config: aws_config::SdkConfig = config_builder.load().await;
     Ok(Arc::new(BedrockConverse::new(
         Arc::new((&config).into()),
         model_id.to_string(),

--- a/crates/runtime-secrets/Cargo.toml
+++ b/crates/runtime-secrets/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 # Optional dependencies for feature-gated secret stores
 aws-config = { workspace = true, optional = true }
+aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge", optional = true }
 aws-sdk-secretsmanager = { workspace = true, optional = true }
 aws-sdk-sts = { workspace = true, optional = true }
 keyring = { version = "3.6.3", features = [
@@ -39,6 +40,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "te
 [features]
 aws-secrets-manager = [
     "dep:aws-config",
+    "dep:aws-sdk-credential-bridge",
     "dep:aws-sdk-secretsmanager",
     "dep:aws-sdk-sts",
 ]

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -24,10 +24,11 @@ use crate::SecretStore;
 
 use aws_sdk_secretsmanager::{error::SdkError, operation::get_secret_value::GetSecretValueError};
 
-use aws_config::{self, BehaviorVersion};
 use aws_sdk_secretsmanager::{self};
 
 use snafu::{OptionExt, ResultExt, Snafu};
+
+use aws_sdk_credential_bridge::default_aws_config;
 
 const SPICE_KEY_PREFIX: &str = "spice_";
 
@@ -74,9 +75,7 @@ impl AwsSecretsManager {
     /// - If the AWS configuration cannot be loaded.
     /// - If the call to STS `get_caller_identity` fails, which might be due to invalid or expired AWS credentials.
     pub async fn init(&self) -> Result<()> {
-        let config = aws_config::defaults(BehaviorVersion::v2025_08_07())
-            .load()
-            .await;
+        let config = default_aws_config().load().await;
 
         let sts_client = aws_sdk_sts::Client::new(&config);
 
@@ -98,9 +97,7 @@ impl SecretStore for AwsSecretsManager {
             self.secret_name
         );
 
-        let config = aws_config::defaults(BehaviorVersion::v2025_08_07())
-            .load()
-            .await;
+        let config = default_aws_config().load().await;
 
         let asm = aws_sdk_secretsmanager::Client::new(&config);
 

--- a/crates/runtime/src/catalogconnector/glue/provider.rs
+++ b/crates/runtime/src/catalogconnector/glue/provider.rs
@@ -126,6 +126,7 @@ impl GlueCatalogProvider {
             "session_token",
             &parameters.parameters,
         )
+        .await
         .context(ConfigurationLoadingFailedSnafu)?
         .load()
         .await;

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -296,6 +296,7 @@ impl CatalogConnector for IcebergCatalog {
                 "s3_session_token",
                 &self.params,
             )
+            .await
             .map_err(|e| super::Error::InvalidConfiguration {
                 connector: "iceberg".into(),
                 message: e.to_string(),

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -469,20 +469,18 @@ impl DataConnectorFactory for DatabricksFactory {
             Box::pin(async move {
                 // Initialize AWS SDK credentials only if using IAM role authentication.
                 // Skip if explicit AWS credentials are provided.
-                match (
-                    params.parameters.contains("aws_access_key_id"),
-                    params.parameters.contains("aws_secret_access_key"),
-                ) {
-                    (false, false) => {
-                        if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await
-                        {
-                            tracing::warn!(
-                                "Unable to initialize AWS credentials for Databricks connector: {err}"
-                            );
-                        }
-                    }
-                    _ => {
-                        // Skip AWS SDK initialization - use explicit credentials
+                let has_explicit_key = params.parameters.get("aws_access_key_id").ok().is_some();
+                let has_explicit_secret = params
+                    .parameters
+                    .get("aws_secret_access_key")
+                    .ok()
+                    .is_some();
+
+                if !has_explicit_key && !has_explicit_secret {
+                    if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
+                        tracing::warn!(
+                            "Unable to initialize AWS credentials for Databricks connector: {err}"
+                        );
                     }
                 }
 

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -467,12 +467,25 @@ impl DataConnectorFactory for DatabricksFactory {
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         if let Some(runtime) = params.runtime {
             Box::pin(async move {
-                // Initialize the AWS SDK and make it available.
-                if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
-                    tracing::warn!(
-                        "Unable to initialize AWS credentials for Databricks connector: {err}"
-                    );
+                // Initialize AWS SDK credentials only if using IAM role authentication.
+                // Skip if explicit AWS credentials are provided.
+                match (
+                    params.parameters.contains("aws_access_key_id"),
+                    params.parameters.contains("aws_secret_access_key"),
+                ) {
+                    (false, false) => {
+                        if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await
+                        {
+                            tracing::warn!(
+                                "Unable to initialize AWS credentials for Databricks connector: {err}"
+                            );
+                        }
+                    }
+                    _ => {
+                        // Skip AWS SDK initialization - use explicit credentials
+                    }
                 }
+
                 let databricks = Databricks::new(
                     params.parameters,
                     params.io_runtime,

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -476,12 +476,13 @@ impl DataConnectorFactory for DatabricksFactory {
                     .ok()
                     .is_some();
 
-                if !has_explicit_key && !has_explicit_secret {
-                    if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
-                        tracing::warn!(
-                            "Unable to initialize AWS credentials for Databricks connector: {err}"
-                        );
-                    }
+                if !has_explicit_key
+                    && !has_explicit_secret
+                    && let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await
+                {
+                    tracing::warn!(
+                        "Unable to initialize AWS credentials for Databricks connector: {err}"
+                    );
                 }
 
                 let databricks = Databricks::new(

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -127,12 +127,13 @@ impl DataConnectorFactory for DeltaLakeFactory {
                 .ok()
                 .is_some();
 
-            if !has_explicit_key && !has_explicit_secret {
-                if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
-                    tracing::warn!(
-                        "Unable to initialize AWS credentials for Delta Lake connector: {err}"
-                    );
-                }
+            if !has_explicit_key
+                && !has_explicit_secret
+                && let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await
+            {
+                tracing::warn!(
+                    "Unable to initialize AWS credentials for Delta Lake connector: {err}"
+                );
             }
 
             let delta = DeltaLake::new(params.parameters, params.io_runtime);

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -120,19 +120,18 @@ impl DataConnectorFactory for DeltaLakeFactory {
         Box::pin(async move {
             // Initialize AWS SDK credentials only if using IAM role authentication.
             // Skip if explicit AWS credentials are provided.
-            match (
-                params.parameters.contains("aws_access_key_id"),
-                params.parameters.contains("aws_secret_access_key"),
-            ) {
-                (false, false) => {
-                    if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
-                        tracing::warn!(
-                            "Unable to initialize AWS credentials for Delta Lake connector: {err}"
-                        );
-                    }
-                }
-                _ => {
-                    // Skip AWS SDK initialization - use explicit credentials
+            let has_explicit_key = params.parameters.get("aws_access_key_id").ok().is_some();
+            let has_explicit_secret = params
+                .parameters
+                .get("aws_secret_access_key")
+                .ok()
+                .is_some();
+
+            if !has_explicit_key && !has_explicit_secret {
+                if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
+                    tracing::warn!(
+                        "Unable to initialize AWS credentials for Delta Lake connector: {err}"
+                    );
                 }
             }
 

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -118,12 +118,24 @@ impl DataConnectorFactory for DeltaLakeFactory {
         params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            // Initialize the AWS SDK and make it available.
-            if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
-                tracing::warn!(
-                    "Unable to initialize AWS credentials for Delta Lake connector: {err}"
-                );
+            // Initialize AWS SDK credentials only if using IAM role authentication.
+            // Skip if explicit AWS credentials are provided.
+            match (
+                params.parameters.contains("aws_access_key_id"),
+                params.parameters.contains("aws_secret_access_key"),
+            ) {
+                (false, false) => {
+                    if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
+                        tracing::warn!(
+                            "Unable to initialize AWS credentials for Delta Lake connector: {err}"
+                        );
+                    }
+                }
+                _ => {
+                    // Skip AWS SDK initialization - use explicit credentials
+                }
             }
+
             let delta = DeltaLake::new(params.parameters, params.io_runtime);
             Ok(Arc::new(delta) as Arc<dyn DataConnector>)
         })

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -122,6 +122,7 @@ impl DataConnector for DynamoDB {
             "aws_session_token",
             &self.params,
         )
+        .await
         .map_err(|message| DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: "dynamodb".to_string(),
             connector_component: ConnectorComponent::from(dataset),

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -216,7 +216,8 @@ impl GlueDataConnector {
             "secret",
             "session_token",
             &self.params,
-        )?
+        )
+        .await?
         .load()
         .await;
 

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -147,6 +147,7 @@ impl IcebergDataConnector {
                 "s3_session_token",
                 &self.params,
             )
+            .await
             .map_err(|e| Error::InvalidConfiguration {
                 dataconnector: "iceberg".into(),
                 message: e.to_string(),

--- a/crates/runtime/src/dataconnector/parameters/aws.rs
+++ b/crates/runtime/src/dataconnector/parameters/aws.rs
@@ -198,7 +198,7 @@ impl Validator for AuthValidator {
 /// Initiate a [`ConfigLoader`] with AWS credentials as we'd expect them to be defined in [`Parameters`] (for a given `provider_name`).
 ///
 /// Return [`ConfigLoader`] to allow further customisation.
-pub fn initiate_config_with_credentials(
+pub async fn initiate_config_with_credentials(
     provider_name: &'static str,
     region_name: &'static str,
     key_name: &'static str,
@@ -243,7 +243,11 @@ pub fn initiate_config_with_credentials(
                 .credentials_provider(credentials)
         }
         _ => {
-            // This will automatically load AWS credentials from the environment, via IAM roles if configured.
+            // Initialize AWS SDK credentials for IAM role authentication.
+            // This will automatically load credentials from the environment or IAM roles.
+            if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
+                tracing::warn!("Unable to initialize AWS credentials for {provider_name}: {err}");
+            }
             default_aws_config().region(Region::new(region))
         }
     })

--- a/crates/runtime/src/dataconnector/parameters/aws.rs
+++ b/crates/runtime/src/dataconnector/parameters/aws.rs
@@ -228,8 +228,8 @@ pub async fn initiate_config_with_credentials(
         .ok()
         .map(ToString::to_string);
 
-    Ok(match (access_key_id, secret_access_key) {
-        (Some(access_key_id), Some(secret_access_key)) => {
+    Ok(
+        if let (Some(access_key_id), Some(secret_access_key)) = (access_key_id, secret_access_key) {
             let credentials = Credentials::new(
                 access_key_id,
                 secret_access_key,
@@ -241,14 +241,13 @@ pub async fn initiate_config_with_credentials(
             default_aws_config()
                 .region(Region::new(region))
                 .credentials_provider(credentials)
-        }
-        _ => {
+        } else {
             // Initialize AWS SDK credentials for IAM role authentication.
             // This will automatically load credentials from the environment or IAM roles.
             if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
                 tracing::warn!("Unable to initialize AWS credentials for {provider_name}: {err}");
             }
             default_aws_config().region(Region::new(region))
-        }
-    })
+        },
+    )
 }

--- a/crates/runtime/src/dataconnector/parameters/aws.rs
+++ b/crates/runtime/src/dataconnector/parameters/aws.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use aws_config::{BehaviorVersion, ConfigLoader, Region};
+use aws_config::{ConfigLoader, Region};
 use aws_credential_types::Credentials;
 use snafu::prelude::*;
 use tonic::async_trait;
@@ -22,6 +22,10 @@ use tonic::async_trait;
 use crate::parameters::{ParamLookup, Parameters};
 
 use super::{ConnectorParams, Validator};
+
+// Re-export the default AWS config function from aws-sdk-credential-bridge
+// to provide a single source of truth for AWS SDK configuration.
+pub use aws_sdk_credential_bridge::default_aws_config;
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html
 pub const AWS_REGIONS: [&str; 32] = [
@@ -234,13 +238,13 @@ pub fn initiate_config_with_credentials(
                 provider_name,
             );
 
-            aws_config::defaults(BehaviorVersion::v2025_08_07())
+            default_aws_config()
                 .region(Region::new(region))
                 .credentials_provider(credentials)
         }
         _ => {
             // This will automatically load AWS credentials from the environment, via IAM roles if configured.
-            aws_config::defaults(BehaviorVersion::v2025_08_07()).region(Region::new(region))
+            default_aws_config().region(Region::new(region))
         }
     })
 }

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -173,10 +173,10 @@ impl DataConnectorFactory for S3Factory {
             // Initialize AWS SDK credentials for IAM role authentication (default).
             // Skip initialization only for 'public' and 'key' auth methods which use explicit credentials.
             match params.parameters.get("auth").expose().ok() {
-                Some("public") | Some("key") => {
+                Some("public" | "key") => {
                     // Skip AWS SDK initialization - use explicit auth method directly
                 }
-                None | Some("iam_role") | Some(_) => {
+                None | Some("iam_role" | _) => {
                     if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
                         tracing::warn!(
                             "Unable to initialize AWS credentials for S3 connector: {err}"

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -170,11 +170,13 @@ impl DataConnectorFactory for S3Factory {
                 validator.validate(&mut params).await?;
             }
 
-            // `get_or_init_sdk_config` emits a warning if the credentials provider cannot be initialized
-            // so we skip it if the auth method is public.
+            // Initialize AWS SDK credentials for IAM role authentication (default).
+            // Skip initialization only for 'public' and 'key' auth methods which use explicit credentials.
             match params.parameters.get("auth").expose().ok() {
-                None | Some("public") => (),
-                _ => {
+                Some("public") | Some("key") => {
+                    // Skip AWS SDK initialization - use explicit auth method directly
+                }
+                None | Some("iam_role") | Some(_) => {
                     if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config().await {
                         tracing::warn!(
                             "Unable to initialize AWS credentials for S3 connector: {err}"

--- a/crates/runtime/src/embeddings/index/s3/mod.rs
+++ b/crates/runtime/src/embeddings/index/s3/mod.rs
@@ -218,7 +218,8 @@ async fn try_vector_table(
         "aws_secret_access_key",
         "aws_session_token",
         &params,
-    )?;
+    )
+    .await?;
 
     if let Some(dur) = client_timeout {
         config_bldr =

--- a/crates/runtime/src/model/util.rs
+++ b/crates/runtime/src/model/util.rs
@@ -38,7 +38,7 @@ pub(super) async fn create_bedrock_client(
     credential_provider_name: &'static str,
 ) -> Result<BedrockClient, Box<dyn std::error::Error + Send + Sync>> {
     // Build AWS config
-    let mut config_builder = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    let mut config_builder = aws_sdk_credential_bridge::default_aws_config();
 
     // Set region if provided
     if let Some(region) = extract_secret!(params, "aws_region") {

--- a/crates/runtime/tests/dynamodb/mod.rs
+++ b/crates/runtime/tests/dynamodb/mod.rs
@@ -27,7 +27,7 @@ use crate::{configure_test_datafusion, init_tracing, utils::test_request_context
 
 use aws_config::Region;
 use aws_credential_types::Credentials;
-use aws_sdk_dynamodb::config::BehaviorVersion;
+use aws_sdk_credential_bridge::default_aws_config;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
     ScalarAttributeType,
@@ -571,7 +571,7 @@ fn get_test_dataset(from: &str, name: &str) -> Dataset {
 
 #[allow(clippy::missing_panics_doc)]
 #[allow(clippy::missing_errors_doc)]
-pub fn get_dynamodb_client() -> Result<aws_sdk_dynamodb::Client, anyhow::Error> {
+pub async fn get_dynamodb_client() -> Result<aws_sdk_dynamodb::Client, anyhow::Error> {
     let Ok(dynamodb_access_key_id) = env::var("AWS_DYNAMODB_KEY") else {
         panic!("AWS_DYNAMODB_KEY not set")
     };
@@ -588,13 +588,13 @@ pub fn get_dynamodb_client() -> Result<aws_sdk_dynamodb::Client, anyhow::Error> 
         "dynamodb",
     );
 
-    let config = aws_sdk_dynamodb::Config::builder()
-        .behavior_version(BehaviorVersion::latest())
+    let config = default_aws_config()
         .region(Region::new("ap-northeast-2"))
         .credentials_provider(credentials)
-        .build();
+        .load()
+        .await;
 
-    let client = aws_sdk_dynamodb::Client::from_conf(config);
+    let client = aws_sdk_dynamodb::Client::new(&config);
 
     Ok(client)
 }
@@ -602,7 +602,7 @@ pub fn get_dynamodb_client() -> Result<aws_sdk_dynamodb::Client, anyhow::Error> 
 #[allow(clippy::too_many_lines)]
 #[allow(dead_code)]
 async fn init_test_table(table_name: &str) -> Result<(), anyhow::Error> {
-    let client = get_dynamodb_client()?;
+    let client = get_dynamodb_client().await?;
 
     tracing::info!("Initializing test table: {}", table_name);
 

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use aws_config::{BehaviorVersion, Region};
+use aws_config::Region;
 use aws_credential_types::Credentials;
+use runtime::dataconnector::parameters::aws::default_aws_config;
 use s3_vectors::Client;
 use serde_json::json;
 use snafu::ResultExt;
@@ -1007,7 +1008,7 @@ async fn delete_index(
     bucket_name: &str,
     index_name: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = aws_config::defaults(BehaviorVersion::v2025_08_07())
+    let config = default_aws_config()
         .region(Region::from_static("us-east-2"))
         .credentials_provider(Credentials::new(
             std::env::var("AWS_S3_VECTORS_KEY").ok().unwrap_or_default(),


### PR DESCRIPTION
This pull request improves the reliability and robustness of AWS SDK credential initialization by enhancing the retry logic and adding comprehensive test coverage for retry exhaustion scenarios. The changes ensure that credential loading can tolerate extended AWS outages, provide better error reporting, and are thoroughly tested for edge cases.

**Enhancements to retry logic:**

* Introduced configurable constants for maximum retry attempts (`MAX_CREDENTIAL_RETRIES`, set to 300) and maximum retry interval duration (`MAX_RETRY_DURATION_SECS`, set to 600 seconds), allowing the retry mechanism to handle up to ~48 hours of AWS downtime with Fibonacci backoff.
* Updated the `retry_with_backoff` function to track the number of attempts, cap retries, and provide detailed error messages when all retries are exhausted. The function now logs structured information about each retry, including attempt number, maximum retries, next retry interval, and error details.
* Simplified the SDK config initialization by removing the intermediate `initialize_sdk_config_with_retry` function and directly using the improved retry logic in `get_or_init_sdk_config`.

**Testing improvements:**

* Added a new test (`retry_with_backoff_exhausts_retries`) to verify that the retry logic correctly exhausts the allowed number of attempts and returns an error when persistent failures occur, ensuring robust handling of edge cases.