### PR TITLE
Fix DuckDB on_commit sink race

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Spice provides four industry standard APIs in a lightweight, portable runtime (s
 
 Spice's primary features include:
 
-- **Data Federation**: SQL query across any database, data warehouse, or data lake. Deploy with single-node or distributed multi-node query execution. [Learn More](https://spiceai.org/docs/features/query-federation).
-- **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries with Arrow, DuckDB, SQLite, PostgreSQL, or Cayenne (Vortex+SQLite) for simplified multi-file acceleration. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai)
-- **Hybrid Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and petabyte-scale vector similarity search via Amazon S3 Vectors or pgvector for structured and unstructured data.
-- **SQL LLM Inference**: Call LLMs directly from SQL. Generate, summarize, and enrich data using the Spice SQL AI function or Text-to-SQL. Use Spice as an AI-database powering retrieval-augmented generation (RAG) and intelligent agents with OpenAI-compatible APIs and MCP integration. [Learn More](https://spiceai.org/docs/use-cases/rag).
+- **Data Federation**: SQL query across any database, data warehouse, or data lake. Scale from single-node to distributed multi-node query execution. [Learn More](https://spiceai.org/docs/features/query-federation).
+- **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries with Arrow, DuckDB, SQLite, PostgreSQL, or Spice Cayenne (Vortex). [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai)
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and petabyte-scale vector similarity search via Amazon S3 Vectors or pgvector for structured and unstructured data.
+- **AI apps and agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents with OpenAI-compatible APIs and MCP integration. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 If you want to build with DataFusion, DuckDB, or Vortex, Spice provides a simple, flexible, and production-ready engine you can just use.
 
@@ -131,7 +131,7 @@ Limited = Partial or restricted support
 
 - **OpenAI-compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI, Amazon Bedrock) or deploy locally (Llama, NVIDIA NIM) with OpenAI Responses API support for advanced interactions. [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
 - **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down for fast retrieval. Scale to distributed multi-node query execution with Apache Ballista. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
-- **Hybrid Search and RAG**: Search and retrieve context with accelerated embeddings for retrieval-augmented generation (RAG) workflows. Native Amazon S3 Vectors integration for petabyte-scale vector search. Full-text search (FTS) via Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL via `text_search` and `vector_search` UDTFs. Reciprocal rank fusion (RRF) for hybrid search. [Amazon S3 Vectors Cookbook Recipe](https://github.com/spiceai/cookbook/tree/trunk/vectors/s3/README.md)
+- **Search and RAG**: Search and retrieve context with accelerated embeddings for retrieval-augmented generation (RAG) workflows. Native Amazon S3 Vectors integration for petabyte-scale vector search. Full-text search (FTS) via Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL via `text_search` and `vector_search` UDTFs. Reciprocal rank fusion (RRF) for hybrid search. [Amazon S3 Vectors Cookbook Recipe](https://github.com/spiceai/cookbook/tree/trunk/vectors/s3/README.md)
 - **LLM Memory and Observability**: Store and retrieve history and context for AI agents while gaining deep visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability & Monitoring Features Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Spice provides four industry standard APIs in a lightweight, portable runtime (s
 
 Spice's primary features include:
 
-- **Data Federation**: SQL query across any database, data warehouse, or data lake. Scale from single-node to distributed multi-node query execution. [Learn More](https://spiceai.org/docs/features/query-federation).
-- **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries with Arrow, DuckDB, SQLite, PostgreSQL, or Spice Cayenne (Vortex). [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai)
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and petabyte-scale vector similarity search via Amazon S3 Vectors or pgvector for structured and unstructured data.
-- **AI apps and agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents with OpenAI-compatible APIs and MCP integration. [Learn More](https://spiceai.org/docs/use-cases/rag).
+- **Data Federation**: SQL query across any database, data warehouse, or data lake. Deploy with single-node or distributed multi-node query execution. [Learn More](https://spiceai.org/docs/features/query-federation).
+- **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries with Arrow, DuckDB, SQLite, PostgreSQL, or Cayenne (Vortex+SQLite) for simplified multi-file acceleration. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai)
+- **Hybrid Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and petabyte-scale vector similarity search via Amazon S3 Vectors or pgvector for structured and unstructured data.
+- **SQL LLM Inference**: Call LLMs directly from SQL. Generate, summarize, and enrich data using the Spice SQL AI function or Text-to-SQL. Use Spice as an AI-database powering retrieval-augmented generation (RAG) and intelligent agents with OpenAI-compatible APIs and MCP integration. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 If you want to build with DataFusion, DuckDB, or Vortex, Spice provides a simple, flexible, and production-ready engine you can just use.
 
@@ -131,7 +131,7 @@ Limited = Partial or restricted support
 
 - **OpenAI-compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI, Amazon Bedrock) or deploy locally (Llama, NVIDIA NIM) with OpenAI Responses API support for advanced interactions. [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
 - **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down for fast retrieval. Scale to distributed multi-node query execution with Apache Ballista. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
-- **Search and RAG**: Search and retrieve context with accelerated embeddings for retrieval-augmented generation (RAG) workflows. Native Amazon S3 Vectors integration for petabyte-scale vector search. Full-text search (FTS) via Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL via `text_search` and `vector_search` UDTFs. Reciprocal rank fusion (RRF) for hybrid search. [Amazon S3 Vectors Cookbook Recipe](https://github.com/spiceai/cookbook/tree/trunk/vectors/s3/README.md)
+- **Hybrid Search and RAG**: Search and retrieve context with accelerated embeddings for retrieval-augmented generation (RAG) workflows. Native Amazon S3 Vectors integration for petabyte-scale vector search. Full-text search (FTS) via Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL via `text_search` and `vector_search` UDTFs. Reciprocal rank fusion (RRF) for hybrid search. [Amazon S3 Vectors Cookbook Recipe](https://github.com/spiceai/cookbook/tree/trunk/vectors/s3/README.md)
 - **LLM Memory and Observability**: Store and retrieve history and context for AI agents while gaining deep visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability & Monitoring Features Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/sink.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/sink.rs
@@ -331,7 +331,7 @@ fn insert_overwrite(
     table_definition: &Arc<TableDefinition>,
     batch_rx: Receiver<(String, PartitionData)>,
     on_conflict: Option<&OnConflict>,
-    mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
+    on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
     schema: &SchemaRef,
     write_settings: &DuckDBWriteSettings,
 ) -> datafusion::common::Result<u64> {
@@ -366,7 +366,7 @@ fn insert_overwrite(
     .map_err(to_retriable_data_write_error)?;
 
     on_commit_transaction
-        .try_recv()
+        .blocking_recv()
         .map_err(to_retriable_data_write_error)?;
 
     for new_table in &tables {
@@ -433,7 +433,7 @@ fn insert_append(
     table_definition: &Arc<TableDefinition>,
     batch_rx: Receiver<(String, PartitionData)>,
     on_conflict: Option<&OnConflict>,
-    mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
+    on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
     schema: &SchemaRef,
     write_settings: &DuckDBWriteSettings,
 ) -> datafusion::common::Result<u64> {
@@ -474,7 +474,7 @@ fn insert_append(
     }
 
     on_commit_transaction
-        .try_recv()
+        .blocking_recv()
         .map_err(to_retriable_data_write_error)?;
 
     tx.commit()
@@ -764,6 +764,7 @@ mod test {
     use datafusion::prelude::col;
     use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
     use runtime_table_partition::expression::PartitionedBy;
+    use std::{thread, time::Duration};
 
     fn get_mem_duckdb() -> Arc<DuckDbConnectionPool> {
         Arc::new(
@@ -781,6 +782,20 @@ mod test {
             RelationName::new("test_table"),
             schema,
         ))
+    }
+
+    fn make_partition_batch(schema: &SchemaRef, region: &str, ids: &[i64]) -> RecordBatch {
+        let id_values: Vec<Option<i64>> = ids.iter().copied().map(Some).collect();
+        let region_values: Vec<Option<&str>> = ids.iter().map(|_| Some(region)).collect();
+
+        RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![
+                Arc::new(Int64Array::from(id_values)),
+                Arc::new(StringArray::from(region_values)),
+            ],
+        )
+        .expect("should create a record batch")
     }
 
     fn verify_state_after_write(
@@ -1130,6 +1145,110 @@ mod test {
         verify_partition_does_not_exist(&tx2, &table_definition, "region=us-west-1", true);
 
         tx2.rollback().expect("to rollback");
+    }
+
+    #[test]
+    fn test_insert_overwrite_waits_for_commit_signal() {
+        let pool = get_mem_duckdb();
+        let table_definition = get_test_table_definition();
+        let schema = table_definition.schema();
+
+        let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(2);
+        let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
+
+        let batch = make_partition_batch(&schema, "us-east-1", &[1, 2]);
+
+        batch_tx
+            .blocking_send((
+                "region=us-east-1".to_string(),
+                PartitionData::Batches(vec![batch]),
+            ))
+            .expect("to send partition batch");
+        drop(batch_tx);
+
+        let write_settings = DuckDBWriteSettings::default();
+
+        let handle = thread::spawn({
+            let pool = Arc::clone(&pool);
+            let table_definition = Arc::clone(&table_definition);
+            let schema = Arc::clone(&schema);
+            let write_settings = write_settings.clone();
+
+            move || {
+                insert_overwrite(
+                    pool,
+                    &table_definition,
+                    batch_rx,
+                    None,
+                    commit_rx,
+                    &schema,
+                    &write_settings,
+                )
+            }
+        });
+
+        thread::sleep(Duration::from_millis(50));
+
+        commit_tx.send(()).expect("to send commit signal");
+
+        let rows = handle
+            .join()
+            .expect("insert thread to finish")
+            .expect("insert_overwrite to succeed");
+
+        assert_eq!(rows, 2, "expected rows to be written after commit signal");
+    }
+
+    #[test]
+    fn test_insert_append_waits_for_commit_signal() {
+        let pool = get_mem_duckdb();
+        let table_definition = get_test_table_definition();
+        let schema = table_definition.schema();
+
+        let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(2);
+        let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
+
+        let batch = make_partition_batch(&schema, "us-west-1", &[10, 11, 12]);
+
+        batch_tx
+            .blocking_send((
+                "region=us-west-1".to_string(),
+                PartitionData::Batches(vec![batch]),
+            ))
+            .expect("to send partition batch");
+        drop(batch_tx);
+
+        let write_settings = DuckDBWriteSettings::default();
+
+        let handle = thread::spawn({
+            let pool = Arc::clone(&pool);
+            let table_definition = Arc::clone(&table_definition);
+            let schema = Arc::clone(&schema);
+            let write_settings = write_settings.clone();
+
+            move || {
+                insert_append(
+                    pool,
+                    &table_definition,
+                    batch_rx,
+                    None,
+                    commit_rx,
+                    &schema,
+                    &write_settings,
+                )
+            }
+        });
+
+        thread::sleep(Duration::from_millis(50));
+
+        commit_tx.send(()).expect("to send commit signal");
+
+        let rows = handle
+            .join()
+            .expect("insert thread to finish")
+            .expect("insert_append to succeed");
+
+        assert_eq!(rows, 3, "expected rows to be written after commit signal");
     }
 
     #[tokio::test]


### PR DESCRIPTION
This pull request improves the reliability and clarity of data writing operations in the DuckDB tables mode sink by ensuring that insert operations (`insert_overwrite` and `insert_append`) properly wait for a commit signal before proceeding. It also updates documentation to better reflect current terminology and features. The most important changes are grouped below:

**Data Write Synchronization Improvements**

* Changed both `insert_overwrite` and `insert_append` functions to use `blocking_recv()` instead of `try_recv()` for the commit signal, ensuring these operations reliably wait for the commit before proceeding. This prevents premature writes and improves transactional safety. [[1]](diffhunk://#diff-fcab84247823929c04638e18411be017ec464266e8654639c73dfc7ac8fb2324L369-R369) [[2]](diffhunk://#diff-fcab84247823929c04638e18411be017ec464266e8654639c73dfc7ac8fb2324L477-R477)
* Removed unnecessary use of `mut` for the `on_commit_transaction` receiver parameter in both functions, reflecting that the receiver is no longer mutated. [[1]](diffhunk://#diff-fcab84247823929c04638e18411be017ec464266e8654639c73dfc7ac8fb2324L334-R334) [[2]](diffhunk://#diff-fcab84247823929c04638e18411be017ec464266e8654639c73dfc7ac8fb2324L436-R436)

**Testing Enhancements**

* Added two new unit tests (`test_insert_overwrite_waits_for_commit_signal` and `test_insert_append_waits_for_commit_signal`) to verify that insert operations correctly wait for the commit signal before writing data, increasing confidence in transactional behavior.
* Introduced a helper function `make_partition_batch` to simplify test setup for partitioned data batches.
* Included necessary imports for thread and timing utilities in the test module.