### PR TITLE
Update threat model for v1.9.2

### DIFF
--- a/docs/threat_models/v1.9.2.md
+++ b/docs/threat_models/v1.9.2.md
@@ -1,0 +1,43 @@
+# Threat Model for Spice.ai OSS v1.9.2
+
+*Owner*: Phillip LeBlanc
+*Description*: Spice is a portable accelerated SQL query, search, and LLM-inference engine, written in Rust, for data-grounded AI apps and agents.
+
+## Overview
+
+Any entity that can send requests to a Spice instance is a potential threat actor. The main risk is Spice doing *more* than the runtime explicitly configured it to do.
+
+In our model, the `spicepod.yaml` is the **Root of Trust**. The runtime's job is to faithfully execute that configuration and enforce the boundaries it defines. If the runtime fails to enforce those boundaries, that is a vulnerability in Spice.
+
+## Threat Actors
+
+Since Spice acts as a middleware or "sidecar," the threat actors are primarily defined by their network position relative to Spice.
+
+- **The "Lateral" Attacker**: An attacker who has compromised a different service in the same Kubernetes cluster or VPC. They have network access to Spice’s ports but no filesystem access. They want to use Spice as a proxy to reach upstream databases (Postgres/MySQL) that are firewalled off from the rest of the network, or to steal the credentials Spice holds in memory. Without an API key, they should not be able to perform any actions with Spice or leak any information.
+- **The Malicious Client**: A valid user or service authorized to query Spice (has an API key), but wants to do more than allowed. They are trying to escalate their privilege beyond what they are supposed to be able to do in Spice. They have access to `Dataset A` but are crafting SQL inputs to try and read `Dataset B` (which exists in the source but not exposed to them) or write data. This is probably our most important threat actor, they must be tightly constrained by the configuration.
+
+## Assets
+
+Spice is responsible for protecting:
+
+- **Upstream credentials**: The connection strings, passwords, or keys Spice uses to talk to backend databases (e.g., Postgres, Dremio, Snowflake).
+- **Upstream Data Integrity**: The data sitting in the backend. (Spice must not accidentally allow deletion or modification).
+- **Data Confidentiality (Scope)**: Ensuring data from `Table A` is not leaked when querying `Table B`.
+
+## Threat Surface & Vectors
+
+The threat surface is the **Network API** (HTTP, Flight, OpenTelemetry) and the **SQL Engine Logic**.
+
+The main vectors for exploitation are:
+
+- **Isolation breakout ("table hopping")**: An attacker sends a query for a valid dataset, but uses SQL injection or engine flaws to reference a dataset not exposed in the `spicepod.yaml`, or uses a "Pass-through" vulnerability to execute commands directly on the backend.
+- **Read-Only Bypass (Integrity Violation)**: An attacker constructs a query that results in a state change in the backend database.
+- **Authentication Bypass (API Surface)**: If `spicepod.yaml` mandates an API Key (`api_key_auth`), the runtime must enforce it globally.
+- **Information Leakage via Errors**: Spice encounters an error (e.g., connection failure to Postgres) and returns the raw error message to the client. Example: User runs a bad query. Spice responds: `Error connecting to postgres://admin:SuperSecretPassword@10.0.0.5....`
+- **Function-Based SSRF (Server-Side Request Forgery)**: Even if the config is static, SQL engines often support functions that reach out to the network (e.g., `http_get`, `load_extension`). An attacker submits a SQL query that uses a built-in function to make Spice initiate a network connection to an internal server.
+
+## Trust assumptions
+
+- The host/K8s environment and `spicepod.yaml` are controlled by a trusted operator.
+- Attackers **do not** have direct filesystem or ConfigMap edit access. **An attacker with filesystem access to modify `spicepod.yaml` is already considered to have full control of the environment.** If you can edit files on the Spice host, you almost certainly have network-level access as well. In Kubernetes, modifying the ConfigMap that supplies `spicepod.yaml` requires elevated permissions to the K8s API, which likewise implies full control over the deployment environment.
+- Denial-of-service via expensive queries is treated as “expected database behavior” and handled by infra controls, not Spice itself.


### PR DESCRIPTION
## 📝 Summary

Updates the threat model for v1.9.2, this time using a text-based markdown format that is focused on the threat surface for Spice itself, not the threat surface of a service that is integrating with Spice.