### PR TITLE
Fix spiced metrics reporting as part of benchmark tests

### DIFF
--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -179,8 +179,6 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     emit_acceleration_size_if_applicable(&app, &spiced_instance.get_tempdir_path())?;
 
-    telemetry.emit().await?;
-
     let records = metrics.with_memory_usage(max_memory).build_records()?;
     print_batches(&records)?;
 
@@ -188,6 +186,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     // Stop and process metrics scraper if enabled
     super::process_spiced_metrics(metrics_scraper, args.common.metrics, &[]).await;
+
+    telemetry.emit().await?;
 
     spiced_instance.stop()?;
     let health_report = health_report?;


### PR DESCRIPTION
Previously, metrics were exported before `process_spiced_metrics` was executed.

## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
