### PR TITLE
Testoperator dispatch: respect `verify_results` dispatch configuration

### DIFF
--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -44,9 +44,6 @@ pub struct DispatchArgs {
 
     #[arg(long, default_value = "false", action = ArgAction::Set)]
     pub(crate) update_snapshots: bool,
-
-    #[arg(long, action = ArgAction::Set, default_value_t = false, default_missing_value = "true", num_args = 0..=1, require_equals = false)]
-    pub(crate) validate: bool,
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
@@ -134,12 +131,6 @@ impl BenchArgs {
     #[must_use]
     pub fn with_update_snapshots(mut self, update_snapshots: UpdateSnapshots) -> Self {
         self.update_snapshots = Some(update_snapshots);
-        self
-    }
-
-    #[must_use]
-    pub fn with_validate(mut self, validate: bool) -> Self {
-        self.validate_results = Some(validate);
         self
     }
 }

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -62,8 +62,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                 serde_json::json!(WorkflowArgs {
                     specific_args: bench
                         .clone()
-                        .with_update_snapshots(args.update_snapshots.into())
-                        .with_validate(args.validate),
+                        .with_update_snapshots(args.update_snapshots.into()),
                     spiced_commit: args.spiced_commit.clone(),
                 })
             }


### PR DESCRIPTION
## 📝 Summary

Manual `verify_results` setting [has been removed ](https://github.com/spiceai/spiceai/commit/942f787cdb9878dea110f9b70eaa3abed875f3c9) and based on verify default value (false) we always override dispatch yaml setting so `verify_results` is always disabled.

<img width="496" height="141" alt="image" src="https://github.com/user-attachments/assets/47af2504-c343-4ce5-bc16-0c13a88418b3" />


<img width="663" height="286" alt="image" src="https://github.com/user-attachments/assets/48f5287b-ee7b-4d7f-8acf-a971c664ca43" />


PR removes `verify_results` global override that can't be specified and is always default to false so yaml configuration is respected.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
