### PR TITLE
Fix potential timing attack for API key auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14844,6 +14844,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu",
+ "subtle",
  "tokio",
  "tracing",
  "url",

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -21,6 +21,7 @@ serde-value = "0.7.0"
 serde_json.workspace = true
 serde_yaml.workspace = true
 snafu.workspace = true
+subtle = "2.6"
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -16,6 +16,8 @@ limitations under the License.
 
 use std::{collections::HashMap, error::Error, sync::Arc, time::Duration};
 
+use subtle::ConstantTimeEq;
+
 use super::{
     caching::{Caching, ResultsCache},
     default_true, is_default, is_default_or_none,
@@ -357,12 +359,32 @@ pub struct ApiKeyAuth {
 
 /// API key for authentication. Keys can be read-only or read-write.
 /// The key value is redacted in Debug output to prevent credential leakage.
-#[derive(Clone, PartialEq)]
+///
+/// All comparisons (both `ApiKey` to `ApiKey` and `ApiKey` to `&str`) use
+/// constant-time comparison via the `subtle` crate to prevent timing attacks.
+#[derive(Clone)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum ApiKey {
     ReadOnly { key: String },
     ReadWrite { key: String },
 }
+
+/// Constant-time comparison for `ApiKey` to `ApiKey`.
+/// Both variants must match AND the key values must be equal using constant-time comparison.
+impl PartialEq for ApiKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ApiKey::ReadOnly { key: a }, ApiKey::ReadOnly { key: b })
+            | (ApiKey::ReadWrite { key: a }, ApiKey::ReadWrite { key: b }) => {
+                a.as_bytes().ct_eq(b.as_bytes()).into()
+            }
+            // Different variants are never equal
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ApiKey {}
 
 /// Custom Debug implementation that redacts the key value to prevent
 /// credential leakage in logs or error messages.
