### PR TITLE
Fix tracing of 's3_vector_query_and_get'

### DIFF
--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -532,6 +532,7 @@ impl ExecutionPlan for S3VectorsQueryExec {
     }
 }
 
+/// Wraps a single [`S3Vectors::get_vectors`] for better input, output and error handling.
 async fn get_vectors_call(
     client: Arc<dyn S3Vectors + Send + Sync>,
     idx: &S3VectorIdentifier,
@@ -576,6 +577,7 @@ async fn get_vectors_call(
         .collect())
 }
 
+/// Wraps a single [`S3Vectors::query_vectors`] for better input, output and error handling.
 async fn query_vectors_call(
     client: Arc<dyn S3Vectors + Send + Sync>,
     idx: &S3VectorIdentifier,

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -33,7 +33,7 @@ use arrow::{
 use async_trait::async_trait;
 use datafusion::{
     catalog::{Session, TableProvider},
-    common::{Constraints, exec_err, project_schema},
+    common::{Constraints, HashMap, exec_err, project_schema},
     datasource::TableType,
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
@@ -50,8 +50,8 @@ use datafusion::{
     prelude::Expr,
 };
 use s3_vectors::{
-    Document, GetVectorsInput, GetVectorsOutput, QueryOutputVector, QueryVectorsInput,
-    QueryVectorsOutput, S3Vectors, SdkError, VectorData,
+    Document, GetVectorsInput, GetVectorsOutput, QueryOutputVector, QueryVectorsInput, S3Vectors,
+    SdkError, VectorData,
 };
 use s3_vectors_metadata_filter::{convert_datafusion_filters_to_s3_vectors, document_to_json_map};
 use snafu::ResultExt;
@@ -532,38 +532,61 @@ impl ExecutionPlan for S3VectorsQueryExec {
     }
 }
 
-#[allow(clippy::too_many_lines)]
-async fn query_vector_stream(
+async fn get_vectors_call(
     client: Arc<dyn S3Vectors + Send + Sync>,
-    idx: S3VectorIdentifier,
-    query: Vec<f32>,
-    schema: SchemaRef,
-    limit: i32,
-    filters: Vec<Expr>,
-    tx: Sender<DataFusionResult<RecordBatch, DataFusionError>>,
-) -> DataFusionResult<()> {
-    let start = std::time::Instant::now();
-
+    idx: &S3VectorIdentifier,
+    keys: Vec<String>,
+) -> DataFusionResult<HashMap<String, VectorData>> {
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let (json_schema, vector_sizes) = loosen_vector_schema(&schema);
-    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
-
-    let s3_filter_pre = convert_datafusion_filters_to_s3_vectors(&filters)?;
-    let s3_filter: Option<Document> = s3_filter_pre.clone().map(Into::into);
-
-    let combined_span = info_span!(
-        target: "task_history",
-        "s3_vector_query_and_get",
-        bucket_name = bucket_name,
-        index_name = index_name,
-        arn = arn,
-        top_k = limit
-    );
-
-    let QueryVectorsOutput {
-        vectors: mut query_vectors,
+    let GetVectorsOutput {
+        vectors: output_vectors,
         ..
     } = client
+        .get_vectors(
+            GetVectorsInput::builder()
+                .set_keys(Some(keys))
+                .set_vector_bucket_name(bucket_name.clone())
+                .set_index_arn(arn.clone())
+                .set_index_name(index_name.clone())
+                .set_return_data(Some(true))
+                .build()
+                .boxed()
+                .map_err(DataFusionError::External)?,
+        )
+        .instrument(info_span!(
+            target: "task_history",
+            "s3_get_vectors",
+            bucket_name = bucket_name,
+            index_name = index_name,
+            arn = arn,
+        ))
+        .await
+        .map_err(|e| {
+            DataFusionError::External(
+                Error::S3VectorGetVectorsError {
+                    source: Box::new(e.into_service_error()),
+                }
+                .into(),
+            )
+        })?;
+
+    Ok(output_vectors
+        .into_iter()
+        .filter_map(|v| Some((v.key, v.data?)))
+        .collect())
+}
+
+async fn query_vectors_call(
+    client: Arc<dyn S3Vectors + Send + Sync>,
+    idx: &S3VectorIdentifier,
+    query: Vec<f32>,
+    filters: Vec<Expr>,
+    limit: i32,
+) -> DataFusionResult<Vec<QueryOutputVector>> {
+    let (arn, bucket_name, index_name) = idx.index_identifier_variables();
+    let s3_filter_pre = convert_datafusion_filters_to_s3_vectors(&filters)?;
+    let s3_filter: Option<Document> = s3_filter_pre.clone().map(Into::into);
+    let output = client
         .query_vectors(
             QueryVectorsInput::builder()
                 .query_vector(VectorData::Float32(query))
@@ -586,7 +609,6 @@ async fn query_vector_stream(
             arn = arn,
             top_k = limit
         ))
-        .instrument(combined_span.clone())
         .await
         .map_err(|e| {
             if let SdkError::ServiceError(service_error) = &e
@@ -614,59 +636,53 @@ async fn query_vector_stream(
             )
         })?;
 
-    let num_vectors = query_vectors.len();
+    Ok(output.vectors)
+}
+
+#[allow(clippy::too_many_lines)]
+async fn query_vector_stream(
+    client: Arc<dyn S3Vectors + Send + Sync>,
+    idx: S3VectorIdentifier,
+    query: Vec<f32>,
+    schema: SchemaRef,
+    limit: i32,
+    filters: Vec<Expr>,
+    tx: Sender<DataFusionResult<RecordBatch, DataFusionError>>,
+) -> DataFusionResult<()> {
+    let start = std::time::Instant::now();
+
+    let (arn, bucket_name, index_name) = idx.index_identifier_variables();
+    let (json_schema, vector_sizes) = loosen_vector_schema(&schema);
+    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
+
+    let combined_span = info_span!(
+        target: "task_history",
+        "s3_vector_query_and_get",
+        bucket_name = bucket_name,
+        index_name = index_name,
+        arn = arn,
+        top_k = limit
+    );
+
+    let mut query_vectors = query_vectors_call(Arc::clone(&client), &idx, query, filters, limit)
+        .instrument(combined_span.clone())
+        .await?;
 
     // Only fetch vector data if the embeddings column is in the projection.
     // Check if "data" column is present in the schema.
-    let needs_embeddings = schema.column_with_name(S3_VECTOR_EMBEDDING_NAME).is_some();
-
-    if needs_embeddings {
-        // Get the vector data for each output using GetVectors API.
-        let keys = query_vectors.iter().map(|v| v.key.clone()).collect();
-        let GetVectorsOutput {
-            vectors: output_vectors,
-            ..
-        } = client
-            .get_vectors(
-                GetVectorsInput::builder()
-                    .set_keys(Some(keys))
-                    .set_vector_bucket_name(bucket_name.clone())
-                    .set_index_arn(arn.clone())
-                    .set_index_name(index_name.clone())
-                    .set_return_data(Some(true))
-                    .build()
-                    .boxed()
-                    .map_err(DataFusionError::External)?,
-            )
-            .instrument(info_span!(
-                target: "task_history",
-                "s3_get_vectors",
-                bucket_name = bucket_name,
-                index_name = index_name,
-                arn = arn,
-            ))
-            .instrument(combined_span)
-            .await
-            .map_err(|e| {
-                DataFusionError::External(
-                    Error::S3VectorGetVectorsError {
-                        source: Box::new(e.into_service_error()),
-                    }
-                    .into(),
-                )
-            })?;
-
-        // Put the vector data in the query_vectors
-        // Use HashMap for O(n) lookup instead of O(n²) nested loop
-        let output_map: std::collections::HashMap<_, _> = output_vectors
-            .into_iter()
-            .map(|v| (v.key.clone(), v))
-            .collect();
+    if schema.column_with_name(S3_VECTOR_EMBEDDING_NAME).is_some() {
+        let mut vector_data = get_vectors_call(
+            Arc::clone(&client),
+            &idx,
+            query_vectors.iter().map(|v| v.key.clone()).collect(),
+        )
+        .instrument(combined_span.clone())
+        .await?;
 
         let mut missing_keys = Vec::new();
         for query_vector in &mut query_vectors {
-            if let Some(output_vector) = output_map.get(&query_vector.key) {
-                query_vector.data.clone_from(&output_vector.data);
+            if let Some(output_vector) = vector_data.remove(&query_vector.key) {
+                query_vector.data = Some(output_vector);
             } else {
                 missing_keys.push(&query_vector.key);
             }
@@ -706,7 +722,10 @@ async fn query_vector_stream(
         }
     }
     let duration = start.elapsed();
-    tracing::trace!("S3 Vectors Query retrieved {num_vectors} vectors in {duration:?}");
+    tracing::trace!(
+        "S3 Vectors Query retrieved {} vectors in {duration:?}",
+        rows.len()
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## 📝 Summary
**Before**
```shell
>>> spice trace sql_query --include-input
Spice.ai OSS CLI v1.9.0-unstable-build.bab76ee12-dev
TREE                          STATUS DURATION   SPAN ID          INPUT
sql_query                     ✅      6543.00ms 47091774e93da111 select id, score from vector_search(test, 'the', answer) order by score desc limit 3;
  ├── text_embed              ✅       566.00ms 3b4e40f245d8e205 "the"
  ├── text_embed              ✅         0.21ms 2c3b6214b599342a "the" # this is a cached embedding call.
  ├── text_embed              ✅       690.68ms 5394b03edac7fef0 "the"
  ├── s3_vector_query_and_get ✅       681.92ms b9e71c4572a8f511 <empty>
  ├── s3_query_vectors        ✅       681.81ms ea08d479a4a2b983 <empty>
  ├── s3_get_vectors        ✅      1544.64ms cc2101552fbcd9b8 <empty>
  ├── s3_vector_query_and_get ✅       877.60ms 47bbc5884c889059 <empty>
  ├── s3_query_vectors        ✅       877.56ms 827e0916b488c9d0 <empty>
  ├── s3_get_vectors        ✅      1576.97ms ae91dba9b92a81b5 <empty>
  ├── s3_vector_query_and_get ✅      1060.79ms 0b50b74255135fa6 <empty>
  ├── s3_query_vectors        ✅      1060.67ms 6f54f005582d243e <empty>
  └── s3_get_vectors        ✅      1576.97ms ae91dba9b92a81b5 <empty>
  ```
**Now**
```shell
>>> spice trace sql_query --include-input
TREE                          STATUS DURATION   SPAN ID          INPUT
sql_query                     ✅      6432.79ms 785a6ced0669a6f4 select id, question_embedding, score from vector_search(test, 'hello', question) order by score desc limit 5;
  ├── text_embed              ✅         0.51ms 99cd964b43132dc5 "hello"
  ├── text_embed              ✅         0.18ms 407fdfc42d4598a3 "hello"
  ├── text_embed              ✅         0.59ms f5d7f365b30e5b81 "hello"
  ├── s3_vector_query_and_get ✅      2018.70ms 94affe3d0005c794 <empty>
  │ ├── s3_query_vectors      ✅       473.49ms 676f55d5dc6f49d9 <empty>
  │ └── s3_get_vectors        ✅      1544.64ms cc2101552fbcd9b8 <empty>
  ├── s3_vector_query_and_get ✅      2010.01ms 3d2573f78f27de49 <empty>
  │ ├── s3_query_vectors      ✅       432.60ms 630169250501421c <empty>
  │ └── s3_get_vectors        ✅      1576.97ms ae91dba9b92a81b5 <empty>
  └── s3_vector_query_and_get ✅      2012.25ms 8bdb361efde3dde7 <empty>
    ├── s3_query_vectors      ✅      1290.16ms 80bc225512984c71 <empty>
    └── s3_get_vectors        ✅       721.76ms 0d0018e2d778d877 <empty>
  ```
