### PR TITLE
Fix validation path

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -79,28 +79,28 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF1
         run: |
-          for file in ./tools/testoperator/dispatch/tpch/sf1/**/*.yaml; do
+          for file in ./test/spicepods/tpch/sf1/**/*.yaml; do
             echo "Validating $file"
             ./target/release/spicepod-validator "$file"
           done
 
       - name: Validate spicepods - TPCDS
         run: |
-          for file in ./tools/testoperator/dispatch/tpcds/sf1/**/*.yaml; do
+          for file in ./test/spicepods/tpcds/**/*.yaml; do
             echo "Validating $file"
             ./target/release/spicepod-validator "$file"
           done
 
       - name: Validate spicepods - ClickBench
         run: |
-          for file in ./tools/testoperator/dispatch/clickbench/sf1/**/*.yaml; do
+          for file in ./test/spicepods/clickbench/**/*.yaml; do
             echo "Validating $file"
             ./target/release/spicepod-validator "$file"
           done
 
       - name: Validate spicepods - TPCH - SF100
         run: |
-          for file in ./tools/testoperator/dispatch/tpch/sf100/**/*.yaml; do
+          for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
             echo "Validating $file"
             ./target/release/spicepod-validator "$file"
           done
@@ -180,28 +180,28 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF1
         run: |
-          for file in ./tools/testoperator/dispatch/tpch/sf1/**/*.yaml; do
+          for file in ./test/spicepods/tpch/sf1/**/*.yaml; do
             echo "Validating $file"
             spicepod-validator "$file"
           done
 
       - name: Validate spicepods - TPCDS
         run: |
-          for file in ./tools/testoperator/dispatch/tpcds/sf1/**/*.yaml; do
+          for file in ./test/spicepods/tpcds/**/*.yaml; do
             echo "Validating $file"
             spicepod-validator "$file"
           done
 
       - name: Validate spicepods - ClickBench
         run: |
-          for file in ./tools/testoperator/dispatch/clickbench/sf1/**/*.yaml; do
+          for file in ./test/spicepods/clickbench/**/*.yaml; do
             echo "Validating $file"
             spicepod-validator "$file"
           done
 
       - name: Validate spicepods - TPCH - SF100
         run: |
-          for file in ./tools/testoperator/dispatch/tpch/sf100/**/*.yaml; do
+          for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
             echo "Validating $file"
             spicepod-validator "$file"
           done


### PR DESCRIPTION
This pull request updates the validation steps in the `.github/workflows/testoperator_dispatch.yml` workflow to use the new locations for spicepod YAML files. The validator scripts now reference the `./test/spicepods/` directory instead of the old `./tools/testoperator/dispatch/` paths.

Validation workflow updates:

* Changed the file paths in all spicepod validation steps (`TPCH - SF1`, `TPCDS`, `ClickBench`, and `TPCH - SF100`) to use the new `./test/spicepods/` directory structure, ensuring the workflow validates the correct set of YAML files. [[1]](diffhunk://#diff-8167c43a6ca2fc8578931a778138b5b373b6207c16f599679a80d90c39a2230fL82-R103) [[2]](diffhunk://#diff-8167c43a6ca2fc8578931a778138b5b373b6207c16f599679a80d90c39a2230fL183-R204)