### PR TITLE
[Acceleration] DuckDB tables mode partitioner + CTE rewrite optimizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4b8f8329f715c47cde9a3d30a73cfe98bfb16154#4b8f8329f715c47cde9a3d30a73cfe98bfb16154"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5394b17d6ac668db14ab02dcbc0c30fefbf3b790#5394b17d6ac668db14ab02dcbc0c30fefbf3b790"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = 
 datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "251010e26c8529bd345cc2cea28ef56e5d9aaf65" }               # spiceai/spiceai-50
 datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "251010e26c8529bd345cc2cea28ef56e5d9aaf65" }                   # spiceai/spiceai-50
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4b8f8329f715c47cde9a3d30a73cfe98bfb16154" } # Jeadie:jeadie/25-11-11/undo
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5394b17d6ac668db14ab02dcbc0c30fefbf3b790"} # spiceai
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "d6e7ebd853463acafaf8132dced23c98c45f7947" } # jeadie/25-10-31/temp
 

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -345,7 +345,8 @@ impl PartitionCreator for DuckDBPartitionCreator {
 
         let duckdb_table_factory = DuckDBTableFactory::new(Arc::clone(&self.pool))
             .with_dialect(new_duckdb_dialect())
-            .with_schema(Arc::clone(&self.schema));
+            .with_schema(Arc::clone(&self.schema))
+            .with_indexes(self.table_definition.indexes().iter().cloned().collect());
 
         let mut partitions = Vec::with_capacity(partitioned_tables.len());
         for table in partitioned_tables {

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -346,7 +346,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
         let duckdb_table_factory = DuckDBTableFactory::new(Arc::clone(&self.pool))
             .with_dialect(new_duckdb_dialect())
             .with_schema(Arc::clone(&self.schema))
-            .with_indexes(self.table_definition.indexes().iter().cloned().collect());
+            .with_indexes(self.table_definition.indexes().to_vec());
 
         let mut partitions = Vec::with_capacity(partitioned_tables.len());
         for table in partitioned_tables {


### PR DESCRIPTION
## 📝 Summary

Related: https://github.com/datafusion-contrib/datafusion-table-providers/pull/489

- Specifies indexes from table definition so that `DuckSqlExec` has them, and the CTE optimizer can do its rewrite
- For this to trigger
  - The indexes must be on different columns from those that are partitioned
  - You still need to satisfy `...where index_predicate AND something_else`, because just index_predicate = keep original query