### PR TITLE
Rework caching accelerator to use the `stale-while-revalidate` pattern.

### DIFF
--- a/crates/arrow_tools/src/format.rs
+++ b/crates/arrow_tools/src/format.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 use crate::schema::to_source_native_type_name;
 use arrow::array::{Array, ArrayRef, FixedSizeListArray, ListArray, RecordBatch, StructArray};
 use arrow::buffer::OffsetBuffer;
@@ -384,6 +385,105 @@ pub fn table_schemas_to_markdown_table(table_schemas: Vec<(String, Schema)>) -> 
     table_schemas_formatted.join("\n\n")
 }
 
+/// Pretty prints an Arrow Schema in a format similar to Python's pyarrow output.
+///
+/// Example format:
+/// col1: string
+/// col2: int64
+/// col3: list<item: float32>
+///
+/// # Errors
+///
+/// Returns a `std::fmt::Error` if writing to the output fails.
+pub fn pretty_print_schema(
+    schema: &Arc<Schema>,
+    output: &mut impl std::fmt::Write,
+) -> std::fmt::Result {
+    // Helper function to recursively format complex types directly to a writer
+    fn write_data_type(data_type: &DataType, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        match data_type {
+            DataType::List(field) => {
+                w.write_str("list<item: ")?;
+                write_data_type(field.data_type(), w)?;
+                w.write_char('>')
+            }
+            DataType::LargeList(field) => {
+                w.write_str("large_list<item: ")?;
+                write_data_type(field.data_type(), w)?;
+                w.write_char('>')
+            }
+            DataType::Struct(fields) => {
+                w.write_str("struct<")?;
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 {
+                        w.write_str(", ")?;
+                    }
+                    w.write_str(f.name())?;
+                    w.write_char(' ')?;
+                    write_data_type(f.data_type(), w)?;
+                }
+                w.write_char('>')
+            }
+            // For all other simple types (Int32, Utf8, Timestamp, etc.)
+            _ => {
+                // Write Debug format in lowercase without allocating
+                write!(w, "{data_type:?}")?;
+                Ok(())
+            }
+        }
+    }
+
+    // Write Debug format of DataType in lowercase
+    fn write_data_type_lowercase(
+        data_type: &DataType,
+        w: &mut impl std::fmt::Write,
+    ) -> std::fmt::Result {
+        struct LowercaseWriter<'a, W: std::fmt::Write>(&'a mut W);
+
+        impl<W: std::fmt::Write> std::fmt::Write for LowercaseWriter<'_, W> {
+            fn write_str(&mut self, s: &str) -> std::fmt::Result {
+                for c in s.chars() {
+                    self.0.write_char(c.to_ascii_lowercase())?;
+                }
+                Ok(())
+            }
+        }
+
+        write_data_type(data_type, &mut LowercaseWriter(w))
+    }
+
+    for field in schema.fields() {
+        output.write_char(' ')?;
+        output.write_str(field.name())?;
+        output.write_str(": ")?;
+        write_data_type_lowercase(field.data_type(), output)?;
+        if field.is_nullable() {
+            output.write_str(" (nullable)")?;
+        }
+        output.write_char('\n')?;
+    }
+
+    Ok(())
+}
+
+/// A wrapper that implements `Display` for pretty-printing an Arrow schema.
+///
+/// This allows zero-allocation schema formatting when used with `tracing` macros
+/// or any other context that accepts `Display` types.
+///
+/// # Example
+/// ```ignore
+/// use arrow_tools::format::SchemaDisplay;
+/// tracing::debug!("Schema: {}", SchemaDisplay(&schema));
+/// ```
+pub struct SchemaDisplay<'a>(pub &'a Arc<Schema>);
+
+impl std::fmt::Display for SchemaDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        pretty_print_schema(self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use arrow::{
@@ -578,5 +678,38 @@ Cras venenatis euismod malesuada.",
         let output = table_schemas_to_markdown_table(vec![("users".to_string(), schema)]);
 
         insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_pretty_print_schema() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new(
+                "scores",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+            Field::new(
+                "metadata",
+                DataType::Struct(
+                    vec![
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Utf8, true),
+                    ]
+                    .into(),
+                ),
+                true,
+            ),
+        ]));
+
+        let mut pretty_output = String::new();
+        pretty_print_schema(&schema, &mut pretty_output).expect("write schema");
+        insta::assert_snapshot!(pretty_output, @r"
+        id: int64
+        name: utf8 (nullable)
+        scores: list<item: float32> (nullable)
+        metadata: struct<key utf8, value utf8> (nullable)
+        ");
     }
 }

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -114,6 +114,9 @@ fn check_cache_freshness(
     };
 
     // Directly scan Arrow arrays for freshness (avoid DataFusion overhead)
+    // Track the worst freshness status seen
+    let mut worst_freshness = CacheFreshness::Fresh;
+
     for batch in batches {
         let col_idx = batch
             .schema()
@@ -130,20 +133,22 @@ fn check_cache_freshness(
             })?;
         for i in 0..ts_array.len() {
             if !ts_array.is_valid(i) {
-                // Null value = rotten
+                // Null value = rotten, return immediately (can't get worse)
                 return Ok(CacheFreshness::Rotten);
             }
             let ts = ts_array.value(i);
             if ts < rotten_threshold {
+                // Rotten is the worst, return immediately
                 return Ok(CacheFreshness::Rotten);
             }
-            if ts < fresh_threshold {
-                return Ok(CacheFreshness::Stale);
+            if ts < fresh_threshold && worst_freshness == CacheFreshness::Fresh {
+                // Found a stale row - update worst status but continue checking for rotten
+                worst_freshness = CacheFreshness::Stale;
             }
         }
     }
 
-    Ok(CacheFreshness::Fresh)
+    Ok(worst_freshness)
 }
 
 /// Helper functions for cache refresh operations

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1458,13 +1458,11 @@ mod tests {
             .as_nanos() as i64;
 
         let max_age = Duration::from_secs(60);
-        let stale_while_revalidate = Some(Duration::from_secs(30));
+        let stale_while_revalidate = Duration::from_secs(30);
         #[expect(clippy::cast_possible_truncation)]
         let max_age_nanos = max_age.as_nanos() as i64;
         #[expect(clippy::cast_possible_truncation)]
-        let swr_nanos = stale_while_revalidate
-            .expect("swr should be Some")
-            .as_nanos() as i64;
+        let swr_nanos = stale_while_revalidate.as_nanos() as i64;
 
         // Just within max_age (59 seconds ago)
         let refresh_timestamps_fresh =

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -59,43 +59,90 @@ fn get_first_fetched_at_timestamp(batch: &RecordBatch) -> Option<i64> {
     Some(ts_array.value(0))
 }
 
-/// Check if cached data is stale based on TTL
-async fn is_data_stale(batches: Vec<RecordBatch>, ttl: Duration) -> DataFusionResult<bool> {
+/// Represents the freshness state of cached data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheFreshness {
+    /// Data is within `max_age` TTL - can be served directly without refresh
+    Fresh,
+    /// Data is past `max_age` but within `stale_while_revalidate` - serve but trigger background refresh
+    Stale,
+    /// Data is past both TTLs - treat as cache miss
+    Rotten,
+}
+
+/// Check the freshness state of cached data based on `max_age` and `stale_while_revalidate` TTLs
+///
+/// - `Fresh`: Data was fetched within `max_age` duration
+/// - `Stale`: Data was fetched more than `max_age` ago but within `max_age + stale_while_revalidate`
+/// - `Rotten`: Data was fetched more than `max_age + stale_while_revalidate` ago (or has no timestamp)
+async fn check_cache_freshness(
+    batches: &[RecordBatch],
+    max_age: Duration,
+    stale_while_revalidate: Option<Duration>,
+) -> DataFusionResult<CacheFreshness> {
     if batches.is_empty() {
-        return Ok(false); // No data means not stale
+        return Ok(CacheFreshness::Fresh); // No data means nothing to check
     }
 
     // Check the first batch for schema information
     let schema = batches[0].schema();
     if schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_none() {
-        // No metadata column means data was never refreshed in cache mode
-        return Ok(true);
+        // No metadata column means data was never refreshed in cache mode - treat as rotten
+        return Ok(CacheFreshness::Rotten);
     }
 
-    // Data fetched before this threshold is considered stale
     #[expect(clippy::cast_possible_truncation)] // Safe: nanoseconds won't exceed i64::MAX
-    let stale_threshold = (SystemTime::now() - ttl)
+    let now_nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?
         .as_nanos() as i64;
 
-    // Use DataFrame API to check for stale rows
-    let ctx = SessionContext::new();
-    let df = ctx.read_batches(batches)?;
+    // Calculate thresholds
+    #[expect(clippy::cast_possible_truncation)]
+    let max_age_nanos = max_age.as_nanos() as i64;
+    let fresh_threshold = now_nanos - max_age_nanos;
 
-    // Filter for stale rows: fetched_at IS NULL OR fetched_at < stale_threshold
-    let stale_filter = col(CACHE_REFRESHED_AT_COLUMN)
+    // Calculate rotten threshold (max_age + stale_while_revalidate)
+    let rotten_threshold = if let Some(swr) = stale_while_revalidate {
+        #[expect(clippy::cast_possible_truncation)]
+        let swr_nanos = swr.as_nanos() as i64;
+        now_nanos - max_age_nanos - swr_nanos
+    } else {
+        // If no stale_while_revalidate, stale items become rotten immediately
+        fresh_threshold
+    };
+
+    // Use DataFrame API to check freshness
+    let ctx = SessionContext::new();
+    let df = ctx.read_batches(batches.to_vec())?;
+
+    // Check for rotten rows first: fetched_at IS NULL OR fetched_at < rotten_threshold
+    let rotten_filter = col(CACHE_REFRESHED_AT_COLUMN)
         .is_null()
         .or(
             col(CACHE_REFRESHED_AT_COLUMN).lt(lit(ScalarValue::TimestampNanosecond(
-                Some(stale_threshold),
+                Some(rotten_threshold),
                 None,
             ))),
         );
 
-    let stale_count = df.filter(stale_filter)?.count().await?;
+    let rotten_count = df.clone().filter(rotten_filter)?.count().await?;
+    if rotten_count > 0 {
+        return Ok(CacheFreshness::Rotten);
+    }
 
-    Ok(stale_count > 0)
+    // Check for stale rows: fetched_at < fresh_threshold (but not rotten, checked above)
+    let stale_filter = col(CACHE_REFRESHED_AT_COLUMN).lt(lit(ScalarValue::TimestampNanosecond(
+        Some(fresh_threshold),
+        None,
+    )));
+
+    let stale_count = df.filter(stale_filter)?.count().await?;
+    if stale_count > 0 {
+        return Ok(CacheFreshness::Stale);
+    }
+
+    Ok(CacheFreshness::Fresh)
 }
 
 /// Helper functions for cache refresh operations
@@ -431,12 +478,19 @@ impl CacheRefreshHelper {
 
     /// Handle a cache hit by returning cached data and optionally triggering background refresh.
     /// Returns a `SendableRecordBatchStream` containing the cached data.
+    ///
+    /// Cache behavior based on freshness:
+    /// - `Fresh`: Return cached data immediately, no refresh needed
+    /// - `Stale`: Return cached data immediately, trigger background refresh
+    /// - `Rotten`: This should not be called for rotten data (handled as cache miss)
+    #[expect(clippy::too_many_arguments)]
     async fn handle_cache_hit(
         cached_batches: Vec<RecordBatch>,
         federated: &Arc<dyn TableProvider>,
         accelerator: &Arc<dyn TableProvider>,
         dataset_name: &str,
-        ttl: Option<Duration>,
+        max_age: Option<Duration>,
+        stale_while_revalidate: Option<Duration>,
         io_runtime: &Handle,
         schema: SchemaRef,
     ) -> SendableRecordBatchStream {
@@ -451,48 +505,65 @@ impl CacheRefreshHelper {
             cached_batches.len()
         );
 
-        // Check if data is stale and trigger background refresh if needed
-        if let Some(ttl) = ttl
-            && is_data_stale(cached_batches.clone(), ttl)
+        // Check freshness and trigger background refresh if stale
+        if let Some(max_age) = max_age {
+            let freshness = check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
                 .await
-                .unwrap_or(false)
-        {
-            tracing::debug!(
-                "Data is stale for dataset={dataset_name}, triggering background refresh"
-            );
+                .unwrap_or(CacheFreshness::Rotten);
 
-            // Log current fetched_at for debugging
-            if let Some(timestamp) = get_first_fetched_at_timestamp(&cached_batches[0]) {
-                tracing::debug!(
-                    "Current stale data has {CACHE_REFRESHED_AT_COLUMN} timestamp={timestamp}"
-                );
-            }
-
-            let federated_clone = Arc::clone(federated);
-            let accelerator_clone = Arc::clone(accelerator);
-            let dataset_name_clone = dataset_name.to_string();
-
-            io_runtime.spawn(async move {
-                tracing::debug!("Background refresh task started for dataset={dataset_name_clone}");
-                match Self::refresh_stale_rows(
-                    federated_clone,
-                    accelerator_clone,
-                    &dataset_name_clone,
-                    ttl,
-                )
-                .await
-                {
-                    Ok(rows) => {
-                        tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows");
-                    }
-                    Err(e) => {
-                        tracing::error!("Background refresh task failed for dataset={dataset_name_clone}: {e}");
-                    }
+            match freshness {
+                CacheFreshness::Fresh => {
+                    tracing::debug!(
+                        "Data is fresh for dataset={dataset_name}, no background refresh needed"
+                    );
                 }
-            });
+                CacheFreshness::Stale => {
+                    tracing::debug!(
+                        "Data is stale for dataset={dataset_name}, triggering background refresh"
+                    );
+
+                    // Log current fetched_at for debugging
+                    if let Some(timestamp) = get_first_fetched_at_timestamp(&cached_batches[0]) {
+                        tracing::debug!(
+                            "Current stale data has {CACHE_REFRESHED_AT_COLUMN} timestamp={timestamp}"
+                        );
+                    }
+
+                    let federated_clone = Arc::clone(federated);
+                    let accelerator_clone = Arc::clone(accelerator);
+                    let dataset_name_clone = dataset_name.to_string();
+
+                    io_runtime.spawn(async move {
+                        tracing::debug!(
+                            "Background refresh task started for dataset={dataset_name_clone}"
+                        );
+                        match Self::refresh_stale_rows(
+                            federated_clone,
+                            accelerator_clone,
+                            &dataset_name_clone,
+                            max_age,
+                        )
+                        .await
+                        {
+                            Ok(rows) => {
+                                tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows");
+                            }
+                            Err(e) => {
+                                tracing::error!("Background refresh task failed for dataset={dataset_name_clone}: {e}");
+                            }
+                        }
+                    });
+                }
+                CacheFreshness::Rotten => {
+                    // This shouldn't happen as rotten data should be handled as cache miss
+                    tracing::warn!(
+                        "Unexpected rotten data in handle_cache_hit for dataset={dataset_name}"
+                    );
+                }
+            }
         } else {
             tracing::debug!(
-                "Data is fresh for dataset={dataset_name}, no background refresh needed"
+                "No caching_ttl configured for dataset={dataset_name}, serving cached data without refresh check"
             );
         }
 
@@ -507,7 +578,10 @@ impl CacheRefreshHelper {
 pub struct CachingAccelerationScanExec {
     input: Arc<dyn ExecutionPlan>,
     plan_properties: PlanProperties,
-    ttl: Option<Duration>,
+    /// Maximum time data is considered "fresh" - can be served without refresh
+    max_age: Option<Duration>,
+    /// Time window after `max_age` during which stale data can be served while revalidating
+    stale_while_revalidate: Option<Duration>,
     federated: Arc<dyn TableProvider>,
     accelerator: Arc<dyn TableProvider>,
     dataset_name: String,
@@ -521,7 +595,8 @@ impl CachingAccelerationScanExec {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
-        ttl: Option<Duration>,
+        max_age: Option<Duration>,
+        stale_while_revalidate: Option<Duration>,
         federated: Arc<dyn TableProvider>,
         accelerator: Arc<dyn TableProvider>,
         dataset_name: String,
@@ -530,8 +605,8 @@ impl CachingAccelerationScanExec {
         projection: Option<Vec<usize>>,
         limit: Option<usize>,
     ) -> Self {
-        // Default TTL to 30 seconds if not specified
-        let ttl = ttl.or(Some(Duration::from_secs(30)));
+        // Default max_age (TTL) to 30 seconds if not specified
+        let max_age = max_age.or(Some(Duration::from_secs(30)));
 
         let plan_properties = input
             .properties()
@@ -542,7 +617,8 @@ impl CachingAccelerationScanExec {
         Self {
             input,
             plan_properties,
-            ttl,
+            max_age,
+            stale_while_revalidate,
             federated,
             accelerator,
             dataset_name,
@@ -597,7 +673,8 @@ impl ExecutionPlan for CachingAccelerationScanExec {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(Self::new(
             Arc::clone(&children[0]),
-            self.ttl,
+            self.max_age,
+            self.stale_while_revalidate,
             Arc::clone(&self.federated),
             Arc::clone(&self.accelerator),
             self.dataset_name.clone(),
@@ -628,7 +705,8 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         let dataset_name = self.dataset_name.clone();
         let filters = self.filters.clone();
         let limit = self.limit;
-        let ttl = self.ttl;
+        let max_age = self.max_age;
+        let stale_while_revalidate = self.stale_while_revalidate;
         let io_runtime = self.io_runtime.clone();
 
         tracing::debug!(
@@ -670,12 +748,38 @@ impl ExecutionPlan for CachingAccelerationScanExec {
             let total_cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
 
             if total_cached_rows > 0 {
+                // Check if data is rotten (past max_age + stale_while_revalidate)
+                // If rotten, treat as cache miss
+                if let Some(max_age) = max_age {
+                    let freshness =
+                        check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
+                            .await
+                            .unwrap_or(CacheFreshness::Rotten);
+
+                    if freshness == CacheFreshness::Rotten {
+                        tracing::debug!(
+                            "Data is rotten for dataset={dataset_name}, treating as cache miss"
+                        );
+                        return CacheRefreshHelper::handle_cache_miss(
+                            federated,
+                            accelerator,
+                            &dataset_name,
+                            &filters,
+                            limit,
+                            Arc::clone(&schema_clone),
+                        )
+                        .await;
+                    }
+                }
+
+                // Data is fresh or stale - serve from cache (stale triggers background refresh)
                 CacheRefreshHelper::handle_cache_hit(
                     cached_batches,
                     &federated,
                     &accelerator,
                     &dataset_name,
-                    ttl,
+                    max_age,
+                    stale_while_revalidate,
                     &io_runtime,
                     Arc::clone(&schema_clone),
                 )
@@ -739,352 +843,6 @@ mod tests {
                 true,
             ),
         ]))
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_no_refresh_column() {
-        let schema = create_test_schema_without_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2, 3]);
-        let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(id_array), Arc::new(name_array)],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(
-            result,
-            "Data without refresh column should be considered stale"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_fresh_data() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2, 3]);
-        let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
-
-        // Create timestamps that are very recent (within TTL)
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        let refresh_timestamps = TimestampNanosecondArray::from(vec![
-            Some(now - 10_000_000_000), // 10 seconds ago
-            Some(now - 20_000_000_000), // 20 seconds ago
-            Some(now - 5_000_000_000),  // 5 seconds ago
-        ]);
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60); // 60 second TTL
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(!result, "Data refreshed within TTL should not be stale");
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_stale_data() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2]);
-        let name_array = StringArray::from(vec!["alice", "bob"]);
-
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        let refresh_timestamps = TimestampNanosecondArray::from(vec![
-            Some(now - 90_000_000_000),  // 90 seconds ago (stale)
-            Some(now - 120_000_000_000), // 120 seconds ago (stale)
-        ]);
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60); // 60 second TTL
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(result, "Data older than TTL should be stale");
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_null_timestamps() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2]);
-        let name_array = StringArray::from(vec!["alice", "bob"]);
-
-        let refresh_timestamps = TimestampNanosecondArray::from(vec![None, None]);
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(
-            result,
-            "Data with null timestamps should be considered stale"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_mixed_timestamps() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2, 3]);
-        let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
-
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        // Mix of fresh and stale timestamps - if ANY is stale, the whole batch is stale
-        let refresh_timestamps = TimestampNanosecondArray::from(vec![
-            Some(now - 10_000_000_000), // 10 seconds ago (fresh)
-            Some(now - 90_000_000_000), // 90 seconds ago (stale)
-            Some(now - 5_000_000_000),  // 5 seconds ago (fresh)
-        ]);
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(
-            result,
-            "Data with any stale timestamp should be considered stale"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_ttl_boundary() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(vec![1, 2]);
-        let name_array = StringArray::from(vec!["alice", "bob"]);
-
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        let ttl = Duration::from_secs(60);
-        #[expect(clippy::cast_possible_truncation)]
-        let ttl_nanos = ttl.as_nanos() as i64;
-
-        // Well within TTL boundary - this should NOT be stale
-        let refresh_timestamps_fresh = TimestampNanosecondArray::from(vec![
-            Some(now - ttl_nanos + 1_000_000_000),
-            Some(now - ttl_nanos + 2_000_000_000),
-        ]); // 1-2 seconds within boundary
-
-        let batch_fresh = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array.clone()),
-                Arc::new(name_array.clone()),
-                Arc::new(refresh_timestamps_fresh),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let result_fresh = is_data_stale(vec![batch_fresh], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(
-            !result_fresh,
-            "Data well within TTL boundary should not be stale"
-        );
-
-        // Well past the TTL boundary - this SHOULD be stale
-        let refresh_timestamps_stale = TimestampNanosecondArray::from(vec![
-            Some(now - ttl_nanos - 1_000_000_000),
-            Some(now - ttl_nanos - 2_000_000_000),
-        ]); // 1-2 seconds past boundary
-
-        let batch_stale = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps_stale),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let result_stale = is_data_stale(vec![batch_stale], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(result_stale, "Data well past TTL boundary should be stale");
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_empty_slice() {
-        let batches: Vec<RecordBatch> = Vec::new();
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(batches, ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(!result, "Empty slice should not be considered stale");
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_empty_batch() {
-        let schema = create_test_schema_with_refresh_timestamp();
-        let id_array = Int32Array::from(Vec::<i32>::new());
-        let name_array = StringArray::from(Vec::<&str>::new());
-        let refresh_timestamps = TimestampNanosecondArray::from(Vec::<Option<i64>>::new());
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(id_array),
-                Arc::new(name_array),
-                Arc::new(refresh_timestamps),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(
-            !result,
-            "Batch with zero rows should not be considered stale"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_multiple_batches_all_fresh() {
-        let schema = create_test_schema_with_refresh_timestamp();
-
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        let batch1 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["alice", "bob"])),
-                Arc::new(TimestampNanosecondArray::from(vec![
-                    Some(now - 10_000_000_000), // 10 seconds ago
-                    Some(now - 20_000_000_000), // 20 seconds ago
-                ])),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let batch2 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int32Array::from(vec![3, 4])),
-                Arc::new(StringArray::from(vec!["charlie", "dave"])),
-                Arc::new(TimestampNanosecondArray::from(vec![
-                    Some(now - 15_000_000_000), // 15 seconds ago
-                    Some(now - 25_000_000_000), // 25 seconds ago
-                ])),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch1, batch2], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(!result, "All fresh batches should not be stale");
-    }
-
-    #[tokio::test]
-    async fn test_is_data_stale_multiple_batches_one_stale() {
-        let schema = create_test_schema_with_refresh_timestamp();
-
-        #[expect(clippy::cast_possible_truncation)]
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as i64;
-
-        // First batch is fresh
-        let batch1 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["alice", "bob"])),
-                Arc::new(TimestampNanosecondArray::from(vec![
-                    Some(now - 10_000_000_000), // 10 seconds ago
-                    Some(now - 20_000_000_000), // 20 seconds ago
-                ])),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        // Second batch has stale data
-        let batch2 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int32Array::from(vec![3, 4])),
-                Arc::new(StringArray::from(vec!["charlie", "dave"])),
-                Arc::new(TimestampNanosecondArray::from(vec![
-                    Some(now - 15_000_000_000),  // 15 seconds ago (fresh)
-                    Some(now - 120_000_000_000), // 120 seconds ago (stale)
-                ])),
-            ],
-        )
-        .expect("Failed to create batch");
-
-        let ttl = Duration::from_secs(60);
-        let result = is_data_stale(vec![batch1, batch2], ttl)
-            .await
-            .expect("Should successfully check staleness");
-        assert!(result, "Should be stale if any row in any batch is stale");
     }
 
     #[test]
