### PR TITLE
fix: Increase TPCDS DuckDB connection pool size

### DIFF
--- a/test/spicepods/tpcds/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
@@ -15,6 +15,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
   - from: databricks:spiceai_sandbox.tpcds.call_center
     name: call_center
     params: *databricks_delta_params

--- a/test/spicepods/tpcds/sf1/accelerated/file[parquet]-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/file[parquet]-duckdb[file].yaml
@@ -8,6 +8,8 @@ datasets:
       engine: duckdb
       mode: file
       enabled: true
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_returns.parquet
     name: catalog_returns
     acceleration: *acceleration

--- a/test/spicepods/tpcds/sf1/accelerated/file[parquet]-duckdb[memory].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/file[parquet]-duckdb[memory].yaml
@@ -8,6 +8,8 @@ datasets:
       engine: duckdb
       mode: memory
       enabled: true
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_returns.parquet
     name: catalog_returns
     acceleration: *acceleration

--- a/test/spicepods/tpcds/sf1/accelerated/mysql-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/mysql-duckdb[file].yaml
@@ -16,6 +16,8 @@ definitions:
     enabled: true
     engine: duckdb
     mode: file
+    params:
+      connection_pool_size: 25
 
 datasets:
   - from: mysql:call_center

--- a/test/spicepods/tpcds/sf1/accelerated/mysql-duckdb[memory].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/mysql-duckdb[memory].yaml
@@ -16,6 +16,8 @@ definitions:
     enabled: true
     engine: duckdb
     mode: memory
+    params:
+      connection_pool_size: 25
 
 datasets:
   - from: mysql:call_center

--- a/test/spicepods/tpcds/sf1/accelerated/on_zero_results/file[parquet]-duckdb[file]-on_zero_results.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/on_zero_results/file[parquet]-duckdb[file]-on_zero_results.yaml
@@ -10,6 +10,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_returns.parquet
     name: catalog_returns
     acceleration:
@@ -18,6 +20,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/inventory.parquet
     name: inventory
     acceleration:
@@ -26,6 +30,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM inventory LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store_sales.parquet
     name: store_sales
     acceleration:
@@ -34,6 +40,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store_returns.parquet
     name: store_returns
     acceleration:
@@ -42,6 +50,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_sales.parquet
     name: web_sales
     acceleration:
@@ -50,6 +60,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_returns.parquet
     name: web_returns
     acceleration:
@@ -58,6 +70,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer.parquet
     name: customer
     acceleration:
@@ -66,6 +80,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer_address.parquet
     name: customer_address
     acceleration:
@@ -74,6 +90,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_address LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer_demographics.parquet
     name: customer_demographics
     acceleration:
@@ -82,6 +100,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/date_dim.parquet
     name: date_dim
     acceleration:
@@ -90,6 +110,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM date_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/household_demographics.parquet
     name: household_demographics
     acceleration:
@@ -98,6 +120,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM household_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/item.parquet
     name: item
     acceleration:
@@ -106,6 +130,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM item LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/promotion.parquet
     name: promotion
     acceleration:
@@ -114,6 +140,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM promotion LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/ship_mode.parquet
     name: ship_mode
     acceleration:
@@ -122,6 +150,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM ship_mode LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store.parquet
     name: store
     acceleration:
@@ -130,6 +160,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/time_dim.parquet
     name: time_dim
     acceleration:
@@ -138,6 +170,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM time_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/warehouse.parquet
     name: warehouse
     acceleration:
@@ -146,6 +180,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM warehouse LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_page.parquet
     name: web_page
     acceleration:
@@ -154,6 +190,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_site.parquet
     name: web_site
     acceleration:
@@ -162,6 +200,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_site LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/reason.parquet
     name: reason
     acceleration:
@@ -170,6 +210,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM reason LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/call_center.parquet
     name: call_center
     acceleration:
@@ -178,6 +220,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM call_center LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/income_band.parquet
     name: income_band
     acceleration:
@@ -186,6 +230,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM income_band LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_page.parquet
     name: catalog_page
     acceleration:
@@ -194,3 +240,5 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25

--- a/test/spicepods/tpcds/sf1/accelerated/on_zero_results/file[parquet]-duckdb[memory]-on_zero_results.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/on_zero_results/file[parquet]-duckdb[memory]-on_zero_results.yaml
@@ -10,6 +10,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_returns.parquet
     name: catalog_returns
     acceleration:
@@ -18,6 +20,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/inventory.parquet
     name: inventory
     acceleration:
@@ -26,6 +30,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM inventory LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store_sales.parquet
     name: store_sales
     acceleration:
@@ -34,6 +40,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store_returns.parquet
     name: store_returns
     acceleration:
