### PR TITLE
Clarify /v1/nsql datasets sampling hint

### DIFF
--- a/.schema/openapi.json
+++ b/.schema/openapi.json
@@ -4259,11 +4259,11 @@
               "array",
               "null"
             ],
-      "items": {
-        "type": "string"
-      },
-      "description": "Names of datasets to sample from when constructing model context; this is a hint for sampling only and does not restrict which tables the model can generate queries against. If omitted, all datasets are used for sampling."
-    },
+            "items": {
+              "type": "string"
+            },
+            "description": "Names of datasets to sample from when constructing model context; this is a sampling hint and does not restrict which tables queries can target. If omitted, all datasets are used."
+          },
           "model": {
             "type": "string",
             "description": "The name of the model to use for SQL generation. Default: \"nql\""

--- a/.schema/openapi.json
+++ b/.schema/openapi.json
@@ -4259,11 +4259,11 @@
               "array",
               "null"
             ],
-            "items": {
-              "type": "string"
-            },
-            "description": "Names of datasets to sample from. If omitted, all datasets are used."
-          },
+      "items": {
+        "type": "string"
+      },
+      "description": "Names of datasets to sample from when constructing model context; this is a hint for sampling only and does not restrict which tables the model can generate queries against. If omitted, all datasets are used for sampling."
+    },
           "model": {
             "type": "string",
             "description": "The name of the model to use for SQL generation. Default: \"nql\""

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -141,7 +141,7 @@ pub struct Request {
     #[serde(default = "default_sample_data_enabled")]
     pub sample_data_enabled: bool,
 
-    /// Names of datasets to sample from. If omitted, all datasets are used.
+    /// Names of datasets to sample from when constructing model context; this is a sampling hint and does not restrict which tables queries can target. If omitted, all datasets are used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datasets: Option<Vec<String>>,
 }


### PR DESCRIPTION
## Summary
- clarify that the /v1/nsql datasets parameter only hints sampling for context and does not restrict tables

## Testing
- make lint-rust