### PR TITLE
Remove incorrect tool name validation

### DIFF
--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -83,6 +83,17 @@ impl ServerHandler for RuntimeServer {
                 ));
             }
 
+            // Security: Validate tool name contains only safe characters
+            if !tool_name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '/')
+            {
+                return Err(McpError::invalid_params(
+                    "Tool name contains invalid characters. Only alphanumeric, underscore, hyphen, and dot allowed".to_string(),
+                    None,
+                ));
+            }
+
             let Some(tool) = self.get_tool(tool_name.to_string().as_str()).await else {
                 return Err(McpError::method_not_found::<CallToolRequestMethod>());
             };

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -83,17 +83,6 @@ impl ServerHandler for RuntimeServer {
                 ));
             }
 
-            // Security: Validate tool name contains only safe characters
-            if !tool_name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
-            {
-                return Err(McpError::invalid_params(
-                    "Tool name contains invalid characters. Only alphanumeric, underscore, hyphen, and dot allowed".to_string(),
-                    None,
-                ));
-            }
-
             let Some(tool) = self.get_tool(tool_name.to_string().as_str()).await else {
                 return Err(McpError::method_not_found::<CallToolRequestMethod>());
             };


### PR DESCRIPTION
## 📝 Summary
From MCP [cookbook](https://github.com/spiceai/cookbook/blob/trunk/mcp/) testing:
```
WARN rmcp::service: response error id=4 error=ErrorData { code: ErrorCode(-32602), message: "Tool name contains invalid characters. Only alphanumeric, underscore, hyphen, and dot allowed", data: None }
```
