### PR TITLE
CLI file persisted history with `.clear` and `.clear history` commands

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/api"
 	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
+	"github.com/spiceai/spiceai/bin/spice/pkg/history"
 	spice_http "github.com/spiceai/spiceai/bin/spice/pkg/http"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
@@ -659,13 +660,34 @@ spice chat --model <model> "What is Spice.ai?"
 		cmd.Println("Welcome to the Spice.ai chat REPL! Type your message to chat with the model.")
 		cmd.Println()
 
+		// Initialize history manager
+		historyMgr, err := history.NewManager(history.ChatHistory)
+		if err != nil {
+			slog.Warn("failed to initialize chat history", "error", err)
+			historyMgr = nil
+		}
+
 		line := liner.NewLiner()
 		line.SetCtrlCAborts(true)
 		defer func() {
+			// Save history before closing
+			if historyMgr != nil {
+				if err := historyMgr.Save(); err != nil {
+					slog.Warn("failed to save chat history", "error", err)
+				}
+			}
 			if err := line.Close(); err != nil {
 				slog.Error("closing line", "error", err)
 			}
 		}()
+
+		// Load history into liner
+		if historyMgr != nil {
+			historyMgr.LoadIntoLiner(line)
+			// Enable tab completion based on history
+			line.SetCompleter(historyMgr.GetCompleter())
+		}
+
 		for {
 			message, err := line.Prompt("chat> ")
 			if err == liner.ErrPromptAborted {
@@ -678,7 +700,30 @@ spice chat --model <model> "What is Spice.ai?"
 				break
 			}
 
+			if strings.ToLower(message) == ".clear history" {
+				if historyMgr != nil {
+					historyMgr.Clear()
+					if err := historyMgr.Save(); err != nil {
+						cmd.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+					} else {
+						cmd.Println("Chat history cleared.")
+					}
+				} else {
+					cmd.Println("History is not available.")
+				}
+				continue
+			}
+
 			line.AppendHistory(message)
+
+			// Add to persistent history and save immediately
+			if historyMgr != nil {
+				historyMgr.Add(message)
+				if err := historyMgr.Save(); err != nil {
+					slog.Warn("failed to save chat history", "error", err)
+				}
+			}
+
 			messages = append(messages, Message{Role: "user", Content: message})
 
 			messages, err = getChatResponse(messages, true, false)
@@ -1066,14 +1111,34 @@ func runRemoteChatREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, ht
 	cmd.Printf("Welcome to the Spice.ai chat REPL! Type your message to chat with '%s'.\n", model)
 	cmd.Println()
 
+	// Initialize history manager
+	historyMgr, err := history.NewManager(history.ChatHistory)
+	if err != nil {
+		slog.Warn("failed to initialize chat history", "error", err)
+		historyMgr = nil
+	}
+
 	var messages []Message
 	line := liner.NewLiner()
 	line.SetCtrlCAborts(true)
 	defer func() {
+		// Save history before closing
+		if historyMgr != nil {
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save chat history", "error", err)
+			}
+		}
 		if err := line.Close(); err != nil {
 			slog.Error("closing line", "error", err)
 		}
 	}()
+
+	// Load history into liner
+	if historyMgr != nil {
+		historyMgr.LoadIntoLiner(line)
+		// Enable tab completion based on history
+		line.SetCompleter(historyMgr.GetCompleter())
+	}
 
 	for {
 		message, err := line.Prompt("chat> ")
@@ -1087,7 +1152,36 @@ func runRemoteChatREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, ht
 			break
 		}
 
+		if strings.ToLower(message) == ".clear" {
+			// Clear the screen using ANSI escape codes
+			cmd.Print("\033[H\033[2J")
+			continue
+		}
+
+		if strings.ToLower(message) == ".clear history" {
+			if historyMgr != nil {
+				historyMgr.Clear()
+				if err := historyMgr.Save(); err != nil {
+					cmd.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+				} else {
+					cmd.Println("Chat history cleared.")
+				}
+			} else {
+				cmd.Println("History is not available.")
+			}
+			continue
+		}
+
 		line.AppendHistory(message)
+
+		// Add to persistent history and save immediately
+		if historyMgr != nil {
+			historyMgr.Add(message)
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save chat history", "error", err)
+			}
+		}
+
 		messages = append(messages, Message{Role: "user", Content: message})
 
 		messages, err = sendChatRequest(messages, true, false)

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/display"
+	"github.com/spiceai/spiceai/bin/spice/pkg/history"
 	spice_http "github.com/spiceai/spiceai/bin/spice/pkg/http"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
