### PR TITLE
Upgrade shutdown signal Ordering

### DIFF
--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -87,7 +87,7 @@ impl RuntimeStatus {
 
     #[must_use]
     pub fn is_shutdown(&self) -> bool {
-        self.is_shutdown.load(Ordering::Relaxed)
+        self.is_shutdown.load(Ordering::SeqCst)
     }
 
     /// Updates the status of a component and tracks if it has ever been ready.
@@ -273,6 +273,6 @@ impl RuntimeStatus {
 
     /// Sets the runtime to the shutting down state.
     pub fn mark_shutdown(&self) {
-        self.is_shutdown.store(true, Ordering::Relaxed);
+        self.is_shutdown.store(true, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
## 📝 Summary

We've been using `Ordering::Relaxed` which seems to be insufficient to properly handle synchronization between threads in single-digit millisecond timeframes. 
Upgraded to `Ordering::SeqCst` to ensure the shutdown flag is immediately visible across all threads.

Example:
```
2025-11-10T23:37:25.012729Z  INFO runtime: Shutdown initiated; waiting up to 30s for connections to drain
2025-11-10T23:37:25.014379Z  WARN runtime::accelerated_table::refresh_task: Failed to load data for dataset data_upsert (duckdb): Failed to find latest timestamp in accelerated table. Is the 'time_column' parameter correct?
```