### PR TITLE
feat: Add an ExactLeftAccumulator implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "futures",
  "log",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-compression",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4430,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4462,12 +4462,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 
 [[package]]
 name = "datafusion-execution"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4544,7 +4544,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6)",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4614,7 +4614,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6)",
  "datafusion-physical-expr-common",
  "itertools 0.14.0",
  "log",
@@ -4624,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4639,14 +4639,14 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
  "datafusion-functions-window-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "chrono",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4811,7 +4811,7 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate-common",
+ "datafusion-functions-aggregate",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "chrono",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7650a35285a04b540b695858128d980d1d1e3d23#7650a35285a04b540b695858128d980d1d1e3d23"
+source = "git+https://github.com/spiceai/datafusion.git?rev=d4649aaba84e02a452cbcad9e11e16b57f934cb6#d4649aaba84e02a452cbcad9e11e16b57f934cb6"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -5306,7 +5306,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5693,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7542,7 +7542,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8132,7 +8132,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10084,7 +10084,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12201,7 +12201,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12238,9 +12238,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13650,7 +13650,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15676,7 +15676,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15868,7 +15868,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark",
@@ -18432,7 +18432,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,25 +307,25 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                       # spiceai/spiceai-50
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }               # spiceai/spiceai-50
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                # spiceai/spiceai-50
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }        # spiceai/spiceai-50
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }            # spiceai/spiceai-50
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }    # spiceai/spiceai-50
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }             # spiceai/spiceai-50
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                  # spiceai/spiceai-50
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }           # spiceai/spiceai-50
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }             # spiceai/spiceai-50
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }         # spiceai/spiceai-50
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" } # spiceai/spiceai-50
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }  # spiceai/spiceai-50
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }         # spiceai/spiceai-50
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                 # spiceai/spiceai-50
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }          # spiceai/spiceai-50
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }               # spiceai/spiceai-50
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }               # spiceai/spiceai-50
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "7650a35285a04b540b695858128d980d1d1e3d23" }                   # spiceai/spiceai-50
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }                       # spiceai/spiceai-50
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }               # spiceai/spiceai-50
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }                # spiceai/spiceai-50
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }        # spiceai/spiceai-50
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }            # spiceai/spiceai-50
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }    # spiceai/spiceai-50
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }             # spiceai/spiceai-50
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }                  # spiceai/spiceai-50
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }           # spiceai/spiceai-50
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }             # spiceai/spiceai-50
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }         # spiceai/spiceai-50
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" } # spiceai/spiceai-50
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }  # spiceai/spiceai-50
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }         # spiceai/spiceai-50
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }                 # spiceai/spiceai-50
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }          # spiceai/spiceai-50
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }               # spiceai/spiceai-50
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }               # spiceai/spiceai-50
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "d4649aaba84e02a452cbcad9e11e16b57f934cb6" }                   # spiceai/spiceai-50
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "9fa10f280175667a54ca18b55aa1320e82737840" } # spiceai
 

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -131,7 +131,7 @@ impl ColumnBounds for ExactColumnBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, Int32Array};
+    use arrow::array::{ArrayRef, Int32Array, UInt64Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::expressions::col;
 
@@ -218,9 +218,9 @@ mod tests {
     #[test]
     fn test_exact_left_accumulator_exceeds_memory() {
         // Test that when the accumulated arrays exceed the maximum in-list memory size, we fallback to a no-op filter
-        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
-        let large_array: ArrayRef = Arc::new(Int32Array::from(
-            (0..(MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION + 1) as i32).collect::<Vec<i32>>(),
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
+        let large_array: ArrayRef = Arc::new(UInt64Array::from(
+            (0..(MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION + 1) as u64).collect::<Vec<u64>>(),
         ));
         let batch = RecordBatch::try_new(Arc::new(schema), vec![large_array])
             .expect("Should create large record batch");

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -16,13 +16,23 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use arrow::{array::{Array, RecordBatch}, datatypes::SchemaRef};
-use datafusion::{physical_plan::{expressions::{InListExpr, Literal}, joins::{CollectLeftAccumulator, ColumnBounds}, PhysicalExpr}, scalar::ScalarValue};
+use arrow::{
+    array::{Array, RecordBatch},
+    datatypes::SchemaRef,
+};
 use datafusion::error::Result as DataFusionResult;
+use datafusion::{
+    physical_plan::{
+        PhysicalExpr,
+        expressions::{InListExpr, Literal},
+        joins::{CollectLeftAccumulator, ColumnBounds},
+    },
+    scalar::ScalarValue,
+};
 
 /// A simple implementation of a CollectLeftAccumulator that collects exact values for dynamic filtering.
 /// Performs no approximation or range merging, simply storing all values seen.
-/// 
+///
 /// Tradeoff: potentially higher memory usage on the build-side of the join, but more precise filtering on the probe-side.
 /// If `JoinSelection` has correctly re-ordered the plan so the larger scan is on the probe-side, this can be beneficial.
 pub struct ExactLeftAccumulator {
@@ -60,24 +70,34 @@ pub struct ExactColumnBounds {
 
 impl ColumnBounds for ExactColumnBounds {
     /// Converts the collected arrays into an InListExpr for use in dynamic filtering.
-     /// This builds an IN expression with all collected values.
+    /// This builds an IN expression with all collected values.
     fn physical_expr(
-            &self,
-            left_expr: Arc<dyn PhysicalExpr>,
-        ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-        let scalar_values = self.arrays.iter().map(|array| {
-            (0..array.len()).map(|i| ScalarValue::try_from_array(array.as_ref(), i)).collect::<DataFusionResult<Vec<ScalarValue>>>()
-        }).collect::<DataFusionResult<Vec<Vec<ScalarValue>>>>()?.into_iter().flatten().collect::<Vec<ScalarValue>>();
-        
-        let expr_values = scalar_values.into_iter().map(|sv| {
-            Arc::new(Literal::new(sv)) as Arc<dyn PhysicalExpr>
-        }).collect::<Vec<_>>();
+        &self,
+        left_expr: Arc<dyn PhysicalExpr>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let scalar_values = self
+            .arrays
+            .iter()
+            .map(|array| {
+                (0..array.len())
+                    .map(|i| ScalarValue::try_from_array(array.as_ref(), i))
+                    .collect::<DataFusionResult<Vec<ScalarValue>>>()
+            })
+            .collect::<DataFusionResult<Vec<Vec<ScalarValue>>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<ScalarValue>>();
+
+        let expr_values = scalar_values
+            .into_iter()
+            .map(|sv| Arc::new(Literal::new(sv)) as Arc<dyn PhysicalExpr>)
+            .collect::<Vec<_>>();
 
         let in_expr = Arc::new(InListExpr::new(
-             left_expr,
+            left_expr,
             expr_values,
             false, // not negated (IN, not NOT IN)
-             None   // no static filter optimization
+            None,  // no static filter optimization
         ));
 
         Ok(in_expr)
@@ -86,15 +106,13 @@ impl ColumnBounds for ExactColumnBounds {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::physical_plan::expressions::col;
     use super::*;
-    use arrow::array::{Int32Array, ArrayRef};
+    use arrow::array::{ArrayRef, Int32Array};
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::expressions::col;
 
     fn create_test_batch() -> RecordBatch {
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-        ]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let a: ArrayRef = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>()));
         RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
     }
@@ -108,23 +126,34 @@ mod tests {
 
         let left_expr = col("a", &schema).expect("Should create column expr");
 
-        let mut accumulator = ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema()).expect("Should create accumulator");
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
 
-        accumulator.update_batch(&batch).expect("Should update batches");
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update batches");
 
         let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
-        let in_expr = column_bounds.physical_expr(left_expr).expect("Should create physical expr");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
 
         // Validate the expression is an InListExpr with the expected values
         if let Some(in_list_expr) = in_expr.as_any().downcast_ref::<InListExpr>() {
-            let expected_values: Vec<ScalarValue> = (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
-            let actual_values: Vec<ScalarValue> = in_list_expr.list().iter().map(|expr| {
-                if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
-                    literal.value().clone()
-                } else {
-                    panic!("Expected Literal expression");
-                }
-            }).collect();
+            let expected_values: Vec<ScalarValue> =
+                (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
+            let actual_values: Vec<ScalarValue> = in_list_expr
+                .list()
+                .iter()
+                .map(|expr| {
+                    if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
+                        literal.value().clone()
+                    } else {
+                        panic!("Expected Literal expression");
+                    }
+                })
+                .collect();
 
             assert_eq!(expected_values, actual_values);
         } else {

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -40,7 +40,7 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
 
     fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
         // eagerly evaluate the expression and store the resulting array
-        // this avoids storing the entire record batch in memory, only storing the evaluated column(s?)
+        // this avoids storing the entire record batch in memory, only storing the evaluated column
         let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
         self.arrays.push(array);
         Ok(())
@@ -59,6 +59,8 @@ pub struct ExactColumnBounds {
 }
 
 impl ColumnBounds for ExactColumnBounds {
+    /// Converts the collected arrays into an InListExpr for use in dynamic filtering.
+     /// This builds an IN expression with all collected values.
     fn physical_expr(
             &self,
             left_expr: Arc<dyn PhysicalExpr>,
@@ -74,8 +76,8 @@ impl ColumnBounds for ExactColumnBounds {
         let in_expr = Arc::new(InListExpr::new(
              left_expr,
             expr_values,
-             false,
-             None
+            false, // not negated (IN, not NOT IN)
+             None   // no static filter optimization
         ));
 
         Ok(in_expr)

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -99,7 +99,7 @@ impl ColumnBounds for ExactColumnBounds {
             return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
         }
 
-        let unique_values= self
+        let unique_values = self
             .arrays
             .iter()
             .flat_map(|array| {
@@ -251,7 +251,8 @@ mod tests {
         // Test that duplicate values are correctly handled and only unique values are included in the InListExpr
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 2, 3, 3, 3]));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
 
         let left_expr = col("a", &batch.schema()).expect("Should create column expr");
 
@@ -271,8 +272,10 @@ mod tests {
         // Validate the expression is an InListExpr with the expected unique values
         let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
         let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
-        let expected_values: Vec<ScalarValue> =
-            vec![1, 2, 3].into_iter().map(|i| ScalarValue::Int32(Some(i))).collect();
+        let expected_values: Vec<ScalarValue> = vec![1, 2, 3]
+            .into_iter()
+            .map(|i| ScalarValue::Int32(Some(i)))
+            .collect();
         let mut actual_values: Vec<ScalarValue> = in_list_expr
             .list()
             .iter()

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -30,8 +30,8 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-const MAXIMUM_INLIST_MEMORY_BYTES: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 128 million i32 keys per partition calculated
-// bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES
+const MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 128 million i32 keys per partition calculated
+// bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION
 // similarly, because rows are distributed across partitions the rows per partition is total_rows / num_partitions
 
 /// A simple implementation of a CollectLeftAccumulator that collects exact values for dynamic filtering.
@@ -89,11 +89,11 @@ impl ColumnBounds for ExactColumnBounds {
             .map(|array| array.get_array_memory_size())
             .sum::<usize>();
 
-        if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES {
+        if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION {
             tracing::debug!(
                 "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes).",
                 total_memory_size,
-                MAXIMUM_INLIST_MEMORY_BYTES
+                MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION
             );
 
             return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
@@ -168,7 +168,7 @@ mod tests {
         let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
         let expected_values: Vec<ScalarValue> =
             (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
-        let actual_values: Vec<ScalarValue> = in_list_expr
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
             .list()
             .iter()
             .map(|expr| {
@@ -179,6 +179,7 @@ mod tests {
                 literal.value().clone()
             })
             .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
         assert_eq!(expected_values, actual_values);
     }
 
@@ -219,7 +220,7 @@ mod tests {
         // Test that when the accumulated arrays exceed the maximum in-list memory size, we fallback to a no-op filter
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let large_array: ArrayRef = Arc::new(Int32Array::from(
-            (0..(MAXIMUM_INLIST_MEMORY_BYTES + 1) as i32).collect::<Vec<i32>>(),
+            (0..(MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION + 1) as i32).collect::<Vec<i32>>(),
         ));
         let batch = RecordBatch::try_new(Arc::new(schema), vec![large_array])
             .expect("Should create large record batch");
@@ -289,6 +290,62 @@ mod tests {
             .collect();
         actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
 
+        assert_eq!(expected_values, actual_values);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_multiple_batches() {
+        // Test that multiple batches can be accumulated correctly
+        let batch1 = {
+            let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+            let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+        };
+
+        let batch2 = {
+            let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+            let a: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+        };
+
+        let left_expr = col("a", &batch1.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch1.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch1)
+            .expect("Should update with batch 1");
+        accumulator
+            .update_batch(&batch2)
+            .expect("Should update with batch 2");
+        accumulator
+            .update_batch(&batch1)
+            .expect("Should update with batch 1 a second time");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected values
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> =
+            (1..=6).map(|i| ScalarValue::Int32(Some(i))).collect();
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
         assert_eq!(expected_values, actual_values);
     }
 }

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use arrow::{
     array::{Array, RecordBatch},
@@ -95,20 +95,17 @@ impl ColumnBounds for ExactColumnBounds {
             return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
         }
 
-        let scalar_values = self
+        let unique_values: HashSet<_> = self
             .arrays
             .iter()
-            .map(|array| {
-                (0..array.len())
-                    .map(|i| ScalarValue::try_from_array(array.as_ref(), i))
-                    .collect::<DataFusionResult<Vec<ScalarValue>>>()
+            .flat_map(|array| {
+                (0..array.len()).map(move |i| ScalarValue::try_from_array(array.as_ref(), i))
             })
-            .collect::<DataFusionResult<Vec<Vec<ScalarValue>>>>()?
+            .collect::<DataFusionResult<Vec<ScalarValue>>>()?
             .into_iter()
-            .flatten()
-            .collect::<Vec<ScalarValue>>();
+            .collect();
 
-        let expr_values = scalar_values
+        let expr_values = unique_values
             .into_iter()
             .map(|sv| Arc::new(Literal::new(sv)) as Arc<dyn PhysicalExpr>)
             .collect::<Vec<_>>();
@@ -160,24 +157,21 @@ mod tests {
             .expect("Should create physical expr");
 
         // Validate the expression is an InListExpr with the expected values
-        if let Some(in_list_expr) = in_expr.as_any().downcast_ref::<InListExpr>() {
-            let expected_values: Vec<ScalarValue> =
-                (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
-            let actual_values: Vec<ScalarValue> = in_list_expr
-                .list()
-                .iter()
-                .map(|expr| {
-                    if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
-                        literal.value().clone()
-                    } else {
-                        panic!("Expected Literal expression");
-                    }
-                })
-                .collect();
-
-            assert_eq!(expected_values, actual_values);
-        } else {
-            panic!("Expected InListExpr");
-        }
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> =
+            (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
+        let actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        assert_eq!(expected_values, actual_values);
     }
 }

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -99,15 +99,13 @@ impl ColumnBounds for ExactColumnBounds {
             return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
         }
 
-        let unique_values: HashSet<_> = self
+        let unique_values= self
             .arrays
             .iter()
             .flat_map(|array| {
                 (0..array.len()).map(move |i| ScalarValue::try_from_array(array.as_ref(), i))
             })
-            .collect::<DataFusionResult<Vec<ScalarValue>>>()?
-            .into_iter()
-            .collect();
+            .collect::<DataFusionResult<HashSet<ScalarValue>>>()?;
 
         if unique_values.is_empty() {
             // No values collected - return a no-op filter (always true)
@@ -214,5 +212,80 @@ mod tests {
         let literal_expr = literal_expr.expect("Should downcast to Literal");
         let expected_value = ScalarValue::Boolean(Some(true));
         assert_eq!(literal_expr.value(), &expected_value);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_exceeds_memory() {
+        // Test that when the accumulated arrays exceed the maximum in-list memory size, we fallback to a no-op filter
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let large_array: ArrayRef = Arc::new(Int32Array::from(
+            (0..(MAXIMUM_INLIST_MEMORY_BYTES + 1) as i32).collect::<Vec<i32>>(),
+        ));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![large_array])
+            .expect("Should create large record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with large batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is a Literal true (no-op filter)
+        let literal_expr = physical_expr.as_any().downcast_ref::<Literal>();
+        let literal_expr = literal_expr.expect("Should downcast to Literal");
+        let expected_value = ScalarValue::Boolean(Some(true));
+        assert_eq!(literal_expr.value(), &expected_value);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_duplicate_values() {
+        // Test that duplicate values are correctly handled and only unique values are included in the InListExpr
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 2, 3, 3, 3]));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected unique values
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> =
+            vec![1, 2, 3].into_iter().map(|i| ScalarValue::Int32(Some(i))).collect();
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
+
+        assert_eq!(expected_values, actual_values);
     }
 }

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -1,0 +1,132 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use arrow::{array::{Array, RecordBatch}, datatypes::SchemaRef};
+use datafusion::{physical_plan::{expressions::{InListExpr, Literal}, joins::{CollectLeftAccumulator, ColumnBounds}, PhysicalExpr}, scalar::ScalarValue};
+use datafusion::error::Result as DataFusionResult;
+
+/// A simple implementation of a CollectLeftAccumulator that collects exact values for dynamic filtering.
+/// Performs no approximation or range merging, simply storing all values seen.
+/// 
+/// Tradeoff: potentially higher memory usage on the build-side of the join, but more precise filtering on the probe-side.
+/// If `JoinSelection` has correctly re-ordered the plan so the larger scan is on the probe-side, this can be beneficial.
+pub struct ExactLeftAccumulator {
+    arrays: Vec<Arc<dyn Array>>,
+    expr: Arc<dyn PhysicalExpr>,
+}
+
+impl CollectLeftAccumulator for ExactLeftAccumulator {
+    fn try_new(expr: Arc<dyn PhysicalExpr>, _schema: &SchemaRef) -> DataFusionResult<Self> {
+        Ok(Self {
+            arrays: Vec::new(),
+            expr,
+        })
+    }
+
+    fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+        // eagerly evaluate the expression and store the resulting array
+        // this avoids storing the entire record batch in memory, only storing the evaluated column(s?)
+        let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
+        self.arrays.push(array);
+        Ok(())
+    }
+
+    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
+        Ok(Arc::new(ExactColumnBounds {
+            arrays: self.arrays,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ExactColumnBounds {
+    arrays: Vec<Arc<dyn Array>>,
+}
+
+impl ColumnBounds for ExactColumnBounds {
+    fn physical_expr(
+            &self,
+            left_expr: Arc<dyn PhysicalExpr>,
+        ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let scalar_values = self.arrays.iter().map(|array| {
+            (0..array.len()).map(|i| ScalarValue::try_from_array(array.as_ref(), i)).collect::<DataFusionResult<Vec<ScalarValue>>>()
+        }).collect::<DataFusionResult<Vec<Vec<ScalarValue>>>>()?.into_iter().flatten().collect::<Vec<ScalarValue>>();
+        
+        let expr_values = scalar_values.into_iter().map(|sv| {
+            Arc::new(Literal::new(sv)) as Arc<dyn PhysicalExpr>
+        }).collect::<Vec<_>>();
+
+        let in_expr = Arc::new(InListExpr::new(
+             left_expr,
+            expr_values,
+             false,
+             None
+        ));
+
+        Ok(in_expr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::physical_plan::expressions::col;
+    use super::*;
+    use arrow::array::{Int32Array, ArrayRef};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    fn create_test_batch() -> RecordBatch {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+        ]);
+        let a: ArrayRef = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>()));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    #[test]
+    fn test_exact_left_accumulator() {
+        // Test the ExactLeftAccumulator implementation. Define a sample PhysicalExpr with a projection for a column to be scanned into a dynamic filter
+        // In this scenario, we pass through a record batch with 10 values. We then build the column bounds, and verify the returned PhysicalExpr is an InListExpr with the expected values.
+        let batch = create_test_batch();
+        let schema = batch.schema();
+
+        let left_expr = col("a", &schema).expect("Should create column expr");
+
+        let mut accumulator = ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema()).expect("Should create accumulator");
+
+        accumulator.update_batch(&batch).expect("Should update batches");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds.physical_expr(left_expr).expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected values
+        if let Some(in_list_expr) = in_expr.as_any().downcast_ref::<InListExpr>() {
+            let expected_values: Vec<ScalarValue> = (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
+            let actual_values: Vec<ScalarValue> = in_list_expr.list().iter().map(|expr| {
+                if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
+                    literal.value().clone()
+                } else {
+                    panic!("Expected Literal expression");
+                }
+            }).collect();
+
+            assert_eq!(expected_values, actual_values);
+        } else {
+            panic!("Expected InListExpr");
+        }
+    }
+}

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -30,7 +30,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-const MAXIMUM_INLIST_MEMORY_BYTES: usize = 128 * 1024 * 1024; // 128Mb - approx 128 million i32 keys per partition calculated
+const MAXIMUM_INLIST_MEMORY_BYTES: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 128 million i32 keys per partition calculated
 // bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES
 // similarly, because rows are distributed across partitions the rows per partition is total_rows / num_partitions
 
@@ -53,6 +53,10 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
     }
 
     fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+
         // eagerly evaluate the expression and store the resulting array
         // this avoids storing the entire record batch in memory, only storing the evaluated column
         let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
@@ -104,6 +108,11 @@ impl ColumnBounds for ExactColumnBounds {
             .collect::<DataFusionResult<Vec<ScalarValue>>>()?
             .into_iter()
             .collect();
+
+        if unique_values.len() == 0 {
+            // No values collected - return a no-op filter (always true)
+            return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true)))));
+        }
 
         let expr_values = unique_values
             .into_iter()
@@ -173,5 +182,36 @@ mod tests {
             })
             .collect();
         assert_eq!(expected_values, actual_values);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_empty_batch() {
+        // Test that updating with an empty batch does not cause errors and results in an always-true filter
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let empty_batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(
+            Vec::<i32>::new(),
+        ))])
+        .expect("Should create empty record batch");
+
+        let left_expr = col("a", &empty_batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &empty_batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&empty_batch)
+            .expect("Should update with empty batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is a Literal true (no-op filter)
+        let literal_expr = physical_expr.as_any().downcast_ref::<Literal>();
+        let literal_expr = literal_expr.expect("Should downcast to Literal");
+        let expected_value = ScalarValue::Boolean(Some(true));
+        assert_eq!(literal_expr.value(), &expected_value);
     }
 }

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -188,9 +188,10 @@ mod tests {
     fn test_exact_left_accumulator_empty_batch() {
         // Test that updating with an empty batch does not cause errors and results in an always-true filter
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
-        let empty_batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(
-            Vec::<i32>::new(),
-        ))])
+        let empty_batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new()))],
+        )
         .expect("Should create empty record batch");
 
         let left_expr = col("a", &empty_batch.schema()).expect("Should create column expr");

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -86,9 +86,8 @@ impl ColumnBounds for ExactColumnBounds {
             .sum::<usize>();
 
         if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES {
-            tracing::warn!(
-                "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes). \
-                Consider using a different accumulator with approximation or range merging to reduce memory usage.",
+            tracing::debug!(
+                "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes).",
                 total_memory_size,
                 MAXIMUM_INLIST_MEMORY_BYTES
             );

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -34,7 +34,7 @@ const MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION: usize = 128 * 1024 * 1024; // 1
 // bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION
 // similarly, because rows are distributed across partitions the rows per partition is total_rows / num_partitions
 
-/// A simple implementation of a CollectLeftAccumulator that collects exact values for dynamic filtering.
+/// A simple implementation of a `CollectLeftAccumulator` that collects exact values for dynamic filtering.
 /// Performs no approximation or range merging, simply storing all values seen.
 ///
 /// Tradeoff: potentially higher memory usage on the build-side of the join, but more precise filtering on the probe-side.
@@ -77,7 +77,7 @@ pub struct ExactColumnBounds {
 }
 
 impl ColumnBounds for ExactColumnBounds {
-    /// Converts the collected arrays into an InListExpr for use in dynamic filtering.
+    /// Converts the collected arrays into an `InListExpr` for use in dynamic filtering.
     /// This builds an IN expression with all collected values.
     fn physical_expr(
         &self,
@@ -86,7 +86,7 @@ impl ColumnBounds for ExactColumnBounds {
         let total_memory_size = self
             .arrays
             .iter()
-            .map(|array| array.get_array_memory_size())
+            .map(arrow::array::Array::get_array_memory_size)
             .sum::<usize>();
 
         if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION {

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -30,6 +30,10 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
+const MAXIMUM_INLIST_MEMORY_BYTES: usize = 128 * 1024 * 1024; // 128Mb - approx 128 million i32 keys per partition calculated
+// bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES
+// similarly, because rows are distributed across partitions the rows per partition is total_rows / num_partitions
+
 /// A simple implementation of a CollectLeftAccumulator that collects exact values for dynamic filtering.
 /// Performs no approximation or range merging, simply storing all values seen.
 ///
@@ -75,6 +79,23 @@ impl ColumnBounds for ExactColumnBounds {
         &self,
         left_expr: Arc<dyn PhysicalExpr>,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let total_memory_size = self
+            .arrays
+            .iter()
+            .map(|array| array.get_array_memory_size())
+            .sum::<usize>();
+
+        if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES {
+            tracing::warn!(
+                "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes). \
+                Consider using a different accumulator with approximation or range merging to reduce memory usage.",
+                total_memory_size,
+                MAXIMUM_INLIST_MEMORY_BYTES
+            );
+
+            return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
+        }
+
         let scalar_values = self
             .arrays
             .iter()

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -109,7 +109,7 @@ impl ColumnBounds for ExactColumnBounds {
             .into_iter()
             .collect();
 
-        if unique_values.len() == 0 {
+        if unique_values.is_empty() {
             // No values collected - return a no-op filter (always true)
             return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true)))));
         }

--- a/crates/runtime-datafusion/src/lib.rs
+++ b/crates/runtime-datafusion/src/lib.rs
@@ -19,6 +19,7 @@ pub mod execution_plan;
 pub mod extension;
 pub mod schema_provider;
 pub mod stream_utils;
+pub mod join_accumulator;
 
 use snafu::prelude::*;
 

--- a/crates/runtime-datafusion/src/lib.rs
+++ b/crates/runtime-datafusion/src/lib.rs
@@ -17,9 +17,9 @@ limitations under the License.
 pub mod config;
 pub mod execution_plan;
 pub mod extension;
+pub mod join_accumulator;
 pub mod schema_provider;
 pub mod stream_utils;
-pub mod join_accumulator;
 
 use snafu::prelude::*;
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds an `ExactLeftAccumulator` implementation of a `CollectLeftAccumulator` for exact hash-join build side dynamic filter column bounds calculation.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #8052 