@@ -179,13 +180,34 @@ spice search --cloud
 		cmd.Println("Welcome to the Spice.ai search REPL! Enter your search queries.")
 		cmd.Println()
 
+		// Initialize history manager
+		historyMgr, err := history.NewManager(history.SearchHistory)
+		if err != nil {
+			slog.Warn("failed to initialize search history", "error", err)
+			historyMgr = nil
+		}
+
 		line := liner.NewLiner()
 		line.SetCtrlCAborts(true)
 		defer func() {
+			// Save history before closing
+			if historyMgr != nil {
+				if err := historyMgr.Save(); err != nil {
+					slog.Warn("failed to save search history", "error", err)
+				}
+			}
 			if err := line.Close(); err != nil {
 				slog.Error("closing line", "error", err)
 			}
 		}()
+
+		// Load history into liner
+		if historyMgr != nil {
+			historyMgr.LoadIntoLiner(line)
+			// Enable tab completion based on history
+			line.SetCompleter(historyMgr.GetCompleter())
+		}
+
 		for {
 			message, err := line.Prompt("search> ")
 			if err == liner.ErrPromptAborted {
@@ -203,7 +225,36 @@ spice search --cloud
 				continue
 			}
 
+			if strings.ToLower(message) == ".clear" {
+				// Clear the screen using ANSI escape codes
+				cmd.Print("\033[H\033[2J")
+				continue
+			}
+
+			if strings.ToLower(message) == ".clear history" {
+				if historyMgr != nil {
+					historyMgr.Clear()
+					if err := historyMgr.Save(); err != nil {
+						cmd.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+					} else {
+						cmd.Println("Search history cleared.")
+					}
+				} else {
+					cmd.Println("History is not available.")
+				}
+				continue
+			}
+
 			line.AppendHistory(message)
+
+			// Add to persistent history and save immediately
+			if historyMgr != nil {
+				historyMgr.Add(message)
+				if err := historyMgr.Save(); err != nil {
+					slog.Warn("failed to save search history", "error", err)
+				}
+			}
+
 			done := make(chan bool)
 			go func() {
 				util.ShowSpinner(done)
@@ -414,13 +465,33 @@ func runRemoteSearchREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, 
 	}
 	cmd.Println()
 
+	// Initialize history manager
+	historyMgr, err := history.NewManager(history.SearchHistory)
+	if err != nil {
+		slog.Warn("failed to initialize search history", "error", err)
+		historyMgr = nil
+	}
+
 	line := liner.NewLiner()
 	line.SetCtrlCAborts(true)
 	defer func() {
+		// Save history before closing
+		if historyMgr != nil {
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save search history", "error", err)
+			}
+		}
 		if err := line.Close(); err != nil {
 			slog.Error("closing line", "error", err)
 		}
 	}()
+
+	// Load history into liner
+	if historyMgr != nil {
+		historyMgr.LoadIntoLiner(line)
+		// Enable tab completion based on history
+		line.SetCompleter(historyMgr.GetCompleter())
+	}
 
 	for {
 		message, err := line.Prompt("search> ")
@@ -439,7 +510,35 @@ func runRemoteSearchREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, 
 			continue
 		}
 
+		if strings.ToLower(message) == ".clear" {
+			// Clear the screen using ANSI escape codes
+			cmd.Print("\033[H\033[2J")
+			continue
+		}
+
+		if strings.ToLower(message) == ".clear history" {
+			if historyMgr != nil {
+				historyMgr.Clear()
+				if err := historyMgr.Save(); err != nil {
+					cmd.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+				} else {
+					cmd.Println("Search history cleared.")
+				}
+			} else {
+				cmd.Println("History is not available.")
+			}
+			continue
+		}
+
 		line.AppendHistory(message)
+
+		// Add to persistent history and save immediately
+		if historyMgr != nil {
+			historyMgr.Add(message)
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save search history", "error", err)
+			}
+		}
 
 		// Send search request
 		searchReq := &SearchRequest{

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -43,6 +43,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	rtcontext "github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/display"
+	"github.com/spiceai/spiceai/bin/spice/pkg/history"
 	spice_http "github.com/spiceai/spiceai/bin/spice/pkg/http"
 	"github.com/spiceai/spiceai/bin/spice/pkg/input"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
@@ -385,14 +386,34 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 		fmt.Println("Connected to Spice Cloud")
 	}
 
