### PR TITLE
Fix Cayenne partition_by metadata flaky integration test

### DIFF
--- a/crates/runtime/tests/acceleration/partition_by_cayenne.rs
+++ b/crates/runtime/tests/acceleration/partition_by_cayenne.rs
@@ -125,6 +125,8 @@ async fn test_cayenne_partition_by_bucket() -> Result<(), anyhow::Error> {
             let temp_dir = tempfile::tempdir()
                 .map_err(|e| anyhow::anyhow!("Failed to create temp directory: {e}"))?;
             let cayenne_path = temp_dir.path().to_path_buf();
+            // Keep a per-test metadata DB to avoid SQLite contention with other concurrent Cayenne tests.
+            let metadata_dir = temp_dir.path().join("metadata");
 
             crate::configure_test_datafusion();
 
@@ -138,6 +140,10 @@ async fn test_cayenne_partition_by_bucket() -> Result<(), anyhow::Error> {
             params.insert(
                 "cayenne_file_path".to_string(),
                 cayenne_path.display().to_string(),
+            );
+            params.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
             );
 
             dataset.acceleration = Some(Acceleration {
@@ -245,6 +251,7 @@ async fn test_cayenne_partition_by_bucket() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
 #[ignore = "Data duplication issue with multiple partition expressions - needs investigation"]
+#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_multiple_expressions() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 
@@ -259,6 +266,7 @@ async fn test_cayenne_partition_by_multiple_expressions() -> Result<(), anyhow::
             let temp_dir = tempfile::tempdir()
                 .map_err(|e| anyhow::anyhow!("Failed to create temp directory: {e}"))?;
             let cayenne_path = temp_dir.path().to_path_buf();
+            let metadata_dir = temp_dir.path().join("metadata");
 
             crate::configure_test_datafusion();
 
@@ -273,6 +281,10 @@ async fn test_cayenne_partition_by_multiple_expressions() -> Result<(), anyhow::
             param_map.insert(
                 "cayenne_file_path".to_string(),
                 cayenne_path.display().to_string(),
+            );
+            param_map.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
             );
             let acceleration_params = spicepod::param::Params::from_string_map(param_map);
 
@@ -398,6 +410,7 @@ async fn test_cayenne_partition_by_bucket_with_nulls() -> Result<(), anyhow::Err
             let temp_dir = tempfile::tempdir()
                 .map_err(|e| anyhow::anyhow!("Failed to create temp directory: {e}"))?;
             let cayenne_path = temp_dir.path().to_path_buf();
+            let metadata_dir = temp_dir.path().join("metadata");
 
             crate::configure_test_datafusion();
 
@@ -411,6 +424,10 @@ async fn test_cayenne_partition_by_bucket_with_nulls() -> Result<(), anyhow::Err
             param_map.insert(
                 "cayenne_file_path".to_string(),
                 cayenne_path.display().to_string(),
+            );
+            param_map.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
             );
             let acceleration_params = Params::from_string_map(param_map);
 
@@ -551,6 +568,7 @@ async fn test_cayenne_partition_by_bucket_numeric_nulls() -> Result<(), anyhow::
             let temp_dir = tempfile::tempdir()
                 .map_err(|e| anyhow::anyhow!("Failed to create temp directory: {e}"))?;
             let cayenne_path = temp_dir.path().to_path_buf();
+            let metadata_dir = temp_dir.path().join("metadata");
 
             crate::configure_test_datafusion();
 
@@ -564,6 +582,10 @@ async fn test_cayenne_partition_by_bucket_numeric_nulls() -> Result<(), anyhow::
             param_map.insert(
                 "cayenne_file_path".to_string(),
                 cayenne_path.display().to_string(),
+            );
+            param_map.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
             );
             let acceleration_params = Params::from_string_map(param_map);
 
@@ -690,6 +712,7 @@ async fn test_cayenne_partition_by_bucket_numeric_nulls() -> Result<(), anyhow::
 /// 3. Physical plans show correct partition structure with month-based partitions
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
+#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_date_part() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 
@@ -704,6 +727,7 @@ async fn test_cayenne_partition_by_date_part() -> Result<(), anyhow::Error> {
             let temp_dir = tempfile::tempdir()
                 .map_err(|e| anyhow::anyhow!("Failed to create temp directory: {e}"))?;
             let cayenne_path = temp_dir.path().to_path_buf();
+            let metadata_dir = temp_dir.path().join("metadata");
 
             crate::configure_test_datafusion();
 
@@ -717,6 +741,10 @@ async fn test_cayenne_partition_by_date_part() -> Result<(), anyhow::Error> {
             param_map.insert(
                 "cayenne_file_path".to_string(),
                 cayenne_path.display().to_string(),
+            );
+            param_map.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
             );
             let acceleration_params = Params::from_string_map(param_map);
 


### PR DESCRIPTION
## Summary
- give each Cayenne partition_by integration test its own metadata directory to avoid SQLite contention when tests run in parallel
- annotate long Cayenne partition_by tests with clippy expectations

## Testing
- cargo test -p runtime --test integration -- --nocapture acceleration::partition_by_cayenne::test_cayenne_partition_by_bucket_numeric_nulls acceleration::partition_by_cayenne::test_cayenne_partition_by_date_part --test-threads=2
- make lint-rust