### PR TITLE
fix: Avoid pruning bucket partitions for != and NOT IN operators

### DIFF
--- a/crates/runtime-table-partition/src/provider/pruning.rs
+++ b/crates/runtime-table-partition/src/provider/pruning.rs
@@ -211,9 +211,13 @@ pub(crate) fn prune_partition(
             matches!(
                 f,
                 Expr::BinaryExpr(BinaryExpr {
-                    op: Operator::Gt | Operator::GtEq | Operator::Lt | Operator::LtEq,
+                    op: Operator::Gt
+                        | Operator::GtEq
+                        | Operator::Lt
+                        | Operator::LtEq
+                        | Operator::NotEq,
                     ..
-                })
+                }) | Expr::InList(InList { negated: true, .. })
             )
         });
 
@@ -485,11 +489,19 @@ fn evaluate_bucket_inequality(
                         Operator::LtEq => {
                             upper_bound = Some((lit.clone(), true));
                         }
+                        Operator::NotEq => {
+                            // For bucket partitions with != don't prune any partitions
+                            return Ok(false);
+                        }
                         _ => {}
                     }
                 }
                 _ => {}
             }
+        } else if let Expr::InList(InList { negated: true, .. }) = filter {
+            // Handle negated IN list (NOT IN)
+            // For bucket partitioning with NOT IN, don't prune any partitions
+            return Ok(false);
         }
     }
 
