### PR TITLE
Fix `.clear history`

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -701,6 +701,9 @@ spice chat --model <model> "What is Spice.ai?"
 			}
 
 			if strings.ToLower(message) == ".clear history" {
+				// Clear session history (in-memory)
+				line.ClearHistory()
+				// Clear persistent history
 				if historyMgr != nil {
 					historyMgr.Clear()
 					if err := historyMgr.Save(); err != nil {
@@ -1159,6 +1162,9 @@ func runRemoteChatREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, ht
 		}
 
 		if strings.ToLower(message) == ".clear history" {
+			// Clear session history (in-memory)
+			line.ClearHistory()
+			// Clear persistent history
 			if historyMgr != nil {
 				historyMgr.Clear()
 				if err := historyMgr.Save(); err != nil {

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -232,6 +232,9 @@ spice search --cloud
 			}
 
 			if strings.ToLower(message) == ".clear history" {
+				// Clear session history (in-memory)
+				line.ClearHistory()
+				// Clear persistent history
 				if historyMgr != nil {
 					historyMgr.Clear()
 					if err := historyMgr.Save(); err != nil {
@@ -517,6 +520,9 @@ func runRemoteSearchREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, 
 		}
 
 		if strings.ToLower(message) == ".clear history" {
+			// Clear session history (in-memory)
+			line.ClearHistory()
+			// Clear persistent history
 			if historyMgr != nil {
 				historyMgr.Clear()
 				if err := historyMgr.Save(); err != nil {

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -595,6 +595,9 @@ func runREPLWithHealthAndMetadata(endpoint string, executor QueryExecutor, metad
 		}
 
 		if strings.ToLower(queryStr) == ".clear history" {
+			// Clear session history (in-memory)
+			line.ClearHistory()
+			// Clear persistent history
 			if historyMgr != nil {
 				historyMgr.Clear()
 				if err := historyMgr.Save(); err != nil {

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -22,6 +22,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use ansi_term::Colour;
 use arrow_flight::sql::{CommandStatementQuery, ProstMessageExt};
 use arrow_flight::{
@@ -136,6 +139,22 @@ const SPECIAL_COMMANDS: [&str; 8] = [
     ".clear history",
 ];
 const PROMPT_COLOR: Colour = Colour::Fixed(8);
+
+/// Set secure permissions (0600) on a file to ensure only the user can read/write it
+#[cfg(unix)]
+fn set_secure_permissions(path: &std::path::Path) -> std::io::Result<()> {
+    let metadata = std::fs::metadata(path)?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o600);
+    std::fs::set_permissions(path, permissions)
+}
+
+#[cfg(not(unix))]
+fn set_secure_permissions(_path: &std::path::Path) -> std::io::Result<()> {
+    // On Windows, file permissions work differently
+    // The file is created with user-only access by default
+    Ok(())
+}
 
 #[derive(Clone)]
 struct KeyEventHandler;
@@ -403,10 +422,12 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                 // Clear the readline history
                 let _ = rl.clear_history();
                 // Save the empty history to file (if path is available)
-                if let Some(ref path) = history_path
-                    && let Err(e) = rl.save_history(path)
-                {
-                    eprintln!("Warning: Failed to save cleared history: {e}");
+                if let Some(ref path) = history_path {
+                    if let Err(e) = rl.save_history(path) {
+                        eprintln!("Warning: Failed to save cleared history: {e}");
+                    } else if let Err(e) = set_secure_permissions(path) {
+                        eprintln!("Warning: Failed to set secure permissions on history file: {e}");
+                    }
                 }
                 println!("Query history cleared.");
                 let _ = std::io::stdout().flush();
@@ -486,10 +507,12 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
     }
 
     // Save history before exiting (if path is available)
-    if let Some(ref path) = history_path
-        && let Err(e) = rl.save_history(path)
-    {
-        eprintln!("Warning: Failed to save history on exit: {e}");
+    if let Some(ref path) = history_path {
+        if let Err(e) = rl.save_history(path) {
+            eprintln!("Warning: Failed to save history on exit: {e}");
+        } else if let Err(e) = set_secure_permissions(path) {
+            eprintln!("Warning: Failed to set secure permissions on history file: {e}");
+        }
     }
 
     if let Some(helper) = rl.helper_mut() {


### PR DESCRIPTION
This pull request improves the security of the REPL history file by ensuring it has user-only read/write permissions after it is cleared or saved. The changes add a cross-platform function to set secure file permissions and update the logic for saving history to apply these permissions.

**Security improvements for history file:**

* Added a new cross-platform `set_secure_permissions` function to set user-only permissions (0600) on the history file after saving or clearing it, with a Unix-specific implementation and a Windows stub. (`crates/flightrepl/src/lib.rs`) [[1]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R25-R27) [[2]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343R143-R158)
* Updated history saving logic to call `set_secure_permissions` after saving the history file, both when clearing history and when exiting, and to warn if setting permissions fails. (`crates/flightrepl/src/lib.rs`) [[1]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343L406-R430) [[2]](diffhunk://#diff-44fd6172ba8fc8cc0c54bc3702e4ba04b6de48a271503fd9eb4a059741f1e343L489-R515)