### PR TITLE
Add TinyLFU caching policy

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -308,7 +308,7 @@ jobs:
         run: |
           spice add spiceai/quickstart
           cat spicepod.yaml
-  
+
       - name: Wait for dataset to be ready
         working-directory: test_app
         timeout-minutes: 1
@@ -1256,7 +1256,7 @@ jobs:
           echo "  caching:" >> spicepod.yaml
           echo "    sql_results:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      eviction_policy: lru" >> spicepod.yaml
+          echo "      caching_policy: lru" >> spicepod.yaml
           echo "      max_size: 128MiB" >> spicepod.yaml
           echo "      item_ttl: 300s" >> spicepod.yaml
           echo "datasets:" >> spicepod.yaml

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -382,7 +382,12 @@ impl QueryResultsCacheProvider {
         // Cache TTL should be the base TTL plus the stale-while-revalidate window
         // so entries aren't evicted before they can be served as stale
         let cache_ttl = ttl + stale_while_revalidate_ttl.unwrap_or_default();
-        let cache = Arc::new(LruCache::new(cache_max_size, cache_ttl, hash_builder));
+        let cache = Arc::new(LruCache::new(
+            cache_max_size,
+            cache_ttl,
+            hash_builder,
+            config.caching_policy,
+        ));
 
         let encoder = encoding::get_encoder(config.encoding);
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -28,7 +28,7 @@ use byte_unit::Byte;
 use datafusion::sql::TableReference;
 use moka::future::Cache;
 use snafu::ResultExt;
-use spicepod::component::caching::CacheConfig;
+use spicepod::component::caching::{CacheConfig, CachingPolicy};
 use std::fmt::Display;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
@@ -110,7 +110,12 @@ pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'sta
     };
 
     let hash_builder = get_hash_builder(cache_config.hashing_algorithm)?;
-    Ok(Arc::new(LruCache::new(cache_max_size, ttl, hash_builder)))
+    Ok(Arc::new(LruCache::new(
+        cache_max_size,
+        ttl,
+        hash_builder,
+        cache_config.caching_policy,
+    )))
 }
 
 impl<