@@ -1225,6 +983,364 @@ mod tests {
             filters.len(),
             0,
             "Should extract 0 filters when columns are missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_fresh_data() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // Data fetched 10 seconds ago
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![
+            Some(now - 10_000_000_000),
+            Some(now - 15_000_000_000),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Fresh,
+            "Data within max_age should be fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_stale_data_with_swr() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // Data fetched 70 seconds ago (past max_age of 60s, but within max_age + swr of 90s)
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![
+            Some(now - 70_000_000_000),
+            Some(now - 75_000_000_000),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Stale,
+            "Data past max_age but within swr should be stale"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_rotten_data() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // Data fetched 100 seconds ago (past max_age + swr of 90s)
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![
+            Some(now - 100_000_000_000),
+            Some(now - 110_000_000_000),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Rotten,
+            "Data past max_age + swr should be rotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_no_swr_stale_becomes_rotten() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // Data fetched 70 seconds ago (past max_age of 60s)
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![
+            Some(now - 70_000_000_000),
+            Some(now - 75_000_000_000),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = None; // No stale-while-revalidate
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Rotten,
+            "Without swr, data past max_age should be rotten (not stale)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_null_timestamps_are_rotten() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![None, None]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Rotten,
+            "Data with null timestamps should be rotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_no_refresh_column_is_rotten() {
+        let schema = create_test_schema_without_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec!["alice", "bob"]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(id_array), Arc::new(name_array)],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Rotten,
+            "Data without refresh column should be rotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_mixed_timestamps_worst_case_wins() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2, 3]);
+        let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // Mix: fresh (10s), stale (70s), rotten (100s)
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![
+            Some(now - 10_000_000_000),  // Fresh
+            Some(now - 70_000_000_000),  // Stale (past 60s, within 90s)
+            Some(now - 100_000_000_000), // Rotten (past 90s)
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Rotten,
+            "If any row is rotten, the whole batch should be considered rotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_boundary_conditions() {
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1]);
+        let name_array = StringArray::from(vec!["alice"]);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+        #[expect(clippy::cast_possible_truncation)]
+        let max_age_nanos = max_age.as_nanos() as i64;
+        #[expect(clippy::cast_possible_truncation)]
+        let swr_nanos = stale_while_revalidate
+            .expect("swr should be Some")
+            .as_nanos() as i64;
+
+        // Just within max_age (59 seconds ago)
+        let refresh_timestamps_fresh =
+            TimestampNanosecondArray::from(vec![Some(now - max_age_nanos + 1_000_000_000)]);
+
+        let batch_fresh = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array.clone()),
+                Arc::new(name_array.clone()),
+                Arc::new(refresh_timestamps_fresh),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let freshness = check_cache_freshness(&[batch_fresh], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(freshness, CacheFreshness::Fresh, "Just within max_age");
+
+        // Just past max_age but within swr (61 seconds ago)
+        let refresh_timestamps_stale =
+            TimestampNanosecondArray::from(vec![Some(now - max_age_nanos - 1_000_000_000)]);
+
+        let batch_stale = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array.clone()),
+                Arc::new(name_array.clone()),
+                Arc::new(refresh_timestamps_stale),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let freshness = check_cache_freshness(&[batch_stale], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(freshness, CacheFreshness::Stale, "Just past max_age");
+
+        // Just past max_age + swr (91 seconds ago)
+        let refresh_timestamps_rotten = TimestampNanosecondArray::from(vec![Some(
+            now - max_age_nanos - swr_nanos - 1_000_000_000,
+        )]);
+
+        let batch_rotten = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps_rotten),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let freshness = check_cache_freshness(&[batch_rotten], max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(freshness, CacheFreshness::Rotten, "Just past max_age + swr");
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness_empty_batches() {
+        let batches: Vec<RecordBatch> = Vec::new();
+        let max_age = Duration::from_secs(60);
+        let stale_while_revalidate = Some(Duration::from_secs(30));
+
+        let freshness = check_cache_freshness(&batches, max_age, stale_while_revalidate)
+            .await
+            .expect("Should check freshness");
+        assert_eq!(
+            freshness,
+            CacheFreshness::Fresh,
+            "Empty batches should be considered fresh (nothing to check)"
         );
     }
 }

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -26,7 +26,7 @@ use arrow_tools::format::SchemaDisplay;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::TaskContext;
-use datafusion::logical_expr::{Expr, dml::InsertOp};
+use datafusion::logical_expr::{Expr, dml::InsertOp, not};
 use datafusion::logical_expr::{col, lit};
 use datafusion::physical_plan::execution_plan::EmissionType;
 use datafusion::physical_plan::{
@@ -38,6 +38,7 @@ use datafusion::prelude::SessionContext;
 use datafusion::scalar::ScalarValue;
 use futures::{StreamExt, TryStreamExt};
 use tokio::runtime::Handle;
+use tokio::sync::Mutex;
 
 use crate::dataupdate::StreamingDataUpdateExecutionPlan;
 
@@ -374,6 +375,162 @@ impl CacheRefreshHelper {
         Ok(())
     }
 
+    /// Insert new data into the accelerator by combining with existing data and overwriting.
+    /// This is used when there is no existing data in the cache for the given filters (cache miss).
+    ///
+    /// Note: We use read-combine-overwrite instead of `InsertOp::Append` because the DuckDB
+    /// accelerator uses views with underlying data tables, and DuckDB views don't support
+    /// direct INSERT operations. The `InsertOp::Append` fails with "is not an table" error.
+    async fn insert_into_accelerator(
+        accelerator: &Arc<dyn TableProvider>,
+        dataset_name: &str,
+        new_batches: Vec<RecordBatch>,
+    ) -> DataFusionResult<()> {
+        if new_batches.is_empty() {
+            tracing::debug!(
+                "insert_into_accelerator called with empty batches for dataset={dataset_name}"
+            );
+            return Ok(());
+        }
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let new_rows: usize = new_batches.iter().map(RecordBatch::num_rows).sum();
+
+        tracing::debug!(
+            "insert_into_accelerator - reading existing data from accelerator for dataset={}",
+            dataset_name
+        );
+
+        // Scan all existing data from the accelerator
+        let plan = accelerator.scan(&state, None, &[], None).await?;
+        let task_ctx = Arc::new(TaskContext::default());
+        let existing_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
+
+        let existing_rows: usize = existing_batches.iter().map(RecordBatch::num_rows).sum();
+        tracing::debug!(
+            "insert_into_accelerator - found {} existing rows, adding {} new rows for dataset={}",
+            existing_rows,
+            new_rows,
+            dataset_name
+        );
+
+        // Combine existing data with new data
+        let mut combined_batches = existing_batches;
+        combined_batches.extend(new_batches);
+
+        // Overwrite the accelerator with the combined data
+        Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, combined_batches).await
+    }
+
+    /// Upsert data into the accelerator by removing rows matching the filters and inserting new data.
+    /// This is used when cached data exists but is rotten (expired).
+    ///
+    /// The process:
+    /// 1. Scan all data from the accelerator
+    /// 2. Filter out rows that match the provided filters (these are the rotten rows to replace)
+    /// 3. Combine remaining rows with new data
+    /// 4. Overwrite the accelerator with the combined data
+    async fn upsert_into_accelerator(
+        accelerator: &Arc<dyn TableProvider>,
+        dataset_name: &str,
+        filters: &[Expr],
+        new_batches: Vec<RecordBatch>,
+    ) -> DataFusionResult<()> {
+        if new_batches.is_empty() {
+            tracing::debug!(
+                "upsert_into_accelerator called with empty batches for dataset={dataset_name}"
+            );
+            return Ok(());
+        }
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+
+        tracing::debug!(
+            "upsert_into_accelerator - reading existing data from accelerator for dataset={}",
+            dataset_name
+        );
+
+        // Scan all data from the accelerator (no filters to get everything)
+        let plan = accelerator.scan(&state, None, &[], None).await?;
+        let task_ctx = Arc::new(TaskContext::default());
+        let existing_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
+
+        let existing_rows: usize = existing_batches.iter().map(RecordBatch::num_rows).sum();
+        tracing::debug!(
+            "upsert_into_accelerator - found {} existing rows in accelerator for dataset={}",
+            existing_rows,
+            dataset_name
+        );
+
+        // If there's no existing data, just insert the new data
+        if existing_batches.is_empty() || existing_rows == 0 {
+            tracing::debug!(
+                "upsert_into_accelerator - no existing data, performing simple insert for dataset={}",
+                dataset_name
+            );
+            return Self::insert_into_accelerator(accelerator, dataset_name, new_batches).await;
+        }
+
+        // Build a filter to exclude rows that match the provided filters
+        // We need to keep rows that DON'T match the filters
+        let exclusion_filter = Self::build_exclusion_filter(filters);
+
+        tracing::debug!(
+            "upsert_into_accelerator - filtering out matching rows with {} filters for dataset={}",
+            filters.len(),
+            dataset_name
+        );
+
+        // Filter existing data to keep only non-matching rows
+        let df = ctx.read_batches(existing_batches)?;
+        let filtered_df = if let Some(filter) = exclusion_filter {
+            df.filter(filter)?
+        } else {
+            // No filters means replace everything
+            tracing::debug!(
+                "upsert_into_accelerator - no filters provided, will replace all data for dataset={}",
+                dataset_name
+            );
+            // Return early with just the new batches
+            return Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, new_batches)
+                .await;
+        };
+
+        let kept_batches = filtered_df.collect().await?;
+        let kept_rows: usize = kept_batches.iter().map(RecordBatch::num_rows).sum();
+        let new_rows: usize = new_batches.iter().map(RecordBatch::num_rows).sum();
+
+        tracing::debug!(
+            "upsert_into_accelerator - keeping {} rows, adding {} new rows for dataset={}",
+            kept_rows,
+            new_rows,
+            dataset_name
+        );
+
+        // Combine kept rows with new rows
+        let mut combined_batches = kept_batches;
+        combined_batches.extend(new_batches);
+
+        // Overwrite the accelerator with the combined data
+        Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, combined_batches).await
+    }
+
+    /// Build an exclusion filter that matches rows NOT matching the provided filters.
+    /// Returns `None` if no filters are provided.
+    ///
+    /// For example, if filters are [path = '/api/users', query = 'page=1'],
+    /// this returns: NOT (path = '/api/users' AND query = 'page=1')
+    fn build_exclusion_filter(filters: &[Expr]) -> Option<Expr> {
+        if filters.is_empty() {
+            return None;
+        }
+
+        // Combine all filters with AND, then negate
+        filters.iter().cloned().reduce(Expr::and).map(not)
+    }
+
     /// Fetch data from federated source for given filters
     async fn fetch_from_source(
         federated: &Arc<dyn TableProvider>,
@@ -415,6 +572,12 @@ impl CacheRefreshHelper {
 
     /// Handle a cache miss by fetching from source and returning a stream.
     /// Returns a `SendableRecordBatchStream` containing the fetched data, empty stream, or error stream.
+    ///
+    /// # Arguments
+    /// * `is_rotten` - If `true`, data exists in the cache but is expired (rotten), so we use upsert.
+    ///   If `false`, no data exists in the cache, so we use insert (append).
+    /// * `accelerator_mutex` - Mutex to protect concurrent access to the accelerator.
+    #[expect(clippy::too_many_arguments)]
     async fn handle_cache_miss(
         federated: Arc<dyn TableProvider>,
         accelerator: Arc<dyn TableProvider>,
@@ -422,6 +585,8 @@ impl CacheRefreshHelper {
         filters: &[Expr],
         limit: Option<usize>,
         fallback_schema: SchemaRef,
+        is_rotten: bool,
+        accelerator_mutex: Arc<Mutex<()>>,
     ) -> SendableRecordBatchStream {
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
             Ok(batches) if !batches.is_empty() => {
@@ -433,10 +598,29 @@ impl CacheRefreshHelper {
                     dataset_name
                 );
 
+                // Acquire the mutex to protect accelerator operations
+                let lock_guard = accelerator_mutex.lock().await;
+
                 // Store in accelerator for future queries
-                if let Err(e) =
-                    Self::overwrite_accelerator(accelerator, dataset_name, batches.clone()).await
-                {
+                let store_result = if is_rotten {
+                    // Data exists but is expired - upsert (remove matching rows, add new)
+                    tracing::debug!("Upserting rotten cache entry for dataset={dataset_name}");
+                    Self::upsert_into_accelerator(
+                        &accelerator,
+                        dataset_name,
+                        filters,
+                        batches.clone(),
+                    )
+                    .await
+                } else {
+                    // No data exists - insert (append)
+                    tracing::debug!("Inserting new cache entry for dataset={dataset_name}");
+                    Self::insert_into_accelerator(&accelerator, dataset_name, batches.clone()).await
+                };
+
+                drop(lock_guard); // Release the mutex
+
+                if let Err(e) = store_result {
                     tracing::warn!(
                         "Failed to store fetched data in accelerator for dataset {}: {}",
                         dataset_name,
@@ -589,6 +773,8 @@ pub struct CachingAccelerationScanExec {
     filters: Vec<Expr>,
     projection: Option<Vec<usize>>,
     limit: Option<usize>,
+    /// Mutex to protect concurrent access to the accelerator during cache operations
+    accelerator_mutex: Arc<Mutex<()>>,
 }
 
 impl CachingAccelerationScanExec {
@@ -604,6 +790,7 @@ impl CachingAccelerationScanExec {
         filters: Vec<Expr>,
         projection: Option<Vec<usize>>,
         limit: Option<usize>,
+        accelerator_mutex: Arc<Mutex<()>>,
     ) -> Self {
         // Default max_age (TTL) to 30 seconds if not specified
         let max_age = max_age.or(Some(Duration::from_secs(30)));
@@ -626,6 +813,7 @@ impl CachingAccelerationScanExec {
             filters,
             projection,
             limit,
+            accelerator_mutex,
         }
     }
 }
@@ -682,6 +870,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
             self.filters.clone(),
             self.projection.clone(),
             self.limit,
+            Arc::clone(&self.accelerator_mutex),
         )))
     }
 
@@ -708,6 +897,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         let max_age = self.max_age;
         let stale_while_revalidate = self.stale_while_revalidate;
         let io_runtime = self.io_runtime.clone();
+        let accelerator_mutex = Arc::clone(&self.accelerator_mutex);
 
         tracing::debug!(
             "CacheAccelerationScanExec::execute about to spawn cache check for dataset={}",
@@ -749,7 +939,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
 
             if total_cached_rows > 0 {
                 // Check if data is rotten (past max_age + stale_while_revalidate)
-                // If rotten, treat as cache miss
+                // If rotten, treat as cache miss with is_rotten=true (will upsert)
                 if let Some(max_age) = max_age {
                     let freshness =
                         check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
@@ -758,7 +948,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
 
                     if freshness == CacheFreshness::Rotten {
                         tracing::debug!(
-                            "Data is rotten for dataset={dataset_name}, treating as cache miss"
+                            "Data is rotten for dataset={dataset_name}, treating as cache miss (upsert)"
                         );
                         return CacheRefreshHelper::handle_cache_miss(
                             federated,
@@ -767,6 +957,8 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             &filters,
                             limit,
                             Arc::clone(&schema_clone),
+                            true, // is_rotten = true, will upsert
+                            accelerator_mutex,
                         )
                         .await;
                     }
@@ -786,6 +978,9 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                 .await
             } else {
                 // Cache miss - no data in accelerator - retrieve from source and store in accelerator
+                tracing::debug!(
+                    "No cached data for dataset={dataset_name}, treating as cache miss (insert)"
+                );
                 CacheRefreshHelper::handle_cache_miss(
                     federated,
                     accelerator,
@@ -793,6 +988,8 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     &filters,
                     limit,
                     Arc::clone(&schema_clone),
+                    false, // is_rotten = false, will insert (append)
+                    accelerator_mutex,
                 )
                 .await
             }

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1498,9 +1498,10 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let freshness = check_cache_freshness(&[batch_stale], max_age, stale_while_revalidate)
-            .await
-            .expect("Should check freshness");
+        let freshness =
+            check_cache_freshness(&[batch_stale], max_age, Some(stale_while_revalidate))
+                .await
+                .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Stale, "Just past max_age");
 
         // Just past max_age + swr (91 seconds ago)
@@ -1518,9 +1519,10 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let freshness = check_cache_freshness(&[batch_rotten], max_age, stale_while_revalidate)
-            .await
-            .expect("Should check freshness");
+        let freshness =
+            check_cache_freshness(&[batch_rotten], max_age, Some(stale_while_revalidate))
+                .await
+                .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Rotten, "Just past max_age + swr");
     }
 

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -19,69 +19,83 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use arrow::array::StringArray;
 use arrow::array::{Array, RecordBatch, TimestampNanosecondArray};
 use arrow::datatypes::SchemaRef;
-use datafusion::catalog::Session;
+use arrow_tools::format::SchemaDisplay;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Expr, dml::InsertOp};
+use datafusion::logical_expr::{col, lit};
+use datafusion::physical_plan::execution_plan::EmissionType;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, SendableRecordBatchStream,
     stream::RecordBatchStreamAdapter,
 };
+use datafusion::physical_plan::{Distribution, Partitioning, PlanProperties};
 use datafusion::prelude::SessionContext;
-use futures::StreamExt;
+use datafusion::scalar::ScalarValue;
+use futures::{StreamExt, TryStreamExt};
 use tokio::runtime::Handle;
 
 use crate::dataupdate::StreamingDataUpdateExecutionPlan;
 
 pub const CACHE_REFRESHED_AT_COLUMN: &str = "fetched_at";
 
-/// Check if cached data is stale based on TTL
-fn is_data_stale(batch: &RecordBatch, ttl: Duration) -> DataFusionResult<bool> {
-    // Find the refreshed_at column
-    let schema = batch.schema();
-    let refreshed_at_idx = schema
-        .column_with_name(CACHE_REFRESHED_AT_COLUMN)
-        .map(|(idx, _)| idx);
+/// Maximum number of concurrent refresh requests
+const MAX_CONCURRENT_REFRESHES: usize = 10;
 
-    let Some(refreshed_at_idx) = refreshed_at_idx else {
+/// Get the first `fetched_at` timestamp from a batch, if present and not null.
+fn get_first_fetched_at_timestamp(batch: &RecordBatch) -> Option<i64> {
+    let (idx, _) = batch.schema().column_with_name(CACHE_REFRESHED_AT_COLUMN)?;
+    let ts_array = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()?;
+    if ts_array.is_empty() || ts_array.is_null(0) {
+        return None;
+    }
+    Some(ts_array.value(0))
+}
+
+/// Check if cached data is stale based on TTL
+async fn is_data_stale(batches: Vec<RecordBatch>, ttl: Duration) -> DataFusionResult<bool> {
+    if batches.is_empty() {
+        return Ok(false); // No data means not stale
+    }
+
+    // Check the first batch for schema information
+    let schema = batches[0].schema();
+    if schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_none() {
         // No metadata column means data was never refreshed in cache mode
         return Ok(true);
-    };
+    }
 
-    let refreshed_at_array = batch.column(refreshed_at_idx);
-    let refreshed_at_array = refreshed_at_array
-        .as_any()
-        .downcast_ref::<TimestampNanosecondArray>()
-        .ok_or_else(|| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Expected '{CACHE_REFRESHED_AT_COLUMN}' column to be TimestampNanosecondArray"
-            ))
-        })?;
-
-    // Check if any row has stale data
+    // Data fetched before this threshold is considered stale
     #[expect(clippy::cast_possible_truncation)] // Safe: nanoseconds won't exceed i64::MAX
