### PR TITLE
benchmarks: Default to update snapshots when run on a non-release branch

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -101,14 +101,15 @@ jobs:
         run: |
           update_mode="${{ github.event.inputs.update_snapshots }}"
           if [ "${update_mode}" = "default" ] || [ -z "${update_mode}" ]; then
-            if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            branch_name="${{ github.ref_name }}"
+            if [[ "${branch_name}" == "release/"* ]]; then
               update_mode="no"
             else
               update_mode="always"
             fi
           fi
 
-          echo "Using update_snapshots=${update_mode}"
+          echo "Using update_snapshots=${update_mode}" >&2
           echo "update_snapshots=${update_mode}" >> "${GITHUB_OUTPUT}"
 
       - name: Set spicepod path

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -68,9 +68,10 @@ on:
       update_snapshots:
         description: 'Update the snapshots?'
         required: false
-        default: 'no'
+        default: 'default'
         type: choice
         options:
+          - 'default'
           - 'always'
           - 'no'
       validate_results:
@@ -94,6 +95,21 @@ jobs:
           DB_NAME: tpch_sf1
     steps:
       - uses: actions/checkout@v6
+
+      - name: Determine snapshot update mode
+        id: determine_update_snapshots
+        run: |
+          update_mode="${{ github.event.inputs.update_snapshots }}"
+          if [ "${update_mode}" = "default" ] || [ -z "${update_mode}" ]; then
+            if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+              update_mode="no"
+            else
+              update_mode="always"
+            fi
+          fi
+
+          echo "Using update_snapshots=${update_mode}"
+          echo "update_snapshots=${update_mode}" >> "${GITHUB_OUTPUT}"
 
       - name: Set spicepod path
         id: set_spicepod_path
@@ -223,7 +239,7 @@ jobs:
           DREMIO_ENDPOINT: ${{ secrets.TEST_DREMIO_ENDPOINT}}
           DREMIO_USERNAME: ${{ secrets.TEST_DREMIO_USERNAME}}
           DREMIO_PASSWORD: ${{ secrets.TEST_DREMIO_PASSWORD}}
-          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots}}
+          INSTA_UPDATE: ${{ steps.determine_update_snapshots.outputs.update_snapshots}}
           MSSQL_HOST: localhost
           MSSQL_USER: sa
           MSSQL_PASSWORD: S3cretP@ssw0rd
@@ -287,7 +303,7 @@ jobs:
           DREMIO_ENDPOINT: ${{ secrets.TEST_DREMIO_ENDPOINT}}
           DREMIO_USERNAME: ${{ secrets.TEST_DREMIO_USERNAME}}
           DREMIO_PASSWORD: ${{ secrets.TEST_DREMIO_PASSWORD}}
-          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots}}
+          INSTA_UPDATE: ${{ steps.determine_update_snapshots.outputs.update_snapshots}}
           MSSQL_HOST: localhost
           MSSQL_USER: sa
           MSSQL_PASSWORD: S3cretP@ssw0rd
@@ -300,7 +316,7 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
 
       - name: Install GH CLI
-        if: github.event.inputs.update_snapshots == 'always'
+        if: steps.determine_update_snapshots.outputs.update_snapshots == 'always'
         run: |
           (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
           && sudo mkdir -p -m 755 /etc/apt/keyrings \
@@ -312,7 +328,7 @@ jobs:
           && sudo apt install gh -y
 
       - name: Upload benchmark snapshots to branch
-        if: github.event.inputs.update_snapshots == 'always'
+        if: steps.determine_update_snapshots.outputs.update_snapshots == 'always'
         run: |
           # if the spiced commit is set, use that as the branch ID
           if [ -n "${{ github.event.inputs.spiced_commit || '' }}" ]; then


### PR DESCRIPTION
Modifies the `testoperator_run_bench.yml` workflow to include a new default option for `update_snapshots`. When used, it will enable snapshot updating for non-release branches, and will keep the current `no` behavior for release branches.