@@ -118,7 +123,18 @@ impl<
     T: BuildHasher + Clone + Send + Sync + 'static,
 > LruCache<V, T>
 {
-    pub fn new(cache_max_size: u64, ttl: Duration, hasher: T) -> Self {
+    #[must_use]
+    pub fn new(
+        cache_max_size: u64,
+        ttl: Duration,
+        hasher: T,
+        caching_policy: CachingPolicy,
+    ) -> Self {
+        let moka_eviction_policy = match caching_policy {
+            CachingPolicy::Lru => moka::policy::EvictionPolicy::lru(),
+            CachingPolicy::TinyLfu => moka::policy::EvictionPolicy::tiny_lfu(),
+        };
+
         let cache: Cache<u64, V, T> = Cache::builder()
             .time_to_live(ttl)
             .weigher(|_key, value: &V| -> u32 {
@@ -138,7 +154,7 @@ impl<
                 }
             })
             .max_capacity(cache_max_size)
-            .eviction_policy(moka::policy::EvictionPolicy::lru())
+            .eviction_policy(moka_eviction_policy)
             .support_invalidation_closures()
             .eviction_listener(|_key, _value, cause| {
                 if cause.was_evicted() {
@@ -307,7 +323,7 @@ mod tests {
     use arrow::array::{Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
     use rstest::rstest;
-    use spicepod::component::caching::HashingAlgorithm;
+    use spicepod::component::caching::{CachingPolicy, HashingAlgorithm};
     use std::collections::{HashMap, HashSet};
     use std::hash::RandomState;
     use std::time::Duration;
@@ -373,7 +389,7 @@ mod tests {
         #[case] hasher: T,
     ) {
         let cache: LruCache<CachedQueryResult, _> =
-            LruCache::new(10, Duration::from_secs(60), hasher);
+            LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
 
@@ -398,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn test_cache_miss<T: BuildHasher + Clone + Send + Sync + 'static>(#[case] hasher: T) {
         let cache: LruCache<CachedQueryResult, _> =
-            LruCache::new(10, Duration::from_secs(60), hasher);
+            LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let key = CacheKey::Query("nonexistent_query", None).as_raw_key(cache.hasher());
 
         // Try to get a non-existent key
@@ -417,7 +433,7 @@ mod tests {
         #[case] hasher: T,
     ) {
         let cache: LruCache<CachedQueryResult, _> =
-            LruCache::new(10, Duration::from_secs(60), hasher);
+            LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let table_ref = TableReference::Bare {
             table: Arc::from("test_table"),
         };
@@ -458,7 +474,7 @@ mod tests {
         #[case] hasher: T,
     ) {
         let cache: LruCache<CachedSearchResult, _> =
-            LruCache::new(10, Duration::from_secs(60), hasher);
+            LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let table_ref = TableReference::Bare {
             table: Arc::from("test_table"),
         };
@@ -498,7 +514,7 @@ mod tests {
         let hasher = get_hash_builder(hashing_algo).expect("Failed to get hash builder");
 
         let cache: LruCache<CachedQueryResult, _> =
-            LruCache::new(10, Duration::from_millis(100), hasher);
+            LruCache::new(10, Duration::from_millis(100), hasher, CachingPolicy::Lru);
         let key = || CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
 
@@ -533,7 +549,7 @@ mod tests {
         let hasher = get_hash_builder(hashing_algo).expect("Failed to get hash builder");
 
         let cache: LruCache<CachedQueryResult, _> =
-            LruCache::new(10, Duration::from_millis(100), hasher);
+            LruCache::new(10, Duration::from_millis(100), hasher, CachingPolicy::Lru);
         let key = || CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
 
@@ -556,5 +572,30 @@ mod tests {
             .is_none()
             .then_some(())
             .expect("cache should not contain key after TTL expiry");
+    }
+
+    #[rstest]
+    #[case::lru(CachingPolicy::Lru)]
+    #[case::tiny_lfu(CachingPolicy::TinyLfu)]
+    #[tokio::test]
+    async fn test_cache_with_caching_policy(#[case] caching_policy: CachingPolicy) {
+        let hasher = RandomState::default();
+        let cache: LruCache<CachedQueryResult, _> =
+            LruCache::new(10, Duration::from_secs(60), hasher, caching_policy);
+
+        let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
+        let result = create_test_cached_result().await;
+
+        // Put a value in the cache
+        cache.put_raw_key(&key.as_u64(), result.clone()).await;
+
+        // Get the value from the cache
+        let retrieved = cache.get_raw_key(&key.as_u64()).await;
+        let retrieved = retrieved.expect("cache should contain the key");
+        let retrieved_len = retrieved.records().await.expect("Failed to decode").len();
+        let result_len = result.records().await.expect("Failed to decode").len();
+        (retrieved_len == result_len)
+            .then_some(())
+            .expect("retrieved and result should have same length");
     }
 }

--- a/crates/spicepod/src/component/caching.rs
+++ b/crates/spicepod/src/component/caching.rs
@@ -58,6 +58,20 @@ pub enum Encoding {
     Zstd,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CachingPolicy {
+    /// Least Recently Used caching policy.
+    /// Suitable for workloads with strong recency bias, such as streaming data processing.
+    #[default]
+    Lru,
+    /// TinyLFU caching policy.
+    /// Combines LRU eviction with LFU-based admission policy.
+    /// Suitable for most workloads including database, search, and analytics.
+    TinyLfu,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -88,7 +102,8 @@ pub struct CacheConfig {
     pub enabled: bool,
     pub max_size: Option<String>,
     pub item_ttl: Option<String>,
-    pub eviction_policy: Option<String>,
+    #[serde(default, alias = "eviction_policy")]
+    pub caching_policy: CachingPolicy,
     #[serde(default)]
     pub hashing_algorithm: HashingAlgorithm,
 }
@@ -99,7 +114,7 @@ impl Default for CacheConfig {
             enabled: true,
             max_size: None,
             item_ttl: None,
-            eviction_policy: None,
+            caching_policy: CachingPolicy::default(),
             hashing_algorithm: HashingAlgorithm::default(),
         }
     }
@@ -116,7 +131,8 @@ pub struct SQLResultsCacheConfig {
     pub enabled: bool,
     pub max_size: Option<String>,
     pub item_ttl: Option<String>,
-    pub eviction_policy: Option<String>,
+    #[serde(default, alias = "eviction_policy")]
+    pub caching_policy: CachingPolicy,
     #[serde(default)]
     pub hashing_algorithm: HashingAlgorithm,
     #[serde(default)]
@@ -140,7 +156,7 @@ impl Default for SQLResultsCacheConfig {
             enabled: true,
             max_size: None,
             item_ttl: None,
-            eviction_policy: None,
+            caching_policy: CachingPolicy::default(),
             hashing_algorithm: HashingAlgorithm::default(),
             cache_key_type: CacheKeyType::default(),
             stale_while_revalidate_ttl: None,
@@ -157,7 +173,8 @@ pub struct ResultsCache {
     pub enabled: bool,
     pub cache_max_size: Option<String>,
     pub item_ttl: Option<String>,
-    pub eviction_policy: Option<String>,
+    #[serde(default, alias = "eviction_policy")]
+    pub caching_policy: CachingPolicy,
     #[serde(default)]
     pub cache_key_type: CacheKeyType,
     #[serde(default)]
@@ -172,7 +189,7 @@ impl Default for ResultsCache {
             enabled: true,
             cache_max_size: None,
             item_ttl: None,
-            eviction_policy: None,
+            caching_policy: CachingPolicy::default(),
             cache_key_type: CacheKeyType::default(),
             hashing_algorithm: HashingAlgorithm::default(),
             max_stale_while_revalidate: None,
@@ -186,7 +203,7 @@ impl From<ResultsCache> for SQLResultsCacheConfig {
             enabled: val.enabled,
             max_size: val.cache_max_size,
             item_ttl: val.item_ttl,
-            eviction_policy: val.eviction_policy,
+            caching_policy: val.caching_policy,
             hashing_algorithm: val.hashing_algorithm,
             cache_key_type: val.cache_key_type,
             stale_while_revalidate_ttl: None,
@@ -212,7 +229,7 @@ mod tests {
         assert_eq!(sql_results.cache_key_type, CacheKeyType::default());
         assert!(sql_results.max_size.is_none());
         assert!(sql_results.item_ttl.is_none());
-        assert!(sql_results.eviction_policy.is_none());
+        assert_eq!(sql_results.caching_policy, CachingPolicy::Lru);
         assert_eq!(sql_results, SQLResultsCacheConfig::default());
 
         let search_results = caching.search_results.expect("Should have cache config");
@@ -223,7 +240,7 @@ mod tests {
         );
         assert!(search_results.max_size.is_none());
         assert!(search_results.item_ttl.is_none());
-        assert!(search_results.eviction_policy.is_none());
+        assert_eq!(search_results.caching_policy, CachingPolicy::Lru);
         assert_eq!(search_results, CacheConfig::default());
 
         let embeddings = caching.embeddings.expect("Should have cache config");
@@ -231,7 +248,7 @@ mod tests {
         assert_eq!(embeddings.hashing_algorithm, HashingAlgorithm::default());
         assert!(embeddings.max_size.is_none());
         assert!(embeddings.item_ttl.is_none());
-        assert!(embeddings.eviction_policy.is_none());
+        assert_eq!(embeddings.caching_policy, CachingPolicy::Lru);
         assert_eq!(embeddings, CacheConfig::default());
     }
 }

--- a/crates/spicepod/src/component/caching.rs
+++ b/crates/spicepod/src/component/caching.rs
@@ -66,7 +66,7 @@ pub enum CachingPolicy {
     /// Suitable for workloads with strong recency bias, such as streaming data processing.
     #[default]
     Lru,
-    /// TinyLFU caching policy.
+    /// `TinyLFU` caching policy.
     /// Combines LRU eviction with LFU-based admission policy.
     /// Suitable for most workloads including database, search, and analytics.
     TinyLfu,


### PR DESCRIPTION
This pull request introduces support for configurable caching policies in the cache subsystem, replacing the previous hardcoded LRU eviction policy with a new `CachingPolicy` enum. This allows users to select between LRU and TinyLFU caching strategies via configuration, improving flexibility for different workloads. The changes update configuration structures, cache construction logic, and tests to use the new policy.

**Caching policy configuration and propagation:**

* Added a new `CachingPolicy` enum (`Lru`, `TinyLfu`) to `spicepod::component::caching` and updated all relevant cache configuration structs (`CacheConfig`, `SQLResultsCacheConfig`, `ResultsCache`) to use it instead of the previous `eviction_policy` string. Default policy is set to `Lru`. [[1]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835R61-R74) [[2]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L91-R106) [[3]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L102-R117) [[4]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L119-R135) [[5]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L143-R159) [[6]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L160-R177) [[7]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L175-R192) [[8]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L189-R206)

* Updated YAML generation in the GitHub workflow to use `caching_policy` instead of `eviction_policy` for SQL results cache configuration.

**Cache implementation updates:**

* Modified the `LruCache` constructor and builder logic to accept a `CachingPolicy` parameter and select the appropriate eviction policy for the underlying cache implementation. [[1]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL113-R137) [[2]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL141-R157)

* Updated cache provider logic to pass the configured caching policy when constructing caches.

**Testing and validation:**

* Updated all cache tests to use the new `CachingPolicy` parameter, and added new tests to validate both `Lru` and `TinyLfu` policies. [[1]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL310-R326) [[2]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL376-R392) [[3]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL401-R417) [[4]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL420-R436) [[5]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL461-R477) [[6]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL501-R517) [[7]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceL536-R552) [[8]](diffhunk://#diff-c89da1341e0e65dcd5594953cead7aff510fd7322d5a847c80f8bdca0213e9ceR576-R600)

* Adjusted configuration tests to check for the correct default caching policy instead of the previous eviction policy field. [[1]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L215-R232) [[2]](diffhunk://#diff-a2343d2e423bf596e9290d8cef82109a93b06e874fc2a7658d28c6d43e3cc835L226-R251)