-    let now = SystemTime::now()
+    let stale_threshold = (SystemTime::now() - ttl)
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?
         .as_nanos() as i64;
 
-    #[expect(clippy::cast_possible_truncation)] // Safe: Duration nanoseconds fit in i64
-    let ttl_nanos = ttl.as_nanos() as i64;
+    // Use DataFrame API to check for stale rows
+    let ctx = SessionContext::new();
+    let df = ctx.read_batches(batches)?;
 
-    for i in 0..refreshed_at_array.len() {
-        if refreshed_at_array.is_null(i) {
-            return Ok(true); // Null timestamp means stale
-        }
-        let refreshed_at = refreshed_at_array.value(i);
-        if now - refreshed_at > ttl_nanos {
-            return Ok(true); // Data is stale
-        }
-    }
+    // Filter for stale rows: fetched_at IS NULL OR fetched_at < stale_threshold
+    let stale_filter = col(CACHE_REFRESHED_AT_COLUMN)
+        .is_null()
+        .or(
+            col(CACHE_REFRESHED_AT_COLUMN).lt(lit(ScalarValue::TimestampNanosecond(
+                Some(stale_threshold),
+                None,
+            ))),
+        );
 
-    Ok(false)
+    let stale_count = df.filter(stale_filter)?.count().await?;
+
+    Ok(stale_count > 0)
 }
 
 /// Helper functions for cache refresh operations
