### PR TITLE
Load views in topological order

### DIFF
--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -23,7 +23,9 @@ use crate::{
     metrics,
     secrets::Secrets,
     status,
-    topological_ordering::construct_effected_in_topological_order,
+    topological_ordering::{
+        construct_effected_in_topological_order, construct_topological_ordering,
+    },
     view, warn_spaced,
 };
 use app::App;
@@ -37,7 +39,48 @@ impl Runtime {
     pub(crate) fn load_views(self: Arc<Self>, app: &Arc<App>) {
         let views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
 
-        for view in views {
+        // Determine the dependency order for views based on their SQL dependencies
+        let views_in_dependency_order = match views
+            .iter()
+            .map(|v| {
+                let statements =
+                    DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {})
+                        .boxed()?;
+                let Some(statement) = statements.into_iter().next() else {
+                    return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!(
+                        "no statements found in view {}",
+                        v.name
+                    )));
+                };
+
+                let deps = view::get_dependent_table_names(&statement);
+                Ok((v.name.clone(), deps))
+            })
+            .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>()
+        {
+            Ok(deps) => {
+                if let Some(ordered_names) = construct_topological_ordering(deps) {
+                    // Return views in topological order
+                    ordered_names
+                        .into_iter()
+                        .filter_map(|name| views.iter().find(|v| v.name == name).cloned())
+                        .collect::<Vec<_>>()
+                } else {
+                    tracing::warn!(
+                        "Circular dependency detected in views. Loading views in original order."
+                    );
+                    views
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Unable to determine dependency order for views: {e}. Loading views in original order."
+                );
+                views
+            }
+        };
+
+        for view in views_in_dependency_order {
             let runtime = Arc::clone(&self);
             let secrets = runtime.secrets();
             if let Err(e) = runtime.load_view(&view, secrets) {

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -35,50 +35,78 @@ use itertools::Itertools;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
+/// Extract view dependencies from SQL and return them in topological order.
+/// Returns None if dependencies cannot be determined or a cycle is detected.
+fn order_views_by_dependencies(views: &[Arc<View>]) -> Option<Vec<Arc<View>>> {
+    let deps_result = views
+        .iter()
+        .map(|v| {
+            let statements =
+                DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {}).boxed()?;
+            let Some(statement) = statements.into_iter().next() else {
+                return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!(
+                    "no statements found in view {}",
+                    v.name
+                )));
+            };
+
+            let deps = view::get_dependent_table_names(&statement);
+            Ok((v.name.clone(), deps))
+        })
+        .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>();
+
+    match deps_result {
+        Ok(deps) => {
+            // Filter out dependencies that are not views (e.g., datasets) to prevent false cycle detection
+            let view_names: HashSet<_> = deps.keys().cloned().collect();
+            let view_only_deps: HashMap<_, _> = deps
+                .into_iter()
+                .map(|(view, deps)| {
+                    let filtered_deps: Vec<_> = deps
+                        .into_iter()
+                        .filter(|dep| view_names.contains(dep))
+                        .collect();
+                    (view, filtered_deps)
+                })
+                .collect();
+
+            if let Some(ordered_names) = construct_topological_ordering(view_only_deps) {
+                // Return views in topological order
+                Some(
+                    ordered_names
+                        .into_iter()
+                        .filter_map(|name| {
+                            let view = views.iter().find(|v| v.name == name).cloned();
+                            if view.is_none() {
+                                tracing::warn!("View {name} returned by topological ordering but not found in views vector");
+                            }
+                            view
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                tracing::warn!(
+                    "Circular dependency detected in views. Loading views in original order."
+                );
+                None
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Unable to determine dependency order for views: {e}. Loading views in original order."
+            );
+            None
+        }
+    }
+}
+
 impl Runtime {
     pub(crate) fn load_views(self: Arc<Self>, app: &Arc<App>) {
         let views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
 
         // Determine the dependency order for views based on their SQL dependencies
-        let views_in_dependency_order = match views
-            .iter()
-            .map(|v| {
-                let statements =
-                    DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {})
-                        .boxed()?;
-                let Some(statement) = statements.into_iter().next() else {
-                    return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!(
-                        "no statements found in view {}",
-                        v.name
-                    )));
-                };
-
-                let deps = view::get_dependent_table_names(&statement);
-                Ok((v.name.clone(), deps))
-            })
-            .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>()
-        {
-            Ok(deps) => {
-                if let Some(ordered_names) = construct_topological_ordering(deps) {
-                    // Return views in topological order
-                    ordered_names
-                        .into_iter()
-                        .filter_map(|name| views.iter().find(|v| v.name == name).cloned())
-                        .collect::<Vec<_>>()
-                } else {
-                    tracing::warn!(
-                        "Circular dependency detected in views. Loading views in original order."
-                    );
-                    views
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Unable to determine dependency order for views: {e}. Loading views in original order."
-                );
-                views
-            }
-        };
+        let views_in_dependency_order =
+            order_views_by_dependencies(&views).unwrap_or_else(|| views.clone());
 
         for view in views_in_dependency_order {
             let runtime = Arc::clone(&self);
@@ -330,26 +358,51 @@ impl Runtime {
 
         // Get ordering of views to load, including those unchanged but with dependencies that have changed
         // If we can't determine the order, we'll just load the views in the order they are in the app
-        let affected_views_in_order_of_dependencies = match valid_views
-            .iter()
-            .map(|v| {
-                let Some(statement) =
-                    DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {})
-                        .boxed()?.pop_front() else {
-                            return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!("no statements found in view {}", v.name)));
-                        };
+        let affected_views_in_order_of_dependencies = {
+            let deps_result = valid_views
+                .iter()
+                .map(|v| {
+                    let Some(statement) =
+                        DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {})
+                            .boxed()?
+                            .pop_front()
+                    else {
+                        return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!(
+                            "no statements found in view {}",
+                            v.name
+                        )));
+                    };
 
-                let deps = view::get_dependent_table_names(&statement);
-                Ok((v.name.clone(), deps))
-            })
-            .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>()
-        {
-            Err(e) => {
-                tracing::warn!("Unable to determine order to update views: {e}. Will still attempt to update views.");
-                None
+                    let deps = view::get_dependent_table_names(&statement);
+                    Ok((v.name.clone(), deps))
+                })
+                .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>();
+
+            match deps_result {
+                Err(e) => {
+                    tracing::warn!(
+                        "Unable to determine order to update views: {e}. Will still attempt to update views."
+                    );
+                    None
+                }
+                Ok(deps) => {
+                    // Filter out dependencies that are not views (e.g., datasets) to prevent false cycle detection
+                    let view_names: HashSet<_> = deps.keys().cloned().collect();
+                    let view_only_deps: HashMap<_, _> = deps
+                        .into_iter()
+                        .map(|(view, deps)| {
+                            let filtered_deps: Vec<_> = deps
+                                .into_iter()
+                                .filter(|dep| view_names.contains(dep))
+                                .collect();
+                            (view, filtered_deps)
+                        })
+                        .collect();
+                    construct_effected_in_topological_order(view_only_deps, &views_that_changed)
+                }
             }