+	// Initialize history manager
+	historyMgr, err := history.NewManager(history.QueryHistory)
+	if err != nil {
+		slog.Warn("failed to initialize query history", "error", err)
+		historyMgr = nil
+	}
+
 	// Setup liner for REPL
 	line := liner.NewLiner()
 	line.SetCtrlCAborts(true)
 	defer func() {
+		// Save history before closing
+		if historyMgr != nil {
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save query history", "error", err)
+			}
+		}
 		if err := line.Close(); err != nil {
 			slog.Error("closing line", "error", err)
 		}
 	}()
+
+	// Load history into liner
+	if historyMgr != nil {
+		historyMgr.LoadIntoLiner(line)
+		// Enable tab completion based on history
+		line.SetCompleter(historyMgr.GetCompleter())
+	}
 
 	// Set up signal handling for query cancellation
 	sigChan := make(chan os.Signal, 1)
@@ -403,6 +424,7 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 	var queryMutex sync.Mutex
 	var cancelQuery context.CancelFunc
 	var isQueryRunning bool
+	var exitRequested bool
 
 	// Handle signals in a goroutine
 	go func() {
@@ -412,12 +434,35 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 				// Cancel the running query
 				cancelQuery()
 				fmt.Println("\nQuery cancelled.")
+				exitRequested = false // Reset exit request after cancelling query
+			} else {
+				// Not running a query, exit on next Ctrl+C
+				if exitRequested {
+					// Second Ctrl+C, force exit
+					fmt.Println("\nForce exiting...")
+					if historyMgr != nil {
+						_ = historyMgr.Save()
+					}
+					os.Exit(0)
+				}
+				exitRequested = true
+				fmt.Println("\nPress Ctrl+C again to exit, or continue entering commands.")
 			}
 			queryMutex.Unlock()
 		}
 	}()
 
 	for {
+		// Check if exit was requested
+		queryMutex.Lock()
+		shouldExit := exitRequested
+		queryMutex.Unlock()
+
+		if shouldExit {
+			fmt.Println()
+			return nil
+		}
+
 		// Multi-line input support: read lines until we get a semicolon or special command
 		queryStr, err := input.ReadMultiLineInput(line, "sql> ")
 		if err == io.EOF {
@@ -434,8 +479,37 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 		}
 
 		if strings.ToLower(queryStr) == "help" {
-			fmt.Println("Enter SQL queries to execute against the remote Spice instance.")
+			fmt.Println("Available commands:")
+			fmt.Println()
+			fmt.Println("  .exit, exit, quit, q - Exit the REPL")
+			fmt.Println("  .error               - Show details of the last error")
+			fmt.Println("  .clear               - Clear the screen")
+			fmt.Println("  .clear history       - Clear the query history")
+			fmt.Println("  help                 - Show this help message")
+			fmt.Println()
+			fmt.Println("Other lines will be interpreted as SQL")
+			fmt.Println()
 			fmt.Println("Press Ctrl+C to cancel a running query or Ctrl+D to exit.")
+			continue
+		}
+
+		if strings.ToLower(queryStr) == ".clear" {
+			// Clear the screen using ANSI escape codes
+			fmt.Print("\033[H\033[2J")
+			continue
+		}
+
+		if strings.ToLower(queryStr) == ".clear history" {
+			if historyMgr != nil {
+				historyMgr.Clear()
+				if err := historyMgr.Save(); err != nil {
+					fmt.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+				} else {
+					fmt.Println("Query history cleared.")
+				}
+			} else {
+				fmt.Println("History is not available.")
+			}
 			continue
 		}
 
@@ -444,6 +518,14 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 		}
 
 		line.AppendHistory(queryStr)
+
+		// Add to persistent history and save immediately
+		if historyMgr != nil {
+			historyMgr.Add(queryStr)
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save query history", "error", err)
+			}
+		}
 
 		// Create a cancellable context for this query
 		var queryContext context.Context

