### PR TITLE
Improve `IndexerExec` to properly handle limit pushdown

### DIFF
--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -25,18 +25,25 @@ use std::{
 
 use async_trait::async_trait;
 use datafusion::{
-    arrow::datatypes::Schema,
+    arrow::datatypes::{Schema, SchemaRef},
     common::{
-        DFSchemaRef,
+        DFSchemaRef, Statistics,
         tree_node::{Transformed, TreeNode, TreeNodeRecursion},
     },
+    config::ConfigOptions,
     datasource::DefaultTableSource,
     error::{DataFusionError, Result},
     execution::{SendableRecordBatchStream, SessionState, TaskContext},
     logical_expr::{Extension, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore},
     optimizer::{OptimizerConfig, OptimizerRule},
     physical_plan::{
-        DisplayAs, DisplayFormatType, ExecutionPlan, execution_plan::CardinalityEffect,
+        DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PhysicalExpr,
+        execution_plan::{CardinalityEffect, InvariantLevel, check_default_invariants},
+        filter_pushdown::{
+            ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        metrics::MetricsSet,
+        projection::ProjectionExec,
         stream::RecordBatchStreamAdapter,
     },
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
@@ -355,9 +362,16 @@ impl DisplayAs for IndexerExec {
         Ok(())
     }
 }
-
+#[deny(clippy::missing_trait_methods)]
 impl ExecutionPlan for IndexerExec {
     fn name(&self) -> &'static str {
+        "IndexerExec"
+    }
+
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
         "IndexerExec"
     }
 
@@ -365,16 +379,55 @@ impl ExecutionPlan for IndexerExec {
         self
     }
 
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(self.properties().eq_properties.schema())
+    }
+
     fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
         self.input_exec.properties()
+    }
+
+    fn check_invariants(&self, check: InvariantLevel) -> Result<()> {
+        check_default_invariants(self, check)
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input_exec]
     }
 
+    fn required_input_ordering(
+        &self,
+    ) -> Vec<Option<datafusion::physical_expr::OrderingRequirements>> {
+        vec![None; self.children().len()]
+    }
+
+    /// Require single partition input to ensure limit is correctly applied before indexing.
+    /// This also allows the indexer to manage its own thread pool/batching optimally
+    /// and avoid thread contention and overhead when processing small batches in parallel.
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition]
+    }
+
     fn maintains_input_order(&self) -> Vec<bool> {
         vec![true; self.children().len()]
+    }
+
+    /// Prevents the introduction of additional `RepartitionExec` that does not support limit pushdown
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _config: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+        let children = self.children().into_iter().cloned().collect();
+        self.with_new_children(children)
     }
 
     fn with_new_children(
@@ -397,6 +450,7 @@ impl ExecutionPlan for IndexerExec {
         }))
     }
 
+    // Allow optimizer to push limits through to inputs
     fn supports_limit_pushdown(&self) -> bool {
         true
     }
