### PR TITLE
Add health probe override

### DIFF
--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -220,6 +220,7 @@ pub struct HttpTableProvider {
     max_query_length: usize,
     allow_body_filters: bool,
     max_body_bytes: usize,
+    health_probe: Option<String>,
 }
 
 impl std::fmt::Debug for HttpTableProvider {
@@ -260,6 +261,7 @@ impl HttpTableProvider {
             max_query_length: DEFAULT_MAX_QUERY_LENGTH,
             allow_body_filters: false,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            health_probe: None,
         }
     }
 
@@ -384,6 +386,12 @@ impl HttpTableProvider {
     }
 
     #[must_use]
+    pub fn with_health_probe(mut self, health_probe: Option<String>) -> Self {
+        self.health_probe = health_probe;
+        self
+    }
+
+    #[must_use]
     pub fn base_table_schema() -> Schema {
         Schema::new(vec![
             Field::new("request_path", DataType::Utf8, false),
@@ -403,34 +411,50 @@ impl HttpTableProvider {
         )
     }
 
-    /// Validates the HTTP endpoint by attempting a request to a non-existent path.
-    /// This helps detect issues like DNS errors, connection problems, or invalid URLs
-    /// early in the initialization process.
+    /// Validates the HTTP endpoint by attempting a request to a custom health probe path if configured,
+    /// or a non-existent path otherwise.
+    /// This helps detect issues like DNS errors, connection problems,
+    /// or invalid URLs early in the initialization process.
     pub async fn validate_endpoint(&self) -> Result<()> {
-        use rand::Rng;
-        use rand::distr::Alphanumeric;
+        let test_url = if let Some(ref health_probe_path) = self.health_probe {
+            let mut test_url = self.base_url.clone();
+            test_url.set_path(health_probe_path);
+            test_url
+        } else {
+            use rand::Rng;
+            use rand::distr::Alphanumeric;
 
-        // Generate a random path that should return 404
-        let random_suffix: String = rand::rng()
-            .sample_iter(Alphanumeric)
-            .take(16)
-            .map(char::from)
-            .collect();
-        let test_path = format!("/__spice_health_check_{random_suffix}");
+            // Generate a random path that should return 404
+            let random_suffix: String = rand::rng()
+                .sample_iter(Alphanumeric)
+                .take(16)
+                .map(char::from)
+                .collect();
+            let test_path = format!("/__spice_health_check_{random_suffix}");
 
-        let mut test_url = self.base_url.clone();
-        test_url.set_path(&test_path);
+            let mut test_url = self.base_url.clone();
+            test_url.set_path(&test_path);
+            test_url
+        };
 
         tracing::debug!("Validating HTTP endpoint: {}", self.base_url);
 
         match self.client.get(test_url).send().await {
             Ok(response) => {
                 let status = response.status();
-                tracing::debug!(
-                    "HTTP endpoint validation response: {} (status: {})",
-                    self.base_url,
-                    status
-                );
+                if self.health_probe.is_some() {
+                    tracing::debug!(
+                        "HTTP endpoint validation response using health probe: {} (status: {})",
+                        self.base_url,
+                        status
+                    );
+                } else {
+                    tracing::debug!(
+                        "HTTP endpoint validation response: {} (status: {}). 404 is expected for the random probe path.",
+                        self.base_url,
+                        status
+                    );
+                }
                 // Any response (including 404) means the endpoint is reachable
                 Ok(())
             }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -471,8 +471,7 @@ impl HttpTableProvider {
                         return Err(Error::HttpClientError {
                             status: status.as_u16(),
                             message: format!(
-                                "Health probe endpoint returned non-success status: {}",
-                                status
+                                "Health probe endpoint returned non-success status: {status}"
                             ),
                         });
                     }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -455,31 +455,29 @@ impl HttpTableProvider {
             test_url
         };
 
-        tracing::debug!("Validating HTTP endpoint: {}", self.base_url);
+        tracing::debug!("Validating HTTP endpoint: {test_url}");
 
-        match self.client.get(test_url).send().await {
+        match self.client.get(test_url.clone()).send().await {
             Ok(response) => {
                 let status = response.status();
                 if self.health_probe.is_some() {
                     tracing::debug!(
-                        "HTTP endpoint validation response using health probe: {} (status: {})",
-                        self.base_url,
-                        status
+                        "HTTP endpoint validation response using health probe: {test_url} (status: {status})"
                     );
                     // For custom health probe, require successful status (2xx)
                     if !status.is_success() {
                         return Err(Error::HttpClientError {
                             status: status.as_u16(),
                             message: format!(
-                                "Health probe endpoint returned non-success status: {status}"
+                                "Failed to validate HTTP endpoint {}: Health probe {} returned non-success status {status}. Ensure the health probe endpoint is accessible and returns a 2xx status code.",
+                                self.base_url,
+                                test_url.path()
                             ),
                         });
                     }
                 } else {
                     tracing::debug!(
-                        "HTTP endpoint validation response: {} (status: {}). Any status (including 404) is expected for the random probe path.",
-                        self.base_url,
-                        status
+                        "HTTP endpoint validation response: {test_url} (status: {status}). Any status (including 404) is expected for the random probe path."
                     );
                     // Any response (including 404) means the endpoint is reachable
                 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -385,10 +385,28 @@ impl HttpTableProvider {
         self
     }
 
-    #[must_use]
-    pub fn with_health_probe(mut self, health_probe: Option<String>) -> Self {
+    pub fn with_health_probe(mut self, health_probe: Option<String>) -> Result<Self> {
+        if let Some(ref path) = health_probe {
+            // Basic validation for health probe path
+            ensure!(
+                path.starts_with('/'),
+                ConfigurationSnafu {
+                    message: format!("health_probe path must start with '/'. Got: '{path}'",)
+                }
+            );
+            ensure!(
+                path.len() <= MAX_REQUEST_PATH_LENGTH,
+                ConfigurationSnafu {
+                    message: format!(
+                        "health_probe path is too long ({} characters). Maximum allowed is {}",
+                        path.len(),
+                        MAX_REQUEST_PATH_LENGTH
+                    )
+                }
+            );
+        }
         self.health_probe = health_probe;
-        self
+        Ok(self)
     }
 
     #[must_use]
@@ -448,14 +466,24 @@ impl HttpTableProvider {
                         self.base_url,
                         status
                     );
+                    // For custom health probe, require successful status (2xx)
+                    if !status.is_success() {
+                        return Err(Error::HttpClientError {
+                            status: status.as_u16(),
+                            message: format!(
+                                "Health probe endpoint returned non-success status: {}",
+                                status
+                            ),
+                        });
+                    }
                 } else {
                     tracing::debug!(
-                        "HTTP endpoint validation response: {} (status: {}). 404 is expected for the random probe path.",
+                        "HTTP endpoint validation response: {} (status: {}). Any status (including 404) is expected for the random probe path.",
                         self.base_url,
                         status
                     );
+                    // Any response (including 404) means the endpoint is reachable
                 }
-                // Any response (including 404) means the endpoint is reachable
                 Ok(())
             }
             Err(e) => {

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -338,7 +338,14 @@ impl Https {
         .with_max_retry_duration(max_retry_duration)
         .with_retry_jitter(retry_jitter)
         .with_headers(custom_headers)
-        .with_health_probe(health_probe);
+        .with_health_probe(health_probe)
+        .boxed()
+        .map_err(|e| DataConnectorError::InvalidConfiguration {
+            dataconnector: "https".to_string(),
+            message: format!("Invalid health_probe configuration: {e}"),
+            connector_component: ConnectorComponent::from(dataset),
+            source: Box::new(e),
+        })?;
 
         provider = Self::apply_allowed_paths(dataset, provider, allowed_paths)?;
 
@@ -476,7 +483,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
         ParameterSpec::runtime("max_request_body_bytes")
             .description("Maximum size (in bytes) for request_body filter values. Default: 16384 (16KiB)."),
         ParameterSpec::runtime("health_probe")
-            .description("Custom health probe path for endpoint validation (e.g., '/health', '/api/status'). If not set, a random path is used."),
+            .description("Custom health probe path for endpoint validation (e.g., '/health', '/api/status'). The endpoint must return a 2xx status code to pass validation. If not set, a random path is used and any status (including 404) is accepted."),
     ]);
     all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
     all_parameters

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -339,12 +339,11 @@ impl Https {
         .with_retry_jitter(retry_jitter)
         .with_headers(custom_headers)
         .with_health_probe(health_probe)
-        .boxed()
         .map_err(|e| DataConnectorError::InvalidConfiguration {
             dataconnector: "https".to_string(),
             message: format!("Invalid health_probe configuration: {e}"),
             connector_component: ConnectorComponent::from(dataset),
-            source: Box::new(e),
+            source: e.into(),
         })?;
 
         provider = Self::apply_allowed_paths(dataset, provider, allowed_paths)?;

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -66,6 +66,7 @@ struct HttpProviderParams {
     max_query_length: usize,
     allow_body_filters: bool,
     max_body_bytes: usize,
+    health_probe: Option<String>,
 }
 
 impl Https {
@@ -154,6 +155,13 @@ impl Https {
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(data_components::http::provider::DEFAULT_MAX_BODY_BYTES);
 
+        let health_probe = self
+            .params
+            .get("health_probe")
+            .expose()
+            .ok()
+            .map(std::string::ToString::to_string);
+
         HttpProviderParams {
             file_format,
             acceleration_enabled: dataset.is_accelerated(),
@@ -167,6 +175,7 @@ impl Https {
             max_query_length,
             allow_body_filters,
             max_body_bytes,
+            health_probe,
         }
     }
 
@@ -315,6 +324,7 @@ impl Https {
             max_query_length,
             allow_body_filters,
             max_body_bytes,
+            health_probe,
         } = self.resolve_http_provider_params(dataset);
 
         let mut provider = data_components::http::provider::HttpTableProvider::new(
@@ -327,7 +337,8 @@ impl Https {
         .with_backoff_method(backoff_method)
         .with_max_retry_duration(max_retry_duration)
         .with_retry_jitter(retry_jitter)
-        .with_headers(custom_headers);
+        .with_headers(custom_headers)
+        .with_health_probe(health_probe);
 
         provider = Self::apply_allowed_paths(dataset, provider, allowed_paths)?;
 
@@ -464,6 +475,8 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             .one_of(&["enabled", "disabled"]),
         ParameterSpec::runtime("max_request_body_bytes")
             .description("Maximum size (in bytes) for request_body filter values. Default: 16384 (16KiB)."),
+        ParameterSpec::runtime("health_probe")
+            .description("Custom health probe path for endpoint validation (e.g., '/health', '/api/status'). If not set, a random path is used."),
     ]);
     all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
     all_parameters


### PR DESCRIPTION
This pull request introduces support for configuring a custom health probe path for HTTP endpoint validation in the data connector. This allows the system to validate endpoints using a user-specified path instead of a random non-existent path, improving flexibility and reliability for health checks.

**Health Probe Support**

* Added a new `health_probe` field to the `HttpTableProvider` and related parameters, allowing configuration of a custom path for endpoint validation. [[1]](diffhunk://#diff-17cd38db4690c99406689c051fcee4d8ae7ff45fc30f600c09e0b254d6da497cR223) [[2]](diffhunk://#diff-90fe0bb5e16555db2cb7392a36f0766da0bed334313c8a7ea8e8b960c47d51f7R69)
* Implemented the `with_health_probe` method in `HttpTableProvider` for setting the health probe path.
* Updated endpoint validation logic to use the custom health probe path if configured, and adjusted debug logging to clarify which path is used during validation. [[1]](diffhunk://#diff-17cd38db4690c99406689c051fcee4d8ae7ff45fc30f600c09e0b254d6da497cL406-R423) [[2]](diffhunk://#diff-17cd38db4690c99406689c051fcee4d8ae7ff45fc30f600c09e0b254d6da497cR437-R457)

**Parameter Handling**

* Parsed the new `health_probe` parameter from runtime configuration and passed it through to the provider. [[1]](diffhunk://#diff-90fe0bb5e16555db2cb7392a36f0766da0bed334313c8a7ea8e8b960c47d51f7R158-R164) [[2]](diffhunk://#diff-90fe0bb5e16555db2cb7392a36f0766da0bed334313c8a7ea8e8b960c47d51f7R178) [[3]](diffhunk://#diff-90fe0bb5e16555db2cb7392a36f0766da0bed334313c8a7ea8e8b960c47d51f7R327) [[4]](diffhunk://#diff-90fe0bb5e16555db2cb7392a36f0766da0bed334313c8a7ea8e8b960c47d51f7L330-R341)
* Documented the `health_probe` parameter in the runtime parameter specification, explaining its purpose and usage.