### PR TITLE
Upgrade OpenTelemetry to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
  "paste",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8725874ecfbf399e071150b8619c4071d7b2b7a2f117e173dddef53c6bdb6bb1"
 dependencies = [
  "async-graphql",
- "axum",
+ "axum 0.8.6",
  "bytes",
  "futures-util",
  "serde_json",
@@ -1737,11 +1737,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.5",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -1753,7 +1780,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1770,6 +1797,26 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1797,8 +1844,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.8.6",
+ "axum-core 0.5.5",
  "bytes",
  "futures-util",
  "headers",
@@ -2011,7 +2058,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "url",
  "uuid 1.18.1",
@@ -2039,7 +2086,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2053,7 +2100,7 @@ source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=5d71a6d3f07
 dependencies = [
  "arrow-flight",
  "async-trait",
- "axum",
+ "axum 0.8.6",
  "ballista-core",
  "clap",
  "dashmap",
@@ -2070,7 +2117,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2214,7 +2261,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2714,7 +2761,7 @@ dependencies = [
  "fundu",
  "futures",
  "moka",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "rstest 0.25.0",
  "snafu",
  "spicepod",
@@ -4180,7 +4227,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-util",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "tracing-subscriber",
  "turso",
@@ -5295,7 +5342,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5682,7 +5729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6038,7 +6085,7 @@ dependencies = [
  "rustls-native-certs 0.8.2",
  "secrecy",
  "snafu",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -6051,7 +6098,7 @@ dependencies = [
  "futures",
  "parquet",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -6073,7 +6120,7 @@ dependencies = [
  "rustyline",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "winver",
 ]
@@ -6086,7 +6133,7 @@ dependencies = [
  "clap",
  "futures",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -7475,7 +7522,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7581,7 +7628,7 @@ dependencies = [
  "strum 0.27.2",
  "thrift",
  "tokio",
- "typed-builder 0.20.1",
+ "typed-builder",
  "url",
  "uuid 1.18.1",
  "zstd",
@@ -7624,7 +7671,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "typed-builder 0.20.1",
+ "typed-builder",
  "uuid 1.18.1",
 ]
 
@@ -8075,7 +8122,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9059,6 +9106,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -9600,7 +9653,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "typed-builder 0.20.1",
+ "typed-builder",
  "uuid 1.18.1",
  "webpki-roots 0.26.11",
 ]
@@ -10027,7 +10080,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10697,23 +10750,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -10725,108 +10764,84 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "reqwest",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b834e966ea5e2d03dfe5f2253f03d22cce21403ee940265070eeee96cee0bcc"
+checksum = "098a71a4430bb712be6130ed777335d2e5b19bc8566de5f2edddfce906def6ab"
 dependencies = [
  "once_cell",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
- "protobuf",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.13.5",
  "serde",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
-
-[[package]]
-name = "opentelemetry-zipkin"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c630342febc883d74af134b87f75f0bded45bd56d1a7673685df23d400a9d26"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 1.3.1",
- "once_cell",
- "opentelemetry 0.27.1",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.27.1",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "typed-builder 0.18.2",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "opentelemetry 0.27.1",
- "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
+ "tonic 0.12.3",
  "tracing",
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
+name = "opentelemetry-zipkin"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "b63918f8bfbda96f303f4f0755a04aad8b0529b9fc7982f361d92ae67104088d"
+dependencies = [
+ "futures-core",
+ "http 1.3.1",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "typed-builder",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "glob",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -10915,8 +10930,8 @@ dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -10926,7 +10941,7 @@ dependencies = [
  "clap",
  "opentelemetry-proto",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -11768,9 +11783,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -11778,7 +11793,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -11922,9 +11937,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psm"
@@ -12137,7 +12166,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12174,9 +12203,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12848,7 +12877,7 @@ name = "rmcp"
 version = "0.1.5"
 source = "git+https://github.com/spiceai/modelcontextprotocol-rust-sdk.git?rev=a66f66ae345a0fafde1e2ee496ec137d77aef82a#a66f66ae345a0fafde1e2ee496ec137d77aef82a"
 dependencies = [
- "axum",
+ "axum 0.8.6",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -13011,7 +13040,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-glue",
  "aws-sdk-sts",
- "axum",
+ "axum 0.8.6",
  "axum-extra",
  "azure_core 0.30.1",
  "azure_storage",
@@ -13082,10 +13111,10 @@ dependencies = [
  "ns_lookup",
  "object_store",
  "once_cell",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry-prometheus",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry_sdk",
  "otel-arrow",
  "package",
  "paste",
@@ -13140,8 +13169,10 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
- "tonic",
- "tonic-health",
+ "tonic 0.12.3",
+ "tonic 0.13.1",
+ "tonic-health 0.12.3",
+ "tonic-health 0.13.1",
  "tools",
  "tower 0.5.2",
  "tower-http",
@@ -13176,7 +13207,7 @@ dependencies = [
  "fundu",
  "futures",
  "object_store",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "runtime-parameters",
  "runtime-secrets",
  "serde",
@@ -13207,12 +13238,12 @@ name = "runtime-auth"
 version = "1.10.0-unstable"
 dependencies = [
  "app",
- "axum",
+ "axum 0.8.6",
  "base64 0.22.1",
  "futures",
  "http 1.3.1",
  "pin-project",
- "tonic",
+ "tonic 0.13.1",
  "tower 0.5.2",
  "tracing",
 ]
@@ -13230,7 +13261,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-federation",
  "futures",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "runtime-request-context",
  "snafu",
  "tokio",
@@ -13326,11 +13357,11 @@ version = "1.10.0-unstable"
 dependencies = [
  "app",
  "async-trait",
- "axum",
+ "axum 0.8.6",
  "futures",
  "headers",
  "http 1.3.1",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "percent-encoding",
  "regex",
  "runtime-auth",
@@ -13563,7 +13594,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14654,7 +14685,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "url",
  "uuid 1.18.1",
@@ -14719,7 +14750,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "winver",
 ]
@@ -14734,11 +14765,11 @@ dependencies = [
  "flightrepl",
  "futures",
  "mimalloc",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-prometheus",
  "opentelemetry-zipkin",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry_sdk",
  "otel-arrow",
  "prometheus",
  "reqwest",
@@ -15570,8 +15601,8 @@ dependencies = [
  "async-trait",
  "flight_client",
  "hostname 0.4.1",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "otel-arrow",
  "sha2",
  "snafu",
@@ -15588,7 +15619,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15668,8 +15699,8 @@ dependencies = [
  "insta",
  "nix",
  "octocrab",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "otel-arrow",
  "rand 0.9.2",
  "regex",
@@ -15687,7 +15718,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.13.1",
  "util",
  "uuid 1.18.1",
 ]
@@ -15780,7 +15811,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark",
@@ -16342,12 +16373,46 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-native-certs 0.8.2",
+ "rustls-pemfile 2.2.0",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.6",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -16388,6 +16453,19 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "tonic-health"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
@@ -16395,7 +16473,7 @@ dependencies = [
  "prost 0.13.5",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -16415,8 +16493,11 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -16567,14 +16648,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -16975,31 +17056,11 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
-dependencies = [
- "typed-builder-macro 0.18.2",
-]
-
-[[package]]
-name = "typed-builder"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
- "typed-builder-macro 0.20.1",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.108",
+ "typed-builder-macro",
 ]
 
 [[package]]
@@ -17354,7 +17415,7 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum",
+ "axum 0.8.6",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -18409,7 +18470,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,17 +184,17 @@ object_store = { version = "0.12.4", features = [
     "http",
 ] }
 odbc-api = { version = "14" }
-opentelemetry = { version = "0.27", default-features = false, features = [
+opentelemetry = { version = "0.29.0", default-features = false, features = [
     "metrics",
     "trace",
 ] }
-opentelemetry-http = { version = "0.27", features = ["reqwest-rustls"] }
-opentelemetry-prometheus = "0.27"
-opentelemetry-zipkin = { version = "0.27", default-features = false, features = [
+opentelemetry-http = { version = "0.29.0", features = ["reqwest-rustls"] }
+opentelemetry-prometheus = "0.29.1"
+opentelemetry-zipkin = { version = "0.29.0", default-features = false, features = [
     "reqwest",
     "reqwest-rustls",
 ] }
-opentelemetry_sdk = { version = "0.27", default-features = false, features = [
+opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
     "metrics",
     "rt-tokio",
     "trace",
@@ -205,7 +205,7 @@ pem = "3.0.4"
 percent-encoding = "2.3.1"
 pin-project = "1.1"
 postcard = { version = "1.1.3", features = ["use-std"] }
-prometheus = "0.13"
+prometheus = "0.14"
 r2d2 = "0.8.10"
 rand = "0.9.2"
 rdkafka = { version = "0.38.0" }
@@ -258,7 +258,7 @@ tower = "0.5.2"
 tower-http = { version = "0.6.2", features = ["cors", "limit"] }
 tracing = "0.1.41"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = "0.30.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tract-core = "0.22.0"
 turso = "0.3.0"

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -525,28 +525,22 @@ gopkg.in/yaml.v3, https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE, MIT
 - opendal 0.54.1, Apache-2.0 
   <br/>https://github.com/apache/opendal
 
-- opentelemetry 0.27.1, Apache-2.0 
+- opentelemetry 0.29.1, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust
 
-- opentelemetry 0.30.0, Apache-2.0 
-  <br/>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry
-
-- opentelemetry-http 0.27.0, Apache-2.0 
+- opentelemetry-http 0.29.0, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust
 
-- opentelemetry-prometheus 0.27.0, Apache-2.0 
+- opentelemetry-prometheus 0.29.1, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust
 
-- opentelemetry-proto 0.30.0, Apache-2.0 
+- opentelemetry-proto 0.29.0, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto
 
-- opentelemetry-zipkin 0.27.0, Apache-2.0 
+- opentelemetry-zipkin 0.29.0, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin
 
-- opentelemetry_sdk 0.27.1, Apache-2.0 
-  <br/>https://github.com/open-telemetry/opentelemetry-rust
-
-- opentelemetry_sdk 0.30.0, Apache-2.0 
+- opentelemetry_sdk 0.29.0, Apache-2.0 
   <br/>https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk
 
 - oracle 0.6.3, Apache-2.0 OR UPL-1.0 
@@ -807,7 +801,7 @@ gopkg.in/yaml.v3, https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE, MIT
 - tracing-log 0.2.0, MIT 
   <br/>https://github.com/tokio-rs/tracing
 
-- tracing-opentelemetry 0.28.0, MIT 
+- tracing-opentelemetry 0.30.0, MIT 
   <br/>https://github.com/tokio-rs/tracing-opentelemetry
 
 - tracing-subscriber 0.3.20, MIT 
@@ -908,4 +902,3 @@ gopkg.in/yaml.v3, https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE, MIT
 
 - zip 4.6.1, MIT 
   <br/>https://github.com/zip-rs/zip2.git
-

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -30,7 +30,6 @@ use flightrepl::ReplConfig;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-use opentelemetry_sdk::runtime::Tokio;
 use otel_arrow::OtelArrowExporter;
 use runtime::config::Config as RuntimeConfig;
 use runtime::datafusion::DataFusion;
@@ -351,7 +350,7 @@ fn init_metrics(
     df: &Arc<DataFusion>,
     registry: prometheus::Registry,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let resource = Resource::default();
+    let resource = Resource::builder_empty().build();
 
     let prometheus_exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry)
@@ -364,9 +363,8 @@ fn init_metrics(
     let spice_metrics_exporter =
         OtelArrowExporter::new(spice_metrics::SpiceMetricsExporter::new(df));
 
-    let periodic_reader = PeriodicReader::builder(spice_metrics_exporter, Tokio)
+    let periodic_reader = PeriodicReader::builder(spice_metrics_exporter)
         .with_interval(Duration::from_secs(30))
-        .with_timeout(Duration::from_secs(10))
         .build();
 
     let provider = SdkMeterProvider::builder()

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -87,7 +87,6 @@ fn main() {
         });
     }
 
-    global::shutdown_tracer_provider();
     // There is no global::shutdown_meter_provider, so we replace currently used meter provider with a noop one to clean up resources
     global::set_meter_provider(NoopMeterProvider::new());
     tracing::info!("Goodbye!");

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{borrow::Cow, sync::Arc};
+use std::{pin::Pin, sync::Arc};
 
 use app::spicepod::component::runtime::OutputLevel;
 use app::{App, spicepod::component::runtime::TracingConfig};
-use futures::future::BoxFuture;
-use opentelemetry::InstrumentationScope;
+use opentelemetry::{InstrumentationScope, trace::TracerProvider};
 use opentelemetry_sdk::{
     Resource,
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::TracerProvider,
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter},
 };
 use reqwest::Client;
 use runtime::{datafusion::DataFusion, task_history};
@@ -195,30 +194,29 @@ where
         .transpose()?
         .flatten();
 
-    let mut exporters: Vec<Box<dyn SpanExporter>> = vec![Box::new(
-        task_history::otel_exporter::TaskHistoryExporter::new(
-            df,
-            captured_output,
-            min_sql_duration_ms,
-            captured_plan,
-            min_plan_duration_ms,
-        ),
-    )];
+    let task_history_exporter = task_history::otel_exporter::TaskHistoryExporter::new(
+        df,
+        captured_output,
+        min_sql_duration_ms,
+        captured_plan,
+        min_plan_duration_ms,
+    );
 
-    if let Ok(Some(zipkin_exporter)) = zipkin_task_history_otel_exporter(app_name, config).await {
-        exporters.push(zipkin_exporter);
+    let zipkin_exporter = zipkin_task_history_otel_exporter(config).await?;
+
+    let exporter = OtelExportMultiplexer::new(task_history_exporter, zipkin_exporter);
+
+    let mut provider_builder = SdkTracerProvider::builder().with_batch_exporter(exporter);
+    let mut resource_builder = Resource::builder_empty();
+    if let Some(app_name) = app_name.as_ref() {
+        resource_builder = resource_builder.with_service_name(app_name.clone());
     }
-
-    let exporter = OtelExportMultiplexer::new(exporters);
-
-    let mut provider_builder =
-        TracerProvider::builder().with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio);
-    provider_builder = provider_builder.with_resource(Resource::default());
+    provider_builder = provider_builder.with_resource(resource_builder.build());
     let provider = provider_builder.build();
     let scope = InstrumentationScope::builder("task_history")
         .with_version(env!("CARGO_PKG_VERSION"))
         .build();
-    let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
+    let tracer = provider.tracer_with_scope(scope);
 
     let layer = tracing_opentelemetry::layer()
         .with_tracer(tracer)
@@ -230,9 +228,9 @@ where
 }
 
 async fn zipkin_task_history_otel_exporter(
-    app_name: Option<String>,
     config: Option<&TracingConfig>,
-) -> Result<Option<Box<dyn SpanExporter>>, Box<dyn std::error::Error>> {
+) -> Result<Option<opentelemetry_zipkin::ZipkinExporter>, Box<dyn std::error::Error + Send + Sync>>
+{
     let Some(config) = config else {
         return Ok(None);
     };
@@ -251,18 +249,13 @@ async fn zipkin_task_history_otel_exporter(
         return Ok(None);
     }
 
-    let service_name: Cow<'static, str> = match app_name {
-        Some(name) => Cow::Owned(name),
-        None => Cow::Borrowed("Spice.ai"),
-    };
+    let exporter = opentelemetry_zipkin::ZipkinExporter::builder()
+        .with_service_address(([0, 0, 0, 0], 0).into())
+        .with_http_client(Client::new())
+        .with_collector_endpoint(zipkin_endpoint)
+        .build()?;
 
-    Ok(Some(Box::new(
-        opentelemetry_zipkin::new_pipeline()
-            .with_service_name(service_name)
-            .with_collector_endpoint(zipkin_endpoint)
-            .with_http_client(Client::new())
-            .init_exporter()?,
-    )))
+    Ok(Some(exporter))
 }
 
 async fn is_zipkin_endpoint_reachable(endpoint: &str) -> bool {
@@ -279,50 +272,62 @@ async fn is_zipkin_endpoint_reachable(endpoint: &str) -> bool {
 
 #[derive(Debug)]
 struct OtelExportMultiplexer {
-    exporters: Vec<Box<dyn SpanExporter>>,
+    task_history_exporter: task_history::otel_exporter::TaskHistoryExporter,
+    zipkin_exporter: Option<opentelemetry_zipkin::ZipkinExporter>,
 }
 
 impl OtelExportMultiplexer {
-    pub fn new(exporters: Vec<Box<dyn SpanExporter>>) -> Self {
-        Self { exporters }
+    pub fn new(
+        task_history_exporter: task_history::otel_exporter::TaskHistoryExporter,
+        zipkin_exporter: Option<opentelemetry_zipkin::ZipkinExporter>,
+    ) -> Self {
+        Self {
+            task_history_exporter,
+            zipkin_exporter,
+        }
     }
 }
 
 impl SpanExporter for OtelExportMultiplexer {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-        let mut futures = Vec::new();
-        for exporter in &mut self.exporters {
-            futures.push(exporter.export(batch.clone()));
+    fn export(
+        &self,
+        batch: Vec<SpanData>,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        let mut futures: Vec<Pin<Box<dyn std::future::Future<Output = OTelSdkResult> + Send>>> =
+            Vec::with_capacity(2);
+        futures.push(Box::pin(self.task_history_exporter.export(batch.clone())));
+        if let Some(exporter) = &self.zipkin_exporter {
+            futures.push(Box::pin(exporter.export(batch)));
         }
 
-        Box::pin(async move {
-            futures::future::join_all(futures).await;
-
+        async move {
+            let results = futures::future::join_all(futures).await;
+            for result in results {
+                let _ = result;
+            }
             Ok(())
-        })
+        }
     }
 
-    fn shutdown(&mut self) {
-        for exporter in &mut self.exporters {
-            exporter.shutdown();
+    fn shutdown(&mut self) -> OTelSdkResult {
+        self.task_history_exporter.shutdown()?;
+        if let Some(exporter) = &mut self.zipkin_exporter {
+            exporter.shutdown()?;
         }
+        Ok(())
     }
 
-    fn force_flush(&mut self) -> BoxFuture<'static, ExportResult> {
-        let mut futures = Vec::new();
-        for exporter in &mut self.exporters {
-            futures.push(exporter.force_flush());
+    fn force_flush(&mut self) -> OTelSdkResult {
+        self.task_history_exporter.force_flush()?;
+        if let Some(exporter) = &mut self.zipkin_exporter {
+            exporter.force_flush()?;
         }
-
-        Box::pin(async move {
-            futures::future::join_all(futures).await;
-
-            Ok(())
-        })
+        Ok(())
     }
 
     fn set_resource(&mut self, resource: &Resource) {
-        for exporter in &mut self.exporters {
+        self.task_history_exporter.set_resource(resource);
+        if let Some(exporter) = &mut self.zipkin_exporter {
             exporter.set_resource(resource);
         }
     }

--- a/crates/otel-arrow/src/converter.rs
+++ b/crates/otel-arrow/src/converter.rs
@@ -480,11 +480,13 @@ impl OtelToArrowConverter {
         resource: &Resource,
         instrument_scope: &InstrumentationScope,
     ) {
+        let time_unix_nano = system_time_to_nanos(sum.time);
+        let start_time_unix_nano = system_time_to_nanos(sum.start_time);
+
         for data_point in &sum.data_points {
-            self.time_unix_nano_builder
-                .append_option(data_point.time.map(system_time_to_nanos));
+            self.time_unix_nano_builder.append_value(time_unix_nano);
             self.start_time_unix_nano_builder
-                .append_option(data_point.start_time.map(system_time_to_nanos));
+                .append_value(start_time_unix_nano);
 
             self.add_resource(resource);
             self.add_scope(instrument_scope);
@@ -516,11 +518,13 @@ impl OtelToArrowConverter {
         resource: &Resource,
         instrument_scope: &InstrumentationScope,
     ) {
+        let time_unix_nano = system_time_to_nanos(gauge.time);
+        let start_time_unix_nano = gauge.start_time.map(system_time_to_nanos);
+
         for data_point in &gauge.data_points {
-            self.time_unix_nano_builder
-                .append_option(data_point.time.map(system_time_to_nanos));
+            self.time_unix_nano_builder.append_value(time_unix_nano);
             self.start_time_unix_nano_builder
-                .append_option(data_point.start_time.map(system_time_to_nanos));
+                .append_option(start_time_unix_nano);
 
             self.add_resource(resource);
             self.add_scope(instrument_scope);
@@ -551,11 +555,13 @@ impl OtelToArrowConverter {
         resource: &Resource,
         instrument_scope: &InstrumentationScope,
     ) {
+        let time_unix_nano = system_time_to_nanos(histogram.time);
+        let start_time_unix_nano = system_time_to_nanos(histogram.start_time);
+
         for data_point in &histogram.data_points {
-            self.time_unix_nano_builder
-                .append_value(system_time_to_nanos(data_point.time));
+            self.time_unix_nano_builder.append_value(time_unix_nano);
             self.start_time_unix_nano_builder
-                .append_value(system_time_to_nanos(data_point.start_time));
+                .append_value(start_time_unix_nano);
 
             self.add_resource(resource);
             self.add_scope(instrument_scope);

--- a/crates/otel-arrow/src/exporter.rs
+++ b/crates/otel-arrow/src/exporter.rs
@@ -16,24 +16,28 @@ limitations under the License.
 
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
-use opentelemetry_sdk::metrics::{
-    MetricError, Temporality, data::ResourceMetrics, exporter::PushMetricExporter,
+use opentelemetry_sdk::{
+    error::{OTelSdkError, OTelSdkResult},
+    metrics::{Temporality, data::ResourceMetrics, exporter::PushMetricExporter},
 };
 
 use crate::converter::OtelToArrowConverter;
 
 #[async_trait]
 pub trait ArrowExporter: Send + Sync + 'static {
-    async fn export(&self, metrics: RecordBatch) -> Result<(), MetricError>;
+    async fn export(&self, metrics: RecordBatch) -> OTelSdkResult;
 
-    async fn force_flush(&self) -> Result<(), MetricError>;
-
-    /// Shutdown the exporter.
-    ///
     /// # Errors
-    ///
-    /// This function will return an error if the shutdown couldn't complete successfully.
-    fn shutdown(&self) -> Result<(), MetricError>;
+    /// Returns an error if the exporter fails to flush metrics.
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    /// # Errors
+    /// Returns an error if shutting down the exporter fails.
+    fn shutdown(&self) -> OTelSdkResult {
+        Ok(())
+    }
 }
 
 pub struct OtelArrowExporter<E: ArrowExporter> {
@@ -55,19 +59,28 @@ impl<E: ArrowExporter> OtelArrowExporter<E> {
 }
 
 #[async_trait]
-impl<E: ArrowExporter> PushMetricExporter for OtelArrowExporter<E> {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<(), MetricError> {
+impl<E: ArrowExporter + Clone> PushMetricExporter for OtelArrowExporter<E> {
+    fn export(
+        &self,
+        metrics: &mut ResourceMetrics,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
         let mut converter = OtelToArrowConverter::new(metrics.scope_metrics.len());
-        let batch = converter.convert(metrics)?;
+        let exporter = self.exporter.clone();
 
-        self.exporter.export(batch).await
+        async move {
+            let batch = converter
+                .convert(metrics)
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+            exporter.export(batch).await
+        }
     }
 
-    async fn force_flush(&self) -> Result<(), MetricError> {
-        self.exporter.force_flush().await
+    fn force_flush(&self) -> OTelSdkResult {
+        self.exporter.force_flush()
     }
 
-    fn shutdown(&self) -> Result<(), MetricError> {
+    fn shutdown(&self) -> OTelSdkResult {
         self.exporter.shutdown()
     }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -92,7 +92,7 @@ object_store = { workspace = true, features = ["aws", "http", "azure"] }
 once_cell = "1.21.3"
 opentelemetry.workspace = true
 opentelemetry-prometheus.workspace = true
-opentelemetry-proto = { version = "0.30", features = [
+opentelemetry-proto = { version = "0.29.0", features = [
     "gen-tonic-messages",
     "gen-tonic",
     "metrics",
@@ -161,6 +161,11 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true
+tonic-health012 = { package = "tonic-health", version = "0.12" }
+tonic012 = { package = "tonic", version = "0.12", features = [
+    "gzip",
+    "tls-native-roots",
+] }
 tools = { path = "../tools" }
 tower.workspace = true
 tower-http.workspace = true

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1071,15 +1071,12 @@ mod tests {
         ) -> bool {
             for _attempt in 0..max_attempts {
                 let metrics = registry.gather();
-                if let Some(metric) = metrics
-                    .iter()
-                    .find(|m| m.get_name() == "dataset_load_state")
+                if let Some(metric) = metrics.iter().find(|m| m.name() == "dataset_load_state")
                     && metric.get_field_type() == MetricType::GAUGE
+                    && let Some(gauge) = metric.get_metric()[0].get_gauge().as_ref()
+                    && gauge.value().is_eq(f64::from(desired as i32))
                 {
-                    let value = metric.get_metric()[0].get_gauge().get_value();
-                    if value.is_eq(f64::from(desired as i32)) {
-                        return true;
-                    }
+                    return true;
                 }
                 tokio::time::sleep(delay).await;
             }
@@ -1088,7 +1085,7 @@ mod tests {
 
         let registry = prometheus::Registry::new();
 
-        let resource = Resource::default();
+        let resource = Resource::builder_empty().build();
 
         let prometheus_exporter = opentelemetry_prometheus::exporter()
             .with_registry(registry.clone())

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -17,8 +17,8 @@ use csv::Writer;
 use flight_client::{Credentials, FlightClient};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
-use tonic::transport::Channel;
-use tonic_health::{ServingStatus, pb::health_client::HealthClient};
+use tonic_health012::{ServingStatus, pb::health_client::HealthClient};
+use tonic012::transport::Channel;
 
 use axum::{
     Extension, Json,
@@ -211,7 +211,7 @@ async fn get_opentelemetry_status(
     let mut client = HealthClient::new(channel);
 
     let resp = client
-        .check(tonic_health::pb::HealthCheckRequest {
+        .check(tonic_health012::pb::HealthCheckRequest {
             service: String::new(),
         })
         .await?;

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -148,7 +148,7 @@ fn handle_http_request(
                 for metric in family.get_metric() {
                     let histogram = metric.get_histogram();
                     let summary =
-                        histogram_to_summary(family.get_name(), metric.get_label(), histogram);
+                        histogram_to_summary(family.name(), metric.get_label(), histogram);
                     histogram_summaries.push(summary);
                 }
             }
@@ -225,20 +225,22 @@ fn histogram_to_summary(
     let cumulative_counts: Vec<u64> = h
         .get_bucket()
         .iter()
-        .map(Bucket::get_cumulative_count)
+        .map(Bucket::cumulative_count)
         .collect();
-    let bounds: Vec<f64> = h.get_bucket().iter().map(Bucket::get_upper_bound).collect();
+    let bounds: Vec<f64> = h.get_bucket().iter().map(Bucket::upper_bound).collect();
 
     let mut summary_proto = prometheus::proto::Summary::new();
 
+    let mut quantiles = Vec::new();
     for &p in &PERCENTILES {
         let value = calculate_percentile(&cumulative_counts, &bounds, total_count, p);
         let mut quantile = prometheus::proto::Quantile::new();
         quantile.set_quantile(p / 100.0);
         quantile.set_value(value);
-        summary_proto.mut_quantile().push(quantile);
+        quantiles.push(quantile);
     }
 
+    summary_proto.set_quantile(quantiles);
     summary_proto.set_sample_count(total_count);
     summary_proto.set_sample_sum(total_sum);
 
@@ -310,11 +312,11 @@ mod tests {
     #[test]
     fn test_histogram_to_summary() {
         let (family, metric, histogram) = create_test_histogram();
-        let summary = histogram_to_summary(family.get_name(), metric.get_label(), &histogram);
+        let summary = histogram_to_summary(family.name(), metric.get_label(), &histogram);
 
-        assert_eq!(summary.get_name(), "test_histogram_summary");
+        assert_eq!(summary.name(), "test_histogram_summary");
         assert_eq!(
-            summary.get_help(),
+            summary.help(),
             "Summary derived from histogram test_histogram"
         );
         assert_eq!(summary.get_field_type(), MetricType::SUMMARY);
@@ -322,13 +324,13 @@ mod tests {
         let metric = &summary.get_metric()[0];
         let summary_proto = metric.get_summary();
 
-        assert_eq!(summary_proto.get_sample_count(), 550);
-        assert_float_eq(summary_proto.get_sample_sum(), 35750.0);
+        assert_eq!(summary_proto.sample_count(), 550);
+        assert_float_eq(summary_proto.sample_sum(), 35750.0);
 
         let quantiles: Vec<(f64, f64)> = summary_proto
             .get_quantile()
             .iter()
-            .map(|q| (q.get_quantile(), q.get_value()))
+            .map(|q| (q.quantile(), q.value()))
             .collect();
 
         assert_eq!(quantiles.len(), 4);
@@ -357,19 +359,22 @@ mod tests {
         let mut cumulative_count = 0;
         let mut sample_sum = 0.0;
 
+        let mut histogram_buckets = Vec::new();
+
         for (i, &upper_bound) in buckets.iter().enumerate() {
             let count = (i + 1) * 10;
             cumulative_count += count as u64;
             let mut bucket = Bucket::new();
             bucket.set_cumulative_count(cumulative_count);
             bucket.set_upper_bound(upper_bound);
-            histogram.mut_bucket().push(bucket);
+            histogram_buckets.push(bucket);
 
             // Calculate sample sum (approximate)
             let lower_bound = if i == 0 { 0.0 } else { buckets[i - 1] };
             sample_sum += f64::midpoint(lower_bound, upper_bound) * count as f64;
         }
 
+        histogram.set_bucket(histogram_buckets);
         histogram.set_sample_count(cumulative_count);
         histogram.set_sample_sum(sample_sum);
 

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -43,19 +43,17 @@ use opentelemetry_proto::tonic::metrics::v1::NumberDataPoint;
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
 use runtime_auth::GrpcAuth;
-use runtime_auth::layer::grpc::make_interceptor;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use tokio_util::sync::CancellationToken;
-use tonic::Request;
-use tonic::Response;
-use tonic::Status;
-use tonic::async_trait;
-use tonic::codec::CompressionEncoding;
-use tonic::service::InterceptorLayer;
-use tonic::transport::{Identity, Server, ServerTlsConfig};
-use tonic_health::pb::health_server::Health;
-use tonic_health::pb::health_server::HealthServer;
+use tonic_health012::pb::health_server::Health;
+use tonic_health012::pb::health_server::HealthServer;
+use tonic012::Request;
+use tonic012::Response;
+use tonic012::Status;
+use tonic012::async_trait;
+use tonic012::codec::CompressionEncoding;
+use tonic012::transport::{Identity, Server, ServerTlsConfig};
 
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
@@ -68,7 +66,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to serve: {source}"))]
-    UnableToServe { source: tonic::transport::Error },
+    UnableToServe { source: tonic012::transport::Error },
 
     #[snafu(display("Failed to build record batch from OpenTelemetry metrics: {source}"))]
     FailedToBuildRecordBatch { source: arrow::error::ArrowError },
@@ -97,7 +95,7 @@ pub enum Error {
     FirstMetricDataPointHasNoValue { metric: String },
 
     #[snafu(display("Unable to configure TLS on the Flight server: {source}"))]
-    UnableToConfigureTls { source: tonic::transport::Error },
+    UnableToConfigureTls { source: tonic012::transport::Error },
 
     #[snafu(display(
         "Address {addr} is already in use by another process. Either stop the existing process or change the address: https://spiceai.org/docs/cli/reference/run"
@@ -205,7 +203,7 @@ impl MetricsService for Service {
 }
 
 async fn create_health_service() -> HealthServer<impl Health> {
-    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    let (mut health_reporter, health_service) = tonic_health012::server::health_reporter();
     health_reporter
         .set_serving::<MetricsServiceServer<Service>>()
         .await;
@@ -591,7 +589,7 @@ pub async fn start(
     bind_address: SocketAddr,
     datafusion: Arc<DataFusion>,
     tls_config: Option<Arc<TlsConfig>>,
-    grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
+    _grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
     shutdown_signal: Option<CancellationToken>,
 ) -> Result<()> {
     let service = Service {
@@ -615,7 +613,6 @@ pub async fn start(
     }
 
     let server = server
-        .layer(InterceptorLayer::new(make_interceptor(grpc_auth)))
         .add_service(create_health_service().await)
         .add_service(svc);
 
@@ -641,7 +638,7 @@ pub async fn start(
     Ok(())
 }
 
-fn is_address_in_use_error(err: &tonic::transport::Error) -> bool {
+fn is_address_in_use_error(err: &tonic012::transport::Error) -> bool {
     let mut source: Option<&dyn std::error::Error> = Some(err);
     while let Some(e) = source {
         if let Some(io_err) = e.downcast_ref::<std::io::Error>() {

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use datafusion::sql::TableReference;
-use opentelemetry_sdk::metrics::MetricError;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
@@ -46,6 +46,7 @@ pub enum Error {
 
 /// Uses a `Weak` reference to `DataFusion` to prevent blocking its cleanup after runtime termination.
 /// This ensures `DataFusion` can gracefully shut down, even when metrics persist.
+#[derive(Clone)]
 pub struct SpiceMetricsExporter {
     datafusion: Weak<DataFusion>,
 }
@@ -60,7 +61,7 @@ impl SpiceMetricsExporter {
 
 #[async_trait]
 impl otel_arrow::ArrowExporter for SpiceMetricsExporter {
-    async fn export(&self, metrics: RecordBatch) -> Result<(), MetricError> {
+    async fn export(&self, metrics: RecordBatch) -> OTelSdkResult {
         let data_update = DataUpdate {
             schema: metrics.schema(),
             data: vec![metrics],
@@ -69,22 +70,14 @@ impl otel_arrow::ArrowExporter for SpiceMetricsExporter {
 
         let Some(df) = self.datafusion.upgrade() else {
             // this should never happen as the exporter must be shutdown before the DataFusion instance is dropped
-            return Err(MetricError::Other(
+            return Err(OTelSdkError::InternalFailure(
                 "Failed to export metrics as the DataFusion instance has already been dropped.\nReport an issue on GitHub: https://github.com/spiceai/spiceai/issues".to_string(),
             ));
         };
 
         df.write_data(&get_metrics_table_reference(), data_update)
             .await
-            .map_err(|e| MetricError::Other(e.to_string()))
-    }
-
-    async fn force_flush(&self) -> Result<(), MetricError> {
-        Ok(())
-    }
-
-    fn shutdown(&self) -> Result<(), MetricError> {
-        Ok(())
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))
     }
 }
 

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -22,9 +22,9 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use tracing::Instrument;
 
-use futures::future::BoxFuture;
-use opentelemetry::trace::{SpanId, TraceError};
-use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+use opentelemetry::trace::SpanId;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
 use spicepod::component::runtime::{TaskHistoryCapturedOutput, TaskHistoryCapturedPlan};
 
 use crate::datafusion::DataFusion;
@@ -281,7 +281,10 @@ impl TaskHistoryExporter {
 }
 
 impl SpanExporter for TaskHistoryExporter {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(
+        &self,
+        batch: Vec<SpanData>,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
         let min_sql_duration_ms = self.min_sql_duration_ms;
         let captured_plan = self.captured_plan.clone();
         let min_plan_duration_ms = self.min_plan_duration_ms;
@@ -296,12 +299,14 @@ impl SpanExporter for TaskHistoryExporter {
             .filter(should_include)
             .collect();
 
-        Box::pin(async move {
+        async move {
             // Separate logic: if plan capture is disabled, write all spans directly
             if matches!(captured_plan, TaskHistoryCapturedPlan::None) {
-                return TaskSpan::write(Arc::clone(&df), spans)
+                TaskSpan::write(Arc::clone(&df), spans)
                     .await
-                    .map_err(|e| TraceError::Other(Box::new(e)));
+                    .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+                return Ok(());
             }
 
             // Filter spans that need plan capture before cloning
@@ -333,7 +338,7 @@ impl SpanExporter for TaskHistoryExporter {
             // Write all spans first
             TaskSpan::write(Arc::clone(&df), spans)
                 .await
-                .map_err(|e| TraceError::Other(Box::new(e)))?;
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
             // Spawn async task to capture plans for filtered spans
             // The task runs in the background without blocking the export operation
@@ -354,7 +359,7 @@ impl SpanExporter for TaskHistoryExporter {
             }
 
             Ok(())
-        })
+        }
     }
 }
 

--- a/crates/runtime/tests/management/mod.rs
+++ b/crates/runtime/tests/management/mod.rs
@@ -83,7 +83,7 @@ async fn management_data_export() -> Result<(), anyhow::Error> {
             let _ = execute_query(&rt, "SELECT invalid_query as test_event").await;
 
             // Ensure local events are flushed
-            trace_provider.force_flush();
+            let _ = trace_provider.force_flush();
             // Add delay to ensure flushed events are propogated (data export is done every 5 seconds)
             tracing::info!("Waiting 7s for events to be exported...");
             tokio::time::sleep(Duration::from_secs(7)).await;
@@ -94,7 +94,7 @@ async fn management_data_export() -> Result<(), anyhow::Error> {
 
             // Verify final export during shutdown
             let _ = execute_query(&rt, "SELECT 6789 as test_event").await;
-            trace_provider.force_flush();
+            let _ = trace_provider.force_flush();
             rt.shutdown().await;
             let exported_events = execute_query(&data_endpoint_rt, "SELECT input, captured_output, error_message FROM runtime.task_history where input like '%test_event%' order by input ").await?;
             insta::assert_snapshot!("shutdown_export", pretty_format_batches(&exported_events)?);

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -53,7 +53,7 @@ mod nsql {
         HeaderMap, HeaderValue,
         header::{ACCEPT, CONTENT_TYPE},
     };
-    use opentelemetry_sdk::trace::TracerProvider;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
 
     use crate::models::http_post;
 
@@ -65,7 +65,7 @@ mod nsql {
     pub async fn run_nsql_test(
         base_url: &str,
         ts: &TestCase,
-        trace_provider: &TracerProvider,
+        trace_provider: &SdkTracerProvider,
     ) -> Result<(), anyhow::Error> {
         tracing::info!("Running test cases {}", ts.name);
         let task_start_time = std::time::SystemTime::now();

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -41,7 +41,7 @@ use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use jsonpath_rust::JsonPath;
 use llms::chat::Chat;
-use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use runtime::tools::utils::get_tools;
 use runtime::{Runtime, auth::EndpointAuth, model::try_to_chat_model};
 use serde_json::Value;
@@ -974,7 +974,7 @@ async fn openai_responses_api_tools() -> Result<(), anyhow::Error> {
 #[allow(clippy::expect_used)]
 async fn verify_sql_query_chat_completion(
     rt: Arc<Runtime>,
-    trace_provider: &TracerProvider,
+    trace_provider: &SdkTracerProvider,
 ) -> Result<(), anyhow::Error> {
     let model =
         get_openai_chat_model(Arc::clone(&rt), "gpt-4o-mini", "openai_model", "auto").await?;

--- a/crates/runtime/tests/utils/mod.rs
+++ b/crates/runtime/tests/utils/mod.rs
@@ -21,8 +21,8 @@ use std::{
     time::Duration,
 };
 
-use opentelemetry::InstrumentationScope;
-use opentelemetry_sdk::{runtime::TokioCurrentThread, trace::TracerProvider};
+use opentelemetry::{InstrumentationScope, trace::TracerProvider};
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use runtime::{Runtime, task_history::otel_exporter::TaskHistoryExporter};
 use spicepod::component::runtime::TaskHistoryCapturedOutput;
 use tracing::subscriber::DefaultGuard;
@@ -150,7 +150,7 @@ pub(crate) fn to_pretty_display(batches: &[RecordBatch]) -> Result<impl Display,
 pub(crate) fn init_tracing_with_task_history(
     default_level: Option<&str>,
     rt: &Runtime,
-) -> (DefaultGuard, TracerProvider) {
+) -> (DefaultGuard, SdkTracerProvider) {
     let filter = match (default_level, std::env::var("SPICED_LOG").ok()) {
         (_, Some(log)) => EnvFilter::new(log),
         (Some(level), None) => EnvFilter::new(level),
@@ -167,15 +167,14 @@ pub(crate) fn init_tracing_with_task_history(
         None, // min_plan_duration_ms
     );
 
-    // Tests hang if we don't use TokioCurrentThread here (similar to https://github.com/open-telemetry/opentelemetry-rust/issues/868)
-    let provider = TracerProvider::builder()
-        .with_batch_exporter(task_history_exporter, TokioCurrentThread)
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(task_history_exporter)
         .build();
 
     let scope = InstrumentationScope::builder("task_history")
         .with_version(env!("CARGO_PKG_VERSION"))
         .build();
-    let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
+    let tracer = provider.tracer_with_scope(scope);
 
     let task_history_layer = tracing_opentelemetry::layer()
         .with_tracer(tracer)

--- a/crates/telemetry/src/anonymous.rs
+++ b/crates/telemetry/src/anonymous.rs
@@ -27,7 +27,6 @@ use opentelemetry_sdk::{
         PeriodicReader, SdkMeterProvider, data::ResourceMetrics, exporter::PushMetricExporter,
         reader::MetricReader,
     },
-    runtime::Tokio,
 };
 use otel_arrow::OtelArrowExporter;
 use sha2::{Digest, Sha256};
@@ -42,7 +41,6 @@ pub static ENDPOINT: LazyLock<Arc<str>> = LazyLock::new(|| {
 
 /// How often to send telemetry data to the endpoint
 const TELEMETRY_INTERVAL_SECONDS: u64 = 3600; // 1 hour
-const TELEMETRY_TIMEOUT_SECONDS: u64 = 30;
 
 fn resource(spicepod_name: &str, telemetry_properties: Vec<KeyValue>) -> Resource {
     let hostname = hostname::get()
@@ -60,13 +58,16 @@ fn resource(spicepod_name: &str, telemetry_properties: Vec<KeyValue>) -> Resourc
     spicepod_id_hasher.update(spicepod_name);
     let spicepod_id = format!("{:x}", spicepod_id_hasher.finalize());
 
-    Resource::new(telemetry_properties.into_iter().chain(vec![
-        KeyValue::new("service.name", "spiced"), // May be overridden by setting OTEL_SERVICE_NAME env variable
-        KeyValue::new("name", "spiced"),
-        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
-        KeyValue::new("service.instance.id", instance_id),
-        KeyValue::new("spicepod.id", spicepod_id),
-    ]))
+    Resource::builder()
+        .with_attributes(telemetry_properties)
+        .with_attributes([
+            KeyValue::new("service.name", "spiced"), // May be overridden by setting OTEL_SERVICE_NAME env variable
+            KeyValue::new("name", "spiced"),
+            KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+            KeyValue::new("service.instance.id", instance_id),
+            KeyValue::new("spicepod.id", spicepod_id),
+        ])
+        .build()
 }
 
 pub async fn start(spicepod_name: &str, telemetry_properties: Vec<KeyValue>) {
@@ -84,9 +85,8 @@ pub async fn start(spicepod_name: &str, telemetry_properties: Vec<KeyValue>) {
 
     let oss_telemetry_exporter = OtelArrowExporter::new(exporter);
 
-    let periodic_reader = PeriodicReader::builder(oss_telemetry_exporter.clone(), Tokio)
+    let periodic_reader = PeriodicReader::builder(oss_telemetry_exporter.clone())
         .with_interval(Duration::from_secs(TELEMETRY_INTERVAL_SECONDS))
-        .with_timeout(Duration::from_secs(TELEMETRY_TIMEOUT_SECONDS))
         .build();
 
     let initial_reader = InitialReader::new();

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use flight_client::{Credentials, FlightClient};
-use opentelemetry_sdk::metrics::MetricError;
+use opentelemetry_sdk::error::OTelSdkResult;
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -99,7 +99,7 @@ pub struct TelemetryExporter {
 
 #[async_trait]
 impl otel_arrow::ArrowExporter for TelemetryExporter {
-    async fn export(&self, metrics: RecordBatch) -> Result<(), MetricError> {
+    async fn export(&self, metrics: RecordBatch) -> OTelSdkResult {
         let Some(mut flight_client) = self.flight_client.clone() else {
             return Ok(());
         };
@@ -111,14 +111,6 @@ impl otel_arrow::ArrowExporter for TelemetryExporter {
             tracing::trace!("Unable to publish telemetry: {e}");
         }
 
-        Ok(())
-    }
-
-    async fn force_flush(&self) -> Result<(), MetricError> {
-        Ok(())
-    }
-
-    fn shutdown(&self) -> Result<(), MetricError> {
         Ok(())
     }
 }

--- a/crates/telemetry/src/reader.rs
+++ b/crates/telemetry/src/reader.rs
@@ -16,9 +16,12 @@ limitations under the License.
 
 use std::sync::{Arc, Weak};
 
-use opentelemetry_sdk::metrics::{
-    InstrumentKind, ManualReader, Pipeline, Temporality, data::ResourceMetrics,
-    reader::MetricReader,
+use opentelemetry_sdk::{
+    error::OTelSdkResult,
+    metrics::{
+        InstrumentKind, ManualReader, Pipeline, Temporality, data::ResourceMetrics,
+        reader::MetricReader,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -50,11 +53,11 @@ impl MetricReader for InitialReader {
         self.reader.collect(rm)
     }
 
-    fn force_flush(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         self.reader.force_flush()
     }
 
-    fn shutdown(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         self.reader.shutdown()
     }
 

--- a/tools/otelpublisher/Cargo.toml
+++ b/tools/otelpublisher/Cargo.toml
@@ -10,14 +10,13 @@ version.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-opentelemetry-proto = { version = "0.30", features = [
+opentelemetry-proto = { version = "0.29.0", features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",
 ] }
 tokio.workspace = true
-tonic = { workspace = true, features = [
+tonic = { version = "0.12", features = [
   "transport",
-  "tls-ring",
   "tls-native-roots",
 ] }

--- a/tools/otelpublisher/src/main.rs
+++ b/tools/otelpublisher/src/main.rs
@@ -29,7 +29,7 @@ use opentelemetry_proto::tonic::{
 use tonic::{
     IntoRequest,
     metadata::MetadataValue,
-    transport::{Channel, ClientTlsConfig},
+    transport::{Certificate, Channel, ClientTlsConfig},
 };
 
 #[derive(Parser)]
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut otel_endpoint = args.otel_endpoint;
     let channel = if let Some(tls_root_certificate_file) = args.tls_root_certificate_file {
         let tls_root_certificate = std::fs::read(tls_root_certificate_file)?;
-        let tls_root_certificate = tonic::transport::Certificate::from_pem(tls_root_certificate);
+        let tls_root_certificate = Certificate::from_pem(tls_root_certificate);
         let client_tls_config = ClientTlsConfig::new().ca_certificate(tls_root_certificate);
         if otel_endpoint == "http://localhost:50052" {
             otel_endpoint = "https://localhost:50052".to_string();

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -124,17 +124,19 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let spiced_commit_sha = std::env::var("SPICED_COMMIT").unwrap_or("unknown".to_string());
     let spiced_version = metrics.spiced_version.clone();
     let app_name = app.name.clone();
-    let benchmark_resource = Resource::new(vec![
-        KeyValue::new("service.name", "testoperator"),
-        KeyValue::new("type", "benchmark_query"),
-        KeyValue::new("name", app_name.clone()),
-        KeyValue::new("spiced_version", spiced_version.clone()),
-        KeyValue::new("query_set", query_set.to_string()),
-        KeyValue::new("testoperator_commit_sha", commit_sha.clone()),
-        KeyValue::new("spiced_commit_sha", spiced_commit_sha),
-        KeyValue::new("branch_name", metrics.branch_name.clone()),
-        KeyValue::new("scale_factor", args.scale_factor.unwrap_or(1.0).to_string()),
-    ]);
+    let benchmark_resource = Resource::builder()
+        .with_attributes([
+            KeyValue::new("service.name", "testoperator"),
+            KeyValue::new("type", "benchmark_query"),
+            KeyValue::new("name", app_name.clone()),
+            KeyValue::new("spiced_version", spiced_version.clone()),
+            KeyValue::new("query_set", query_set.to_string()),
+            KeyValue::new("testoperator_commit_sha", commit_sha.clone()),
+            KeyValue::new("spiced_commit_sha", spiced_commit_sha),
+            KeyValue::new("branch_name", metrics.branch_name.clone()),
+            KeyValue::new("scale_factor", args.scale_factor.unwrap_or(1.0).to_string()),
+        ])
+        .build();
 
     let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
 

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -176,14 +176,16 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     println!("Top errors:\n{}\n", arrow_to_json(&top_errors)?);
 
     // Record benchmark results
-    let benchmark_resource = Resource::new(vec![
-        KeyValue::new("service.name", "testoperator"),
-        KeyValue::new("type", "model_benchmark"),
-        KeyValue::new("spiced_version", spiced_instance.version().to_string()),
-        KeyValue::new("spiced_commit_sha", git::get_commit_sha()),
-        KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
-        KeyValue::new("branch_name", git::get_branch_name()),
-    ]);
+    let benchmark_resource = Resource::builder()
+        .with_attributes([
+            KeyValue::new("service.name", "testoperator"),
+            KeyValue::new("type", "model_benchmark"),
+            KeyValue::new("spiced_version", spiced_instance.version().to_string()),
+            KeyValue::new("spiced_commit_sha", git::get_commit_sha()),
+            KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
+            KeyValue::new("branch_name", git::get_branch_name()),
+        ])
+        .build();
 
     let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
 

--- a/tools/testoperator/src/commands/search/mod.rs
+++ b/tools/testoperator/src/commands/search/mod.rs
@@ -35,6 +35,7 @@ use test_framework::{
 };
 use tokio::time::sleep;
 
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
     let (app, start_request) = get_app_and_start_request(&args.common).await?;
 
@@ -119,20 +120,22 @@ pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
     let spiced_commit_sha = std::env::var("SPICED_COMMIT").unwrap_or(git::get_commit_sha());
 
     // Record benchmark results
-    let benchmark_resource = Resource::new(vec![
-        KeyValue::new("service.name", "testoperator"),
-        KeyValue::new("type", "search"),
-        KeyValue::new("name", app.name.clone()),
-        KeyValue::new("spiced_version", spiced_instance.version().to_string()),
-        KeyValue::new("spiced_commit_sha", spiced_commit_sha),
-        KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
-        KeyValue::new("branch_name", git::get_branch_name()),
-        KeyValue::new("config_name", app.name), // use app name as search configuration
-        KeyValue::new(
-            "benchmark_dataset",
-            args.benchmark_dataset.clone().unwrap_or_default(),
-        ),
-    ]);
+    let benchmark_resource = Resource::builder()
+        .with_attributes([
+            KeyValue::new("service.name", "testoperator"),
+            KeyValue::new("type", "search"),
+            KeyValue::new("name", app.name.clone()),
+            KeyValue::new("spiced_version", spiced_instance.version().to_string()),
+            KeyValue::new("spiced_commit_sha", spiced_commit_sha),
+            KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
+            KeyValue::new("branch_name", git::get_branch_name()),
+            KeyValue::new("config_name", app.name), // use app name as search configuration
+            KeyValue::new(
+                "benchmark_dataset",
+                args.benchmark_dataset.clone().unwrap_or_default(),
+            ),
+        ])
+        .build();
 
     let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
 


### PR DESCRIPTION
- downgrade opentelemetry, sdk, http, zipkin, proto and tracing-opentelemetry deps to 0.29/0.30 along with tonic 0.13
- update telemetry/task history exporters, otelpublisher client and metrics pipeline for new APIs
- adjust prometheus 0.14 APIs and refresh tracing/metric setup across runtime and tests

Tests: make lint-rust