### PR TITLE
Add install-dev target back to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,12 @@ install: build
 	install -m 755 target/release/spice ~/.spice/bin/spice
 	install -m 755 target/release/spiced ~/.spice/bin/spiced
 
+.PHONY: install-dev
+install-dev: build-dev
+	mkdir -p ~/.spice/bin
+	install -m 755 target/release/spice ~/.spice/bin/spice
+	install -m 755 target/debug/spiced ~/.spice/bin/spiced
+
 .PHONY: install-with-models
 install-with-models:
 	make install SPICED_NON_DEFAULT_FEATURES="models"


### PR DESCRIPTION
## 📝 Summary
Bad merge conflict resolution in #8089 removed `install-dev` Makefile target.