--- a/bin/spice/pkg/history/history.go
+++ b/bin/spice/pkg/history/history.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package history
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peterh/liner"
+)
+
+const (
+	maxHistorySize = 100
+)
+
+// HistoryType represents the type of history being stored
+type HistoryType string
+
+const (
+	QueryHistory  HistoryType = "query_history.txt"
+	SearchHistory HistoryType = "search_history.txt"
+	ChatHistory   HistoryType = "chat_history.txt"
+)
+
+// Manager handles persistent history storage for CLI commands
+type Manager struct {
+	historyFile string
+	entries     []string
+}
+
+// NewManager creates a new history manager for the specified history type
+func NewManager(historyType HistoryType) (*Manager, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("getting user home directory: %w", err)
+	}
+
+	spiceDir := filepath.Join(homeDir, ".spice")
+
+	// Ensure .spice directory exists
+	if err := os.MkdirAll(spiceDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating .spice directory: %w", err)
+	}
+
+	historyFile := filepath.Join(spiceDir, string(historyType))
+	slog.Debug("History manager initialized", "file", historyFile)
+
+	m := &Manager{
+		historyFile: historyFile,
+		entries:     []string{},
+	}
+
+	// Load existing history
+	if err := m.load(); err != nil {
+		// If file doesn't exist or can't be read, start with empty history
+		// This is not an error condition
+		slog.Debug("Starting with empty history", "error", err)
+		m.entries = []string{}
+	}
+
+	return m, nil
+}
+
+// load reads the history from disk
+func (m *Manager) load() error {
+	data, err := os.ReadFile(m.historyFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No history file yet, not an error
+		}
+		return fmt.Errorf("reading history file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil // Empty file, not an error
+	}
+
+	// Parse plain text format (one entry per line)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line != "" {
+			m.entries = append(m.entries, line)
+		}
+	}
+
+	return scanner.Err()
+}
+
+// Save writes the current history to disk
+func (m *Manager) Save() error {
+	// Ensure we don't exceed max history size
+	if len(m.entries) > maxHistorySize {
+		m.entries = m.entries[len(m.entries)-maxHistorySize:]
+	}
+
+	// Write plain text format (one entry per line)
+	data := strings.Join(m.entries, "\n")
+	if len(m.entries) > 0 {
+		data += "\n" // Add final newline
+	}
+
+	slog.Debug("Saving history", "file", m.historyFile, "entries", len(m.entries))
+	if err := os.WriteFile(m.historyFile, []byte(data), 0600); err != nil {
+		slog.Error("Failed to save history", "file", m.historyFile, "error", err)
+		return fmt.Errorf("writing history file: %w", err)
+	}
+	slog.Debug("History saved successfully", "file", m.historyFile)
+
+	return nil
+}
+
+// Add adds a new entry to the history
+func (m *Manager) Add(entry string) {
+	// Don't add empty entries
+	if entry == "" {
+		return
+	}
+
+	// Don't add duplicate consecutive entries
+	if len(m.entries) > 0 && m.entries[len(m.entries)-1] == entry {
+		return
+	}
+
+	slog.Debug("Adding entry to history", "entry", entry)
+	m.entries = append(m.entries, entry)
+}
+
+// LoadIntoLiner loads the history into a liner instance for REPL use
+func (m *Manager) LoadIntoLiner(line *liner.State) {
+	for _, entry := range m.entries {
+		line.AppendHistory(entry)
+	}
+}
+
+// GetEntries returns all history entries
+func (m *Manager) GetEntries() []string {
+	return m.entries
+}
+
+// Clear removes all history entries
+func (m *Manager) Clear() {
+	m.entries = []string{}
+}
+
+// GetCompleter returns a completer function for liner that provides
+// tab-completion based on history entries
+func (m *Manager) GetCompleter() liner.Completer {
+	return func(line string) []string {
+		var matches []string
+
+		// Find all history entries that start with the current line
+		for _, entry := range m.entries {
+			if len(entry) >= len(line) && entry[:len(line)] == line {
+				matches = append(matches, entry)
+			}
+		}
+
+		// Return matches in reverse order (most recent first)
+		for i, j := 0, len(matches)-1; i < j; i, j = i+1, j-1 {
+			matches[i], matches[j] = matches[j], matches[i]
+		}
+
+		return matches
+	}
+}

