### PR TITLE
Suppress `delta_kernel::listed_log_files` warnings

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -85,7 +85,7 @@ const INTERNAL_COMPONENTS: &[&str] = &[
     "datafusion",
 ];
 
-const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
+const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,delta_kernel::listed_log_files=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
 
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {


### PR DESCRIPTION
## 📝 Summary

Suppresses spurious warnings coming from `delta_kernel` that were fixed upstream in `0.17`.
