### PR TITLE
[CLI] Improve auto-complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6032,6 +6032,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "tracing",
  "winver",
 ]
 

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -448,11 +448,6 @@ func runGRPCREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, grpcEndpoint
 	return runREPLWithMetadata(grpcEndpoint, grpcExecutor, metadataFetcher)
 }
 
-// runREPL provides a common REPL experience for all SQL execution modes
-func runREPL(endpoint string, executor QueryExecutor) error {
-	return runREPLWithMetadata(endpoint, executor, nil)
-}
-
 // runREPLWithMetadata provides a common REPL experience with metadata fetching support
 func runREPLWithMetadata(endpoint string, executor QueryExecutor, metadataFetcher sqlcompleter.MetadataFetcher) error {
 	return runREPLWithHealthAndMetadata(endpoint, executor, metadataFetcher, 0, false)

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -46,6 +46,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/history"
 	spice_http "github.com/spiceai/spiceai/bin/spice/pkg/http"
 	"github.com/spiceai/spiceai/bin/spice/pkg/input"
+	"github.com/spiceai/spiceai/bin/spice/pkg/sqlcompleter"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
@@ -295,8 +296,43 @@ func runCloudREPL(cmd *cobra.Command, apiKey string) error {
 		return nil
 	}
 
-	// Use the consolidated REPL
-	return runREPL("spice-cloud", cloudExecutor)
+	// Create metadata fetcher for autocomplete
+	cloudMetadataFetcher := func(ctx context.Context, query string) ([]string, error) {
+		reader, err := spiceClient.Query(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Release()
+
+		var results []string
+		for reader.Next() {
+			record := reader.Record()
+			if record.NumCols() == 0 {
+				continue
+			}
+
+			// Get the first column
+			col := record.Column(0)
+
+			// Convert to string array
+			if stringArray, ok := col.(*array.String); ok {
+				for i := 0; i < stringArray.Len(); i++ {
+					if !stringArray.IsNull(i) {
+						results = append(results, stringArray.Value(i))
+					}
+				}
+			}
+		}
+
+		if err := reader.Err(); err != nil {
+			return nil, err
+		}
+
+		return results, nil
+	}
+
+	// Use the consolidated REPL with metadata support
+	return runREPLWithMetadata("spice-cloud", cloudExecutor, cloudMetadataFetcher)
 }
 
 func runGRPCREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, grpcEndpoint string) error {
@@ -373,17 +409,62 @@ func runGRPCREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, grpcEndpoint
 		return nil
 	}
 
-	// Use the consolidated REPL
-	return runREPL(grpcEndpoint, grpcExecutor)
+	// Create metadata fetcher for autocomplete
+	metadataFetcher := func(ctx context.Context, query string) ([]string, error) {
+		reader, err := spiceClient.Query(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Release()
+
+		var results []string
+		for reader.Next() {
+			record := reader.Record()
+			if record.NumCols() == 0 {
+				continue
+			}
+
+			// Get the first column
+			col := record.Column(0)
+
+			// Convert to string array
+			if stringArray, ok := col.(*array.String); ok {
+				for i := 0; i < stringArray.Len(); i++ {
+					if !stringArray.IsNull(i) {
+						results = append(results, stringArray.Value(i))
+					}
+				}
+			}
+		}
+
+		if err := reader.Err(); err != nil {
+			return nil, err
+		}
+
+		return results, nil
+	}
+
+	// Use the consolidated REPL with metadata support
+	return runREPLWithMetadata(grpcEndpoint, grpcExecutor, metadataFetcher)
 }
 
 // runREPL provides a common REPL experience for all SQL execution modes
 func runREPL(endpoint string, executor QueryExecutor) error {
-	return runREPLWithHealth(endpoint, executor, 0, false)
+	return runREPLWithMetadata(endpoint, executor, nil)
+}
+
+// runREPLWithMetadata provides a common REPL experience with metadata fetching support
+func runREPLWithMetadata(endpoint string, executor QueryExecutor, metadataFetcher sqlcompleter.MetadataFetcher) error {
+	return runREPLWithHealthAndMetadata(endpoint, executor, metadataFetcher, 0, false)
 }
 
 // runREPLWithHealth provides a common REPL experience with optional health check info
 func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration time.Duration, healthOk bool) error {
+	return runREPLWithHealthAndMetadata(endpoint, executor, nil, checkDuration, healthOk)
+}
+
+// runREPLWithHealthAndMetadata provides a common REPL experience with optional health check info and metadata fetching
+func runREPLWithHealthAndMetadata(endpoint string, executor QueryExecutor, metadataFetcher sqlcompleter.MetadataFetcher, checkDuration time.Duration, healthOk bool) error {
 	fmt.Println("Welcome to the Spice.ai SQL REPL! Type 'help' for help.")
 	fmt.Println()
 	if endpoint == "spice-cloud" {
@@ -412,11 +493,26 @@ func runREPLWithHealth(endpoint string, executor QueryExecutor, checkDuration ti
 		}
 	}()
 
-	// Load history into liner
+	// Load history into liner and setup SQL-aware completer
 	if historyMgr != nil {
 		historyMgr.LoadIntoLiner(line)
-		// Enable tab completion based on history
-		line.SetCompleter(historyMgr.GetCompleter())
+
+		// Create SQL-aware completer
+		sqlComp := sqlcompleter.New()
+		sqlComp.SetHistoryCompleter(historyMgr.GetCompleter())
+
+		// Set metadata fetcher if provided
+		if metadataFetcher != nil {
+			sqlComp.SetMetadataFetcher(metadataFetcher)
+			// Perform initial metadata refresh synchronously to ensure autocomplete works immediately
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			if err := sqlComp.RefreshMetadata(ctx); err != nil {
+				slog.Debug("failed to refresh metadata for autocomplete", "error", err)
+			}
+			cancel()
+		}
+
+		line.SetCompleter(sqlComp.Complete)
 	}
 
 	// Set up signal handling for query cancellation

--- a/bin/spice/pkg/history/history.go
+++ b/bin/spice/pkg/history/history.go
@@ -182,3 +182,8 @@ func (m *Manager) GetCompleter() liner.Completer {
 		return matches
 	}
 }
+
+// GetHistoryEntries returns the history entries for use by other completers
+func (m *Manager) GetHistoryEntries() []string {
+	return m.entries
+}

