### PR TITLE
Add partitioned duckdb

### DIFF
--- a/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-partitioned.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-partitioned.yaml
@@ -1,0 +1,46 @@
+version: v1
+kind: Spicepod
+name: s3[parquet]-duckdb[file]_partitioned
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer.parquet
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+      partition_by: bucket(32, c_name)
+  - from: s3://benchmarks/tpch_sf1/lineitem.parquet
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation.parquet
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders.parquet
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part.parquet
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp.parquet
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region.parquet
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier.parquet
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file]_partitioned.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file]_partitioned.yaml
@@ -1,0 +1,15 @@
+tests:
+  bench:
+    spicepod_path: accelerated/file[parquet]-duckdb[file]_partitioned.yaml
+    query_set: tpch
+    runner_type: spiceai-dev-runners
+    validate_results: true
+  throughput:
+    spicepod_path: accelerated/file[parquet]-duckdb[file]_partitioned.yaml
+    query_set: tpch
+    runner_type: spiceai-dev-runners
+  load:
+    spicepod_path: accelerated/file[parquet]-duckdb[file]_partitioned.yaml
+    query_set: tpch
+    runner_type: spiceai-dev-runners
+    duration: 28800


### PR DESCRIPTION
This pull request introduces a new accelerated TPCH benchmark configuration for partitioned Parquet datasets on DuckDB, and adds corresponding test definitions to support benchmarking and validation workflows.

New benchmark configuration:

* Added `s3[parquet]-duckdb[file]_partitioned.yaml` in `test/spicepods/tpch/sf1/accelerated/` to define TPCH datasets sourced from S3 Parquet files, with DuckDB file-based acceleration and partitioning by bucket on `c_name`. ([test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-partitioned.yamlR1-R46](diffhunk://#diff-fd2e5e024bc541a72383a3585d9a60769d071c1d4022007de49dbfc70397d6ceR1-R46))

Test integration:

* Added test definitions in `tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file]_partitioned.yaml` for running benchmark, throughput, and load tests using the new configuration, including result validation and long-duration load testing. ([tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file]_partitioned.yamlR1-R15](diffhunk://#diff-83a1d4f672d21868a7f117bd272c22a9ff7d3fae5289e9cf43efa1a0842ce7e1R1-R15))