### PR TITLE
Use bmi1 target feature for x86_64

### DIFF
--- a/bin/spiced/.cargo/config.toml
+++ b/bin/spiced/.cargo/config.toml
@@ -3,7 +3,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 # x86_64 optimization with AVX2, FMA, BMI, etc. Portable across all AWS x86_64 C6/C7/C8 instances.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+avx2,+fma,+bmi,+bmi2,+lzcnt,+popcnt"]
+rustflags = ["-C", "target-feature=+avx2,+fma,+bmi1,+bmi2,+lzcnt,+popcnt"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "target-cpu=native"]


### PR DESCRIPTION
## 📝 Summary
- switch the x86_64 rustflags target feature from +bmi to +bmi1 to match the stable flag and remove the warning

```text
warning: unknown and unstable feature specified for `-Ctarget-feature`: `bmi`
  |
  = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
  = help: you might have meant: `bmi1`
```