-            Ok(deps) => construct_effected_in_topological_order(deps,&views_that_changed ),
-        }.unwrap_or(valid_views.iter().map(|v| v.name.clone()).collect());
+            .unwrap_or_else(|| valid_views.iter().map(|v| v.name.clone()).collect())
+        };
 
         for view_name in affected_views_in_order_of_dependencies {
             if let Some(view) = valid_views.iter().find(|v| v.name == view_name) {

--- a/crates/runtime/tests/view/mod.rs
+++ b/crates/runtime/tests/view/mod.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use arrow::array::RecordBatch;
+use datafusion::sql::TableReference;
 use futures::TryStreamExt;
 use runtime::Runtime;
 use runtime::{
@@ -172,6 +173,116 @@ async fn accelerated_view_duckdb() -> Result<(), anyhow::Error> {
 
             // Remove the file
             std::fs::remove_file("./taxi_trips_vw.db").expect("to remove file");
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_view_dependency_ordering() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // Create a test CSV file
+            let test_csv = "value\n5\n15\n25\n50\n75\n150";
+            std::fs::write("./test_view_deps.csv", test_csv).expect("write file");
+
+            // Create a dataset
+            let dataset = Dataset::new("file:./test_view_deps.csv", "base_data");
+
+            // Create a view that depends on the dataset
+            let mut view1 = View::new("view_level_1".to_string());
+            view1.sql = Some("SELECT * FROM base_data WHERE value > 10".to_string());
+
+            // Create a view that depends on view1
+            let mut view2 = View::new("view_level_2".to_string());
+            view2.sql = Some("SELECT * FROM view_level_1 WHERE value < 100".to_string());
+
+            // Create a view that depends on view2
+            let mut view3 = View::new("view_level_3".to_string());
+            view3.sql = Some("SELECT COUNT(*) as count FROM view_level_2".to_string());
+
+            // Add views in WRONG order (should be auto-sorted by dependency)
+            let app = app::AppBuilder::new("test_view_dependency_ordering")
+                .with_dataset(dataset)
+                .with_view(view3.clone()) // Level 3 first
+                .with_view(view1.clone()) // Level 1 second
+                .with_view(view2.clone()) // Level 2 third
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for views to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify all views are registered and ready
+            let status = rt.status();
+            let view_statuses = status.get_view_statuses();
+
+            let view1_ref = TableReference::bare("view_level_1");
+            let view1_status = view_statuses.get(&view1_ref).expect("view_level_1 should exist");
+            assert_eq!(
+                *view1_status,
+                runtime::status::ComponentStatus::Ready,
+                "view_level_1 should be ready, got {view1_status:?}"
+            );
+
+            let view2_ref = TableReference::bare("view_level_2");
+            let view2_status = view_statuses.get(&view2_ref).expect("view_level_2 should exist");
+            assert_eq!(
+                *view2_status,
+                runtime::status::ComponentStatus::Ready,
+                "view_level_2 should be ready, got {view2_status:?}"
+            );
+
+            let view3_ref = TableReference::bare("view_level_3");
+            let view3_status = view_statuses.get(&view3_ref).expect("view_level_3 should exist");
+            assert_eq!(
+                *view3_status,
+                runtime::status::ComponentStatus::Ready,
+                "view_level_3 should be ready, got {view3_status:?}"
+            );
+
+            // Test that we can query the final view (which depends on the chain)
+            let query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM view_level_3")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?
+                .data
+                .try_collect::<Vec<RecordBatch>>()
+                .await;
+
+            assert!(
+                query_result.is_ok(),
+                "Should be able to query view_level_3 which depends on view_level_2 which depends on view_level_1"
+            );
+
+            // Verify the count is correct (should be 3: values 15, 25, 50, 75 are > 10 and < 100)
+            let batches = query_result.expect("query succeeded");
+            let pretty = arrow::util::pretty::pretty_format_batches(&batches)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+
+            // Should see count of 4 (15, 25, 50, 75)
+            assert!(pretty.to_string().contains('4'), "Expected count of 4 in result: {pretty}");
+
+            rt.shutdown().await;
+
+            // Clean up test file
+            std::fs::remove_file("./test_view_deps.csv").ok();
 
             Ok(())
         })

--- a/crates/runtime/tests/view/mod.rs
+++ b/crates/runtime/tests/view/mod.rs
@@ -288,3 +288,190 @@ async fn test_view_dependency_ordering() -> Result<(), anyhow::Error> {
         })
         .await
 }
