### PR TITLE
Add support for `amazon.nova-2-multimodal-embeddings-v1:0`

### DIFF
--- a/crates/llms/src/bedrock/embed/cohere.rs
+++ b/crates/llms/src/bedrock/embed/cohere.rs
@@ -191,7 +191,7 @@ impl BedrockEmbeddingConfig<CohereEmbedRequest, CohereEmbedResponse> for CohereC
     fn extract_embeddings(
         &self,
         mut resp: CohereEmbedResponse,
-    ) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
+    ) -> EmbedResult<(Vec<Vec<f32>>, Option<u32>)> {
         // Estimate token count for Cohere models (approximate)
         let estimated_tokens: u32 = if let Some(texts) = resp.texts {
             texts
@@ -212,7 +212,7 @@ impl BedrockEmbeddingConfig<CohereEmbedRequest, CohereEmbedResponse> for CohereC
                 ),
             })?;
 
-        Ok((float_embedding, estimated_tokens))
+        Ok((float_embedding, Some(estimated_tokens)))
     }
 
     fn to_request_blobs(&self, input_text: Vec<String>) -> EmbedResult<Vec<CohereEmbedRequest>> {

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -123,11 +123,6 @@ pub fn new_text_only_nova_multimodal(
     embedding_purpose: NovaEmbeddingPurpose,
     truncation_mode: NovaTruncationMode,
 ) -> BedrockEmbed<NovaEmbedRequest, NovaEmbedResponse> {
-    tracing::debug!(
-        "Initializing Nova Multimodal embedder: dimensions={dimensions}, embedding_purpose={embedding_purpose:?}, truncation_mode={truncation_mode:?}, rate_limit={:?}",
-        client.rate_controller
-    );
-
     let config = Arc::new(NovaConfig {
         model_name: NOVA_MULTIMODAL_EMBED_V2.to_string(),
         dimensions,

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -20,6 +20,10 @@ use crate::bedrock::embed::cohere::{
     CohereConfig, CohereEmbedRequest, CohereEmbedResponse, CohereEmbeddingInputType,
     CohereEmbeddingTruncate, CohereEmbeddingType,
 };
+use crate::bedrock::embed::nova::{
+    NOVA_MULTIMODAL_EMBED_V2, NovaConfig, NovaEmbedRequest, NovaEmbedResponse,
+    NovaEmbeddingPurpose, NovaTruncationMode,
+};
 use crate::bedrock::embed::titan::{
     TITAN_TEXT_EMBED_V2, TitanConfig, TitanEmbedRequest, TitanEmbedResponse,
 };
@@ -45,6 +49,7 @@ use std::sync::Arc;
 use tracing::warn;
 
 pub mod cohere;
+pub mod nova;
 pub mod titan;
 
 #[derive(Debug, Clone)]
@@ -111,9 +116,35 @@ pub fn new_cohere(
     }
 }
 
+#[must_use]
+pub fn new_text_only_nova_multimodal(
+    client: BedrockClient,
+    dimensions: u32,
+    embedding_purpose: NovaEmbeddingPurpose,
+    truncation_mode: NovaTruncationMode,
+) -> BedrockEmbed<NovaEmbedRequest, NovaEmbedResponse> {
+    tracing::debug!(
+        "Initializing Nova Multimodal embedder: dimensions={dimensions}, embedding_purpose={embedding_purpose:?}, truncation_mode={truncation_mode:?}, rate_limit={:?}",
+        client.rate_controller
+    );
+
+    let config = Arc::new(NovaConfig {
+        model_name: NOVA_MULTIMODAL_EMBED_V2.to_string(),
+        dimensions,
+        embedding_purpose,
+        truncation_mode,
+    }) as Arc<dyn BedrockEmbeddingConfig<NovaEmbedRequest, NovaEmbedResponse>>;
+
+    BedrockEmbed::<NovaEmbedRequest, NovaEmbedResponse> {
+        client,
+        config,
+        cache: None,
+    }
+}
+
 impl<Rq, Rsp> BedrockEmbed<Rq, Rsp>
 where
-    Rq: Serialize + Sized,
+    Rq: Serialize + Sized + Debug,
     Rsp: DeserializeOwned,
 {
     async fn embed_texts(&self, texts: Vec<String>) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
@@ -122,6 +153,11 @@ where
         if request_payloads.is_empty() {
             return Ok((Vec::new(), 0));
         }
+
+        tracing::debug!(
+            "Embedding requests look like: {:?}",
+            request_payloads.first()
+        );
 
         // join all requests, as the inner rate limit will manage concurrency
         let results = futures::future::try_join_all(
@@ -213,7 +249,7 @@ where
 /// [`BedrockEmbeddingConfig`] handles the model-specific request and response payloads expected by AWS Bedrock.
 ///
 /// AWS Bedrock does not have a standard API interface for its models. For each model, or model family, a different API is exposed.
-pub trait BedrockEmbeddingConfig<Rq: Serialize + Sized, Rsp: DeserializeOwned>:
+pub trait BedrockEmbeddingConfig<Rq: Serialize + Sized + Debug, Rsp: DeserializeOwned>:
     Debug + Sync + Send
 {
     fn model_id(&self) -> &String;

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -143,6 +143,15 @@ where
     Rsp: DeserializeOwned,
 {
     async fn embed_texts(&self, texts: Vec<String>) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
+        let mut estimated_tokens: u32 = texts
+            .iter()
+            .map(|t| u32::try_from(t.len()))
+            .collect::<Result<_, _>>()
+            .map_err(|e| EmbedError::FailedToExtractEmbeddings {
+                message: format!("Too many embeddings ({}) in single request", texts.len()),
+            })?
+            .sum();
+        estimated_tokens = estimated_tokens.div_ceil(4); // Rough estimate: 4 characters per token + buffer
         let request_payloads = self.config.to_request_blobs(texts)?;
 
         if request_payloads.is_empty() {
@@ -162,18 +171,24 @@ where
         )
         .await?;
 
-        let results = results.into_iter().fold(
-            (Vec::new(), 0),
+        let (vectors, input_tokens_opt) = results.into_iter().fold(
+            (Vec::new(), Some(0)),
             |(mut acc_vectors, acc_tokens), (vectors, tokens)| {
                 acc_vectors.extend(vectors);
-                (acc_vectors, acc_tokens + tokens)
+                (
+                    acc_vectors,
+                    match (acc_tokens, tokens) {
+                        (Some(a), Some(b)) => Some(a + b),
+                        _ => None,
+                    },
+                )
             },
         );
 
-        Ok(results)
+        Ok((vectors, input_tokens_opt.unwrap_or(estimated_tokens)))
     }
 
-    async fn process_single_request(&self, req: Rq) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
+    async fn process_single_request(&self, req: Rq) -> EmbedResult<(Vec<Vec<f32>>, Option<u32>)> {
         let body = serde_json::to_string(&req)
             .boxed()
             .context(FailedToPrepareInputSnafu)?;
@@ -250,11 +265,13 @@ pub trait BedrockEmbeddingConfig<Rq: Serialize + Sized + Debug, Rsp: Deserialize
     fn model_id(&self) -> &String;
     fn dimensions(&self) -> i32;
 
-    /// For given text to embed, construct a set of request payloads (i.e. [`Blob`]) to provider to Bedrock runtime.
+    /// For given text to embed, construct a set of request payloads (i.e. [`Blob`]) to provider to Bedrock runtime and return an estimated number of model tokens produced
+    ///
+    /// The token estimate will be used if [`Self::extract_embeddings`] cannot provide a token count from the response.
     fn to_request_blobs(&self, input_text: Vec<String>) -> EmbedResult<Vec<Rq>>;
 
     /// For responses content from AWS Bedrock, extract the embedding vectors and the number of tokens embedded.
-    fn extract_embeddings(&self, resp: Rsp) -> EmbedResult<(Vec<Vec<f32>>, u32)>;
+    fn extract_embeddings(&self, resp: Rsp) -> EmbedResult<(Vec<Vec<f32>>, Option<u32>)>;
 }
 
 #[async_trait]

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -123,6 +123,10 @@ pub fn new_text_only_nova_multimodal(
     embedding_purpose: NovaEmbeddingPurpose,
     truncation_mode: NovaTruncationMode,
 ) -> BedrockEmbed<NovaEmbedRequest, NovaEmbedResponse> {
+    tracing::debug!(
+        "Initializing Nova multimodal embedder: dimensions={dimensions}, embedding_purpose={embedding_purpose:?}, truncation_mode={truncation_mode:?}, rate_limit={:?}",
+        client.rate_controller
+    );
     let config = Arc::new(NovaConfig {
         model_name: NOVA_MULTIMODAL_EMBED_V2.to_string(),
         dimensions,
@@ -146,10 +150,11 @@ where
         let mut estimated_tokens: u32 = texts
             .iter()
             .map(|t| u32::try_from(t.len()))
-            .collect::<Result<_, _>>()
-            .map_err(|e| EmbedError::FailedToExtractEmbeddings {
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| EmbedError::FailedToExtractEmbeddings {
                 message: format!("Too many embeddings ({}) in single request", texts.len()),
             })?
+            .into_iter()
             .sum();
         estimated_tokens = estimated_tokens.div_ceil(4); // Rough estimate: 4 characters per token + buffer
         let request_payloads = self.config.to_request_blobs(texts)?;

--- a/crates/llms/src/bedrock/embed/nova.rs
+++ b/crates/llms/src/bedrock/embed/nova.rs
@@ -1,0 +1,312 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use snafu::ensure;
+
+use crate::{
+    bedrock::embed::BedrockEmbeddingConfig,
+    embeddings::{Error as EmbedError, FailedToExtractEmbeddingsSnafu, Result as EmbedResult},
+};
+
+pub const NOVA_MULTIMODAL_EMBED_V2: &str = "amazon.nova-2-multimodal-embeddings-v1:0";
+const MAX_NOVA_TEXT_LENGTH: usize = 8192;
+
+#[derive(Debug)]
+pub struct NovaConfig {
+    pub model_name: String,
+    pub dimensions: u32,
+    pub embedding_purpose: NovaEmbeddingPurpose,
+    pub truncation_mode: NovaTruncationMode,
+}
+
+impl BedrockEmbeddingConfig<NovaEmbedRequest, NovaEmbedResponse> for NovaConfig {
+    fn model_id(&self) -> &String {
+        &self.model_name
+    }
+
+    fn dimensions(&self) -> i32 {
+        match self.dimensions {
+            256 => 256,
+            384 => 384,
+            1024 => 1024,
+            _ => 3072,
+        }
+    }
+
+    fn extract_embeddings(&self, resp: NovaEmbedResponse) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
+        tracing::debug!("Embedding response look like: {resp:?}");
+        let embeddings: Vec<Vec<f32>> = resp.embeddings.into_iter().map(|e| e.embedding).collect();
+
+        // Nova doesn't return token count, so we estimate it
+        let total_chars: u32 = embeddings.len() as u32 * self.dimensions;
+        let estimated_tokens = total_chars / 4; // Rough estimate: 4 chars per token
+
+        Ok((embeddings, estimated_tokens))
+    }
+
+    fn to_request_blobs(&self, input_text: Vec<String>) -> EmbedResult<Vec<NovaEmbedRequest>> {
+        input_text
+            .into_iter()
+            .map(|t| {
+                ensure!(
+                    t.len() <= MAX_NOVA_TEXT_LENGTH,
+                    FailedToExtractEmbeddingsSnafu {
+                        message: format!(
+                            "Input text length {} exceeds maximum supported length {MAX_NOVA_TEXT_LENGTH}",
+                            t.len(),
+                        )
+                    }
+                );
+
+                Ok(NovaEmbedRequest {
+                    schema_version: Some("nova-multimodal-embed-v1".to_string()),
+                    task_type: NovaTaskType::SingleEmbedding,
+                    single_embedding_params: NovaSingleEmbeddingParams {
+                        embedding_purpose: self.embedding_purpose.clone(),
+                        embedding_dimension: Some(self.dimensions),
+                        text: Some(NovaTextInput {
+                            truncation_mode: self.truncation_mode.clone(),
+                            value: Some(t),
+                            source: None,
+                        }),
+                        image: None,
+                        audio: None,
+                        video: None,
+                    },
+                })
+            })
+            .collect::<EmbedResult<Vec<NovaEmbedRequest>>>()
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaEmbeddingPurpose {
+    #[default]
+    GenericIndex,
+    GenericRetrieval,
+    TextRetrieval,
+    ImageRetrieval,
+    VideoRetrieval,
+    DocumentRetrieval,
+    AudioRetrieval,
+    Classification,
+    Clustering,
+}
+
+impl FromStr for NovaEmbeddingPurpose {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "GENERIC_INDEX" => Ok(NovaEmbeddingPurpose::GenericIndex),
+            "GENERIC_RETRIEVAL" => Ok(NovaEmbeddingPurpose::GenericRetrieval),
+            "TEXT_RETRIEVAL" => Ok(NovaEmbeddingPurpose::TextRetrieval),
+            "IMAGE_RETRIEVAL" => Ok(NovaEmbeddingPurpose::ImageRetrieval),
+            "VIDEO_RETRIEVAL" => Ok(NovaEmbeddingPurpose::VideoRetrieval),
+            "DOCUMENT_RETRIEVAL" => Ok(NovaEmbeddingPurpose::DocumentRetrieval),
+            "AUDIO_RETRIEVAL" => Ok(NovaEmbeddingPurpose::AudioRetrieval),
+            "CLASSIFICATION" => Ok(NovaEmbeddingPurpose::Classification),
+            "CLUSTERING" => Ok(NovaEmbeddingPurpose::Clustering),
+            _ => Err(format!("Invalid NovaEmbeddingPurpose: {}", s)),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaTruncationMode {
+    Start,
+    End,
+
+    #[default]
+    None,
+}
+
+impl NovaTruncationMode {
+    #[must_use]
+    pub fn all() -> Vec<NovaTruncationMode> {
+        vec![Self::Start, Self::End, Self::None]
+    }
+}
+
+impl FromStr for NovaTruncationMode {
+    type Err = EmbedError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "START" => Ok(NovaTruncationMode::Start),
+            "END" => Ok(NovaTruncationMode::End),
+            "NONE" => Ok(NovaTruncationMode::None),
+            _ => Err(EmbedError::InvalidParamError {
+                param_key: "input_type",
+                value: s.to_string(),
+                reason: format!(
+                    "For Nova multi-modal model, 'truncation_mode' must be one of: {:?}",
+                    NovaTruncationMode::all()
+                ),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaTaskType {
+    SingleEmbedding,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaEmbedRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    pub task_type: NovaTaskType,
+    pub single_embedding_params: NovaSingleEmbeddingParams,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaSingleEmbeddingParams {
+    pub embedding_purpose: NovaEmbeddingPurpose,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding_dimension: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<NovaTextInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<NovaImageInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio: Option<NovaAudioInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video: Option<NovaVideoInput>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaTextInput {
+    pub truncation_mode: NovaTruncationMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<NovaSourceObject>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaImageInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail_level: Option<NovaImageDetailLevel>,
+    pub format: NovaImageFormat,
+    pub source: NovaSourceObject,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaImageDetailLevel {
+    StandardImage,
+    DocumentImage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NovaImageFormat {
+    Png,
+    Jpeg,
+    Gif,
+    Webp,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaAudioInput {
+    pub format: NovaAudioFormat,
+    pub source: NovaSourceObject,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NovaAudioFormat {
+    Mp3,
+    Wav,
+    Ogg,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaVideoInput {
+    pub format: NovaVideoFormat,
+    pub source: NovaSourceObject,
+    pub embedding_mode: NovaVideoEmbeddingMode,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NovaVideoFormat {
+    Mp4,
+    Mov,
+    Mkv,
+    Webm,
+    Flv,
+    Mpeg,
+    Mpg,
+    Wmv,
+    #[serde(rename = "3gp")]
+    ThreeGp,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaVideoEmbeddingMode {
+    AudioVideoCombined,
+    AudioVideoSeparate,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NovaSourceObject {
+    // This would contain S3 URI or bytes - implementation depends on use case
+    // For now, keeping it simple as a placeholder
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub s3_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NovaEmbedResponse {
+    pub embeddings: Vec<NovaEmbeddingResult>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NovaEmbeddingResult {
+    pub embedding_type: NovaEmbeddingType,
+    pub embedding: Vec<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated_char_length: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NovaEmbeddingType {
+    Text,
+    Image,
+    Video,
+    Audio,
+    AudioVideoCombined,
+}

--- a/crates/llms/src/bedrock/embed/nova.rs
+++ b/crates/llms/src/bedrock/embed/nova.rs
@@ -50,7 +50,6 @@ impl BedrockEmbeddingConfig<NovaEmbedRequest, NovaEmbedResponse> for NovaConfig 
     }
 
     fn extract_embeddings(&self, resp: NovaEmbedResponse) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
-        tracing::debug!("Embedding response look like: {resp:?}");
         let embeddings: Vec<Vec<f32>> = resp.embeddings.into_iter().map(|e| e.embedding).collect();
 
         // Nova doesn't return token count, so we estimate it
@@ -279,8 +278,6 @@ pub enum NovaVideoEmbeddingMode {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NovaSourceObject {
-    // This would contain S3 URI or bytes - implementation depends on use case
-    // For now, keeping it simple as a placeholder
     #[serde(skip_serializing_if = "Option::is_none")]
     pub s3_uri: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/llms/src/bedrock/embed/nova.rs
+++ b/crates/llms/src/bedrock/embed/nova.rs
@@ -53,7 +53,13 @@ impl BedrockEmbeddingConfig<NovaEmbedRequest, NovaEmbedResponse> for NovaConfig 
         let embeddings: Vec<Vec<f32>> = resp.embeddings.into_iter().map(|e| e.embedding).collect();
 
         // Nova doesn't return token count, so we estimate it
-        let total_chars: u32 = embeddings.len() as u32 * self.dimensions;
+        let total_chars: u32 =
+            u32::try_from(embeddings.len()).map_err(|e| EmbedError::FailedToExtractEmbeddings {
+                message: format!(
+                    "Too many embeddings ({}) in single request",
+                    embeddings.len()
+                ),
+            })? * self.dimensions;
         let estimated_tokens = total_chars / 4; // Rough estimate: 4 chars per token
 
         Ok((embeddings, estimated_tokens))
@@ -123,7 +129,7 @@ impl FromStr for NovaEmbeddingPurpose {
             "AUDIO_RETRIEVAL" => Ok(NovaEmbeddingPurpose::AudioRetrieval),
             "CLASSIFICATION" => Ok(NovaEmbeddingPurpose::Classification),
             "CLUSTERING" => Ok(NovaEmbeddingPurpose::Clustering),
-            _ => Err(format!("Invalid NovaEmbeddingPurpose: {}", s)),
+            _ => Err(format!("Invalid NovaEmbeddingPurpose: {s}")),
         }
     }
 }

--- a/crates/llms/src/bedrock/embed/nova.rs
+++ b/crates/llms/src/bedrock/embed/nova.rs
@@ -49,20 +49,14 @@ impl BedrockEmbeddingConfig<NovaEmbedRequest, NovaEmbedResponse> for NovaConfig 
         }
     }
 
-    fn extract_embeddings(&self, resp: NovaEmbedResponse) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
-        let embeddings: Vec<Vec<f32>> = resp.embeddings.into_iter().map(|e| e.embedding).collect();
-
-        // Nova doesn't return token count, so we estimate it
-        let total_chars: u32 =
-            u32::try_from(embeddings.len()).map_err(|e| EmbedError::FailedToExtractEmbeddings {
-                message: format!(
-                    "Too many embeddings ({}) in single request",
-                    embeddings.len()
-                ),
-            })? * self.dimensions;
-        let estimated_tokens = total_chars / 4; // Rough estimate: 4 chars per token
-
-        Ok((embeddings, estimated_tokens))
+    fn extract_embeddings(
+        &self,
+        resp: NovaEmbedResponse,
+    ) -> EmbedResult<(Vec<Vec<f32>>, Option<u32>)> {
+        Ok((
+            resp.embeddings.into_iter().map(|e| e.embedding).collect(),
+            None,
+        ))
     }
 
     fn to_request_blobs(&self, input_text: Vec<String>) -> EmbedResult<Vec<NovaEmbedRequest>> {
@@ -160,7 +154,7 @@ impl FromStr for NovaTruncationMode {
             "END" => Ok(NovaTruncationMode::End),
             "NONE" => Ok(NovaTruncationMode::None),
             _ => Err(EmbedError::InvalidParamError {
-                param_key: "input_type",
+                param_key: "truncation_mode",
                 value: s.to_string(),
                 reason: format!(
                     "For Nova multi-modal model, 'truncation_mode' must be one of: {:?}",

--- a/crates/llms/src/bedrock/embed/titan.rs
+++ b/crates/llms/src/bedrock/embed/titan.rs
@@ -43,8 +43,11 @@ impl BedrockEmbeddingConfig<TitanEmbedRequest, TitanEmbedResponse> for TitanConf
         }
     }
 
-    fn extract_embeddings(&self, resp: TitanEmbedResponse) -> EmbedResult<(Vec<Vec<f32>>, u32)> {
-        Ok((vec![resp.embedding], resp.input_text_token_count))
+    fn extract_embeddings(
+        &self,
+        resp: TitanEmbedResponse,
+    ) -> EmbedResult<(Vec<Vec<f32>>, Option<u32>)> {
+        Ok((vec![resp.embedding], Some(resp.input_text_token_count)))
     }
 
     fn to_request_blobs(&self, input_text: Vec<String>) -> EmbedResult<Vec<TitanEmbedRequest>> {

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -24,7 +24,10 @@ use llms::HealthCheck;
 #[cfg(feature = "bedrock")]
 use llms::bedrock::{
     self,
-    embed::cohere::{CohereEmbeddingInputType, CohereEmbeddingTruncate, CohereEmbeddingType},
+    embed::{
+        cohere::{CohereEmbeddingInputType, CohereEmbeddingTruncate, CohereEmbeddingType},
+        nova::{NovaEmbeddingPurpose, NovaTruncationMode},
+    },
 };
 use runtime_secrets::{Secrets, get_params_with_secrets};
 
@@ -245,17 +248,16 @@ async fn bedrock(
         } else {
             CohereEmbeddingTruncate::default()
         };
-        let input_type = if let Some(input_type_str) = extract_secret!(params, "input_type") {
-            CohereEmbeddingInputType::from_str(input_type_str).map_err(|e| {
-                EmbedError::InvalidParamError {
-                    param_key: "input_type",
-                    value: input_type_str.to_string(),
-                    reason: e.to_string(),
-                }
+        let input_type_str = extract_secret!(params, "input_type");
+        let input_type = input_type_str
+            .map(CohereEmbeddingInputType::from_str)
+            .transpose()
+            .map_err(|e| EmbedError::InvalidParamError {
+                param_key: "input_type",
+                value: input_type_str.unwrap_or_default().to_string(),
+                reason: e.to_string(),
             })?
-        } else {
-            CohereEmbeddingInputType::default()
-        };
+            .unwrap_or_default();
         Ok(Arc::new(
             bedrock::embed::new_cohere(
                 client,
@@ -263,6 +265,59 @@ async fn bedrock(
                 truncate,
                 input_type,
                 CohereEmbeddingType::Float,
+            )
+            .set_cache(embeddings_cache),
+        ) as Arc<dyn Embed>)
+    } else if model_id.starts_with("amazon.nova-2-multimodal-embeddings") {
+        let Some(dimensions) = params
+            .get("dimensions")
+            .map(|s| s.expose_secret().parse::<u32>())
+            .transpose()
+            .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!("Failed to parse 'dimensions' parameter: {e}").into(),
+            })?
+        else {
+            return Err(EmbedError::MissingParamError {
+                param_key: "dimensions",
+            });
+        };
+
+        if !matches!(dimensions, 256 | 384 | 1024 | 3072) {
+            return Err(EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!(
+                    "Invalid dimensions '{dimensions}' for Titan model. Must be 256, 384, 1024, or 3072"
+                )
+                .into(),
+            });
+        }
+
+        let embedding_purpose = params
+            .get("embedding_purpose")
+            .map(|s| s.expose_secret())
+            .map(NovaEmbeddingPurpose::from_str)
+            .transpose()
+            .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!("Failed to parse 'dimensions' parameter: {e}").into(),
+            })?
+            .unwrap_or_default();
+
+        let truncate = if let Some(truncate_str) = extract_secret!(params, "truncate") {
+            NovaTruncationMode::from_str(truncate_str)
+                .boxed()
+                .map_err(|e| EmbedError::InvalidParamError {
+                    param_key: "truncate",
+                    value: truncate_str.to_string(),
+                    reason: e.to_string(),
+                })?
+        } else {
+            NovaTruncationMode::default()
+        };
+        Ok(Arc::new(
+            bedrock::embed::new_text_only_nova_multimodal(
+                client,
+                dimensions,
+                embedding_purpose,
+                truncate,
             )
             .set_cache(embeddings_cache),
         ) as Arc<dyn Embed>)

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -186,6 +186,7 @@ fn model2vec(
 }
 
 #[cfg(feature = "bedrock")]
+#[allow(clippy::too_many_lines)]
 async fn bedrock(
     model_id: Option<String>,
     params: &HashMap<String, SecretString>,
@@ -293,7 +294,9 @@ async fn bedrock(
             });
         }
 
-        let embedding_purpose_str = params.get("embedding_purpose").map(|s| s.expose_secret());
+        let embedding_purpose_str = params
+            .get("embedding_purpose")
+            .map(ExposeSecret::expose_secret);
         let embedding_purpose = embedding_purpose_str
             .map(NovaEmbeddingPurpose::from_str)
             .transpose()

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -237,11 +237,13 @@ async fn bedrock(
             bedrock::embed::new_titan_v2(client, normalize, dimensions).set_cache(embeddings_cache),
         ) as Arc<dyn Embed>)
     } else if model_id.starts_with("cohere.embed") {
-        let truncate = if let Some(truncate_str) = extract_secret!(params, "truncate") {
+        let truncate = if let Some(truncate_str) =
+            extract_secret!(params, "truncate_mode").or(extract_secret!(params, "truncate"))
+        {
             CohereEmbeddingTruncate::from_str(truncate_str)
                 .boxed()
                 .map_err(|e| EmbedError::InvalidParamError {
-                    param_key: "truncate",
+                    param_key: "truncate_mode",
                     value: truncate_str.to_string(),
                     reason: e.to_string(),
                 })?
@@ -285,27 +287,32 @@ async fn bedrock(
         if !matches!(dimensions, 256 | 384 | 1024 | 3072) {
             return Err(EmbedError::FailedToInstantiateEmbeddingModel {
                 source: format!(
-                    "Invalid dimensions '{dimensions}' for Titan model. Must be 256, 384, 1024, or 3072"
+                    "Invalid dimensions '{dimensions}' for Nova model. Must be 256, 384, 1024, or 3072"
                 )
                 .into(),
             });
         }
 
-        let embedding_purpose = params
-            .get("embedding_purpose")
-            .map(|s| s.expose_secret())
+        let embedding_purpose_str = params.get("embedding_purpose").map(|s| s.expose_secret());
+        let embedding_purpose = embedding_purpose_str
             .map(NovaEmbeddingPurpose::from_str)
             .transpose()
-            .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel {
-                source: format!("Failed to parse 'dimensions' parameter: {e}").into(),
+            .map_err(|_| EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!(
+                    "Invalid 'embedding_purpose' parameter: '{}'",
+                    embedding_purpose_str.unwrap_or_default()
+                )
+                .into(),
             })?
             .unwrap_or_default();
 
-        let truncate = if let Some(truncate_str) = extract_secret!(params, "truncate") {
+        let truncate = if let Some(truncate_str) =
+            extract_secret!(params, "truncate_mode").or(extract_secret!(params, "truncate"))
+        {
             NovaTruncationMode::from_str(truncate_str)
                 .boxed()
                 .map_err(|e| EmbedError::InvalidParamError {
-                    param_key: "truncate",
+                    param_key: "truncate_mode",
                     value: truncate_str.to_string(),
                     reason: e.to_string(),
                 })?


### PR DESCRIPTION
## 📝 Summary
Add text-based support for  'amazon.nova-2-multimodal-embeddings-v1:0'
```yaml
embeddings:
  - from: bedrock:amazon.nova-2-multimodal-embeddings-v1:0
    name: makes-embeddings
    params:
      dimensions: '3072' # Required 
      truncation_mode:  START  # Optional. Default NONE (i.e. return error)
      embedding_purpose:  GENERIC_RETRIEVAL # Optional. Default GENERIC_INDEX
```
Values for enum fields are from: https://docs.aws.amazon.com/nova/latest/userguide/embeddings-schema.html


## 📚 Docs
 - [x] Docs for Amazon Nova embedding model