### PR TITLE
Acceleration file_create mode

### DIFF
--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -58,7 +58,12 @@ impl From<spicepod_acceleration::RefreshMode> for RefreshMode {
 pub enum Mode {
     #[default]
     Memory,
+    /// Open an existing file if it exists, otherwise create a new one.
+    /// This is the default file behavior that preserves data across restarts.
     File,
+    /// Always create a new file, truncating/overwriting any existing file on startup.
+    /// Use this when you want a fresh acceleration on each startup.
+    FileCreate,
 }
 
 impl From<spicepod_acceleration::Mode> for Mode {
@@ -66,6 +71,7 @@ impl From<spicepod_acceleration::Mode> for Mode {
         match mode {
             spicepod_acceleration::Mode::Memory => Mode::Memory,
             spicepod_acceleration::Mode::File => Mode::File,
+            spicepod_acceleration::Mode::FileCreate => Mode::FileCreate,
         }
     }
 }
@@ -75,6 +81,7 @@ impl Display for Mode {
         match self {
             Mode::Memory => write!(f, "memory"),
             Mode::File => write!(f, "file"),
+            Mode::FileCreate => write!(f, "file_create"),
         }
     }
 }

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -552,7 +552,11 @@ impl Dataset {
                 return true;
             }
 
-            return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
+            return acceleration.enabled
+                && matches!(
+                    acceleration.mode,
+                    acceleration::Mode::File | acceleration::Mode::FileCreate
+                );
         }
 
         false

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -239,7 +239,11 @@ impl AccelerationSource for View {
             if acceleration.engine == acceleration::Engine::PostgreSQL {
                 return false;
             }
-            return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
+            return acceleration.enabled
+                && matches!(
+                    acceleration.mode,
+                    acceleration::Mode::File | acceleration::Mode::FileCreate
+                );
         }
         false
     }

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use super::{AccelerationSource, DataAccelerator};
-use crate::component::dataset::acceleration::{Engine, RefreshMode};
+use crate::component::dataset::acceleration::{Engine, Mode, RefreshMode};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
@@ -629,6 +629,22 @@ impl DataAccelerator for CayenneAccelerator {
         }
 
         let dir_path = self.file_path(source)?;
