### PR TITLE
Update `generate_changelog` script

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -56,15 +56,17 @@ def main():
         trunk_patch_to_hash[patch_id] = commit_hash
 
     # Get release branch commits since tag
-    release_commits = run_git(f"git log {tag}..origin/{release_branch} --format=%H").split('\n')
+    release_commits = run_git(f"git log {tag}..origin/{release_branch} --format=\"%H-%s\"").split('\n')
 
     print()
     print("### Changelog")
     print()
 
-    for release_hash in reversed(release_commits):
+    for commit in reversed(release_commits):
+        commit_hash, commit_title = commit.split("-", 1)
+
         # Calculate its patch-id
-        patch_id_output = run_git(f"git show {release_hash} | git patch-id --stable").split()
+        patch_id_output = run_git(f"git show {commit_hash} | git patch-id --stable").split()
         if not patch_id_output:
             continue
         patch_id = patch_id_output[0]
@@ -77,6 +79,8 @@ def main():
         if pr_info:
             pr_number, username, title = pr_info
             print(f"- {title} by [@{username}](https://github.com/{username}) in [#{pr_number}](https://github.com/{owner}/{repo}/pull/{pr_number})")
+        else:
+            print(f"- !!!! (PR NOT FOUND) - {commit_title} - https://github.com/{owner}/{repo}/commit/{commit_hash}/")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 📝 Summary

Currently commits that we couldn't match with PRs (most likely due to manual conflict resolution) are ignored.

With this new change we will show them with a clear message:
```
- !!!! (PR NOT FOUND) - DuckDB: `on_refresh_recompute_statistics ` param + ANALYZE for table-based partitioning (#7719) - https://github.com/spiceai/spiceai/commit/9f7d094550bfde1fb2311fc2b8531bdd54b2f95d/
```