@@ -97,27 +111,18 @@ impl CacheRefreshHelper {
         dataset_name: &str,
         ttl: Duration,
     ) -> DataFusionResult<usize> {
-        use datafusion::logical_expr::{col, lit};
-        use datafusion::scalar::ScalarValue;
-
         let ctx = SessionContext::new();
         let state = ctx.state();
 
-        // Calculate the staleness threshold
+        // Data fetched before this threshold is considered stale
         #[expect(clippy::cast_possible_truncation)] // Safe: nanoseconds won't exceed i64::MAX
-        let now = SystemTime::now()
+        let stale_threshold = (SystemTime::now() - ttl)
             .duration_since(SystemTime::UNIX_EPOCH)
             .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?
             .as_nanos() as i64;
-        #[expect(clippy::cast_possible_truncation)] // Safe: Duration nanoseconds fit in i64
-        let ttl_nanos = ttl.as_nanos() as i64;
-        let stale_threshold = now - ttl_nanos;
 
         tracing::debug!(
-            "Caching: Querying for stale rows in dataset {} with TTL {:?} (threshold: {})",
-            dataset_name,
-            ttl,
-            stale_threshold
+            "Querying for stale rows in dataset {dataset_name} with TTL {ttl:?} (threshold: {stale_threshold})",
         );
 
         // Scan the accelerator with a filter for stale rows
@@ -132,56 +137,75 @@ impl CacheRefreshHelper {
 
         let plan = accelerator.scan(&state, None, &filters, None).await?;
         let task_ctx = Arc::new(TaskContext::default());
-        let mut total_refreshed = 0;
 
-        // For each stale request combination, re-fetch from the source
-        for partition in 0..plan.properties().output_partitioning().partition_count() {
-            let mut stream = plan.execute(partition, Arc::clone(&task_ctx))?;
+        // Collect all stale rows from accelerator
+        let stale_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
 
-            while let Some(batch_result) = stream.next().await {
-                let batch = batch_result?;
+        // Extract filter sets from all stale rows
+        let mut filter_sets: Vec<Vec<Expr>> = Vec::new();
+        for batch in &stale_batches {
+            for row_idx in 0..batch.num_rows() {
+                let row_filters = Self::extract_filters_from_row(batch, row_idx)?;
+                filter_sets.push(row_filters);
+            }
+        }
 
-                for row_idx in 0..batch.num_rows() {
-                    // Extract the filter parameters for this row
-                    let filters = Self::extract_filters_from_row(&batch, row_idx)?;
+        tracing::debug!(
+            "Found {} stale rows to refresh for dataset {}",
+            filter_sets.len(),
+            dataset_name
+        );
 
-                    // Re-fetch from the federated source with these filters
-                    tracing::debug!(
-                        "Caching: Refreshing stale data for dataset {} with {} filters",
+        if filter_sets.is_empty() {
+            return Ok(0);
+        }
+
+        // Create futures for all refresh operations and run them with limited concurrency
+        let refresh_futures = filter_sets.into_iter().map(|row_filters| {
+            let federated = Arc::clone(&federated);
+            let dataset_name = dataset_name.to_string();
+
+            async move {
+                tracing::debug!(
+                    "Refreshing stale data for dataset {} with {} filters",
+                    dataset_name,
+                    row_filters.len()
+                );
+
+                Self::fetch_from_source(&federated, &dataset_name, &row_filters, None).await
+            }
+        });
+
+        let mut refresh_stream =
+            futures::stream::iter(refresh_futures).buffer_unordered(MAX_CONCURRENT_REFRESHES);
+
+        let mut all_refreshed_batches: Vec<RecordBatch> = Vec::new();
+        while let Some(result) = refresh_stream.next().await {
+            match result {
+                Ok(batches) => {
+                    all_refreshed_batches.extend(batches);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to refresh stale data for dataset {}: {}",
                         dataset_name,
-                        filters.len()
+                        e
                     );
-
-                    match Self::fetch_from_source_on_miss(
-                        Arc::clone(&federated),
-                        Arc::clone(&accelerator),
-                        dataset_name,
-                        &filters,
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(batches) => {
-                            total_refreshed +=
-                                batches.iter().map(RecordBatch::num_rows).sum::<usize>();
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Caching: Failed to refresh stale data for dataset {}: {}",
-                                dataset_name,
-                                e
-                            );
-                        }
-                    }
                 }
             }
         }
 
-        tracing::info!(
-            "Caching: Refreshed {} stale rows for dataset {}",
-            total_refreshed,
-            dataset_name
-        );
+        if all_refreshed_batches.is_empty() {
+            return Ok(0);
+        }
+
+        let total_refreshed: usize = all_refreshed_batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum();
+
+        // Perform a single overwrite with all refreshed data
+        Self::overwrite_accelerator(accelerator, dataset_name, all_refreshed_batches).await?;
 
         Ok(total_refreshed)
     }
@@ -191,95 +215,50 @@ impl CacheRefreshHelper {
         batch: &RecordBatch,
         row_idx: usize,
     ) -> DataFusionResult<Vec<Expr>> {
-        use arrow::array::StringArray;
-        use datafusion::logical_expr::{col, lit};
-
         let schema = batch.schema();
         let mut filters = Vec::new();
 
-        // Extract request_path
-        if let Some((idx, _)) = schema.column_with_name("request_path") {
-            let array = batch
-                .column(idx)
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .ok_or_else(|| {
-                    datafusion::error::DataFusionError::Execution(
-                        "request_path column is not a StringArray".to_string(),
-                    )
-                })?;
+        let filter_columns = ["request_path", "request_query", "request_body"];
 
-            if !array.is_null(row_idx) {
-                let value = array.value(row_idx).to_string();
-                // Only add filter if value is non-empty (empty string means no path filter)
-                if !value.is_empty() {
-                    tracing::debug!("Caching: Extracted request_path filter: {}", value);
-                    filters.push(col("request_path").eq(lit(value)));
-                }
-            }
-        }
+        for column_name in filter_columns {
+            if let Some((idx, _)) = schema.column_with_name(column_name) {
+                let array = batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "{column_name} column is not a StringArray"
+                        ))
+                    })?;
 
-        // Extract request_query
-        if let Some((idx, _)) = schema.column_with_name("request_query") {
-            let array = batch
-                .column(idx)
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .ok_or_else(|| {
-                    datafusion::error::DataFusionError::Execution(
-                        "request_query column is not a StringArray".to_string(),
-                    )
-                })?;
-
-            if !array.is_null(row_idx) {
-                let value = array.value(row_idx).to_string();
-                // Only add filter if value is non-empty (empty string means no query filter)
-                if !value.is_empty() {
-                    tracing::debug!("Caching: Extracted request_query filter: {}", value);
-                    filters.push(col("request_query").eq(lit(value)));
-                }
-            }
-        }
-
-        // Extract request_body
-        if let Some((idx, _)) = schema.column_with_name("request_body") {
-            let array = batch
-                .column(idx)
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .ok_or_else(|| {
-                    datafusion::error::DataFusionError::Execution(
-                        "request_body column is not a StringArray".to_string(),
-                    )
-                })?;
-
-            if !array.is_null(row_idx) {
-                let value = array.value(row_idx).to_string();
-                // Only add filter if value is non-empty (empty string means no body filter)
-                if !value.is_empty() {
-                    tracing::debug!("Caching: Extracted request_body filter: {}", value);
-                    filters.push(col("request_body").eq(lit(value)));
+                if !array.is_null(row_idx) {
+                    let value = array.value(row_idx).to_string();
+                    // Only add filter if value is non-empty (empty string means no filter)
+                    if !value.is_empty() {
+                        tracing::debug!("Extracted {column_name} filter: {value}");
+                        filters.push(col(column_name).eq(lit(value)));
+                    }
                 }
             }
         }
 
         tracing::debug!(
-            "Caching: Extracted {} total filters from row (including empty values)",
+            "Extracted {} total filters from row (including empty values)",
             filters.len()
         );
         Ok(filters)
     }
 
-    /// Insert batches into the accelerator
-    async fn insert_into_accelerator(
+    /// Overwrite the data in the accelerator with the provided batches
+    async fn overwrite_accelerator(
         accelerator: Arc<dyn TableProvider>,
         dataset_name: &str,
         batches: Vec<RecordBatch>,
     ) -> DataFusionResult<()> {
         if batches.is_empty() {
             tracing::debug!(
-                "Caching: insert_into_accelerator called with empty batches for dataset={}",
-                dataset_name
+                "overwrite_accelerator called with empty batches for dataset={dataset_name}"
             );
             return Ok(());
         }
@@ -293,7 +272,7 @@ impl CacheRefreshHelper {
             .sum();
 
         tracing::debug!(
-            "Caching: insert_into_accelerator STARTED - inserting {} batches ({} total rows) into accelerator for dataset={}",
+            "overwrite_accelerator - inserting {} batches ({} total rows) into accelerator for dataset={}",
             batches.len(),
             total_rows,
             dataset_name
@@ -301,21 +280,10 @@ impl CacheRefreshHelper {
 
         // Log the schema and sample data for debugging
         if let Some(first_batch) = batches.first()
-            && let Some((idx, _)) = first_batch
-                .schema()
-                .column_with_name(CACHE_REFRESHED_AT_COLUMN)
-            && let Some(ts_array) = first_batch
-                .column(idx)
-                .as_any()
-                .downcast_ref::<TimestampNanosecondArray>()
-            && first_batch.num_rows() > 0
-            && !ts_array.is_null(0)
+            && let Some(timestamp) = get_first_fetched_at_timestamp(first_batch)
         {
-            let timestamp = ts_array.value(0);
             tracing::debug!(
-                "Caching: insert_into_accelerator first batch has {} timestamp={}",
-                CACHE_REFRESHED_AT_COLUMN,
-                timestamp
+                "overwrite_accelerator first batch has {CACHE_REFRESHED_AT_COLUMN} timestamp={timestamp}"
             );
         }
 
@@ -335,16 +303,10 @@ impl CacheRefreshHelper {
         // (e.g., search results), which would violate primary key constraints if we used
         // InsertOp::Append. This means each query overwrites the cache, which is acceptable
         // for the caching use case.
-        //
-        // Note: True multi-filter caching (storing results from different queries separately)
-        // would require either:
-        // 1. Adding a row number column to make each row unique
-        // 2. Using DELETE WHERE + INSERT instead of overwrite
-        // 3. Storing responses as JSON blobs
         let insert_op = InsertOp::Overwrite;
 
         tracing::debug!(
-            "Caching: insert_into_accelerator calling accelerator.insert_into with op={:?} for dataset={}",
+            "overwrite_accelerator calling accelerator.insert_into with op={:?} for dataset={}",
             insert_op,
             dataset_name
         );
@@ -352,221 +314,199 @@ impl CacheRefreshHelper {
 
         // Execute the insertion
         tracing::debug!(
-            "Caching: insert_into_accelerator executing insert plan for dataset={}",
+            "overwrite_accelerator executing insert plan for dataset={}",
             dataset_name
         );
         let task_ctx = Arc::new(TaskContext::default());
-        let result = datafusion::physical_plan::collect(insert_plan, task_ctx).await?;
+        let _ = datafusion::physical_plan::collect(insert_plan, task_ctx).await?;
         tracing::debug!(
-            "Caching: insert_into_accelerator execution complete, result batches={} for dataset={}",
-            result.len(),
-            dataset_name
-        );
-
-        tracing::debug!(
-            "Caching: insert_into_accelerator COMPLETED - successfully inserted {} rows into accelerator for dataset={}",
+            "overwrite_accelerator COMPLETED - successfully inserted {} rows into accelerator for dataset={}",
             total_rows,
             dataset_name
         );
         Ok(())
     }
 
-    /// Fetch from source on cache miss (synchronous - blocks the query)
-    async fn fetch_from_source_on_miss(
-        federated: Arc<dyn TableProvider>,
-        accelerator: Arc<dyn TableProvider>,
+    /// Fetch data from federated source for given filters
+    async fn fetch_from_source(
+        federated: &Arc<dyn TableProvider>,
         dataset_name: &str,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Vec<RecordBatch>> {
-        tracing::info!(
-            "Caching: FETCH FROM SOURCE STARTED on cache miss for dataset {} with {} filters, limit={:?}",
-            dataset_name,
-            filters.len(),
-            limit
+        tracing::debug!(
+            "Fetching from source for dataset {dataset_name} with {} filters, limit={limit:?}",
+            filters.len()
         );
         for (i, filter) in filters.iter().enumerate() {
-            tracing::info!("Caching: Source fetch filter {}: {:?}", i, filter);
+            tracing::debug!("Source fetch filter {i}: {}", filter.human_display());
         }
 
         let ctx = SessionContext::new();
         let state = ctx.state();
 
         // Query source with same filters/limit but all columns
-        tracing::info!(
-            "Caching: About to SCAN federated source for dataset={}",
-            dataset_name
-        );
+        tracing::debug!("About to scan federated source for dataset={dataset_name}");
         let plan = federated.scan(&state, None, filters, limit).await?;
-        tracing::info!(
-            "Caching: Federated source SCAN successful for dataset={}, plan has {} partitions",
-            dataset_name,
+        tracing::debug!(
+            "Federated source SCAN successful for dataset={dataset_name}, plan has {} partitions",
             plan.properties().output_partitioning().partition_count()
         );
         let task_ctx = Arc::new(TaskContext::default());
 
-        // Execute and collect
-        let mut all_batches = Vec::new();
-        for partition in 0..plan.properties().output_partitioning().partition_count() {
-            tracing::info!(
-                "Caching: Executing federated source partition {} for dataset={}",
-                partition,
-                dataset_name
-            );
-            let mut stream = plan.execute(partition, Arc::clone(&task_ctx))?;
-            tracing::info!(
-                "Caching: Federated source partition {} stream created for dataset={}, reading batches...",
-                partition,
-                dataset_name
-            );
-            while let Some(batch) = stream.next().await {
-                let batch = batch?;
-                tracing::info!(
-                    "Caching: Federated source partition {} returned batch with {} rows for dataset={}",
-                    partition,
-                    batch.num_rows(),
-                    dataset_name
-                );
-                if batch.num_rows() > 0 {
-                    all_batches.push(batch);
-                }
-            }
-            tracing::info!(
-                "Caching: Finished reading federated source partition {} for dataset={}",
-                partition,
-                dataset_name
-            );
-        }
+        // Execute and collect all batches
+        let all_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
 
-        // Store in accelerator for future queries
-        tracing::info!(
-            "Caching: About to INSERT {} batches into accelerator for dataset={}",
+        tracing::debug!(
+            "Federated source returned {} batches for dataset={}",
             all_batches.len(),
-            dataset_name
-        );
-        Self::insert_into_accelerator(Arc::clone(&accelerator), dataset_name, all_batches.clone())
-            .await?;
-        tracing::info!(
-            "Caching: INSERT into accelerator COMPLETE for dataset={}",
             dataset_name
         );
 
         Ok(all_batches)
     }
 
-    /// Query the source and update the accelerator with fresh data (background refresh)
-    async fn refresh_from_source(
+    /// Handle a cache miss by fetching from source and returning a stream.
+    /// Returns a `SendableRecordBatchStream` containing the fetched data, empty stream, or error stream.
+    async fn handle_cache_miss(
         federated: Arc<dyn TableProvider>,
         accelerator: Arc<dyn TableProvider>,
         dataset_name: &str,
         filters: &[Expr],
         limit: Option<usize>,
-    ) -> DataFusionResult<usize> {
-        tracing::info!(
-            "Caching: refresh_from_source STARTED for dataset={}, filters={:?}, limit={:?}",
-            dataset_name,
-            filters,
-            limit
-        );
+        fallback_schema: SchemaRef,
+    ) -> SendableRecordBatchStream {
+        match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
+            Ok(batches) if !batches.is_empty() => {
+                let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+                tracing::debug!(
+                    "Fetched {} batches ({} total rows) from source for dataset {}",
+                    batches.len(),
+                    total_rows,
+                    dataset_name
+                );
 
-        // Create a session to query the source
-        let ctx = SessionContext::new();
-        let state = ctx.state();
-
-        // Run the same filters/limit but fetch all columns (no projection)
-        tracing::info!(
-            "Caching: refresh_from_source calling federated.scan() for dataset={}",
-            dataset_name
-        );
-        let plan = federated.scan(&state, None, filters, limit).await?;
-        tracing::info!(
-            "Caching: refresh_from_source federated.scan() completed for dataset={}, partitions={}",
-            dataset_name,
-            plan.properties().output_partitioning().partition_count()
-        );
-
-        let task_ctx = Arc::new(TaskContext::default());
-
-        // Execute all partitions and collect data
-        let mut all_batches = Vec::new();
-        for partition in 0..plan.properties().output_partitioning().partition_count() {
-            tracing::info!(
-                "Caching: refresh_from_source executing partition {} for dataset={}",
-                partition,
-                dataset_name
-            );
-            let mut stream = plan.execute(partition, Arc::clone(&task_ctx))?;
-            while let Some(batch) = stream.next().await {
-                let batch = batch?;
-                if batch.num_rows() > 0 {
-                    tracing::info!(
-                        "Caching: refresh_from_source partition {} returned {} rows for dataset={}",
-                        partition,
-                        batch.num_rows(),
-                        dataset_name
+                // Store in accelerator for future queries
+                if let Err(e) =
+                    Self::overwrite_accelerator(accelerator, dataset_name, batches.clone()).await
+                {
+                    tracing::warn!(
+                        "Failed to store fetched data in accelerator for dataset {}: {}",
+                        dataset_name,
+                        e
                     );
-
-                    // Log fetched_at timestamp if present
-                    if let Some((idx, _)) =
-                        batch.schema().column_with_name(CACHE_REFRESHED_AT_COLUMN)
-                        && let Some(ts_array) = batch
-                            .column(idx)
-                            .as_any()
-                            .downcast_ref::<TimestampNanosecondArray>()
-                        && !ts_array.is_null(0)
-                    {
-                        let timestamp = ts_array.value(0);
-                        tracing::info!(
-                            "Caching: refresh_from_source fetched data has {} timestamp={}",
-                            CACHE_REFRESHED_AT_COLUMN,
-                            timestamp
-                        );
-                    }
-
-                    all_batches.push(batch);
                 }
+
+                // Use the schema from the fetched batches, not from the accelerator scan
+                let batch_schema = batches[0].schema();
+                tracing::debug!("Fetched batch schema:\n{}", SchemaDisplay(&batch_schema));
+                let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
+                let adapter = RecordBatchStreamAdapter::new(batch_schema, batch_stream);
+                Box::pin(adapter)
+            }
+            Ok(_) => {
+                // Source returned empty data (no error, just no rows)
+                tracing::debug!(
+                    "Cache miss - source also has no data for dataset {}",
+                    dataset_name
+                );
+                let empty_stream =
+                    RecordBatchStreamAdapter::new(fallback_schema, futures::stream::empty());
+                Box::pin(empty_stream)
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Cache miss fetch failed for dataset {}: {}",
+                    dataset_name,
+                    e
+                );
+                let error_stream = RecordBatchStreamAdapter::new(
+                    fallback_schema,
+                    futures::stream::once(async move { Err(e) }),
+                );
+                Box::pin(error_stream)
             }
         }
+    }
 
-        if all_batches.is_empty() {
-            tracing::info!(
-                "Caching: refresh_from_source - no data fetched from source for dataset {}",
-                dataset_name
+    /// Handle a cache hit by returning cached data and optionally triggering background refresh.
+    /// Returns a `SendableRecordBatchStream` containing the cached data.
+    async fn handle_cache_hit(
+        cached_batches: Vec<RecordBatch>,
+        federated: &Arc<dyn TableProvider>,
+        accelerator: &Arc<dyn TableProvider>,
+        dataset_name: &str,
+        ttl: Option<Duration>,
+        io_runtime: &Handle,
+        schema: SchemaRef,
+    ) -> SendableRecordBatchStream {
+        let total_cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
+
+        tracing::debug!(
+            dataset = %dataset_name,
+            num_batches = cached_batches.len(),
+            total_rows = total_cached_rows,
+            "CACHE HIT - accelerator returned {} rows in {} batches",
+            total_cached_rows,
+            cached_batches.len()
+        );
+
+        // Check if data is stale and trigger background refresh if needed
+        if let Some(ttl) = ttl
+            && is_data_stale(cached_batches.clone(), ttl)
+                .await
+                .unwrap_or(false)
+        {
+            tracing::debug!(
+                "Data is stale for dataset={dataset_name}, triggering background refresh"
             );
-            return Ok(0);
+
+            // Log current fetched_at for debugging
+            if let Some(timestamp) = get_first_fetched_at_timestamp(&cached_batches[0]) {
+                tracing::debug!(
+                    "Current stale data has {CACHE_REFRESHED_AT_COLUMN} timestamp={timestamp}"
+                );
+            }
+
+            let federated_clone = Arc::clone(federated);
+            let accelerator_clone = Arc::clone(accelerator);
+            let dataset_name_clone = dataset_name.to_string();
+
+            io_runtime.spawn(async move {
+                tracing::debug!("Background refresh task started for dataset={dataset_name_clone}");
+                match Self::refresh_stale_rows(
+                    federated_clone,
+                    accelerator_clone,
+                    &dataset_name_clone,
+                    ttl,
+                )
+                .await
+                {
+                    Ok(rows) => {
+                        tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows");
+                    }
+                    Err(e) => {
+                        tracing::error!("Background refresh task failed for dataset={dataset_name_clone}: {e}");
+                    }
+                }
+            });
+        } else {
+            tracing::debug!(
+                "Data is fresh for dataset={dataset_name}, no background refresh needed"
+            );
         }
 
-        let total_rows: usize = all_batches
-            .iter()
-            .map(arrow::array::RecordBatch::num_rows)
-            .sum();
-
-        tracing::info!(
-            "Caching: refresh_from_source fetched {} batches ({} total rows) from source for dataset {}",
-            all_batches.len(),
-            total_rows,
-            dataset_name
-        );
-
-        // Insert/replace the batches into the accelerator
-        tracing::info!(
-            "Caching: refresh_from_source calling insert_into_accelerator for dataset={}",
-            dataset_name
-        );
-        Self::insert_into_accelerator(accelerator, dataset_name, all_batches).await?;
-        tracing::info!(
-            "Caching: refresh_from_source COMPLETED successfully for dataset={}, refreshed {} rows",
-            dataset_name,
-            total_rows
-        );
-
-        Ok(total_rows)
+        // Return the cached data
+        let batch_stream = futures::stream::iter(cached_batches.into_iter().map(Ok));
+        let adapter = RecordBatchStreamAdapter::new(schema, batch_stream);
+        Box::pin(adapter)
     }
 }
 
 /// Caching acceleration execution plan that checks staleness and triggers background refresh
 pub struct CachingAccelerationScanExec {
     input: Arc<dyn ExecutionPlan>,
+    plan_properties: PlanProperties,
     ttl: Option<Duration>,
     federated: Arc<dyn TableProvider>,
     accelerator: Arc<dyn TableProvider>,
@@ -593,8 +533,15 @@ impl CachingAccelerationScanExec {
         // Default TTL to 30 seconds if not specified
         let ttl = ttl.or(Some(Duration::from_secs(30)));
 
+        let plan_properties = input
+            .properties()
+            .clone()
+            .with_emission_type(EmissionType::Final)
+            .with_partitioning(Partitioning::UnknownPartitioning(1));
+
         Self {
             input,
+            plan_properties,
             ttl,
             federated,
             accelerator,
@@ -604,48 +551,6 @@ impl CachingAccelerationScanExec {
             projection,
             limit,
         }
-    }
-
-    /// Check if we should trigger a background refresh
-    #[expect(dead_code)]
-    fn should_refresh(&self, batch: &RecordBatch) -> bool {
-        let Some(ttl) = self.ttl else {
-            return false; // No TTL configured, never refresh
-        };
-
-        is_data_stale(batch, ttl).unwrap_or(false)
-    }
-
-    /// Run the user's query on the source (federated table) to fetch fresh data
-    #[expect(dead_code)]
-    async fn fetch_from_source(
-        federated: Arc<dyn TableProvider>,
-        dataset_name: &str,
-        state: &dyn Session,
-        filters: &[Expr],
-        projection: Option<&Vec<usize>>,
-        limit: Option<usize>,
-    ) -> DataFusionResult<Vec<RecordBatch>> {
-        tracing::debug!(
-            "Caching: Fetching fresh data from source for dataset {}",
-            dataset_name
-        );
-
-        // Simply run the same query the user requested, but on the source
-        let plan = federated.scan(state, projection, filters, limit).await?;
-        let _ctx = SessionContext::new(); // TODO: Use for execution context when implementing background refresh
-        let task_ctx = Arc::new(TaskContext::default());
-
-        // Execute all partitions
-        let mut all_batches = Vec::new();
-        for partition in 0..plan.properties().output_partitioning().partition_count() {
-            let mut stream = plan.execute(partition, Arc::clone(&task_ctx))?;
-            while let Some(batch) = stream.next().await {
-                all_batches.push(batch?);
-            }
-        }
-
-        Ok(all_batches)
     }
 }
 
@@ -675,7 +580,11 @@ impl ExecutionPlan for CachingAccelerationScanExec {
     }
 
     fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
-        self.input.properties()
+        &self.plan_properties
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition; 1]
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -699,27 +608,20 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         )))
     }
 
-    #[expect(clippy::too_many_lines)]
     fn execute(
         &self,
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         tracing::debug!(
-            "CachingAccelerationScanExec::execute called for dataset={} partition={}",
-            self.dataset_name,
-            partition
+            "CachingAccelerationScanExec::execute called for dataset={} partition={partition}",
+            self.dataset_name
         );
 
         // Execute the accelerator scan
-        let mut accelerator_stream = self.input.execute(partition, Arc::clone(&context))?;
+        let accelerator_stream = self.input.execute(partition, Arc::clone(&context))?;
         let schema = accelerator_stream.schema();
         let schema_clone = Arc::clone(&schema);
-
-        // For multi-partition accelerators (e.g., DuckDB), only partition 0 should handle cache miss.
-        // Other partitions should just return accelerator data (or empty if no cached data).
-        // This prevents multiple partitions from concurrently fetching and inserting the same data.
-        let is_primary_partition = partition == 0;
 
         let federated = Arc::clone(&self.federated);
         let accelerator = Arc::clone(&self.accelerator);
@@ -741,201 +643,57 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                 dataset_name
             );
 
-            // Check if accelerator has data
+            // Collect all batches from the accelerator stream
             tracing::debug!(
                 dataset = %dataset_name,
                 num_filters = filters.len(),
-                "CACHING EXEC: About to read first batch from accelerator stream"
+                "About to read batches from accelerator stream"
             );
-            if let Some(first_batch) = accelerator_stream.next().await {
-                match first_batch {
-                    Ok(batch) if batch.num_rows() > 0 => {
-                        tracing::debug!(
-                            dataset = %dataset_name,
-                            num_rows = batch.num_rows(),
-                            num_columns = batch.num_columns(),
-                            "CACHING EXEC: CACHE HIT - accelerator returned {} rows",
-                            batch.num_rows()
-                        );
-                        // Check if data is stale and trigger background refresh if needed
-                        if let Some(ttl) = ttl
-                            && is_data_stale(&batch, ttl).unwrap_or(false) {
-                                tracing::debug!("Caching: Data is STALE for dataset={}, triggering background refresh", dataset_name);
 
-                                // Log current fetched_at for debugging
-                                if let Some((idx, _)) = batch.schema().column_with_name(CACHE_REFRESHED_AT_COLUMN)
-                                    && let Some(ts_array) = batch.column(idx).as_any().downcast_ref::<TimestampNanosecondArray>()
-                                        && batch.num_rows() > 0 && !ts_array.is_null(0) {
-                                            let current_timestamp = ts_array.value(0);
-                                            tracing::debug!("Caching: Current stale data has {} timestamp={}", CACHE_REFRESHED_AT_COLUMN, current_timestamp);
-                                        }
-
-                                let federated_clone = Arc::clone(&federated);
-                                let accelerator_clone = Arc::clone(&accelerator);
-                                let dataset_name_clone = dataset_name.clone();
-                                let filters_clone = filters.clone();
-
-                                io_runtime.spawn(async move {
-                                    tracing::debug!("Caching: Background refresh task STARTED for dataset={}", dataset_name_clone);
-                                    match CacheRefreshHelper::refresh_from_source(
-                                        federated_clone,
-                                        accelerator_clone,
-                                        &dataset_name_clone,
-                                        &filters_clone,
-                                        limit,
-                                    ).await {
-                                        Ok(rows) => {
-                                            tracing::info!("Caching: Background refresh task COMPLETED SUCCESSFULLY for dataset={}, refreshed {} rows", dataset_name_clone, rows);
-                                        }
-                                        Err(e) => {
-                                            tracing::error!("Caching: Background refresh task FAILED for dataset={}: {}", dataset_name_clone, e);
-                                        }
-                                    }
-                                });
-                            } else {
-                                tracing::debug!("Caching: Data is FRESH for dataset={}, no background refresh needed", dataset_name);
-                            }
-
-                        // Return the accelerator data (piece back the stream with first batch)
-                        let first_batch_stream = futures::stream::once(async move { Ok(batch) });
-                        let adapter = RecordBatchStreamAdapter::new(
-                            Arc::clone(&schema_clone),
-                            first_batch_stream.chain(accelerator_stream),
-                        );
-                        Box::pin(adapter) as SendableRecordBatchStream
-                    }
-                    Ok(_batch) => {
-                        // Empty batch (0 rows) - treat as cache miss
-                        // Only the primary partition (partition 0) handles cache miss fetching
-                        // to avoid multiple partitions trying to insert the same data
-                        if is_primary_partition {
-                            tracing::debug!(
-                                dataset = %dataset_name,
-                                "CACHING EXEC: CACHE MISS (0 rows) - accelerator returned empty batch, fetching from source"
-                            );
-
-                            // Fetch from source synchronously
-                            match CacheRefreshHelper::fetch_from_source_on_miss(Arc::clone(&federated), Arc::clone(&accelerator), &dataset_name, &filters, limit).await {
-                                Ok(batches) if !batches.is_empty() => {
-                                    let total_rows: usize = batches.iter().map(arrow::array::RecordBatch::num_rows).sum();
-                                    tracing::debug!("Caching: Fetched {} batches ({} total rows) from source for dataset {}",
-                                        batches.len(),
-                                        total_rows,
-                                        dataset_name);
-
-                                    let batch_schema = batches[0].schema();
-                                    let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
-                                    let adapter = RecordBatchStreamAdapter::new(batch_schema, batch_stream);
-                                    Box::pin(adapter) as SendableRecordBatchStream
-                                }
-                                Ok(_) => {
-                                    // Source returned empty data (no error, just no rows)
-                                    tracing::warn!(
-                                        dataset = %dataset_name,
-                                        "Caching: Source returned empty data on cache miss"
-                                    );
-                                    let empty_stream = RecordBatchStreamAdapter::new(
-                                        Arc::clone(&schema_clone),
-                                        futures::stream::empty(),
-                                    );
-                                    Box::pin(empty_stream) as SendableRecordBatchStream
-                                }
-                                Err(e) => {
-                                    // Error from source - propagate it!
-                                    tracing::error!(
-                                        dataset = %dataset_name,
-                                        error = %e,
-                                        "Caching: Error fetching from source on cache miss"
-                                    );
-                                    let error_stream = RecordBatchStreamAdapter::new(
-                                        Arc::clone(&schema_clone),
-                                        futures::stream::once(async move { Err(e) }),
-                                    );
-                                    Box::pin(error_stream) as SendableRecordBatchStream
-                                }
-                            }
-                        } else {
-                            tracing::debug!(
-                                dataset = %dataset_name,
-                                partition = partition,
-                                "CACHING EXEC: CACHE MISS (0 rows) - non-primary partition, returning empty"
-                            );
-                            let empty_stream = RecordBatchStreamAdapter::new(
-                                Arc::clone(&schema_clone),
-                                futures::stream::empty(),
-                            );
-                            Box::pin(empty_stream) as SendableRecordBatchStream
-                        }
-                    }
-                    Err(e) => {
-                        // Error from accelerator - return the error
-                        let error_stream = RecordBatchStreamAdapter::new(
-                            Arc::clone(&schema_clone),
-                            futures::stream::once(async move { Err(e) }),
-                        );
-                        Box::pin(error_stream) as SendableRecordBatchStream
-                    }
-                }
-            } else {
-                // Cache miss - accelerator returned no data
-                // Only the primary partition (partition 0) handles cache miss fetching
-                // to avoid multiple partitions trying to insert the same data
-                if is_primary_partition {
-                    tracing::info!("Caching: CACHE MISS (no first batch) for dataset {} - accelerator returned None, fetching from source", dataset_name);
-
-                    // Fetch from source synchronously
-                    match CacheRefreshHelper::fetch_from_source_on_miss(federated, Arc::clone(&accelerator), &dataset_name, &filters, limit).await {
-                        Ok(batches) if !batches.is_empty() => {
-                            let total_rows: usize = batches.iter().map(arrow::array::RecordBatch::num_rows).sum();
-                            tracing::info!("Caching: Fetched {} batches ({} total rows) from source for dataset {}",
-                                batches.len(),
-                                total_rows,
-                                dataset_name);
-
-                            // Debug: log the schema and first batch data
-                            if let Some(first_batch) = batches.first() {
-                                tracing::info!("Caching: Fetched batch schema: {:?}", first_batch.schema());
-                                tracing::info!("Caching: First batch data: {:?}", first_batch);
-                            }
-
-                            // Use the schema from the fetched batches, not from the accelerator scan
-                            let batch_schema = batches[0].schema();
-                            let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
-                            let adapter = RecordBatchStreamAdapter::new(batch_schema, batch_stream);
-                            Box::pin(adapter) as SendableRecordBatchStream
-                        }
-                        Ok(_) => {
-                            // Source also returned no data
-                            tracing::debug!("Caching: Cache miss - source also has no data for dataset {}", dataset_name);
-                            let empty_stream = RecordBatchStreamAdapter::new(
-                                Arc::clone(&schema_clone),
-                                futures::stream::empty(),
-                            );
-                            Box::pin(empty_stream) as SendableRecordBatchStream
-                        }
-                        Err(e) => {
-                            tracing::error!("Caching: Cache miss fetch failed for dataset {}: {}", dataset_name, e);
-                            let error_stream = RecordBatchStreamAdapter::new(
-                                Arc::clone(&schema_clone),
-                                futures::stream::once(async move { Err(e) }),
-                            );
-                            Box::pin(error_stream) as SendableRecordBatchStream
-                        }
-                    }
-                } else {
-                    tracing::debug!(
-                        "Caching: CACHE MISS (no first batch) for dataset {} - non-primary partition {}, returning empty",
-                        dataset_name,
-                        partition
-                    );
-                    let empty_stream = RecordBatchStreamAdapter::new(
+            let cached_batches: Vec<RecordBatch> = match accelerator_stream.try_collect().await {
+                Ok(batches) => batches,
+                Err(e) => {
+                    // Error from accelerator - return the error
+                    let error_stream = RecordBatchStreamAdapter::new(
                         Arc::clone(&schema_clone),
-                        futures::stream::empty(),
+                        futures::stream::once(async move { Err(e) }),
                     );
-                    Box::pin(empty_stream) as SendableRecordBatchStream
+                    return Box::pin(error_stream) as SendableRecordBatchStream;
                 }
+            };
+
+            // Filter out empty batches and count total rows
+            let cached_batches: Vec<RecordBatch> = cached_batches
+                .into_iter()
+                .filter(|b| b.num_rows() > 0)
+                .collect();
+            let total_cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
+
+            if total_cached_rows > 0 {
+                CacheRefreshHelper::handle_cache_hit(
+                    cached_batches,
+                    &federated,
+                    &accelerator,
+                    &dataset_name,
+                    ttl,
+                    &io_runtime,
+                    Arc::clone(&schema_clone),
+                )
+                .await
+            } else {
+                // Cache miss - no data in accelerator - retrieve from source and store in accelerator
+                CacheRefreshHelper::handle_cache_miss(
+                    federated,
+                    accelerator,
+                    &dataset_name,
+                    &filters,
+                    limit,
+                    Arc::clone(&schema_clone),
+                )
+                .await
             }
-        }).flatten();
+        })
+        .flatten();
 
         let adapter = RecordBatchStreamAdapter::new(schema, cache_miss_or_stale_stream);
         Ok(Box::pin(adapter))
@@ -983,8 +741,8 @@ mod tests {
         ]))
     }
 
-    #[test]
-    fn test_is_data_stale_no_refresh_column() {
+    #[tokio::test]
+    async fn test_is_data_stale_no_refresh_column() {
         let schema = create_test_schema_without_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2, 3]);
         let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
@@ -996,15 +754,17 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60);
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(
             result,
             "Data without refresh column should be considered stale"
         );
     }
 
-    #[test]
-    fn test_is_data_stale_fresh_data() {
+    #[tokio::test]
+    async fn test_is_data_stale_fresh_data() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2, 3]);
         let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
@@ -1033,12 +793,14 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60); // 60 second TTL
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(!result, "Data refreshed within TTL should not be stale");
     }
 
-    #[test]
-    fn test_is_data_stale_stale_data() {
+    #[tokio::test]
+    async fn test_is_data_stale_stale_data() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2]);
         let name_array = StringArray::from(vec!["alice", "bob"]);
@@ -1065,12 +827,14 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60); // 60 second TTL
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(result, "Data older than TTL should be stale");
     }
 
-    #[test]
-    fn test_is_data_stale_null_timestamps() {
+    #[tokio::test]
+    async fn test_is_data_stale_null_timestamps() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2]);
         let name_array = StringArray::from(vec!["alice", "bob"]);
