### PR TITLE
fix(glue): Prevent OpenDAL from automatic loading of AWS credentials from environment

### DIFF
--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -424,6 +424,11 @@ async fn create_iceberg_provider(
         props.insert(S3_SESSION_TOKEN.to_string(), session_token.to_string());
     }
 
+    // Disable OpenDAL's automatic credential loading from environment variables and config files.
+    // As we provide explicit credentials, we don't want OpenDAL to pick up AWS_SESSION_TOKEN
+    // or other credentials from the environment that may not be valid for this specific connection.
+    props.insert("s3.disable-config-load".to_string(), "true".to_string());
+
     props.insert(
         GLUE_CATALOG_PROP_WAREHOUSE.to_string(),
         metadata_location.to_string(),


### PR DESCRIPTION
## 📝 Summary

The `iceberg-rust` library uses [OpenDAL](https://github.com/apache/opendal) for S3 file operations. By default, OpenDAL's S3 backend loads credentials from multiple sources including:
1. Explicitly provided properties
2. Environment variables (AWS_ACCESS_KEY_ID, etc.)
3. AWS config files (~/.aws/config)

Even when we always explicitly provide all credentials in the props, OpenDAL would still pick up `AWS_SESSION_TOKEN` from the environment and include it in AWS API requests. This causes authentication failures as the session token can be associated with different credentials than the explicitly provided access key/secret.

To prevent this behavior, we specify `s3.disable-config-load=true` to tell OpenDAL to only use the credentials explicitly provided in props, ignoring environment variables and AWS config files.

## 🔗 Related

Fixes 
 - https://github.com/spiceai/spiceai/issues/8332

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
