### PR TITLE
fix: Ensure caching metrics are emitted after Prometheus startup

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -106,9 +106,9 @@ pub trait CacheProvider<V: Clone + Send + Sync + 'static>:
 {
     async fn get_raw_key(&self, key: &u64) -> Option<V>;
     async fn put_raw_key(&self, key: &u64, value: V);
-    fn invalidate_all(&self);
-    fn size_bytes(&self) -> u64;
-    fn item_count(&self) -> u64;
+    async fn invalidate_all(&self);
+    async fn size_bytes(&self) -> u64;
+    async fn item_count(&self) -> u64;
     fn max_size(&self) -> usize;
     async fn checkpoint(&self);
 }
@@ -427,13 +427,13 @@ impl QueryResultsCacheProvider {
     }
 
     #[must_use]
-    pub fn size(&self) -> u64 {
-        self.cache.size_bytes()
+    pub async fn size(&self) -> u64 {
+        self.cache.size_bytes().await
     }
 
     #[must_use]
-    pub fn item_count(&self) -> u64 {
-        self.cache.item_count()
+    pub async fn item_count(&self) -> u64 {
+        self.cache.item_count().await
     }
 
     /// Returns the base TTL for cache entries (used for staleness checks).

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -140,8 +140,6 @@ impl<
             .support_invalidation_closures()
             .build_with_hasher(hasher.clone());
 
-        V::init();
-
         LruCache {
             cache,
             hasher,
@@ -200,50 +198,36 @@ impl<
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5
-            && self
-                .metrics_last_reported_time
-                .compare_exchange(
-                    last_emitted,
-                    now_seconds,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                )
-                .is_ok()
-        {
-            V::record_item_count(self.item_count());
-            V::record_size(self.size_bytes());
+        if now_seconds.saturating_sub(last_emitted) >= 5 {
+            self.metrics_last_reported_time
+                .store(now_seconds, Ordering::Relaxed);
+            V::record_item_count(self.item_count().await);
+            V::record_size(self.size_bytes().await);
             V::record_max_size(self.max_size() as u64);
         }
     }
 
-    fn invalidate_all(&self) {
+    async fn invalidate_all(&self) {
         self.cache.invalidate_all();
 
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5
-            && self
-                .metrics_last_reported_time
-                .compare_exchange(
-                    last_emitted,
-                    now_seconds,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                )
-                .is_ok()
-        {
-            V::record_item_count(self.item_count());
-            V::record_size(self.size_bytes());
+        if now_seconds.saturating_sub(last_emitted) >= 5 {
+            self.metrics_last_reported_time
+                .store(now_seconds, Ordering::Relaxed);
+            V::record_item_count(self.item_count().await);
+            V::record_size(self.size_bytes().await);
         }
     }
 
-    fn size_bytes(&self) -> u64 {
+    async fn size_bytes(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
         self.cache.weighted_size()
     }
 
-    fn item_count(&self) -> u64 {
+    async fn item_count(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
         self.cache.entry_count()
     }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -198,9 +198,19 @@ impl<
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5 {
-            self.metrics_last_reported_time
-                .store(now_seconds, Ordering::Relaxed);
+        // compare_exchange ensures only 1 active thread emits metric updates every 5 seconds
+        // performance is comparable with relaxed load/store
+        if now_seconds.saturating_sub(last_emitted) >= 5
+            && self
+                .metrics_last_reported_time
+                .compare_exchange(
+                    last_emitted,
+                    now_seconds,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+        {
             V::record_item_count(self.item_count().await);
             V::record_size(self.size_bytes().await);
             V::record_max_size(self.max_size() as u64);
@@ -213,9 +223,19 @@ impl<
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5 {
-            self.metrics_last_reported_time
-                .store(now_seconds, Ordering::Relaxed);
+        // compare_exchange ensures only 1 active thread emits metric updates every 5 seconds
+        // performance is comparable with relaxed load/store
+        if now_seconds.saturating_sub(last_emitted) >= 5
+            && self
+                .metrics_last_reported_time
+                .compare_exchange(
+                    last_emitted,
+                    now_seconds,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+        {
             V::record_item_count(self.item_count().await);
             V::record_size(self.size_bytes().await);
         }

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -110,15 +110,17 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
         self.cache.insert(*key, value).await;
     }
 
-    fn invalidate_all(&self) {
+    async fn invalidate_all(&self) {
         self.cache.invalidate_all();
     }
 
-    fn size_bytes(&self) -> u64 {
+    async fn size_bytes(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
         self.cache.weighted_size()
     }
 
-    fn item_count(&self) -> u64 {
+    async fn item_count(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
         self.cache.entry_count()
     }
 
@@ -248,7 +250,7 @@ mod tests {
         assert!(retrieved.is_some());
 
         // Invalidate the cache for the table
-        cache.invalidate_all();
+        cache.invalidate_all().await;
 
         // Verify the value is no longer in the cache
         let retrieved = cache.get_raw_key(&key.as_u64()).await;

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1815,10 +1815,10 @@ impl DataFusion {
         Ok(plan)
     }
 
-    pub(crate) fn clear_cached_plans(&self) {
+    pub(crate) async fn clear_cached_plans(&self) {
         tracing::trace!("clearing cached logical plans");
         if let Some(cache_provider) = self.plans_cache_provider() {
-            cache_provider.invalidate_all();
+            cache_provider.invalidate_all().await;
         }
     }
 
@@ -1991,7 +1991,7 @@ mod tests {
         };
 
         cache_provider.checkpoint().await; // Ensure entry gets logged
-        assert_eq!(cache_provider.item_count(), 1);
+        assert_eq!(cache_provider.item_count().await, 1);
         drop(cache_provider);
 
         // Reusing the same query should no longer at to the cache
@@ -2003,6 +2003,6 @@ mod tests {
             unreachable!("Cache provider should be available");
         };
         cache_provider.checkpoint().await; // Ensure entry gets logged
-        assert_eq!(cache_provider.item_count(), 1);
+        assert_eq!(cache_provider.item_count().await, 1);
     }
 }

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -641,7 +641,7 @@ mod tests {
 
         // Verify it starts empty
         assert_eq!(
-            cache_provider.item_count(),
+            cache_provider.item_count().await,
             0,
             "Plan cache should be empty initially"
         );

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -470,7 +470,7 @@ impl Runtime {
 
         // Updating a dataset may cause the cached LogicalPlans to be
         // obsolete, so we remove them
-        self.df.clear_cached_plans();
+        self.df.clear_cached_plans().await;
 
         match Arc::clone(&self)
             .load_dataset_connector(Arc::clone(&ds))

--- a/test/body.txt
+++ b/test/body.txt
@@ -1,0 +1,1 @@
+select count(1) from nation;

--- a/test/body.txt
+++ b/test/body.txt
@@ -1,1 +1,0 @@
-select count(1) from nation;


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

**Problem:**

* `V::init()` in `LruCache::new()` is called when `RuntimeBuilder::build()` is called. The runtime builder is built before prometheus is configured. `V::init()` makes some initial metrics calls to populate some of the cache metrics before records are inserted. However, because they init before Prometheus is initialized, they emit to a global meter which is not yet configured.
* When the metrics are emitted to Prometheus, the cache item count and size in bytes always report as `0`

**Fix:**

* Removes `V::init()`. The result of this is that every cache metric is now late materializing, including cache size, item count and max size. An alternative would be deferring the init for x seconds, but it's possible Prometheus still hasn't started after this wait.
* Updates `item_count()` and `size_bytes()` to run the cache `clear_pending_tasks()` before emitting these metrics, as there could be pending tasks that cause these values to emit invalid values (like item counts of 0, or sizes of 0)

