### PR TITLE
Use use_rustls_tls for Spice Cloud /connect

### DIFF
--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -87,6 +87,10 @@ pub enum Error {
     #[snafu(display("Failed to build catalog: {source}"))]
     #[snafu(visibility(pub(crate)))]
     UnableToBuildCatalog { source: iceberg::Error },
+
+    #[snafu(display("Failed to build catalog client: {source}"))]
+    #[snafu(visibility(pub(crate)))]
+    UnableToBuildCatalogClient { source: reqwest::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -15,7 +15,9 @@ limitations under the License.
 */
 
 use super::{CatalogConnector, ConnectorComponent, ParameterSpec, Parameters};
-use crate::catalogconnector::iceberg::{Error as IcebergError, UnableToBuildCatalogSnafu};
+use crate::catalogconnector::iceberg::{
+    Error as IcebergError, UnableToBuildCatalogClientSnafu, UnableToBuildCatalogSnafu,
+};
 use crate::component::dataset::builder::DatasetBuilder;
 use crate::{
     App, Runtime,
@@ -124,8 +126,14 @@ impl SpiceCloudPlatformCatalog {
             props.insert("token".to_string(), api_key.to_string());
         }
 
+        let client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .build()
+            .context(UnableToBuildCatalogClientSnafu)?;
+
         props.insert(REST_CATALOG_PROP_URI.to_string(), endpoint.to_string());
         let iceberg_rest_catalog = RestCatalogBuilder::default()
+            .with_client(client)
             .load("rest", props)
             .await
             .context(UnableToBuildCatalogSnafu)?;

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -146,6 +146,7 @@ impl SpiceExtension {
         body: Req,
     ) -> Result<Resp, Error> {
         let client = reqwest::Client::builder()
+            .use_rustls_tls()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(1800))
             .build()


### PR DESCRIPTION
This pull request makes a minor change to the HTTP client configuration in the `SpiceExtension` implementation. The change ensures that the `reqwest` client uses Rustls for TLS connections, which can improve security and compatibility.

* Updated the HTTP client in `crates/spice_cloud/src/lib.rs` to use Rustls for TLS by adding `.use_rustls_tls()` to the `reqwest::Client` builder.