### PR TITLE
fix: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/bin/spice/pkg/util/untar.go
+++ b/bin/spice/pkg/util/untar.go
@@ -170,18 +170,6 @@ func untar(r io.Reader, dir string, isGzipped bool) (err error) {
 	return nil
 }
 
-// dangerousPatterns contains glob patterns that indicate path traversal attempts
-// or absolute paths that should be rejected in tar archives
-var dangerousPatterns = []string{
-	"*/..*", // Unix parent directory traversal
-	"*..*",  // Parent at start (Unix)
-	`*\..*`, // Windows parent directory traversal
-	"*..*",  // Parent at start (Windows)
-	"/*",    // Unix absolute path
-	`?:*`,   // Windows drive letter
-	`\\*`,   // Windows UNC path or absolute
-}
-
 // isSubpath checks that the target (child) path is within the root directory,
 // preventing directory traversal or absolute path escapes.
 func isSubpath(root, target string) bool {

--- a/bin/spice/pkg/util/untar.go
+++ b/bin/spice/pkg/util/untar.go
@@ -56,6 +56,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -92,11 +93,20 @@ func untar(r io.Reader, dir string, isGzipped bool) (err error) {
 		if err != nil {
 			return fmt.Errorf("tar error: %v", err)
 		}
-		if !validRelPath(f.Name) {
-			return fmt.Errorf("tar contained invalid name error %q", f.Name)
-		}
 		rel := filepath.FromSlash(f.Name)
 		abs := filepath.Join(dir, rel)
+		// Check that abs is within the target directory, preventing directory traversal
+		dirAbs, errAbs := filepath.Abs(dir)
+		if errAbs != nil {
+			return fmt.Errorf("failed to resolve target directory: %v", errAbs)
+		}
+		absAbs, errAbs2 := filepath.Abs(abs)
+		if errAbs2 != nil {
+			return fmt.Errorf("failed to resolve extraction path: %v", errAbs2)
+		}
+		if !isSubpath(dirAbs, absAbs) {
+			return fmt.Errorf("tar contained invalid name: potential path traversal or absolute path %q", f.Name)
+		}
 
 		fi := f.FileInfo()
 		mode := fi.Mode()
@@ -172,18 +182,14 @@ var dangerousPatterns = []string{
 	`\\*`,   // Windows UNC path or absolute
 }
 
-func validRelPath(p string) bool {
-	if p == "" {
-		return false
+// isSubpath checks that the target (child) path is within the root directory,
+// preventing directory traversal or absolute path escapes.
+func isSubpath(root, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	// Ensure trailing separator on root, so subpath (itself) matches
+	if !strings.HasSuffix(root, string(os.PathSeparator)) {
+		root += string(os.PathSeparator)
 	}
-
-	// Use filepath.Match to detect path traversal patterns on all platforms
-	// This handles both Unix (/) and Windows (\) path separators correctly
-	for _, pattern := range dangerousPatterns {
-		if matched, _ := filepath.Match(pattern, p); matched {
-			return false
-		}
-	}
-
-	return true
+	return strings.HasPrefix(target, root)
 }

--- a/bin/spice/pkg/util/untar_test.go
+++ b/bin/spice/pkg/util/untar_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUntarPreventsPathTraversal(t *testing.T) {
+	tarData := createTarArchive(t, map[string]string{
+		"../escape.txt": "malicious content",
+	})
+
+	targetDir := t.TempDir()
+	err := Untar(bytes.NewReader(tarData), targetDir, false)
+
+	assert.Error(t, err)
+	_, statErr := os.Stat(filepath.Join(targetDir, "..", "escape.txt"))
+	assert.True(t, os.IsNotExist(statErr), "expected no file to be written outside target directory")
+}
+
+func TestUntarExtractsWithinTargetDirectory(t *testing.T) {
+	const (
+		filePath = "nested/file.txt"
+		content  = "safe content"
+	)
+
+	tarData := createTarArchive(t, map[string]string{
+		filePath: content,
+	})
+
+	targetDir := t.TempDir()
+	err := Untar(bytes.NewReader(tarData), targetDir, false)
+
+	require.NoError(t, err)
+	extractedBytes, readErr := os.ReadFile(filepath.Join(targetDir, filePath))
+	require.NoError(t, readErr)
+	assert.Equal(t, content, string(extractedBytes))
+}
+
+func createTarArchive(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	tw := tar.NewWriter(&buffer)
+
+	for name, content := range entries {
+		data := []byte(content)
+		header := &tar.Header{
+			Name: name,
+			Mode: 0o600,
+			Size: int64(len(data)),
+		}
+
+		require.NoError(t, tw.WriteHeader(header))
+
+		_, writeErr := tw.Write(data)
+		require.NoError(t, writeErr)
+	}
+
+	require.NoError(t, tw.Close())
+
+	return buffer.Bytes()
+}


### PR DESCRIPTION
Fix for an issue that came up during a code audit.

To robustly prevent directory traversal attacks during archive extraction, the best fix is to check, for each file entry, that its resolved absolute extraction path is a descendant of the intended extraction root directory (`dir`). This involves, after joining `dir` and the archive entry name, resolving the absolute path and ensuring it shares the `dir` prefix (the root directory). Additionally, files with empty names or absolute paths should be rejected. 

The concrete changes required are:
- In the extraction loop, after constructing `abs`, resolve both `dir` and `abs` with `filepath.Abs`.
- Check that `abs` starts with `dir`, indicating it's contained within the extraction directory; if not, error out.
- Remove or replace `validRelPath` with this check. Optionally, still reject empty names and names with path separator traversal, but the main check is containment.
- Only modify the code in `bin/spice/pkg/util/untar.go` within the shown snippet (lines 88–189). 
- Add the necessary import for `"strings"` if not present in the shown snippet.