--- a/bin/spice/pkg/sqlcompleter/completer.go
+++ b/bin/spice/pkg/sqlcompleter/completer.go
@@ -1,0 +1,406 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlcompleter
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/peterh/liner"
+)
+
+// MetadataFetcher is a function that executes a query and returns string results
+type MetadataFetcher func(ctx context.Context, query string) ([]string, error)
+
+// Completer provides intelligent SQL autocomplete
+type Completer struct {
+	keywords    []string
+	tables      []string
+	schemas     []string
+	columns     []string
+	udfs        []string
+	udtfs       []string
+	historyFunc liner.Completer
+	fetcher     MetadataFetcher
+}
+
+// New creates a new SQL completer
+func New() *Completer {
+	return &Completer{
+		keywords: []string{},
+		tables:   []string{},
+		schemas:  []string{},
+		columns:  []string{},
+		udfs:     []string{},
+		udtfs:    []string{},
+	}
+}
+
+// SetMetadataFetcher sets the function to fetch metadata from the database
+func (c *Completer) SetMetadataFetcher(fetcher MetadataFetcher) {
+	c.fetcher = fetcher
+}
+
+// RefreshMetadata fetches fresh metadata from the database
+func (c *Completer) RefreshMetadata(ctx context.Context) error {
+	if c.fetcher == nil {
+		return nil
+	}
+
+	// Fetch tables and views with schema information
+	// We need both table_schema and table_name to handle public schema specially
+	tablesWithSchema, err := c.fetcher(ctx, "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name")
+	if err == nil {
+		// Process table names to handle public schema specially
+		tableMap := make(map[string]bool)
+		for _, fullName := range tablesWithSchema {
+			// Always add the fully qualified name
+			tableMap[fullName] = true
+			
+			// For public schema, also add unqualified name
+			if len(fullName) > 7 && fullName[:7] == "public." {
+				unqualifiedName := fullName[7:] // Remove "public." prefix
+				tableMap[unqualifiedName] = true
+			}
+		}
+		
+		// Convert map to slice
+		c.tables = make([]string, 0, len(tableMap))
+		for name := range tableMap {
+			c.tables = append(c.tables, name)
+		}
+	}
+
+	// Fetch schemas
+	schemas, err := c.fetcher(ctx, "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY table_schema")
+	if err == nil {
+		c.schemas = schemas
+	}
+
+	// Fetch columns
+	columns, err := c.fetcher(ctx, "--autocomplete\nSELECT DISTINCT column_name FROM information_schema.columns ORDER BY column_name")
+	if err == nil {
+		c.columns = columns
+	}
+
+	// Fetch UDFs (User Defined Functions)
+	udfs, err := c.fetcher(ctx, "--autocomplete\nSELECT name FROM list_udfs() ORDER BY name")
+	if err == nil {
+		c.udfs = udfs
+	}
+
+	// Fetch UDTFs (User Defined Table Functions)
+	udtfs, err := c.fetcher(ctx, "--autocomplete\nSELECT name FROM list_udtfs() ORDER BY name")
+	if err == nil {
+		c.udtfs = udtfs
+	}
+
+	// Fetch DataFusion keywords - use SQL standard keywords if query fails
+	keywords, err := c.fetcher(ctx, "--autocomplete\nSELECT keyword FROM information_schema.df_settings WHERE name = 'datafusion.sql_parser.keywords'")
+	if err == nil && len(keywords) > 0 {
+		// Parse keywords if they come as a comma-separated string
+		var allKeywords []string
+		if len(keywords) == 1 {
+			allKeywords = strings.Split(strings.ToLower(keywords[0]), ",")
+			for i := range allKeywords {
+				allKeywords[i] = strings.TrimSpace(allKeywords[i])
+			}
+		} else {
+			allKeywords = keywords
+		}
+		
+		// Filter to only include useful statement keywords and common clauses
+		// Exclude reserved words that aren't useful as autocomplete suggestions
+		c.keywords = filterUsefulKeywords(allKeywords)
+	} else {
+		// Fallback to common SQL keywords if we can't fetch from DataFusion
+		c.keywords = []string{
+			"select", "from", "where", "join", "inner", "left", "right", "outer",
+			"on", "and", "or", "not", "in", "like", "between", "is", "null",
+			"order", "by", "group", "having", "limit", "offset", "distinct",
+			"as", "case", "when", "then", "else", "end", "union", "intersect",
+			"except", "insert", "into", "values", "update", "set", "delete",
+			"create", "table", "index", "view", "drop", "alter", "truncate",
+			"desc", "asc", "primary", "key", "foreign", "references", "constraint",
+			"unique", "check", "default", "with", "exists", "any", "all",
+			"cross", "natural", "using", "cast", "extract", "interval",
+			"show", "tables", "databases", "schemas", "columns",
+		}
+	}
+
+	return nil
+}
+
+// filterUsefulKeywords filters the full list of DataFusion keywords to only include
+// those that are useful as autocomplete suggestions (statement starters and common clauses)
+func filterUsefulKeywords(allKeywords []string) []string {
+	// Define useful keyword categories
+	useful := map[string]bool{
+		// Query statements
+		"select": true, "from": true, "where": true, "having": true, "order": true, "group": true,
+		"limit": true, "offset": true, "distinct": true, "union": true, "intersect": true, "except": true,
+		
+		// Join types
+		"join": true, "inner": true, "left": true, "right": true, "full": true, "cross": true,
+		"outer": true, "natural": true, "on": true, "using": true,
+		
+		// Boolean operators
+		"and": true, "or": true, "not": true, "in": true, "exists": true, "between": true,
+		"like": true, "ilike": true, "is": true, "null": true,
+		
+		// Common keywords
+		"as": true, "asc": true, "desc": true, "by": true, "all": true, "any": true,
+		"case": true, "when": true, "then": true, "else": true, "end": true,
+		
+		// DML statements
+		"insert": true, "into": true, "values": true, "update": true, "set": true, "delete": true,
+		
+		// DDL statements
+		"create": true, "alter": true, "drop": true, "truncate": true,
+		"table": true, "view": true, "index": true, "schema": true, "database": true,
+		
+		// Constraints and keys
+		"primary": true, "foreign": true, "key": true, "references": true,
+		"unique": true, "constraint": true, "check": true, "default": true,
+		
+		// Functions and casts
+		"cast": true, "extract": true, "interval": true, "current_date": true, "current_time": true,
+		"current_timestamp": true,
+		
+		// CTEs and subqueries
+		"with": true, "recursive": true,
+		
+		// SHOW commands
+		"show": true, "tables": true, "schemas": true, "columns": true, "databases": true,
+		
+		// DESCRIBE/EXPLAIN
+		"describe": true, "explain": true, "analyze": true,
+	}
+	
+	var filtered []string
+	for _, kw := range allKeywords {
+		if useful[kw] {
+			filtered = append(filtered, kw)
+		}
+	}
+	
+	// If filtering resulted in too few keywords, use the fallback list
+	if len(filtered) < 20 {
+		return []string{
+			"select", "from", "where", "join", "inner", "left", "right", "outer",
+			"on", "and", "or", "not", "in", "like", "between", "is", "null",
+			"order", "by", "group", "having", "limit", "offset", "distinct",
+			"as", "case", "when", "then", "else", "end", "union", "intersect",
+			"except", "insert", "into", "values", "update", "set", "delete",
+			"create", "table", "index", "view", "drop", "alter", "truncate",
+			"desc", "asc", "primary", "key", "foreign", "references", "constraint",
+			"unique", "check", "default", "with", "exists", "any", "all",
+			"cross", "natural", "using", "cast", "extract", "interval",
+			"show", "tables", "databases", "schemas", "columns",
+		}
+	}
+	
+	return filtered
+}
+
+// SetKeywords updates the list of SQL keywords
+func (c *Completer) SetKeywords(keywords []string) {
+	c.keywords = keywords
+}
+
+// SetTables updates the list of available tables
+func (c *Completer) SetTables(tables []string) {
+	c.tables = tables
+}
+
+// SetColumns updates the list of available columns
+func (c *Completer) SetColumns(columns []string) {
+	c.columns = columns
+}
+
+// SetUDFs updates the list of available user-defined functions
+func (c *Completer) SetUDFs(udfs []string) {
+	c.udfs = udfs
+}
+
+// SetHistoryCompleter sets the history-based completer
+func (c *Completer) SetHistoryCompleter(historyFunc liner.Completer) {
+	c.historyFunc = historyFunc
+}
+
+// Complete implements liner.Completer interface
+func (c *Completer) Complete(line string) []string {
+	if line == "" {
+		return []string{}
+	}
+
+	// Extract the current word being typed
+	word, beforeWord := extractCurrentWord(line)
+	wordLower := strings.ToLower(word)
+	beforeWordLower := strings.ToLower(beforeWord)
+
+	var matches []string
+	seen := make(map[string]bool)
+
+	// Determine context based on what comes before
+	shouldSuggestOnlyTables := shouldSuggestTables(beforeWordLower)
+
+	if shouldSuggestOnlyTables {
+		// Only suggest tables after FROM or JOIN
+		for _, table := range c.tables {
+			if strings.HasPrefix(strings.ToLower(table), wordLower) {
+				completion := reconstructCompletion(line, word, table+" ")
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+	} else {
+		// Suggest keywords
+		for _, keyword := range c.keywords {
+			if strings.HasPrefix(keyword, wordLower) {
+				completion := reconstructCompletion(line, word, keyword+" ")
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+
+		// Suggest schemas
+		for _, schema := range c.schemas {
+			if strings.HasPrefix(strings.ToLower(schema), wordLower) {
+				completion := reconstructCompletion(line, word, schema+".")
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+
+		// Suggest UDFs
+		for _, udf := range c.udfs {
+			if strings.HasPrefix(strings.ToLower(udf), wordLower) {
+				completion := reconstructCompletion(line, word, udf)
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+
+		// Suggest UDTFs
+		for _, udtf := range c.udtfs {
+			if strings.HasPrefix(strings.ToLower(udtf), wordLower) {
+				completion := reconstructCompletion(line, word, udtf)
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+
+		// Suggest tables
+		for _, table := range c.tables {
+			if strings.HasPrefix(strings.ToLower(table), wordLower) {
+				completion := reconstructCompletion(line, word, table+" ")
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+
+		// Suggest columns
+		for _, column := range c.columns {
+			if strings.HasPrefix(strings.ToLower(column), wordLower) {
+				completion := reconstructCompletion(line, word, column+" ")
+				if !seen[completion] {
+					matches = append(matches, completion)
+					seen[completion] = true
+				}
+			}
+		}
+	}
+
+	// Add history-based suggestions only if the line is completely empty
+	if c.historyFunc != nil && line == "" {
+		historyMatches := c.historyFunc(line)
+		for _, match := range historyMatches {
+			if !seen[match] {
+				matches = append(matches, match)
+				seen[match] = true
+			}
+		}
+	}
+
+	return matches
+}
+
+// extractCurrentWord extracts the word currently being typed and everything before it
+func extractCurrentWord(line string) (word string, beforeWord string) {
+	// Find the position of the last word boundary
+	pos := len(line)
+	for i := len(line) - 1; i >= 0; i-- {
+		if isWordBoundary(rune(line[i])) {
+			pos = i + 1
+			break
+		}
+		if i == 0 {
+			pos = 0
+		}
+	}
+
+	word = line[pos:]
+	beforeWord = strings.TrimRight(line[:pos], " \t\n\r")
+	return word, beforeWord
+}
+
+// isWordBoundary returns true if the character is a word boundary
+func isWordBoundary(ch rune) bool {
+	return unicode.IsSpace(ch) ||
+		ch == '(' || ch == ')' || ch == ',' || ch == ';' ||
+		ch == '=' || ch == '<' || ch == '>' || ch == '!' ||
+		ch == '+' || ch == '-' || ch == '*' || ch == '/' || ch == '%' ||
+		ch == '\'' || ch == '"' || ch == '`' ||
+		ch == '.' || ch == '[' || ch == ']' || ch == '{' || ch == '}' ||
+		ch == '|' || ch == '&' || ch == '^' || ch == '~'
+}
+
+// shouldSuggestTables returns true if we should only suggest tables (after FROM or JOIN)
+func shouldSuggestTables(beforeWord string) bool {
+	// Check if the last complete word is "from" or "join"
+	words := strings.Fields(beforeWord)
+	if len(words) == 0 {
+		return false
+	}
+
+	lastWord := words[len(words)-1]
+	return lastWord == "from" || lastWord == "join"
+}
+
+// reconstructCompletion rebuilds the full line with the completion
+func reconstructCompletion(line, word, completion string) string {
+	if word == "" {
+		return line + completion
+	}
+	// Replace the current word with the completion
+	pos := len(line) - len(word)
+	return line[:pos] + completion
+}

--- a/bin/spice/pkg/sqlcompleter/completer.go
+++ b/bin/spice/pkg/sqlcompleter/completer.go
@@ -71,14 +71,14 @@ func (c *Completer) RefreshMetadata(ctx context.Context) error {
 		for _, fullName := range tablesWithSchema {
 			// Always add the fully qualified name
 			tableMap[fullName] = true
-			
+
 			// For public schema, also add unqualified name
 			if len(fullName) > 7 && fullName[:7] == "public." {
 				unqualifiedName := fullName[7:] // Remove "public." prefix
 				tableMap[unqualifiedName] = true
 			}
 		}
-		
+
 		// Convert map to slice
 		c.tables = make([]string, 0, len(tableMap))
 		for name := range tableMap {
@@ -123,7 +123,7 @@ func (c *Completer) RefreshMetadata(ctx context.Context) error {
 		} else {
 			allKeywords = keywords
 		}
-		
+
 		// Filter to only include useful statement keywords and common clauses
 		// Exclude reserved words that aren't useful as autocomplete suggestions
 		c.keywords = filterUsefulKeywords(allKeywords)
@@ -154,51 +154,51 @@ func filterUsefulKeywords(allKeywords []string) []string {
 		// Query statements
 		"select": true, "from": true, "where": true, "having": true, "order": true, "group": true,
 		"limit": true, "offset": true, "distinct": true, "union": true, "intersect": true, "except": true,
-		
+
 		// Join types
 		"join": true, "inner": true, "left": true, "right": true, "full": true, "cross": true,
 		"outer": true, "natural": true, "on": true, "using": true,
-		
+
 		// Boolean operators
 		"and": true, "or": true, "not": true, "in": true, "exists": true, "between": true,
 		"like": true, "ilike": true, "is": true, "null": true,
-		
+
 		// Common keywords
 		"as": true, "asc": true, "desc": true, "by": true, "all": true, "any": true,
 		"case": true, "when": true, "then": true, "else": true, "end": true,
-		
+
 		// DML statements
 		"insert": true, "into": true, "values": true, "update": true, "set": true, "delete": true,
-		
+
 		// DDL statements
 		"create": true, "alter": true, "drop": true, "truncate": true,
 		"table": true, "view": true, "index": true, "schema": true, "database": true,
-		
+
 		// Constraints and keys
 		"primary": true, "foreign": true, "key": true, "references": true,
 		"unique": true, "constraint": true, "check": true, "default": true,
-		
+
 		// Functions and casts
 		"cast": true, "extract": true, "interval": true, "current_date": true, "current_time": true,
 		"current_timestamp": true,
-		
+
 		// CTEs and subqueries
 		"with": true, "recursive": true,
-		
+
 		// SHOW commands
 		"show": true, "tables": true, "schemas": true, "columns": true, "databases": true,
-		
+
 		// DESCRIBE/EXPLAIN
 		"describe": true, "explain": true, "analyze": true,
 	}
-	
+
 	var filtered []string
 	for _, kw := range allKeywords {
 		if useful[kw] {
 			filtered = append(filtered, kw)
 		}
 	}
-	
+
 	// If filtering resulted in too few keywords, use the fallback list
 	if len(filtered) < 20 {
 		return []string{
@@ -214,7 +214,7 @@ func filterUsefulKeywords(allKeywords []string) []string {
 			"show", "tables", "databases", "schemas", "columns",
 		}
 	}
-	
+
 	return filtered
 }
 

--- a/bin/spice/pkg/sqlcompleter/completer.go
+++ b/bin/spice/pkg/sqlcompleter/completer.go
@@ -110,6 +110,12 @@ func (c *Completer) RefreshMetadata(ctx context.Context) error {
 		c.udtfs = udtfs
 	}
 
+	// Fetch built-in functions from information_schema.routines
+	builtinFunctions, err := c.fetcher(ctx, "--autocomplete\nSELECT routine_name FROM information_schema.routines ORDER BY routine_name")
+	if err == nil {
+		c.udfs = append(c.udfs, builtinFunctions...)
+	}
+
 	// Fetch DataFusion keywords - use SQL standard keywords if query fails
 	keywords, err := c.fetcher(ctx, "--autocomplete\nSELECT keyword FROM information_schema.df_settings WHERE name = 'datafusion.sql_parser.keywords'")
 	if err == nil && len(keywords) > 0 {

--- a/bin/spice/pkg/sqlcompleter/completer_test.go
+++ b/bin/spice/pkg/sqlcompleter/completer_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlcompleter
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRefreshMetadata(t *testing.T) {
+	c := New()
+
+	// Mock metadata fetcher
+	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
+		switch {
+		case query == "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
+			// Return schema-qualified names (simulating public.users, analytics.products, etc.)
+			return []string{"public.users", "analytics.products", "public.orders"}, nil
+		case query == "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY table_schema":
+			return []string{"public", "analytics"}, nil
+		case query == "--autocomplete\nSELECT DISTINCT column_name FROM information_schema.columns ORDER BY column_name":
+			return []string{"id", "name", "email", "price"}, nil
+		case query == "--autocomplete\nSELECT name FROM list_udfs() ORDER BY name":
+			return []string{"count", "sum", "avg"}, nil
+		case query == "--autocomplete\nSELECT name FROM list_udtfs() ORDER BY name":
+			return []string{"generate_series", "unnest"}, nil
+		default:
+			// For keywords query, return fallback
+			return []string{}, nil
+		}
+	})
+
+	// Refresh metadata
+	err := c.RefreshMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshMetadata failed: %v", err)
+	}
+
+	// Verify tables were populated - should have both qualified and unqualified names
+	// public.users -> users, public.users
+	// analytics.products -> analytics.products only
+	// public.orders -> orders, public.orders
+	// Total: 5 unique names
+	if len(c.tables) != 5 {
+		t.Errorf("Expected 5 table entries (with public schema unqualified), got %d: %v", len(c.tables), c.tables)
+	}
+
+	// Verify schemas were populated
+	if len(c.schemas) != 2 {
+		t.Errorf("Expected 2 schemas, got %d", len(c.schemas))
+	}
+
+	// Verify columns were populated
+	if len(c.columns) != 4 {
+		t.Errorf("Expected 4 columns, got %d", len(c.columns))
+	}
+
+	// Verify UDFs were populated
+	if len(c.udfs) != 3 {
+		t.Errorf("Expected 3 UDFs, got %d", len(c.udfs))
+	}
+
+	// Verify UDTFs were populated
+	if len(c.udtfs) != 2 {
+		t.Errorf("Expected 2 UDTFs, got %d", len(c.udtfs))
+	}
+
+	// Verify keywords fallback was used
+	if len(c.keywords) == 0 {
+		t.Error("Expected fallback keywords to be populated")
+	}
+}
+
+func TestExtractCurrentWord(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedWord   string
+		expectedBefore string
+	}{
+		{
+			name:           "empty string",
+			input:          "",
+			expectedWord:   "",
+			expectedBefore: "",
+		},
+		{
+			name:           "single word",
+			input:          "select",
+			expectedWord:   "select",
+			expectedBefore: "",
+		},
+		{
+			name:           "partial keyword",
+			input:          "sel",
+			expectedWord:   "sel",
+			expectedBefore: "",
+		},
+		{
+			name:           "after space",
+			input:          "select ",
+			expectedWord:   "",
+			expectedBefore: "select",
+		},
+		{
+			name:           "multiple words",
+			input:          "select * fr",
+			expectedWord:   "fr",
+			expectedBefore: "select *",
+		},
+		{
+			name:           "with comma",
+			input:          "select name,ag",
+			expectedWord:   "ag",
+			expectedBefore: "select name,",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			word, before := extractCurrentWord(tt.input)
+			if word != tt.expectedWord {
+				t.Errorf("extractCurrentWord(%q) word = %q, want %q", tt.input, word, tt.expectedWord)
+			}
+			if before != tt.expectedBefore {
+				t.Errorf("extractCurrentWord(%q) before = %q, want %q", tt.input, before, tt.expectedBefore)
+			}
+		})
+	}
+}
+
+func TestShouldSuggestTables(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "after from",
+			input:    "select * from",
+			expected: true,
+		},
+		{
+			name:     "after join",
+			input:    "select * from users join",
+			expected: true,
+		},
+		{
+			name:     "after where",
+			input:    "select * from users where",
+			expected: false,
+		},
+		{
+			name:     "at start",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "after select",
+			input:    "select",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSuggestTables(tt.input)
+			if result != tt.expected {
+				t.Errorf("shouldSuggestTables(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompleterComplete(t *testing.T) {
+	c := New()
+	c.SetKeywords([]string{"select", "from", "where", "update", "insert"})
+	c.SetTables([]string{"users", "products", "orders"})
+	c.SetColumns([]string{"id", "name", "email", "price"})
+	c.SetUDFs([]string{"count", "sum", "avg"})
+
+	tests := []struct {
+		name           string
+		input          string
+		expectedInList []string
+		notInList      []string
+	}{
+		{
+			name:           "keyword completion",
+			input:          "sel",
+			expectedInList: []string{"select "},
+		},
+		{
+			name:           "table after from",
+			input:          "select * from u",
+			expectedInList: []string{"select * from users "},
+			notInList:      []string{"select * from update "}, // Should not suggest keywords in this context
+		},
+		{
+			name:           "column completion",
+			input:          "select na",
+			expectedInList: []string{"select name "},
+		},
+		{
+			name:           "udf completion",
+			input:          "select cou",
+			expectedInList: []string{"select count"},
+		},
+		{
+			name:           "multiple matches",
+			input:          "select * from ",
+			expectedInList: []string{"select * from users ", "select * from products ", "select * from orders "},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := c.Complete(tt.input)
+
+			// Check expected items are in results
+			for _, expected := range tt.expectedInList {
+				found := false
+				for _, result := range results {
+					if result == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Complete(%q) missing expected %q in results %v", tt.input, expected, results)
+				}
+			}
+		})
+	}
+}
+
+func TestPublicSchemaUnqualified(t *testing.T) {
+	c := New()
+	
+	// Mock metadata fetcher with public and non-public schemas
+	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
+		switch {
+		case query == "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
+			// Return mix of public and non-public tables
+			return []string{"public.tvmaze", "public.users", "analytics.metrics", "scp.task_history"}, nil
+		default:
+			return []string{}, nil
+		}
+	})
+	
+	// Refresh metadata
+	err := c.RefreshMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshMetadata failed: %v", err)
+	}
+	
+	// Verify we have both qualified and unqualified for public schema
+	hasQualified := false
+	hasUnqualified := false
+	hasNonPublic := false
+	
+	for _, table := range c.tables {
+		if table == "public.tvmaze" {
+			hasQualified = true
+		}
+		if table == "tvmaze" {
+			hasUnqualified = true
+		}
+		if table == "analytics.metrics" {
+			hasNonPublic = true
+		}
+		// Should NOT have unqualified non-public tables
+		if table == "metrics" {
+			t.Error("Should not have unqualified 'metrics' from analytics schema")
+		}
+	}
+	
+	if !hasQualified {
+		t.Error("Should have qualified name 'public.tvmaze'")
+	}
+	if !hasUnqualified {
+		t.Error("Should have unqualified name 'tvmaze' for public schema table")
+	}
+	if !hasNonPublic {
+		t.Error("Should have qualified name 'analytics.metrics'")
+	}
+	
+	// Test completion
+	results := c.Complete("select * from tv")
+	found := false
+	for _, result := range results {
+		// Complete() returns the full reconstructed line
+		if strings.Contains(result, "tvmaze") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Should autocomplete 'tv' to include 'tvmaze', got: %v", results)
+	}
+}
+
+func TestTabCompletionFromClause(t *testing.T) {
+	c := New()
+	
+	// Set up completer with a public.tvmaze table
+	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
+		switch {
+		case strings.Contains(query, "table_schema || '.' || table_name"):
+			return []string{"public.tvmaze", "public.users"}, nil
+		default:
+			return []string{}, nil
+		}
+	})
+	
+	err := c.RefreshMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshMetadata failed: %v", err)
+	}
+	
+	// Debug: print what tables we have
+	t.Logf("Available tables: %v", c.tables)
+	
+	// Test the exact use case: "select * from tv" should complete to "select * from tvmaze "
+	input := "select * from tv"
+	results := c.Complete(input)
+	
+	t.Logf("Input: %q", input)
+	t.Logf("Results: %v", results)
+	
+	// Check that we get a completion with tvmaze
+	found := false
+	var matchedResult string
+	for _, result := range results {
+		if strings.Contains(result, "tvmaze") && !strings.Contains(result, "public.tvmaze") {
+			found = true
+			matchedResult = result
+			break
+		}
+	}
+	
+	if !found {
+		t.Errorf("Tab completion failed for 'select * from tv'\nExpected: completion containing 'tvmaze' (not 'public.tvmaze')\nGot: %v", results)
+	} else {
+		t.Logf("✓ Found completion: %q", matchedResult)
+	}
+}
+
+func TestSimpleTabCompletion(t *testing.T) {
+	c := New()
+	
+	// Directly set tables - bypass metadata fetcher to test core logic
+	c.SetTables([]string{"public.tvmaze", "tvmaze", "public.users", "users"})
+	
+	tests := []struct {
+		name     string
+		input    string
+		wantWord string
+	}{
+		{
+			name:     "from tv",
+			input:    "select * from tv",
+			wantWord: "tvmaze",
+		},
+		{
+			name:     "FROM tv uppercase",
+			input:    "SELECT * FROM tv",
+			wantWord: "tvmaze",
+		},
+		{
+			name:     "join tv",
+			input:    "select * from users join tv",
+			wantWord: "tvmaze",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := c.Complete(tt.input)
+			t.Logf("Input: %q", tt.input)
+			t.Logf("Results: %v", results)
+			
+			found := false
+			for _, result := range results {
+				if strings.Contains(result, tt.wantWord+" ") && !strings.Contains(result, "public."+tt.wantWord) {
+					found = true
+					break
+				}
+			}
+			
+			if !found {
+				t.Errorf("Expected completion containing %q (unqualified), got: %v", tt.wantWord, results)
+			}
+		})
+	}
+}
+
+func TestCTECompletion(t *testing.T) {
+	c := New()
+	c.SetKeywords([]string{"with", "as", "select", "from"})
+	c.SetTables([]string{"users", "orders"})
+	
+	tests := []struct {
+		name     string
+		input    string
+		wantWord string
+	}{
+		{
+			name:     "with keyword",
+			input:    "wit",
+			wantWord: "with",
+		},
+		{
+			name:     "table after cte",
+			input:    "with cte as (select * from u",
+			wantWord: "users",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := c.Complete(tt.input)
+			found := false
+			for _, result := range results {
+				if strings.Contains(result, tt.wantWord+" ") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected completion containing %q, got: %v", tt.wantWord, results)
+			}
+		})
+	}
+}

--- a/bin/spice/pkg/sqlcompleter/completer_test.go
+++ b/bin/spice/pkg/sqlcompleter/completer_test.go
@@ -251,7 +251,7 @@ func TestCompleterComplete(t *testing.T) {
 
 func TestPublicSchemaUnqualified(t *testing.T) {
 	c := New()
-	
+
 	// Mock metadata fetcher with public and non-public schemas
 	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
 		switch {
@@ -262,18 +262,18 @@ func TestPublicSchemaUnqualified(t *testing.T) {
 			return []string{}, nil
 		}
 	})
-	
+
 	// Refresh metadata
 	err := c.RefreshMetadata(context.Background())
 	if err != nil {
 		t.Fatalf("RefreshMetadata failed: %v", err)
 	}
-	
+
 	// Verify we have both qualified and unqualified for public schema
 	hasQualified := false
 	hasUnqualified := false
 	hasNonPublic := false
-	
+
 	for _, table := range c.tables {
 		if table == "public.tvmaze" {
 			hasQualified = true
@@ -289,7 +289,7 @@ func TestPublicSchemaUnqualified(t *testing.T) {
 			t.Error("Should not have unqualified 'metrics' from analytics schema")
 		}
 	}
-	
+
 	if !hasQualified {
 		t.Error("Should have qualified name 'public.tvmaze'")
 	}
@@ -299,7 +299,7 @@ func TestPublicSchemaUnqualified(t *testing.T) {
 	if !hasNonPublic {
 		t.Error("Should have qualified name 'analytics.metrics'")
 	}
-	
+
 	// Test completion
 	results := c.Complete("select * from tv")
 	found := false
@@ -317,7 +317,7 @@ func TestPublicSchemaUnqualified(t *testing.T) {
 
 func TestTabCompletionFromClause(t *testing.T) {
 	c := New()
-	
+
 	// Set up completer with a public.tvmaze table
 	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
 		switch {
@@ -327,22 +327,22 @@ func TestTabCompletionFromClause(t *testing.T) {
 			return []string{}, nil
 		}
 	})
-	
+
 	err := c.RefreshMetadata(context.Background())
 	if err != nil {
 		t.Fatalf("RefreshMetadata failed: %v", err)
 	}
-	
+
 	// Debug: print what tables we have
 	t.Logf("Available tables: %v", c.tables)
-	
+
 	// Test the exact use case: "select * from tv" should complete to "select * from tvmaze "
 	input := "select * from tv"
 	results := c.Complete(input)
-	
+
 	t.Logf("Input: %q", input)
 	t.Logf("Results: %v", results)
-	
+
 	// Check that we get a completion with tvmaze
 	found := false
 	var matchedResult string
@@ -353,7 +353,7 @@ func TestTabCompletionFromClause(t *testing.T) {
 			break
 		}
 	}
-	
+
 	if !found {
 		t.Errorf("Tab completion failed for 'select * from tv'\nExpected: completion containing 'tvmaze' (not 'public.tvmaze')\nGot: %v", results)
 	} else {
@@ -363,10 +363,10 @@ func TestTabCompletionFromClause(t *testing.T) {
 
 func TestSimpleTabCompletion(t *testing.T) {
 	c := New()
-	
+
 	// Directly set tables - bypass metadata fetcher to test core logic
 	c.SetTables([]string{"public.tvmaze", "tvmaze", "public.users", "users"})
-	
+
 	tests := []struct {
 		name     string
 		input    string
@@ -388,13 +388,13 @@ func TestSimpleTabCompletion(t *testing.T) {
 			wantWord: "tvmaze",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := c.Complete(tt.input)
 			t.Logf("Input: %q", tt.input)
 			t.Logf("Results: %v", results)
-			
+
 			found := false
 			for _, result := range results {
 				if strings.Contains(result, tt.wantWord+" ") && !strings.Contains(result, "public."+tt.wantWord) {
@@ -402,7 +402,7 @@ func TestSimpleTabCompletion(t *testing.T) {
 					break
 				}
 			}
-			
+
 			if !found {
 				t.Errorf("Expected completion containing %q (unqualified), got: %v", tt.wantWord, results)
 			}
@@ -414,7 +414,7 @@ func TestCTECompletion(t *testing.T) {
 	c := New()
 	c.SetKeywords([]string{"with", "as", "select", "from"})
 	c.SetTables([]string{"users", "orders"})
-	
+
 	tests := []struct {
 		name     string
 		input    string
@@ -431,7 +431,7 @@ func TestCTECompletion(t *testing.T) {
 			wantWord: "users",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := c.Complete(tt.input)

--- a/bin/spice/pkg/sqlcompleter/completer_test.go
+++ b/bin/spice/pkg/sqlcompleter/completer_test.go
@@ -27,17 +27,17 @@ func TestRefreshMetadata(t *testing.T) {
 
 	// Mock metadata fetcher
 	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
-		switch {
-		case query == "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
+		switch query {
+		case "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
 			// Return schema-qualified names (simulating public.users, analytics.products, etc.)
 			return []string{"public.users", "analytics.products", "public.orders"}, nil
-		case query == "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY table_schema":
+		case "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY table_schema":
 			return []string{"public", "analytics"}, nil
-		case query == "--autocomplete\nSELECT DISTINCT column_name FROM information_schema.columns ORDER BY column_name":
+		case "--autocomplete\nSELECT DISTINCT column_name FROM information_schema.columns ORDER BY column_name":
 			return []string{"id", "name", "email", "price"}, nil
-		case query == "--autocomplete\nSELECT name FROM list_udfs() ORDER BY name":
+		case "--autocomplete\nSELECT name FROM list_udfs() ORDER BY name":
 			return []string{"count", "sum", "avg"}, nil
-		case query == "--autocomplete\nSELECT name FROM list_udtfs() ORDER BY name":
+		case "--autocomplete\nSELECT name FROM list_udtfs() ORDER BY name":
 			return []string{"generate_series", "unnest"}, nil
 		default:
 			// For keywords query, return fallback
@@ -254,8 +254,8 @@ func TestPublicSchemaUnqualified(t *testing.T) {
 
 	// Mock metadata fetcher with public and non-public schemas
 	c.SetMetadataFetcher(func(ctx context.Context, query string) ([]string, error) {
-		switch {
-		case query == "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
+		switch query {
+		case "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name":
 			// Return mix of public and non-public tables
 			return []string{"public.tvmaze", "public.users", "analytics.metrics", "scp.task_history"}, nil
 		default:

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -34,6 +34,7 @@ tonic = { workspace = true, features = [
   "tls-ring",
   "tls-native-roots",
 ] }
+tracing.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -13,8 +13,18 @@ use tonic::transport::Channel;
 
 #[derive(Debug, Clone)]
 struct StringValue {
-    pub original: Arc<str>,
-    pub lower: Arc<str>,
+    original: Arc<str>,
+    lower: Arc<str>,
+}
+
+impl StringValue {
+    fn original(&self) -> &str {
+        &self.original
+    }
+
+    fn lower(&self) -> &str {
+        &self.lower
+    }
 }
 
 impl From<String> for StringValue {
@@ -29,6 +39,7 @@ impl From<String> for StringValue {
 pub struct SchemaCache {
     udfs: Vec<String>,
     udtfs: Vec<String>,
+    builtin_functions: Vec<String>,
     schemas: Vec<StringValue>,
     tables: Vec<StringValue>,
     columns: Vec<StringValue>,
@@ -41,6 +52,7 @@ impl SchemaCache {
         Self {
             udfs: Vec::new(),
             udtfs: Vec::new(),
+            builtin_functions: Vec::new(),
             schemas: Vec::new(),
             tables: Vec::new(),
             columns: Vec::new(),
@@ -66,6 +78,10 @@ impl SchemaCache {
 
     fn update_udtfs(&mut self, udtfs: Vec<String>) {
         self.udtfs = udtfs;
+    }
+
+    fn update_builtin_functions(&mut self, builtin_functions: Vec<String>) {
+        self.builtin_functions = builtin_functions;
     }
 }
 
@@ -133,6 +149,27 @@ impl EditorHelper {
     }
 }
 
+/// Helper function to add table completions with proper quoting and deduplication
+fn suggest_tables(
+    tables: &[StringValue],
+    word_lower: &str,
+    seen: &mut std::collections::HashSet<String>,
+    matches: &mut Vec<Pair>,
+) {
+    for table in tables {
+        if table.lower().starts_with(word_lower) {
+            let quoted_name = quote_identifier_if_needed(table.original());
+            let replacement = format!("{quoted_name} ");
+            if seen.insert(replacement.clone()) {
+                matches.push(Pair {
+                    display: table.original().to_string(),
+                    replacement,
+                });
+            }
+        }
+    }
+}
+
 impl Completer for EditorHelper {
     type Candidate = Pair;
 
@@ -178,19 +215,8 @@ impl Completer for EditorHelper {
             };
 
         if should_suggest_only_tables {
-            // Only suggest tables
-            for table in &cache.tables {
-                if table.lower.starts_with(&word_lower) {
-                    let quoted_name = quote_identifier_if_needed(&table.original);
-                    let replacement = format!("{quoted_name} ");
-                    if seen.insert(replacement.clone()) {
-                        matches.push(Pair {
-                            display: table.original.to_string(),
-                            replacement,
-                        });
-                    }
-                }
-            }
+            // Only suggest tables after FROM or JOIN
+            suggest_tables(&cache.tables, &word_lower, &mut seen, &mut matches);
         } else {
             // Suggest keywords
             for keyword in &cache.keywords {
@@ -215,6 +241,16 @@ impl Completer for EditorHelper {
                 }
             }
 
+            // Suggest built-in functions
+            for func_name in &cache.builtin_functions {
+                if func_name.starts_with(&word_lower) && seen.insert(func_name.to_lowercase()) {
+                    matches.push(Pair {
+                        display: func_name.to_lowercase(),
+                        replacement: func_name.to_lowercase(),
+                    });
+                }
+            }
+
             // Suggest UDTFs
             for udtf_name in &cache.udtfs {
                 if udtf_name.starts_with(&word_lower) && seen.insert(udtf_name.to_lowercase()) {
@@ -227,12 +263,12 @@ impl Completer for EditorHelper {
 
             // Suggest schemas
             for schema in &cache.schemas {
-                if schema.lower.starts_with(&word_lower) {
-                    let quoted_name = quote_identifier_if_needed(&schema.original);
+                if schema.lower().starts_with(&word_lower) {
+                    let quoted_name = quote_identifier_if_needed(schema.original());
                     let replacement = format!("{quoted_name}.");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
-                            display: schema.original.to_string(),
+                            display: schema.original().to_string(),
                             replacement,
                         });
                     }
@@ -240,27 +276,16 @@ impl Completer for EditorHelper {
             }
 
             // Suggest tables
-            for table in &cache.tables {
-                if table.lower.starts_with(&word_lower) {
-                    let quoted_name = quote_identifier_if_needed(&table.original);
-                    let replacement = format!("{quoted_name} ");
-                    if seen.insert(replacement.clone()) {
-                        matches.push(Pair {
-                            display: table.original.to_string(),
-                            replacement,
-                        });
-                    }
-                }
-            }
+            suggest_tables(&cache.tables, &word_lower, &mut seen, &mut matches);
 
             // Suggest columns
             for column in &cache.columns {
-                if column.lower.starts_with(&word_lower) {
-                    let quoted_name = quote_identifier_if_needed(&column.original);
+                if column.lower().starts_with(&word_lower) {
+                    let quoted_name = quote_identifier_if_needed(column.original());
                     let replacement = format!("{quoted_name} ");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
-                            display: column.original.to_string(),
+                            display: column.original().to_string(),
                             replacement,
                         });
                     }
@@ -285,55 +310,48 @@ impl Completer for EditorHelper {
             }
         }
 
-        // Filter matches to only include valid SQL by testing with DataFusion parser
-        // Only validate statements that look reasonably complete
+        // Filter matches: for complete statements, only include if valid SQL.
+        // For partial completions, always include.
         let valid_matches: Vec<Pair> = matches
             .into_iter()
-            .filter(|pair| should_validate_sql(&pair.replacement))
+            .filter(|pair| {
+                if is_complete_sql(&pair.replacement) {
+                    is_valid_sql(&pair.replacement)
+                } else {
+                    true
+                }
+            })
             .collect();
 
         Ok((start, valid_matches))
     }
 }
 
-/// Determines if a SQL completion should be validated
-/// Only validate complete-looking statements to avoid filtering out partial completions
-fn should_validate_sql(sql: &str) -> bool {
+/// Determines if a SQL completion looks complete enough to validate.
+/// Returns true if the statement should be validated for SQL correctness.
+fn is_complete_sql(sql: &str) -> bool {
     let trimmed = sql.trim().to_lowercase();
 
-    // Always allow if it doesn't contain a statement keyword at all
-    if !trimmed.contains("select")
-        && !trimmed.contains("insert")
-        && !trimmed.contains("update")
-        && !trimmed.contains("delete")
-        && !trimmed.contains("with")
-        && !trimmed.contains("show")
-        && !trimmed.contains("describe")
-        && !trimmed.contains("explain")
-    {
+    // If it has semicolon, it's trying to be a complete statement
+    if trimmed.contains(';') {
         return true;
     }
 
-    // If it has semicolon, it's trying to be a complete statement - validate it
-    if trimmed.contains(';') {
-        return is_valid_sql(sql);
-    }
-
-    // If it's a SELECT and has FROM clause, validate it
+    // If it's a SELECT and has FROM clause, treat as complete
     if trimmed.contains("select") && trimmed.contains("from") {
-        return is_valid_sql(sql);
+        return true;
     }
 
-    // If it's INSERT/UPDATE/DELETE and looks complete, validate it
+    // If it's INSERT/UPDATE/DELETE and looks complete
     if (trimmed.contains("insert") && trimmed.contains("into"))
         || (trimmed.contains("update") && trimmed.contains("set"))
         || (trimmed.contains("delete") && trimmed.contains("from"))
     {
-        return is_valid_sql(sql);
+        return true;
     }
 
-    // Otherwise, it's a partial completion - allow it without validation
-    true
+    // Otherwise, treat as partial completion
+    false
 }
 
 /// Validates that a SQL string can be parsed by `DataFusion`
@@ -342,6 +360,7 @@ fn is_valid_sql(sql: &str) -> bool {
     DFParser::parse_sql(sql).is_ok()
 }
 
+#[allow(clippy::similar_names)]
 async fn refresh_schema(
     client: FlightServiceClient<Channel>,
     schema_cache: &Arc<RwLock<SchemaCache>>,
@@ -352,15 +371,23 @@ async fn refresh_schema(
     let mut client2 = client.clone();
     let mut client3 = client.clone();
     let mut client4 = client.clone();
-    let mut client5 = client;
+    let mut client5 = client.clone();
+    let mut client6 = client;
 
-    #[allow(clippy::similar_names)]
-    let (tables_result, schemas_result, columns_result, udfs_result, udtfs_result) = tokio::join!(
+    let (
+        tables_result,
+        schemas_result,
+        columns_result,
+        udfs_result,
+        udtfs_result,
+        builtin_functions_result,
+    ) = tokio::join!(
         get_tables(&mut client1, api_key, user_agent),
         get_schemas(&mut client2, api_key, user_agent),
         get_columns(&mut client3, api_key, user_agent),
         get_udfs(&mut client4, api_key, user_agent),
-        get_udtfs(&mut client5, api_key, user_agent)
+        get_udtfs(&mut client5, api_key, user_agent),
+        get_builtin_functions(&mut client6, api_key, user_agent)
     );
 
     if let Ok(mut cache) = schema_cache.try_write() {
@@ -383,19 +410,28 @@ async fn refresh_schema(
         if let Ok(udtfs) = udtfs_result {
             cache.update_udtfs(udtfs);
         }
+
+        if let Ok(builtin_functions) = builtin_functions_result {
+            cache.update_builtin_functions(builtin_functions);
+        }
     }
 }
+
+/// Prefix for autocomplete metadata queries to help the runtime identify and potentially optimize these queries
+const AUTOCOMPLETE_PREFIX: &str = "--autocomplete\n";
 
 async fn get_tables(
     client: &mut FlightServiceClient<Channel>,
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name";
+    let query = format!(
+        "{AUTOCOMPLETE_PREFIX}SELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name"
+    );
 
     let records = crate::get_records(
         client.clone(),
-        query,
+        &query,
         api_key,
         user_agent,
         crate::cache_control::CacheControl::NoCache,
@@ -431,11 +467,14 @@ async fn get_schemas(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime')";
+    // Query schemata to include all schemas, not just those with tables
+    let query = format!(
+        "{AUTOCOMPLETE_PREFIX}SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema', 'runtime')"
+    );
 
     let records = crate::get_records(
         client.clone(),
-        query,
+        &query,
         api_key,
         user_agent,
         crate::cache_control::CacheControl::NoCache,
@@ -459,11 +498,11 @@ async fn get_columns(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "--autocomplete\nSELECT column_name FROM information_schema.columns";
+    let query = format!("{AUTOCOMPLETE_PREFIX}SELECT column_name FROM information_schema.columns");
 
     let records = crate::get_records(
         client.clone(),
-        query,
+        &query,
         api_key,
         user_agent,
         crate::cache_control::CacheControl::NoCache,
@@ -487,11 +526,11 @@ async fn get_udfs(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "--autocomplete\nSELECT name FROM list_udfs()";
+    let query = format!("{AUTOCOMPLETE_PREFIX}SELECT name FROM list_udfs()");
 
     let records = crate::get_records(
         client.clone(),
-        query,
+        &query,
         api_key,
         user_agent,
         crate::cache_control::CacheControl::NoCache,
@@ -515,11 +554,11 @@ async fn get_udtfs(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "--autocomplete\nSELECT name FROM list_udtfs()";
+    let query = format!("{AUTOCOMPLETE_PREFIX}SELECT name FROM list_udtfs()");
 
     let records = crate::get_records(
         client.clone(),
-        query,
+        &query,
         api_key,
         user_agent,
         crate::cache_control::CacheControl::NoCache,
@@ -538,38 +577,54 @@ async fn get_udtfs(
     Ok(udtfs)
 }
 
-/// Quote an identifier if it contains uppercase letters, reserved keywords, or special characters
+async fn get_builtin_functions(
+    client: &mut FlightServiceClient<Channel>,
+    api_key: Option<&String>,
+    user_agent: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let query =
+        format!("{AUTOCOMPLETE_PREFIX}SELECT routine_name FROM information_schema.routines");
+
+    let records = crate::get_records(
+        client.clone(),
+        &query,
+        api_key,
+        user_agent,
+        crate::cache_control::CacheControl::NoCache,
+    )
+    .await?;
+
+    let mut functions = Vec::new();
+    for batch in records.0 {
+        if let Some(array) = batch.column(0).as_any().downcast_ref::<StringArray>() {
+            for func_name in array.iter().flatten() {
+                functions.push(func_name.to_string());
+            }
+        }
+    }
+
+    Ok(functions)
+}
+
+/// Quote an identifier if it contains uppercase letters or special characters.
+/// Handles schema-qualified names by quoting each part independently.
 fn quote_identifier_if_needed(identifier: &str) -> String {
-    // Check if identifier needs quoting
-    let needs_quoting = identifier.chars().any(char::is_uppercase)
-        || identifier.contains('.')  // Already qualified, handle parts separately
-        || identifier.chars().any(|c| !c.is_alphanumeric() && c != '_' && c != '.');
-
-    if !needs_quoting {
-        return identifier.to_string();
-    }
-
-    // Handle schema-qualified names (e.g., "MySchema"."MyTable")
-    if identifier.contains('.') {
-        let parts: Vec<&str> = identifier.split('.').collect();
-        let quoted_parts: Vec<String> = parts
-            .iter()
-            .map(|part| {
-                if part
-                    .chars()
-                    .any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_')
-                {
-                    format!("\"{part}\"")
-                } else {
-                    (*part).to_string()
-                }
-            })
-            .collect();
-        quoted_parts.join(".")
-    } else {
-        // Single identifier
-        format!("\"{identifier}\"")
-    }
+    // Always split on dots and quote each part as needed
+    let parts: Vec<&str> = identifier.split('.').collect();
+    let quoted_parts: Vec<String> = parts
+        .iter()
+        .map(|part| {
+            if part
+                .chars()
+                .any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_')
+            {
+                format!("\"{part}\"")
+            } else {
+                (*part).to_string()
+            }
+        })
+        .collect();
+    quoted_parts.join(".")
 }
 
 fn extract_word(line: &str, pos: usize) -> (usize, &str) {
@@ -727,6 +782,7 @@ mod tests {
         let schema_cache = Arc::new(RwLock::new(SchemaCache {
             udfs: vec!["count".to_string(), "sum".to_string(), "concat".to_string()],
             udtfs: vec!["generate_series".to_string(), "unnest".to_string()],
+            builtin_functions: vec!["avg".to_string(), "max".to_string(), "min".to_string()],
             schemas: vec!["public".to_string(), "analytics".to_string()]
                 .into_iter()
                 .map(StringValue::from)

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -136,6 +136,7 @@ impl EditorHelper {
 impl Completer for EditorHelper {
     type Candidate = Pair;
 
+    #[allow(clippy::too_many_lines)]
     fn complete(
         &self,
         line: &str,
@@ -181,7 +182,7 @@ impl Completer for EditorHelper {
             for table in &cache.tables {
                 if table.lower.starts_with(&word_lower) {
                     let quoted_name = quote_identifier_if_needed(&table.original);
-                    let replacement = format!("{} ", quoted_name);
+                    let replacement = format!("{quoted_name} ");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
                             display: table.original.to_string(),
@@ -206,25 +207,21 @@ impl Completer for EditorHelper {
 
             // Suggest UDFs
             for udf_name in &cache.udfs {
-                if udf_name.starts_with(&word_lower) {
-                    if seen.insert(udf_name.to_lowercase()) {
-                        matches.push(Pair {
-                            display: udf_name.to_lowercase(),
-                            replacement: udf_name.to_lowercase(),
-                        });
-                    }
+                if udf_name.starts_with(&word_lower) && seen.insert(udf_name.to_lowercase()) {
+                    matches.push(Pair {
+                        display: udf_name.to_lowercase(),
+                        replacement: udf_name.to_lowercase(),
+                    });
                 }
             }
 
             // Suggest UDTFs
             for udtf_name in &cache.udtfs {
-                if udtf_name.starts_with(&word_lower) {
-                    if seen.insert(udtf_name.to_lowercase()) {
-                        matches.push(Pair {
-                            display: udtf_name.to_lowercase(),
-                            replacement: udtf_name.to_lowercase(),
-                        });
-                    }
+                if udtf_name.starts_with(&word_lower) && seen.insert(udtf_name.to_lowercase()) {
+                    matches.push(Pair {
+                        display: udtf_name.to_lowercase(),
+                        replacement: udtf_name.to_lowercase(),
+                    });
                 }
             }
 
@@ -232,7 +229,7 @@ impl Completer for EditorHelper {
             for schema in &cache.schemas {
                 if schema.lower.starts_with(&word_lower) {
                     let quoted_name = quote_identifier_if_needed(&schema.original);
-                    let replacement = format!("{}.", quoted_name);
+                    let replacement = format!("{quoted_name}.");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
                             display: schema.original.to_string(),
@@ -246,7 +243,7 @@ impl Completer for EditorHelper {
             for table in &cache.tables {
                 if table.lower.starts_with(&word_lower) {
                     let quoted_name = quote_identifier_if_needed(&table.original);
-                    let replacement = format!("{} ", quoted_name);
+                    let replacement = format!("{quoted_name} ");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
                             display: table.original.to_string(),
@@ -260,7 +257,7 @@ impl Completer for EditorHelper {
             for column in &cache.columns {
                 if column.lower.starts_with(&word_lower) {
                     let quoted_name = quote_identifier_if_needed(&column.original);
-                    let replacement = format!("{} ", quoted_name);
+                    let replacement = format!("{quoted_name} ");
                     if seen.insert(replacement.clone()) {
                         matches.push(Pair {
                             display: column.original.to_string(),
@@ -278,13 +275,11 @@ impl Completer for EditorHelper {
             for idx in (0..history.len()).rev() {
                 if let Ok(Some(result)) = history.get(idx, SearchDirection::Reverse) {
                     let entry_str = result.entry.as_ref();
-                    if !entry_str.is_empty() {
-                        if seen.insert(entry_str.to_string()) {
-                            matches.push(Pair {
-                                display: entry_str.to_string(),
-                                replacement: entry_str.to_string(),
-                            });
-                        }
+                    if !entry_str.is_empty() && seen.insert(entry_str.to_string()) {
+                        matches.push(Pair {
+                            display: entry_str.to_string(),
+                            replacement: entry_str.to_string(),
+                        });
                     }
                 }
             }
@@ -341,7 +336,7 @@ fn should_validate_sql(sql: &str) -> bool {
     true
 }
 
-/// Validates that a SQL string can be parsed by DataFusion
+/// Validates that a SQL string can be parsed by `DataFusion`
 fn is_valid_sql(sql: &str) -> bool {
     // Try to parse the SQL with DataFusion's parser
     DFParser::parse_sql(sql).is_ok()
@@ -359,6 +354,7 @@ async fn refresh_schema(
     let mut client4 = client.clone();
     let mut client5 = client;
 
+    #[allow(clippy::similar_names)]
     let (tables_result, schemas_result, columns_result, udfs_result, udtfs_result) = tokio::join!(
         get_tables(&mut client1, api_key, user_agent),
         get_schemas(&mut client2, api_key, user_agent),
@@ -418,10 +414,10 @@ async fn get_tables(
                 }
 
                 // For public schema, also add unqualified name
-                if let Some(unqualified) = full_name.strip_prefix("public.") {
-                    if table_set.insert(unqualified.to_string()) {
-                        tables.push(unqualified.to_string());
-                    }
+                if let Some(unqualified) = full_name.strip_prefix("public.")
+                    && table_set.insert(unqualified.to_string())
+                {
+                    tables.push(unqualified.to_string());
                 }
             }
         }
@@ -545,7 +541,7 @@ async fn get_udtfs(
 /// Quote an identifier if it contains uppercase letters, reserved keywords, or special characters
 fn quote_identifier_if_needed(identifier: &str) -> String {
     // Check if identifier needs quoting
-    let needs_quoting = identifier.chars().any(|c| c.is_uppercase())
+    let needs_quoting = identifier.chars().any(char::is_uppercase)
         || identifier.contains('.')  // Already qualified, handle parts separately
         || identifier.chars().any(|c| !c.is_alphanumeric() && c != '_' && c != '.');
 
@@ -563,7 +559,7 @@ fn quote_identifier_if_needed(identifier: &str) -> String {
                     .chars()
                     .any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_')
                 {
-                    format!("\"{}\"", part)
+                    format!("\"{part}\"")
                 } else {
                     (*part).to_string()
                 }
@@ -572,7 +568,7 @@ fn quote_identifier_if_needed(identifier: &str) -> String {
         quoted_parts.join(".")
     } else {
         // Single identifier
-        format!("\"{}\"", identifier)
+        format!("\"{identifier}\"")
     }
 }
 
@@ -621,7 +617,7 @@ fn is_word_boundary(ch: char) -> bool {
     }
 }
 
-/// Filter DataFusion's full keyword list to only include useful autocomplete suggestions
+/// Filter `DataFusion`'s full keyword list to only include useful autocomplete suggestions
 fn filter_useful_keywords() -> Vec<String> {
     let useful_keywords = [
         // Query statements
@@ -1004,13 +1000,11 @@ mod tests {
         let completions = get_completions(&helper, sql, sql.len());
         assert!(
             completions.iter().any(|c| c.contains("\"MyTable\"")),
-            "Should suggest quoted MyTable, got: {:?}",
-            completions
+            "Should suggest quoted MyTable, got: {completions:?}"
         );
         assert!(
             completions.iter().any(|c| c.contains("\"MyView\"")),
-            "Should suggest quoted MyView, got: {:?}",
-            completions
+            "Should suggest quoted MyView, got: {completions:?}"
         );
 
         // Test lowercase table is not quoted
@@ -1019,9 +1013,8 @@ mod tests {
         assert!(
             completions
                 .iter()
-                .any(|c| c.contains("users ") && !c.contains("\"")),
-            "Should suggest unquoted users, got: {:?}",
-            completions
+                .any(|c| c.contains("users ") && !c.contains('"')),
+            "Should suggest unquoted users, got: {completions:?}"
         );
     }
 }

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -1,7 +1,6 @@
 use crate::EditorHelper;
 use arrow_flight::flight_service_client::FlightServiceClient;
 use datafusion::arrow::array::{Array, StringArray};
-use datafusion::sql::parser::DFParser;
 use rustyline::Context;
 use rustyline::completion::{Completer, Pair};
 use rustyline::history::SearchDirection;
@@ -310,54 +309,8 @@ impl Completer for EditorHelper {
             }
         }
 
-        // Filter matches: for complete statements, only include if valid SQL.
-        // For partial completions, always include.
-        let valid_matches: Vec<Pair> = matches
-            .into_iter()
-            .filter(|pair| {
-                if is_complete_sql(&pair.replacement) {
-                    is_valid_sql(&pair.replacement)
-                } else {
-                    true
-                }
-            })
-            .collect();
-
-        Ok((start, valid_matches))
+        Ok((start, matches))
     }
-}
-
-/// Determines if a SQL completion looks complete enough to validate.
-/// Returns true if the statement should be validated for SQL correctness.
-fn is_complete_sql(sql: &str) -> bool {
-    let trimmed = sql.trim().to_lowercase();
-
-    // If it has semicolon, it's trying to be a complete statement
-    if trimmed.contains(';') {
-        return true;
-    }
-
-    // If it's a SELECT and has FROM clause, treat as complete
-    if trimmed.contains("select") && trimmed.contains("from") {
-        return true;
-    }
-
-    // If it's INSERT/UPDATE/DELETE and looks complete
-    if (trimmed.contains("insert") && trimmed.contains("into"))
-        || (trimmed.contains("update") && trimmed.contains("set"))
-        || (trimmed.contains("delete") && trimmed.contains("from"))
-    {
-        return true;
-    }
-
-    // Otherwise, treat as partial completion
-    false
-}
-
-/// Validates that a SQL string can be parsed by `DataFusion`
-fn is_valid_sql(sql: &str) -> bool {
-    // Try to parse the SQL with DataFusion's parser
-    DFParser::parse_sql(sql).is_ok()
 }
 
 #[allow(clippy::similar_names)]

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -1,9 +1,10 @@
 use crate::EditorHelper;
 use arrow_flight::flight_service_client::FlightServiceClient;
 use datafusion::arrow::array::{Array, StringArray};
-use datafusion::sql::sqlparser::keywords::ALL_KEYWORDS;
+use datafusion::sql::parser::DFParser;
 use rustyline::Context;
 use rustyline::completion::{Completer, Pair};
+use rustyline::history::SearchDirection;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{RwLock, oneshot};
@@ -12,7 +13,7 @@ use tonic::transport::Channel;
 
 #[derive(Debug, Clone)]
 struct StringValue {
-    _original: Arc<str>,
+    pub original: Arc<str>,
     pub lower: Arc<str>,
 }
 
@@ -21,7 +22,7 @@ impl From<String> for StringValue {
         let original: Arc<str> = Arc::from(s.into_boxed_str());
         let lower: Arc<str> = Arc::from(original.to_lowercase());
         Self {
-            _original: original,
+            original,
             lower,
         }
     }
@@ -30,6 +31,8 @@ impl From<String> for StringValue {
 #[derive(Debug, Clone)]
 pub struct SchemaCache {
     udfs: Vec<String>,
+    udtfs: Vec<String>,
+    schemas: Vec<StringValue>,
     tables: Vec<StringValue>,
     columns: Vec<StringValue>,
 
@@ -40,14 +43,20 @@ impl SchemaCache {
     pub fn new() -> Self {
         Self {
             udfs: Vec::new(),
+            udtfs: Vec::new(),
+            schemas: Vec::new(),
             tables: Vec::new(),
             columns: Vec::new(),
-            keywords: ALL_KEYWORDS.iter().map(|k| k.to_lowercase()).collect(),
+            keywords: filter_useful_keywords(),
         }
     }
 
     fn update_tables(&mut self, tables: Vec<String>) {
         self.tables = tables.into_iter().map(StringValue::from).collect();
+    }
+
+    fn update_schemas(&mut self, schemas: Vec<String>) {
+        self.schemas = schemas.into_iter().map(StringValue::from).collect();
     }
 
     fn update_columns(&mut self, columns: Vec<String>) {
@@ -57,9 +66,27 @@ impl SchemaCache {
     fn update_udfs(&mut self, udfs: Vec<String>) {
         self.udfs = udfs;
     }
+
+    fn update_udtfs(&mut self, udtfs: Vec<String>) {
+        self.udtfs = udtfs;
+    }
 }
 
 impl EditorHelper {
+    /// Perform an initial synchronous refresh of schema metadata
+    pub async fn refresh_now(&mut self) {
+        let Some(client) = self.flight_client.clone() else {
+            return;
+        };
+        refresh_schema(
+            client,
+            &self.schema_cache,
+            self.api_key.as_ref(),
+            &self.user_agent,
+        )
+        .await;
+    }
+
     /// Start the background refresh task
     /// `refresh_interval`: How often to refresh schema (in seconds)
     pub fn start_refreshing(&mut self, refresh_interval: u64) {
@@ -116,11 +143,12 @@ impl Completer for EditorHelper {
         &self,
         line: &str,
         pos: usize,
-        _ctx: &Context<'_>,
+        ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
         let (start, word) = extract_word(line, pos);
         let word_lower = word.to_lowercase();
         let mut matches = Vec::new();
+        let mut seen = std::collections::HashSet::new();
 
         let cache = self.schema_cache.try_read().map_err(|_| {
             rustyline::error::ReadlineError::Io(std::io::Error::other("Cache lock error"))
@@ -155,53 +183,165 @@ impl Completer for EditorHelper {
             // Only suggest tables
             for table in &cache.tables {
                 if table.lower.starts_with(&word_lower) {
-                    matches.push(Pair {
-                        display: table.lower.to_string(),
-                        replacement: format!("{} ", table.lower.as_ref()),
-                    });
+                    let quoted_name = quote_identifier_if_needed(&table.original);
+                    let replacement = format!("{} ", quoted_name);
+                    if seen.insert(replacement.clone()) {
+                        matches.push(Pair {
+                            display: table.original.to_string(),
+                            replacement,
+                        });
+                    }
                 }
             }
         } else {
-            // Suggest everything
+            // Suggest keywords
             for keyword in &cache.keywords {
                 if keyword.starts_with(&word_lower) {
-                    matches.push(Pair {
-                        display: keyword.to_lowercase(),
-                        replacement: format!("{} ", keyword.to_lowercase()),
-                    });
+                    let replacement = format!("{} ", keyword.to_lowercase());
+                    if seen.insert(replacement.clone()) {
+                        matches.push(Pair {
+                            display: keyword.to_lowercase(),
+                            replacement,
+                        });
+                    }
                 }
             }
 
+            // Suggest UDFs
             for udf_name in &cache.udfs {
                 if udf_name.starts_with(&word_lower) {
-                    matches.push(Pair {
-                        display: udf_name.to_lowercase(),
-                        replacement: udf_name.to_lowercase(),
-                    });
+                    if seen.insert(udf_name.to_lowercase()) {
+                        matches.push(Pair {
+                            display: udf_name.to_lowercase(),
+                            replacement: udf_name.to_lowercase(),
+                        });
+                    }
                 }
             }
 
+            // Suggest UDTFs
+            for udtf_name in &cache.udtfs {
+                if udtf_name.starts_with(&word_lower) {
+                    if seen.insert(udtf_name.to_lowercase()) {
+                        matches.push(Pair {
+                            display: udtf_name.to_lowercase(),
+                            replacement: udtf_name.to_lowercase(),
+                        });
+                    }
+                }
+            }
+
+            // Suggest schemas
+            for schema in &cache.schemas {
+                if schema.lower.starts_with(&word_lower) {
+                    let quoted_name = quote_identifier_if_needed(&schema.original);
+                    let replacement = format!("{}.", quoted_name);
+                    if seen.insert(replacement.clone()) {
+                        matches.push(Pair {
+                            display: schema.original.to_string(),
+                            replacement,
+                        });
+                    }
+                }
+            }
+
+            // Suggest tables
             for table in &cache.tables {
                 if table.lower.starts_with(&word_lower) {
-                    matches.push(Pair {
-                        display: table.lower.to_string(),
-                        replacement: format!("{} ", table.lower.as_ref()),
-                    });
+                    let quoted_name = quote_identifier_if_needed(&table.original);
+                    let replacement = format!("{} ", quoted_name);
+                    if seen.insert(replacement.clone()) {
+                        matches.push(Pair {
+                            display: table.original.to_string(),
+                            replacement,
+                        });
+                    }
                 }
             }
 
+            // Suggest columns
             for column in &cache.columns {
                 if column.lower.starts_with(&word_lower) {
-                    matches.push(Pair {
-                        display: column.lower.to_string(),
-                        replacement: format!("{} ", column.lower.as_ref()),
-                    });
+                    let quoted_name = quote_identifier_if_needed(&column.original);
+                    let replacement = format!("{} ", quoted_name);
+                    if seen.insert(replacement.clone()) {
+                        matches.push(Pair {
+                            display: column.original.to_string(),
+                            replacement,
+                        });
+                    }
                 }
             }
         }
 
-        Ok((start, matches))
+        // Add history-based suggestions only if the line is completely empty
+        if line.trim().is_empty() {
+            let history = ctx.history();
+            // Iterate through history in reverse (most recent first)
+            for idx in (0..history.len()).rev() {
+                if let Ok(Some(result)) = history.get(idx, SearchDirection::Reverse) {
+                    let entry_str = result.entry.as_ref();
+                    if !entry_str.is_empty() {
+                        if seen.insert(entry_str.to_string()) {
+                            matches.push(Pair {
+                                display: entry_str.to_string(),
+                                replacement: entry_str.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Filter matches to only include valid SQL by testing with DataFusion parser
+        // Only validate statements that look reasonably complete
+        let valid_matches: Vec<Pair> = matches
+            .into_iter()
+            .filter(|pair| should_validate_sql(&pair.replacement))
+            .collect();
+
+        Ok((start, valid_matches))
     }
+}
+
+/// Determines if a SQL completion should be validated
+/// Only validate complete-looking statements to avoid filtering out partial completions
+fn should_validate_sql(sql: &str) -> bool {
+    let trimmed = sql.trim().to_lowercase();
+    
+    // Always allow if it doesn't contain a statement keyword at all
+    if !trimmed.contains("select") && !trimmed.contains("insert") && 
+       !trimmed.contains("update") && !trimmed.contains("delete") && 
+       !trimmed.contains("with") && !trimmed.contains("show") &&
+       !trimmed.contains("describe") && !trimmed.contains("explain") {
+        return true;
+    }
+    
+    // If it has semicolon, it's trying to be a complete statement - validate it
+    if trimmed.contains(';') {
+        return is_valid_sql(sql);
+    }
+    
+    // If it's a SELECT and has FROM clause, validate it
+    if trimmed.contains("select") && trimmed.contains("from") {
+        return is_valid_sql(sql);
+    }
+    
+    // If it's INSERT/UPDATE/DELETE and looks complete, validate it
+    if (trimmed.contains("insert") && trimmed.contains("into")) ||
+       (trimmed.contains("update") && trimmed.contains("set")) ||
+       (trimmed.contains("delete") && trimmed.contains("from")) {
+        return is_valid_sql(sql);
+    }
+    
+    // Otherwise, it's a partial completion - allow it without validation
+    true
+}
+
+/// Validates that a SQL string can be parsed by DataFusion
+fn is_valid_sql(sql: &str) -> bool {
+    // Try to parse the SQL with DataFusion's parser
+    DFParser::parse_sql(sql).is_ok()
 }
 
 async fn refresh_schema(
@@ -212,17 +352,25 @@ async fn refresh_schema(
 ) {
     let mut client1 = client.clone();
     let mut client2 = client.clone();
-    let mut client3 = client;
+    let mut client3 = client.clone();
+    let mut client4 = client.clone();
+    let mut client5 = client;
 
-    let (tables_result, columns_result, udfs_result) = tokio::join!(
+    let (tables_result, schemas_result, columns_result, udfs_result, udtfs_result) = tokio::join!(
         get_tables(&mut client1, api_key, user_agent),
-        get_columns(&mut client2, api_key, user_agent),
-        get_udfs(&mut client3, api_key, user_agent)
+        get_schemas(&mut client2, api_key, user_agent),
+        get_columns(&mut client3, api_key, user_agent),
+        get_udfs(&mut client4, api_key, user_agent),
+        get_udtfs(&mut client5, api_key, user_agent)
     );
 
     if let Ok(mut cache) = schema_cache.try_write() {
         if let Ok(tables) = tables_result {
             cache.update_tables(tables);
+        }
+
+        if let Ok(schemas) = schemas_result {
+            cache.update_schemas(schemas);
         }
 
         if let Ok(columns) = columns_result {
@@ -232,6 +380,10 @@ async fn refresh_schema(
         if let Ok(udfs) = udfs_result {
             cache.update_udfs(udfs);
         }
+
+        if let Ok(udtfs) = udtfs_result {
+            cache.update_udtfs(udtfs);
+        }
     }
 }
 
@@ -240,7 +392,7 @@ async fn get_tables(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "SELECT table_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime')";
+    let query = "--autocomplete\nSELECT table_schema || '.' || table_name as full_name FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime') UNION SELECT table_schema || '.' || table_name FROM information_schema.views WHERE table_schema NOT IN ('information_schema', 'runtime') ORDER BY full_name";
 
     let records = crate::get_records(
         client.clone(),
@@ -252,10 +404,22 @@ async fn get_tables(
     .await?;
 
     let mut tables = Vec::new();
+    let mut table_set = std::collections::HashSet::new();
+    
     for batch in records.0 {
         if let Some(array) = batch.column(0).as_any().downcast_ref::<StringArray>() {
-            for table_name in array.iter().flatten() {
-                tables.push(table_name.to_string());
+            for full_name in array.iter().flatten() {
+                // Always add the fully qualified name
+                if table_set.insert(full_name.to_string()) {
+                    tables.push(full_name.to_string());
+                }
+                
+                // For public schema, also add unqualified name
+                if let Some(unqualified) = full_name.strip_prefix("public.") {
+                    if table_set.insert(unqualified.to_string()) {
+                        tables.push(unqualified.to_string());
+                    }
+                }
             }
         }
     }
@@ -263,12 +427,40 @@ async fn get_tables(
     Ok(tables)
 }
 
+async fn get_schemas(
+    client: &mut FlightServiceClient<Channel>,
+    api_key: Option<&String>,
+    user_agent: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let query = "--autocomplete\nSELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'runtime')";
+
+    let records = crate::get_records(
+        client.clone(),
+        query,
+        api_key,
+        user_agent,
+        crate::cache_control::CacheControl::NoCache,
+    )
+    .await?;
+
+    let mut schemas = Vec::new();
+    for batch in records.0 {
+        if let Some(array) = batch.column(0).as_any().downcast_ref::<StringArray>() {
+            for schema_name in array.iter().flatten() {
+                schemas.push(schema_name.to_string());
+            }
+        }
+    }
+
+    Ok(schemas)
+}
+
 async fn get_columns(
     client: &mut FlightServiceClient<Channel>,
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "SELECT column_name FROM information_schema.columns";
+    let query = "--autocomplete\nSELECT column_name FROM information_schema.columns";
 
     let records = crate::get_records(
         client.clone(),
@@ -296,7 +488,7 @@ async fn get_udfs(
     api_key: Option<&String>,
     user_agent: &str,
 ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
-    let query = "SELECT name FROM list_udfs()";
+    let query = "--autocomplete\nSELECT name FROM list_udfs()";
 
     let records = crate::get_records(
         client.clone(),
@@ -317,6 +509,65 @@ async fn get_udfs(
     }
 
     Ok(udfs)
+}
+
+async fn get_udtfs(
+    client: &mut FlightServiceClient<Channel>,
+    api_key: Option<&String>,
+    user_agent: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let query = "--autocomplete\nSELECT name FROM list_udtfs()";
+
+    let records = crate::get_records(
+        client.clone(),
+        query,
+        api_key,
+        user_agent,
+        crate::cache_control::CacheControl::NoCache,
+    )
+    .await?;
+
+    let mut udtfs = Vec::new();
+    for batch in records.0 {
+        if let Some(array) = batch.column(0).as_any().downcast_ref::<StringArray>() {
+            for udtf_name in array.iter().flatten() {
+                udtfs.push(udtf_name.to_string());
+            }
+        }
+    }
+
+    Ok(udtfs)
+}
+
+/// Quote an identifier if it contains uppercase letters, reserved keywords, or special characters
+fn quote_identifier_if_needed(identifier: &str) -> String {
+    // Check if identifier needs quoting
+    let needs_quoting = identifier.chars().any(|c| c.is_uppercase())
+        || identifier.contains('.')  // Already qualified, handle parts separately
+        || identifier.chars().any(|c| !c.is_alphanumeric() && c != '_' && c != '.');
+    
+    if !needs_quoting {
+        return identifier.to_string();
+    }
+    
+    // Handle schema-qualified names (e.g., "MySchema"."MyTable")
+    if identifier.contains('.') {
+        let parts: Vec<&str> = identifier.split('.').collect();
+        let quoted_parts: Vec<String> = parts
+            .iter()
+            .map(|part| {
+                if part.chars().any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_') {
+                    format!("\"{}\"", part)
+                } else {
+                    (*part).to_string()
+                }
+            })
+            .collect();
+        quoted_parts.join(".")
+    } else {
+        // Single identifier
+        format!("\"{}\"", identifier)
+    }
 }
 
 fn extract_word(line: &str, pos: usize) -> (usize, &str) {
@@ -364,6 +615,53 @@ fn is_word_boundary(ch: char) -> bool {
     }
 }
 
+/// Filter DataFusion's full keyword list to only include useful autocomplete suggestions
+fn filter_useful_keywords() -> Vec<String> {
+    let useful_keywords = [
+        // Query statements
+        "select", "from", "where", "having", "order", "group",
+        "limit", "offset", "distinct", "union", "intersect", "except",
+        
+        // Join types
+        "join", "inner", "left", "right", "full", "cross",
+        "outer", "natural", "on", "using",
+        
+        // Boolean operators
+        "and", "or", "not", "in", "exists", "between",
+        "like", "ilike", "is", "null",
+        
+        // Common keywords
+        "as", "asc", "desc", "by", "all", "any",
+        "case", "when", "then", "else", "end",
+        
+        // DML statements
+        "insert", "into", "values", "update", "set", "delete",
+        
+        // DDL statements
+        "create", "alter", "drop", "truncate",
+        "table", "view", "index", "schema", "database",
+        
+        // Constraints and keys
+        "primary", "foreign", "key", "references",
+        "unique", "constraint", "check", "default",
+        
+        // Functions and casts
+        "cast", "extract", "interval", "current_date", "current_time",
+        "current_timestamp",
+        
+        // CTEs and subqueries
+        "with", "recursive",
+        
+        // SHOW commands
+        "show", "tables", "schemas", "columns", "databases",
+        
+        // DESCRIBE/EXPLAIN
+        "describe", "explain", "analyze",
+    ];
+    
+    useful_keywords.iter().map(|&s| s.to_string()).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -372,6 +670,11 @@ mod tests {
     fn create_test_editor_helper() -> EditorHelper {
         let schema_cache = Arc::new(RwLock::new(SchemaCache {
             udfs: vec!["count".to_string(), "sum".to_string(), "concat".to_string()],
+            udtfs: vec!["generate_series".to_string(), "unnest".to_string()],
+            schemas: vec!["public".to_string(), "analytics".to_string()]
+                .into_iter()
+                .map(StringValue::from)
+                .collect(),
             tables: vec![
                 "users".to_string(),
                 "products".to_string(),
@@ -395,7 +698,7 @@ mod tests {
             .into_iter()
             .map(StringValue::from)
             .collect(),
-            keywords: ALL_KEYWORDS.iter().map(|k| k.to_lowercase()).collect(),
+            keywords: filter_useful_keywords(),
         }));
 
         EditorHelper {
@@ -567,5 +870,78 @@ mod tests {
                 "Failed for: {sql}"
             );
         }
+    }
+
+    #[test]
+    fn test_schema_completion() {
+        let helper = create_test_editor_helper();
+
+        let completions = get_completions(&helper, "pub", 3);
+        assert!(completions.contains(&"public.".to_string()));
+
+        let completions = get_completions(&helper, "analyt", 6);
+        assert!(completions.contains(&"analytics.".to_string()));
+    }
+
+    #[test]
+    fn test_udtf_completion() {
+        let helper = create_test_editor_helper();
+
+        let completions = get_completions(&helper, "generate", 8);
+        assert!(completions.contains(&"generate_series".to_string()));
+
+        let completions = get_completions(&helper, "unnest", 6);
+        assert!(completions.contains(&"unnest".to_string()));
+    }
+
+    #[test]
+    fn test_quote_identifier_if_needed() {
+        // Lowercase identifiers don't need quoting
+        assert_eq!(quote_identifier_if_needed("users"), "users");
+        assert_eq!(quote_identifier_if_needed("my_table"), "my_table");
+        
+        // Uppercase identifiers need quoting
+        assert_eq!(quote_identifier_if_needed("MyTable"), "\"MyTable\"");
+        assert_eq!(quote_identifier_if_needed("USERS"), "\"USERS\"");
+        
+        // Schema-qualified names with uppercase
+        assert_eq!(quote_identifier_if_needed("MySchema.MyTable"), "\"MySchema\".\"MyTable\"");
+        assert_eq!(quote_identifier_if_needed("public.MyTable"), "public.\"MyTable\"");
+        assert_eq!(quote_identifier_if_needed("MySchema.users"), "\"MySchema\".users");
+        assert_eq!(quote_identifier_if_needed("public.users"), "public.users");
+    }
+
+    #[test]
+    fn test_uppercase_table_completion() {
+        let mut cache = SchemaCache::new();
+        cache.update_tables(vec![
+            "MyTable".to_string(), 
+            "users".to_string(), 
+            "MyView".to_string(),  // Unqualified version
+            "public.MyView".to_string()
+        ]);
+        
+        let helper = EditorHelper {
+            schema_cache: Arc::new(RwLock::new(cache)),
+            flight_client: None,
+            api_key: None,
+            user_agent: String::new(),
+            shutdown_sender: None,
+            refresh_task_handle: None,
+        };
+
+        // Test that uppercase table is quoted
+        let sql = "select * from My";
+        let completions = get_completions(&helper, sql, sql.len());
+        assert!(completions.iter().any(|c| c.contains("\"MyTable\"")), 
+                "Should suggest quoted MyTable, got: {:?}", completions);
+        assert!(completions.iter().any(|c| c.contains("\"MyView\"")), 
+                "Should suggest quoted MyView, got: {:?}", completions);
+        
+        // Test lowercase table is not quoted
+        let sql2 = "select * from user";
+        let completions = get_completions(&helper, sql2, sql2.len());
+        assert!(completions.iter().any(|c| c.contains("users ") && !c.contains("\"")), 
+                "Should suggest unquoted users, got: {:?}", completions);
     }
 }

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -21,10 +21,7 @@ impl From<String> for StringValue {
     fn from(s: String) -> Self {
         let original: Arc<str> = Arc::from(s.into_boxed_str());
         let lower: Arc<str> = Arc::from(original.to_lowercase());
-        Self {
-            original,
-            lower,
-        }
+        Self { original, lower }
     }
 }
 
@@ -308,32 +305,38 @@ impl Completer for EditorHelper {
 /// Only validate complete-looking statements to avoid filtering out partial completions
 fn should_validate_sql(sql: &str) -> bool {
     let trimmed = sql.trim().to_lowercase();
-    
+
     // Always allow if it doesn't contain a statement keyword at all
-    if !trimmed.contains("select") && !trimmed.contains("insert") && 
-       !trimmed.contains("update") && !trimmed.contains("delete") && 
-       !trimmed.contains("with") && !trimmed.contains("show") &&
-       !trimmed.contains("describe") && !trimmed.contains("explain") {
+    if !trimmed.contains("select")
+        && !trimmed.contains("insert")
+        && !trimmed.contains("update")
+        && !trimmed.contains("delete")
+        && !trimmed.contains("with")
+        && !trimmed.contains("show")
+        && !trimmed.contains("describe")
+        && !trimmed.contains("explain")
+    {
         return true;
     }
-    
+
     // If it has semicolon, it's trying to be a complete statement - validate it
     if trimmed.contains(';') {
         return is_valid_sql(sql);
     }
-    
+
     // If it's a SELECT and has FROM clause, validate it
     if trimmed.contains("select") && trimmed.contains("from") {
         return is_valid_sql(sql);
     }
-    
+
     // If it's INSERT/UPDATE/DELETE and looks complete, validate it
-    if (trimmed.contains("insert") && trimmed.contains("into")) ||
-       (trimmed.contains("update") && trimmed.contains("set")) ||
-       (trimmed.contains("delete") && trimmed.contains("from")) {
+    if (trimmed.contains("insert") && trimmed.contains("into"))
+        || (trimmed.contains("update") && trimmed.contains("set"))
+        || (trimmed.contains("delete") && trimmed.contains("from"))
+    {
         return is_valid_sql(sql);
     }
-    
+
     // Otherwise, it's a partial completion - allow it without validation
     true
 }
@@ -405,7 +408,7 @@ async fn get_tables(
 
     let mut tables = Vec::new();
     let mut table_set = std::collections::HashSet::new();
-    
+
     for batch in records.0 {
         if let Some(array) = batch.column(0).as_any().downcast_ref::<StringArray>() {
             for full_name in array.iter().flatten() {
@@ -413,7 +416,7 @@ async fn get_tables(
                 if table_set.insert(full_name.to_string()) {
                     tables.push(full_name.to_string());
                 }
-                
+
                 // For public schema, also add unqualified name
                 if let Some(unqualified) = full_name.strip_prefix("public.") {
                     if table_set.insert(unqualified.to_string()) {
@@ -545,18 +548,21 @@ fn quote_identifier_if_needed(identifier: &str) -> String {
     let needs_quoting = identifier.chars().any(|c| c.is_uppercase())
         || identifier.contains('.')  // Already qualified, handle parts separately
         || identifier.chars().any(|c| !c.is_alphanumeric() && c != '_' && c != '.');
-    
+
     if !needs_quoting {
         return identifier.to_string();
     }
-    
+
     // Handle schema-qualified names (e.g., "MySchema"."MyTable")
     if identifier.contains('.') {
         let parts: Vec<&str> = identifier.split('.').collect();
         let quoted_parts: Vec<String> = parts
             .iter()
             .map(|part| {
-                if part.chars().any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_') {
+                if part
+                    .chars()
+                    .any(|c| c.is_uppercase() || !c.is_alphanumeric() && c != '_')
+                {
                     format!("\"{}\"", part)
                 } else {
                     (*part).to_string()
@@ -619,46 +625,100 @@ fn is_word_boundary(ch: char) -> bool {
 fn filter_useful_keywords() -> Vec<String> {
     let useful_keywords = [
         // Query statements
-        "select", "from", "where", "having", "order", "group",
-        "limit", "offset", "distinct", "union", "intersect", "except",
-        
+        "select",
+        "from",
+        "where",
+        "having",
+        "order",
+        "group",
+        "limit",
+        "offset",
+        "distinct",
+        "union",
+        "intersect",
+        "except",
         // Join types
-        "join", "inner", "left", "right", "full", "cross",
-        "outer", "natural", "on", "using",
-        
+        "join",
+        "inner",
+        "left",
+        "right",
+        "full",
+        "cross",
+        "outer",
+        "natural",
+        "on",
+        "using",
         // Boolean operators
-        "and", "or", "not", "in", "exists", "between",
-        "like", "ilike", "is", "null",
-        
+        "and",
+        "or",
+        "not",
+        "in",
+        "exists",
+        "between",
+        "like",
+        "ilike",
+        "is",
+        "null",
         // Common keywords
-        "as", "asc", "desc", "by", "all", "any",
-        "case", "when", "then", "else", "end",
-        
+        "as",
+        "asc",
+        "desc",
+        "by",
+        "all",
+        "any",
+        "case",
+        "when",
+        "then",
+        "else",
+        "end",
         // DML statements
-        "insert", "into", "values", "update", "set", "delete",
-        
+        "insert",
+        "into",
+        "values",
+        "update",
+        "set",
+        "delete",
         // DDL statements
-        "create", "alter", "drop", "truncate",
-        "table", "view", "index", "schema", "database",
-        
+        "create",
+        "alter",
+        "drop",
+        "truncate",
+        "table",
+        "view",
+        "index",
+        "schema",
+        "database",
         // Constraints and keys
-        "primary", "foreign", "key", "references",
-        "unique", "constraint", "check", "default",
-        
+        "primary",
+        "foreign",
+        "key",
+        "references",
+        "unique",
+        "constraint",
+        "check",
+        "default",
         // Functions and casts
-        "cast", "extract", "interval", "current_date", "current_time",
+        "cast",
+        "extract",
+        "interval",
+        "current_date",
+        "current_time",
         "current_timestamp",
-        
         // CTEs and subqueries
-        "with", "recursive",
-        
+        "with",
+        "recursive",
         // SHOW commands
-        "show", "tables", "schemas", "columns", "databases",
-        
+        "show",
+        "tables",
+        "schemas",
+        "columns",
+        "databases",
         // DESCRIBE/EXPLAIN
-        "describe", "explain", "analyze",
+        "describe",
+        "explain",
+        "analyze",
     ];
-    
+
     useful_keywords.iter().map(|&s| s.to_string()).collect()
 }
 
@@ -899,15 +959,24 @@ mod tests {
         // Lowercase identifiers don't need quoting
         assert_eq!(quote_identifier_if_needed("users"), "users");
         assert_eq!(quote_identifier_if_needed("my_table"), "my_table");
-        
+
         // Uppercase identifiers need quoting
         assert_eq!(quote_identifier_if_needed("MyTable"), "\"MyTable\"");
         assert_eq!(quote_identifier_if_needed("USERS"), "\"USERS\"");
-        
+
         // Schema-qualified names with uppercase
-        assert_eq!(quote_identifier_if_needed("MySchema.MyTable"), "\"MySchema\".\"MyTable\"");
-        assert_eq!(quote_identifier_if_needed("public.MyTable"), "public.\"MyTable\"");
-        assert_eq!(quote_identifier_if_needed("MySchema.users"), "\"MySchema\".users");
+        assert_eq!(
+            quote_identifier_if_needed("MySchema.MyTable"),
+            "\"MySchema\".\"MyTable\""
+        );
+        assert_eq!(
+            quote_identifier_if_needed("public.MyTable"),
+            "public.\"MyTable\""
+        );
+        assert_eq!(
+            quote_identifier_if_needed("MySchema.users"),
+            "\"MySchema\".users"
+        );
         assert_eq!(quote_identifier_if_needed("public.users"), "public.users");
     }
 
@@ -915,12 +984,12 @@ mod tests {
     fn test_uppercase_table_completion() {
         let mut cache = SchemaCache::new();
         cache.update_tables(vec![
-            "MyTable".to_string(), 
-            "users".to_string(), 
-            "MyView".to_string(),  // Unqualified version
-            "public.MyView".to_string()
+            "MyTable".to_string(),
+            "users".to_string(),
+            "MyView".to_string(), // Unqualified version
+            "public.MyView".to_string(),
         ]);
-        
+
         let helper = EditorHelper {
             schema_cache: Arc::new(RwLock::new(cache)),
             flight_client: None,
@@ -933,15 +1002,26 @@ mod tests {
         // Test that uppercase table is quoted
         let sql = "select * from My";
         let completions = get_completions(&helper, sql, sql.len());
-        assert!(completions.iter().any(|c| c.contains("\"MyTable\"")), 
-                "Should suggest quoted MyTable, got: {:?}", completions);
-        assert!(completions.iter().any(|c| c.contains("\"MyView\"")), 
-                "Should suggest quoted MyView, got: {:?}", completions);
-        
+        assert!(
+            completions.iter().any(|c| c.contains("\"MyTable\"")),
+            "Should suggest quoted MyTable, got: {:?}",
+            completions
+        );
+        assert!(
+            completions.iter().any(|c| c.contains("\"MyView\"")),
+            "Should suggest quoted MyView, got: {:?}",
+            completions
+        );
+
         // Test lowercase table is not quoted
         let sql2 = "select * from user";
         let completions = get_completions(&helper, sql2, sql2.len());
-        assert!(completions.iter().any(|c| c.contains("users ") && !c.contains("\"")), 
-                "Should suggest unquoted users, got: {:?}", completions);
+        assert!(
+            completions
+                .iter()
+                .any(|c| c.contains("users ") && !c.contains("\"")),
+            "Should suggest unquoted users, got: {:?}",
+            completions
+        );
     }
 }

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -315,6 +315,9 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         user_agent.to_string(),
     )));
     if let Some(helper) = rl.helper_mut() {
+        // Perform initial refresh to populate autocomplete immediately
+        helper.refresh_now().await;
+        // Start background refresh task for updates
         helper.start_refreshing(300);
     }
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -315,8 +315,12 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         user_agent.to_string(),
     )));
     if let Some(helper) = rl.helper_mut() {
-        // Perform initial refresh to populate autocomplete immediately
-        helper.refresh_now().await;
+        // Perform initial refresh to populate autocomplete immediately with a 2-second timeout
+        let refresh_result =
+            tokio::time::timeout(tokio::time::Duration::from_secs(2), helper.refresh_now()).await;
+        if refresh_result.is_err() {
+            tracing::debug!("Initial autocomplete metadata refresh timed out after 2 seconds");
+        }
         // Start background refresh task for updates
         helper.start_refreshing(300);
     }


### PR DESCRIPTION
This pull request adds an immediate refresh to the autocomplete functionality in the REPL, ensuring suggestions are available right away, and clarifies the order of refresh operations.

Enhancements to autocomplete initialization:

* [`crates/flightrepl/src/lib.rs`](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R318-R320): Added a call to `helper.refresh_now().await` to perform an initial refresh for autocomplete suggestions before starting the periodic background refresh task.