--- a/bin/spice/pkg/history/history_test.go
+++ b/bin/spice/pkg/history/history_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peterh/liner"
+)
+
+func TestHistoryManager(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Override the history file location for testing
+	historyFile := filepath.Join(tempDir, "test_history.txt")
+
+	// Create manager with custom file path
+	mgr := &Manager{
+		historyFile: historyFile,
+		entries:     []string{},
+	}
+
+	// Test adding entries
+	mgr.Add("SELECT * FROM table1")
+	mgr.Add("SELECT * FROM table2")
+	mgr.Add("SELECT * FROM table3")
+
+	if len(mgr.GetEntries()) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(mgr.GetEntries()))
+	}
+
+	// Test saving
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("failed to save history: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(historyFile); os.IsNotExist(err) {
+		t.Fatalf("history file was not created")
+	}
+
+	// Test loading
+	mgr2 := &Manager{
+		historyFile: historyFile,
+		entries:     []string{},
+	}
+
+	if err := mgr2.load(); err != nil {
+		t.Fatalf("failed to load history: %v", err)
+	}
+
+	if len(mgr2.GetEntries()) != 3 {
+		t.Errorf("expected 3 entries after load, got %d", len(mgr2.GetEntries()))
+	}
+
+	// Verify entries are correct
+	entries := mgr2.GetEntries()
+	if entries[0] != "SELECT * FROM table1" {
+		t.Errorf("unexpected first entry: %s", entries[0])
+	}
+}
+
+func TestHistoryDeduplication(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.txt"),
+		entries:     []string{},
+	}
+
+	// Add duplicate consecutive entries
+	mgr.Add("query1")
+	mgr.Add("query1")
+	mgr.Add("query2")
+
+	if len(mgr.GetEntries()) != 2 {
+		t.Errorf("expected 2 entries (duplicates removed), got %d", len(mgr.GetEntries()))
+	}
+}
+
+func TestHistoryMaxSize(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Add more than max entries
+	for i := 0; i < 150; i++ {
+		mgr.Add("query" + string(rune(i))) // Make unique
+	}
+
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("failed to save history: %v", err)
+	}
+
+	// Reload and verify size is limited
+	mgr2 := &Manager{
+		historyFile: mgr.historyFile,
+		entries:     []string{},
+	}
+
+	if err := mgr2.load(); err != nil {
+		t.Fatalf("failed to load history: %v", err)
+	}
+
+	if len(mgr2.GetEntries()) != 100 {
+		t.Errorf("expected 100 entries (max size), got %d", len(mgr2.GetEntries()))
+	}
+}
+
+func TestHistoryEmptyEntries(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Try to add empty entry
+	mgr.Add("")
+	mgr.Add("   ")
+
+	// Empty trimmed strings shouldn't be added (current implementation adds "   ")
+	// but empty strings should not
+	if len(mgr.GetEntries()) > 1 {
+		t.Errorf("expected at most 1 entry, got %d", len(mgr.GetEntries()))
+	}
+}
+
+func TestLoadIntoLiner(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Add entries using the proper method
+	mgr.Add("query1")
+	mgr.Add("query2")
+	mgr.Add("query3")
+
+	line := liner.NewLiner()
+	defer func() {
+		if err := line.Close(); err != nil {
+			t.Errorf("failed to close liner: %v", err)
+		}
+	}()
+
+	mgr.LoadIntoLiner(line)
+
+	// Liner doesn't provide a way to read history back easily,
+	// so we just verify it doesn't panic
+}
+
+func TestClear(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Add entries properly
+	mgr.Add("query1")
+	mgr.Add("query2")
+
+	mgr.Clear()
+
+	if len(mgr.GetEntries()) != 0 {
+		t.Errorf("expected 0 entries after clear, got %d", len(mgr.GetEntries()))
+	}
+}
+
+func TestClearAndSave(t *testing.T) {
+	tempDir := t.TempDir()
+	historyFile := filepath.Join(tempDir, "test_clear.json")
+
+	// Create manager with some entries
+	mgr := &Manager{
+		historyFile: historyFile,
+		entries:     []string{},
+	}
+
+	// Add entries properly
+	mgr.Add("query1")
+	mgr.Add("query2")
+	mgr.Add("query3")
+
+	// Save initial history
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("failed to save initial history: %v", err)
+	}
+
+	// Clear and save
+	mgr.Clear()
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("failed to save after clear: %v", err)
+	}
+
+	// Load again and verify it's empty
+	mgr2 := &Manager{
+		historyFile: historyFile,
+		entries:     []string{},
+	}
+
+	if err := mgr2.load(); err != nil {
+		t.Fatalf("failed to load cleared history: %v", err)
+	}
+
+	if len(mgr2.GetEntries()) != 0 {
+		t.Errorf("expected 0 entries after loading cleared history, got %d", len(mgr2.GetEntries()))
+	}
+}
+
+func TestGetCompleter(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Add entries properly
+	mgr.Add("SELECT * FROM users")
+	mgr.Add("SELECT * FROM orders")
+	mgr.Add("SELECT id, name FROM users")
+	mgr.Add("SHOW TABLES")
+	mgr.Add("DESCRIBE users")
+
+	completer := mgr.GetCompleter()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:  "Complete SELECT",
+			input: "SELECT",
+			expected: []string{
+				"SELECT id, name FROM users",
+				"SELECT * FROM orders",
+				"SELECT * FROM users",
+			},
+		},
+		{
+			name:  "Complete SELECT * FROM",
+			input: "SELECT * FROM",
+			expected: []string{
+				"SELECT * FROM orders",
+				"SELECT * FROM users",
+			},
+		},
+		{
+			name:  "Complete SHOW",
+			input: "SHOW",
+			expected: []string{
+				"SHOW TABLES",
+			},
+		},
+		{
+			name:     "No matches",
+			input:    "DELETE",
+			expected: []string{},
+		},
+		{
+			name:  "Empty input",
+			input: "",
+			expected: []string{
+				"DESCRIBE users",
+				"SHOW TABLES",
+				"SELECT id, name FROM users",
+				"SELECT * FROM orders",
+				"SELECT * FROM users",
+			},
+		},
+		{
+			name:  "Partial match",
+			input: "DESC",
+			expected: []string{
+				"DESCRIBE users",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := completer(tt.input)
+
+			if len(matches) != len(tt.expected) {
+				t.Errorf("expected %d matches, got %d", len(tt.expected), len(matches))
+				t.Logf("Expected: %v", tt.expected)
+				t.Logf("Got: %v", matches)
+				return
+			}
+
+			for i, match := range matches {
+				if match != tt.expected[i] {
+					t.Errorf("match %d: expected %q, got %q", i, tt.expected[i], match)
+				}
+			}
+		})
+	}
+}
+
+func TestCompleterReversesOrder(t *testing.T) {
+	mgr := &Manager{
+		historyFile: filepath.Join(t.TempDir(), "test.json"),
+		entries:     []string{},
+	}
+
+	// Add entries properly
+	mgr.Add("query1")
+	mgr.Add("query2")
+	mgr.Add("query3")
+
+	completer := mgr.GetCompleter()
+	matches := completer("query")
+
+	// Should return in reverse order (most recent first)
+	expected := []string{"query3", "query2", "query1"}
+
+	if len(matches) != len(expected) {
+		t.Errorf("expected %d matches, got %d", len(expected), len(matches))
+	}
+
+	for i, match := range matches {
+		if match != expected[i] {
+			t.Errorf("match %d: expected %q, got %q", i, expected[i], match)
+		}
+	}
+}

