### PR TITLE
Add health probe latency metric

### DIFF
--- a/tools/testoperator/src/health.rs
+++ b/tools/testoperator/src/health.rs
@@ -19,9 +19,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::metrics;
+
 use test_framework::{
     anyhow::{self, Context},
     constants::{HEALTH_ENDPOINT, HTTP_BASE_URL, READY_ENDPOINT},
+    opentelemetry::KeyValue,
     tokio_util::sync::CancellationToken,
 };
 
@@ -116,6 +119,7 @@ impl HealthMonitor {
                     let start = Instant::now();
                     let response = client.get(&url).send().await;
                     let latency = start.elapsed();
+                    let latency_ms = latency.as_secs_f64() * 1_000.0;
 
                     let failure_reason = match response {
                         Ok(response) => {
@@ -133,6 +137,21 @@ impl HealthMonitor {
                         }
                         Err(error) => Some(error.to_string()),
                     };
+
+                    metrics::HEALTH_LATENCY.record(
+                        latency_ms,
+                        &[
+                            KeyValue::new("endpoint", endpoint),
+                            KeyValue::new(
+                                "status",
+                                if failure_reason.is_some() {
+                                    "failure"
+                                } else {
+                                    "success"
+                                },
+                            ),
+                        ],
+                    );
 
                     if let Some(entry) = stats.get_mut(endpoint) {
                         entry.record_sample(latency, failure_reason);

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::sync::LazyLock;
 
-use test_framework::opentelemetry::metrics::Gauge;
+use test_framework::opentelemetry::metrics::{Gauge, Histogram};
 use test_framework::telemetry::METER;
 
 pub static ITERATIONS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
@@ -55,6 +55,14 @@ pub static READY_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
         .u64_gauge("ready_duration_ms")
         .with_description("Duration until the spicepod is ready.")
+        .with_unit("ms")
+        .build()
+});
+
+pub static HEALTH_LATENCY: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("health_latency_ms")
+        .with_description("Latency of /health and /v1/ready probes.")
         .with_unit("ms")
         .build()
 });


### PR DESCRIPTION
Part of #7766

This PR adds a health probe latency histogram metric emitted by testoperator so we can correlate /health and /v1/ready latency with other runtime metrics. The metric records latency in milliseconds with endpoint/status labels.