### PR TITLE
Run integration tests with `AWS_EC2_METADATA_DISABLED` flag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -285,6 +285,7 @@ jobs:
       - name: Run integration test
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
+          AWS_EC2_METADATA_DISABLED: true
           INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
           GITHUB_ORG_TOKEN: ${{ steps.github-app-token.outputs.token }}
@@ -439,6 +440,7 @@ jobs:
 
       - name: Run AWS SDK integration test
         env:
+          AWS_EC2_METADATA_DISABLED: true
           TEST_DATABRICKS_TOKEN: ${{ secrets.NEW_DATABRICKS_TOKEN }}
           AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
           AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
@@ -482,6 +484,7 @@ jobs:
 
       - name: Run AWS SDK credential bridge integration test
         env:
+          AWS_EC2_METADATA_DISABLED: true
           AWS_S3_CLIENT_ID: ${{ secrets.AWS_S3_CLIENT_ID }}
           AWS_S3_IDENTITY_POOL_ID: ${{ secrets.AWS_S3_IDENTITY_POOL_ID }}
           AWS_S3_USERNAME: ${{ secrets.AWS_S3_USERNAME }}


### PR DESCRIPTION
## 📝 Summary

Some tests attempted to access the AWS default metadata host (`169.254.169.254`) and failed due to an incompatible response. Since we are not using AWS metadata, disable its usage in tests.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
