### PR TITLE
fix: Deny assert macros in non-test code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,7 @@ cargo run -p testoperator -- run bench -p ./test/spicepods/tpch/sf1/federated/du
 - **Use `unreachable!()`**: Only for provably impossible cases
 - **Use `ensure!` macro**: Preferred over `if` + `return Err`
 - **Define `Result` type alias**: `pub type Result<T, E = Error> = std::result::Result<T, E>;`
+- **Never use `assert!()` (or related) macros in non-test code**: Prefer proper error handling, or marking with `unreachable!()` if the assertion is truly unreachable. Alternatively, make the assertion a `debug_assert!()` assertion to only fire in debug builds instead of release builds.
 
 ```rust
 // GOOD

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ cargo run -p testoperator -- run bench -p ./test/spicepods/tpch/sf1/federated/du
 - **Use `unreachable!()`**: Only for provably impossible cases
 - **Use `ensure!` macro**: Preferred over `if` + `return Err`
 - **Define `Result` type alias**: `pub type Result<T, E = Error> = std::result::Result<T, E>;`
-- **Never use `assert!()` (or related) macros in non-test code**: Prefer proper error handling, or marking with `unreachable!()` if the assertion is truly unreachable. Alternatively, make the assertion a `debug_assert!()` assertion to only fire in debug builds instead of release builds.
+- **Don't use `assert!()` (or related) macros in non-test code**: Prefer proper error handling, or marking with `unreachable!()` if the assertion is truly unreachable. Alternatively, make the assertion a `debug_assert!()` assertion to only fire in debug builds instead of release builds. `assert!()` macros can have case-by-case exceptions, for example for compile-time assertions that would prevent a build from being released to begin with.
 
 ```rust
 // GOOD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4711,6 +4711,7 @@ dependencies = [
  "duckdb",
  "futures",
  "r2d2",
+ "snafu",
  "tracing",
 ]
 
@@ -13228,6 +13229,7 @@ dependencies = [
  "futures",
  "opentelemetry 0.27.1",
  "runtime-request-context",
+ "snafu",
  "tokio",
  "tracing",
 ]
@@ -13240,6 +13242,7 @@ dependencies = [
  "datafusion",
  "futures",
  "itertools 0.14.0",
+ "snafu",
  "tokio",
  "tracing",
 ]

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ lint: lint-go lint-rust
 lint-rust:
 	cargo fmt --all -- --check
 	## All except metal, cuda
-	cargo clippy $(CARGO_PROFILE) --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,xxhash,cluster --workspace -- \
+	cargo clippy $(CARGO_PROFILE) --lib --bins --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,xxhash,cluster --workspace -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
@@ -87,6 +87,15 @@ lint-rust:
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
 		-Aclippy::large_futures
+	cargo clippy $(CARGO_PROFILE) --tests --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,xxhash,cluster --workspace -- \
+		-Dwarnings \
+		-Dclippy::pedantic \
+		-Dclippy::unwrap_used \
+		-Aclippy::expect_used \
+		-Dclippy::clone_on_ref_ptr \
+		-Aclippy::module_name_repetitions \
+		-Aclippy::large_futures \
+		-Aclippy::disallowed_macros
 
 lint-rust-fix:
 	cargo fmt --all

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,8 @@
 allow-expect-in-tests = true
+disallowed-macros = [
+    { path = "std::assert", reason = "Prefer returning concrete errors instead of assertion panics. If code is truly unreachable, use `unreachable!()` macro." },
+    { path = "std::assert_eq", reason = "Prefer returning concrete errors instead of assertion panics. If code is truly unreachable, use `unreachable!()` macro." },
+    { path = "std::assert_ne", reason = "Prefer returning concrete errors instead of assertion panics. If code is truly unreachable, use `unreachable!()` macro." },
+]
 # Large futures are in tests. 
 future-size-threshold = 45520

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,5 +4,5 @@ disallowed-macros = [
     { path = "std::assert_eq", reason = "Prefer returning concrete errors instead of assertion panics. If code is truly unreachable, use `unreachable!()` macro." },
     { path = "std::assert_ne", reason = "Prefer returning concrete errors instead of assertion panics. If code is truly unreachable, use `unreachable!()` macro." },
 ]