@@ -469,6 +523,59 @@ impl ExecutionPlan for IndexerExec {
             })
             .boxed();
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        self.input_exec.metrics()
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        #[expect(deprecated)]
+        self.input_exec.statistics()
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input_exec.partition_statistics(partition)
+    }
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        // Propagate the fetch limit to the child input if it supports it
+        if let Some(child_with_fetch) = self.input_exec.with_fetch(limit) {
+            return Some(Arc::new(Self::new(child_with_fetch, self.indexes.clone())));
+        }
+        None
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.input_exec.fetch()
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        _projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+
+    fn with_new_state(&self, _state: Arc<dyn Any + Send + Sync>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

Fixes limit pushdown for `IndexerExec` to prevent processing more rows than requested.

Previously, when a `refresh_sql` like `SELECT * FROM table LIMIT 1000` was used with an indexed table, `IndexerExec` would process more rows from the source (e.g., 17,000+ / 16 partitions) before the limit was applied, causing unnecessary computation and populating invalid data

Changes:

1. Add `required_input_distribution()` -> `SinglePartition` to ensure `CoalescePartitionsExec` is inserted (if necessary), which supports fetch/limit.  This also allows the indexer to manage its own thread pool/batching optimally and avoid thread contention and overhead when processing small batches in parallel.
1. Add `benefits_from_input_partitioning()` -> `false` to prevent `RepartitionExec` insertion that does not support limit pushdown
1. Implement `supports_limit_pushdown()` and `with_fetch()` to propagate limits through the plan

Now limits are enforced before reaching `IndexerExec` so only the requested number of rows are processed/indexed.

Before:

```
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                          |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Limit: skip=0, fetch=1000                                                                                                                                                                                                                                                                                     |
|               |   IndexTableScanNode index:s3_vector_index                                                                                                                                                                                                                                                                    |
|               |     Projection: historic_answers.body, FixedSizeList() AS body_embedding, historic_answers.comment_count, historic_answers.creation_date, historic_answers.id, historic_answers.owner_display_name, historic_answers.owner_user_id, historic_answers.parent_id, historic_answers.title                        |
|               |       TableScan: historic_answers projection=[body, comment_count, creation_date, id, owner_display_name, owner_user_id, parent_id, title], fetch=1000                                                                                                                                                        |
| physical_plan | CoalescePartitionsExec: fetch=1000                                                                                                                                                                                                                                                                            |
|               |   IndexerExec index:s3_vector_index input:ProjectionExec: expr=[body@0 as body,  as body_embedding, comment_count@1 as comment_count, creation_date@2 as creation_date, id@3 as id, owner_display_name@4 as owner_display_name, owner_user_id@5 as owner_user_id, parent_id@6 as parent_id, title@7 as title] |
|               |     ProjectionExec: expr=[body@0 as body,  as body_embedding, comment_count@1 as comment_count, creation_date@2 as creation_date, id@3 as id, owner_display_name@4 as owner_display_name, owner_user_id@5 as owner_user_id, parent_id@6 as parent_id, title@7 as title]                                       |
|               |       ProjectionExec: expr=[body@2 as body, comment_count@6 as comment_count, creation_date@3 as creation_date, id@0 as id, owner_display_name@4 as owner_display_name, owner_user_id@5 as owner_user_id, parent_id@7 as parent_id, title@1 as title]                                                         |
|               |         CooperativeExec                                                                                                                                                                                                                                                                                       |
|               |           RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1                                                                                                                                                                                                                               |
|               |             BytesProcessedExec                                                                                                                                                                                                                                                                                |
|               |               CooperativeExec                                                                                                                                                                                                                                                                                 |
|               |                 IcebergTableScan projection:[id,title,body,creation_date,owner_display_name,owner_user_id,comment_count,parent_id] predicate:[] limit:[]                                                                                                                                                      |
|               |                                                                                                                                                                                                                                                                                                               |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

After

```bash
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                   |
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Limit: skip=0, fetch=1000                                                                                                                                                                                                                                                              |
|               |   IndexTableScanNode index:s3_vector_index                                                                                                                                                                                                                                             |
|               |     Projection: historic_answers.body, FixedSizeList() AS body_embedding, historic_answers.comment_count, historic_answers.creation_date, historic_answers.id, historic_answers.owner_display_name, historic_answers.owner_user_id, historic_answers.parent_id, historic_answers.title |
|               |       TableScan: historic_answers projection=[body, comment_count, creation_date, id, owner_display_name, owner_user_id, parent_id, title], fetch=1000                                                                                                                                 |
| physical_plan | IndexerExec index:s3_vector_index input:CoalescePartitionsExec: fetch=1000                                                                                                                                                                                                             |
|               |   CoalescePartitionsExec: fetch=1000                                                                                                                                                                                                                                                   |
|               |     ProjectionExec: expr=[body@0 as body,  as body_embedding, comment_count@1 as comment_count, creation_date@2 as creation_date, id@3 as id, owner_display_name@4 as owner_display_name, owner_user_id@5 as owner_user_id, parent_id@6 as parent_id, title@7 as title]                |
|               |       ProjectionExec: expr=[body@2 as body, comment_count@6 as comment_count, creation_date@3 as creation_date, id@0 as id, owner_display_name@4 as owner_display_name, owner_user_id@5 as owner_user_id, parent_id@7 as parent_id, title@1 as title]                                  |
|               |         CooperativeExec                                                                                                                                                                                                                                                                |
|               |           RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1                                                                                                                                                                                                        |
|               |             BytesProcessedExec                                                                                                                                                                                                                                                         |
|               |               CooperativeExec                                                                                                                                                                                                                                                          |
|               |                 IcebergTableScan projection:[id,title,body,creation_date,owner_display_name,owner_user_id,comment_count,parent_id] predicate:[] limit:[]                                                                                                                               |
|               |                                                                                                                                                                                                                                                                                        |
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I'm also still investigating why initial limit from logic plan is not applied to IcebergTableScan
