### PR TITLE
Protect stale cache revalidation memory usage

### DIFF
--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -49,16 +49,6 @@ macro_rules! generate_cache_metrics {
                     .build()
             });
 
-            pub static IN_PROGRESS_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
-                METER
-                    .u64_gauge(concat!($prefix, "_cache_in_progress_size_bytes"))
-                    .with_description(
-                        "Memory currently used by in-progress cache population in bytes.",
-                    )
-                    .with_unit("By")
-                    .build()
-            });
-
             pub static REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
                 METER
                     .u64_counter(concat!($prefix, "_cache_requests"))
@@ -107,6 +97,32 @@ macro_rules! generate_cache_metrics {
 generate_cache_metrics!("results", sql_results); // TODO: update the prefix to `sql_results` in v2.0 - https://github.com/spiceai/spiceai/issues/6128
 generate_cache_metrics!("search_results", search_results);
 generate_cache_metrics!("embeddings", embeddings);
+
+pub mod sql_results_stale_while_revalidate {
+    use super::{Counter, Gauge, LazyLock, Meter, global};
+
+    static METER: LazyLock<Meter> =
+        LazyLock::new(|| global::meter("results_cache_stale_while_revalidate"));
+
+    pub static IN_PROGRESS_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        METER
+            .u64_gauge("results_cache_stale_while_revalidate_in_progress_size_bytes")
+            .with_description(
+                "Memory currently used by stale-while-revalidate background cache population in bytes.",
+            )
+            .with_unit("By")
+            .build()
+    });
+
+    pub static ABORTED_REQUESTS_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        METER
+            .u64_counter("results_cache_stale_while_revalidate_aborted_requests_total")
+            .with_description(
+                "Number of stale-while-revalidate background cache refreshes aborted due to memory limits.",
+            )
+            .build()
+    });
+}
 
 pub trait CacheMetrics: Send + Sync {
     fn init()

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -49,6 +49,16 @@ macro_rules! generate_cache_metrics {
                     .build()
             });
 
+            pub static IN_PROGRESS_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_gauge(concat!($prefix, "_cache_in_progress_size_bytes"))
+                    .with_description(
+                        "Memory currently used by in-progress cache population in bytes.",
+                    )
+                    .with_unit("By")
+                    .build()
+            });
+
             pub static REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
                 METER
                     .u64_counter(concat!($prefix, "_cache_requests"))

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -584,7 +584,8 @@ fn attach_query_tracker_to_stream(
                         captured_output = write_to_json_string(&[batch.slice(0, batch.num_rows().min(3))]).unwrap_or_default();
                     }
 
-                    num_output_bytes += batch.get_array_memory_size() as u64;
+                    num_output_bytes += u64::try_from(batch.get_array_memory_size())
+                        .unwrap_or(u64::MAX);
 
                     num_records += batch.num_rows() as u64;
                     yield batch_result

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -67,12 +67,29 @@ impl RequestCacheManager {
 
 static BACKGROUND_CACHE_MEMORY_USAGE: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(test)]
