### PR TITLE
DuckDB aggregate pushdown: fix partitioning and schema rewrite bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=9fa10f280175667a54ca18b55aa1320e82737840#9fa10f280175667a54ca18b55aa1320e82737840"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=bfe12b5e9ea31950a724cecce04e543f4db02165#bfe12b5e9ea31950a724cecce04e543f4db02165"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -4942,6 +4942,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "datafusion-federation",
+ "datafusion-physical-expr",
  "duckdb",
  "dyn-clone",
  "fallible-iterator 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = 
 datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "97ea01e40c79e5aaf34a6126cef95721f8bef3cc" }               # spiceai/spiceai-50
 datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "97ea01e40c79e5aaf34a6126cef95721f8bef3cc" }                   # spiceai/spiceai-50
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "9fa10f280175667a54ca18b55aa1320e82737840" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "bfe12b5e9ea31950a724cecce04e543f4db02165" } # spiceai
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "007c82d039220478f406d648417d28c0d40a7987" } # spiceai:spiceai-50
 

--- a/crates/datafusion-optimizer-rules/src/physical_plan/duckdb/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/duckdb/aggregate_pushdown.rs
@@ -73,7 +73,7 @@ impl ExecutionPlan for DuckDBAggregatePushdownMarkerExec {
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
-        self.input.required_input_distribution()
+        vec![Distribution::UnspecifiedDistribution; self.children().len()]
     }
 
     fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
@@ -85,7 +85,7 @@ impl ExecutionPlan for DuckDBAggregatePushdownMarkerExec {
     }
 
     fn benefits_from_input_partitioning(&self) -> Vec<bool> {
-        vec![true]
+        vec![false]
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -241,6 +241,7 @@ impl PhysicalOptimizerRule for DuckDBAggregatePushdownRewriter {
 
             let optimized_sql = unparser.plan_to_sql(&marker.logical_plan)?;
             let logical_plan_schema = Arc::clone(marker.logical_plan.schema().inner());
+
             let rewritten = duck_exec
                 .clone()
                 .with_optimized_sql(optimized_sql.to_string(), Some(logical_plan_schema));

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -58,6 +58,8 @@ use {
     datafusion_optimizer_rules::physical_plan::duckdb::intermediate_index_cte::DuckDBIntermediateIndexMaterializationOptimizer,
 };
 
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_optimizer::optimizer::PhysicalOptimizer;
 use datafusion_optimizer_rules::{
     logical_plan::{
         CacheInvalidationExtensionPlanner, cache_invalidation::CacheInvalidationOptimizerRule,
@@ -267,12 +269,23 @@ impl DataFusionBuilder {
 
         #[cfg(feature = "duckdb")]
         {
+            let mut physical_optimizers_with_duckdb: Vec<
+                Arc<dyn PhysicalOptimizerRule + Send + Sync>,
+            > = vec![
+                DuckDBAggregatePushdownRewriter::new(),
+                DuckDBIntermediateIndexMaterializationOptimizer::new(),
+            ];
+
+            physical_optimizers_with_duckdb.extend(
+                state
+                    .physical_optimizer_rules()
+                    .clone()
+                    .unwrap_or_else(|| PhysicalOptimizer::new().rules),
+            );
+
             state = state
                 .with_optimizer_rule(DuckDBAggregateLogicalPushdown::new())
-                .with_physical_optimizer_rule(DuckDBAggregatePushdownRewriter::new())
-                .with_physical_optimizer_rule(
-                    DuckDBIntermediateIndexMaterializationOptimizer::new(),
-                );
+                .with_physical_optimizer_rules(physical_optimizers_with_duckdb);
         }
 
         state = state


### PR DESCRIPTION
## 📝 Summary

- Partitioning mismatches were due to running the DuckDB optimizers before EnforceDistribution and OutputRequirements
- A HashJoinExec panic was due to plan properties not reflecting the canonical rewritten schema

Fixes #8381
