### PR TITLE
add benchmark spicepods

### DIFF
--- a/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
@@ -1,0 +1,47 @@
+version: v1
+kind: Spicepod
+name: s3[parquet]-duckdb[file]
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer.parquet
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_memory_limit: '2GiB'
+  - from: s3://benchmarks/tpch_sf1/lineitem.parquet
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation.parquet
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders.parquet
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part.parquet
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp.parquet
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region.parquet
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier.parquet
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
@@ -16,7 +16,7 @@ datasets:
       engine: duckdb
       mode: file
       params:
-        duckdb_memory_limit: '2GiB'
+        duckdb_memory_limit: 2GiB
   - from: s3://benchmarks/tpch_sf1/lineitem.parquet
     name: lineitem
     params: *s3_params

--- a/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
@@ -16,7 +16,7 @@ datasets:
       engine: duckdb
       mode: file
       params:
-        duckdb_memory_limit: '4GiB'
+        duckdb_memory_limit: 4GiB
   - from: s3://benchmarks/tpch_sf1/lineitem.parquet
     name: lineitem
     params: *s3_params

--- a/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
@@ -1,0 +1,47 @@
+version: v1
+kind: Spicepod
+name: s3[parquet]-duckdb[file]
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer.parquet
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_memory_limit: '4GiB'
+  - from: s3://benchmarks/tpch_sf1/lineitem.parquet
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation.parquet
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders.parquet
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part.parquet
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp.parquet
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region.parquet
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier.parquet
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration


### PR DESCRIPTION
## 📝 Summary
 - Adds missing spicepods used in testoperator dispatch of benchmarks (See `tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml`) :
   -  `./test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml`
   - `./test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml`
- Example failing benchmarks
  - [bench - tpch - accelerated/s3[parquet]-duckdb[file]-4gib.yaml](https://github.com/spiceai/spiceai/actions/runs/19293674493)
  - [bench - tpch - accelerated/s3[parquet]-duckdb[file]-2gib.yaml](https://github.com/spiceai/spiceai/actions/runs/19293420400)