@@ -42,6 +50,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_sales.parquet
     name: web_sales
     acceleration:
@@ -50,6 +60,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_returns.parquet
     name: web_returns
     acceleration:
@@ -58,6 +70,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer.parquet
     name: customer
     acceleration:
@@ -66,6 +80,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer_address.parquet
     name: customer_address
     acceleration:
@@ -74,6 +90,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_address LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/customer_demographics.parquet
     name: customer_demographics
     acceleration:
@@ -82,6 +100,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/date_dim.parquet
     name: date_dim
     acceleration:
@@ -90,6 +110,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM date_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/household_demographics.parquet
     name: household_demographics
     acceleration:
@@ -98,6 +120,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM household_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/item.parquet
     name: item
     acceleration:
@@ -106,6 +130,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM item LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/promotion.parquet
     name: promotion
     acceleration:
@@ -114,6 +140,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM promotion LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/ship_mode.parquet
     name: ship_mode
     acceleration:
@@ -122,6 +150,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM ship_mode LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/store.parquet
     name: store
     acceleration:
@@ -130,6 +160,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/time_dim.parquet
     name: time_dim
     acceleration:
@@ -138,6 +170,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM time_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/warehouse.parquet
     name: warehouse
     acceleration:
@@ -146,6 +180,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM warehouse LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_page.parquet
     name: web_page
     acceleration:
@@ -154,6 +190,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/web_site.parquet
     name: web_site
     acceleration:
@@ -162,6 +200,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_site LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/reason.parquet
     name: reason
     acceleration:
@@ -170,6 +210,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM reason LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/call_center.parquet
     name: call_center
     acceleration:
@@ -178,6 +220,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM call_center LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/income_band.parquet
     name: income_band
     acceleration:
@@ -186,6 +230,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM income_band LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: file:data/catalog_page.parquet
     name: catalog_page
     acceleration:
@@ -194,3 +240,5 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25

--- a/test/spicepods/tpcds/sf1/accelerated/on_zero_results/s3[parquet]-duckdb[file]-on_zero_results.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/on_zero_results/s3[parquet]-duckdb[file]-on_zero_results.yaml
@@ -17,6 +17,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
     name: catalog_returns
     params: *s3_params
@@ -26,6 +28,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/inventory.parquet
     name: inventory
     params: *s3_params
@@ -35,6 +39,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM inventory LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store_sales.parquet
     name: store_sales
     params: *s3_params
@@ -44,6 +50,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store_returns.parquet
     name: store_returns
     params: *s3_params
@@ -53,6 +61,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_sales.parquet
     name: web_sales
     params: *s3_params
@@ -62,6 +72,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_returns.parquet
     name: web_returns
     params: *s3_params
@@ -71,6 +83,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer.parquet
     name: customer
     params: *s3_params
@@ -80,6 +94,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer_address.parquet
     name: customer_address
     params: *s3_params
@@ -89,6 +105,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_address LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer_demographics.parquet
     name: customer_demographics
     params: *s3_params
@@ -98,6 +116,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/date_dim.parquet
     name: date_dim
     params: *s3_params
@@ -107,6 +127,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM date_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/household_demographics.parquet
     name: household_demographics
     params: *s3_params
@@ -116,6 +138,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM household_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/item.parquet
     name: item
     params: *s3_params
@@ -125,6 +149,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM item LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/promotion.parquet
     name: promotion
     params: *s3_params
@@ -134,6 +160,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM promotion LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/ship_mode.parquet
     name: ship_mode
     params: *s3_params
@@ -143,6 +171,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM ship_mode LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store.parquet
     name: store
     params: *s3_params
@@ -152,6 +182,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/time_dim.parquet
     name: time_dim
     params: *s3_params
@@ -170,6 +202,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM warehouse LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_page.parquet
     name: web_page
     params: *s3_params
@@ -179,6 +213,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_site.parquet
     name: web_site
     params: *s3_params
@@ -188,6 +224,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_site LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/reason.parquet
     name: reason
     params: *s3_params
@@ -197,6 +235,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM reason LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/call_center.parquet
     name: call_center
     params: *s3_params
@@ -206,6 +246,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM call_center LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/income_band.parquet
     name: income_band
     params: *s3_params
@@ -215,6 +257,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM income_band LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_page.parquet
     name: catalog_page
     params: *s3_params
@@ -224,3 +268,5 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25

--- a/test/spicepods/tpcds/sf1/accelerated/on_zero_results/s3[parquet]-duckdb[memory]-on_zero_results.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/on_zero_results/s3[parquet]-duckdb[memory]-on_zero_results.yaml
@@ -17,6 +17,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
     name: catalog_returns
     params: *s3_params
