### PR TITLE
Add v1.9.2 threat model

### DIFF
--- a/docs/threat_models/v1.9.2.json
+++ b/docs/threat_models/v1.9.2.json
@@ -1,7 +1,7 @@
 {
   "version": "2.5.0",
   "summary": {
-    "title": "Spice.ai OSS v1.10.0",
+    "title": "Spice.ai OSS v1.9.2 Threat Model",
     "owner": "Phillip LeBlanc",
     "description": "Spice is a portable, open-source runtime for fast, last-mile SQL query, search, and AI inference with embedded model execution.",
     "id": 0
@@ -469,8 +469,8 @@
             "connector": "smooth",
             "data": {
               "type": "tm.Flow",
-              "name": "Accelerator I/O (DuckDB/SQLite/Vortex)",
-              "description": "File formats: .duckdb, .db, .vortex, Parquet, Arrow IPC",
+              "name": "Accelerator I/O (DuckDB)",
+              "description": "File formats: .duckdb, Parquet, Arrow IPC",
               "outOfScope": false,
               "isTrustBoundary": false,
               "reasonOutOfScope": "",
@@ -482,7 +482,7 @@
               "threats": []
             },
             "labels": [
-              "Accelerator I/O (DuckDB/SQLite/Vortex)"
+              "Accelerator I/O (DuckDB)"
             ],
             "id": "25b3a98a-0e28-4d2b-bf74-bede05ce95eb",
             "source": {
@@ -495,6 +495,55 @@
               {
                 "x": 300,
                 "y": 460
+              }
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Accelerator I/O (SQLite)",
+              "description": "File formats: .sqlite, .db",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "In-memory Arrow",
+              "threats": []
+            },
+            "labels": [
+              "Accelerator I/O (SQLite)"
+            ],
+            "id": "91f4a5b6-c7d8-49e0-a1b2-345c6de7890f",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "81367a19-0ccf-4772-b2fe-55f1232cd67f"
+            },
+            "vertices": [
+              {
+                "x": 420,
+                "y": 500
               }
             ]
           },
@@ -644,6 +693,55 @@
             },
             "target": {
               "cell": "81367a19-0ccf-4772-b2fe-55f1232cd67f"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "File I/O (SQLite persistence storage)",
+              "description": "Embedded SQLite accelerator reads/writes .sqlite/.db files on local filesystem",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "b15fda1e-5c83-4dd7-bb59-1c31d91cb7a1",
+            "source": {
+              "cell": "81367a19-0ccf-4772-b2fe-55f1232cd67f"
+            },
+            "target": {
+              "cell": "03fb0ac1-ff87-46cc-8c51-f75357f8d350"
             }
           },
           {
@@ -1029,6 +1127,94 @@
             "connector": "smooth",
             "data": {
               "type": "tm.Flow",
+              "name": "Model Execution Control",
+              "description": "Runtime issues inference requests to embedded model runtimes and receives responses.",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "In-process",
+              "threats": []
+            },
+            "labels": [
+              "Model Execution Control"
+            ],
+            "id": "7c4d5e6f-12ab-4cde-8f90-1234567890ab",
+            "source": {
+              "cell": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+            },
+            "target": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "vertices": []
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Model File I/O",
+              "description": "Model Execution reads weights and writes cache metadata to Local Model Storage.",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "File I/O",
+              "threats": []
+            },
+            "labels": [
+              "Model File I/O"
+            ],
+            "id": "5de6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f80",
+            "source": {
+              "cell": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+            },
+            "target": {
+              "cell": "f3a4b5c6-d7e8-9f0a-1b2c-3d4e5f6a7b8c"
+            },
+            "vertices": []
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
               "name": "Ballista gRPC (Task Dispatch)",
               "description": "Scheduler sends task assignments to executors",
               "outOfScope": false,
