### PR TITLE
Redact token debug output

### DIFF
--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -170,7 +170,7 @@ struct TokenResponse {
 impl fmt::Debug for TokenResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TokenResponse")
-            .field("access_token", &"<redacted>")
+            .field("access_token", &"[REDACTED]")
             .field("token_type", &self.token_type)
             .field("expires_in", &self.expires_in)
             .field("scope", &self.scope)

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -148,12 +148,23 @@ impl TokenProvider for DatabricksM2MTokenProvider {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 struct TokenResponse {
     access_token: String,
     token_type: String,
     expires_in: u64,
     scope: String,
+}
+
+impl fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenResponse")
+            .field("access_token", &"<redacted>")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field("scope", &self.scope)
+            .finish()
+    }
 }
 
 async fn get_m2m_access_token(

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -146,12 +146,19 @@ impl TokenProvider for DatabricksM2MTokenProvider {
         let (tx, rx) = watch::channel(secret_rx.borrow().expose_secret().to_string());
         tokio::spawn(async move {
             loop {
-                if secret_rx.changed().await.is_err() {
-                    break;
-                }
-                let exposed = secret_rx.borrow().expose_secret().to_string();
-                if tx.send(exposed).is_err() {
-                    break;
+                tokio::select! {
+                    () = tx.closed() => {
+                        break;
+                    }
+                    changed = secret_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                        let exposed = secret_rx.borrow().expose_secret().to_string();
+                        if tx.send(exposed).is_err() {
+                            break;
+                        }
+                    }
                 }
             }
         });

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -16,7 +16,7 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 
 use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use snafu::prelude::*;
 use std::time::Duration;
 use std::{fmt, sync::Arc};
@@ -44,8 +44,7 @@ pub struct DatabricksM2MTokenProvider {
     endpoint: String,
     client_id: String,
 
-    tx: watch::Sender<String>,
-    rx: watch::Receiver<String>,
+    rx: watch::Receiver<SecretString>,
 
     _handle: Arc<JoinHandle<()>>,
 }
@@ -131,7 +130,6 @@ impl DatabricksM2MTokenProvider {
         Ok(Self {
             endpoint,
             client_id,
-            tx,
             rx,
             _handle: Arc::new(handle),
         })
@@ -140,17 +138,30 @@ impl DatabricksM2MTokenProvider {
 
 impl TokenProvider for DatabricksM2MTokenProvider {
     fn get_token(&self) -> String {
-        self.rx.borrow().clone()
+        self.rx.borrow().expose_secret().to_string()
     }
 
     fn subscribe(&self) -> Option<watch::Receiver<String>> {
-        Some(self.tx.subscribe())
+        let mut secret_rx = self.rx.clone();
+        let (tx, rx) = watch::channel(secret_rx.borrow().expose_secret().to_string());
+        tokio::spawn(async move {
+            loop {
+                if secret_rx.changed().await.is_err() {
+                    break;
+                }
+                let exposed = secret_rx.borrow().expose_secret().to_string();
+                if tx.send(exposed).is_err() {
+                    break;
+                }
+            }
+        });
+        Some(rx)
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize)]
 struct TokenResponse {
-    access_token: String,
+    access_token: SecretString,
     token_type: String,
     expires_in: u64,
     scope: String,

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -93,12 +93,19 @@ impl TokenProvider for GitHubAppTokenProvider {
         let (tx, rx) = watch::channel(secret_rx.borrow().expose_secret().to_string());
         tokio::spawn(async move {
             loop {
-                if secret_rx.changed().await.is_err() {
-                    break;
-                }
-                let exposed = secret_rx.borrow().expose_secret().to_string();
-                if tx.send(exposed).is_err() {
-                    break;
+                tokio::select! {
+                    () = tx.closed() => {
+                        break;
+                    }
+                    changed = secret_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                        let exposed = secret_rx.borrow().expose_secret().to_string();
+                        if tx.send(exposed).is_err() {
+                            break;
+                        }
+                    }
                 }
             }
         });

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -23,6 +23,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use token_provider::{Result, TokenProvider};
@@ -68,8 +69,7 @@ pub struct GitHubAppTokenProvider {
     app_client_id: Arc<str>,
     private_key: Arc<str>,
     installation_id: Arc<str>,
-    tx: watch::Sender<String>,
-    rx: watch::Receiver<String>,
+    rx: watch::Receiver<SecretString>,
     _handle: Arc<JoinHandle<()>>,
 }
 
@@ -85,11 +85,24 @@ impl std::fmt::Debug for GitHubAppTokenProvider {
 
 impl TokenProvider for GitHubAppTokenProvider {
     fn get_token(&self) -> String {
-        self.rx.borrow().clone()
+        self.rx.borrow().expose_secret().to_string()
     }
 
     fn subscribe(&self) -> Option<watch::Receiver<String>> {
-        Some(self.tx.subscribe())
+        let mut secret_rx = self.rx.clone();
+        let (tx, rx) = watch::channel(secret_rx.borrow().expose_secret().to_string());
+        tokio::spawn(async move {
+            loop {
+                if secret_rx.changed().await.is_err() {
+                    break;
+                }
+                let exposed = secret_rx.borrow().expose_secret().to_string();
+                if tx.send(exposed).is_err() {
+                    break;
+                }
+            }
+        });
+        Some(rx)
     }
 }
 
@@ -156,7 +169,6 @@ impl GitHubAppTokenProvider {
             app_client_id,
             private_key,
             installation_id,
-            tx,
             rx,
             _handle: Arc::new(handle),
         })
@@ -165,7 +177,7 @@ impl GitHubAppTokenProvider {
 
 #[derive(Clone)]
 pub struct GitHubToken {
-    pub token: String,
+    pub token: SecretString,
     pub expires_at: DateTime<Utc>,
 }
 
@@ -241,7 +253,7 @@ async fn generate_token(
     #[allow(clippy::items_after_statements)]
     #[derive(Deserialize, Debug)]
     struct TokenResponse {
-        token: String,
+        token: SecretString,
         expires_at: String,
     }
     let resp: TokenResponse = response

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -15,14 +15,16 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fmt,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
-use std::time::Duration;
 use token_provider::{Result, TokenProvider};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -161,10 +163,19 @@ impl GitHubAppTokenProvider {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GitHubToken {
     pub token: String,
     pub expires_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for GitHubToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GitHubToken")
+            .field("token", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 impl GitHubToken {
     #[allow(clippy::cast_sign_loss)]

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -184,7 +184,7 @@ pub struct GitHubToken {
 impl fmt::Debug for GitHubToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GitHubToken")
-            .field("token", &"<redacted>")
+            .field("token", &"[REDACTED]")
             .field("expires_at", &self.expires_at)
             .finish()
     }


### PR DESCRIPTION
## Summary
- redact GitHub App token debug output to avoid accidental leakage
- redact Databricks M2M token debug output while keeping serde intact