### PR TITLE
Include root error when failing to find latest timestamp in accelerated table

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -115,7 +115,7 @@ pub enum Error {
     RefreshNotSupportedForChildTable { parent_dataset: TableReference },
 
     #[snafu(display(
-        "Failed to find latest timestamp in accelerated table. Is the 'time_column' parameter correct?"
+        "Failed to find latest timestamp in accelerated table: {source}. Is the 'time_column' parameter correct?"
     ))]
     FailedToQueryLatestTimestamp { source: DataFusionError },
 


### PR DESCRIPTION
## 📝 Summary

Include root error when failing to find latest timestamp in accelerated table to simplify troubleshooting.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