@@ -1088,15 +852,17 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60);
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(
             result,
             "Data with null timestamps should be considered stale"
         );
     }
 
-    #[test]
-    fn test_is_data_stale_mixed_timestamps() {
+    #[tokio::test]
+    async fn test_is_data_stale_mixed_timestamps() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2, 3]);
         let name_array = StringArray::from(vec!["alice", "bob", "charlie"]);
@@ -1125,15 +891,17 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60);
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(
             result,
             "Data with any stale timestamp should be considered stale"
         );
     }
 
-    #[test]
-    fn test_is_data_stale_ttl_boundary() {
+    #[tokio::test]
+    async fn test_is_data_stale_ttl_boundary() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(vec![1, 2]);
         let name_array = StringArray::from(vec!["alice", "bob"]);
@@ -1164,8 +932,9 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let result_fresh =
-            is_data_stale(&batch_fresh, ttl).expect("Should successfully check staleness");
+        let result_fresh = is_data_stale(vec![batch_fresh], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(
             !result_fresh,
             "Data well within TTL boundary should not be stale"
@@ -1187,13 +956,24 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let result_stale =
-            is_data_stale(&batch_stale, ttl).expect("Should successfully check staleness");
+        let result_stale = is_data_stale(vec![batch_stale], ttl)
+            .await
+            .expect("Should successfully check staleness");
         assert!(result_stale, "Data well past TTL boundary should be stale");
     }
 
-    #[test]
-    fn test_is_data_stale_empty_batch() {
+    #[tokio::test]
+    async fn test_is_data_stale_empty_slice() {
+        let batches: Vec<RecordBatch> = Vec::new();
+        let ttl = Duration::from_secs(60);
+        let result = is_data_stale(batches, ttl)
+            .await
+            .expect("Should successfully check staleness");
+        assert!(!result, "Empty slice should not be considered stale");
+    }
+
+    #[tokio::test]
+    async fn test_is_data_stale_empty_batch() {
         let schema = create_test_schema_with_refresh_timestamp();
         let id_array = Int32Array::from(Vec::<i32>::new());
         let name_array = StringArray::from(Vec::<&str>::new());
@@ -1210,8 +990,101 @@ mod tests {
         .expect("Failed to create batch");
 
         let ttl = Duration::from_secs(60);
-        let result = is_data_stale(&batch, ttl).expect("Should successfully check staleness");
-        assert!(!result, "Empty batch should not be considered stale");
+        let result = is_data_stale(vec![batch], ttl)
+            .await
+            .expect("Should successfully check staleness");
+        assert!(
+            !result,
+            "Batch with zero rows should not be considered stale"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_data_stale_multiple_batches_all_fresh() {
+        let schema = create_test_schema_with_refresh_timestamp();
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        let batch1 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["alice", "bob"])),
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    Some(now - 10_000_000_000), // 10 seconds ago
+                    Some(now - 20_000_000_000), // 20 seconds ago
+                ])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![3, 4])),
+                Arc::new(StringArray::from(vec!["charlie", "dave"])),
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    Some(now - 15_000_000_000), // 15 seconds ago
+                    Some(now - 25_000_000_000), // 25 seconds ago
+                ])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let ttl = Duration::from_secs(60);
+        let result = is_data_stale(vec![batch1, batch2], ttl)
+            .await
+            .expect("Should successfully check staleness");
+        assert!(!result, "All fresh batches should not be stale");
+    }
+
+    #[tokio::test]
+    async fn test_is_data_stale_multiple_batches_one_stale() {
+        let schema = create_test_schema_with_refresh_timestamp();
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        // First batch is fresh
+        let batch1 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["alice", "bob"])),
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    Some(now - 10_000_000_000), // 10 seconds ago
+                    Some(now - 20_000_000_000), // 20 seconds ago
+                ])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        // Second batch has stale data
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![3, 4])),
+                Arc::new(StringArray::from(vec!["charlie", "dave"])),
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    Some(now - 15_000_000_000),  // 15 seconds ago (fresh)
+                    Some(now - 120_000_000_000), // 120 seconds ago (stale)
+                ])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let ttl = Duration::from_secs(60);
+        let result = is_data_stale(vec![batch1, batch2], ttl)
+            .await
+            .expect("Should successfully check staleness");
+        assert!(result, "Should be stale if any row in any batch is stale");
     }
 
     #[test]

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -378,8 +378,8 @@ impl CacheRefreshHelper {
     /// Insert new data into the accelerator by combining with existing data and overwriting.
     /// This is used when there is no existing data in the cache for the given filters (cache miss).
     ///
-    /// Note: We use read-combine-overwrite instead of `InsertOp::Append` because the DuckDB
-    /// accelerator uses views with underlying data tables, and DuckDB views don't support
+    /// Note: We use read-combine-overwrite instead of `InsertOp::Append` because the `DuckDB`
+    /// accelerator uses views with underlying data tables, and `DuckDB` views don't support
     /// direct INSERT operations. The `InsertOp::Append` fails with "is not an table" error.
     async fn insert_into_accelerator(
         accelerator: &Arc<dyn TableProvider>,

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -76,7 +76,7 @@ pub enum CacheFreshness {
 /// - `Fresh`: Data was fetched within `max_age` duration
 /// - `Stale`: Data was fetched more than `max_age` ago but within `max_age + stale_while_revalidate`
 /// - `Rotten`: Data was fetched more than `max_age + stale_while_revalidate` ago (or has no timestamp)
-async fn check_cache_freshness(
+fn check_cache_freshness(
     batches: &[RecordBatch],
     max_age: Duration,
     stale_while_revalidate: Option<Duration>,
@@ -113,34 +113,34 @@ async fn check_cache_freshness(
         fresh_threshold
     };
 
-    // Use DataFrame API to check freshness
-    let ctx = SessionContext::new();
-    let df = ctx.read_batches(batches.to_vec())?;
-
-    // Check for rotten rows first: fetched_at IS NULL OR fetched_at < rotten_threshold
-    let rotten_filter = col(CACHE_REFRESHED_AT_COLUMN)
-        .is_null()
-        .or(
-            col(CACHE_REFRESHED_AT_COLUMN).lt(lit(ScalarValue::TimestampNanosecond(
-                Some(rotten_threshold),
-                None,
-            ))),
-        );
-
-    let rotten_count = df.clone().filter(rotten_filter)?.count().await?;
-    if rotten_count > 0 {
-        return Ok(CacheFreshness::Rotten);
-    }
-
-    // Check for stale rows: fetched_at < fresh_threshold (but not rotten, checked above)
-    let stale_filter = col(CACHE_REFRESHED_AT_COLUMN).lt(lit(ScalarValue::TimestampNanosecond(
-        Some(fresh_threshold),
-        None,
-    )));
-
-    let stale_count = df.filter(stale_filter)?.count().await?;
-    if stale_count > 0 {
-        return Ok(CacheFreshness::Stale);
+    // Directly scan Arrow arrays for freshness (avoid DataFusion overhead)
+    for batch in batches {
+        let col_idx = batch
+            .schema()
+            .index_of(CACHE_REFRESHED_AT_COLUMN)
+            .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?;
+        let array = batch.column(col_idx);
+        let ts_array = array
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Execution(
+                    "CACHE_REFRESHED_AT_COLUMN is not TimestampNanosecondArray".to_string(),
+                )
+            })?;
+        for i in 0..ts_array.len() {
+            if !ts_array.is_valid(i) {
+                // Null value = rotten
+                return Ok(CacheFreshness::Rotten);
+            }
+            let ts = ts_array.value(i);
+            if ts < rotten_threshold {
+                return Ok(CacheFreshness::Rotten);
+            }
+            if ts < fresh_threshold {
+                return Ok(CacheFreshness::Stale);
+            }
+        }
     }
 
     Ok(CacheFreshness::Fresh)
@@ -208,9 +208,12 @@ impl CacheRefreshHelper {
             return Ok(0);
         }
 
-        // Create futures for all refresh operations and run them with limited concurrency
+        // Create futures for all refresh operations and run them with limited concurrency.
+        // Each refresh fetches from the source and then upserts into the accelerator,
+        // which preserves data for other cache entries (different request paths/queries).
         let refresh_futures = filter_sets.into_iter().map(|row_filters| {
             let federated = Arc::clone(&federated);
+            let accelerator = Arc::clone(&accelerator);
             let dataset_name = dataset_name.to_string();
 
             async move {
@@ -220,18 +223,32 @@ impl CacheRefreshHelper {
                     row_filters.len()
                 );
 
-                Self::fetch_from_source(&federated, &dataset_name, &row_filters, None).await
+                let batches =
+                    Self::fetch_from_source(&federated, &dataset_name, &row_filters, None).await?;
+
+                if batches.is_empty() {
+                    return Ok::<usize, datafusion::error::DataFusionError>(0);
+                }
+
+                let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+
+                // Upsert this specific cache entry - removes rows matching the filters
+                // and adds the new data, preserving other cache entries.
+                Self::upsert_into_accelerator(&accelerator, &dataset_name, &row_filters, batches)
+                    .await?;
+
+                Ok(refreshed_rows)
             }
         });
 
         let mut refresh_stream =
             futures::stream::iter(refresh_futures).buffer_unordered(MAX_CONCURRENT_REFRESHES);
 
-        let mut all_refreshed_batches: Vec<RecordBatch> = Vec::new();
+        let mut total_refreshed: usize = 0;
         while let Some(result) = refresh_stream.next().await {
             match result {
-                Ok(batches) => {
-                    all_refreshed_batches.extend(batches);
+                Ok(rows) => {
+                    total_refreshed += rows;
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -242,18 +259,6 @@ impl CacheRefreshHelper {
                 }
             }
         }
-
-        if all_refreshed_batches.is_empty() {
-            return Ok(0);
-        }
-
-        let total_refreshed: usize = all_refreshed_batches
-            .iter()
-            .map(RecordBatch::num_rows)
-            .sum();
-
-        // Perform a single overwrite with all refreshed data
-        Self::overwrite_accelerator(accelerator, dataset_name, all_refreshed_batches).await?;
 
         Ok(total_refreshed)
     }
@@ -668,7 +673,7 @@ impl CacheRefreshHelper {
     /// - `Stale`: Return cached data immediately, trigger background refresh
     /// - `Rotten`: This should not be called for rotten data (handled as cache miss)
     #[expect(clippy::too_many_arguments)]
-    async fn handle_cache_hit(
+    fn handle_cache_hit(
         cached_batches: Vec<RecordBatch>,
         federated: &Arc<dyn TableProvider>,
         accelerator: &Arc<dyn TableProvider>,
@@ -692,7 +697,6 @@ impl CacheRefreshHelper {
         // Check freshness and trigger background refresh if stale
         if let Some(max_age) = max_age {
             let freshness = check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
-                .await
                 .unwrap_or(CacheFreshness::Rotten);
 
             match freshness {
@@ -943,7 +947,6 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                 if let Some(max_age) = max_age {
                     let freshness =
                         check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
-                            .await
                             .unwrap_or(CacheFreshness::Rotten);
 
                     if freshness == CacheFreshness::Rotten {
@@ -975,7 +978,6 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     &io_runtime,
                     Arc::clone(&schema_clone),
                 )
-                .await
             } else {
                 // Cache miss - no data in accelerator - retrieve from source and store in accelerator
                 tracing::debug!(
@@ -1215,7 +1217,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1256,7 +1257,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1297,7 +1297,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1338,7 +1337,6 @@ mod tests {
         let stale_while_revalidate = None; // No stale-while-revalidate
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1369,7 +1367,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1394,7 +1391,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1436,7 +1432,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&[batch], max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,
@@ -1480,7 +1475,6 @@ mod tests {
 
         let freshness =
             check_cache_freshness(&[batch_fresh], max_age, Some(stale_while_revalidate))
-                .await
                 .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Fresh, "Just within max_age");
 
@@ -1500,7 +1494,6 @@ mod tests {
 
         let freshness =
             check_cache_freshness(&[batch_stale], max_age, Some(stale_while_revalidate))
-                .await
                 .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Stale, "Just past max_age");
 
@@ -1521,7 +1514,6 @@ mod tests {
 
         let freshness =
             check_cache_freshness(&[batch_rotten], max_age, Some(stale_while_revalidate))
-                .await
                 .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Rotten, "Just past max_age + swr");
     }
@@ -1533,7 +1525,6 @@ mod tests {
         let stale_while_revalidate = Some(Duration::from_secs(30));
 
         let freshness = check_cache_freshness(&batches, max_age, stale_while_revalidate)
-            .await
             .expect("Should check freshness");
         assert_eq!(
             freshness,

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1478,9 +1478,10 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let freshness = check_cache_freshness(&[batch_fresh], max_age, stale_while_revalidate)
-            .await
-            .expect("Should check freshness");
+        let freshness =
+            check_cache_freshness(&[batch_fresh], max_age, Some(stale_while_revalidate))
+                .await
+                .expect("Should check freshness");
         assert_eq!(freshness, CacheFreshness::Fresh, "Just within max_age");
 
         // Just past max_age but within swr (61 seconds ago)

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -158,6 +158,7 @@ impl CacheRefreshHelper {
         accelerator: Arc<dyn TableProvider>,
         dataset_name: &str,
         ttl: Duration,
+        accelerator_mutex: Arc<Mutex<()>>,
     ) -> DataFusionResult<usize> {
         let ctx = SessionContext::new();
         let state = ctx.state();
@@ -215,6 +216,7 @@ impl CacheRefreshHelper {
             let federated = Arc::clone(&federated);
             let accelerator = Arc::clone(&accelerator);
             let dataset_name = dataset_name.to_string();
+            let accelerator_mutex = Arc::clone(&accelerator_mutex);
 
             async move {
                 tracing::debug!(
@@ -232,10 +234,15 @@ impl CacheRefreshHelper {
 
                 let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
+                // Acquire the mutex to protect accelerator operations
+                let lock_guard = accelerator_mutex.lock().await;
+
                 // Upsert this specific cache entry - removes rows matching the filters
                 // and adds the new data, preserving other cache entries.
                 Self::upsert_into_accelerator(&accelerator, &dataset_name, &row_filters, batches)
                     .await?;
+
+                drop(lock_guard); // Release the mutex
 
                 Ok(refreshed_rows)
             }
@@ -682,6 +689,7 @@ impl CacheRefreshHelper {
         stale_while_revalidate: Option<Duration>,
         io_runtime: &Handle,
         schema: SchemaRef,
+        accelerator_mutex: &Arc<Mutex<()>>,
     ) -> SendableRecordBatchStream {
         let total_cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
 
@@ -720,6 +728,7 @@ impl CacheRefreshHelper {
                     let federated_clone = Arc::clone(federated);
                     let accelerator_clone = Arc::clone(accelerator);
                     let dataset_name_clone = dataset_name.to_string();
+                    let accelerator_mutex_clone = Arc::clone(accelerator_mutex);
 
                     io_runtime.spawn(async move {
                         tracing::debug!(
@@ -730,6 +739,7 @@ impl CacheRefreshHelper {
                             accelerator_clone,
                             &dataset_name_clone,
                             max_age,
+                            accelerator_mutex_clone,
                         )
                         .await
                         {
@@ -961,7 +971,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             limit,
                             Arc::clone(&schema_clone),
                             true, // is_rotten = true, will upsert
-                            accelerator_mutex,
+                            Arc::clone(&accelerator_mutex),
                         )
                         .await;
                     }
@@ -977,6 +987,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     stale_while_revalidate,
                     &io_runtime,
                     Arc::clone(&schema_clone),
+                    &accelerator_mutex,
                 )
             } else {
                 // Cache miss - no data in accelerator - retrieve from source and store in accelerator

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -223,6 +223,7 @@ pub struct AcceleratedTable {
     disable_federation: bool,
     synchronized_with: Option<SynchronizedTable>,
     cache_ttl: Option<Duration>,
+    cache_stale_while_revalidate_ttl: Option<Duration>,
     io_runtime: Handle,
 }
 
@@ -286,6 +287,7 @@ pub struct Builder {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     caching_ttl: Option<Duration>,
+    caching_stale_while_revalidate_ttl: Option<Duration>,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
 }
 
@@ -324,6 +326,7 @@ impl Builder {
             cpu_runtime: None,
             io_runtime,
             caching_ttl: None,
+            caching_stale_while_revalidate_ttl: None,
             resource_monitor: None,
         }
     }
@@ -460,6 +463,15 @@ impl Builder {
     /// Set the TTL for cache mode
     pub fn caching_ttl(&mut self, ttl: Option<Duration>) -> &mut Self {
         self.caching_ttl = ttl;
+        self
+    }
+
+    /// Set the stale-while-revalidate duration for cache mode
+    pub fn caching_stale_while_revalidate_ttl(
+        &mut self,
+        stale_while_revalidate: Option<Duration>,
+    ) -> &mut Self {
+        self.caching_stale_while_revalidate_ttl = stale_while_revalidate;
         self
     }
 
@@ -628,6 +640,7 @@ impl Builder {
             disable_federation: self.disable_federation,
             synchronized_with: self.synchronize_with,
             cache_ttl: self.caching_ttl,
+            cache_stale_while_revalidate_ttl: self.caching_stale_while_revalidate_ttl,
             io_runtime: self.io_runtime,
         })
     }
@@ -820,6 +833,7 @@ impl TableProvider for AcceleratedTable {
                 Arc::new(caching::CachingAccelerationScanExec::new(
                     input,
                     self.cache_ttl,
+                    self.cache_stale_while_revalidate_ttl,
                     federated_provider,
                     Arc::clone(&self.accelerator),
                     self.dataset_name.to_string(),

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -54,7 +54,7 @@ use snafu::prelude::*;
 use spicepod::metric::Metrics;
 use synchronized_table::SynchronizedTable;
 use tokio::runtime::Handle;
-use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
+use tokio::sync::{Mutex, Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
 pub mod caching;
@@ -225,6 +225,8 @@ pub struct AcceleratedTable {
     cache_ttl: Option<Duration>,
     cache_stale_while_revalidate_ttl: Option<Duration>,
     io_runtime: Handle,
+    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator
+    cache_mutex: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for AcceleratedTable {
@@ -642,6 +644,7 @@ impl Builder {
             cache_ttl: self.caching_ttl,
             cache_stale_while_revalidate_ttl: self.caching_stale_while_revalidate_ttl,
             io_runtime: self.io_runtime,
+            cache_mutex: Arc::new(Mutex::new(())),
         })
     }
 }
@@ -841,6 +844,7 @@ impl TableProvider for AcceleratedTable {
                     filters.to_vec(),
                     projection.cloned(),
                     limit,
+                    Arc::clone(&self.cache_mutex),
                 ))
             }
             (false, ZeroResultsAction::ReturnEmpty) => input,

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -574,6 +574,8 @@ impl Builder {
         validate_refresh_data_window(&self.refresh, &self.dataset_name, &self.federated.schema());
         let refresh_mode = self.refresh.mode;
         let refresh_params = Arc::new(RwLock::new(self.refresh));
+        // Create the cache mutex early so it can be shared between the Refresher and the AcceleratedTable.
+        let cache_mutex: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
@@ -583,6 +585,7 @@ impl Builder {
             Arc::clone(&self.accelerator),
             self.cpu_runtime.clone(),
             self.io_runtime.clone(),
+            Arc::clone(&cache_mutex),
         );
         refresher.caching(&self.caching);
         refresher.checkpointer(self.checkpointer);
@@ -644,7 +647,7 @@ impl Builder {
             cache_ttl: self.caching_ttl,
             cache_stale_while_revalidate_ttl: self.caching_stale_while_revalidate_ttl,
             io_runtime: self.io_runtime,
-            cache_mutex: Arc::new(Mutex::new(())),
+            cache_mutex,
         })
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -45,6 +45,7 @@ use snafu::prelude::*;
 use spicepod::metric::Metrics;
 use tokio::runtime::Handle;
 use tokio::select;
+use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{RwLock, Semaphore};
@@ -475,6 +476,9 @@ pub struct Refresher {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
+    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
+    /// Shared with `CachingAccelerationScanExec`.
+    cache_mutex: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -500,6 +504,7 @@ impl Refresher {
         accelerator: Arc<dyn TableProvider>,
         cpu_runtime: Option<Handle>,
         io_runtime: Handle,
+        cache_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -523,6 +528,7 @@ impl Refresher {
             cpu_runtime,
             io_runtime,
             resource_monitor: None,
+            cache_mutex,
         }
     }
 
@@ -675,6 +681,7 @@ impl Refresher {
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
             self.io_runtime.clone(),
+            Arc::clone(&self.cache_mutex),
         )
         .with_disable_federation(self.disable_federation);
 
@@ -861,6 +868,7 @@ impl Refresher {
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
                 self.io_runtime.clone(),
+                Arc::clone(&self.cache_mutex),
             )
             .with_disable_federation(self.disable_federation)
             .with_cpu_runtime(self.cpu_runtime.clone())
@@ -1035,6 +1043,7 @@ mod tests {
             Arc::clone(&accelerator),
             None,
             Handle::current(),
+            Arc::new(Mutex::new(())),
         );
 
         refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1245,6 +1254,7 @@ mod tests {
                 Arc::clone(&accelerator),
                 None,
                 Handle::current(),
+                Arc::new(Mutex::new(())),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1404,6 +1414,7 @@ mod tests {
                 Arc::clone(&accelerator),
                 None,
                 Handle::current(),
+                Arc::new(Mutex::new(())),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1613,6 +1624,7 @@ mod tests {
                 Arc::clone(&accelerator),
                 None,
                 Handle::current(),
+                Arc::new(Mutex::new(())),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -83,6 +83,8 @@ pub struct Refresh {
     pub(crate) append_overlap: Option<Duration>,
     pub(crate) retry_enabled: bool,
     pub(crate) retry_max_attempts: Option<usize>,
+    /// TTL for cache entries. Data older than this is considered stale.
+    pub(crate) caching_ttl: Option<Duration>,
 }
 
 /// [`RefreshOverrides`] specifies the configurable options for a individual run of a refresh task.
@@ -185,6 +187,12 @@ impl Refresh {
     #[must_use]
     pub fn append_overlap(mut self, append_overlap: Duration) -> Self {
         self.append_overlap = Some(append_overlap);
+        self
+    }
+
+    #[must_use]
+    pub fn caching_ttl(mut self, caching_ttl: Duration) -> Self {
+        self.caching_ttl = Some(caching_ttl);
         self
     }
 
@@ -430,6 +438,7 @@ impl Default for Refresh {
             append_overlap: None,
             retry_enabled: false,
             retry_max_attempts: None,
+            caching_ttl: None,
         }
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -765,8 +765,8 @@ impl RefreshTask {
         &self,
         refresh: &Refresh,
     ) -> Result<(), RetryError<super::Error>> {
-        // Get the TTL from refresh settings - default to 30 seconds if not specified
-        let ttl = refresh.check_interval.unwrap_or(Duration::from_secs(30));
+        // Get the caching TTL from refresh settings - default to 30 seconds if not specified
+        let ttl = refresh.caching_ttl.unwrap_or(Duration::from_secs(30));
 
         tracing::info!(
             "Starting stale row refresh for dataset {} with TTL {ttl:?}",

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -417,7 +417,7 @@ impl RefreshTask {
             RefreshMode::Changes => unreachable!("changes are handled upstream"),
             RefreshMode::Caching => {
                 // For caching mode, identify and refresh stale rows based on fetched_at and TTL
-                self.refresh_stale_cached_rows(refresh).await
+                return self.refresh_stale_cached_rows(refresh).await;
             }
         };
 
@@ -764,7 +764,7 @@ impl RefreshTask {
     async fn refresh_stale_cached_rows(
         &self,
         refresh: &Refresh,
-    ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
+    ) -> Result<(), RetryError<super::Error>> {
         // Get the TTL from refresh settings - default to 30 seconds if not specified
         let ttl = refresh.check_interval.unwrap_or(Duration::from_secs(30));
 
@@ -789,14 +789,7 @@ impl RefreshTask {
             self.dataset_name,
         );
 
-        // Return an empty streaming update since the refresh was handled internally
-        // by CacheRefreshHelper
-        let schema = self.accelerator.schema();
-        let empty_stream = RecordBatchStreamAdapter::new(schema, futures::stream::empty());
-        Ok(StreamingDataUpdate {
-            data: Box::pin(empty_stream),
-            update_type: UpdateType::Overwrite,
-        })
+        Ok(())
     }
 
     async fn trace_load_completed(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -14,38 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::compute::{SortOptions, filter_record_batch};
-use arrow::{
-    array::{RecordBatch, StructArray, TimestampNanosecondArray, make_comparator},
-    datatypes::DataType,
-};
-use arrow_schema::SchemaRef;
-use async_stream::stream;
-use datafusion::datasource::{DefaultTableSource, TableType};
-use datafusion::execution::SessionStateBuilder;
-use datafusion::logical_expr::dml::InsertOp;
-use datafusion::physical_planner::ExtensionPlanner;
-use datafusion_table_providers::util::retriable_error::{
-    check_and_mark_retriable_error, is_retriable_error,
-};
-use futures::{StreamExt, stream};
-use opentelemetry::KeyValue;
-use runtime_datafusion::execution_plan::schema_cast::EnsureSchema;
-use runtime_datafusion::extension::bytes_processed::BytesProcessedPhysicalOptimizer;
-use runtime_datafusion::optimizer_rule::avoid_vector_columns_on_index::AvoidDerivedVectorColumnOnIndexRule;
-use runtime_datafusion_index::analyzer::{
-    IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule,
-};
-use snafu::{OptionExt, ResultExt};
-use tokio::{
-    runtime::Handle,
-    sync::{Mutex, RwLock, Semaphore, oneshot},
-    time::Instant,
-};
-use tracing::{Instrument, Span};
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
-use util::{RetryError, retry};
-
+use super::metrics;
+use super::refresh::Refresh;
+use super::refresh::get_timestamp;
+use super::sink::AccelerationSink;
+use super::synchronized_table::SynchronizedTable;
+use crate::accelerated_table::caching::CacheRefreshHelper;
+use crate::accelerated_table::timestamp_metrics_utils::with_find_max_timestamp_in_stream;
+use crate::component::dataset::TimeFormat;
 use crate::datafusion::builder::{AnalyzerRulesBuilder, get_df_default_config};
 use crate::datafusion::error::{SpiceExternalError, find_datafusion_root, get_spice_df_error};
 use crate::datafusion::is_spice_internal_dataset;
@@ -61,22 +37,19 @@ use crate::{
     dataupdate::{StreamingDataUpdate, UpdateType},
     status,
 };
-use runtime_datafusion::extension::ExtensionPlanQueryPlanner;
-use runtime_object_store::registry::default_runtime_env;
-
-use super::metrics;
-use super::refresh::get_timestamp;
-use super::sink::AccelerationSink;
-use super::synchronized_table::SynchronizedTable;
-
-use crate::component::dataset::TimeFormat;
-use std::time::{Duration, UNIX_EPOCH};
-use std::{cmp::Ordering, sync::Arc, time::SystemTime};
-
-use super::refresh::Refresh;
-use crate::accelerated_table::timestamp_metrics_utils::with_find_max_timestamp_in_stream;
+use arrow::compute::{SortOptions, filter_record_batch};
+use arrow::{
+    array::{RecordBatch, StructArray, TimestampNanosecondArray, make_comparator},
+    datatypes::DataType,
+};
+use arrow_schema::SchemaRef;
+use async_stream::stream;
 use data_components::poly::PolyTableProvider;
+use datafusion::datasource::{DefaultTableSource, TableType};
+use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::physical_planner::ExtensionPlanner;
 use datafusion::{
     dataframe::DataFrame,
     datasource::TableProvider,
@@ -87,9 +60,33 @@ use datafusion::{
 };
 use datafusion_expr::{LogicalPlanBuilder, UNNAMED_TABLE, ident};
 use datafusion_federation::{FederatedPlanner, FederatedTableProviderAdaptor};
+use datafusion_table_providers::util::retriable_error::{
+    check_and_mark_retriable_error, is_retriable_error,
+};
+use futures::{StreamExt, stream};
+use opentelemetry::KeyValue;
+use runtime_datafusion::execution_plan::schema_cast::EnsureSchema;
+use runtime_datafusion::extension::ExtensionPlanQueryPlanner;
+use runtime_datafusion::extension::bytes_processed::BytesProcessedPhysicalOptimizer;
+use runtime_datafusion::optimizer_rule::avoid_vector_columns_on_index::AvoidDerivedVectorColumnOnIndexRule;
+use runtime_datafusion_index::analyzer::{
+    IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule,
+};
+use runtime_object_store::registry::default_runtime_env;
 use runtime_request_context::{AsyncMarker, RequestContext};
+use snafu::{OptionExt, ResultExt};
 use spicepod::metric::Metrics;
 use std::collections::HashSet;
+use std::time::{Duration, UNIX_EPOCH};
+use std::{cmp::Ordering, sync::Arc, time::SystemTime};
+use tokio::{
+    runtime::Handle,
+    sync::{Mutex, RwLock, Semaphore, oneshot},
+    time::Instant,
+};
+use tracing::{Instrument, Span};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::{RetryError, retry};
 
 mod changes;
 
@@ -768,15 +765,12 @@ impl RefreshTask {
         &self,
         refresh: &Refresh,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
-        use crate::accelerated_table::caching::CacheRefreshHelper;
-
         // Get the TTL from refresh settings - default to 30 seconds if not specified
         let ttl = refresh.check_interval.unwrap_or(Duration::from_secs(30));
 
         tracing::info!(
-            "Cache: Starting stale row refresh for dataset {} with TTL {:?}",
+            "Starting stale row refresh for dataset {} with TTL {ttl:?}",
             self.dataset_name,
-            ttl
         );
 
         // Use the CacheRefreshHelper to identify and refresh stale rows
@@ -791,9 +785,8 @@ impl RefreshTask {
         .map_err(|e| RetryError::permanent(super::Error::FailedToRefreshDataset { source: e }))?;
 
         tracing::info!(
-            "Cache: Completed stale row refresh for dataset {} - refreshed {} rows",
+            "Completed stale row refresh for dataset {} - refreshed {refreshed_count} rows",
             self.dataset_name,
-            refreshed_count
         );
 
         // Return an empty streaming update since the refresh was handled internally

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -111,6 +111,8 @@ pub struct RefreshTaskBuilder {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
+    /// Mutex to protect concurrent access to the accelerator during cache operations.
+    accelerator_mutex: Arc<Mutex<()>>,
 }
 
 impl RefreshTaskBuilder {
@@ -122,6 +124,7 @@ impl RefreshTaskBuilder {
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
+        accelerator_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -135,6 +138,7 @@ impl RefreshTaskBuilder {
             cpu_runtime: None,
             io_runtime,
             resource_monitor: None,
+            accelerator_mutex,
         }
     }
 
@@ -218,6 +222,7 @@ impl RefreshTaskBuilder {
             cpu_runtime: self.cpu_runtime,
             io_runtime: self.io_runtime,
             resource_monitor: self.resource_monitor,
+            accelerator_mutex: self.accelerator_mutex,
         }
     }
 }
@@ -237,6 +242,8 @@ pub struct RefreshTask {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
+    /// Mutex to protect concurrent access to the accelerator during cache operations.
+    accelerator_mutex: Arc<Mutex<()>>,
 }
 
 impl RefreshTask {
@@ -248,6 +255,7 @@ impl RefreshTask {
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
+        accelerator_mutex: Arc<Mutex<()>>,
     ) -> RefreshTaskBuilder {
         RefreshTaskBuilder::new(
             runtime_status,
@@ -256,6 +264,7 @@ impl RefreshTask {
             federated_source,
             accelerator,
             io_runtime,
+            accelerator_mutex,
         )
     }
 
@@ -780,6 +789,7 @@ impl RefreshTask {
             Arc::clone(&self.accelerator),
             self.dataset_name.to_string().as_str(),
             ttl,
+            Arc::clone(&self.accelerator_mutex),
         )
         .await
         .map_err(|e| RetryError::permanent(super::Error::FailedToRefreshDataset { source: e }))?;

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -32,7 +32,7 @@ use tokio::{
 };
 
 use std::{any::Any, panic::AssertUnwindSafe, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use super::refresh::Refresh;
 use datafusion::{datasource::TableProvider, sql::TableReference};
@@ -52,9 +52,13 @@ pub struct RefreshTaskRunnerBuilder {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
+    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
+    /// Shared with `CachingAccelerationScanExec`.
+    cache_mutex: Arc<Mutex<()>>,
 }
 
 impl RefreshTaskRunnerBuilder {
+    #[expect(clippy::too_many_arguments)]
     #[must_use]
     pub fn new(
         runtime_status: Arc<status::RuntimeStatus>,
@@ -64,6 +68,7 @@ impl RefreshTaskRunnerBuilder {
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
+        cache_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -78,6 +83,7 @@ impl RefreshTaskRunnerBuilder {
             cpu_runtime: None,
             io_runtime,
             resource_monitor: None,
+            cache_mutex,
         }
     }
 
@@ -124,6 +130,7 @@ impl RefreshTaskRunnerBuilder {
             self.federated_source,
             self.accelerator,
             self.io_runtime,
+            self.cache_mutex,
         )
         .with_disable_federation(self.disable_federation)
         .with_metrics(self.metrics);
@@ -167,6 +174,7 @@ type RefreshTaskStartSender = Sender<Option<RefreshOverrides>>;
 type RefreshTaskCompletionReceiver = Receiver<super::Result<()>>;
 
 impl RefreshTaskRunner {
+    #[expect(clippy::too_many_arguments)]
     #[must_use]
     pub fn builder(
         runtime_status: Arc<status::RuntimeStatus>,
@@ -176,6 +184,7 @@ impl RefreshTaskRunner {
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
+        cache_mutex: Arc<Mutex<()>>,
     ) -> RefreshTaskRunnerBuilder {
         RefreshTaskRunnerBuilder::new(
             runtime_status,
@@ -185,6 +194,7 @@ impl RefreshTaskRunner {
             refresh,
             accelerator,
             io_runtime,
+            cache_mutex,
         )
     }
 

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -287,6 +287,10 @@ pub struct Acceleration {
 
     pub refresh_check_interval: Option<Duration>,
 
+    pub caching_ttl: Option<Duration>,
+
+    pub caching_stale_while_revalidate_ttl: Option<Duration>,
+
     pub refresh_cron: Option<Arc<str>>,
 
     pub refresh_sql: Option<String>,
@@ -425,6 +429,10 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
 
         let disable_federation = parse_is_query_federation_disabled(&mut params)?;
 
+        let caching_ttl = parse_caching_ttl(&mut params)?;
+        let caching_stale_while_revalidate_ttl =
+            parse_caching_stale_while_revalidate_ttl(&mut params)?;
+
         let refresh_check_interval = try_parse_duration(
             "refresh_check_interval",
             acceleration.refresh_check_interval,
@@ -449,6 +457,8 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             refresh_mode: acceleration.refresh_mode.map(RefreshMode::from),
             refresh_on_startup: RefreshOnStartup::from(acceleration.refresh_on_startup),
             refresh_check_interval,
+            caching_ttl,
+            caching_stale_while_revalidate_ttl,
             refresh_cron,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
@@ -487,6 +497,8 @@ impl Default for Acceleration {
             engine: Engine::default(),
             refresh_mode: None,
             refresh_check_interval: None,
+            caching_ttl: None,
+            caching_stale_while_revalidate_ttl: None,
             refresh_cron: None,
             refresh_sql: None,
             refresh_data_window: None,
@@ -530,6 +542,52 @@ fn parse_is_query_federation_disabled(params: &mut Option<Params>) -> Result<boo
         }
     }
     Ok(false)
+}
+
+/// Parse `caching_ttl` duration from params for caching mode.
+#[expect(clippy::result_large_err)]
+fn parse_caching_ttl(params: &mut Option<Params>) -> Result<Option<Duration>, crate::Error> {
+    parse_duration_param(params, "caching_ttl")
+}
+
+/// Parse `caching_stale_while_revalidate_ttl` duration from params for caching mode.
+#[expect(clippy::result_large_err)]
+fn parse_caching_stale_while_revalidate_ttl(
+    params: &mut Option<Params>,
+) -> Result<Option<Duration>, crate::Error> {
+    parse_duration_param(params, "caching_stale_while_revalidate_ttl")
+}
+
+/// Helper to parse a duration parameter from params.
+#[expect(clippy::result_large_err)]
+fn parse_duration_param(
+    params: &mut Option<Params>,
+    param_name: &str,
+) -> Result<Option<Duration>, crate::Error> {
+    let Some(params) = params else {
+        return Ok(None);
+    };
+    let Some(value) = params.data.remove(param_name) else {
+        return Ok(None);
+    };
+    match value {
+        spicepod::param::ParamValue::String(s) => {
+            fundu::parse_duration(&s)
+                .map(Some)
+                .map_err(|e| crate::Error::InvalidSpicepodDataset {
+                    source: super::Error::UnableToParseFieldAsDuration {
+                        source: e,
+                        field: param_name.into(),
+                    },
+                })
+        }
+        _ => Err(crate::Error::InvalidAccelerationConfiguration {
+            source: format!(
+                "Invalid '{param_name}' param value: {value:?}. Expected a duration string."
+            )
+            .into(),
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1149,11 +1149,12 @@ impl DataFusion {
 
         accelerated_table_builder.caching(Some(Arc::clone(&self.caching)));
 
-        // For caching mode, set the TTL from refresh_check_interval
-        if refresh_mode == RefreshMode::Caching
-            && let Some(check_interval) = acceleration_settings.refresh_check_interval
-        {
-            accelerated_table_builder.caching_ttl(Some(check_interval));
+        // For caching mode, set the TTL (max_age) and stale_while_revalidate from params
+        if refresh_mode == RefreshMode::Caching {
+            accelerated_table_builder.caching_ttl(acceleration_settings.caching_ttl);
+            accelerated_table_builder.caching_stale_while_revalidate_ttl(
+                acceleration_settings.caching_stale_while_revalidate_ttl,
+            );
         }
 
         if acceleration_settings.snapshots.create_enabled()

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -269,6 +269,14 @@ pub enum Error {
     ))]
     AppendRequiresTimeColumn { from: String },
 
+    #[snafu(display(
+        "Failed to create an accelerated table for dataset {dataset_name} ({connector}): `refresh_mode: caching` is only supported with the HTTP/HTTPS data connector. See https://spiceai.org/docs/features/data-acceleration/refresh-modes/caching"
+    ))]
+    InvalidCachingRefreshMode {
+        dataset_name: String,
+        connector: String,
+    },
+
     #[snafu(display("Unable to retrieve underlying table provider from federation"))]
     UnableToRetrieveTableFromFederation { table_name: String },
 
@@ -986,6 +994,18 @@ impl DataFusion {
         };
 
         let refresh_mode = source.resolve_refresh_mode(acceleration_settings.refresh_mode);
+        if refresh_mode == RefreshMode::Caching {
+            let connector = dataset.source();
+            let is_http_connector =
+                connector.eq_ignore_ascii_case("http") || connector.eq_ignore_ascii_case("https");
+            ensure!(
+                is_http_connector,
+                InvalidCachingRefreshModeSnafu {
+                    dataset_name: dataset.name.to_string(),
+                    connector: connector.to_string(),
+                }
+            );
+        }
 
         // Determine if we should pass constraints to the accelerator
         // Only pass constraints if not using refresh_sql (schema might have different column ordering)

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1092,6 +1092,9 @@ impl DataFusion {
         if let Some(append_overlap) = acceleration_settings.refresh_append_overlap {
             refresh = refresh.append_overlap(append_overlap);
         }
+        if let Some(caching_ttl) = acceleration_settings.caching_ttl {
+            refresh = refresh.caching_ttl(caching_ttl);
+        }
 
         // we must not fetch data older than the explicitly set refresh data window or retention period
         let refresh_data_window = dataset.refresh_data_window().or(dataset.retention_period());

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -120,6 +120,7 @@ async fn create_refresh_task(
             None,
             accelerated_table.get_accelerator(),
             Handle::current(),
+            Arc::new(tokio::sync::Mutex::new(())),
         )
         .with_cpu_runtime(rt.datafusion().cpu_runtime().cloned())
         .build(),

--- a/crates/runtime/tests/refresh_worker_panic.rs
+++ b/crates/runtime/tests/refresh_worker_panic.rs
@@ -36,7 +36,7 @@ use runtime::component::dataset::acceleration::RefreshMode;
 use runtime::federated_table::FederatedTable;
 use runtime::status;
 use tokio::runtime::Handle;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::{Duration, timeout};
 
 #[derive(Debug)]
@@ -158,6 +158,7 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
         refresh_state,
         accelerator_provider,
         Handle::current(),
+        Arc::new(Mutex::new(())),
     )
     .build();
 


### PR DESCRIPTION
## 📝 Summary

This reworks the caching accelerator to follow the standard `stale-while-revalidate` pattern that is part of the HTTP standard: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#stale-while-revalidate)

> The Stale-While-Revalidate pattern allows a client to immediately serve a stale cached response to ensure fast load times, while simultaneously triggering an asynchronous background request to the origin to fetch a fresh resource. The max-age directive defines how long the cache is fresh, and stale-while-revalidate sets the subsequent time window during which the cache can be served stale while revalidation occurs. This improves perceived performance by trading temporary staleness for zero-latency retrieval.

The `caching_ttl` and `caching_stale_while_revalidate_ttl` params are set on the accelerator to control these two times:

```yaml
datasets:
  - from: https://api.tvmaze.com
    name: tvmaze
    params:
      file_format: json
      allowed_request_paths: '/search/shows,/shows/*'
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
      refresh_mode: caching
      refresh_check_interval: 30s
      params:
        duckdb_file: tvmaze.db
        caching_ttl: 10s # <-- new parameter to control the `max-age` directive
        caching_stale_while_revalidate_ttl: 30s # <-- new parameter to control the `stale-while-revalidate` directive
```

```text
                   AGE OF CACHED RESPONSE
   0s                      max-age                    max-age+SWR
   |------------------------|-----------------------------|
   ^                        ^                             ^
 cached                  end of                      end of
  time                 "fresh" window          stale-while-revalidate

   ┌────────────────────────┐┌─────────────────────────────┐┌──────────────┐
   │        FRESH           ││            STALE            ││    ROTTEN    │
   │   (within max-age)     ││ (beyond max-age, but        ││ (beyond      │
   │                        ││  within stale-while-reval) ││  both)       │
   └────────────────────────┘└─────────────────────────────┘└──────────────┘
```

1) FRESH (0 <= age <= max-age)
   - Cache status: "fresh"
   - Behavior: Serve directly from cache.
   - No revalidation needed.
   - Typical: fast, no network hit.

2) STALE BUT ALLOWED (max-age < age <= max-age + stale-while-revalidate)
   - Cache status: "stale"
   - Behavior: 
       - Serve this stale response IMMEDIATELY to the client.
       - In the background, send a revalidation request.
   - User gets a slightly old response, but quickly.
   - Cache will be updated asynchronously if the origin has newer content.

3) ROTTEN (age > max-age + stale-while-revalidate)
   - Cache status: "too stale" / "rotten"
   - Behavior:
       - The cached response CANNOT be used to satisfy the request.
       - The cache must revalidate or fetch a new copy BEFORE responding.
       - If origin is down and no other grace mechanisms exist, the user may get an error.

## 🔗 Related

- Closes #8350

## 📚 Docs

https://github.com/spiceai/docs/pull/1250

