### PR TITLE
Fix search query provider

### DIFF
--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer_explain.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second', answer) order by score desc LIMIT 4"
+snapshot_kind: text
 ---
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                                                      |
@@ -15,7 +16,7 @@ description: "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second', 
 |               |       ProjectionExec: expr=[id@1 as id, answer@0 as answer, trunc(score@2, 3) as trunc(text_search(qs, Utf8("second"), answer).score,Int64(3)), score@2 as score]                                                         |
 |               |         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                                                              |
 |               |           ProjectionExec: expr=[answer@2 as answer, id@0 as id, score@1 as score]                                                                                                                                         |
-|               |             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[id@0, score@1, answer@3]                                                                                                       |
+|               |             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@1)], projection=[id@0, score@1, answer@2]                                                                                                       |
 |               |               CoalescePartitionsExec                                                                                                                                                                                      |
 |               |                 CooperativeExec                                                                                                                                                                                           |
 |               |                   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                                                    |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_basic_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_basic_explain.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second') order by score desc LIMIT 4"
+snapshot_kind: text
 ---
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                      |
@@ -15,7 +16,7 @@ description: "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second') 
 |               |       ProjectionExec: expr=[id@1 as id, answer@0 as answer, trunc(score@2, 3) as trunc(text_search(qs, Utf8("second")).score,Int64(3)), score@2 as score]                                 |
 |               |         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                              |
 |               |           ProjectionExec: expr=[answer@2 as answer, id@0 as id, score@1 as score]                                                                                                         |
-|               |             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[id@0, score@1, answer@3]                                                                       |
+|               |             HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@1)], projection=[id@0, score@1, answer@2]                                                                       |
 |               |               CoalescePartitionsExec                                                                                                                                                      |
 |               |                 CooperativeExec                                                                                                                                                           |
 |               |                   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                    |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters_explain.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, answer, trunc(score, 3) as score FROM text_search(qs, 'secondary') where subject!='math' order by score desc LIMIT 4"
+snapshot_kind: text
 ---
 +---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                               |
@@ -12,7 +13,7 @@ description: "SELECT id, answer, trunc(score, 3) as score FROM text_search(qs, '
 |               |   SortExec: TopK(fetch=4), expr=[score@2 DESC], preserve_partitioning=[true]                                                                                       |
 |               |     ProjectionExec: expr=[id@0 as id, answer@2 as answer, trunc(score@1, 3) as score]                                                                              |
 |               |       FilterExec: subject@3 != math, projection=[id@0, score@1, answer@2]                                                                                          |
-|               |         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[id@0, score@1, answer@3, subject@4]                                         |
+|               |         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@1)], projection=[id@0, score@1, answer@2, subject@4]                                         |
 |               |           CoalescePartitionsExec                                                                                                                                   |
 |               |             CooperativeExec                                                                                                                                        |
 |               |               RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                 |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_no_score_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_no_score_explain.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, answer FROM text_search(qs, 'second') order by score desc LIMIT 4"
+snapshot_kind: text
 ---
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                              |
@@ -11,7 +12,7 @@ description: "SELECT id, answer FROM text_search(qs, 'second') order by score de
 |               |       TableScan: text_search(qs, Utf8("second")) projection=[answer, id, score]                                                   |
 | physical_plan | ProjectionExec: expr=[id@0 as id, answer@2 as answer]                                                                             |
 |               |   SortExec: TopK(fetch=4), expr=[score@1 DESC], preserve_partitioning=[false]                                                     |
-|               |     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[id@0, score@1, answer@3]                       |
+|               |     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@1)], projection=[id@0, score@1, answer@2]                       |
 |               |       CoalescePartitionsExec                                                                                                      |
 |               |         CooperativeExec                                                                                                           |
 |               |           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                    |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection_explain.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, answer, question, subject, trunc(score, 3) as score FROM text_search(qs, 'second') order by score desc LIMIT 4"
+snapshot_kind: text
 ---
 +---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                                                                         |
@@ -12,8 +13,8 @@ description: "SELECT id, answer, question, subject, trunc(score, 3) as score FRO
 |               |   SortExec: TopK(fetch=4), expr=[score@4 DESC], preserve_partitioning=[true]                                                                                                                                                                 |
 |               |     ProjectionExec: expr=[id@1 as id, answer@0 as answer, question@2 as question, subject@4 as subject, trunc(score@3, 3) as score]                                                                                                          |
 |               |       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                                                                                   |
