### PR TITLE
Set max-age: 0 during stale

### DIFF
--- a/crates/runtime/src/flight/util.rs
+++ b/crates/runtime/src/flight/util.rs
@@ -44,7 +44,14 @@ pub fn attach_cache_metadata<T>(
         if let Some(cache_provider) = df.results_cache_provider()
             && let Some(stale_duration) = cache_provider.stale_while_revalidate_ttl()
         {
-            let max_age = cache_provider.ttl().as_secs();
+            // When serving stale content, set max-age=0 to indicate the response is not fresh
+            // The results-cache-status metadata will indicate STALE
+            let max_age = if results_cache_status == CacheStatus::CacheStaleWhileRevalidate {
+                0
+            } else {
+                cache_provider.ttl().as_secs()
+            };
+
             let cache_control_value = format!(
                 "max-age={}, stale-while-revalidate={}",
                 max_age,

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -304,7 +304,14 @@ fn attach_cache_headers(
         if let Some(cache_provider) = df.results_cache_provider()
             && let Some(stale_duration) = cache_provider.stale_while_revalidate_ttl()
         {
-            let max_age = cache_provider.ttl().as_secs();
+            // When serving stale content, set max-age=0 to indicate the response is not fresh
+            // The Results-Cache-Status header will indicate STALE
+            let max_age = if results_cache_status == CacheStatus::CacheStaleWhileRevalidate {
+                0
+            } else {
+                cache_provider.ttl().as_secs()
+            };
+
             let cache_control_value = format!(
                 "max-age={}, stale-while-revalidate={}",
                 max_age,


### PR DESCRIPTION
This pull request improves cache metadata and header handling for stale cache responses. The main change is to set `max-age=0` in the `Cache-Control` header and metadata when serving stale content, making it clear to clients that the response is not fresh. This ensures better cache behavior and transparency.

**Cache header and metadata handling:**

* Updated `attach_cache_metadata` in `crates/runtime/src/flight/util.rs` to set `max-age=0` in the metadata when serving stale content, with a comment clarifying that the results-cache-status metadata will indicate STALE.
* Updated `attach_cache_headers` in `crates/runtime/src/http/v1/mod.rs` to set `max-age=0` in the HTTP header when serving stale content, with a comment clarifying that the Results-Cache-Status header will indicate STALE.