+
+        // If mode is FileCreate, delete the existing directory to start fresh
+        if let Some(acceleration) = source.acceleration()
+            && acceleration.mode == Mode::FileCreate
+        {
+            let path_buf = PathBuf::from(&dir_path);
+            if path_buf.exists() {
+                tracing::warn!(
+                    "Cayenne acceleration mode is 'file_create', removing existing directory: {}",
+                    dir_path
+                );
+                std::fs::remove_dir_all(&path_buf).map_err(|err| {
+                    Error::AccelerationInitializationFailed { source: err.into() }
+                })?;
+            }
+        }
 
         // Create the vortex data directory if it doesn't exist
         let path_buf = PathBuf::from(&dir_path);

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -202,7 +202,7 @@ impl DuckDBAccelerator {
 
                 // If the path is Some, we're counting the number of file instances
                 if let Some(this_file_path) = path {
-                    if acceleration.mode == Mode::File
+                    if matches!(acceleration.mode, Mode::File | Mode::FileCreate)
                         && let Ok(file_path) = self.file_path(ds.as_ref())
                         && this_file_path == file_path
                     {
@@ -364,6 +364,20 @@ impl DataAccelerator for DuckDBAccelerator {
                 .into());
             }
 
+            // If mode is FileCreate, delete the existing file to start fresh
+            if acceleration.mode == Mode::FileCreate {
+                let file_path = std::path::Path::new(&path);
+                if file_path.exists() {
+                    tracing::warn!(
+                        "DuckDB acceleration mode is 'file_create', removing existing file: {}",
+                        path
+                    );
+                    std::fs::remove_file(file_path).map_err(|err| {
+                        Error::AccelerationInitializationFailed { source: err.into() }
+                    })?;
+                }
+            }
+
             download_snapshot_if_needed(acceleration, source, PathBuf::from(path)).await;
 
             self.get_shared_pool(source).await?;
@@ -433,10 +447,10 @@ impl DataAccelerator for DuckDBAccelerator {
                             .map(|view| view as Arc<dyn AccelerationSource>),
                     )
                     .filter_map(|other_source| {
-                        if other_source
-                            .acceleration()
-                            .is_some_and(|a| a.engine == Engine::DuckDB && a.mode == Mode::File)
-                        {
+                        if other_source.acceleration().is_some_and(|a| {
+                            a.engine == Engine::DuckDB
+                                && matches!(a.mode, Mode::File | Mode::FileCreate)
+                        }) {
                             if other_source.name() == source.name() {
                                 None
                             } else {

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -144,7 +144,7 @@ impl DuckDBAccelerator {
         })?;
 
         let pool = match (duckdb_file, acceleration.mode) {
-            (Ok(duckdb_file), Mode::File) => {
+            (Ok(duckdb_file), Mode::File | Mode::FileCreate) => {
                 let num_accelerating_datasets = self.get_num_accelerating_datasets(
                     Some(duckdb_file.as_str()),
                     &source.app(),
@@ -175,7 +175,7 @@ impl DuckDBAccelerator {
                     .boxed()
                     .context(AccelerationCreationFailedSnafu)?
             }
-            (Err(e), Mode::File) => {
+            (Err(e), Mode::File | Mode::FileCreate) => {
                 return Err(Error::InvalidConfiguration {
                     detail: Arc::from(e.to_string()),
                 });

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -156,7 +156,9 @@ impl SqliteAccelerator {
         })?;
 
         let mode = match acceleration.mode {
-            Mode::File => datafusion_table_providers::sql::db_connection_pool::Mode::File,
+            Mode::File | Mode::FileCreate => {
+                datafusion_table_providers::sql::db_connection_pool::Mode::File
+            }
             Mode::Memory => datafusion_table_providers::sql::db_connection_pool::Mode::Memory,
         };
         let file_path: Arc<str> = sqlite_file.into();

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -245,6 +245,20 @@ impl DataAccelerator for SqliteAccelerator {
                 .into());
             }
 
+            // If mode is FileCreate, delete the existing file to start fresh
+            if acceleration.mode == Mode::FileCreate {
+                let file_path = std::path::Path::new(&path);
+                if file_path.exists() {
+                    tracing::warn!(
+                        "SQLite acceleration mode is 'file_create', removing existing file: {}",
+                        path
+                    );
+                    std::fs::remove_file(file_path).map_err(|err| {
+                        Error::AccelerationInitializationFailed { source: err.into() }
+                    })?;
+                }
+            }
+
             download_snapshot_if_needed(acceleration, source, PathBuf::from(path)).await;
 
             self.get_shared_pool(source).await?;
@@ -285,11 +299,10 @@ impl DataAccelerator for SqliteAccelerator {
             let attach_databases = datasets
                 .iter()
                 .filter_map(|other_dataset| {
-                    if other_dataset
-                        .acceleration
-                        .as_ref()
-                        .is_some_and(|a| a.engine == Engine::Sqlite && a.mode == Mode::File)
-                    {
+                    if other_dataset.acceleration.as_ref().is_some_and(|a| {
+                        a.engine == Engine::Sqlite
+                            && matches!(a.mode, Mode::File | Mode::FileCreate)
+                    }) {
                         if other_dataset.name() == source.name() {
                             None
                         } else {

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -54,7 +54,7 @@ use std::{any::Any, ffi::OsStr, path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
 use crate::{
-    component::dataset::acceleration::Engine,
+    component::dataset::acceleration::{Engine, Mode},
     dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed},
     datafusion::udf::deny_spice_specific_functions,
     make_spice_data_directory,
@@ -481,6 +481,20 @@ impl DataAccelerator for TursoAccelerator {
                     extension: extension.to_string(),
                 }
                 .into());
+            }
+
+            // If mode is FileCreate, delete the existing file to start fresh
+            if acceleration.mode == Mode::FileCreate {
+                let file_path = std::path::Path::new(&path);
+                if file_path.exists() {
+                    tracing::warn!(
+                        "Turso acceleration mode is 'file_create', removing existing file: {}",
+                        path
+                    );
+                    std::fs::remove_file(file_path).map_err(|err| {
+                        Error::AccelerationInitializationFailed { source: err.into() }
+                    })?;
+                }
             }
 
             download_snapshot_if_needed(acceleration, source, PathBuf::from(path)).await;

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -80,7 +80,7 @@ fn acceleration_info(
 ) -> String {
     let mut info: String = acceleration.engine.to_string();
 
-    if acceleration.mode == Mode::File {
+    if matches!(acceleration.mode, Mode::File | Mode::FileCreate) {
         info.push_str(":file");
     }
 

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -38,11 +38,16 @@ pub enum RefreshMode {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Mode {
     #[default]
     Memory,
+    /// Open an existing file if it exists, otherwise create a new one.
+    /// This is the default file behavior that preserves data across restarts.
     File,
+    /// Always create a new file, truncating/overwriting any existing file on startup.
+    /// Use this when you want a fresh acceleration on each startup.
+    FileCreate,
 }
 
 impl Display for Mode {
@@ -50,6 +55,7 @@ impl Display for Mode {
         match self {
             Mode::Memory => write!(f, "memory"),
             Mode::File => write!(f, "file"),
+            Mode::FileCreate => write!(f, "file_create"),
         }
     }
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -45,7 +45,7 @@ fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::R
     // determine if any dataset has acceleration enabled with a file mode engine
     if !app.datasets.iter().any(|ds| {
         ds.acceleration.as_ref().is_some_and(|accel| {
-            accel.mode == Mode::File
+            matches!(accel.mode, Mode::File | Mode::FileCreate)
                 && accel.enabled
                 && matches!(
                     accel.engine.as_deref(),


### PR DESCRIPTION
This pull request introduces a new acceleration mode called `FileCreate` across the runtime and pod components, allowing accelerators to always start with a fresh file or directory by deleting any existing data on startup. The changes ensure consistent handling of this new mode in all relevant data accelerator implementations and update logic throughout the codebase to recognize both `File` and `FileCreate` modes where appropriate.

**New acceleration mode support**

* Added a new `Mode::FileCreate` variant to the `Mode` enum in both `crates/runtime/src/component/dataset/acceleration.rs` and `crates/spicepod/src/acceleration/mod.rs`, with corresponding documentation and serialization changes. Also updated `Display` impl to support the new variant. [[1]](diffhunk://#diff-06a609276374dc5843d7d4aabfe2103557bfdbaae8789fe2708d3b4b397e7433R61-R74) [[2]](diffhunk://#diff-ffd0f99a436e6cb04abc37797418f21a8f761b463c7df7af39d91ff945773cfcL41-R58) [[3]](diffhunk://#diff-06a609276374dc5843d7d4aabfe2103557bfdbaae8789fe2708d3b4b397e7433R84)

**Data accelerator initialization logic**

* Updated `CayenneAccelerator`, `DuckDBAccelerator`, `SqliteAccelerator`, and `TursoAccelerator` to delete existing files or directories when `Mode::FileCreate` is set, ensuring a clean slate on each startup. [[1]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817R633-R648) [[2]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65R367-R380) [[3]](diffhunk://#diff-5d25568388463053d28e6c987f8e4ce316e0656be3cd9849f0bdc54f8a36faeeR248-R261) [[4]](diffhunk://#diff-bc5f8c3c3461578fd76b0d750e9bca08e383b90fa93b87e2c02d7e9d995fc304R486-R499)

**Mode recognition and logic consistency**

* Updated logic throughout the codebase to treat both `File` and `FileCreate` modes equivalently where file-based acceleration is required, including in dataset/view checks, file counting, attach logic, and tracing output. [[1]](diffhunk://#diff-acc59d490facbf94df24c25fb68d5de42ae92a5350e46954bc6f87305070c5f9L555-R559) [[2]](diffhunk://#diff-a15483e828ece3b12a5be5329f9bf5375e21515edb88f77eb2d2c50c5b5a427eL242-R246) [[3]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65L205-R205) [[4]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65L436-R453) [[5]](diffhunk://#diff-5d25568388463053d28e6c987f8e4ce316e0656be3cd9849f0bdc54f8a36faeeL288-R305) [[6]](diffhunk://#diff-16b3edcbb4b5d03afd7f9c374f51ec50cc3455368d29c04372a39aef17245f47L83-R83) [[7]](diffhunk://#diff-ad88502cdc3c2475baae2477516c93aef6f7800c5f9576bd73506102b5bb7c5cL48-R48)

**Imports and code hygiene**

* Updated imports in several files to include the new `Mode` variant where needed for proper type resolution. [[1]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817L42-R42) [[2]](diffhunk://#diff-bc5f8c3c3461578fd76b0d750e9bca08e383b90fa93b87e2c02d7e9d995fc304L57-R57)

These changes collectively provide a more flexible and robust acceleration initialization process, supporting workflows that require either persistent or always-fresh file-based acceleration.