### PR TITLE
fix: Prevent SortExec from ordering below SchemaCastScanExec

### DIFF
--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -143,7 +143,7 @@ impl ExecutionPlan for SchemaCastScanExec {
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true; self.children().len()]
+        vec![false; self.children().len()]
     }
 
     fn benefits_from_input_partitioning(&self) -> Vec<bool> {


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Prevents `SortExec` from reordering to below `SchemaCastScanExec`, where the schema may not be what we require for the sort yet.
