### PR TITLE
Test operator: avoid duplicate Flight requests when using --http-clients

### DIFF
--- a/crates/test-framework/src/spicetest/append/mod.rs
+++ b/crates/test-framework/src/spicetest/append/mod.rs
@@ -181,9 +181,9 @@ impl SpiceTest<AppendStarted> {
                     id,
                     self.state.queries.clone(),
                     EndCondition::Duration(self.state.end_duration),
-                    spice_client.clone(),
                     self.name.clone(),
                 )
+                .with_flight_client(spice_client.clone())
                 .with_explain_plan_snapshot(self.explain_plan_snapshot)
                 .with_results_snapshot(self.results_snapshot_predicate);
 

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -197,16 +197,10 @@ impl SpiceTest<NotStarted> {
 
         let mut query_workers = Vec::new();
         for id in 0..self.state.parallel_count {
-            let spice_client = self
-                .get_spiced()?
-                .spice_client(self.api_key.clone(), self.state.disable_caching)
-                .await?;
-
             let mut worker = SpiceTestQueryWorker::new(
                 id,
                 self.state.query_set.clone(),
                 self.state.end_condition,
-                spice_client,
                 self.name.clone(),
             )
             .with_explain_plan_snapshot(self.explain_plan_snapshot)
@@ -220,6 +214,12 @@ impl SpiceTest<NotStarted> {
 
             if self.state.http_client {
                 worker = worker.with_http_client(http_client.clone());
+            } else {
+                let spice_client = self
+                    .get_spiced()?
+                    .spice_client(self.api_key.clone(), self.state.disable_caching)
+                    .await?;
+                worker = worker.with_flight_client(spice_client);
             }
 
             if let Some(validation_data) = &self.state.validation_data {

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -49,7 +49,7 @@ pub(crate) struct SpiceTestQueryWorker {
     pub progress_bar: Option<ProgressBar>,
     validate: bool,
     scale_factor: f64,
-    spice_client: Arc<SpiceClient>,
+    spice_client: Option<Arc<SpiceClient>>,
     http_client: Option<reqwest::Client>,
     /// Optional custom validation data for scenario queries
     validation_data: Option<HashMap<Arc<str>, Vec<RecordBatch>>>,
@@ -96,14 +96,13 @@ impl SpiceTestQueryWorker {
         id: usize,
         query_set: Vec<Query>,
         end_condition: EndCondition,
-        spice_client: SpiceClient,
         name: String,
     ) -> Self {
         Self {
             id,
             query_set,
             end_condition,
-            spice_client: Arc::new(spice_client),
+            spice_client: None,
             explain_plan_snapshot: false,
             results_snapshot_predicate: None,
             name,
@@ -117,6 +116,11 @@ impl SpiceTestQueryWorker {
 
     pub fn with_http_client(mut self, http_client: reqwest::Client) -> Self {
         self.http_client = Some(http_client);
+        self
+    }
+
+    pub fn with_flight_client(mut self, spice_client: SpiceClient) -> Self {
+        self.spice_client = Some(Arc::new(spice_client));
         self
     }
 
@@ -265,10 +269,13 @@ impl SpiceTestQueryWorker {
                             ));
                         }
 
-                        if self.explain_plan_snapshot && self.id == 0 {
+                        if self.explain_plan_snapshot
+                            && self.id == 0
+                            && let Some(client) = &self.spice_client
+                        {
                             println!("Worker {} - Query '{}' - Explain plan", self.id, query.name);
                             if let Err(e) = record_explain_plan(
-                                Arc::clone(&self.spice_client),
+                                Arc::clone(client),
                                 self.name.as_str(),
                                 query,
                                 self.scale_factor,
@@ -457,10 +464,13 @@ impl SpiceTestQueryWorker {
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
+        let Some(spice_client) = self.spice_client.as_ref() else {
+            return Ok(());
+        };
+
         let query_start = Instant::now();
 
-        let mut result_stream = self
-            .spice_client
+        let mut result_stream = spice_client
             .query_with_params(&query.sql, query.get_parameters_batch().transpose()?)
             .await?;
 


### PR DESCRIPTION
## 📝 Summary

This update makes it possible to isolate and measure the performance of the HTTP-only workload, without running parallel Flight requests.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
