### PR TITLE
Pass IndexedTableProvider down in 'changes_stream' and 'append_stream'

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1170,8 +1170,7 @@ impl DataFusion {
             && dataset.time_column.is_none()
             && acceleration_settings.engine != Engine::Cayenne
         {
-            let append_stream = source.append_stream(source_table_provider);
-            if let Some(append_stream) = append_stream {
+            if let Some(append_stream) = source.append_stream(source_table_provider) {
                 accelerated_table_builder.append_stream(append_stream);
             } else {
                 return Err(Error::AppendRequiresTimeColumn {

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -23,6 +23,7 @@ use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResul
 use crate::embeddings::execution_plan::{
     compute_additional_embedding_columns, construct_record_batch,
 };
+use crate::embeddings::index::VectorScanTableProvider;
 use crate::embeddings::index::table::wrap_table_as_index;
 use crate::federated_table::FederatedTable;
 use crate::model::ENABLE_MODEL_SUPPORT_MESSAGE;
@@ -34,6 +35,7 @@ use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use itertools::Itertools;
 use runtime_datafusion_index::IndexedTableProvider;
+use search::generation::text_search::index::FullTextDatabaseIndex;
 use spicepod::component::embeddings::ColumnEmbeddingConfig;
 
 use std::any::Any;
@@ -246,14 +248,24 @@ impl DataConnector for EmbeddingConnector {
             .downcast_ref::<IndexedTableProvider>()
             .cloned()
         {
-            let indexed_table = Arc::new(indexed_table);
             let Some(underlying_federated_table) =
                 underlying_federated_table_for_indexed_table(&table_provider)
             else {
                 return self.inner_connector.changes_stream(federated_table);
             };
 
-            let indexes = Indexes::new(indexed_table.get_all_indexes());
+            // Avoid reindexing full-text indexes.
+            let indexes = Indexes::new(
+                indexed_table
+                    .get_all_indexes()
+                    .into_iter()
+                    .filter(|idx| {
+                        idx.as_any()
+                            .downcast_ref::<FullTextDatabaseIndex>()
+                            .is_none()
+                    })
+                    .collect(),
+            );
 
             let stream = self
                 .inner_connector

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -23,7 +23,6 @@ use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResul
 use crate::embeddings::execution_plan::{
     compute_additional_embedding_columns, construct_record_batch,
 };
-use crate::embeddings::index::VectorScanTableProvider;
 use crate::embeddings::index::table::wrap_table_as_index;
 use crate::federated_table::FederatedTable;
 use crate::model::ENABLE_MODEL_SUPPORT_MESSAGE;

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+use super::index::VectorScanTableProvider;
 use crate::accelerated_table::AcceleratedTable;
 use crate::changes::Indexes;
 use crate::changes::index_change_envelope;
@@ -36,7 +37,6 @@ use itertools::Itertools;
 use runtime_datafusion_index::IndexedTableProvider;
 use search::generation::text_search::index::FullTextDatabaseIndex;
 use spicepod::component::embeddings::ColumnEmbeddingConfig;
-
 use std::any::Any;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -273,24 +273,34 @@ impl DataConnector for EmbeddingConnector {
                 .boxed();
 
             return Some(stream);
+
+        // `VectorScanTableProvider` is generally wrapped by a `IndexedTableProvider` (as above), but in the case both [`Self`] and the [`FullTextConnector`] exist, the latter will unwrap the `IndexedTableProvider` first. It will correctly handle indexing vector indexes as that point.
+        } else if let Some(vector_scan) = table_provider
+            .as_any()
+            .downcast_ref::<VectorScanTableProvider>()
+        {
+            self.inner_connector
+                .changes_stream(Arc::new(FederatedTable::Immediate(Arc::clone(
+                    &vector_scan.table_provider,
+                ))))
+        } else if let Some(embedding_table) =
+            table_provider.as_any().downcast_ref::<EmbeddingTable>()
+        {
+            let embedding_table = Arc::new(embedding_table.clone());
+            let underlying_table = Arc::clone(&embedding_table.base_table);
+            let underlying_federated_table = Arc::new(FederatedTable::Immediate(underlying_table));
+
+            Some(
+                self.inner_connector
+                    .changes_stream(underlying_federated_table)?
+                    .then(move |item| {
+                        Self::embed_change_envelope(item, Arc::clone(&embedding_table))
+                    })
+                    .boxed(),
+            )
+        } else {
+            None
         }
-
-        let embedding_table = Arc::new(
-            table_provider
-                .as_any()
-                .downcast_ref::<EmbeddingTable>()?
-                .clone(),
-        );
-        let underlying_table = Arc::clone(&embedding_table.base_table);
-        let underlying_federated_table = Arc::new(FederatedTable::Immediate(underlying_table));
-
-        let stream = self
-            .inner_connector
-            .changes_stream(underlying_federated_table)?
-            .then(move |item| Self::embed_change_envelope(item, Arc::clone(&embedding_table)))
-            .boxed();
-
-        Some(stream)
     }
 
     fn supports_append_stream(&self) -> bool {

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -272,7 +272,7 @@ impl DataConnector for EmbeddingConnector {
                 .then(move |item| index_change_envelope(item, Arc::clone(&indexes)))
                 .boxed();
 
-            return Some(stream);
+            Some(stream)
 
         // `VectorScanTableProvider` is generally wrapped by a `IndexedTableProvider` (as above), but in the case both [`Self`] and the [`FullTextConnector`] exist, the latter will unwrap the `IndexedTableProvider` first. It will correctly handle indexing vector indexes as that point.
         } else if let Some(vector_scan) = table_provider

--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -104,7 +104,14 @@ async fn wrap_table_as_index_s3(
                 .map(|embed| (c.name.clone(), embed.clone()))
         })
         .collect();
-    let mut provider = IndexedTableProvider::new(Arc::clone(&inner_table_provider));
+    let mut provider = if let Some(indexed) = inner_table_provider
+        .as_any()
+        .downcast_ref::<IndexedTableProvider>()
+    {
+        indexed.clone()
+    } else {
+        IndexedTableProvider::new(Arc::clone(&inner_table_provider))
+    };
     for (column, config) in embedding_columns {
         let (columns, index_schema) = if config.chunking.as_ref().is_some_and(|cfg| cfg.enabled) {
             updated_chunked_search_index_format(&inner_table_provider, columns, &column)

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -332,7 +332,19 @@ impl VectorSearchTableFunc {
             find_index_in_table_provider::<S3Vector>(tbl),
             find_index_in_table_provider::<ChunkedSearchIndex>(tbl),
         ) {
-            (_, Some((chunked_index, _))) => chunked_index
+            (Some((vector_index, _)), Some((chunked_index, _))) => {
+                let mut indexes = chunked_index
+                    .into_iter()
+                    .map(|c| Arc::new(c.clone()) as Arc<dyn SearchIndex>)
+                    .collect::<Vec<_>>();
+                indexes.extend(
+                    vector_index
+                        .into_iter()
+                        .map(|c| Arc::new(c.clone()) as Arc<dyn SearchIndex>),
+                );
+                indexes
+            }
+            (None, Some((chunked_index, _))) => chunked_index
                 .into_iter()
                 .map(|c| Arc::new(c.clone()) as Arc<dyn SearchIndex>)
                 .collect::<Vec<_>>(),

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexedTableProvider};
 use search::generation::text_search::index::FullTextDatabaseIndex;
 use std::any::Any;
 use std::sync::Arc;
@@ -31,7 +31,7 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
-use crate::search::util::find_index_in_table_provider;
+use crate::search::util::{find_concrete_table_provider, find_index_in_table_provider};
 use futures::StreamExt;
 
 /// A [`DataConnector`] middleware that, for [`Dataset`]s needing full text search capabilies, creates a [`IndexedTableProvider`] using the underlying [`TableProvider`]s and a [`FullTextDatabaseIndex`]. If no full text search capabilities are needed it is not unnecessarily nested.
@@ -55,29 +55,18 @@ impl FullTextConnector {
         F: Fn(&Arc<dyn DataConnector>, Arc<FederatedTable>) -> Option<ChangesStream>,
     {
         let table_provider = federated_table.try_table_provider_sync()?;
-        let Some((indexed, _)) =
-            find_index_in_table_provider::<FullTextDatabaseIndex>(&table_provider)
-        else {
-            tracing::debug!(
-                "FullTextConnector didn't wrap underlying table with index - this is unexpected"
-            );
-            return None;
-        };
-        let indexed = Indexes::new(
-            indexed
-                .into_iter()
-                .cloned()
-                .map(|i| Arc::new(i) as Arc<dyn Index + Send + Sync>)
-                .collect(),
-        );
+        let indexed_table = find_concrete_table_provider::<IndexedTableProvider>(&table_provider)?;
 
-        // Use `table_provider` to preserve IndexedTableProvider for `self.inner_connector` whom may need it.
-        let ft = Arc::new(FederatedTable::Immediate(Arc::clone(&table_provider)));
+        // This will process all `Index`s, including vector indexes if provided (i.e. from `EmbeddingConnector`).
+        // This is required so that [`IndexedTableProvider`] can be unwrapped (i.e. [`IndexedTableProvider::get_underlying`])
+        //  in both cases there is and isn't a `EmbeddingConnector` underneath.
+        let indexes = Indexes::new(indexed_table.get_all_indexes());
+        let ft = Arc::new(FederatedTable::Immediate(indexed_table.get_underlying()));
 
         let stream = f(&self.inner_connector, ft)?;
         Some(
             stream
-                .then(move |item| index_change_envelope(item, Arc::clone(&indexed)))
+                .then(move |item| index_change_envelope(item, Arc::clone(&indexes)))
                 .boxed(),
         )
     }

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,7 +16,8 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexedTableProvider};
+use search::generation::text_search::index::FullTextDatabaseIndex;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -30,10 +31,8 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
-use crate::search::util::find_index_in_table_provider;
+use crate::search::util::{find_concrete_table_provider, find_index_in_table_provider};
 use futures::StreamExt;
-
-use search::generation::text_search::index::FullTextDatabaseIndex;
 
 /// A [`DataConnector`] middleware that, for [`Dataset`]s needing full text search capabilies, creates a [`IndexedTableProvider`] using the underlying [`TableProvider`]s and a [`FullTextDatabaseIndex`]. If no full text search capabilities are needed it is not unnecessarily nested.
 #[derive(Debug)]
@@ -56,8 +55,7 @@ impl FullTextConnector {
         F: Fn(&Arc<dyn DataConnector>, Arc<FederatedTable>) -> Option<ChangesStream>,
     {
         let table_provider = federated_table.try_table_provider_sync()?;
-
-        let Some((indexed, underlying)) =
+        let Some((indexes, _)) =
             find_index_in_table_provider::<FullTextDatabaseIndex>(&table_provider)
         else {
             tracing::debug!(
@@ -65,15 +63,16 @@ impl FullTextConnector {
             );
             return None;
         };
+        let indexed = Indexes::new(
+            indexes
+                .into_iter()
+                .cloned()
+                .map(|i| Arc::new(i) as Arc<dyn Index + Send + Sync>)
+                .collect(),
+        );
 
-        let indexed = indexed
-            .into_iter()
-            .cloned()
-            .map(|i| Arc::new(i) as Arc<dyn Index + Send + Sync>)
-            .collect();
-
-        let indexed = Indexes::new(indexed);
-        let ft = Arc::new(FederatedTable::Immediate(underlying));
+        // Use `table_provider` to preserve IndexedTableProvider for `self.inner_connector` whom may need it.
+        let ft = Arc::new(FederatedTable::Immediate(Arc::clone(&table_provider)));
 
         let stream = f(&self.inner_connector, ft)?;
         Some(

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
-use runtime_datafusion_index::{Index, IndexedTableProvider};
+use runtime_datafusion_index::Index;
 use search::generation::text_search::index::FullTextDatabaseIndex;
 use std::any::Any;
 use std::sync::Arc;
@@ -31,7 +31,7 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
-use crate::search::util::{find_concrete_table_provider, find_index_in_table_provider};
+use crate::search::util::find_index_in_table_provider;
 use futures::StreamExt;
 
 /// A [`DataConnector`] middleware that, for [`Dataset`]s needing full text search capabilies, creates a [`IndexedTableProvider`] using the underlying [`TableProvider`]s and a [`FullTextDatabaseIndex`]. If no full text search capabilities are needed it is not unnecessarily nested.
@@ -55,7 +55,7 @@ impl FullTextConnector {
         F: Fn(&Arc<dyn DataConnector>, Arc<FederatedTable>) -> Option<ChangesStream>,
     {
         let table_provider = federated_table.try_table_provider_sync()?;
-        let Some((indexes, _)) =
+        let Some((indexed, _)) =
             find_index_in_table_provider::<FullTextDatabaseIndex>(&table_provider)
         else {
             tracing::debug!(
@@ -64,7 +64,7 @@ impl FullTextConnector {
             return None;
         };
         let indexed = Indexes::new(
-            indexes
+            indexed
                 .into_iter()
                 .cloned()
                 .map(|i| Arc::new(i) as Arc<dyn Index + Send + Sync>)

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -30,7 +30,7 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
-use crate::search::util::{find_concrete_table_provider, find_index_in_table_provider};
+use crate::search::util::find_concrete_table_provider;
 use futures::StreamExt;
 
 /// A [`DataConnector`] middleware that, for [`Dataset`]s needing full text search capabilies, creates a [`IndexedTableProvider`] using the underlying [`TableProvider`]s and a [`FullTextDatabaseIndex`]. If no full text search capabilities are needed it is not unnecessarily nested.

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,8 +16,7 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
-use runtime_datafusion_index::{Index, IndexedTableProvider};
-use search::generation::text_search::index::FullTextDatabaseIndex;
+use runtime_datafusion_index::IndexedTableProvider;
 use std::any::Any;
 use std::sync::Arc;
 


### PR DESCRIPTION
## 📝 Summary
 - Issue when FTS and S3vector index on same table for `refresh_mode: changes`. FTS was removing the `IndexedTableProvider` expected by `EmbeddingConnector`. 