### PR TITLE
Run Integration tests on spiceai-dev-runners

### DIFF
--- a/.github/actions/setup-oracle-odpi/action.yml
+++ b/.github/actions/setup-oracle-odpi/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Oracle ODPI-C'
+description: 'Install Oracle ODPI-C'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Oracle Instant Client
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libaio1
+
+        # Download and extract Oracle Instant Client
+        curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        mkdir linux
+        unzip basic.zip -d linux -x "META-INF/*"
+        IC_DIR=$PWD/$(ls -d linux/instantclient*)
+
+        # Handle both old and new libaio naming conventions for maximum compatibility
+        # Ubuntu 24.04+ renamed libaio.so.1 to libaio.so.1t64
+        if [ -f /usr/lib/x86_64-linux-gnu/libaio.so.1t64 ] && [ ! -f $IC_DIR/libaio.so.1 ]; then
+          ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 $IC_DIR/libaio.so.1
+        fi
+
+        # Set up library path for Oracle Instant Client
+        echo "LD_LIBRARY_PATH=$IC_DIR:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "Oracle ODPI-C setup completed. Library path: $IC_DIR"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -202,7 +202,7 @@ jobs:
     needs: [build, check_changes]
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: spiceai-dev-runners
     strategy:
       fail-fast: false
       matrix:
@@ -227,13 +227,7 @@ jobs:
 
       - name: Install Oracle ODPI-C
         if: needs.check_changes.outputs.relevant_changes == 'true'
-        run: |
-          curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
-          mkdir linux
-          unzip basic.zip -d linux -x "META-INF/*"
-          IC_DIR=$PWD/$(ls -d linux/instantclient*)
-          ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 $IC_DIR/libaio.so.1
-          echo LD_LIBRARY_PATH=$IC_DIR:$LD_LIBRARY_PATH >> $GITHUB_ENV
+        uses: ./.github/actions/setup-oracle-odpi
 
       # Download the test archive artifact
       - name: Download test archive

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -154,15 +154,7 @@ jobs:
 
       - name: Install Oracle ODPI-C
         if: ${{ contains(github.event.inputs.spicepod_path, 'oracle') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libaio1
-
-          curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
-          mkdir linux
-          unzip basic.zip -d linux -x "META-INF/*"
-          IC_DIR=$PWD/$(ls -d linux/instantclient*)
-          echo LD_LIBRARY_PATH=$IC_DIR:$LD_LIBRARY_PATH >> $GITHUB_ENV
+        uses: ./.github/actions/setup-oracle-odpi
 
       - name: Run the benchmark test - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides == '' }}


### PR DESCRIPTION
## 📝 Summary

Avoid disk space issues when running integration tests by switching to `spiceai-runners` self-hosted runners.
>   2025-11-10T02:44:09.027164Z ERROR integration::refresh_retry::mysql: start_mysql_docker_container: Docker responded with status code 500: write /var/lib/docker/containers/1fd5ff14b5f048b9675dfb7630b84c7b2b4a83dba85630e2601b11572e78b380/hosts: no space left on device

Also create re-usable GH Action to install Oracle ODPI-C

Example test run: https://github.com/spiceai/spiceai/actions/runs/19223431742/job/54946708588

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