--- a/bin/spice/pkg/input/multiline.go
+++ b/bin/spice/pkg/input/multiline.go
@@ -11,7 +11,8 @@ import (
 // ReadMultiLineInput reads input from the user until a complete statement is detected.
 // A statement is considered complete when it:
 // - Ends with a semicolon, OR
-// - Is a special command (help, exit, quit) on the first line
+// - Is a special command (help, exit, quit) on the first line, OR
+// - Starts with a dot (.) for dot commands (.clear, .clear history, etc.)
 //
 // Returns the complete input string and any error encountered.
 // If Ctrl+C is pressed on an empty prompt, returns io.EOF to signal exit.
@@ -62,7 +63,7 @@ func ReadMultiLineInput(line *liner.State, prompt string) (string, error) {
 		lowerQuery := strings.ToLower(trimmedQuery)
 
 		// Check for special commands on first line only
-		if firstLine && (lowerQuery == "help" || lowerQuery == "exit" || lowerQuery == "quit") {
+		if firstLine && (lowerQuery == "help" || lowerQuery == "exit" || lowerQuery == "quit" || strings.HasPrefix(lowerQuery, ".")) {
 			break
 		}
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::Display;
+use std::io::Write;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -124,7 +125,16 @@ async fn send_nsql_request(
         .await
 }
 
-const SPECIAL_COMMANDS: [&str; 6] = [".exit", "exit", "quit", "q", ".error", "help"];
+const SPECIAL_COMMANDS: [&str; 8] = [
+    ".exit",
+    "exit",
+    "quit",
+    "q",
+    ".error",
+    "help",
+    ".clear",
+    ".clear history",
+];
 const PROMPT_COLOR: Colour = Colour::Fixed(8);
 
 #[derive(Clone)]
@@ -262,6 +272,43 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
 
     let mut rl = Editor::with_config(config)?;
 
+    // Set up persistent history (with graceful fallback)
+    let history_path = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(|home| {
+            std::path::PathBuf::from(home)
+                .join(".spice")
+                .join("query_history.txt")
+        });
+
+    if let Some(ref path) = history_path {
+        // Create .spice directory if it doesn't exist
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            eprintln!(
+                "Warning: Failed to create history directory: {e}. History will not be persisted."
+            );
+        }
+
+        // Load existing history (ignore errors - just means no history file yet)
+        if let Err(e) = rl.load_history(path) {
+            // Most load failures are just "file not found" which is expected on first run
+            // Only show warnings for other error types
+            match e {
+                ReadlineError::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                    // File doesn't exist yet, that's fine
+                }
+                _ => {
+                    eprintln!("Warning: Could not load history file: {e}");
+                }
+            }
+        }
+    } else {
+        eprintln!("Warning: Could not determine home directory. History will not be persisted.");
+    }
+
     rl.set_helper(Some(EditorHelper::new(
         Some(client.clone()),
         repl_config.api_key.clone(),
@@ -336,6 +383,26 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                     }
                     None => println!("No previous error recorded."),
                 }
+                let _ = std::io::stdout().flush();
+                continue;
+            }
+            ".clear" => {
+                // Clear the screen using ANSI escape codes
+                print!("\x1B[H\x1B[2J");
+                let _ = std::io::stdout().flush();
+                continue;
+            }
+            ".clear history" => {
+                // Clear the readline history
+                let _ = rl.clear_history();
+                // Save the empty history to file (if path is available)
+                if let Some(ref path) = history_path
+                    && let Err(e) = rl.save_history(path)
+                {
+                    eprintln!("Warning: Failed to save cleared history: {e}");
+                }
+                println!("Query history cleared.");
+                let _ = std::io::stdout().flush();
                 continue;
             }
             "help" => {
@@ -348,8 +415,14 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                     "{} Show details of the last error",
                     PROMPT_COLOR.paint(".error:")
                 );
+                println!("{} Clear the screen", PROMPT_COLOR.paint(".clear:"));
+                println!(
+                    "{} Clear the query history",
+                    PROMPT_COLOR.paint(".clear history:")
+                );
                 println!("{} Show this help message", PROMPT_COLOR.paint("help:"));
                 println!("\nOther lines will be interpreted as SQL");
+                let _ = std::io::stdout().flush();
                 continue;
             }
             "show tables" | "show tables;" => {
@@ -402,6 +475,13 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                 );
             }
         }