@@ -1148,44 +1334,13 @@
             },
             "target": {
               "cell": "df26fc07-6901-4028-b816-f7fdc36bffb5"
-            }
-          },
-          {
-            "position": {
-              "x": 760,
-              "y": 250
             },
-            "size": {
-              "width": 180,
-              "height": 110
-            },
-            "attrs": {
-              "text": {
-                "text": "Federated Query & Catalog Orchestration"
-              },
-              "body": {
-                "stroke": "#333333",
-                "strokeWidth": 1.5,
-                "strokeDasharray": null
+            "vertices": [
+              {
+                "x": 450,
+                "y": 305
               }
-            },
-            "visible": true,
-            "shape": "process",
-            "zIndex": 21,
-            "id": "6e3f0d3b-04a1-4b2c-9f4c-1db0bd0e8c9c",
-            "data": {
-              "type": "tm.Process",
-              "name": "Federated Query & Catalog Orchestration",
-              "description": "DataFusion-based federation layer coordinating multi-source SQL, Unity Catalog/Glue metadata, and catalog-backed governance enforcement.",
-              "outOfScope": false,
-              "reasonOutOfScope": "",
-              "hasOpenThreats": false,
-              "handlesCardPayment": false,
-              "handlesGoodsOrServices": false,
-              "isWebApplication": false,
-              "privilegeLevel": "",
-              "threats": []
-            }
+            ]
           },
           {
             "shape": "flow",
@@ -1274,8 +1429,54 @@
             }
           },
           {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Data Flow",
+              "description": "",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              "Data Flow"
+            ],
+            "id": "0d294445-6bfa-460f-b845-869e0c96db90",
+            "source": {
+              "x": 680,
+              "y": 720
+            },
+            "target": {
+              "x": 850,
+              "y": 700
+            },
+            "vertices": []
+          },
+          {
             "position": {
-              "x": 1120,
+              "x": 1250,
               "y": 80
             },
             "size": {
@@ -1284,7 +1485,7 @@
             },
             "attrs": {
               "text": {
-                "text": "Data Source(s)"
+                "text": "Data Sources"
               },
               "topLine": {
                 "strokeWidth": 1.5,
@@ -1383,7 +1584,7 @@
             "id": "b7b0e199-6a96-4240-b70e-5a349ec627bc",
             "data": {
               "type": "tm.Store",
-              "name": "Data Source(s)",
+              "name": "Data Sources",
               "description": "Any number of data sources (databases via ODBC FFI boundary, warehouses, cloud storage) serving CSV, JSON, Parquet, Delta, Iceberg formats. ODBC connections cross native/foreign function interface boundary.",
               "outOfScope": false,
               "reasonOutOfScope": "",
@@ -2061,7 +2262,7 @@
           },
           {
             "position": {
-              "x": 1120,
+              "x": 1250,
               "y": 230
             },
             "size": {
@@ -2184,7 +2385,7 @@
           },
           {
             "position": {
-              "x": 1120,
+              "x": 1250,
               "y": 380
             },
             "size": {
@@ -2559,7 +2760,126 @@
           },
           {
             "position": {
-              "x": 1120,
+              "x": 780,
+              "y": 200
+            },
+            "size": {
+              "width": 180,
+              "height": 110
+            },
+            "attrs": {
+              "text": {
+                "text": "Federated Query & Catalog Orchestration"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 21,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "195e90b7-7a51-4fe5-b9f7-a5a0f52f1e52"
+                },
+                {
+                  "group": "right",
+                  "id": "5fb79512-aa43-43db-b2bb-f43b0d85e093"
+                },
+                {
+                  "group": "bottom",
+                  "id": "9b194ece-3062-4eb9-8769-0a45d86b1bc0"
+                },
+                {
+                  "group": "left",
+                  "id": "49637664-6f7f-458f-9d75-a10d2873bb0f"
+                }
+              ]
+            },
+            "id": "6e3f0d3b-04a1-4b2c-9f4c-1db0bd0e8c9c",
+            "data": {
+              "type": "tm.Process",
+              "name": "Federated Query & Catalog Orchestration",
+              "description": "DataFusion-based federation layer coordinating multi-source SQL, Unity Catalog/Glue metadata, and catalog-backed governance enforcement.",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": false,
+              "privilegeLevel": "",
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 1250,
               "y": 530
             },
             "size": {
@@ -2696,8 +3016,8 @@
           },
           {
             "position": {
-              "x": 720,
-              "y": 400
+              "x": 760,
+              "y": 420
             },
             "size": {
               "width": 170,
@@ -2815,8 +3135,8 @@
           },
           {
             "position": {
-              "x": 730,
-              "y": 600
+              "x": 760,
+              "y": 610
             },
             "size": {
               "width": 180,

--- a/docs/threat_models/v1.9.2.json
+++ b/docs/threat_models/v1.9.2.json
@@ -1,0 +1,2947 @@
+{
+  "version": "2.5.0",
+  "summary": {
+    "title": "Spice.ai OSS v1.10.0",
+    "owner": "Phillip LeBlanc",
+    "description": "Spice is a portable, open-source runtime for fast, last-mile SQL query, search, and AI inference with embedded model execution.",
+    "id": 0
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [
+      {
+        "id": 0,
+        "title": "Data + AI Runtime (Local/Network)",
+        "diagramType": "STRIDE",
+        "placeholder": "New STRIDE diagram description",
+        "thumbnail": "./public/content/images/thumbnail.stride.jpg",
+        "version": "2.5.0",
+        "cells": [
+          {
+            "position": {
+              "x": 420,
+              "y": 140
+            },
+            "size": {
+              "width": 520,
+              "height": 420
+            },
+            "attrs": {
+              "headerText": {
+                "text": "Spice Runtime Process"
+              }
+            },
+            "visible": true,
+            "shape": "trust-boundary-box",
+            "zIndex": -1,
+            "id": "d7fa1282-6622-4dda-b3c8-a4f51746ef86",
+            "data": {
+              "type": "tm.BoundaryBox",
+              "name": "Spice Runtime Process",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": true
+            }
+          },
+          {
+            "position": {
+              "x": 30,
+              "y": 40
+            },
+            "size": {
+              "width": 990,
+              "height": 820
+            },
+            "attrs": {
+              "headerText": {
+                "text": "Internet/Untrusted Network"
+              }
+            },
+            "visible": true,
+            "shape": "trust-boundary-box",
+            "zIndex": -1,
+            "id": "b2bbd52d-f20e-4d29-8246-5c24a7d84de6",
+            "data": {
+              "type": "tm.BoundaryBox",
+              "name": "Internet/Untrusted Network",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            }
+          },
+          {
+            "position": {
+              "x": 80,
+              "y": 190
+            },
+            "size": {
+              "width": 260,
+              "height": 250
+            },
+            "attrs": {
+              "headerText": {
+                "text": "Application Process"
+              }
+            },
+            "visible": true,
+            "shape": "trust-boundary-box",
+            "zIndex": -1,
+            "id": "e98ca2eb-b692-4154-a852-b6329be72330",
+            "data": {
+              "type": "tm.BoundaryBox",
+              "name": "Application Process",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            }
+          },
+          {
+            "position": {
+              "x": 560,
+              "y": 280
+            },
+            "size": {
+              "width": 180,
+              "height": 130
+            },
+            "attrs": {
+              "text": {
+                "text": "Spice Runtime"
+              },
+              "body": {
+                "stroke": "red",
+                "strokeWidth": 2.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 1,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "42b19b8a-f078-4c28-80fd-4c83e9ebb3a4"
+                },
+                {
+                  "group": "right",
+                  "id": "3c208bf7-1343-44bf-860f-017b608ffc68"
+                },
+                {
+                  "group": "bottom",
+                  "id": "1e776aca-9502-4456-b86c-8b8aadd20d36"
+                },
+                {
+                  "group": "left",
+                  "id": "4188ee74-cce4-4279-a28e-539d3a6567d2"
+                }
+              ]
+            },
+            "id": "910108ef-e112-4d35-869a-55bae2e7e631",
+            "data": {
+              "type": "tm.Process",
+              "name": "Spice Runtime",
+              "description": "Rust daemon with embedded Mistral.rs (LLM), Tract (ONNX), Candle/TEI (embeddings). Exposes Arrow Flight SQL (gRPC), HTTP (REST/OpenAI/MCP/Iceberg), and Ballista gRPC APIs.",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": true,
+              "privilegeLevel": "",
+              "threats": [
+                {
+                  "id": "dff68689-b77c-4a7d-8ac0-f5dd0f68c832",
+                  "title": "Bypass data source AuthN/AuthZ",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "Users with access to the Spice runtime APIs can access information from the data source either via federated SQL query or through queries on a configured accelerator, potentially getting access to data they don't normally have access to.",
+                  "mitigation": "This is an expected behavior of the system. Spice can be used by design to provide access to data without needing to divulge the underlying connection information.\n\nThe current supported deployment model is that endpoints aren't exposed to untrusted entities.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 4,
+                  "score": ""
+                },
+                {
+                  "id": "5caf188d-20ad-44e8-9668-fd8bbb2fff5b",
+                  "title": "Task history reset on restart",
+                  "status": "Open",
+                  "severity": "Low",
+                  "type": "Repudiation",
+                  "description": "The task history table is only kept in-memory, which means any tasks that would be captured are lost if an attacker wants to conceal what they did by either timing their activity to occur before a maintenance activity that results in a restart, or by purposefully causing the runtime to restart.",
+                  "mitigation": "Persist task_history locally",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 5,
+                  "score": ""
+                },
+                {
+                  "id": "4c5c5857-7dd9-4507-9901-65a46bca1e4f",
+                  "title": "Expensive queries can lead to denial of service",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Denial of service",
+                  "description": "An attacker or misconfigured application could potentially cause a denial of service on the Spice runtime.",
+                  "mitigation": "Configurable limit on how much time a query can take\nDeploy more Spice instances, where each Spice instance has its own resource limits",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 6,
+                  "score": ""
+                },
+                {
+                  "id": "6f77fbb6-e541-4cf7-8a01-66c8fb5fa1fc",
+                  "title": "No persistent audit logs",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Repudiation",
+                  "description": "Spice does not provide audit logging of actions taken that could repudiate that a certain action was taken.\nAll access to Spice assumes the caller is trusted, so no identity information could be gathered even if audit logs were maintained",
+                  "mitigation": "Implement a proper audit/task history log tracking both changes to the runtime operation (i.e. modifying Spicepod, runtime settings) as well as data operations (queries, refreshes) that is persistent across restarts.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 11,
+                  "score": ""
+                },
+                {
+                  "id": "3b998f5e-b14c-471a-821a-70492d1f03cf",
+                  "title": "Data source connection details (or any secrets) leaked via errors/logging",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "Metadata about connected data sources is leaked through error messages, revealing sensitive infrastructure details.",
+                  "mitigation": "Review code where logs are emitted to ensure that potential sensitive information (i.e. credentials encoded in headers) is not leaked via error messages.\n- [Action]: Remove ODBC printing the connection string",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 12,
+                  "score": ""
+                },
+                {
+                  "id": "060959c9-eef4-4f5c-b2ec-883b817d4fb6",
+                  "title": "Excessive acceleration",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Denial of service",
+                  "description": "An attacker with the ability to control the Spicepod (or an unintentionally misconfigured Spicepod through legitimate means) can cause the runtime to load an acceleration that is too large to fit in-memory on the filesystem, or causes the running organization to incur excessive costs from the remote data source.",
+                  "mitigation": "",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 13,
+                  "score": ""
+                },
+                {
+                  "id": "1b7e7d8e-91f6-44c2-8b23-4e6ae2e59e1f",
+                  "title": "Malicious SQL / SQL injection leading to ACE",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Elevation of privilege",
+                  "description": "A user exploits a vulnerability in the SQL parser to execute arbitrary code (ACE) on the Spice runtime.",
+                  "mitigation": "We reject queries that would allow modifying the state of the runtime at the parsing layer.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 14,
+                  "score": ""
+                },
+                {
+                  "id": "279a3e89-40a7-463e-b6f0-33a1a76e9579",
+                  "title": "Results caching reuse",
+                  "status": "NotApplicable",
+                  "severity": "Low",
+                  "type": "Information disclosure",
+                  "description": "A malicious actor targets the results caching mechanism to retrieve sensitive data from previous queries.",
+                  "mitigation": "Not a current threat, but could become one if we don't implement results caching with proper AuthN",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 16,
+                  "score": ""
+                },
+                {
+                  "id": "b2f796eb-4409-446f-8888-61d46a165b49",
+                  "title": "Malicious compressed small payload has unbounded/very large size",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Denial of service",
+                  "description": "If an attacker is able to send a payload to a Spice endpoint that is compressed, and the decompression of that payload causes Spice to run out of memory due to the payload itself having a very large/potentially unbounded size - then it could cause a denial of service. (i.e. Zipbomb)",
+                  "mitigation": "- No known Gzip attack vector and the HTTP endpoints only accept Gzip compression\n- For connecting to data sources, we rely on object_store's implementation which should protect against this.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 18,
+                  "score": ""
+                },
+                {
+                  "id": "9982eda7-8112-42ee-9459-a6606d997b28",
+                  "title": "Task History shows truncated results",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "If you have access to the runtime, you can access the task_history table along with some truncated outputs of data you might not normally be able to access.\n\nThis isn't a problem in v0.17.4-beta, because if you can access the task_history table, then you trivially can access any of the data sources.",
+                  "mitigation": "No mitigation currently. Once we add AuthN/AuthZ, we will need to design how to lock this down appropriately. (i.e. RLS)",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 19,
+                  "score": ""
+                },
+                {
+                  "id": "5432e91b-7e85-45eb-ae9f-0d9649b3c969",
+                  "title": "Malicious SQL / SQL injection leading to information disclosure",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "If there are functions that allow reading from the environment/file-system, this could lead to unexpected information disclosure of the system details/secrets",
+                  "mitigation": "- Run in a chroot process with limited file-system access\n- Disable functions that allow this access",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 21,
+                  "score": ""
+                },
+                {
+                  "id": "0c78df7c-43c7-4be4-9a31-78bb4d60acd6",
+                  "title": "Supply chain attack leading to compromised dependency",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Elevation of privilege",
+                  "description": "If an attacker is able to compromise a dependency that we depend on, and we release a version of Spice with that compromised dependency, then all of Spice users would potentially be affected.",
+                  "mitigation": "- CVE scanner/dependabot to scan for known issues with dependencies\n- Adopt a policy of waiting before upgrading a dependency to allow for the community to identify\n- Processing scanning to identify suspicious behavior",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 22,
+                  "score": ""
+                },
+                {
+                  "id": "27386708-0996-4c5c-b635-7c831d1493f7",
+                  "title": "Unprotected control plane endpoints",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Elevation of privilege",
+                  "description": "HTTP/Arrow Flight/OpenAI-compatible/MCP/Iceberg APIs accept requests without built-in authentication or rate limits by default. Exposure of these endpoints beyond a trusted network allows attackers to run arbitrary queries or inference, modify runtime state, or exfiltrate data.",
+                  "mitigation": "Terminate traffic behind an API gateway with mTLS/JWT, restrict bind addresses/firewall rules, enable runtime-auth when available, and apply per-endpoint rate limiting before exposing services to untrusted clients.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 23,
+                  "score": ""
+                },
+                {
+                  "id": "8c4afad7-263c-427f-9aae-24ee944d2c5d",
+                  "title": "Prompt injection via SQL AI/LLM functions",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Information disclosure",
+                  "description": "Model-backed SQL helpers (e.g., text-to-SQL, sql_ai, MCP tools) can be influenced by attacker-provided prompts or corpora, leading to over-broad queries, unauthorized data access, or untrusted tool execution.",
+                  "mitigation": "Constrain AI-generated SQL to read-only allowlists, sandbox tool execution, validate model outputs, and filter/escape untrusted inputs before invoking LLM-backed functions.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 24,
+                  "score": ""
+                },
+                {
+                  "id": "db0f037e-6d2e-4eed-a4b4-e513783ce935",
+                  "title": "Telemetry and traces leak sensitive data",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "Verbose traces, query logs, or model prompt/response bodies may include secrets or PII that are exported to OTEL/metrics backends without redaction.",
+                  "mitigation": "Default to minimal logging, scrub sensitive fields before emission, isolate telemetry destinations, and apply retention policies/PII filtering in observability pipelines.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 28,
+                  "score": ""
+                },
+                {
+                  "id": "8a2cce08-2b76-4d23-9b6d-0b7a28e0280a",
+                  "title": "Unauthorized Iceberg table writes",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Tampering",
+                  "description": "The Iceberg connector supports writes while other data sources are read-only. Without strong authentication, input validation, and authorization, attackers with endpoint access can corrupt, drop, or poison Iceberg tables.",
+                  "mitigation": "Require mTLS/JWT on write-capable endpoints, enforce schema/operation allowlists, validate write destinations, and run Iceberg connectors on isolated identities with least-privilege storage permissions.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 29,
+                  "score": ""
+                },
+                {
+                  "id": "f8a9c2e1-4d7b-4c8f-9e3a-1b5f6a7d8c9e",
+                  "title": "Excessive model inference causing DoS",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Denial of service",
+                  "description": "An attacker with access to LLM inference endpoints can trigger resource-intensive model execution (large context windows, many concurrent requests) causing memory exhaustion, CPU saturation, or GPU starvation that denies service to legitimate users.",
+                  "mitigation": "Implement rate limiting per client/endpoint, enforce maximum context length and token limits, set timeouts for inference requests, and implement queuing with backpressure for model execution.",
+                  "modelType": "STRIDE",
+                  "new": true,
+                  "number": 31,
+                  "score": ""
+                },
+                {
+                  "id": "c3b4d5e6-7f8a-9b0c-1d2e-3f4a5b6c7d8e",
+                  "title": "Embedded model runtime vulnerabilities",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Elevation of privilege",
+                  "description": "Vulnerabilities in embedded model runtimes (Mistral.rs, Tract, Candle) could allow malicious model files (GGUF, ONNX, SafeTensors) to exploit parsing bugs, buffer overflows, or unsafe deserialization leading to arbitrary code execution.",
+                  "mitigation": "Keep model runtime dependencies updated, validate model file checksums/signatures before loading, run model execution in sandboxed processes with limited privileges, and implement file format validation before parsing.",
+                  "modelType": "STRIDE",
+                  "new": true,
+                  "number": 32,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Accelerator I/O (DuckDB/SQLite/Vortex)",
+              "description": "File formats: .duckdb, .db, .vortex, Parquet, Arrow IPC",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "In-memory Arrow",
+              "threats": []
+            },
+            "labels": [
+              "Accelerator I/O (DuckDB/SQLite/Vortex)"
+            ],
+            "id": "25b3a98a-0e28-4d2b-bf74-bede05ce95eb",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "f32481b0-efee-44f0-991f-ad091abceba2"
+            },
+            "vertices": [
+              {
+                "x": 300,
+                "y": 460
+              }
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "File I/O (DuckDB persistence)",
+              "description": "Formats: .duckdb files",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "fb051e3e-9e0f-4158-87c4-610a8435286e",
+            "source": {
+              "cell": "f32481b0-efee-44f0-991f-ad091abceba2"
+            },
+            "target": {
+              "cell": "03fb0ac1-ff87-46cc-8c51-f75357f8d350"
+            },
+            "vertices": []
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "File I/O (Cayenne/Vortex persistence)",
+              "description": "Formats: .vortex, .sqlite files",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "635ec413-fcc8-458b-b664-debefc2c249d",
+            "source": {
+              "cell": "5c1a6f0c-3b1b-4b8c-bc2d-0c05345d52a6"
+            },
+            "target": {
+              "cell": "03fb0ac1-ff87-46cc-8c51-f75357f8d350"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "File I/O (SQLite persistence)",
+              "description": "Formats: .db, .sqlite files",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "fa7ba349-b32b-4435-bf04-62dc4c148cd9",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "81367a19-0ccf-4772-b2fe-55f1232cd67f"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Arrow Flight SQL (gRPC)",
+              "description": "SQL queries over gRPC with Arrow IPC response format",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "Arrow Flight SQL",
+              "threats": []
+            },
+            "labels": [
+              "Arrow Flight SQL (gRPC)"
+            ],
+            "id": "aae7d043-5c7c-46ca-b335-b2c62e0e7fca",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "df26fc07-6901-4028-b816-f7fdc36bffb5"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Connector Data Flow (CSV/JSON/Parquet/Delta/Iceberg/ODBC)",
+              "description": "Formats: CSV, JSON, Parquet, Arrow IPC, ORC, Delta Lake, Iceberg. ODBC connectors (SQL Server, Oracle, MySQL, PostgreSQL) cross FFI boundary to native database drivers.",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "TLS/HTTPS/ODBC",
+              "threats": [
+                {
+                  "id": "a6c73295-0d6b-4b9d-af68-80fc976115a0",
+                  "title": "Man-in-the-middle Data Sources",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Tampering",
+                  "description": "A potential man-in-the-middle attack is possible where an attacker can inject themselves in the middle of the data source data stream to modify data in transit, causing Spice to return attacker-controlled payloads to the client applications.",
+                  "mitigation": "Connect to remote data sources using TLS/SSL\nFor data connectors that don't support TLS (FTP, Debezium) - connect over a secure network instead.\n",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 9,
+                  "score": ""
+                },
+                {
+                  "id": "1ce4c004-6b61-43ae-9555-7a39e1b60544",
+                  "title": "Unauthenticated Iceberg write path abuse",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Tampering",
+                  "description": "Because Iceberg supports writes, a compromised or unauthenticated caller could alter, overwrite, or delete Iceberg tables via the data connector.",
+                  "mitigation": "Enforce authentication/authorization for Iceberg write endpoints, isolate Iceberg credentials, and apply storage-level ACLs and table-level governance.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 30,
+                  "score": ""
+                }
+              ]
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "2f011021-dff5-4dc3-9e8d-218272cbfe15",
+            "source": {
+              "cell": "b7b0e199-6a96-4240-b70e-5a349ec627bc"
+            },
+            "target": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "vertices": [
+              {
+                "x": 900,
+                "y": 160
+              }
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "External LLM API Calls (HTTPS)",
+              "description": "OpenAI-compatible API calls to hosted providers",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "HTTPS",
+              "threats": [
+                {
+                  "id": "b9623f17-5bda-4fdf-a354-ea4d2bdf1f36",
+                  "title": "Model gateway key leakage and unbounded spend",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "Hosted model and embedding providers are called with API keys. A compromised runtime, verbose logs, or replay of this channel can expose keys or allow attackers to trigger costly inference at scale.",
+                  "mitigation": "Store provider keys in runtime-secrets, avoid logging headers/bodies, enforce egress allowlists and rate limits, and rotate provider credentials regularly.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 25,
+                  "score": ""
+                }
+              ]
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "9ba63256-5f79-4aae-b8b9-4f68c4c0b591",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "7e3894d9-f316-4f7b-bcec-7be3d95b34c1"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Snapshot Download (HTTPS/S3)",
+              "description": "Formats: Arrow, Parquet, Vortex files from S3/object storage",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "HTTPS/S3",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "4de5fd32-1f5b-40d2-8c79-5f64f0338a2c",
+            "source": {
+              "cell": "27af5e68-7bba-4d32-8b5d-f073f73ff9f2"
+            },
+            "target": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Ballista gRPC (Scheduler Control Plane)",
+              "description": "Unauthenticated gRPC for task scheduling and executor registration",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "gRPC",
+              "threats": [
+                {
+                  "id": "58b52a2c-a47e-4476-a098-2da60355b6a4",
+                  "title": "Rogue cluster node injection",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Elevation of privilege",
+                  "description": "Ballista scheduler and executor communication occurs over unauthenticated gRPC. A malicious host on the network could register a fake executor or intercept traffic to read data, corrupt results, or disrupt queries.",
+                  "mitigation": "Keep cluster traffic on a private network, front with mTLS sidecars, restrict scheduler/executor discovery to allowlisted peers, and disable the cluster feature when not required.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 27,
+                  "score": ""
+                }
+              ]
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "8b05b05c-4a71-4d60-9ae9-6a823bdc4412",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "0f2b61f2-3f68-46e3-a9e8-0646b8d9c071"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Model Download (HTTPS)",
+              "description": "Downloads model files: GGUF, GGML, SafeTensors, ONNX, PyTorch (.bin, .pth, .pt) to ~/.spice/models/",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "HTTPS",
+              "threats": [
+                {
+                  "id": "b7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e",
+                  "title": "HuggingFace API token leakage",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "HuggingFace API tokens used to download private models could be leaked through logs, error messages, or environment variable exposure, allowing unauthorized access to private model repositories.",
+                  "mitigation": "- Store HF tokens in runtime-secrets only\n- Scrub tokens from all log output and error messages\n- Use environment variable protection and secret management systems\n- Rotate tokens regularly\n- Use read-only tokens with minimal scope",
+                  "modelType": "STRIDE",
+                  "new": true,
+                  "number": 35,
+                  "score": ""
+                }
+              ]
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "a2b3c4d5-e6f7-8a9b-0c1d-2e3f4a5b6c7d",
+            "source": {
+              "cell": "e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b"
+            },
+            "target": {
+              "cell": "f3a4b5c6-d7e8-9f0a-1b2c-3d4e5f6a7b8c"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Ballista gRPC (Task Dispatch)",
+              "description": "Scheduler sends task assignments to executors",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "gRPC",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "4d3eeb77-3a4b-4b29-98fb-932e8aa1b027",
+            "source": {
+              "cell": "0f2b61f2-3f68-46e3-a9e8-0646b8d9c071"
+            },
+            "target": {
+              "cell": "d5e905d2-3d15-4b74-bb79-8fd3cb37f405"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Accelerator I/O (Cayenne)",
+              "description": "Runtime reads/writes Vortex columnar data",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "",
+              "threats": []
+            },
+            "labels": [
+              {
+                "attrs": {
+                  "label": {
+                    "text": "Data Flow"
+                  }
+                }
+              }
+            ],
+            "id": "d0b2f763-0a56-4d70-bd63-5846cfacdd19",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "5c1a6f0c-3b1b-4b8c-bc2d-0c05345d52a6"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "HTTP REST / MCP APIs",
+              "description": "HTTP-based endpoints: REST (/v1/query) and MCP (SSE) transport for tools and agents",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "HTTP/SSE",
+              "threats": []
+            },
+            "labels": [
+              "HTTP REST / MCP APIs"
+            ],
+            "id": "8b8c9cc2-6f4d-43b3-9b48-2d9ef3d7b8c7",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "df26fc07-6901-4028-b816-f7fdc36bffb5"
+            }
+          },
+          {
+            "position": {
+              "x": 760,
+              "y": 250
+            },
+            "size": {
+              "width": 180,
+              "height": 110
+            },
+            "attrs": {
+              "text": {
+                "text": "Federated Query & Catalog Orchestration"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 21,
+            "id": "6e3f0d3b-04a1-4b2c-9f4c-1db0bd0e8c9c",
+            "data": {
+              "type": "tm.Process",
+              "name": "Federated Query & Catalog Orchestration",
+              "description": "DataFusion-based federation layer coordinating multi-source SQL, Unity Catalog/Glue metadata, and catalog-backed governance enforcement.",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": false,
+              "privilegeLevel": "",
+              "threats": []
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Federated SQL Planning",
+              "description": "Spice Runtime hands federated SQL requests to orchestration for logical planning, source selection, and policy evaluation.",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isBidirectional": true,
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "protocol": "In-process",
+              "threats": []
+            },
+            "labels": [
+              "Federated SQL Planning"
+            ],
+            "id": "c4cb5dd0-7f3d-4948-9c1c-3b5c4f39642f",
+            "source": {
+              "cell": "910108ef-e112-4d35-869a-55bae2e7e631"
+            },
+            "target": {
+              "cell": "6e3f0d3b-04a1-4b2c-9f4c-1db0bd0e8c9c"
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Catalog Discovery & Governance",
+              "description": "Unity Catalog, AWS Glue, and other catalog connectors queried for schemas, permissions, and table locations over HTTPS.",
+              "outOfScope": false,
+              "isTrustBoundary": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isBidirectional": false,
+              "isEncrypted": false,
+              "isPublicNetwork": true,
+              "protocol": "HTTPS",
+              "threats": []
+            },
+            "labels": [
+              "Catalog Discovery & Governance"
+            ],
+            "id": "1a8a5a33-1f04-4f54-9b1f-8b978fd96b2b",
+            "source": {
+              "cell": "6e3f0d3b-04a1-4b2c-9f4c-1db0bd0e8c9c"
+            },
+            "target": {
+              "cell": "b7b0e199-6a96-4240-b70e-5a349ec627bc"
+            }
+          },
+          {
+            "position": {
+              "x": 1120,
+              "y": 80
+            },
+            "size": {
+              "width": 220,
+              "height": 100
+            },
+            "attrs": {
+              "text": {
+                "text": "Data Source(s)"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 12,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "34fc0ec6-1488-4f36-91b9-68bf28aaae72"
+                },
+                {
+                  "group": "right",
+                  "id": "462683f0-7699-444d-85b8-df3164f34ff4"
+                },
+                {
+                  "group": "bottom",
+                  "id": "71d2dde8-07c4-4e59-a215-66e46e968b06"
+                },
+                {
+                  "group": "left",
+                  "id": "80ecfb22-b833-4acb-8dd9-8f64a3e5a2f5"
+                }
+              ]
+            },
+            "id": "b7b0e199-6a96-4240-b70e-5a349ec627bc",
+            "data": {
+              "type": "tm.Store",
+              "name": "Data Source(s)",
+              "description": "Any number of data sources (databases via ODBC FFI boundary, warehouses, cloud storage) serving CSV, JSON, Parquet, Delta, Iceberg formats. ODBC connections cross native/foreign function interface boundary.",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 140,
+              "y": 600
+            },
+            "size": {
+              "width": 150,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Embedded \nDuckDB"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 13,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "17fb3e7f-195e-4d54-a0ad-46f792e890f8"
+                },
+                {
+                  "group": "right",
+                  "id": "08b0bf87-edd4-4875-a6ae-c42fd96b60de"
+                },
+                {
+                  "group": "bottom",
+                  "id": "dbd71551-c4b2-4840-9183-c27e6aa45ab4"
+                },
+                {
+                  "group": "left",
+                  "id": "e74b8d90-1b84-4c38-b7a0-a8ab52cf1703"
+                }
+              ]
+            },
+            "id": "f32481b0-efee-44f0-991f-ad091abceba2",
+            "data": {
+              "type": "tm.Store",
+              "name": "Embedded \nDuckDB",
+              "description": "In-memory/file-based accelerator (.duckdb files, Parquet, CSV)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 120,
+              "y": 250
+            },
+            "size": {
+              "width": 170,
+              "height": 110
+            },
+            "attrs": {
+              "text": {
+                "text": "Client Application"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 14,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "b2ad80b5-8d69-45cd-9fc5-84001aede015"
+                },
+                {
+                  "group": "right",
+                  "id": "529ebea6-77ad-4cb9-ade7-fc1d78fd8f0c"
+                },
+                {
+                  "group": "bottom",
+                  "id": "62a2ad39-66cd-4591-9386-be2295f3c4af"
+                },
+                {
+                  "group": "left",
+                  "id": "ae3a1230-ae74-45eb-a010-88ece19838ff"
+                }
+              ]
+            },
+            "id": "df26fc07-6901-4028-b816-f7fdc36bffb5",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Client Application",
+              "description": "Application using Spice via Arrow Flight SQL, HTTP REST, or OpenAI-compatible endpoints",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "providesAuthentication": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 330,
+              "y": 600
+            },
+            "size": {
+              "width": 150,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Embedded SQLite"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 15,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "514fd376-86dd-4f07-bd9c-0a9fdb295703"
+                },
+                {
+                  "group": "right",
+                  "id": "3c5614b5-bdf1-4d5d-9845-db0db1edf3f8"
+                },
+                {
+                  "group": "bottom",
+                  "id": "08640b04-1073-4fbf-9c35-42f56ecd5c0f"
+                },
+                {
+                  "group": "left",
+                  "id": "50702f55-b94f-47f9-8d15-2038475b212f"
+                }
+              ]
+            },
+            "id": "81367a19-0ccf-4772-b2fe-55f1232cd67f",
+            "data": {
+              "type": "tm.Store",
+              "name": "Embedded SQLite",
+              "description": "SQLite accelerator (.db, .sqlite files)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 520,
+              "y": 600
+            },
+            "size": {
+              "width": 170,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Cayenne Accelerator\n(Vortex + SQLite)"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 15,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "3b4dfc6a-2663-4168-bc38-f57883d887c3"
+                },
+                {
+                  "group": "right",
+                  "id": "83a94f61-0986-4c78-ad0c-e29a859f6c0b"
+                },
+                {
+                  "group": "bottom",
+                  "id": "4ac0f641-8664-4579-b31e-0891c776fe82"
+                },
+                {
+                  "group": "left",
+                  "id": "6dbc9061-2e60-416f-98ff-cb6b8c95e196"
+                }
+              ]
+            },
+            "id": "5c1a6f0c-3b1b-4b8c-bc2d-0c05345d52a6",
+            "data": {
+              "type": "tm.Store",
+              "name": "Cayenne Accelerator (Vortex + SQLite)",
+              "description": "Multi-file acceleration format (.vortex columnar files + .sqlite metadata)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 90,
+              "y": 720
+            },
+            "size": {
+              "width": 860,
+              "height": 120
+            },
+            "attrs": {
+              "text": {
+                "text": "Local Machine Filesystem"
+              },
+              "topLine": {
+                "stroke": "red",
+                "strokeWidth": 2.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "stroke": "red",
+                "strokeWidth": 2.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 16,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "a5d9cfd6-164f-4e59-ac80-35caa0aea41f"
+                },
+                {
+                  "group": "right",
+                  "id": "df0e0e1e-e95c-4015-afd8-d8e7395b49f3"
+                },
+                {
+                  "group": "bottom",
+                  "id": "3949db90-dd85-4612-bf91-e27d062dcfc5"
+                },
+                {
+                  "group": "left",
+                  "id": "5d02622a-f49e-458c-8057-a6029ca6abf6"
+                }
+              ]
+            },
+            "id": "03fb0ac1-ff87-46cc-8c51-f75357f8d350",
+            "data": {
+              "type": "tm.Store",
+              "name": "Local Machine Filesystem",
+              "description": "Storage for accelerators, models, and Spicepod configuration",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": false,
+              "threats": [
+                {
+                  "id": "f243829c-4d65-4fb8-9a24-ddf941c6fc48",
+                  "title": "Tampering with file-based accelerators",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Tampering",
+                  "description": "Modifying file-based accelerators to inject malicious content",
+                  "mitigation": "- Run Spice as a least privileged user.\n- Run application with least privilege, ideally without file-system access.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 1,
+                  "score": ""
+                },
+                {
+                  "id": "1dd96996-2703-4cc7-9e02-9dee68efc22d",
+                  "title": "Bypass underlying data source AuthN/AuthZ by reading accelerator files",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Information disclosure",
+                  "description": "When Spice is configured to accelerate data from a data source to a file (i.e. DuckDB/SQLite) then its possible to bypass all AuthN/AuthZ measures if the attacker has access to the file.",
+                  "mitigation": "- Limit the file permissions to only the user running the Spice instance\n  - [Action]: Change default file permission to 600\n  - [Action]: Configuration to allow changing permission\n- Instead of running Spice on the same machine, run it in a separate machine in the trusted network.\n- chroot the Spice instance AND chroot the application",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 17,
+                  "score": ""
+                },
+                {
+                  "id": "946eec8b-6e87-45d4-976a-c11cbebc1d70",
+                  "title": "Tampering with the Spicepod",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Tampering",
+                  "description": "If an attacker can access/modify the Spicepod, they can tamper with how the Spice runtime loads data sources and potentially point them to data sources that the attacker controls, to disrupt/poison the operations of applications configured to query this Spice instance.",
+                  "mitigation": "- Proper file permissions so that only the Spice instance can access the Spicepod.\n- [Action]: Update deployment examples to limit file permissions of Spicepod.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 20,
+                  "score": ""
+                },
+                {
+                  "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+                  "title": "Malicious model file injection",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Elevation of privilege",
+                  "description": "An attacker with filesystem access could replace legitimate model files (GGUF, ONNX, SafeTensors) in ~/.spice/models/ or local model directories with malicious payloads designed to exploit model runtime parsers, leading to code execution when models are loaded.",
+                  "mitigation": "- Restrict filesystem permissions on model cache directory (~/.spice/models/) to runtime user only\n- Validate model file checksums/signatures before loading\n- Use read-only mounts for model directories where possible\n- Implement file integrity monitoring for model storage",
+                  "modelType": "STRIDE",
+                  "new": true,
+                  "number": 33,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 1120,
+              "y": 230
+            },
+            "size": {
+              "width": 220,
+              "height": 100
+            },
+            "attrs": {
+              "text": {
+                "text": "Hosted Model Provider"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 17,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "8814239e-e821-4f62-b387-bb71245df2ee"
+                },
+                {
+                  "group": "right",
+                  "id": "3a0ee107-8c15-4374-b4f7-fd2a2e9b8100"
+                },
+                {
+                  "group": "bottom",
+                  "id": "41ed0322-ea0e-477f-8f21-0d3adba47b73"
+                },
+                {
+                  "group": "left",
+                  "id": "eee7a688-5c83-4ee4-b6fe-786f61df88de"
+                }
+              ]
+            },
+            "id": "7e3894d9-f316-4f7b-bcec-7be3d95b34c1",
+            "data": {
+              "type": "tm.Store",
+              "name": "Hosted Model Provider",
+              "description": "Third-party LLM/embedding APIs (OpenAI, Anthropic, Azure, Databricks, Bedrock, etc.)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 1120,
+              "y": 380
+            },
+            "size": {
+              "width": 240,
+              "height": 100
+            },
+            "attrs": {
+              "text": {
+                "text": "Acceleration Snapshots / Object Storage"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 18,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "bf6fd4d8-4971-4866-9e5c-f9045b9ae0fb"
+                },
+                {
+                  "group": "right",
+                  "id": "babd1196-75c6-4b4d-93da-800b1ea2d832"
+                },
+                {
+                  "group": "bottom",
+                  "id": "b9d3179e-d10a-403d-9a28-5e3b5fc74623"
+                },
+                {
+                  "group": "left",
+                  "id": "e3cc9d1b-5f81-4b84-90af-5650490b4265"
+                }
+              ]
+            },
+            "id": "27af5e68-7bba-4d32-8b5d-f073f73ff9f2",
+            "data": {
+              "type": "tm.Store",
+              "name": "Acceleration Snapshots / Object Storage",
+              "description": "Remote S3/object storage for snapshot bootstrap (Arrow, Parquet, Vortex formats)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": [
+                {
+                  "id": "b316a5f7-69c3-4f52-9f8d-e89bf8d579c7",
+                  "title": "Unsigned acceleration snapshots or artifacts",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Tampering",
+                  "description": "Acceleration snapshots, Vortex files, or Arrow artifacts fetched from external object storage can be replaced or poisoned, leading to corrupted query results or malicious payload execution paths.",
+                  "mitigation": "Serve artifacts from access-controlled buckets, validate checksums/signatures before load, pin expected digests, and run the runtime as a least-privileged user with read-only mounts.",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 26,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 450,
+              "y": 160
+            },
+            "size": {
+              "width": 110,
+              "height": 70
+            },
+            "attrs": {
+              "text": {
+                "text": "Ballista Scheduler"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 19,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "3f99143f-898b-4fe5-89c8-aed2b0d6d37d"
+                },
+                {
+                  "group": "right",
+                  "id": "b21a42bf-8d85-4f96-9fcf-f192bb73d584"
+                },
+                {
+                  "group": "bottom",
+                  "id": "11514fd4-d0b0-43b7-844c-ee80793738cb"
+                },
+                {
+                  "group": "left",
+                  "id": "8f294148-7a1a-4a4e-bd0c-323a8584c526"
+                }
+              ]
+            },
+            "id": "0f2b61f2-3f68-46e3-a9e8-0646b8d9c071",
+            "data": {
+              "type": "tm.Process",
+              "name": "Ballista Scheduler",
+              "description": "Distributed query scheduler managing task distribution to executors via gRPC",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": false,
+              "privilegeLevel": "",
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 640,
+              "y": 170
+            },
+            "size": {
+              "width": 120,
+              "height": 70
+            },
+            "attrs": {
+              "text": {
+                "text": "Ballista Executor"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 20,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "3c6b03c3-f0d9-4338-abdb-2de2400a812d"
+                },
+                {
+                  "group": "right",
+                  "id": "8c5de1ae-66a7-45a2-a6da-99998220b2ef"
+                },
+                {
+                  "group": "bottom",
+                  "id": "07c2ef11-15bd-4c83-9c14-3d32aecfc5d3"
+                },
+                {
+                  "group": "left",
+                  "id": "d8e6aa0a-b5df-4e82-8b90-79359b4fcd15"
+                }
+              ]
+            },
+            "id": "d5e905d2-3d15-4b74-bb79-8fd3cb37f405",
+            "data": {
+              "type": "tm.Process",
+              "name": "Ballista Executor",
+              "description": "Distributed query executor processing tasks and exchanging shuffle data via Arrow Flight",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": false,
+              "privilegeLevel": "",
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 1120,
+              "y": 530
+            },
+            "size": {
+              "width": 220,
+              "height": 100
+            },
+            "attrs": {
+              "text": {
+                "text": "HuggingFace Hub"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 21,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "7b87ab00-4b25-42aa-b0f2-48cd5be9a084"
+                },
+                {
+                  "group": "right",
+                  "id": "acd9c244-8441-4d51-aeef-9a5437a325a0"
+                },
+                {
+                  "group": "bottom",
+                  "id": "d2a04c28-dd31-4321-88fd-2a1ac0e029c5"
+                },
+                {
+                  "group": "left",
+                  "id": "1f46e549-f62a-4f0a-bc87-75b45eec26b2"
+                }
+              ]
+            },
+            "id": "e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b",
+            "data": {
+              "type": "tm.Store",
+              "name": "HuggingFace Hub",
+              "description": "Model repository hosting LLMs, embeddings, and ML models (GGUF, GGML, SafeTensors, ONNX, PyTorch formats)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": true,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": [
+                {
+                  "id": "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a",
+                  "title": "Malicious model download from HuggingFace",
+                  "status": "Open",
+                  "severity": "High",
+                  "type": "Tampering",
+                  "description": "An attacker could compromise a HuggingFace repository or perform a man-in-the-middle attack during model download, replacing legitimate models with malicious ones containing exploits for model runtime parsers (Mistral.rs, Tract, Candle).",
+                  "mitigation": "- Verify model checksums/signatures from trusted sources\n- Pin specific model revisions/commits in Spicepod\n- Use private HuggingFace repos with access tokens for sensitive deployments\n- Implement allowlist of trusted model repositories\n- Download models over HTTPS only",
+                  "modelType": "STRIDE",
+                  "new": true,
+                  "number": 34,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 720,
+              "y": 400
+            },
+            "size": {
+              "width": 170,
+              "height": 110
+            },
+            "attrs": {
+              "text": {
+                "text": "Model Execution"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 21,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "dad44d17-7386-407c-9407-1b5ad889acd3"
+                },
+                {
+                  "group": "right",
+                  "id": "c37dea93-1628-4d17-884a-566a8be74927"
+                },
+                {
+                  "group": "bottom",
+                  "id": "382920cf-99fc-41c5-a595-54f1d4b53ec9"
+                },
+                {
+                  "group": "left",
+                  "id": "9a06b018-1c57-420b-85d7-36f903967427"
+                }
+              ]
+            },
+            "id": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "data": {
+              "type": "tm.Process",
+              "name": "Model Execution",
+              "description": "Embedded model runtimes: Mistral.rs (LLMs), Tract (ONNX), Candle/TEI (embeddings)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "handlesCardPayment": false,
+              "handlesGoodsOrServices": false,
+              "isWebApplication": false,
+              "privilegeLevel": "",
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 730,
+              "y": 600
+            },
+            "size": {
+              "width": 180,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Local Model Storage"
+              },
+              "topLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1.5,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "zIndex": 22,
+            "ports": {
+              "groups": {
+                "top": {
+                  "position": "top",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "position": "right",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "bottom": {
+                  "position": "bottom",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                },
+                "left": {
+                  "position": "left",
+                  "attrs": {
+                    "circle": {
+                      "r": 4,
+                      "magnet": true,
+                      "stroke": "#5F95FF",
+                      "strokeWidth": 1,
+                      "fill": "#fff",
+                      "style": {
+                        "visibility": "hidden"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": [
+                {
+                  "group": "top",
+                  "id": "82c8aad1-b8a6-4ca6-bb1a-01f401948745"
+                },
+                {
+                  "group": "right",
+                  "id": "852e259e-afe3-4c15-a2d4-7ed375066ac7"
+                },
+                {
+                  "group": "bottom",
+                  "id": "50abe127-ba6a-4af0-aa07-2e28ea04937b"
+                },
+                {
+                  "group": "left",
+                  "id": "748d636d-ef5b-427d-9993-bfcac6b97e29"
+                }
+              ]
+            },
+            "id": "f3a4b5c6-d7e8-9f0a-1b2c-3d4e5f6a7b8c",
+            "data": {
+              "type": "tm.Store",
+              "name": "Local Model Storage",
+              "description": "Local filesystem or ~/.spice/models/ cache containing downloaded models (GGUF, ONNX, SafeTensors)",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "hasOpenThreats": false,
+              "isALog": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "storesCredentials": false,
+              "storesInventory": true,
+              "threats": []
+            }
+          }
+        ],
+        "description": "Models the components involved in federated query, acceleration, embedded model execution (Mistral.rs/Tract/Candle), LLM inference, and distributed execution (Ballista) for the Spice runtime. Includes specific API surfaces (Arrow Flight SQL, HTTP, Ballista gRPC), file formats (CSV, JSON, Parquet, Delta, Iceberg, GGUF, ONNX, SafeTensors, Vortex), and model execution flows."
+      }
+    ],
+    "diagramTop": 2,
+    "reviewer": "Spice AI Engineering Team",
+    "threatTop": 37
+  }
+}


### PR DESCRIPTION
## 📝 Summary

This attempts to add some things that were not previously represented in the 1.9x threat model.

#### High level components
- HuggingFace as an external store
- Local model storage as an explicit store
- Model execution as an explicit process with mention of libraries we use

#### Data flows
- Model I/O (from HF, to disk, etc)
- Ballista I/O (shuffles, RPC)
- Catalog I/O

#### Threats
- Model inference DoS
- Model data poisoning (either via DNS hijacking of HF, or local model hijacking -- generally "supply chain" attack surface)
- Shuffle data poisoning and interception

<img width="1230" height="723" alt="image" src="https://github.com/user-attachments/assets/26d48ed2-947e-402e-bff7-e71a5bf4712f" />