-|               |         ProjectionExec: expr=[answer@3 as answer, id@0 as id, question@2 as question, score@1 as score, subject@4 as subject]                                                                                                                |
-|               |           HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[id@0, score@1, question@3, answer@4, subject@5]                                                                                                     |
+|               |         ProjectionExec: expr=[answer@2 as answer, id@0 as id, question@3 as question, score@1 as score, subject@4 as subject]                                                                                                                |
+|               |           HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@1)], projection=[id@0, score@1, answer@2, question@4, subject@5]                                                                                                     |
 |               |             CoalescePartitionsExec                                                                                                                                                                                                           |
 |               |               CooperativeExec                                                                                                                                                                                                                |
 |               |                 RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                                                                         |

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -154,6 +154,7 @@ impl SearchQueryProvider {
 
         base_table_cols.extend(self.primary_key.clone());
 
+        // Include columns for all filters.
         let before_final_filter: Vec<String> = filters
             .iter()
             .flat_map(|f| {
@@ -171,16 +172,41 @@ impl SearchQueryProvider {
             .sorted()
             .collect();
 
-        let before_final_filter =
-            projection_from_columns(&self.table_provider.schema(), &before_final_filter);
+        let mut scan = LogicalPlanBuilder::scan(
+            "base_table",
+            Arc::new(DefaultTableSource::new(
+                Arc::clone(&self.table_provider) as Arc<dyn TableProvider>
+            )),
+            Some(projection_from_columns(
+                &self.table_provider.schema(),
+                &before_final_filter,
+            )),
+        )?;
 
-        // Get filters that can be pushed down to the base table
+        if let Some(f) = self.base_table_filters(filters)? {
+            scan = scan.filter(f)?;
+        }
+
+        // Only return columns 1. asked for in projection or 2. Needed by filters but not in search schema.
+        // Previous projection `before_final_filter` included all columns needed by filters.
+        base_table_cols.extend(columns_missing_from(filters, search_index_schema));
+        scan.project(
+            base_table_cols
+                .iter()
+                .map(|c| SelectExpr::Expression(col(c)))
+                .collect::<Vec<_>>(),
+        )?
+        .build()
+    }
+
+    // Get filters that can be pushed down to the base table
+    fn base_table_filters(&self, filters: &[Expr]) -> Result<Option<Expr>, DataFusionError> {
         let filter_refs: Vec<_> = filters.iter().collect();
         let supported_filters = self
             .table_provider
             .supports_filters_pushdown(filter_refs.as_slice())?;
 
-        let pushdown_filter: Option<Expr> = filters
+        Ok(filters
             .iter()
             .zip(supported_filters.iter())
             .filter_map(|(f, supp)| {
@@ -191,27 +217,7 @@ impl SearchQueryProvider {
                     Some(f.clone())
                 }
             })
-            .reduce(Expr::and);
-
-        let mut scan = LogicalPlanBuilder::scan(
-            "base_table",
-            Arc::new(DefaultTableSource::new(
-                Arc::clone(&self.table_provider) as Arc<dyn TableProvider>
-            )),
-            Some(before_final_filter),
-        )?;
-
-        if let Some(f) = pushdown_filter {
-            scan = scan.filter(f)?;
-        }
-        base_table_cols.extend(columns_missing_from(filters, search_index_schema));
-        scan.project(
-            base_table_cols
-                .iter()
-                .map(|c| SelectExpr::Expression(col(c)))
-                .collect::<Vec<_>>(),
-        )?
-        .build()
+            .reduce(Expr::and))
     }
 
     fn join_with_base(

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -34,7 +34,9 @@ use datafusion::{
     prelude::{Expr, array_element, binary_expr, cast, col, ident, lit, substring},
     sql::TableReference,
 };
+use datafusion_expr::select_expr::SelectExpr;
 use futures::future::BoxFuture;
+use itertools::Itertools;
 
 use crate::{
     SEARCH_MATCH_COLUMN_NAME, SEARCH_SCORE_COLUMN_NAME,
@@ -149,14 +151,28 @@ impl SearchQueryProvider {
         for f in search_index_schema.fields() {
             base_table_cols.remove(f.name());
         }
+
         base_table_cols.extend(self.primary_key.clone());
 
-        // Also include any columns needed for filters on base table.
-        base_table_cols.extend(columns_missing_from(filters, search_index_schema));
-        let base_table_cols: Vec<_> = base_table_cols.into_iter().collect();
-        let mut base_proj =
-            projection_from_columns(&self.table_provider.schema(), &base_table_cols);
-        base_proj.sort_unstable(); // Deterministic LogicalPlans
+        let before_final_filter: Vec<String> = filters
+            .iter()
+            .flat_map(|f| {
+                f.column_refs()
+                    .iter()
+                    .map(|c| c.name().to_string())
+                    .collect::<Vec<_>>()
+            })
+            // Sort for deterministic LogicalPlans
+            .collect::<HashSet<String>>()
+            .union(&base_table_cols)
+            .cloned()
+            .collect::<Vec<String>>()
+            .into_iter()
+            .sorted()
+            .collect();
+
+        let before_final_filter =
+            projection_from_columns(&self.table_provider.schema(), &before_final_filter);
 
         // Get filters that can be pushed down to the base table
         let filter_refs: Vec<_> = filters.iter().collect();
@@ -164,7 +180,7 @@ impl SearchQueryProvider {
             .table_provider
             .supports_filters_pushdown(filter_refs.as_slice())?;
 
-        let underlying_filter: Option<Expr> = filters
+        let pushdown_filter: Option<Expr> = filters
             .iter()
             .zip(supported_filters.iter())
             .filter_map(|(f, supp)| {
@@ -182,13 +198,20 @@ impl SearchQueryProvider {
             Arc::new(DefaultTableSource::new(
                 Arc::clone(&self.table_provider) as Arc<dyn TableProvider>
             )),
-            Some(base_proj),
+            Some(before_final_filter),
         )?;
 
-        if let Some(f) = underlying_filter {
+        if let Some(f) = pushdown_filter {
             scan = scan.filter(f)?;
         }
-        scan.build()
+        base_table_cols.extend(columns_missing_from(filters, search_index_schema));
+        scan.project(
+            base_table_cols
+                .iter()
+                .map(|c| SelectExpr::Expression(col(c)))
+                .collect::<Vec<_>>(),
+        )?
+        .build()
     }
 
     fn join_with_base(

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -194,7 +194,7 @@ impl SearchQueryProvider {
             base_table_cols
                 .iter()
                 .map(|c| SelectExpr::Expression(ident(c)))
-                .sorted_by_key(|c| c.to_string()), // Sort for deterministic LogicalPlans
+                .sorted_by_key(ToString::to_string), // Sort for deterministic LogicalPlans
         )?
         .build()
     }

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -193,8 +193,7 @@ impl SearchQueryProvider {
         scan.project(
             base_table_cols
                 .iter()
-                .map(|c| SelectExpr::Expression(col(c)))
-                .collect::<Vec<_>>(),
+                .map(|c| SelectExpr::Expression(col(c))),
         )?
         .build()
     }

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -193,7 +193,8 @@ impl SearchQueryProvider {
         scan.project(
             base_table_cols
                 .iter()
-                .map(|c| SelectExpr::Expression(col(c))),
+                .map(|c| SelectExpr::Expression(ident(c)))
+                .sorted_by_key(|c| c.to_string()), // Sort for deterministic LogicalPlans
         )?
         .build()
     }


### PR DESCRIPTION
This pull request updates the search query provider logic and refines several test snapshots to ensure more accurate and deterministic query planning. The main changes are focused on improving how base table columns and filters are handled for search queries, as well as updating the expected query plans in test snapshots to reflect these improvements.

**Search Query Provider Improvements:**

* Refactored the logic for determining which columns to include in the base table scan, now collecting all columns referenced by filters and ensuring deterministic ordering using sorting. This results in more accurate and predictable logical plans for queries involving filters.
* Changed the projection step to use `SelectExpr::Expression(ident(c))` for each column, sorted for deterministic logical plans, and separated the logic for applying filters that can be pushed down to the base table into a dedicated method `base_table_filters`.
* Updated the filter pushdown logic to return an `Option<Expr>` directly, simplifying the code and improving readability.
* Added imports for `SelectExpr` and `Itertools` to support new projection and sorting logic.

**Test Snapshot Updates:**

* Updated several test snapshots (`integration_models__models__search__text_search_*_explain.snap`) to reflect changes in the logical plan, mainly updating the `HashJoinExec` step to use correct join keys and projections based on the new column handling logic. [[1]](diffhunk://#diff-ae171fdc159d4c3d8b4a0e92b8d083568806ff7691dc405494bf06a9876de0aaL18-R19) [[2]](diffhunk://#diff-28b0b6df57f8094b74b075e3ef186c74c69d851dca0f842766ad97bb931e54c2L18-R19) [[3]](diffhunk://#diff-9c58fe4a1c32a98ad65edde92708fda1f11da468b132ae51c3484c055746f040L15-R16) [[4]](diffhunk://#diff-6c6411ec54879937aec60ed5716b099bc9116af4824a567945950c4dfd146d20L14-R15) [[5]](diffhunk://#diff-91c33d9b7660c674ed56507fadadc6ae40f389dbedcd6fb4bb014715c9678ff5L15-R17)
* Added `snapshot_kind: text` to all affected test snapshot files for consistency and clarity. [[1]](diffhunk://#diff-ae171fdc159d4c3d8b4a0e92b8d083568806ff7691dc405494bf06a9876de0aaR4) [[2]](diffhunk://#diff-28b0b6df57f8094b74b075e3ef186c74c69d851dca0f842766ad97bb931e54c2R4) [[3]](diffhunk://#diff-9c58fe4a1c32a98ad65edde92708fda1f11da468b132ae51c3484c055746f040R4) [[4]](diffhunk://#diff-6c6411ec54879937aec60ed5716b099bc9116af4824a567945950c4dfd146d20R4) [[5]](diffhunk://#diff-91c33d9b7660c674ed56507fadadc6ae40f389dbedcd6fb4bb014715c9678ff5R4)