@@ -454,27 +476,14 @@ impl Serialize for ApiKey {
 impl PartialEq<str> for ApiKey {
     /// Compares the API key with another string using constant-time comparison
     /// to prevent timing attacks that could leak key information.
+    ///
+    /// Uses the `subtle` crate which is specifically designed for cryptographic
+    /// constant-time operations and handles edge cases like length differences
+    /// correctly without leaking timing information.
     fn eq(&self, other: &str) -> bool {
         match self {
             ApiKey::ReadOnly { key } | ApiKey::ReadWrite { key } => {
-                // Use constant-time comparison to prevent timing attacks.
-                // Even if lengths differ, we still compare to avoid leaking length info.
-                let key_bytes = key.as_bytes();
-                let other_bytes = other.as_bytes();
-
-                // XOR comparison result accumulator
-                let mut result: u8 = u8::from(key_bytes.len() != other_bytes.len());
-
-                // Compare byte-by-byte. If lengths differ, we compare with zeros
-                // to maintain constant time regardless of input.
-                let max_len = key_bytes.len().max(other_bytes.len());
-                for i in 0..max_len {
-                    let a = key_bytes.get(i).copied().unwrap_or(0);
-                    let b = other_bytes.get(i).copied().unwrap_or(0);
-                    result |= a ^ b;
-                }
-
-                result == 0
+                key.as_bytes().ct_eq(other.as_bytes()).into()
             }
         }
     }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -704,6 +704,76 @@ mod tests {
     }
 
     #[test]
+    fn test_api_key_constant_time_comparison() {
+        let key = ApiKey::ReadOnly {
+            key: "secret-api-key-12345".to_string(),
+        };
+
+        // Test exact match
+        assert!(key == *"secret-api-key-12345");
+
+        // Test mismatch at different positions
+        assert!(key != *"xecret-api-key-12345"); // First char different
+        assert!(key != *"secret-api-key-1234x"); // Last char different
+        assert!(key != *"secret-xpi-key-12345"); // Middle char different
+
+        // Test different lengths
+        assert!(key != *"secret-api-key-1234"); // Shorter
+        assert!(key != *"secret-api-key-123456"); // Longer
+        assert!(key != *""); // Empty string
+
+        // Test with ReadWrite variant
+        let rw_key = ApiKey::ReadWrite {
+            key: "rw-key".to_string(),
+        };
+        assert!(rw_key == *"rw-key");
+        assert!(rw_key != *"rw-key2");
+    }
+
+    #[test]
+    fn test_api_key_debug_redaction() {
+        let readonly_key = ApiKey::ReadOnly {
+            key: "super-secret-key".to_string(),
+        };
+        let readwrite_key = ApiKey::ReadWrite {
+            key: "another-secret".to_string(),
+        };
+
+        let readonly_debug = format!("{readonly_key:?}");
+        let readwrite_debug = format!("{readwrite_key:?}");
+
+        // Ensure the actual key values are NOT in the debug output
+        assert!(
+            !readonly_debug.contains("super-secret-key"),
+            "Debug output should not contain the actual key"
+        );
+        assert!(
+            !readwrite_debug.contains("another-secret"),
+            "Debug output should not contain the actual key"
+        );
+
+        // Ensure [REDACTED] is present
+        assert!(
+            readonly_debug.contains("[REDACTED]"),
+            "Debug output should contain [REDACTED]"
+        );
+        assert!(
+            readwrite_debug.contains("[REDACTED]"),
+            "Debug output should contain [REDACTED]"
+        );
+
+        // Ensure the variant name is present for debugging purposes
+        assert!(
+            readonly_debug.contains("ReadOnly"),
+            "Debug output should indicate the variant type"
+        );
+        assert!(
+            readwrite_debug.contains("ReadWrite"),
+            "Debug output should indicate the variant type"
+        );
+    }
+
+    #[test]
     fn test_memory_limit_migration() {
         // Test when only memory_limit is present
         let yaml = r"

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -355,11 +355,30 @@ pub struct ApiKeyAuth {
     pub keys: Vec<ApiKey>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// API key for authentication. Keys can be read-only or read-write.
+/// The key value is redacted in Debug output to prevent credential leakage.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum ApiKey {
     ReadOnly { key: String },
     ReadWrite { key: String },
+}
+
+/// Custom Debug implementation that redacts the key value to prevent
+/// credential leakage in logs or error messages.
+impl std::fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiKey::ReadOnly { .. } => f
+                .debug_struct("ApiKey::ReadOnly")
+                .field("key", &"[REDACTED]")
+                .finish(),
+            ApiKey::ReadWrite { .. } => f
+                .debug_struct("ApiKey::ReadWrite")
+                .field("key", &"[REDACTED]")
+                .finish(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -433,9 +452,30 @@ impl Serialize for ApiKey {
 }
 
 impl PartialEq<str> for ApiKey {
+    /// Compares the API key with another string using constant-time comparison
+    /// to prevent timing attacks that could leak key information.
     fn eq(&self, other: &str) -> bool {
         match self {
-            ApiKey::ReadOnly { key } | ApiKey::ReadWrite { key } => key == other,
+            ApiKey::ReadOnly { key } | ApiKey::ReadWrite { key } => {
+                // Use constant-time comparison to prevent timing attacks.
+                // Even if lengths differ, we still compare to avoid leaking length info.
+                let key_bytes = key.as_bytes();
+                let other_bytes = other.as_bytes();
+
+                // XOR comparison result accumulator
+                let mut result: u8 = u8::from(key_bytes.len() != other_bytes.len());
+
+                // Compare byte-by-byte. If lengths differ, we compare with zeros
+                // to maintain constant time regardless of input.
+                let max_len = key_bytes.len().max(other_bytes.len());
+                for i in 0..max_len {
+                    let a = key_bytes.get(i).copied().unwrap_or(0);
+                    let b = other_bytes.get(i).copied().unwrap_or(0);
+                    result |= a ^ b;
+                }
+
+                result == 0
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the security of API key handling in the `ApiKey` enum by preventing accidental credential leakage in debug output and improving key comparison to resist timing attacks. It also introduces thorough tests to verify these changes.

Security improvements:

* Implemented a custom `Debug` for the `ApiKey` enum that redacts the actual key value, ensuring credentials are not leaked in logs or error messages.
* Updated `PartialEq<str>` for `ApiKey` to use constant-time comparison, mitigating timing attacks that could reveal key information.

Testing enhancements:

* Added tests to validate constant-time key comparison and ensure debug output redacts key values and includes the correct variant type.