### PR TITLE
DistributeFileScanOptimizer: Improve planning performance

### DIFF
--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -234,7 +234,7 @@ impl DistributeFileScanOptimizer {
         .with_batch_size(original_file_scan.batch_size)
         .with_constraints(original_file_scan.constraints.clone())
         .with_expr_adapter(original_file_scan.expr_adapter_factory.clone())
-        .with_file_compression_type(original_file_scan.file_compression_type.clone())
+        .with_file_compression_type(original_file_scan.file_compression_type)
         .with_file_groups(stage)
         .with_limit(original_file_scan.limit)
         .with_metadata_cols(original_file_scan.metadata_cols.clone())

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -238,7 +238,7 @@ impl DistributeFileScanOptimizer {
         .with_file_groups(stage)
         .with_limit(original_file_scan.limit)
         .with_metadata_cols(original_file_scan.metadata_cols.clone())
-        .with_object_versioning_type(original_file_scan.object_versioning_type)
+        .with_object_versioning_type(original_file_scan.object_versioning_type.clone())
         .with_output_ordering(original_file_scan.output_ordering.clone())
         .with_projection(original_file_scan.projection.clone())
         .with_statistics(original_file_scan.statistics()?)

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -238,7 +238,7 @@ impl DistributeFileScanOptimizer {
         .with_file_groups(stage)
         .with_limit(original_file_scan.limit)
         .with_metadata_cols(original_file_scan.metadata_cols.clone())
-        .with_object_versioning_type(original_file_scan.object_versioning_type.clone())
+        .with_object_versioning_type(original_file_scan.object_versioning_type)
         .with_output_ordering(original_file_scan.output_ordering.clone())
         .with_projection(original_file_scan.projection.clone())
         .with_statistics(original_file_scan.statistics()?)

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -228,8 +228,8 @@ impl DistributeFileScanOptimizer {
         // expensive to clone for large scans
         let new_scan = FileScanConfigBuilder::new(
             original_file_scan.object_store_url.clone(),
-            original_file_scan.file_schema.clone(),
-            original_file_scan.file_source.clone(),
+            Arc::clone(&original_file_scan.file_schema),
+            Arc::clone(&original_file_scan.file_source),
         )
         .with_batch_size(original_file_scan.batch_size)
         .with_constraints(original_file_scan.constraints.clone())

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -231,7 +231,7 @@ impl DistributeFileScanOptimizer {
             original_file_scan.file_schema.clone(),
             original_file_scan.file_source.clone(),
         )
-        .with_batch_size(original_file_scan.batch_size.clone())
+        .with_batch_size(original_file_scan.batch_size)
         .with_constraints(original_file_scan.constraints.clone())
         .with_expr_adapter(original_file_scan.expr_adapter_factory.clone())
         .with_file_compression_type(original_file_scan.file_compression_type.clone())

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -236,7 +236,7 @@ impl DistributeFileScanOptimizer {
         .with_expr_adapter(original_file_scan.expr_adapter_factory.clone())
         .with_file_compression_type(original_file_scan.file_compression_type.clone())
         .with_file_groups(stage)
-        .with_limit(original_file_scan.limit.clone())
+        .with_limit(original_file_scan.limit)
         .with_metadata_cols(original_file_scan.metadata_cols.clone())
         .with_object_versioning_type(original_file_scan.object_versioning_type.clone())
         .with_output_ordering(original_file_scan.output_ordering.clone())

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/distribute_file_scan.rs
@@ -145,7 +145,7 @@ impl DistributeFileScanOptimizer {
         let partitioned_files = file_scan_config
             .file_groups
             .iter()
-            .flat_map(|fg| fg.clone().into_inner())
+            .flat_map(|fg| fg.iter().cloned())
             .collect::<Vec<_>>();
 
         let read_size: u64 = partitioned_files.iter().map(Self::read_size).sum();
@@ -218,6 +218,46 @@ impl DistributeFileScanOptimizer {
 
         Ok(new_exec)
     }
+
+    fn stage_to_new_file_scan(
+        original_file_scan: &FileScanConfig,
+        stage: Vec<FileGroup>,
+        task_partitions: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Copy all existing attributes including projection, excluding file groups as they are potentially
+        // expensive to clone for large scans
+        let new_scan = FileScanConfigBuilder::new(
+            original_file_scan.object_store_url.clone(),
+            original_file_scan.file_schema.clone(),
+            original_file_scan.file_source.clone(),
+        )
+        .with_batch_size(original_file_scan.batch_size.clone())
+        .with_constraints(original_file_scan.constraints.clone())
+        .with_expr_adapter(original_file_scan.expr_adapter_factory.clone())
+        .with_file_compression_type(original_file_scan.file_compression_type.clone())
+        .with_file_groups(stage)
+        .with_limit(original_file_scan.limit.clone())
+        .with_metadata_cols(original_file_scan.metadata_cols.clone())
+        .with_object_versioning_type(original_file_scan.object_versioning_type.clone())
+        .with_output_ordering(original_file_scan.output_ordering.clone())
+        .with_projection(original_file_scan.projection.clone())
+        .with_statistics(original_file_scan.statistics()?)
+        .with_table_partition_cols(
+            original_file_scan
+                .table_partition_cols
+                .iter()
+                .map(|field| field.as_ref().clone())
+                .collect(),
+        )
+        .build();
+
+        // Propagate source partitioning
+        let new_scan_partitioning = new_scan.output_partitioning();
+        let new_data_source_exec =
+            DataSourceExec::new(Arc::new(new_scan)).with_partitioning(new_scan_partitioning);
+
+        Self::with_stage_repartition(Arc::new(new_data_source_exec), task_partitions)
+    }
 }
 
 impl PhysicalOptimizerRule for DistributeFileScanOptimizer {
@@ -262,18 +302,9 @@ impl PhysicalOptimizerRule for DistributeFileScanOptimizer {
             let exploded_scans = new_stages
                 .into_iter()
                 .map(|stage| {
-                    // Copy all existing attributes including projection, but override file groups
-                    let new_scan = FileScanConfigBuilder::from(file_scan_config.clone())
-                        .with_file_groups(stage)
-                        .build();
-
-                    // Propagate source partitioning
-                    let new_scan_partitioning = new_scan.output_partitioning();
-                    let new_data_source_exec = DataSourceExec::new(Arc::new(new_scan))
-                        .with_partitioning(new_scan_partitioning);
-
-                    Self::with_stage_repartition(
-                        Arc::new(new_data_source_exec),
+                    Self::stage_to_new_file_scan(
+                        file_scan_config,
+                        stage,
                         config.execution.target_partitions,
                     )
                 })

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -526,6 +526,9 @@ pub async fn start(
     };
 
     // If running an executor, we may have resolved another port to bind if 50051 is taken
+    // Cast truncation for port is OK: was originally widened from u32 because it's a u32 in
+    // Ballista `ExecutorRegistration`
+    #[allow(clippy::cast_possible_truncation)]
     #[cfg(feature = "cluster")]
     let bind_address = rt
         .df
@@ -547,7 +550,7 @@ pub async fn start(
             })
         })
         .and_then(|mut addrs| addrs.next())
-        .unwrap_or_else(|| bind_address);
+        .unwrap_or(bind_address);
 
     tracing::info!("Spice Runtime Flight listening on {bind_address}");
     runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -541,10 +541,11 @@ pub async fn start(
                 .and_then(|e| e.metadata.host.clone().map(|h| (h, e.metadata.port as u16)))
         })
         .and_then(|spec| {
+            let (host, port) = &spec;
             tokio::task::block_in_place(|| match spec.to_socket_addrs() {
                 Ok(sa) => Some(sa),
                 Err(e) => {
-                    tracing::error!("Unable to resolve bound executor host {e}");
+                    tracing::error!("Unable to resolve bound executor host {host}:{port}: {e}");
                     None
                 }
             })

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -19,6 +19,7 @@ use {
     crate::config::ClusterMode,
     ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     ballista_executor::flight_service::BallistaFlightService, std::net::SocketAddr,
+    std::net::ToSocketAddrs,
 };
 
 use crate::auth::EndpointAuth;
@@ -527,23 +528,19 @@ pub async fn start(
 
     // If running an executor, we may have resolved another port to bind if 50051 is taken
     #[cfg(feature = "cluster")]
-    let bind_address: SocketAddr = if let Some((host, port)) =
-        rt.df.executor.read().ok().and_then(|maybe_executor| {
+    let bind_address = rt
+        .df
+        .executor
+        .read()
+        .ok()
+        .and_then(|maybe_executor| {
             maybe_executor
                 .as_ref()
-                .and_then(|e| e.metadata.host.clone().map(|h| (h, e.metadata.port)))
-        }) {
-        if let Ok(addr) = format!("{host}:{port}").parse() {
-            addr
-        } else {
-            tracing::warn!(
-                "Failed to parse executor address {host}:{port}, using default bind_address {bind_address}"
-            );
-            bind_address
-        }
-    } else {
-        bind_address
-    };
+                .and_then(|e| e.metadata.host.clone().map(|h| (h, e.metadata.port as u16)))
+        })
+        .and_then(|spec| spec.to_socket_addrs().ok())
+        .and_then(|mut addrs| addrs.next())
+        .unwrap_or_else(|| bind_address);
 
     tracing::info!("Spice Runtime Flight listening on {bind_address}");
     runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -18,8 +18,7 @@ limitations under the License.
 use {
     crate::config::ClusterMode,
     ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
-    ballista_executor::flight_service::BallistaFlightService, std::net::SocketAddr,
-    std::net::ToSocketAddrs,
+    ballista_executor::flight_service::BallistaFlightService, std::net::ToSocketAddrs,
 };
 
 use crate::auth::EndpointAuth;
@@ -538,7 +537,15 @@ pub async fn start(
                 .as_ref()
                 .and_then(|e| e.metadata.host.clone().map(|h| (h, e.metadata.port as u16)))
         })
-        .and_then(|spec| spec.to_socket_addrs().ok())
+        .and_then(|spec| {
+            tokio::task::block_in_place(|| match spec.to_socket_addrs() {
+                Ok(sa) => Some(sa),
+                Err(e) => {
+                    tracing::error!("Unable to resolve bound executor host {e}");
+                    None
+                }
+            })
+        })
         .and_then(|mut addrs| addrs.next())
         .unwrap_or_else(|| bind_address);
 

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -445,6 +445,7 @@ fn is_address_in_use_error(err: &tonic::transport::Error) -> bool {
 /// # Panics
 /// If running in clustered mode, will panic unless TLS is configured or user manually overrides
 /// this safety check, as RPC will transmit sensitive information to executors.
+#[allow(clippy::too_many_lines)]
 pub async fn start(
     bind_address: std::net::SocketAddr,
     app: Option<Arc<App>>,

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -526,7 +526,7 @@ pub async fn start(
     };
 
     // If running an executor, we may have resolved another port to bind if 50051 is taken
-    // Cast truncation for port is OK: was originally widened from u32 because it's a u32 in
+    // Cast truncation for port is OK: was originally widened to u32 because it's a u32 in
     // Ballista `ExecutorRegistration`
     #[allow(clippy::cast_possible_truncation)]
     #[cfg(feature = "cluster")]


### PR DESCRIPTION
## 📝 Summary

I profiled the planning pipeline and found that this was cloning FileScanConfig only to dump its original groups. For large data lake tables this planning step could take over a minute. For the same scan it now takes ~10s.

Before:
<img width="659" height="305" alt="image" src="https://github.com/user-attachments/assets/f15760aa-a969-4579-b7b5-eee3f951c5aa" />

After: (now JSON ser/de from the Delta scan is the highest time spend)
<img width="669" height="398" alt="image" src="https://github.com/user-attachments/assets/252edb5e-e5ab-435e-88b6-3008645ebf41" />
