### PR TITLE
Optimize DuckDB Intermediate Index Materialization for No-Index Case

### DIFF
--- a/crates/datafusion-optimizer-rules/src/physical_plan/duckdb_intermediate_index.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/duckdb_intermediate_index.rs
@@ -328,6 +328,10 @@ impl PhysicalOptimizerRule for DuckDBIntermediateIndexMaterializationOptimizer {
             return Ok(plan);
         };
 
+        if duck_exec.indexes().is_empty() {
+            return Ok(plan);
+        }
+
         // Get its SQL + statement
         let sql = duck_exec.base_sql().map_err(|e| {
             DataFusionError::Execution(format!("Unable to generate DuckDB SQL: {e}"))


### PR DESCRIPTION
## 📝 Summary

The DuckDB intermediate index materialization optimizer was performing SQL generation and AST parsing even when no indexes were defined on the table.

Added an early return check immediately after obtaining the DuckSqlExec to verify if any indexes exist before proceeding with further operations.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
