### PR TITLE
Migrate trust_dns_resolver to hickory_resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=ec122b03325b86e8f5f194292419f73d26ba7d52#ec122b03325b86e8f5f194292419f73d26ba7d52"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=9fa10f280175667a54ca18b55aa1320e82737840#9fa10f280175667a54ca18b55aa1320e82737840"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -4949,6 +4949,7 @@ dependencies = [
  "fundu",
  "futures",
  "geo-types",
+ "hickory-resolver 0.25.2",
  "itertools 0.13.0",
  "mongodb",
  "mysql_async",
@@ -4971,7 +4972,6 @@ dependencies = [
  "tokio-postgres",
  "tokio-rusqlite",
  "tracing",
- "trust-dns-resolver",
  "url",
  "uuid 1.18.1",
 ]
@@ -7098,11 +7098,36 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 1.1.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand 0.8.5",
  "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -7117,7 +7142,7 @@ checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "ipconfig",
  "lru-cache",
  "once_cell",
@@ -7126,6 +7151,27 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -7738,16 +7784,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -9570,8 +9606,8 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.24.4",
+ "hickory-resolver 0.24.4",
  "hmac",
  "macro_magic",
  "md-5",
@@ -10005,10 +10041,10 @@ dependencies = [
 name = "ns_lookup"
 version = "1.10.0-unstable"
 dependencies = [
+ "hickory-resolver 0.25.2",
  "snafu",
  "tokio",
  "tracing",
- "trust-dns-resolver",
  "url",
 ]
 
@@ -10564,7 +10600,9 @@ version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
+ "critical-section",
  "parking_lot_core 0.9.12",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -16776,52 +16814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot 0.12.5",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17266,7 +17258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = 
 datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }               # spiceai/spiceai-50
 datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                   # spiceai/spiceai-50
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "ec122b03325b86e8f5f194292419f73d26ba7d52" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "9fa10f280175667a54ca18b55aa1320e82737840" } # spiceai
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "007c82d039220478f406d648417d28c0d40a7987" } # spiceai:spiceai-50
 

--- a/crates/datafusion-optimizer-rules/src/physical_plan/duckdb_intermediate_index.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/duckdb_intermediate_index.rs
@@ -354,7 +354,7 @@ impl PhysicalOptimizerRule for DuckDBIntermediateIndexMaterializationOptimizer {
             if node_key == old_exec_key {
                 let new_exec = duck_exec
                     .clone()
-                    .with_optimized_sql(format!("{new_statement}"));
+                    .with_optimized_sql(format!("{new_statement}"), None);
 
                 Ok(Transformed::yes(Arc::new(new_exec)))
             } else {

--- a/crates/ns_lookup/Cargo.toml
+++ b/crates/ns_lookup/Cargo.toml
@@ -12,5 +12,5 @@ version.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-trust-dns-resolver = "0.23.2"
+hickory-resolver = "0.25.2"
 url.workspace = true

--- a/crates/ns_lookup/src/lib.rs
+++ b/crates/ns_lookup/src/lib.rs
@@ -17,10 +17,10 @@ limitations under the License.
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use hickory_resolver::Resolver;
 use snafu::prelude::*;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use trust_dns_resolver::AsyncResolver;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -80,10 +80,12 @@ pub async fn verify_endpoint_connection(endpoint: &str) -> Result<()> {
 pub async fn verify_ns_lookup_and_tcp_connect(host: &str, port: u16) -> Result<()> {
     // DefaultConfig uses google as upstream nameservers which won't work for kubernetes name
     // resolving
-    let resolver = AsyncResolver::tokio_from_system_conf().map_err(|_| Error::UnableToConnect {
-        host: host.to_string(),
-        port,
-    })?;
+    let resolver = Resolver::builder_tokio()
+        .map_err(|_| Error::UnableToConnect {
+            host: host.to_string(),
+            port,
+        })?
+        .build();
     match resolver.lookup_ip(host).await {
         Ok(ips) => {
             for ip in ips.iter() {


### PR DESCRIPTION
## 📝 Summary

`trust_dns_resolver` was renamed to `history_resolver`

- Brings in https://github.com/datafusion-contrib/datafusion-table-providers/pull/494
- Also migrates our own usage of `trust_dns_resolver` to `hickory_resolver`.