@@ -2485,6 +2497,62 @@ mod tests {
         // date_part can return Int32 or Float64 depending on the extracted part
         // For year, it returns Int32
         assert_eq!(result, ScalarValue::Int32(Some(2024)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_prune_partition_bucket_no_pruning() -> Result<(), DataFusionError> {
+        // Test that bucket partitions with != and NOT IN filters
+        // For bucket partitioning, these operators should generally not prune any partitions
+        // because buckets can contain multiple values
+        let schema = Schema::new(vec![Field::new("user_id", DataType::Int32, false)]);
+        let partition_by = Expr::ScalarFunction(ScalarFunction {
+            func: Arc::new(ScalarUDF::new_from_impl(bucket::Bucket::new())),
+            args: vec![lit(10_i64), col("user_id")],
+        });
+
+        // Test Case 1: user_id != 42
+        // For bucket partitioning with !=, no partitions should be pruned because:
+        // - Each bucket can contain multiple values
+        // - Even if a bucket contains 42, it likely contains other values that are != 42
+        let filters_not_equal = &[col("user_id").not_eq(lit(42_i32))];
+
+        for partition_value in 0..10_i32 {
+            let pruned = prune_partition(
+                &filters_not_equal[..],
+                &partition_by,
+                &ScalarValue::Int32(Some(partition_value)),
+                &schema,
+            )?;
+            assert!(
+                !pruned,
+                "Partition {partition_value} should not be pruned for user_id != 42 (bucket partitioning)",
+            );
+        }
+
+        // Test Case 2: user_id NOT IN (10, 20, 30)
+        // For bucket partitioning with NOT IN, no partitions should be pruned because:
+        // - Each bucket can contain multiple values
+        // - Even if a bucket contains one of the excluded values, it likely contains other values not in the list
+        let filters_not_in = &[in_list(
+            col("user_id"),
+            vec![lit(10_i32), lit(20_i32), lit(30_i32)],
+            true, // NOT IN
+        )];
+
+        for partition_value in 0..10_i32 {
+            let pruned = prune_partition(
+                &filters_not_in[..],
+                &partition_by,
+                &ScalarValue::Int32(Some(partition_value)),
+                &schema,
+            )?;
+            assert!(
+                !pruned,
+                "Partition {partition_value} should not be pruned for user_id NOT IN (10, 20, 30) (bucket partitioning)",
+            );
+        }
 
         Ok(())
     }

--- a/crates/runtime-table-partition/src/provider/pruning.rs
+++ b/crates/runtime-table-partition/src/provider/pruning.rs
@@ -1161,33 +1161,34 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_partition_hash_not_inlist() -> Result<(), DataFusionError> {
-        let schema = Schema::new(vec![Field::new("account_id", DataType::Int32, false)]);
-        let partition_by = bucket_expr(vec![lit(10i64), col("account_id")]);
-        let filters = &[in_list(
-            col("account_id"),
-            vec![lit(1), lit(2), lit(3)],
-            true,
+    fn test_prune_partition_bucket_with_not_inlist() -> Result<(), DataFusionError> {
+        // Test Case: user_id NOT IN (10, 20, 30)
+        // For bucket partitioning with NOT IN, no partitions should be pruned because:
+        // - Each bucket can contain multiple values
+        // - Even if a bucket contains one of the excluded values, it likely contains other values not in the list
+
+        let schema = Schema::new(vec![Field::new("user_id", DataType::Int32, false)]);
+        let partition_by = Expr::ScalarFunction(ScalarFunction {
+            func: Arc::new(ScalarUDF::new_from_impl(bucket::Bucket::new())),
+            args: vec![lit(10_i64), col("user_id")],
+        });
+
+        let filters_not_in = &[in_list(
+            col("user_id"),
+            vec![lit(10_i32), lit(20_i32), lit(30_i32)],
+            true, // NOT IN
         )];
-        let f = ScalarUDF::new_from_impl(bucket::Bucket::new());
-        let hashed_values = (1..=6)
-            .map(|i| {
-                let ScalarValue::Int32(Some(val)) = call(
-                    &f,
-                    vec![ScalarValue::Int64(Some(10)), ScalarValue::Int32(Some(i))],
-                )?
-                else {
-                    panic!("expected Int32");
-                };
-                Ok(val)
-            })
-            .collect::<Result<Vec<_>, DataFusionError>>()?;
-        for (val, should_prune) in hashed_values.into_iter().zip((1..=6).map(|i| i <= 3)) {
-            let partition_value = ScalarValue::Int32(Some(val));
-            assert_eq!(
-                prune_partition(filters.as_slice(), &partition_by, &partition_value, &schema)?,
-                should_prune,
-                "partition_value = {partition_value:?}, should_prune = {should_prune}",
+
+        for partition_value in 0..10_i32 {
+            let pruned = prune_partition(
+                &filters_not_in[..],
+                &partition_by,
+                &ScalarValue::Int32(Some(partition_value)),
+                &schema,
+            )?;
+            assert!(
+                !pruned,
+                "Partition {partition_value} should not be pruned for user_id NOT IN (10, 20, 30) (bucket partitioning)",
             );
         }
         Ok(())
@@ -2502,20 +2503,16 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_partition_bucket_no_pruning() -> Result<(), DataFusionError> {
-        // Test that bucket partitions with != and NOT IN filters
-        // For bucket partitioning, these operators should generally not prune any partitions
-        // because buckets can contain multiple values
+    fn test_prune_partition_bucket_with_not_eq() -> Result<(), DataFusionError> {
+        // Test Case: user_id != 42
+        // For bucket partitioning with !=, no partitions should be pruned because:
+        // - Each bucket can contain multiple values
+        // - Even if a bucket contains 42, it likely contains other values that are != 42
         let schema = Schema::new(vec![Field::new("user_id", DataType::Int32, false)]);
         let partition_by = Expr::ScalarFunction(ScalarFunction {
             func: Arc::new(ScalarUDF::new_from_impl(bucket::Bucket::new())),
             args: vec![lit(10_i64), col("user_id")],
         });
-
-        // Test Case 1: user_id != 42
-        // For bucket partitioning with !=, no partitions should be pruned because:
-        // - Each bucket can contain multiple values
-        // - Even if a bucket contains 42, it likely contains other values that are != 42
         let filters_not_equal = &[col("user_id").not_eq(lit(42_i32))];
 
         for partition_value in 0..10_i32 {
@@ -2528,29 +2525,6 @@ mod tests {
             assert!(
                 !pruned,
                 "Partition {partition_value} should not be pruned for user_id != 42 (bucket partitioning)",
-            );
-        }
-
-        // Test Case 2: user_id NOT IN (10, 20, 30)
-        // For bucket partitioning with NOT IN, no partitions should be pruned because:
-        // - Each bucket can contain multiple values
-        // - Even if a bucket contains one of the excluded values, it likely contains other values not in the list
-        let filters_not_in = &[in_list(
-            col("user_id"),
-            vec![lit(10_i32), lit(20_i32), lit(30_i32)],
-            true, // NOT IN
-        )];
-
-        for partition_value in 0..10_i32 {
-            let pruned = prune_partition(
-                &filters_not_in[..],
-                &partition_by,
-                &ScalarValue::Int32(Some(partition_value)),
-                &schema,
-            )?;
-            assert!(
-                !pruned,
-                "Partition {partition_value} should not be pruned for user_id NOT IN (10, 20, 30) (bucket partitioning)",
             );
         }
 


### PR DESCRIPTION
## 📝 Summary

Bucket partitioning uses hash-based distribution where each bucket can contain multiple values. For exclusion operators (!= and NOT IN), we need to be conservative and avoid pruning partitions because:
- Even if a bucket contains the excluded value(s), it likely also contains other values that should be included in the result
- Incorrectly pruning these partitions leads to missing records in query results

## 🔗 Related

 - https://github.com/spiceai/spiceai/issues/8162

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
