### PR TITLE
Don't block on lock in FTS query path

### DIFF
--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -52,6 +52,7 @@ pub struct FullTextDatabaseIndex {
 
     // Read queries will be blocking during index writes.
     pub index: Arc<std::sync::RwLock<tantivy::Index>>,
+    pub reader: tantivy::IndexReader,
 }
 
 impl std::fmt::Debug for FullTextDatabaseIndex {
@@ -121,12 +122,14 @@ impl FullTextDatabaseIndex {
         } else {
             tantivy::Index::create_in_ram(tantivy_schema)
         };
+        let reader = index.reader().context(TextSearchIndexingSnafu)?;
 
         Ok(Self {
             base_table: inner,
             search_fields,
             index: Arc::new(std::sync::RwLock::new(index)),
             primary_key: pks,
+            reader,
         })
     }
 
@@ -157,13 +160,8 @@ impl FullTextDatabaseIndex {
         &self,
         search_field: &str,
     ) -> Result<FullTextSearchFieldIndex, super::Error> {
-        let index_read = self
-            .index
-            .read()
-            .map_err(|_| super::Error::TemporarilyFailedToAccessSearchIndex {})?;
-
         let mut search_index = FullTextSearchFieldIndex::try_new(
-            &index_read,
+            self.reader.searcher(),
             search_field.to_string(),
             self.primary_key.clone(),
         )?;
@@ -274,7 +272,9 @@ impl FullTextDatabaseIndex {
                 .context(FailedToInsertDataIntoIndexSnafu)?;
         }
         drop(index_writable);
-        Ok(())
+        self.reader.reload().boxed().context(InvalidIndexingSnafu {
+            context: "Data successfully rewritten to full-text index, but failed to reload search path. Queries will be served from previous revision until the next update.".to_string(),
+        })
     }
 
     #[must_use]
@@ -297,6 +297,7 @@ impl FullTextDatabaseIndex {
             primary_key: self.primary_key.clone(),
             index: Arc::clone(&self.index),
             base_table,
+            reader: self.reader.clone(),
         }
     }
 

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -29,6 +29,7 @@ use runtime_datafusion_index::Index;
 use snafu::ResultExt;
 use tantivy::schema::{DocParsingError, SchemaBuilder};
 use tantivy::{TantivyDocument, TantivyError};
+use tokio::sync::Mutex;
 
 use crate::aggregation::write_to_json_string;
 use crate::generation::text_search::query::FullTextSearchQuery;
@@ -50,8 +51,8 @@ pub struct FullTextDatabaseIndex {
     pub primary_key: Vec<String>,
     pub base_table: Arc<dyn TableProvider>,
 
-    // Read queries will be blocking during index writes.
-    pub index: Arc<std::sync::RwLock<tantivy::Index>>,
+    // `index` access should only be needed for write path. Query/reads should use [`self::reader`].
+    pub index: Arc<Mutex<tantivy::Index>>,
     pub reader: tantivy::IndexReader,
 }
 
