### PR TITLE
fix: Cayenne configuration options

### DIFF
--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -160,20 +160,28 @@ pub struct VortexConfig {
 impl Default for VortexConfig {
     fn default() -> Self {
         Self {
-            // Enable all SIMD-optimized encodings by default
+            // Enable encodings optimized for read performance
+            // ALP: Excellent for floating-point queries (SIMD-friendly decompression)
             enable_alp: true,
+            // FSST: Fast string decompression, good for string-heavy workloads
             enable_fsst: true,
+            // BitPacking: Very fast SIMD decompression for integers
             enable_bitpacking: true,
-            enable_delta: true,
+            // Delta: Disable for reads - requires sequential decompression
+            enable_delta: false,
+            // RLE: Enable for low-cardinality/repeated values (very fast scans)
             enable_rle: true,
+            // Dictionary: Enable for low-cardinality columns (fast lookups)
             enable_dict: true,
+            // FOR: Fast integer decompression, SIMD-friendly
             enable_for: true,
+            // ZigZag: Minimal overhead, keep enabled for signed integers
             enable_zigzag: true,
-            // Cache configuration
+            // Larger caches improve read performance
             footer_cache_mb: 128,
             segment_cache_mb: 256,
-            // Target file size: 256 MB
-            target_vortex_file_size_mb: 256,
+            // Smaller files = better parallelism and predicate pushdown
+            target_vortex_file_size_mb: 128,
         }
     }
 }

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -171,7 +171,7 @@ impl Default for VortexConfig {
             enable_zigzag: true,
             // Cache configuration
             footer_cache_mb: 128,
-            segment_cache_mb: 512,
+            segment_cache_mb: 256,
             // Target file size: 256 MB
             target_vortex_file_size_mb: 256,
         }

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -153,7 +153,7 @@ pub struct VortexConfig {
     /// Target size for individual Vortex files in MB. When writes exceed this size,
     /// a new Vortex file will be created in the same listing directory. This allows
     /// for better parallelism and more granular statistics for query optimization.
-    /// Defaults to 256 MB.
+    /// Defaults to 128 MB.
     pub target_vortex_file_size_mb: usize,
 }
 

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -171,7 +171,7 @@ impl Default for VortexConfig {
             enable_zigzag: true,
             // Cache configuration
             footer_cache_mb: 128,
-            segment_cache_mb: 32,
+            segment_cache_mb: 512,
             // Target file size: 256 MB
             target_vortex_file_size_mb: 256,
         }

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -314,22 +314,25 @@ impl CayenneAccelerator {
                     .unwrap_or(default)
             };
 
-            // Parse encoding options
-            config.enable_alp = get_enabled("cayenne_alp", true);
-            config.enable_fsst = get_enabled("cayenne_fsst", true);
-            config.enable_bitpacking = get_enabled("cayenne_bitpacking", true);
-            config.enable_delta = get_enabled("cayenne_delta", true);
-            config.enable_rle = get_enabled("cayenne_rle", true);
-            config.enable_dict = get_enabled("cayenne_dict", true);
-            config.enable_for = get_enabled("cayenne_for", true);
-            config.enable_zigzag = get_enabled("cayenne_zigzag", true);
+            // Parse encoding options - use VortexConfig defaults if not specified
+            config.enable_alp = get_enabled("cayenne_alp", config.enable_alp);
+            config.enable_fsst = get_enabled("cayenne_fsst", config.enable_fsst);
+            config.enable_bitpacking = get_enabled("cayenne_bitpacking", config.enable_bitpacking);
+            config.enable_delta = get_enabled("cayenne_delta", config.enable_delta);
+            config.enable_rle = get_enabled("cayenne_rle", config.enable_rle);
+            config.enable_dict = get_enabled("cayenne_dict", config.enable_dict);
+            config.enable_for = get_enabled("cayenne_for", config.enable_for);
+            config.enable_zigzag = get_enabled("cayenne_zigzag", config.enable_zigzag);
 
-            // Parse cache options
-            config.footer_cache_mb = parse_usize("cayenne_footer_cache_mb", 64);
-            config.segment_cache_mb = parse_usize("cayenne_segment_cache_mb", 0);
+            // Parse cache options - use VortexConfig defaults if not specified
+            config.footer_cache_mb =
+                parse_usize("cayenne_footer_cache_mb", config.footer_cache_mb);
+            config.segment_cache_mb =
+                parse_usize("cayenne_segment_cache_mb", config.segment_cache_mb);
 
             // Parse file size options
-            config.target_vortex_file_size_mb = parse_usize("cayenne_target_file_size_mb", 256);
+            config.target_vortex_file_size_mb =
+                parse_usize("cayenne_target_file_size_mb", config.target_vortex_file_size_mb);
 
             tracing::debug!(
                 "Cayenne Vortex config: ALP={}, FSST={}, BitPacking={}, Delta={}, RLE={}, Dict={}, FOR={}, ZigZag={}, footer_cache={}MB, segment_cache={}MB, target_file_size={}MB",

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -325,14 +325,15 @@ impl CayenneAccelerator {
             config.enable_zigzag = get_enabled("cayenne_zigzag", config.enable_zigzag);
 
             // Parse cache options - use VortexConfig defaults if not specified
-            config.footer_cache_mb =
-                parse_usize("cayenne_footer_cache_mb", config.footer_cache_mb);
+            config.footer_cache_mb = parse_usize("cayenne_footer_cache_mb", config.footer_cache_mb);
             config.segment_cache_mb =
                 parse_usize("cayenne_segment_cache_mb", config.segment_cache_mb);
 
             // Parse file size options
-            config.target_vortex_file_size_mb =
-                parse_usize("cayenne_target_file_size_mb", config.target_vortex_file_size_mb);
+            config.target_vortex_file_size_mb = parse_usize(
+                "cayenne_target_file_size_mb",
+                config.target_vortex_file_size_mb,
+            );
 
             tracing::debug!(
                 "Cayenne Vortex config: ALP={}, FSST={}, BitPacking={}, Delta={}, RLE={}, Dict={}, FOR={}, ZigZag={}, footer_cache={}MB, segment_cache={}MB, target_file_size={}MB",

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -1876,7 +1876,10 @@ mod accelerator_compat_tests {
             assert_eq!(total_rows, 100, "{:?}: should have {} rows", engine, 100);
 
             // Test 2: Filter with WHERE clause (id > 50)
-            // Note: Arrow and Vortex engines don't support filter pushdown, so they return all rows
+            // Note: Arrow and Vortex engines don't support filter pushdown at the TableProvider
+            // level (via scan() method). Vortex supports filter pushdown at the physical plan
+            // level via DataFusion's FilterPushdown optimizer rule, but that only applies when
+            // running SQL queries, not when calling scan() directly.
             let filter = col("id").gt(lit(50_i64));
             let scan = table
                 .scan(&ctx.state(), None, &[filter], None)
@@ -1910,7 +1913,8 @@ mod accelerator_compat_tests {
             );
 
             // Test 4: LIMIT clause
-            // Note: Arrow and Vortex engines don't support limit pushdown
+            // Note: Arrow doesn't support limit pushdown. Vortex supports limit pushdown via
+            // FileScanConfig.limit at the TableProvider level when scan() is called with a limit.
             let limit = Some(10);
             let scan = table
                 .scan(&ctx.state(), None, &[], limit)
@@ -1930,7 +1934,9 @@ mod accelerator_compat_tests {
             }
 
             // Test 5: Combined filter + projection + limit
-            // Note: Arrow and Vortex engines don't support filter/limit pushdown
+            // Note: Arrow doesn't support filter/limit pushdown at the TableProvider level.
+            // Vortex supports limit pushdown via FileScanConfig.limit but filter pushdown
+            // only works via DataFusion's physical optimizer (when running SQL queries).
             let filter = col("id").lt(lit(30_i64));
             let projection = Some(vec![1_usize]); // name only
             let limit = Some(5);
@@ -2378,7 +2384,9 @@ mod accelerator_compat_tests {
                 .expect("scan successful");
 
             let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
-            // Arrow and Vortex don't support filter pushdown, so they return all rows
+            // Arrow and Vortex don't support filter pushdown at the TableProvider level
+            // (when calling scan() directly). Filter pushdown for Vortex only works via
+            // DataFusion's physical optimizer when running SQL queries.
             // IDs are 0-9, so id > 5 gives IDs 6,7,8,9 = 4 rows
             let expected_rows = if engine == Engine::Arrow || engine == Engine::Cayenne {
                 10
@@ -2404,7 +2412,7 @@ mod accelerator_compat_tests {
                 .expect("scan successful");
 
             let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
-            // Arrow and Vortex don't support filter pushdown, so they return all rows
+            // Arrow and Vortex don't support filter pushdown at the TableProvider level
             let expected_rows = if engine == Engine::Arrow || engine == Engine::Cayenne {
                 10
             } else {
@@ -2428,7 +2436,7 @@ mod accelerator_compat_tests {
                 .expect("scan successful");
 
             let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
-            // Arrow and Vortex don't support filter pushdown, so they return all rows
+            // Arrow and Vortex don't support filter pushdown at the TableProvider level
             let expected_rows = if engine == Engine::Arrow || engine == Engine::Cayenne {
                 10
             } else {
@@ -2454,7 +2462,7 @@ mod accelerator_compat_tests {
                 .expect("scan successful");
 
             let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
-            // Arrow and Vortex don't support filter pushdown, so they return all rows
+            // Arrow and Vortex don't support filter pushdown at the TableProvider level
             let expected_rows = if engine == Engine::Arrow || engine == Engine::Cayenne {
                 10
             } else {
@@ -2602,9 +2610,10 @@ mod accelerator_compat_tests {
                 .expect("combined scan successful");
 
             let total_rows: usize = results.iter().map(|b| b.num_rows()).sum();
-            // Arrow doesn't support filter or limit pushdown, so it returns all rows
-            // Vortex doesn't support filter pushdown but does support limit pushdown
-            // DuckDB supports both filter and limit pushdown
+            // Arrow doesn't support filter or limit pushdown at the TableProvider level
+            // Vortex doesn't support filter pushdown at TableProvider level (only via physical
+            // optimizer when running SQL), but does support limit pushdown via FileScanConfig.limit
+            // DuckDB supports both filter and limit pushdown at TableProvider level
             if engine == Engine::Arrow {
                 // No pushdown - returns all 10 rows
                 assert_eq!(


### PR DESCRIPTION
This pull request updates how configuration defaults are handled for the Cayenne (Vortex) accelerator and improves the clarity and accuracy of documentation in the accelerator compatibility tests. The main code change ensures that if a configuration value is not explicitly set, it falls back to the default from `VortexConfig` rather than a hardcoded value. The test comments are revised to more precisely describe the filter and limit pushdown capabilities of Arrow and Vortex engines.

**Configuration handling improvements:**

* In `crates/runtime/src/dataaccelerator/cayenne.rs`, configuration options for encoding and caching now use the defaults from `VortexConfig` if not specified, rather than fixed values. This makes configuration more flexible and consistent with the intended defaults.

**Test documentation and clarity:**

* In `crates/runtime/src/dataaccelerator/mod.rs`, comments in the accelerator compatibility tests are updated to clarify that Arrow and Vortex do not support filter pushdown at the `TableProvider` level when using the `scan()` method, but Vortex supports filter pushdown via DataFusion's physical optimizer when running SQL queries. [[1]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L1879-R1882) [[2]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L2381-R2389) [[3]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L2407-R2415) [[4]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L2431-R2439) [[5]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L2457-R2465)

* Comments regarding limit pushdown are corrected to indicate that Vortex supports limit pushdown via `FileScanConfig.limit` at the `TableProvider` level, while Arrow does not. [[1]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L1913-R1917) [[2]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L1933-R1939) [[3]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L2605-R2616)