+
+#[tokio::test]
+async fn test_view_depending_on_dataset() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // Create a test CSV file
+            let test_csv = "id,name\n1,Alice\n2,Bob\n3,Charlie";
+            std::fs::write("./test_view_dataset_dep.csv", test_csv).expect("write file");
+
+            // Create a dataset
+            let dataset = Dataset::new("file:./test_view_dataset_dep.csv", "users");
+
+            // Create a view that depends on the dataset (not another view)
+            let mut view1 = View::new("active_users".to_string());
+            view1.sql = Some("SELECT * FROM users WHERE id > 0".to_string());
+
+            // Create another view that depends on BOTH a dataset and a view
+            let mut view2 = View::new("user_summary".to_string());
+            view2.sql = Some("SELECT COUNT(*) as total FROM active_users".to_string());
+
+            // Add in order that would fail without dataset dependency filtering
+            let app = app::AppBuilder::new("test_view_dataset_dep")
+                .with_dataset(dataset)
+                .with_view(view1.clone())
+                .with_view(view2.clone())
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for views to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify both views are ready (would fail with false cycle detection)
+            let status = rt.status();
+            let view_statuses = status.get_view_statuses();
+
+            let view1_ref = TableReference::bare("active_users");
+            let view1_status = view_statuses.get(&view1_ref).expect("active_users should exist");
+            assert_eq!(
+                *view1_status,
+                runtime::status::ComponentStatus::Ready,
+                "active_users should be ready (depends on dataset), got {view1_status:?}"
+            );
+
+            let view2_ref = TableReference::bare("user_summary");
+            let view2_status = view_statuses.get(&view2_ref).expect("user_summary should exist");
+            assert_eq!(
+                *view2_status,
+                runtime::status::ComponentStatus::Ready,
+                "user_summary should be ready (depends on view and dataset), got {view2_status:?}"
+            );
+
+            // Test query to ensure data flows correctly
+            let query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM user_summary")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?
+                .data
+                .try_collect::<Vec<RecordBatch>>()
+                .await;
+
+            assert!(
+                query_result.is_ok(),
+                "Should be able to query user_summary which depends on active_users which depends on dataset"
+            );
+
+            let batches = query_result.expect("query succeeded");
+            let pretty = arrow::util::pretty::pretty_format_batches(&batches)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+
+            // Should see count of 3 (Alice, Bob, Charlie)
+            assert!(pretty.to_string().contains('3'), "Expected count of 3 in result: {pretty}");
+
+            rt.shutdown().await;
+
+            // Clean up test file
+            std::fs::remove_file("./test_view_dataset_dep.csv").ok();
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_multiple_views_same_dataset() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // Create a test CSV file
+            let test_csv = "product,price\nApple,1.50\nBanana,0.75\nCherry,2.00\nDate,3.50";
+            std::fs::write("./test_multi_view_dataset.csv", test_csv).expect("write file");
+
+            // Create a dataset
+            let dataset = Dataset::new("file:./test_multi_view_dataset.csv", "products");
+
+            // Create multiple views that all depend on the same dataset
+            let mut cheap_products = View::new("cheap_products".to_string());
+            cheap_products.sql = Some("SELECT * FROM products WHERE price < 2.0".to_string());
+
+            let mut expensive_products = View::new("expensive_products".to_string());
+            expensive_products.sql = Some("SELECT * FROM products WHERE price >= 2.0".to_string());
+
+            let mut product_count = View::new("product_count".to_string());
+            product_count.sql = Some("SELECT COUNT(*) as count FROM products".to_string());
+
+            // Add all views - none depend on each other, all depend on dataset
+            let app = app::AppBuilder::new("test_multi_view_dataset")
+                .with_dataset(dataset)
+                .with_view(expensive_products.clone())
+                .with_view(cheap_products.clone())
+                .with_view(product_count.clone())
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for views to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify all views are ready (no false cycles even though multiple views depend on same dataset)
+            let status = rt.status();
+            let view_statuses = status.get_view_statuses();
+
+            for view_name in ["cheap_products", "expensive_products", "product_count"] {
+                let view_ref = TableReference::bare(view_name);
+                let view_status = view_statuses
+                    .get(&view_ref)
+                    .unwrap_or_else(|| panic!("{view_name} should exist"));
+                assert_eq!(
+                    *view_status,
+                    runtime::status::ComponentStatus::Ready,
+                    "{view_name} should be ready, got {view_status:?}"
+                );
+            }
+
+            // Verify queries work
+            let cheap_result = rt
+                .datafusion()
+                .query_builder("SELECT COUNT(*) as cnt FROM cheap_products")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?
+                .data
+                .try_collect::<Vec<RecordBatch>>()
+                .await
+                .expect("query succeeded");
+
+            let pretty = arrow::util::pretty::pretty_format_batches(&cheap_result)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+            assert!(
+                pretty.to_string().contains('2'),
+                "Expected 2 cheap products: {pretty}"
+            );
+
+            rt.shutdown().await;
+
+            // Clean up test file
+            std::fs::remove_file("./test_multi_view_dataset.csv").ok();
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
This pull request introduces dependency-aware loading for views in the runtime, ensuring that views are initialized in the correct order based on their SQL dependencies. It also adds a comprehensive integration test to verify that views are loaded and queried successfully even when added out of dependency order.

**Dependency-aware view loading:**

* Updated the `Runtime::load_views` method in `crates/runtime/src/init/view.rs` to analyze SQL dependencies between views and use `construct_topological_ordering` to determine the correct load order. If circular dependencies or errors are detected, falls back to the original order and logs a warning.
* Imported `construct_topological_ordering` in addition to `construct_effected_in_topological_order` in `crates/runtime/src/init/view.rs` to support the new dependency ordering logic.

**Testing and validation:**

* Added a new integration test `test_view_dependency_ordering` in `crates/runtime/tests/view/mod.rs` that creates a chain of views with explicit dependencies, adds them in reverse order, and verifies that they are loaded and queried correctly in dependency order. The test also checks the final query result for correctness and cleans up after itself.
* Imported `TableReference` in the test module to support view status checks.