-# Large futures are in tests. 
+# Large futures are in tests
 future-size-threshold = 45520

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -72,6 +72,11 @@ pub enum Error {
         "Delta Lake Table checkpoint files are missing or incorrect. Recreate the checkpoint for the Delta Lake Table and try again. {source}"
     ))]
     DeltaCheckpointError { source: delta_kernel::Error },
+
+    #[snafu(display(
+        "Invalid Delta Lake Table partition value count. The PartitionedFile has a different number of partition values than the number of partition columns."
+    ))]
+    InvalidPartitionValueCount,
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/data_components/src/delta_lake/pruning.rs
+++ b/crates/data_components/src/delta_lake/pruning.rs
@@ -24,6 +24,7 @@ use arrow::{
 use datafusion::{
     common::DFSchema,
     datasource::listing::{PartitionedFile, helpers::expr_applicable_for_cols},
+    error::DataFusionError,
     execution::context::ExecutionProps,
     logical_expr::Expr,
     physical_expr::create_physical_expr,
@@ -45,12 +46,14 @@ pub(crate) fn prune_partitions(
     // We will use DataFusion itself to evaluate the filters on the partition values, so we need to
     // first extract the partition values from the `PartitionedFile`s and create a `RecordBatch`.
     // First verify all files have the correct number of partition values
-    assert!(
-        partitioned_files
-            .iter()
-            .all(|file| file.partition_values.len() == partition_cols.len()),
-        "PartitionedFile has a different number of partition values than the number of partition columns"
-    );
+    if !partitioned_files
+        .iter()
+        .all(|file| file.partition_values.len() == partition_cols.len())
+    {
+        return Err(DataFusionError::External(
+            super::Error::InvalidPartitionValueCount.into(),
+        ));
+    }
 
     let partition_arrays: Vec<ArrayRef> = (0..partition_cols.len())
         .map(|col_idx| {
@@ -97,7 +100,11 @@ pub(crate) fn prune_partitions(
     };
 
     // Sanity check
-    assert_eq!(prepared.len(), partitioned_files.len());
+    if prepared.len() != partitioned_files.len() {
+        return Err(DataFusionError::External(
+            super::Error::InvalidPartitionValueCount.into(),
+        ));
+    }
 
     // Filter the `PartitionedFile`s based on the mask
     let filtered = partitioned_files

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::rate_limit::RateLimiter;
+use crate::{graphql::InvalidPaginationRegexSnafu, rate_limit::RateLimiter};
 use token_provider::TokenProvider;
 use tokio::sync::Semaphore;
 
@@ -496,11 +496,11 @@ impl PaginationParameters {
         (None, None)
     }
 
-    fn apply(&self, query: &str, limit: Option<usize>, cursor: Option<String>) -> String {
-        #[allow(clippy::needless_raw_string_hashes)]
-        let pattern = format!(r#"{}\s*\(.*\)"#, self.resource_name);
-        let regex =
-            Regex::new(&pattern).unwrap_or_else(|_| panic!("Invalid regex query resource pattern"));
+    fn apply(&self, query: &str, limit: Option<usize>, cursor: Option<String>) -> Result<String> {
+        let pattern = format!(r"{}\s*\(.*\)", self.resource_name);
+        let regex = Regex::new(&pattern).context(InvalidPaginationRegexSnafu {
+            resource_name: self.resource_name.clone(),
+        })?;
 
         let arguments = self.parameters_string(limit, cursor);
 
@@ -513,7 +513,7 @@ impl PaginationParameters {
             ),
         );
 
-        new_query.to_string()
+        Ok(new_query.to_string())
     }
 
     fn get_next_cursor_from_response(&self, response: &Value) -> Option<String> {
@@ -714,15 +714,16 @@ impl GraphQLQuery {
         self
     }
 
-    #[must_use]
-    pub fn to_string(&self, limit: Option<usize>, cursor: Option<String>) -> String {
+    pub fn to_string(&self, limit: Option<usize>, cursor: Option<String>) -> Result<String> {
         let query = self.ast.to_string();
 
-        if let Some(pagination_parameters) = &self.pagination_parameters {
-            pagination_parameters.apply(&query, limit, cursor)
-        } else {
-            query
-        }
+        Ok(
+            if let Some(pagination_parameters) = &self.pagination_parameters {
+                pagination_parameters.apply(&query, limit, cursor)?
+            } else {
+                query
+            },
+        )
     }
 
     pub fn limit_reached(&mut self, limit: Option<usize>, record_count: usize) -> bool {
@@ -847,7 +848,7 @@ impl GraphQLClient {
                 })?;
         }
 
-        let query_string = query.to_string(limit, cursor.clone());
+        let query_string = query.to_string(limit, cursor.clone())?;
 
         // Validate query string is not empty
         if query_string.trim().is_empty() {
@@ -1574,7 +1575,9 @@ mod tests {
         let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
-        let new_query = query.to_string(None, Some("new_cursor".to_string()));
+        let new_query = query
+            .to_string(None, Some("new_cursor".to_string()))
+            .expect("Should build query");
         let expected_query = r#"query {
   users (first: 10, after: "new_cursor") {
     name
@@ -1600,7 +1603,9 @@ mod tests {
         let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
-        let new_query = query.to_string(None, Some("new_cursor".to_string()));
+        let new_query = query
+            .to_string(None, Some("new_cursor".to_string()))
+            .expect("Should build query");
         let expected_query = r#"query {
   users (first: 10, after: "new_cursor") {
     name
@@ -1626,7 +1631,9 @@ mod tests {
         let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
-        let new_query = query.to_string(Some(5), Some("new_cursor".to_string()));
+        let new_query = query
+            .to_string(Some(5), Some("new_cursor".to_string()))
+            .expect("Should build query");
         let expected_query = r#"query {
   users (first: 5, after: "new_cursor") {
     name

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -86,6 +86,14 @@ pub enum Error {
         column: usize,
         query: String,
     },
+
+    #[snafu(display(
+        "Failed to build a valid regex from pagination parameters due to the resource name {resource_name}. {source}"
+    ))]
+    InvalidPaginationRegex {
+        source: regex::Error,
+        resource_name: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/data_components/src/s3_vectors/partition.rs
+++ b/crates/data_components/src/s3_vectors/partition.rs
@@ -34,6 +34,7 @@ const _NUM_SEPARATORS: usize = 3; // 3 periods '.' separate the 4 parts
 const _S3_VECTOR_INDEX_NAME_MAX_LENGTH: usize = 63;
 
 // Check at compile time that we use the full amount allowed from S3
+#[allow(clippy::disallowed_macros)]
 const _: () = {
     assert!(
         INDEX_NAME_MAX_LENGTH

--- a/crates/datafusion-optimizer-rules/Cargo.toml
+++ b/crates/datafusion-optimizer-rules/Cargo.toml
@@ -1,28 +1,25 @@
 [package]
-name = "datafusion-optimizer-rules"
 edition.workspace = true
 exclude.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "datafusion-optimizer-rules"
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+async-stream.workspace = true
+async-trait.workspace = true
+cache = { path = "../cache" }
 datafusion.workspace = true
 datafusion-expr.workspace = true
 datafusion-table-providers.workspace = true
-r2d2 = { optional = true, workspace = true }
 duckdb = { optional = true, workspace = true }
-async-stream.workspace = true
-async-trait.workspace = true
-tracing.workspace = true
 futures.workspace = true
-cache = { path = "../cache" }
+r2d2 = { optional = true, workspace = true }
+snafu.workspace = true
+tracing.workspace = true
 
 [features]
-duckdb = [
-    "datafusion-table-providers/duckdb",
-    "dep:duckdb",
-    "dep:r2d2"
-]
+duckdb = ["datafusion-table-providers/duckdb", "dep:duckdb", "dep:r2d2"]

--- a/crates/datafusion-optimizer-rules/src/lib.rs
+++ b/crates/datafusion-optimizer-rules/src/lib.rs
@@ -18,3 +18,14 @@ pub mod common;
 pub mod logical_plan;
 pub mod pass_thru;
 pub mod physical_plan;
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid input count. Expected only one input, got {input_len}."))]
+    InvalidInputCount { input_len: usize },
+
+    #[snafu(display("Invalid expression count. Expected no expressions, got {expr_len}."))]
+    InvalidExpressionCount { expr_len: usize },
+}

--- a/crates/datafusion-optimizer-rules/src/logical_plan/cache_invalidation.rs
+++ b/crates/datafusion-optimizer-rules/src/logical_plan/cache_invalidation.rs
@@ -33,7 +33,7 @@ use datafusion::{
         DFSchemaRef,
         tree_node::{Transformed, TreeNode, TreeNodeRecursion},
     },
-    error::Result,
+    error::{DataFusionError, Result},
     execution::SendableRecordBatchStream,
     logical_expr::{Extension, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore},
     optimizer::{OptimizerConfig, OptimizerRule},
@@ -44,7 +44,7 @@ use datafusion::{
 };
 use futures::StreamExt;
 
-use crate::pass_thru::PassThruExec;
+use crate::{Error, pass_thru::PassThruExec};
 
 /// [`OptimizerRule`] that detects write operations in a `DataFusion` logical plan and injects a cache invalidation node [`CacheInvalidationNode`].
 ///
@@ -170,11 +170,28 @@ impl UserDefinedLogicalNodeCore for CacheInvalidationNode {
     }
 
     fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
-        assert_eq!(inputs.len(), 1, "should have one input");
-        assert_eq!(exprs.len(), 0, "should have no expressions");
+        if inputs.len() != 1 {
+            return Err(DataFusionError::External(
+                Error::InvalidInputCount {
+                    input_len: inputs.len(),
+                }
+                .into(),
+            ));
+        }
+
+        if !exprs.is_empty() {
+            return Err(DataFusionError::External(
+                Error::InvalidExpressionCount {
+                    expr_len: exprs.len(),
+                }
+                .into(),
+            ));
+        }
+
         let Some(input) = inputs.into_iter().next() else {
             unreachable!("should have one input");
         };
+
         Ok(Self {
             input,
             table: self.table.clone(),

--- a/crates/runtime-datafusion-index/Cargo.toml
+++ b/crates/runtime-datafusion-index/Cargo.toml
@@ -13,8 +13,8 @@ async-trait.workspace = true
 datafusion.workspace = true
 futures.workspace = true
 itertools.workspace = true
+snafu.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
-

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -237,11 +237,28 @@ impl UserDefinedLogicalNodeCore for IndexTableScanNode {
     }
 
     fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
-        assert_eq!(inputs.len(), 1, "should have one input");
-        assert_eq!(exprs.len(), 0, "should have no expressions");
+        if inputs.len() != 1 {
+            return Err(DataFusionError::External(
+                crate::Error::MultipleInputs {
+                    input_len: inputs.len(),
+                }
+                .into(),
+            ));
+        }
+
+        if !exprs.is_empty() {
+            return Err(DataFusionError::External(
+                crate::Error::NoExpressions {
+                    expr_len: exprs.len(),
+                }
+                .into(),
+            ));
+        }
+
         let Some(input) = inputs.into_iter().next() else {
-            panic!("should have one input");
+            unreachable!("should have one input");
         };
+
         Ok(Self {
             input,
             indexes: self.indexes.clone(),

--- a/crates/runtime-datafusion-index/src/lib.rs
+++ b/crates/runtime-datafusion-index/src/lib.rs
@@ -19,10 +19,22 @@ use std::{any::Any, fmt::Debug};
 
 use datafusion::arrow::array::RecordBatch;
 use datafusion::error::Result;
+use snafu::prelude::*;
 
 pub mod analyzer;
 mod provider;
 pub use provider::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Index table scans should have only one input. Received {input_len} inputs."))]
+    MultipleInputs { input_len: usize },
+
+    #[snafu(display(
+        "Index table scans should have no expressions. Received {expr_len} expressions."
+    ))]
+    NoExpressions { expr_len: usize },
+}
 
 #[async_trait]
 pub trait Index: Debug + Send + Sync + 'static {

--- a/crates/runtime-datafusion-udfs/src/ai.rs
+++ b/crates/runtime-datafusion-udfs/src/ai.rs
@@ -482,11 +482,15 @@ impl Ai {
         let ordered_results: Vec<Option<String>> =
             results.into_iter().map(|(_, result)| result).collect();
 
-        debug_assert_eq!(
-            ordered_results.len(),
-            array_len,
-            "Result array length must match input array length"
-        );
+        // debug assertion only
+        #[allow(clippy::disallowed_macros)]
+        {
+            debug_assert_eq!(
+                ordered_results.len(),
+                array_len,
+                "Result array length must match input array length"
+            );
+        }
 
         Ok(Arc::new(StringArray::from(ordered_results)) as ArrayRef)
     }

--- a/crates/runtime-datafusion-udfs/src/bucket.rs
+++ b/crates/runtime-datafusion-udfs/src/bucket.rs
@@ -33,6 +33,13 @@ use snafu::{ResultExt as _, Snafu};
 /// Maximum number of buckets, chosen to support large-scale partitioning while preventing excessive memory usage.
 const MAX_NUM_BUCKETS: i64 = 1_000_000;
 
+/// Compile-time assertion that `MAX_NUM_BUCKETS` does not exceed `i32::MAX`
+#[allow(clippy::disallowed_macros)]
+const _: () = assert!(
+    MAX_NUM_BUCKETS <= i32::MAX as i64,
+    "MAX_NUM_BUCKETS exceeds i32::MAX"
+);
+
 /// Static `RandomState` for deterministic hashing.
 static RANDOM_STATE: LazyLock<RandomState> =
     LazyLock::new(|| RandomState::with_seeds(0x53, 0x50, 0x49, 0x43_45));
@@ -174,15 +181,12 @@ fn compute_bucket_array(array: &ArrayRef, num_buckets: i64) -> Result<Int32Array
         &hash_array,
         &Int32Array::from_value(num_buckets, array.len()),
         |hash, n| {
-            const _: () = assert!(
-                MAX_NUM_BUCKETS <= i32::MAX as i64,
-                "MAX_NUM_BUCKETS exceeds i32::MAX"
-            );
-            #[allow(clippy::expect_used)]
-            // SAFETY: unwrap is safe because we restrict MAX_NUM_BUCKETS at compile time
-            u64::try_from(n)
-                .and_then(|n| i32::try_from(hash % n))
-                .expect("MAX_NUM_BUCKETS smaller than i32 positive maximum")
+            let Ok(n) = u64::try_from(n).and_then(|n| i32::try_from(hash % n)) else {
+                // MAX_NUM_BUCKETS is checked at compile-time to be less than i32::MAX
+                unreachable!("MAX_NUM_BUCKETS smaller than i32 positive maximum");
+            };
+
+            n
         },
     )?;
 

--- a/crates/runtime-datafusion/Cargo.toml
+++ b/crates/runtime-datafusion/Cargo.toml
@@ -19,6 +19,7 @@ datafusion-federation = { workspace = true }
 futures.workspace = true
 opentelemetry.workspace = true
 runtime-request-context = { path = "../runtime-request-context" }
+snafu.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -258,9 +258,17 @@ impl ExecutionPlan for BytesProcessedExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(children.len(), 1, "should have one input");
+        if children.len() != 1 {
+            return Err(DataFusionError::External(
+                crate::Error::InvalidChildrenCount {
+                    children_count: children.len(),
+                }
+                .into(),
+            ));
+        }
+
         let Some(input) = children.into_iter().next() else {
-            panic!("should have one input");
+            unreachable!("should have one input");
         };
         Ok(Arc::new(Self {
             input_exec: input,

--- a/crates/runtime-datafusion/src/lib.rs
+++ b/crates/runtime-datafusion/src/lib.rs
@@ -1,3 +1,27 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 pub mod execution_plan;
 pub mod extension;
 pub mod schema_provider;
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid children count. Expected only one input, got {children_count}."))]
+    InvalidChildrenCount { children_count: usize },
+}

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -189,12 +189,12 @@ pub enum AcceleratedTableBuilderError {
     #[snafu(display(
         "Refresh mode must be set to `changes` to use a changes stream. For details, visit: https://spiceai.org/docs/features/cdc"
     ))]
-    ExpectedChangesStreamForChangesMode,
+    ExpectedChangesModeForChangesStream,
 
     #[snafu(display(
         "Refresh mode must be set to `append` to use an append stream. For details, visit: https://spiceai.org/docs/components/data-accelerators/data-refresh#append"
     ))]
-    ExpectedAppendStreamForAppendMode,
+    ExpectedAppendModeForAppendStream,
 
     #[snafu(transparent)]
     AcceleratedTableError { source: Error },
@@ -445,11 +445,11 @@ impl Builder {
     #[allow(clippy::too_many_lines)]
     pub async fn build(self) -> AcceleratedTableBuilderResult<AcceleratedTable> {
         if self.refresh.mode != RefreshMode::Changes && self.changes_stream.is_some() {
-            return ExpectedChangesStreamForChangesModeSnafu.fail();
+            return ExpectedChangesModeForChangesStreamSnafu.fail();
         }
 
         if self.refresh.mode != RefreshMode::Append && self.append_stream.is_some() {
-            return ExpectedAppendStreamForAppendModeSnafu.fail();
+            return ExpectedAppendModeForAppendStreamSnafu.fail();
         }
 
         let on_complete_notification = Arc::new(Notify::new());

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -157,9 +157,12 @@ pub enum Error {
 
     #[snafu(display("{source}"))]
     InvalidTimeColumnTimeFormat { source: refresh::Error },
+
+    #[snafu(display("Failed to start refresh task. The task was already started."))]
+    RefreshTaskAlreadyStarted {},
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum AcceleratedTableBuilderError {
@@ -182,6 +185,19 @@ pub enum AcceleratedTableBuilderError {
         "A synchronized accelerated table requires full refresh mode. Set `refresh_mode` to 'full', and try again."
     ))]
     SynchronizedAcceleratedTableRequiresFullRefresh,
+
+    #[snafu(display(
+        "Refresh mode must be set to `changes` to use a changes stream. For details, visit: https://spiceai.org/docs/features/cdc"
+    ))]
+    ExpectedChangesStreamForChangesMode,
+
+    #[snafu(display(
+        "Refresh mode must be set to `append` to use an append stream. For details, visit: https://spiceai.org/docs/components/data-accelerators/data-refresh#append"
+    ))]
+    ExpectedAppendStreamForAppendMode,
+
+    #[snafu(transparent)]
+    AcceleratedTableError { source: Error },
 }
 
 pub type AcceleratedTableBuilderResult<T> = std::result::Result<T, AcceleratedTableBuilderError>;
@@ -350,23 +366,13 @@ impl Builder {
     }
 
     /// Set the changes stream for the accelerated table
-    ///
-    /// # Panics
-    ///
-    /// Panics if the refresh mode isn't `RefreshMode::Changes`.
     pub fn changes_stream(&mut self, changes_stream: ChangesStream) -> &mut Self {
-        assert!(self.refresh.mode == RefreshMode::Changes);
         self.changes_stream = Some(changes_stream);
         self
     }
 
     /// Set the append stream for the accelerated table
-    ///
-    /// # Panics
-    ///
-    /// Panics if the refresh mode isn't `RefreshMode::Append`.
     pub fn append_stream(&mut self, append_stream: ChangesStream) -> &mut Self {
-        assert!(self.refresh.mode == RefreshMode::Append);
         self.append_stream = Some(append_stream);
         self
     }
@@ -438,6 +444,14 @@ impl Builder {
     /// Build the accelerated table
     #[allow(clippy::too_many_lines)]
     pub async fn build(self) -> AcceleratedTableBuilderResult<AcceleratedTable> {
+        if self.refresh.mode != RefreshMode::Changes && self.changes_stream.is_some() {
+            return ExpectedChangesStreamForChangesModeSnafu.fail();
+        }
+
+        if self.refresh.mode != RefreshMode::Append && self.append_stream.is_some() {
+            return ExpectedAppendStreamForAppendModeSnafu.fail();
+        }
+
         let on_complete_notification = Arc::new(Notify::new());
 
         let (acceleration_refresh_mode, refresh_trigger) = match self.refresh.mode {
@@ -539,7 +553,7 @@ impl Builder {
         }
         refresher.with_snapshot_behavior(self.snapshot_behavior, self.snapshot_local_path.clone());
 
-        let refresh_handle = refresher.start(acceleration_refresh_mode).await;
+        let refresh_handle = refresher.start(acceleration_refresh_mode).await?;
         let refresher = Arc::new(refresher);
 
         let mut handlers = vec![];

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -782,7 +782,7 @@ impl Refresher {
     ///
     /// Panics if this function is called on an accelerated table that is not configured with a full refresh mode
     pub async fn add_synchronized_table(&self, synchronized_table: SynchronizedTable) {
-        if matches!(self.refresh.read().await.mode, RefreshMode::Full) {
+        if !matches!(self.refresh.read().await.mode, RefreshMode::Full) {
             unreachable!(
                 "Only tables configured with a full refresh mode can subscribe to new table providers - this is an implementation bug"
             );

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -581,7 +581,7 @@ impl Refresher {
     pub(crate) async fn start(
         &mut self,
         acceleration_refresh_mode: AccelerationRefreshMode,
-    ) -> Option<tokio::task::JoinHandle<()>> {
+    ) -> super::Result<Option<tokio::task::JoinHandle<()>>> {
         let dataset_name = self.dataset_name.clone();
         let time_column = self.refresh.read().await.time_column.clone();
         let initial_refresh_delay = {
@@ -613,13 +613,13 @@ impl Refresher {
         };
 
         let mut on_start_refresh_external = match (acceleration_refresh_mode, time_column) {
-            (AccelerationRefreshMode::Disabled, _) => return None,
+            (AccelerationRefreshMode::Disabled, _) => return Ok(None),
             (
                 AccelerationRefreshMode::Append(receiver) | AccelerationRefreshMode::Full(receiver),
                 _,
             ) => receiver,
             (AccelerationRefreshMode::Changes(stream), _) => {
-                return Some(self.start_changes_stream(stream));
+                return Ok(Some(self.start_changes_stream(stream)));
             }
         };
 
@@ -644,7 +644,7 @@ impl Refresher {
 
         let mut refresh_task_runner = refresh_task_runner.build();
 
-        let (start_refresh, mut on_refresh_complete) = refresh_task_runner.start();
+        let (start_refresh, mut on_refresh_complete) = refresh_task_runner.start()?;
         self.refresh_task_runner = Some(refresh_task_runner);
 
         let notifier = self.on_complete_notification.clone();
@@ -686,7 +686,7 @@ impl Refresher {
         //   1. Periodic and manual refreshes happening at the same time
         //   2. The periodic refresh happening less than `refresh_check_interval` after a manual
         //        refresh (the sleep future is reset when a manual refresh completes).
-        Some(tokio::spawn(async move {
+        Ok(Some(tokio::spawn(async move {
             let mut next_scheduled_refresh_timer =
                 initial_refresh_delay.map(|delay| sleep(Self::compute_delay(delay, max_jitter)));
 
@@ -773,7 +773,7 @@ impl Refresher {
                     }
                 }
             }
-        }))
+        })))
     }
 
     /// Subscribes a new table provider to receive refresh notifications from an existing full refresh mode accelerated table
@@ -782,10 +782,11 @@ impl Refresher {
     ///
     /// Panics if this function is called on an accelerated table that is not configured with a full refresh mode
     pub async fn add_synchronized_table(&self, synchronized_table: SynchronizedTable) {
-        assert!(
-            matches!(self.refresh.read().await.mode, RefreshMode::Full),
-            "Only tables configured with a full refresh mode can subscribe to new table providers - this is an implementation bug"
-        );
+        if matches!(self.refresh.read().await.mode, RefreshMode::Full) {
+            unreachable!(
+                "Only tables configured with a full refresh mode can subscribe to new table providers - this is an implementation bug"
+            );
+        }
 
         if let Some(refresh_task_runner) = &self.refresh_task_runner {
             refresh_task_runner
@@ -990,7 +991,10 @@ mod tests {
 
         let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
         let acceleration_refresh_mode = AccelerationRefreshMode::Full(receiver);
-        let refresh_handle = refresher.start(acceleration_refresh_mode).await;
+        let refresh_handle = refresher
+            .start(acceleration_refresh_mode)
+            .await
+            .expect("Should start refresh task");
 
         trigger
             .send(None)
@@ -1200,7 +1204,10 @@ mod tests {
 
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
-            let refresh_handle = refresher.start(acceleration_refresh_mode).await;
+            let refresh_handle = refresher
+                .start(acceleration_refresh_mode)
+                .await
+                .expect("Should start refresh task");
 
             trigger
                 .send(None)
@@ -1356,7 +1363,10 @@ mod tests {
 
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
-            let refresh_handle = refresher.start(acceleration_refresh_mode).await;
+            let refresh_handle = refresher
+                .start(acceleration_refresh_mode)
+                .await
+                .expect("Should start refresh task");
 
             trigger
                 .send(None)
@@ -1562,7 +1572,10 @@ mod tests {
 
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
-            let refresh_handle = refresher.start(acceleration_refresh_mode).await;
+            let refresh_handle = refresher
+                .start(acceleration_refresh_mode)
+                .await
+                .expect("Should start refresh task");
             trigger
                 .send(None)
                 .await

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -148,6 +148,9 @@ pub struct RefreshTaskRunner {
 type RefreshRunFuture =
     BoxFuture<'static, std::result::Result<super::Result<()>, Box<dyn Any + Send>>>;
 
+type RefreshTaskStartSender = Sender<Option<RefreshOverrides>>;
+type RefreshTaskCompletionReceiver = Receiver<super::Result<()>>;
+
 impl RefreshTaskRunner {
     #[must_use]
     pub fn builder(
@@ -170,16 +173,12 @@ impl RefreshTaskRunner {
         )
     }
 
-    /// # Panics
-    ///
-    /// Panics if `start` is called more than once for the same runner instance.
     pub fn start(
         &mut self,
-    ) -> (
-        Sender<Option<RefreshOverrides>>,
-        Receiver<super::Result<()>>,
-    ) {
-        assert!(self.task.is_none());
+    ) -> super::Result<(RefreshTaskStartSender, RefreshTaskCompletionReceiver)> {
+        if self.task.is_some() {
+            return Err(super::Error::RefreshTaskAlreadyStarted {});
+        }
 
         let (start_refresh, mut on_start_refresh) = mpsc::channel::<Option<RefreshOverrides>>(1);
 
@@ -253,7 +252,7 @@ impl RefreshTaskRunner {
             }
         }));
 
-        (start_refresh, on_refresh_complete)
+        Ok((start_refresh, on_refresh_complete))
     }
 
     /// Subscribes a new acceleration table provider to the existing `AccelerationSink` managed by this `RefreshTask`.

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -78,6 +78,9 @@ pub enum Error {
 
     #[snafu(transparent)]
     IcebergSnafu { source: iceberg::Error },
+
+    #[snafu(display("Failed to start a catalog refresh task. The task is already running."))]
+    RefreshTaskAlreadyStarted {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -239,7 +242,7 @@ pub async fn get_catalog_provider(
             .refreshable_catalog_provider(runtime, catalog)
             .await?,
     )
-    .start_refresh(refresh_interval);
+    .start_refresh(refresh_interval)?;
     Ok(Arc::new(provider))
 }
 
@@ -251,13 +254,6 @@ pub struct RefreshingCatalogProvider {
 }
 
 impl RefreshingCatalogProvider {
-    pub fn new_with_refresh(
-        inner: Arc<dyn RefreshableCatalogProvider>,
-        refresh_interval: Duration,
-    ) -> Self {
-        Self::new(inner).start_refresh(Some(refresh_interval))
-    }
-
     fn new(inner: Arc<dyn RefreshableCatalogProvider>) -> Self {
         Self {
             inner,
@@ -265,8 +261,11 @@ impl RefreshingCatalogProvider {
         }
     }
 
-    fn start_refresh(mut self, interval: Option<Duration>) -> Self {
-        assert!(self.refresh_task.is_none(), "Refresh task already running");
+    fn start_refresh(mut self, interval: Option<Duration>) -> Result<Self> {
+        if self.refresh_task.is_some() {
+            return Err(Error::RefreshTaskAlreadyStarted {});
+        }
+
         let interval = interval.unwrap_or(Duration::from_secs(60));
         let inner = Arc::clone(&self.inner);
         self.refresh_task = Some(tokio::spawn(async move {
@@ -280,7 +279,7 @@ impl RefreshingCatalogProvider {
                 }
             }
         }));
-        self
+        Ok(self)
     }
 }
 

--- a/crates/runtime/tests/refresh_worker_panic.rs
+++ b/crates/runtime/tests/refresh_worker_panic.rs
@@ -161,7 +161,8 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
     )
     .build();
 
-    let (start_refresh, mut on_refresh_complete) = runner.start();
+    let (start_refresh, mut on_refresh_complete) =
+        runner.start().expect("Should start refresh task");
 
     start_refresh.send(None).await.map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Denies `assert` macros in non-test code. Updates `make lint-rust` to split `--lib --bins` and `--tests` targets so we can apply different lint rules to each target type
* Updates occurances of the assertion macro with proper error handling if applicable
* Replaces some usage of `panic!` with `unreachable!` if applicable

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
