### PR TITLE
Make `cluster` a default feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19328,8 +19328,3 @@ checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "ballista"
-version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990#5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ aws-smithy-runtime = "1.9.3"
 aws-smithy-runtime-api = "1.9.1"
 aws-smithy-types = "1.3.3"
 axum = { version = "0.8", features = ["macros"] }
-ballista = "50.0.0"
 ballista-core = "50.0.0"
 ballista-executor = "50.0.0"
 ballista-scheduler = { version = "50.0.0" }
@@ -322,7 +321,6 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a99494a6f3bad72faa7daecd4477ef42f4e9c046" } # jeadie/25-10-31/temp
 
-ballista = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990" }           # spiceai/spiceai-50
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990" }      # spiceai/spiceai-50
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990" }  # spiceai/spiceai-50
 ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "5d71a6d3f07bf99f7b32e74f3b68b17a1e1e7990" } # spiceai/spiceai-50

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 app = { path = "../../crates/app" }
 clap = { workspace = true, features = ["derive"] }
+cluster = ["runtime/cluster"]
 event_stream = { path = "../../crates/event_stream" }
 flightrepl = { path = "../../crates/flightrepl" }
 futures.workspace = true
@@ -49,7 +50,6 @@ alloc-system = []
 anonymous_telemetry = ["telemetry/anonymous_telemetry"]
 aws-secrets-manager = ["runtime/aws-secrets-manager"]
 clickhouse = ["runtime/clickhouse"]
-cluster = ["runtime/cluster"]
 cuda = ["runtime/cuda"]
 databricks = ["runtime/databricks"]
 debezium = ["runtime/debezium"]

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 [dependencies]
 app = { path = "../../crates/app" }
 clap = { workspace = true, features = ["derive"] }
-cluster = ["runtime/cluster"]
 event_stream = { path = "../../crates/event_stream" }
 flightrepl = { path = "../../crates/flightrepl" }
 futures.workspace = true
@@ -50,6 +49,7 @@ alloc-system = []
 anonymous_telemetry = ["telemetry/anonymous_telemetry"]
 aws-secrets-manager = ["runtime/aws-secrets-manager"]
 clickhouse = ["runtime/clickhouse"]
+cluster = ["runtime/cluster"]
 cuda = ["runtime/cuda"]
 databricks = ["runtime/databricks"]
 debezium = ["runtime/debezium"]
@@ -80,6 +80,7 @@ default = [
     "mongodb",
     "iceberg-write",
     "turso",
+    "cluster",
 ]
 delta_lake = ["runtime/delta_lake"]
 dev = ["runtime/dev"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -229,6 +229,7 @@ cuda = ["llms/cuda"]
 databricks = ["data_components/databricks"]
 debezium = ["kafka", "data_components/debezium"]
 default = [
+    "cluster",
     "keyring-secret-store",
     "aws-secrets-manager",
     "sharepoint",

--- a/crates/runtime/src/datafusion/cluster/physical_plan/optimizer/distribute_file_scan.rs
+++ b/crates/runtime/src/datafusion/cluster/physical_plan/optimizer/distribute_file_scan.rs
@@ -396,6 +396,11 @@ pub mod tests {
         let plan = create_data_source_exec(files);
 
         let mut config_with_max_stages = DEFAULT_CONFIG_OPTIONS.clone();
+        // Set target_partitions to ensure deterministic test behavior
+        // With target_partitions=25, stage_size=50, we get exactly 200 stages from 10000 files
+        config_with_max_stages
+            .set("datafusion.execution.target_partitions", "25")
+            .expect("Must set target_partitions");
         config_with_max_stages
             .set("spice.execution.file_scan_expand_max_stages", "200")
             .expect("Must set config");


### PR DESCRIPTION
This pull request updates dependencies and improves test determinism for cluster-related functionality. The main changes are the removal of a duplicate `ballista` dependency, addition of the `cluster` feature to the default runtime configuration, and an update to a test to ensure deterministic behavior by explicitly setting partitioning parameters.

**Dependency management:**

* Removed the standalone `ballista` dependency from `Cargo.toml` to avoid duplication, ensuring only the sub-crate dependencies (`ballista-core`, `ballista-executor`, `ballista-scheduler`) are used. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L105) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L325)

**Feature configuration:**

* Added the `cluster` feature to the default feature set in `crates/runtime/Cargo.toml`, enabling cluster functionality by default.

**Testing improvements:**

* Updated the test in `distribute_file_scan.rs` to set `datafusion.execution.target_partitions` for deterministic stage calculation, improving reliability of test results.