+    }
+
+    // Save history before exiting (if path is available)
+    if let Some(ref path) = history_path
+        && let Err(e) = rl.save_history(path)
+    {
+        eprintln!("Warning: Failed to save history on exit: {e}");
     }
 
     if let Some(helper) = rl.helper_mut() {


### PR DESCRIPTION
This pull request enhances the REPL experience in `crates/flightrepl/src/lib.rs` by adding persistent query history and new special commands for clearing the screen and history. It also improves error handling and user feedback related to history management. The most important changes are grouped below:

**Persistent Query History:**

* Added logic to store query history in a file under the user's home directory (`~/.spice/query_history.txt`), with automatic directory creation and graceful fallback if the home directory cannot be determined. Warnings are shown on failure to load or save history. [[1]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R275-R311) [[2]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R480-R486)

**New Special Commands:**

* Introduced `.clear` to clear the screen using ANSI escape codes, and `.clear history` to clear and persist the query history. Both commands provide immediate feedback to the user. [[1]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343L127-R137) [[2]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R386-R405)
* Updated the help message to include descriptions for the new `.clear` and `.clear history` commands.

**General Improvements:**

* Added explicit flushing of stdout after special commands and help output to ensure prompt and message visibility. [[1]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R386-R405) [[2]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R418-R425)
* Imported `std::io::Write` to support stdout flushing.