### PR TITLE
Exclude MySQL SF100 from test-operator dispatch

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf100/accelerated/indexes/mysql-duckdb[file]-indexes.yaml
+++ b/tools/testoperator/dispatch/tpch/sf100/accelerated/indexes/mysql-duckdb[file]-indexes.yaml
@@ -1,7 +1,0 @@
-tests:
-  bench:
-    spicepod_path: accelerated/indexes/mysql-duckdb[file]-indexes.yaml
-    query_set: tpch
-    runner_type: spiceai-dev-large-runners
-    ready_wait: 6000
-    scale_factor: 100

--- a/tools/testoperator/dispatch/tpch/sf100/accelerated/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf100/accelerated/mysql-duckdb[file].yaml
@@ -1,7 +1,0 @@
-tests:
-  bench:
-    spicepod_path: accelerated/mysql-duckdb[file].yaml
-    query_set: tpch
-    runner_type: spiceai-dev-large-runners
-    ready_wait: 6000
-    scale_factor: 100


### PR DESCRIPTION
## 📝 Summary

Temporary excluding MySQL SF100 benchmarks from test-operator dispatch 

>Unknown database 'tpch_sf100' Ensure the given MySQL database exists

## 🔗 Related

https://github.com/spiceai/spiceai/issues/8178

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
