### PR TITLE
fix: Ensure cache compression writer shuts down

### DIFF
--- a/crates/cache/src/encoding.rs
+++ b/crates/cache/src/encoding.rs
@@ -110,13 +110,16 @@ impl Encoder for ZstdEncoder {
             writer.finish().context(FailedToSerializeSnafu)?;
         }
 
-        let mut encoder =
-            AsyncZstdEncoder::with_quality(ipc_buffer, Level::Precise(self.compression_level));
         let mut compressed_data = Vec::new();
+        let mut encoder = AsyncZstdEncoder::with_quality(
+            &mut compressed_data,
+            Level::Precise(self.compression_level),
+        );
         encoder
-            .write_all(&mut compressed_data)
+            .write_all(&ipc_buffer)
             .await
             .context(FailedToCompressSnafu)?;
+        encoder.shutdown().await.context(FailedToCompressSnafu)?;
         Ok(compressed_data)
     }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensures the cache writer [shuts down](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.shutdown)
* Re-orders the input/output buffers for writing correctly