+fn background_memory_usage_for_test() -> u64 {
+    BACKGROUND_CACHE_MEMORY_USAGE.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+static STALE_ABORTS_FOR_TEST: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+fn stale_abort_count_for_test() -> u64 {
+    STALE_ABORTS_FOR_TEST.load(Ordering::SeqCst)
+}
+
 fn record_in_progress_cache_memory(bytes: u64) {
     sql_results_stale_while_revalidate::IN_PROGRESS_SIZE_BYTES.record(bytes, &[]);
 }
 
 fn record_stale_while_revalidate_abort() {
     sql_results_stale_while_revalidate::ABORTED_REQUESTS_TOTAL.add(1, &[]);
+    #[cfg(test)]
+    {
+        STALE_ABORTS_FOR_TEST.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 struct BackgroundCacheMemoryGuard {
@@ -716,7 +733,9 @@ mod tests {
     use cache::{
         Caching, QueryResultsCacheProvider, SimpleCache, key::CacheKey, result::CacheStatus,
     };
+    use opentelemetry::global;
     use spicepod::component::caching::SQLResultsCacheConfig;
+    use telemetry::noop::NoopMeterProvider;
     use tokio::runtime::Handle;
 
     use crate::{
@@ -737,6 +756,34 @@ mod tests {
                 .with_client_supplied_cache_key(user_cache_key)
                 .build(),
         )
+    }
+
+    #[test]
+    fn background_guard_updates_usage_metrics() {
+        global::set_meter_provider(NoopMeterProvider::new());
+        BACKGROUND_CACHE_MEMORY_USAGE.store(0, Ordering::SeqCst);
+        let mut guard = BackgroundCacheMemoryGuard::new(10);
+        assert!(guard.try_reserve(4));
+        assert_eq!(background_memory_usage_for_test(), 4);
+        assert!(guard.try_reserve(6));
+        assert_eq!(background_memory_usage_for_test(), 10);
+        drop(guard);
+        assert_eq!(background_memory_usage_for_test(), 0);
+    }
+
+    #[test]
+    fn background_guard_records_abort_when_limit_reached() {
+        global::set_meter_provider(NoopMeterProvider::new());
+        BACKGROUND_CACHE_MEMORY_USAGE.store(0, Ordering::SeqCst);
+        STALE_ABORTS_FOR_TEST.store(0, Ordering::SeqCst);
+        let mut guard = BackgroundCacheMemoryGuard::new(5);
+        assert!(guard.try_reserve(5));
+        assert_eq!(background_memory_usage_for_test(), 5);
+        assert!(!guard.try_reserve(1));
+        record_stale_while_revalidate_abort();
+        assert_eq!(stale_abort_count_for_test(), 1);
+        drop(guard);
+        assert_eq!(background_memory_usage_for_test(), 0);
     }
 
     async fn prepare_runtime(

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -546,7 +546,8 @@ impl Query {
         loop {
             match stream.try_next().await {
                 Ok(Some(batch)) => {
-                    let batch_size = batch.get_array_memory_size() as u64;
+                    let batch_size =
+                        u64::try_from(batch.get_array_memory_size()).unwrap_or(u64::MAX);
                     if !guard.try_reserve(batch_size) {
                         record_stale_while_revalidate_abort();
                         tracing::debug!(

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::datafusion::{DataFusion, error::find_datafusion_root, query::error_code::ErrorCode};
 use cache::{
     key::{CacheKey, RawCacheKey},
-    metrics::sql_results,
+    metrics::sql_results_stale_while_revalidate,
     result::CacheStatus,
     result::query::CachedStream,
     to_cached_record_batch_stream,
@@ -68,7 +68,11 @@ impl RequestCacheManager {
 static BACKGROUND_CACHE_MEMORY_USAGE: AtomicU64 = AtomicU64::new(0);
 
 fn record_in_progress_cache_memory(bytes: u64) {
-    sql_results::IN_PROGRESS_SIZE_BYTES.record(bytes, &[]);
+    sql_results_stale_while_revalidate::IN_PROGRESS_SIZE_BYTES.record(bytes, &[]);
+}
+
+fn record_stale_while_revalidate_abort() {
+    sql_results_stale_while_revalidate::ABORTED_REQUESTS_TOTAL.add(1, &[]);
 }
 
 struct BackgroundCacheMemoryGuard {
@@ -544,6 +548,7 @@ impl Query {
                 Ok(Some(batch)) => {
                     let batch_size = batch.get_array_memory_size() as u64;
                     if !guard.try_reserve(batch_size) {
+                        record_stale_while_revalidate_abort();
                         tracing::debug!(
                             cache_key = cache_key_u64,
                             batch_size,

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::datafusion::{DataFusion, error::find_datafusion_root, query::error_code::ErrorCode};
 use cache::{
     key::{CacheKey, RawCacheKey},
+    metrics::sql_results,
     result::CacheStatus,
     result::query::CachedStream,
     to_cached_record_batch_stream,
@@ -36,6 +37,7 @@ use runtime_request_context::{CacheControl, CacheKeyType, Protocol, RequestConte
 use scopeguard;
 use snafu::ResultExt;
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{collections::HashSet, hash::Hasher, sync::Arc};
 use tracing::Span;
 
@@ -60,6 +62,62 @@ impl RequestCacheManager {
 
     pub(super) fn should_cache_results(&self) -> bool {
         !matches!(self.cache_status, CacheStatus::CacheDisabled)
+    }
+}
+
+static BACKGROUND_CACHE_MEMORY_USAGE: AtomicU64 = AtomicU64::new(0);
+
+fn record_in_progress_cache_memory(bytes: u64) {
+    sql_results::IN_PROGRESS_SIZE_BYTES.record(bytes, &[]);
+}
+
+struct BackgroundCacheMemoryGuard {
+    limit: u64,
+    reserved: u64,
+}
+
+impl BackgroundCacheMemoryGuard {
+    fn new(limit: u64) -> Self {
+        Self { limit, reserved: 0 }
+    }
+
+    fn try_reserve(&mut self, bytes: u64) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+
+        let update_result = BACKGROUND_CACHE_MEMORY_USAGE.fetch_update(
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+            |current| {
+                current
+                    .checked_add(bytes)
+                    .filter(|new_total| *new_total <= self.limit)
+            },
+        );
+
+        match update_result {
+            Ok(previous) => {
+                self.reserved = self.reserved.saturating_add(bytes);
+                record_in_progress_cache_memory(previous + bytes);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+impl Drop for BackgroundCacheMemoryGuard {
+    fn drop(&mut self) {
+        if self.reserved == 0 {
+            return;
+        }
+
+        let previous_total =
+            BACKGROUND_CACHE_MEMORY_USAGE.fetch_sub(self.reserved, Ordering::SeqCst);
+        let new_total = previous_total.saturating_sub(self.reserved);
+        record_in_progress_cache_memory(new_total);
+        self.reserved = 0;
     }
 }
 
@@ -461,46 +519,85 @@ impl Query {
         df: &Arc<DataFusion>,
         cache_key: &RawCacheKey,
         cache_key_u64: u64,
-        batches: Vec<arrow::record_batch::RecordBatch>,
-        _schema: arrow::datatypes::SchemaRef,
+        mut stream: SendableRecordBatchStream,
         input_tables: Arc<HashSet<TableReference>>,
     ) {
-        if let Some(cache_provider) = df.results_cache_provider() {
-            let cached_at = std::time::Instant::now();
-            let encoder = cache_provider.encoder();
+        let Some(cache_provider) = df.results_cache_provider() else {
+            tracing::debug!("Background revalidation completed but cache provider unavailable");
+            return;
+        };
 
-            match cache::result::query::CachedQueryResult::from_batches(
-                &batches,
-                input_tables,
-                cached_at,
-                encoder,
-            )
-            .await
-            {
-                Ok(cached_result) => {
-                    if let Err(e) = cache_provider.put_raw_key(cache_key, cached_result).await {
+        let max_cache_size = cache_provider.max_size();
+        if max_cache_size == 0 {
+            tracing::debug!(
+                cache_key = cache_key_u64,
+                "Background revalidation cache max size is zero, skipping cache update"
+            );
+            return;
+        }
+
+        let mut guard = BackgroundCacheMemoryGuard::new(max_cache_size);
+        let mut records: Vec<arrow::record_batch::RecordBatch> = Vec::new();
+
+        loop {
+            match stream.try_next().await {
+                Ok(Some(batch)) => {
+                    let batch_size = batch.get_array_memory_size() as u64;
+                    if !guard.try_reserve(batch_size) {
                         tracing::debug!(
                             cache_key = cache_key_u64,
-                            "Background revalidation failed to cache results: {}",
-                            e
+                            batch_size,
+                            "Background revalidation exceeded in-progress cache memory limit, dropping revalidation"
                         );
-                    } else {
-                        tracing::debug!(
-                            cache_key = cache_key_u64,
-                            "Background revalidation completed successfully and cached"
-                        );
+                        return;
                     }
+
+                    records.push(batch);
                 }
+                Ok(None) => break,
                 Err(e) => {
                     tracing::debug!(
                         cache_key = cache_key_u64,
-                        "Background revalidation failed to encode results: {}",
+                        "Background revalidation failed during collection: {}",
                         e
+                    );
+                    return;
+                }
+            }
+        }
+
+        let cached_at = std::time::Instant::now();
+        let encoder = cache_provider.encoder();
+
+        match cache::result::query::CachedQueryResult::from_batches(
+            &records,
+            input_tables,
+            cached_at,
+            encoder,
+        )
+        .await
+        {
+            Ok(cached_result) => {
+                if let Err(e) = cache_provider.put_raw_key(cache_key, cached_result).await {
+                    tracing::debug!(
+                        cache_key = cache_key_u64,
+                        "Background revalidation failed to cache results: {}",
+                        e
+                    );
+                } else {
+                    tracing::debug!(
+                        cache_key = cache_key_u64,
+                        "Background revalidation completed successfully and cached"
                     );
                 }
             }
-        } else {
-            tracing::debug!("Background revalidation completed but cache provider unavailable");
+            Err(e) => {
+                tracing::debug!(
+                    cache_key = cache_key_u64,
+                    "Background revalidation failed to encode results: {}",
+                    e
+                );
+            }
         }
     }
 
@@ -562,36 +659,18 @@ impl Query {
 
             match result {
                 Ok(query_result) => {
-                    let schema = query_result.data.schema();
                     tracing::debug!(
                         cache_key = cache_key_u64,
-                        "Background query execution succeeded, collecting batches"
+                        "Background query execution succeeded, streaming batches for caching"
                     );
-                    match query_result.data.try_collect::<Vec<_>>().await {
-                        Ok(batches) => {
-                            tracing::debug!(
-                                cache_key = cache_key_u64,
-                                num_batches = batches.len(),
-                                "Collected batches, now caching"
-                            );
-                            Self::cache_revalidation_result(
-                                &df,
-                                &cache_key,
-                                cache_key_u64,
-                                batches,
-                                schema,
-                                input_tables,
-                            )
-                            .await;
-                        }
-                        Err(e) => {
-                            tracing::debug!(
-                                cache_key = cache_key_u64,
-                                "Background revalidation failed during collection: {}",
-                                e
-                            );
-                        }
-                    }
+                    Self::cache_revalidation_result(
+                        &df,
+                        &cache_key,
+                        cache_key_u64,
+                        query_result.data,
+                        input_tables,
+                    )
+                    .await;
                 }
                 Err(e) => {
                     tracing::debug!(

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -87,8 +87,8 @@ impl BackgroundCacheMemoryGuard {
         }
 
         let update_result = BACKGROUND_CACHE_MEMORY_USAGE.fetch_update(
-            Ordering::SeqCst,
-            Ordering::SeqCst,
+            Ordering::AcqRel,
+            Ordering::Acquire,
             |current| {
                 current
                     .checked_add(bytes)
@@ -114,7 +114,7 @@ impl Drop for BackgroundCacheMemoryGuard {
         }
 
         let previous_total =
-            BACKGROUND_CACHE_MEMORY_USAGE.fetch_sub(self.reserved, Ordering::SeqCst);
+            BACKGROUND_CACHE_MEMORY_USAGE.fetch_sub(self.reserved, Ordering::Release);
         let new_total = previous_total.saturating_sub(self.reserved);
         record_in_progress_cache_memory(new_total);
         self.reserved = 0;

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -14,20 +14,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
+use anyhow::Context;
 use app::AppBuilder;
-use arrow::array::RecordBatch;
+use arrow::{
+    array::{Int64Array, RecordBatch},
+    datatypes::{DataType, Field, Schema},
+};
 use cache::result::CacheStatus;
+use datafusion::datasource::MemTable;
 use futures::TryStreamExt;
+use opentelemetry::global;
+use opentelemetry_prometheus::exporter;
+use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
+use prometheus::{Registry, proto::MetricType};
+use telemetry::noop::NoopMeterProvider;
+use tokio::time::sleep;
 
-use runtime::{Runtime, datafusion::query::QueryBuilder};
+use runtime::{
+    Runtime,
+    datafusion::{DataFusion, query::QueryBuilder},
+};
 use spicepod::{
     component::{caching::ResultsCache, dataset::Dataset},
     param::Params,
 };
 
 use crate::{configure_test_datafusion, init_tracing, utils::test_request_context};
+use scopeguard::guard;
 
 fn make_s3_tpch_dataset(name: &str) -> Dataset {
     let mut test_dataset = Dataset::new(
@@ -111,4 +126,201 @@ async fn execute_query_and_check_cache_status(
     assert_eq!(query_result.cache_status, expected_cache_status);
 
     Ok(records)
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn results_cache_stale_while_revalidate_memory_protection_metrics()
+-> Result<(), anyhow::Error> {
+    const CACHE_MAX_SIZE_BYTES: u64 = 1024 * 1024; // 1 MiB
+    const CACHE_MAX_SIZE_BYTES_U32: u32 = 1024 * 1024;
+    const CACHE_MAX_SIZE_BYTES_F64: f64 = 1_048_576.0;
+    const IN_PROGRESS_METRIC: &str = "results_cache_stale_while_revalidate_in_progress_size_bytes";
+    const ABORTED_METRIC: &str = "results_cache_stale_while_revalidate_aborted_requests_total";
+
+    let _tracing = init_tracing(None);
+
+    test_request_context()
+        .scope(async {
+            let registry = Registry::new();
+            let resource = Resource::default();
+            let prometheus_exporter = exporter()
+                .with_registry(registry.clone())
+                .without_scope_info()
+                .without_units()
+                .without_counter_suffixes()
+                .without_target_info()
+                .build()
+                .context("build prometheus exporter")?;
+            let provider = SdkMeterProvider::builder()
+                .with_resource(resource)
+                .with_reader(prometheus_exporter)
+                .build();
+            global::set_meter_provider(provider);
+            let _reset_provider = guard((), |()| {
+                global::set_meter_provider(NoopMeterProvider::new());
+            });
+
+            configure_test_datafusion();
+
+            let results_cache = ResultsCache {
+                item_ttl: Some("0s".to_string()),
+                max_stale_while_revalidate: Some("5s".to_string()),
+                cache_max_size: Some("1MiB".to_string()),
+                ..Default::default()
+            };
+
+            let app = AppBuilder::new("cache_guard_test")
+                .with_results_cache(results_cache)
+                .build();
+
+            let rt = Runtime::builder().with_app(app).build().await;
+            rt.init_cache_metrics();
+
+            let df = rt.datafusion();
+            let rows_per_batch = (CACHE_MAX_SIZE_BYTES_U32 * 3 / 4) / 8;
+            let first_table_batch_bytes =
+                register_large_table(&df, "cache_guard_large_a", rows_per_batch)
+                    .context("register table A")?;
+            let second_table_batch_bytes =
+                register_large_table(&df, "cache_guard_large_b", rows_per_batch)
+                    .context("register table B")?;
+
+            assert!(first_table_batch_bytes < CACHE_MAX_SIZE_BYTES);
+            assert!(second_table_batch_bytes < CACHE_MAX_SIZE_BYTES);
+            assert!(first_table_batch_bytes > CACHE_MAX_SIZE_BYTES / 2);
+            assert!(second_table_batch_bytes > CACHE_MAX_SIZE_BYTES / 2);
+
+            let rt = Arc::new(rt);
+            run_query(&rt, "SELECT * FROM cache_guard_large_a")
+                .await
+                .context("warm cache A")?;
+            run_query(&rt, "SELECT * FROM cache_guard_large_b")
+                .await
+                .context("warm cache B")?;
+
+            let rt_for_a = Arc::clone(&rt);
+            let rt_for_b = Arc::clone(&rt);
+            tokio::try_join!(
+                async move {
+                    run_query(&rt_for_a, "SELECT * FROM cache_guard_large_a")
+                        .await
+                        .map(|_| ())
+                },
+                async move {
+                    run_query(&rt_for_b, "SELECT * FROM cache_guard_large_b")
+                        .await
+                        .map(|_| ())
+                }
+            )
+            .context("trigger stale queries")?;
+
+            let gauge_value = wait_for_metric_value(
+                &registry,
+                IN_PROGRESS_METRIC,
+                MetricType::GAUGE,
+                |value| value > 0.0,
+                Duration::from_secs(5),
+            )
+            .await
+            .context("expected in-progress metric to report usage")?;
+
+            assert!(
+                gauge_value <= CACHE_MAX_SIZE_BYTES_F64,
+                "gauge value {gauge_value} exceeded limit {CACHE_MAX_SIZE_BYTES}"
+            );
+
+            let aborted_value = wait_for_metric_value(
+                &registry,
+                ABORTED_METRIC,
+                MetricType::COUNTER,
+                |value| value >= 1.0,
+                Duration::from_secs(5),
+            )
+            .await
+            .context("expected aborted metric to increment")?;
+
+            assert!(
+                aborted_value >= 1.0,
+                "aborted metric should be at least 1, got {aborted_value}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+fn register_large_table(
+    df: &Arc<DataFusion>,
+    table_name: &str,
+    rows: u32,
+) -> Result<u64, anyhow::Error> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let values = Int64Array::from_iter_values((0..rows).map(i64::from));
+    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(values)])
+        .context("create record batch")?;
+    let batch_size =
+        u64::try_from(batch.get_array_memory_size()).context("record batch size overflowed u64")?;
+    let mem_table = MemTable::try_new(schema, vec![vec![batch]]).context("create memtable")?;
+    df.ctx
+        .register_table(table_name, Arc::new(mem_table))
+        .context("register memtable with session")?;
+    Ok(batch_size)
+}
+
+async fn run_query(rt: &Arc<Runtime>, query: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    let query = QueryBuilder::new(query, rt.datafusion()).build();
+    let query_result = query.run().await.context("execute query")?;
+    let records = query_result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .context("collect query results")?;
+    Ok(records)
+}
+
+async fn wait_for_metric_value<F>(
+    registry: &Registry,
+    metric_name: &str,
+    metric_type: MetricType,
+    predicate: F,
+    timeout: Duration,
+) -> Option<f64>
+where
+    F: Fn(f64) -> bool,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Some(value) = read_metric_value(registry, metric_name, metric_type)
+            && predicate(value)
+        {
+            return Some(value);
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    None
+}
+
+fn read_metric_value(
+    registry: &Registry,
+    metric_name: &str,
+    metric_type: MetricType,
+) -> Option<f64> {
+    for family in registry.gather() {
+        if family.get_name() == metric_name
+            && family.get_field_type() == metric_type
+            && let Some(metric) = family.get_metric().first()
+        {
+            return match metric_type {
+                MetricType::GAUGE => Some(metric.get_gauge().get_value()),
+                MetricType::COUNTER => Some(metric.get_counter().get_value()),
+                _ => None,
+            };
+        }
+    }
+    None
 }

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -14,38 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use anyhow::Context;
 use app::AppBuilder;
-use arrow::{
-    array::{Int64Array, RecordBatch},
-    datatypes::{DataType, Field, Schema},
-};
+use arrow::array::RecordBatch;
 use cache::result::CacheStatus;
-use datafusion::datasource::MemTable;
 use futures::TryStreamExt;
-use opentelemetry::global;
-use opentelemetry_prometheus::exporter;
-use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
-use prometheus::{Registry, proto::MetricType};
-use telemetry::noop::NoopMeterProvider;
-use tokio::time::sleep;
 
-use runtime::{
-    Runtime,
-    datafusion::{DataFusion, query::QueryBuilder},
-};
+use runtime::{Runtime, datafusion::query::QueryBuilder};
 use spicepod::{
-    component::{
-        caching::{ResultsCache, SQLResultsCacheConfig},
-        dataset::Dataset,
-    },
+    component::{caching::ResultsCache, dataset::Dataset},
     param::Params,
 };
 
 use crate::{configure_test_datafusion, init_tracing, utils::test_request_context};
-use scopeguard::guard;
 
 fn make_s3_tpch_dataset(name: &str) -> Dataset {
     let mut test_dataset = Dataset::new(
@@ -129,208 +111,4 @@ async fn execute_query_and_check_cache_status(
     assert_eq!(query_result.cache_status, expected_cache_status);
 
     Ok(records)
-}
-
-#[tokio::test]
-#[allow(clippy::too_many_lines)]
-async fn results_cache_stale_while_revalidate_memory_protection_metrics()
--> Result<(), anyhow::Error> {
-    const CACHE_MAX_SIZE_BYTES: u64 = 1024 * 1024; // 1 MiB
-    const IN_PROGRESS_METRIC: &str = "results_cache_stale_while_revalidate_in_progress_size_bytes";
-    const ABORTED_METRIC: &str = "results_cache_stale_while_revalidate_aborted_requests_total";
-
-    let _tracing = init_tracing(None);
-
-    test_request_context()
-        .scope(async {
-            let registry = Registry::new();
-            let resource = Resource::default();
-            let prometheus_exporter = exporter()
-                .with_registry(registry.clone())
-                .without_scope_info()
-                .without_units()
-                .without_counter_suffixes()
-                .without_target_info()
-                .build()
-                .context("build prometheus exporter")?;
-            let provider = SdkMeterProvider::builder()
-                .with_resource(resource)
-                .with_reader(prometheus_exporter)
-                .build();
-            global::set_meter_provider(provider);
-            let _reset_provider = guard((), |()| {
-                global::set_meter_provider(NoopMeterProvider::new());
-            });
-
-            configure_test_datafusion();
-
-            let mut runtime_config = spicepod::component::runtime::Runtime::default();
-            runtime_config.caching.sql_results = Some(SQLResultsCacheConfig {
-                max_size: Some("1MiB".to_string()),
-                item_ttl: Some("0s".to_string()),
-                stale_while_revalidate_ttl: Some("5s".to_string()),
-                ..SQLResultsCacheConfig::default()
-            });
-
-            let app = AppBuilder::new("cache_guard_test")
-                .with_runtime(runtime_config)
-                .build();
-
-            let rt = Runtime::builder().with_app(app).build().await;
-            rt.init_cache_metrics();
-
-            let df = rt.datafusion();
-            let cache_limit_u32 =
-                u32::try_from(CACHE_MAX_SIZE_BYTES).expect("cache max size fits u32");
-            let cache_limit_bytes_f64 = f64::from(cache_limit_u32);
-            // Create tables sized at ~75% of cache limit (Int64 = 8 bytes each)
-            let rows_per_batch = (cache_limit_u32 * 3 / 4) / 8;
-            let first_table_batch_bytes =
-                register_large_table(&df, "cache_guard_large_a", rows_per_batch)
-                    .context("register table A")?;
-            let second_table_batch_bytes =
-                register_large_table(&df, "cache_guard_large_b", rows_per_batch)
-                    .context("register table B")?;
-
-            assert!(first_table_batch_bytes < CACHE_MAX_SIZE_BYTES);
-            assert!(second_table_batch_bytes < CACHE_MAX_SIZE_BYTES);
-            assert!(first_table_batch_bytes > CACHE_MAX_SIZE_BYTES / 2);
-            assert!(second_table_batch_bytes > CACHE_MAX_SIZE_BYTES / 2);
-
-            let rt = Arc::new(rt);
-            run_query(&rt, "SELECT * FROM cache_guard_large_a")
-                .await
-                .context("warm cache A")?;
-            run_query(&rt, "SELECT * FROM cache_guard_large_b")
-                .await
-                .context("warm cache B")?;
-
-            tokio::time::sleep(Duration::from_millis(10)).await;
-
-            let rt_for_a = Arc::clone(&rt);
-            let rt_for_b = Arc::clone(&rt);
-            tokio::try_join!(
-                async move {
-                    run_query(&rt_for_a, "SELECT * FROM cache_guard_large_a")
-                        .await
-                        .map(|_| ())
-                },
-                async move {
-                    run_query(&rt_for_b, "SELECT * FROM cache_guard_large_b")
-                        .await
-                        .map(|_| ())
-                }
-            )
-            .context("trigger stale queries")?;
-
-            let gauge_value = wait_for_metric_value(
-                &registry,
-                IN_PROGRESS_METRIC,
-                MetricType::GAUGE,
-                |value| value > 0.0,
-                Duration::from_secs(5),
-            )
-            .await
-            .context("expected in-progress metric to report usage")?;
-
-            assert!(
-                gauge_value <= cache_limit_bytes_f64,
-                "gauge value {gauge_value} exceeded limit {CACHE_MAX_SIZE_BYTES}"
-            );
-
-            let aborted_value = wait_for_metric_value(
-                &registry,
-                ABORTED_METRIC,
-                MetricType::COUNTER,
-                |value| value >= 1.0,
-                Duration::from_secs(5),
-            )
-            .await
-            .context("expected aborted metric to increment")?;
-
-            assert!(
-                aborted_value >= 1.0,
-                "aborted metric should be at least 1, got {aborted_value}"
-            );
-
-            Ok(())
-        })
-        .await
-}
-
-fn register_large_table(
-    df: &Arc<DataFusion>,
-    table_name: &str,
-    rows: u32,
-) -> Result<u64, anyhow::Error> {
-    let schema = Arc::new(Schema::new(vec![Field::new(
-        "value",
-        DataType::Int64,
-        false,
-    )]));
-    let values = Int64Array::from_iter_values((0..rows).map(i64::from));
-    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(values)])
-        .context("create record batch")?;
-    let batch_size =
-        u64::try_from(batch.get_array_memory_size()).context("record batch size overflowed u64")?;
-    let mem_table = MemTable::try_new(schema, vec![vec![batch]]).context("create memtable")?;
-    df.ctx
-        .register_table(table_name, Arc::new(mem_table))
-        .context("register memtable with session")?;
-    Ok(batch_size)
-}
-
-async fn run_query(rt: &Arc<Runtime>, query: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
-    let query = QueryBuilder::new(query, rt.datafusion()).build();
-    let query_result = query.run().await.context("execute query")?;
-    let records = query_result
-        .data
-        .try_collect::<Vec<RecordBatch>>()
-        .await
-        .context("collect query results")?;
-    Ok(records)
-}
-
-async fn wait_for_metric_value<F>(
-    registry: &Registry,
-    metric_name: &str,
-    metric_type: MetricType,
-    predicate: F,
-    timeout: Duration,
-) -> Option<f64>
-where
-    F: Fn(f64) -> bool,
-{
-    let deadline = std::time::Instant::now() + timeout;
-    let mut now = std::time::Instant::now();
-    while now < deadline {
-        if let Some(value) = read_metric_value(registry, metric_name, metric_type)
-            && predicate(value)
-        {
-            return Some(value);
-        }
-        sleep(Duration::from_millis(20)).await;
-        now = std::time::Instant::now();
-    }
-    None
-}
-
-fn read_metric_value(
-    registry: &Registry,
-    metric_name: &str,
-    metric_type: MetricType,
-) -> Option<f64> {
-    for family in registry.gather() {
-        if family.get_name() == metric_name
-            && family.get_field_type() == metric_type
-            && let Some(metric) = family.get_metric().first()
-        {
-            return match metric_type {
-                MetricType::GAUGE => Some(metric.get_gauge().get_value()),
-                MetricType::COUNTER => Some(metric.get_counter().get_value()),
-                _ => None,
-            };
-        }
-    }
-    None
 }

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -37,7 +37,10 @@ use runtime::{
     datafusion::{DataFusion, query::QueryBuilder},
 };
 use spicepod::{
-    component::{caching::ResultsCache, dataset::Dataset},
+    component::{
+        caching::{ResultsCache, SQLResultsCacheConfig},
+        dataset::Dataset,
+    },
     param::Params,
 };
 
@@ -161,15 +164,16 @@ async fn results_cache_stale_while_revalidate_memory_protection_metrics()
 
             configure_test_datafusion();
 
-            let results_cache = ResultsCache {
+            let mut runtime_config = spicepod::component::runtime::Runtime::default();
+            runtime_config.caching.sql_results = Some(SQLResultsCacheConfig {
+                max_size: Some("1MiB".to_string()),
                 item_ttl: Some("0s".to_string()),
-                max_stale_while_revalidate: Some("5s".to_string()),
-                cache_max_size: Some("1MiB".to_string()),
-                ..Default::default()
-            };
+                stale_while_revalidate_ttl: Some("5s".to_string()),
+                ..SQLResultsCacheConfig::default()
+            });
 
             let app = AppBuilder::new("cache_guard_test")
-                .with_results_cache(results_cache)
+                .with_runtime(runtime_config)
                 .build();
 
             let rt = Runtime::builder().with_app(app).build().await;
@@ -200,6 +204,8 @@ async fn results_cache_stale_while_revalidate_memory_protection_metrics()
             run_query(&rt, "SELECT * FROM cache_guard_large_b")
                 .await
                 .context("warm cache B")?;
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
 
             let rt_for_a = Arc::clone(&rt);
             let rt_for_b = Arc::clone(&rt);

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -133,8 +133,6 @@ async fn execute_query_and_check_cache_status(
 async fn results_cache_stale_while_revalidate_memory_protection_metrics()
 -> Result<(), anyhow::Error> {
     const CACHE_MAX_SIZE_BYTES: u64 = 1024 * 1024; // 1 MiB
-    const CACHE_MAX_SIZE_BYTES_U32: u32 = 1024 * 1024;
-    const CACHE_MAX_SIZE_BYTES_F64: f64 = 1_048_576.0;
     const IN_PROGRESS_METRIC: &str = "results_cache_stale_while_revalidate_in_progress_size_bytes";
     const ABORTED_METRIC: &str = "results_cache_stale_while_revalidate_aborted_requests_total";
 
@@ -178,7 +176,11 @@ async fn results_cache_stale_while_revalidate_memory_protection_metrics()
             rt.init_cache_metrics();
 
             let df = rt.datafusion();
-            let rows_per_batch = (CACHE_MAX_SIZE_BYTES_U32 * 3 / 4) / 8;
+            let cache_limit_u32 =
+                u32::try_from(CACHE_MAX_SIZE_BYTES).expect("cache max size fits u32");
+            let cache_limit_bytes_f64 = f64::from(cache_limit_u32);
+            // Create tables sized at ~75% of cache limit (Int64 = 8 bytes each)
+            let rows_per_batch = (cache_limit_u32 * 3 / 4) / 8;
             let first_table_batch_bytes =
                 register_large_table(&df, "cache_guard_large_a", rows_per_batch)
                     .context("register table A")?;
@@ -226,7 +228,7 @@ async fn results_cache_stale_while_revalidate_memory_protection_metrics()
             .context("expected in-progress metric to report usage")?;
 
             assert!(
-                gauge_value <= CACHE_MAX_SIZE_BYTES_F64,
+                gauge_value <= cache_limit_bytes_f64,
                 "gauge value {gauge_value} exceeded limit {CACHE_MAX_SIZE_BYTES}"
             );
 
@@ -294,13 +296,15 @@ where
     F: Fn(f64) -> bool,
 {
     let deadline = std::time::Instant::now() + timeout;
-    while std::time::Instant::now() < deadline {
+    let mut now = std::time::Instant::now();
+    while now < deadline {
         if let Some(value) = read_metric_value(registry, metric_name, metric_type)
             && predicate(value)
         {
             return Some(value);
         }
         sleep(Duration::from_millis(20)).await;
+        now = std::time::Instant::now();
     }
     None
 }


### PR DESCRIPTION
## Summary
- gate background cache revalidation memory with a shared atomic counter and update metrics
- stream batches into the background cache writer and abort when the shared buffer exceeds the cache size limit
- expose an in-progress cache memory gauge for visibility

Add two new metrics:
- `results_cache_stale_while_revalidate_in_progress_size_bytes`: Memory currently used by stale-while-revalidate background cache population in bytes.
- `results_cache_stale_while_revalidate_aborted_requests_total`: Number of stale-while-revalidate background cache refreshes aborted due to memory limits.