### PR TITLE
[CLI] Fix cursor issue due to flush

### DIFF
--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -290,6 +290,8 @@ func runCloudREPL(cmd *cobra.Command, apiKey string) error {
 		fmt.Println()
 		fmt.Printf("Time: %v seconds. %d rows. %s (%s/sec).\n",
 			duration.Seconds(), rowCount, humanize.IBytes(dataSize), humanize.IBytes(uint64(transferRate)))
+		// Flush stdout to ensure readline can properly track cursor position
+		_ = os.Stdout.Sync()
 		return nil
 	}
 
@@ -366,6 +368,8 @@ func runGRPCREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, grpcEndpoint
 		fmt.Println()
 		fmt.Printf("Time: %v seconds. %d rows. %s (%s/sec).\n",
 			duration.Seconds(), rowCount, humanize.IBytes(dataSize), humanize.IBytes(uint64(transferRate)))
+		// Flush stdout to ensure readline can properly track cursor position
+		_ = os.Stdout.Sync()
 		return nil
 	}
 
@@ -656,6 +660,8 @@ func runHTTPREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, httpEndpoint
 		fmt.Println()
 		fmt.Printf("Time: %v seconds. %d rows%s. %s (%s/sec).\n",
 			duration.Seconds(), rowCount, cachedStr, humanize.IBytes(dataSize), humanize.IBytes(uint64(transferRate)))
+		// Flush stdout to ensure readline can properly track cursor position
+		_ = os.Stdout.Sync()
 		return nil
 	}
 

--- a/bin/spice/pkg/display/table.go
+++ b/bin/spice/pkg/display/table.go
@@ -18,6 +18,7 @@ package display
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -94,4 +95,6 @@ func Table(colNames []string, colTypes []string, rows [][]string, colWidths []in
 		fmt.Print("+")
 	}
 	fmt.Println()
+	// Flush stdout to ensure readline/liner can properly track cursor position
+	_ = os.Stdout.Sync()
 }

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -75,9 +75,8 @@ impl EditorHelper {
 
         let handle = tokio::spawn(async move {
             let mut interval = interval(Duration::from_secs(refresh_interval));
-
-            // Initial refresh
-            refresh_schema(client.clone(), &schema_cache, api_key.as_ref(), &user_agent).await;
+            // Skip the first tick since interval.tick() returns immediately the first time
+            interval.tick().await;
 
             loop {
                 tokio::select! {

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -473,6 +473,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                     "{} Unexpected Flight error: {e}. Check connection or query syntax.",
                     Colour::Red.paint("Error:")
                 );
+                let _ = std::io::stdout().flush();
             }
         }
     }
@@ -648,6 +649,7 @@ fn display_records(
             if from_cache { " (cached)" } else { "" }
         );
     }
+    let _ = std::io::stdout().flush();
     Ok(pretty_batches)
 }
 
@@ -786,6 +788,7 @@ fn display_grpc_error(err: &Status) {
         "{} {user_err_msg}",
         Colour::Red.paint(format!("{error_type}:"))
     );
+    let _ = std::io::stdout().flush();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request adds explicit flushing of standard output (`stdout`) after printing error and status messages in the `crates/flightrepl/src/lib.rs` file. This ensures that output is immediately visible to the user, especially in scenarios where buffering might delay message display.

Output flushing improvements:

* Added `std::io::stdout().flush()` after printing unexpected Flight errors in the `run` function to ensure error messages are promptly displayed.
* Added `std::io::stdout().flush()` after displaying record status messages in the `display_records` function for immediate output of status information.
* Added `std::io::stdout().flush()` after printing gRPC error messages in the `display_grpc_error` function to guarantee error visibility.