@@ -26,6 +28,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/inventory.parquet
     name: inventory
     params: *s3_params
@@ -35,6 +39,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM inventory LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store_sales.parquet
     name: store_sales
     params: *s3_params
@@ -44,6 +50,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store_returns.parquet
     name: store_returns
     params: *s3_params
@@ -53,6 +61,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_sales.parquet
     name: web_sales
     params: *s3_params
@@ -62,6 +72,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_sales LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_returns.parquet
     name: web_returns
     params: *s3_params
@@ -71,6 +83,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_returns LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer.parquet
     name: customer
     params: *s3_params
@@ -80,6 +94,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer_address.parquet
     name: customer_address
     params: *s3_params
@@ -89,6 +105,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_address LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/customer_demographics.parquet
     name: customer_demographics
     params: *s3_params
@@ -98,6 +116,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM customer_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/date_dim.parquet
     name: date_dim
     params: *s3_params
@@ -107,6 +127,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM date_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/household_demographics.parquet
     name: household_demographics
     params: *s3_params
@@ -116,6 +138,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM household_demographics LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/item.parquet
     name: item
     params: *s3_params
@@ -125,6 +149,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM item LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/promotion.parquet
     name: promotion
     params: *s3_params
@@ -134,6 +160,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM promotion LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/ship_mode.parquet
     name: ship_mode
     params: *s3_params
@@ -143,6 +171,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM ship_mode LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/store.parquet
     name: store
     params: *s3_params
@@ -152,6 +182,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM store LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/time_dim.parquet
     name: time_dim
     params: *s3_params
@@ -161,6 +193,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM time_dim LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/warehouse.parquet
     name: warehouse
     params: *s3_params
@@ -170,6 +204,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM warehouse LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_page.parquet
     name: web_page
     params: *s3_params
@@ -179,6 +215,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/web_site.parquet
     name: web_site
     params: *s3_params
@@ -188,6 +226,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM web_site LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/reason.parquet
     name: reason
     params: *s3_params
@@ -197,6 +237,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM reason LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/call_center.parquet
     name: call_center
     params: *s3_params
@@ -206,6 +248,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM call_center LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/income_band.parquet
     name: income_band
     params: *s3_params
@@ -215,6 +259,8 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM income_band LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_page.parquet
     name: catalog_page
     params: *s3_params
@@ -224,3 +270,5 @@ datasets:
       enabled: true
       refresh_sql: 'SELECT * FROM catalog_page LIMIT 0'
       on_zero_results: use_source
+      params:
+        connection_pool_size: 25

--- a/test/spicepods/tpcds/sf1/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/postgres-duckdb[file].yaml
@@ -15,6 +15,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
   - from: postgres:catalog_returns
     name: catalog_returns
     params: *postgres_params

--- a/test/spicepods/tpcds/sf1/accelerated/postgres-duckdb[memory].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/postgres-duckdb[memory].yaml
@@ -15,6 +15,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
   - from: postgres:catalog_returns
     name: catalog_returns
     params: *postgres_params

--- a/test/spicepods/tpcds/sf1/accelerated/s3[parquet]-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/s3[parquet]-duckdb[file].yaml
@@ -15,6 +15,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
     name: catalog_returns
     params: *s3_params

--- a/test/spicepods/tpcds/sf1/accelerated/s3[parquet]-duckdb[memory].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/s3[parquet]-duckdb[memory].yaml
@@ -15,6 +15,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: memory
+      params:
+        connection_pool_size: 25
   - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
     name: catalog_returns
     params: *s3_params

--- a/test/spicepods/tpcds/sf1/accelerated/spark[databricks]-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/spark[databricks]-duckdb[file].yaml
@@ -8,6 +8,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
     params: &spark_params
       spark_remote: sc://${ env:DATABRICKS_HOST }:443/;use_ssl=true;user_id=spice.ai;token=${ env:DATABRICKS_TOKEN };x-databricks-cluster-id=${ env:DATABRICKS_CLUSTER_ID };
   - from: spark:spiceai_sandbox.tpcds.catalog_returns

--- a/test/spicepods/tpcds/sf1/accelerated/spicecloud-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/spicecloud-duckdb[file].yaml
@@ -8,6 +8,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      params:
+        connection_pool_size: 25
     params: &spicecloud_params
       spiceai_api_key: ${secrets:SPICEAI_TEST_TPCDS_API_KEY}
       spiceai_endpoint: ${secrets:SPICEAI_TEST_ENDPOINT}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* The default connection pool size is 10. If TPCDS tables take too long to accelerate, the pool builder will timeout before a connection becomes free as TPCDS has more than 20 tables. By updating the connection pool size to 25, we allow all tables to accelerate at the same time.