@@ -87,7 +88,7 @@ impl Index for FullTextDatabaseIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        if let Err(e) = self.update_index(batches.as_slice()) {
+        if let Err(e) = self.update_index(batches.as_slice()).await {
             tracing::error!("Failed to update full text search index: {e}");
             return Err(DataFusionError::External(Box::new(e)));
         }
@@ -127,7 +128,7 @@ impl FullTextDatabaseIndex {
         Ok(Self {
             base_table: inner,
             search_fields,
-            index: Arc::new(std::sync::RwLock::new(index)),
+            index: Arc::new(Mutex::new(index)),
             primary_key: pks,
             reader,
         })
@@ -218,7 +219,7 @@ impl FullTextDatabaseIndex {
     /// columns present will be ignored.
     ///
     /// If there is a multi-column primary key (as specified by [`Self::primary_key`]), an additional column is used in the [`tantivy::Index`] for unique lookup (required since updates = deletion -> insertion).
-    fn update_index(&self, rb: &[RecordBatch]) -> Result<(), super::Error> {
+    async fn update_index(&self, rb: &[RecordBatch]) -> Result<(), super::Error> {
         // Construct column for `INDEX_UNIQUE_FIELD_NAME` if needed.
         let rb = if self.primary_key.len() > 1 {
             rb.iter()
@@ -233,14 +234,7 @@ impl FullTextDatabaseIndex {
 
         // Updates in tantivy are a deletion then insertion.
         // Prepare documents to insert/delete with read lock.
-        let index_read =
-            self.index
-                .read()
-                .map_err(|_| super::Error::FailedToInsertDataIntoIndex {
-                    source: TantivyError::Poisoned,
-                })?;
-        let index_schema = index_read.schema();
-        drop(index_read);
+        let index_schema = self.reader.searcher().schema().clone();
         let terms_to_delete = self.existing_terms_to_delete(&index_schema, &rb)?;
         let doc_json = write_to_json_string(&rb).context(InvalidIndexingSnafu {
             context: "Failed to write data to intermediate JSON string for indexing".to_string(),
@@ -248,32 +242,25 @@ impl FullTextDatabaseIndex {
         let docs = parse_json_array(&index_schema, doc_json.as_str())
             .context(FailedToInsertDataIntoIndexSnafu)?;
 
-        // Write to index with write lock.
-        let index_writable =
-            self.index
-                .write()
-                .map_err(|_| super::Error::FailedToInsertDataIntoIndex {
-                    source: TantivyError::Poisoned,
-                })?;
-        {
-            let mut index_writer: tantivy::IndexWriter = index_writable
-                .writer(MINIMUM_MEMORY_BUDGET_FOR_MEMORY_INDEX)
-                .context(IndexCreationSnafu)?;
-            // Deletion.
-            for t in terms_to_delete {
-                index_writer.delete_term(t);
-            }
-            // Insertion.
-            for doc in docs {
-                index_writer.add_document(doc).context(IndexCreationSnafu)?;
-            }
-            index_writer
-                .commit()
-                .context(FailedToInsertDataIntoIndexSnafu)?;
+        let index_writable = self.index.lock().await;
+        let mut index_writer: tantivy::IndexWriter = index_writable
+            .writer(MINIMUM_MEMORY_BUDGET_FOR_MEMORY_INDEX)
+            .context(IndexCreationSnafu)?;
+        // Deletion.
+        for t in terms_to_delete {
+            index_writer.delete_term(t);
         }
+        // Insertion.
+        for doc in docs {
+            index_writer.add_document(doc).context(IndexCreationSnafu)?;
+        }
+        index_writer
+            .commit()
+            .context(FailedToInsertDataIntoIndexSnafu)?;
         drop(index_writable);
+
         self.reader.reload().boxed().context(InvalidIndexingSnafu {
-            context: "Data successfully rewritten to full-text index, but failed to reload search path. Queries will be served from previous revision until the next update.".to_string(),
+            context: "Data successfully written to full-text index, but failed to update search path to reference the latest commit. Queries will be served from previous revision until the next update.".to_string(),
         })
     }
 
@@ -434,7 +421,7 @@ impl SearchIndex for FullTextDatabaseIndex {
         &self,
         record: RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
-        self.update_index(slice::from_ref(&record)).boxed()?;
+        self.update_index(slice::from_ref(&record)).await.boxed()?;
         Ok(record)
     }
 

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -259,7 +259,7 @@ impl FullTextDatabaseIndex {
             .context(FailedToInsertDataIntoIndexSnafu)?;
         drop(index_writable);
 
-        self.reader.reload().context(InvalidIndexingSnafu {
+        self.reader.reload().boxed().context(InvalidIndexingSnafu {
             context: "Data successfully written to full-text index, but failed to update search path to reference the latest commit. Queries will be served from previous revision until the next update.".to_string(),
         })
     }

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -259,7 +259,7 @@ impl FullTextDatabaseIndex {
             .context(FailedToInsertDataIntoIndexSnafu)?;
         drop(index_writable);
 
-        self.reader.reload().boxed().context(InvalidIndexingSnafu {
+        self.reader.reload().context(InvalidIndexingSnafu {
             context: "Data successfully written to full-text index, but failed to update search path to reference the latest commit. Queries will be served from previous revision until the next update.".to_string(),
         })
     }

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -157,7 +157,7 @@ impl Error {
 impl std::fmt::Debug for FullTextSearchFieldIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FullTextSearchFieldIndex")
-            .field("schema", &self.search_schema)
+            .field("schema", self.reader.schema())
             .field("field", &self.field)
             .field("primary_key", &self.primary_key)
             .field("type_hints", &self.type_hints)
@@ -169,9 +169,7 @@ impl std::fmt::Debug for FullTextSearchFieldIndex {
 #[derive(Clone)]
 pub struct FullTextSearchFieldIndex {
     // These are components from a [`tantivy::Index`] required to perform a search on a  [`tantivy::Index`] at a given commit.
-    pub search_schema: tantivy::schema::Schema,
     reader: tantivy::Searcher,
-    tokenizer_manager: tantivy::tokenizer::TokenizerManager,
 
     pub field: String,
     pub primary_key: Vec<String>,
@@ -188,11 +186,8 @@ impl FullTextSearchFieldIndex {
         field: String,
         primary_key: Vec<String>,
     ) -> Result<Self> {
-        let tokenizer_manager = index_search.index().tokenizers().clone();
         let fts = Self {
-            search_schema: index_search.schema().clone(),
             reader: index_search,
-            tokenizer_manager,
             field,
             primary_key,
             type_hints: HashMap::from([(
@@ -221,6 +216,7 @@ impl FullTextSearchFieldIndex {
 
     ///  Schema is based on the [`tantivy::schema::Schema`] with `self.type_hints` applied.
     fn schema(&self) -> Arc<Schema> {
+        let search_schema = self.reader.schema();
         let fields = self
             .all_columns()
             .iter()
@@ -228,8 +224,8 @@ impl FullTextSearchFieldIndex {
                 let (data_type, nullable) = if let Some(f) = self.get_type_hint(field_name) {
                     (f.data_type().clone(), f.is_nullable())
                 } else {
-                    let f = self.search_schema.get_field(field_name).ok()?;
-                    let entry = self.search_schema.get_field_entry(f);
+                    let f = search_schema.get_field(field_name).ok()?;
+                    let entry = search_schema.get_field_entry(f);
                     (tantivy_to_arrow_type(entry.field_type())?, false)
                 };
                 Some(Field::new(field_name, data_type, nullable))
@@ -259,7 +255,8 @@ impl FullTextSearchFieldIndex {
 
     #[must_use]
     pub fn all_columns(&self) -> Vec<String> {
-        self.search_schema
+        self.reader
+            .schema()
             .fields()
             .filter_map(|(_, f)| {
                 if f.is_stored() {
@@ -273,14 +270,15 @@ impl FullTextSearchFieldIndex {
 
     fn query_parser(&self) -> QueryParser {
         let default_field = self
-            .search_schema
+            .reader
+            .schema()
             .find_field(self.field.as_str())
             .map(|(f, _)| vec![f])
             .unwrap_or_default();
         QueryParser::new(
-            self.search_schema.clone(),
+            self.reader.schema().clone(),
             default_field,
-            self.tokenizer_manager.clone(),
+            self.reader.index().tokenizers().clone(),
         )
     }
 
@@ -334,7 +332,7 @@ impl FullTextSearchFieldIndex {
 
                 let mut doc_w_col_names = doc
                     .into_iter()
-                    .map(|(f, v)| (self.search_schema.get_field_name(f), v))
+                    .map(|(f, v)| (self.reader.schema().get_field_name(f), v))
                     .filter(|(name, _)| all_cols.contains(&(*name).to_string()))
                     .collect::<HashMap<_, _>>();
 

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -33,7 +33,7 @@ use futures::{Stream, StreamExt};
 use serde_json::{Number, Value};
 use snafu::{ResultExt, Snafu};
 use tantivy::{
-    Index, ReloadPolicy, TantivyError,
+    Searcher, TantivyError,
     collector::TopDocs,
     query::{Occur, QueryParser, QueryParserError},
     query_grammar::{Delimiter, UserInputAst, UserInputLeaf, UserInputLiteral},
@@ -183,16 +183,16 @@ pub struct FullTextSearchFieldIndex {
 }
 
 impl FullTextSearchFieldIndex {
-    pub fn try_new(index: &Index, field: String, primary_key: Vec<String>) -> Result<Self> {
+    pub fn try_new(
+        index_search: Searcher,
+        field: String,
+        primary_key: Vec<String>,
+    ) -> Result<Self> {
+        let tokenizer_manager = index_search.index().tokenizers().clone();
         let fts = Self {
-            search_schema: index.schema(),
-            reader: index
-                .reader_builder()
-                .reload_policy(ReloadPolicy::OnCommitWithDelay)
-                .try_into()
-                .context(TextSearchSnafu)?
-                .searcher(),
-            tokenizer_manager: index.tokenizers().clone(),
+            search_schema: index_search.schema().clone(),
+            reader: index_search,
+            tokenizer_manager,
             field,
             primary_key,
             type_hints: HashMap::from([(


### PR DESCRIPTION
## 📝 Summary
 - Use `tantivy::IndexReader` associated with `tantivy::Index` to enable query path to not block on `RWLock::read` (can be heavy congestion for streaming data). 
