### PR TITLE
Return computed embeddings from index for partitioned S3Vectors

### DIFF
--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::{any::Any, sync::Arc};
 
 use arrow::array::RecordBatch;
+use arrow::compute::concat_batches;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 use data_components::s3_vectors::compute_query::{CachedQueryVector, ComputeQueryVector};
@@ -120,14 +121,16 @@ impl SearchIndex for S3Vector {
         &self,
         record: RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+        let input_schema = record.schema();
         match self.partition_by.first() {
             Some(partition_by) => {
-                let input_dfschema = DFSchema::try_from(record.schema())?;
+                let input_dfschema = DFSchema::try_from(Arc::clone(&input_schema))?;
                 let execution_props = ExecutionProps::new();
                 let physical_expr =
                     create_physical_expr(partition_by, &input_dfschema, &execution_props)?;
                 let partitions = partition_batch(&record, physical_expr.as_ref())?;
 
+                let mut data = vec![];
                 for (partition_value, partition_record) in partitions.into_values() {
                     let id = self.table.current_index();
                     // change the index name to a partition name
@@ -136,9 +139,17 @@ impl SearchIndex for S3Vector {
                             tracing::warn!(
                                 "Partitioning is not supported when index ARN is provided. Please provide the bucket and index name instead."
                             );
-                            return write::write(self, &self.table, record, self.batch_write_rows)
+                            data.push(
+                                write::write(
+                                    self,
+                                    &self.table,
+                                    partition_record,
+                                    self.batch_write_rows,
+                                )
                                 .await
-                                .boxed();
+                                .boxed()?,
+                            );
+                            continue;
                         }
                         S3VectorIdentifier::Index {
                             bucket_name,
@@ -176,19 +187,22 @@ impl SearchIndex for S3Vector {
                         )
                     })?;
 
-                    write::write(self, &table, partition_record, self.batch_write_rows)
+                    // This is the bug. We don't return the augmented RecordBatch (that has the vectors).
+                    let rb = write::write(self, &table, partition_record, self.batch_write_rows)
                         .await
                         .boxed()?;
+                    data.push(rb);
                 }
+                let schema = data
+                    .first()
+                    .map(|rb| rb.schema())
+                    .unwrap_or_else(|| Arc::clone(&input_schema));
+                concat_batches(&schema, data.iter()).boxed()
             }
-            None => {
-                return write::write(self, &self.table, record, self.batch_write_rows)
-                    .await
-                    .boxed();
-            }
+            None => write::write(self, &self.table, record, self.batch_write_rows)
+                .await
+                .boxed(),
         }
-
-        Ok(record)
     }
 
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -187,7 +187,6 @@ impl SearchIndex for S3Vector {
                         )
                     })?;
 
-                    // This is the bug. We don't return the augmented RecordBatch (that has the vectors).
                     let rb = write::write(self, &table, partition_record, self.batch_write_rows)
                         .await
                         .boxed()?;

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -194,8 +194,7 @@ impl SearchIndex for S3Vector {
                 }
                 let schema = data
                     .first()
-                    .map(|rb| rb.schema())
-                    .unwrap_or_else(|| Arc::clone(&input_schema));
+                    .map_or_else(|| Arc::clone(&input_schema), RecordBatch::schema);
                 concat_batches(&schema, data.iter()).boxed()
             }
             None => write::write(self, &self.table, record, self.batch_write_rows)


### PR DESCRIPTION
## 📝 Summary
**Fix for the following bug**
With spicepod
```yaml
datasets:
  - from: file:./data/mega-science-small.jsonl
    name: mega_science_ds
    acceleration:
      enabled: true
    vectors:
      enabled: true
      engine: s3_vectors
      partition_by:
        - bucket(3, id)
      params:
        s3_vectors_bucket: team-app-journals-jeadie2
    columns:
      - name: question
        embeddings:
          - from: potion_base_8m
            row_id: id
```
Run
```sql
select id, question_embedding from mega_science_ds limit 10;
```
```
+----+--------------------+
| id | question_embedding |
+----+--------------------+
| 6  |                    |
| 15 |                    |
| 23 |                    |
| 27 |                    |
| 28 |                    |
| 36 |                    |
| 45 |                    |
| 63 |                    |
| 64 |                    |
| 65 |                    |
+----+--------------------+

Time: 0.007326209 seconds. 10 rows.
```

Note: This did not affect vector_search i.e.
```sql
--- non-null `question_embedding`
select id, question_embedding from vector_search(mega_science_ds, 'hello') limit 10;
```