### PR TITLE
Update load tests to use truth percentile values

### DIFF
--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -89,7 +89,7 @@ impl<T: ExtendedMetrics> QueryMetric<T> {
         }
 
         let iterations = durations.len();
-        let durations = durations.statistical_set()?;
+
         Ok(Self {
             query_name: name,
             query_status,

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -77,18 +77,19 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     let spiced_instance = warm_up.wait().await?.end()?;
 
     let test_duration = Duration::from_secs(args.test_args.common.duration);
-    let query_set_iterations = (test_duration.as_secs() / 60 / 60).max(1);
+
+    // Calculate baseline duration: 10% of target time, min 1min, max 10min
+    let baseline_duration_secs = (test_duration.as_secs() / 10).clamp(60, 600);
+    let baseline_duration = Duration::from_secs(baseline_duration_secs);
 
     // baseline run
-    println!("Running baseline throughput test");
+    println!("Running baseline throughput test for {baseline_duration_secs}s",);
 
     let (_query_set, test_builder) = super::build_test_with_validation(
         &args.test_args,
         NotStarted::new()
             .with_parallel_count(args.test_args.common.concurrency)
-            .with_end_condition(EndCondition::QuerySetCompleted(
-                query_set_iterations.try_into()?,
-            ))
+            .with_end_condition(EndCondition::Duration(baseline_duration))
             .with_disable_caching(args.test_args.disable_caching)
             .with_http_client(args.test_args.http_clients),
     )?;

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -56,8 +56,28 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         None
     };
 
+    // warm up run
+    println!("Performing warm up");
+
+    let (_query_set, test_builder) = super::build_test_with_validation(
+        &args.test_args,
+        NotStarted::new()
+            .with_parallel_count(args.test_args.common.concurrency)
+            .with_end_condition(EndCondition::QuerySetCompleted(1))
+            .with_disable_caching(args.test_args.disable_caching)
+            .with_http_client(args.test_args.http_clients),
+    )?;
+
+    let warm_up = SpiceTest::new(app.name.clone(), test_builder)
+        .with_spiced_instance(spiced_instance)
+        .with_progress_bars(!args.test_args.common.disable_progress_bars)
+        .start()
+        .await?;
+
+    let spiced_instance = warm_up.wait().await?.end()?;
+
     let test_duration = Duration::from_secs(args.test_args.common.duration);
-    let test_hours = (test_duration.as_secs() / 60 / 60).max(1);
+    let query_set_iterations = (test_duration.as_secs() / 60 / 60).max(1);
 
     // baseline run
     println!("Running baseline throughput test");
@@ -66,7 +86,9 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         &args.test_args,
         NotStarted::new()
             .with_parallel_count(args.test_args.common.concurrency)
-            .with_end_condition(EndCondition::QuerySetCompleted(test_hours.try_into()?))
+            .with_end_condition(EndCondition::QuerySetCompleted(
+                query_set_iterations.try_into()?,
+            ))
             .with_disable_caching(args.test_args.disable_caching)
             .with_http_client(args.test_args.http_clients),
     )?;
@@ -78,10 +100,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         .await?;
 
     let test = baseline_test.wait().await?;
-    let baseline_percentiles = test
-        .get_query_durations()
-        .statistical_set()?
-        .percentile(99.0)?;
+    let baseline_percentiles = test.get_query_durations().percentile(99.0)?;
 
     let baseline_metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Load)?;
     println!("Baseline metrics:");
@@ -120,7 +139,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         .await?;
 
     let test = wait_test_and_memory!(throughput_test, memory_token, memory_readings);
-    let test_durations = test.get_query_durations().statistical_set()?;
+    let test_durations = test.get_query_durations().clone();
     let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Load)?;
     let mut spiced_instance = test.end()?;
     let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;


### PR DESCRIPTION
## 📝 Summary

Load test percentile calculations were using manual outlier-filtered data (`statistical_set()`) which removes values outside 1.5×IQR bounds. 

PR removes manual outlier filtering to ensure percentiles reflect actual system performance including edge cases. 
 - Warm up step for load testing was added to stabilize initial measurements
 - Baseline duration is now 10% of target time, min 1min, max 10min

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
