### PR TITLE
Update TPCDS overrides for spice cloud connector

### DIFF
--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -723,7 +723,9 @@ pub fn get_tpcds_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
         Some(QueryOverrides::Spicecloud) => remove_tpcds_query!(
             queries, 8,  // https://github.com/spiceai/spiceai/issues/4668
             38, // https://github.com/spiceai/spiceai/issues/4667
-            87  // https://github.com/spiceai/spiceai/issues/4667
+            87, // https://github.com/spiceai/spiceai/issues/4667
+            32, 92, // https://github.com/spiceai/spiceai/issues/8150
+            29, 37, 41, 44, 54, 58 // empty results
         ),
         Some(QueryOverrides::SQLite) => remove_tpcds_query!(
             queries, 17, 29, 35, 74, // SQLite does not support `stddev`

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -724,8 +724,10 @@ pub fn get_tpcds_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
             queries, 8,  // https://github.com/spiceai/spiceai/issues/4668
             38, // https://github.com/spiceai/spiceai/issues/4667
             87, // https://github.com/spiceai/spiceai/issues/4667
-            32, 92, // https://github.com/spiceai/spiceai/issues/8150
-            29, 37, 41, 44, 54, 58 // empty results
+            32,
+            92, // correlated scalar subquery not supported - https://github.com/spiceai/spiceai/issues/8150
+            29, 37, 41, 44, 54,
+            58 // empty results - https://github.com/spiceai/spiceai/issues/8153
         ),
         Some(QueryOverrides::SQLite) => remove_tpcds_query!(
             queries, 17, 29, 35, 74, // SQLite does not support `stddev`


### PR DESCRIPTION
## 📝 Summary

This pull request updates the list of TPC-DS test queries that are skipped for the `Spicecloud` override in the test framework. The changes primarily add several queries to the exclusion list, addressing specific issues and cases where queries return empty results.

**Test query exclusions for Spicecloud:**

* Added queries `32` and `92` to the exclusion list due to issue #8150.
* Added queries `29`, `37`, `41`, `44`, `54`, and `58` to the exclusion list because they return empty results.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
