### PR TITLE
deps: Upgrade Vortex to 0.56

### DIFF
--- a/.github/workflows/benchmarks_search.yml
+++ b/.github/workflows/benchmarks_search.yml
@@ -26,6 +26,7 @@ on:
           - 'full_text_search-duckdb[file]'
           - 'hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]'
           - 'model2vec[potion-multilingual-128M]-duckdb[file]'
+          - 'model2vec[potion-multilingual-128M]-cayenne[file]'
 
 concurrency:
   # Allow only one workflow per any non-trunk branch.
@@ -58,6 +59,7 @@ jobs:
               { name: "full_text_search-cayenne[file]" },
               { name: "hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]" },
               { name: "model2vec[potion-multilingual-128M]-duckdb[file]" },
+              { name: "model2vec[potion-multilingual-128M]-cayenne[file]" },
             ];
 
             const configuration = context.payload.inputs?.configuration || 'all';

--- a/.github/workflows/benchmarks_search.yml
+++ b/.github/workflows/benchmarks_search.yml
@@ -18,9 +18,11 @@ on:
         options:
           - 'all'
           - 'openai[text-embedding-3-small]-arrow'
+          - 'openai[text-embedding-3-small]-cayenne[file]'
           - 'openai[text-embedding-3-small]-duckdb[file]'
           - 'openai[text-embedding-3-small[chunking]]-duckdb[file]'
           - 'openai[text-embedding-3-small]-s3_vectors'
+          - 'full_text_search-cayenne[file]'
           - 'full_text_search-duckdb[file]'
           - 'hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]'
           - 'model2vec[potion-multilingual-128M]-duckdb[file]'
