### PR TITLE
fix 'testoperator run search'

### DIFF
--- a/.github/workflows/benchmarks_search.yml
+++ b/.github/workflows/benchmarks_search.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run ${{ matrix.target.name }}
         run: |
           rm -rf .spice/data
-          testoperator run vector-search \
+          testoperator run search \
           --ready-wait 1800 \
           --concurrency 10 \
           --benchmark-dataset quora_retrieval \

--- a/.github/workflows/testoperator_run_search.yml
+++ b/.github/workflows/testoperator_run_search.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Run the benchmark test - ${{ steps.extract_spicepod_filename.outputs.SPICEPOD_FILENAME }}
         run: |
           rm -rf .spice/data
-          testoperator run vector-search \
+          testoperator run search \
             --ready-wait 1800 \
             --concurrency 10 \
             --benchmark-dataset quora_retrieval \

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,7 @@
       "program": "${workspaceFolder}/target/debug/testoperator",
       "args": [
         "run",
-        "vector-search",
+        "search",
         "--ready-wait",
         "1800",
         "--concurrency",

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -290,9 +290,9 @@ Run model evaluations (evals) test. In addition to the common options, supports 
 
 ### Running Vector Search Tests
 
-Running vector search tests with the testoperator is still experimental, and uses statically defined tests within the command file. Vector search tests support the common options.
+Running search tests with the testoperator is still experimental, and uses statically defined tests within the command file. Vector search tests support the common options.
 
-`testoperator run vector-search [OPTIONS]`
+`testoperator run search [OPTIONS]`
 
 ### Running Append Tests
 


### PR DESCRIPTION
## 📝 Summary
 - `search benchmark tests` [runs](https://github.com/spiceai/spiceai/actions/workflows/benchmarks_search.yml) started [failing](https://github.com/spiceai/spiceai/actions/runs/18242866252) because of changes in #7358 changing the command name 
```diff
- testoperator run vector-search
- testoperator run search
```
 - This PR updates CI that uses this to from `vector-search` -> `search`. 