### PR TITLE
Make cache zstd default compression level 6

### DIFF
--- a/crates/cache/src/encoding.rs
+++ b/crates/cache/src/encoding.rs
@@ -85,7 +85,7 @@ impl ZstdEncoder {
 
 impl Default for ZstdEncoder {
     fn default() -> Self {
-        Self::new(3) // Zstd default compression level
+        Self::new(6) // Zstd compression level 6
     }
 }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the default compression level used by the `ZstdEncoder`. The default compression level has been increased from 3 to 6, which may result in better compression ratios at the cost of slightly more CPU usage.

* Increased the default compression level in the `ZstdEncoder` implementation from 3 to 6 (`crates/cache/src/encoding.rs`).