@@ -48,10 +50,12 @@ jobs:
           script: |
             const matrix = [
               { name: "openai[text-embedding-3-small]-arrow" },
+              { name: "openai[text-embedding-3-small]-cayenne[file]" },
               { name: "openai[text-embedding-3-small]-duckdb[file]" },
               { name: "openai[text-embedding-3-small[chunking]]-duckdb[file]" },
               { name: "openai[text-embedding-3-small]-s3_vectors" },
               { name: "full_text_search-duckdb[file]" },
+              { name: "full_text_search-cayenne[file]" },
               { name: "hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]" },
               { name: "model2vec[potion-multilingual-128M]-duckdb[file]" },
             ];

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,6 @@ dependencies = [
  "vortex-datafusion",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-fastlanes",
  "vortex-fsst",
  "vortex-runend",
@@ -3906,6 +3905,16 @@ name = "cudarc"
 version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
+dependencies = [
+ "half",
+ "libloading",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0cfc5e22a6b6f7d04ee45b0151232ca236ede8ca3534210fd4072bdead0d60"
 dependencies = [
  "half",
  "libloading",
@@ -17432,8 +17441,10 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
+ "fastlanes",
+ "rand 0.9.2",
  "vortex-alp",
  "vortex-array",
  "vortex-btrblocks",
@@ -17441,10 +17452,8 @@ dependencies = [
  "vortex-bytebool",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-fastlanes",
  "vortex-file",
  "vortex-flatbuffers",
@@ -17470,7 +17479,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -17489,7 +17498,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arcref",
  "arrow-arith",
@@ -17532,6 +17541,7 @@ dependencies = [
  "vortex-io",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-proto",
  "vortex-scalar",
  "vortex-session",
  "vortex-utils",
@@ -17541,7 +17551,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "getrandom 0.3.4",
  "itertools 0.14.0",
@@ -17554,7 +17564,6 @@ dependencies = [
  "vortex-buffer",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
  "vortex-fastlanes",
@@ -17571,11 +17580,12 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-buffer",
  "bitvec",
  "bytes",
+ "cudarc 0.18.1",
  "itertools 0.14.0",
  "num-traits",
  "simdutf8",
@@ -17585,7 +17595,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -17599,7 +17609,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -17615,7 +17625,7 @@ dependencies = [
 [[package]]
 name = "vortex-datafusion"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -17648,7 +17658,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -17663,7 +17673,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -17673,32 +17683,12 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
-]
-
-[[package]]
-name = "vortex-dict"
-version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "num-traits",
- "prost 0.14.1",
- "rustc-hash 2.1.1",
- "vortex-array",
- "vortex-buffer",
- "vortex-dtype",
- "vortex-error",
- "vortex-mask",
- "vortex-scalar",
- "vortex-utils",
- "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-dtype"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -17722,7 +17712,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -17734,31 +17724,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "vortex-expr"
-version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
-dependencies = [
- "arcref",
- "itertools 0.14.0",
- "parking_lot 0.12.5",
- "paste",
- "prost 0.14.1",
- "termtree",
- "vortex-array",
- "vortex-buffer",
- "vortex-dtype",
- "vortex-error",
- "vortex-mask",
- "vortex-proto",
- "vortex-scalar",
- "vortex-session",
- "vortex-utils",
-]
-
-[[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -17768,6 +17736,7 @@ dependencies = [
  "log",
  "num-traits",
  "prost 0.14.1",
+ "static_assertions",
  "vortex-array",
  "vortex-buffer",
  "vortex-compute",
@@ -17782,7 +17751,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -17802,10 +17771,8 @@ dependencies = [
  "vortex-bytebool",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-fastlanes",
  "vortex-flatbuffers",
  "vortex-fsst",
@@ -17827,7 +17794,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -17836,7 +17803,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "async-trait",
  "fsst-rs",
@@ -17853,7 +17820,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "async-compat",
  "async-fs",
@@ -17883,7 +17850,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -17900,7 +17867,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arcref",
  "arrow-buffer",
@@ -17927,10 +17894,8 @@ dependencies = [
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-flatbuffers",
  "vortex-io",
  "vortex-mask",
@@ -17946,7 +17911,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -17956,7 +17921,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "getrandom 0.3.4",
  "parking_lot 0.12.5",
@@ -17967,23 +17932,25 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "pco",
  "prost 0.14.1",
  "vortex-array",
  "vortex-buffer",
+ "vortex-compute",
  "vortex-dtype",
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -17992,7 +17959,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -18010,7 +17977,7 @@ dependencies = [
 [[package]]
 name = "vortex-scalar"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-array",
  "bytes",
@@ -18021,14 +17988,16 @@ dependencies = [
  "vortex-buffer",
  "vortex-dtype",
  "vortex-error",
+ "vortex-mask",
  "vortex-proto",
  "vortex-utils",
+ "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -18043,7 +18012,6 @@ dependencies = [
  "vortex-buffer",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-io",
  "vortex-layout",
  "vortex-mask",
@@ -18054,7 +18022,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -18072,7 +18040,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "dashmap",
  "vortex-error",
@@ -18082,7 +18050,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -18099,7 +18067,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.1",
@@ -18108,7 +18076,7 @@ dependencies = [
 [[package]]
 name = "vortex-vector"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "paste",
  "static_assertions",
@@ -18121,7 +18089,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "vortex-array",
@@ -18136,7 +18104,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=1ba461239306a4c7def92bc0e6e8cb06dd78adf4#1ba461239306a4c7def92bc0e6e8cb06dd78adf4"
+source = "git+https://github.com/spiceai/vortex?rev=c279ace2ebe54eee109c760930621979cff6372f#c279ace2ebe54eee109c760930621979cff6372f"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ imap = { git = "https://github.com/jonhoo/rust-imap", rev = "6fe22ed11a1ccffe179
 indexmap = "2"
 insta = { version = "1.43.0", features = ["filters"] }
 itertools = "0.14"
+linkme = "0.3.35"
 logos = "0.15.1"
 mailparse = "0.16.1"
 moka = { version = "0.12", features = ["future"] }
@@ -210,7 +211,6 @@ parquet = "56.0.0"
 paste = "1.0.15"
 pem = "3.0.4"
 percent-encoding = "2.3.1"
-linkme = "0.3.35"
 pin-project = "1.1"
 postcard = { version = "1.1.3", features = ["use-std"] }
 prometheus = "0.14"
@@ -279,22 +279,21 @@ url = "2.5"
 util = { path = "crates/util" }
 uuid = "1"
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
-vortex = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-alp = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-array = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-bytebool = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-datetime-parts = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-decimal-byte-parts = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-dict = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-fastlanes = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-fsst = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-runend = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-sequence = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-session = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-sparse = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
-vortex-zigzag = { git = "https://github.com/spiceai/vortex", rev = "1ba461239306a4c7def92bc0e6e8cb06dd78adf4" }
+vortex = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-alp = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-array = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-bytebool = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-datetime-parts = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-decimal-byte-parts = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-fastlanes = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-fsst = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-runend = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-sequence = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-session = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-sparse = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
+vortex-zigzag = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 x509-certificate = "0.25.0"
 # TODO: Switch to official crate once spice-rs is released
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "0ca5a48dae189bc4297350cba7265e9c6036188b" }

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -43,7 +43,6 @@ vortex-bytebool = { workspace = true }
 vortex-datafusion = { workspace = true }
 vortex-datetime-parts = { workspace = true }
 vortex-decimal-byte-parts = { workspace = true }
-vortex-dict = { workspace = true }
 vortex-fastlanes = { workspace = true }
 vortex-fsst = { workspace = true }
 vortex-runend = { workspace = true }

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -109,9 +109,14 @@ fn is_vortex_supported_type(data_type: &DataType) -> bool {
             | DataType::LargeBinary
             | DataType::Utf8
             | DataType::LargeUtf8
+            | DataType::Decimal32(_, _)
+            | DataType::Decimal64(_, _)
             | DataType::Decimal128(_, _)
             | DataType::Decimal256(_, _)
             | DataType::List(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::LargeList(_)
+            | DataType::Struct(_)
     )
 }
 

--- a/test/spicepods/search/mteb/quora/full_text_search-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/quora/full_text_search-cayenne[file].yaml
@@ -1,0 +1,30 @@
+version: v1
+kind: Spicepod
+name: full_text_search-cayenne[file]
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true

--- a/test/spicepods/search/mteb/quora/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/quora/model2vec[potion-multilingual-128M]-cayenne[file].yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-duckdb[file]
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/quora/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/quora/model2vec[potion-multilingual-128M]-cayenne[file].yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: model2vec[potion-multilingual-128M]-duckdb[file]
+name: model2vec[potion-multilingual-128M]-cayenne[file]
 datasets:
 
   # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
@@ -10,7 +10,7 @@ datasets:
     name: corpus
     acceleration:
       enabled: true
-      engine: duckdb
+      engine: cayenne
       mode: file
     columns:
       - name: text

--- a/test/spicepods/search/mteb/quora/openai[text-embedding-3-small]-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/quora/openai[text-embedding-3-small]-cayenne[file].yaml
@@ -1,0 +1,36 @@
+version: v1
+kind: Spicepod
+name: openai[text-embedding-3-small]-cayenne[file]
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: openai_embed
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Upgrades Vortex to 0.56
* Enables some additional data types as being supported by Vortex
* Adds test spicepods for search tests with full text, openai and model2vec backed by Cayenne
