### PR TITLE
SWR caching: serve rotten data instead of error

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -604,6 +604,7 @@ impl CacheRefreshHelper {
         fallback_schema: SchemaRef,
         is_rotten: bool,
         accelerator_mutex: Arc<Mutex<()>>,
+        cached_batches: Option<Vec<RecordBatch>>,
     ) -> SendableRecordBatchStream {
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
             Ok(batches) if !batches.is_empty() => {
@@ -668,11 +669,27 @@ impl CacheRefreshHelper {
                     dataset_name,
                     e
                 );
-                let error_stream = RecordBatchStreamAdapter::new(
-                    fallback_schema,
-                    futures::stream::once(async move { Err(e) }),
-                );
-                Box::pin(error_stream)
+
+                match cached_batches {
+                    Some(rotten_batches) if is_rotten && !rotten_batches.is_empty() => {
+                        tracing::warn!(
+                            "Serving rotten data for dataset {dataset_name}, errored during refresh: {e}"
+                        );
+                        let schema = rotten_batches[0].schema();
+                        let adapter = RecordBatchStreamAdapter::new(
+                            schema,
+                            futures::stream::iter(rotten_batches.into_iter().map(Ok)),
+                        );
+                        Box::pin(adapter)
+                    }
+                    _ => {
+                        let error_stream = RecordBatchStreamAdapter::new(
+                            fallback_schema,
+                            futures::stream::once(async move { Err(e) }),
+                        );
+                        Box::pin(error_stream)
+                    }
+                }
             }
         }
     }
@@ -977,6 +994,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             Arc::clone(&schema_clone),
                             true, // is_rotten = true, will upsert
                             Arc::clone(&accelerator_mutex),
+                            Some(cached_batches),
                         )
                         .await;
                     }
@@ -1008,6 +1026,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     Arc::clone(&schema_clone),
                     false, // is_rotten = false, will insert (append)
                     accelerator_mutex,
+                    None
                 )
                 .await
             }


### PR DESCRIPTION
## 📝 Summary

If we have rotten data, serve that to the user instead of surfacing an error when trying to `fetch_from_source`. Note that this does the fetch _first_, and only surfaces data or failure _after_. So the user is responsible for configuring how quickly they time out + how many times to retry (i.e. if they want a speedy response in the failure case).

## 👀 UX considerations

- Errors let you know something is wrong. Do we want a parameter for this behavior?

#### Reproduce

```python
from fastapi import FastAPI
from datetime import datetime
import uvicorn

app = FastAPI()

@app.get("/")
async def root():
    return {"now": datetime.now()}

if __name__ == "__main__":
    uvicorn.run(
        "server:app",
        host="0.0.0.0",
        port=8000,
        reload=True
    )
```

```yaml
version: v1beta1
kind: Spicepod
name: swr-test
runtime:
  caching:
    sql_results:
      enabled: false

datasets:
  - from: http://localhost:8000/
    name: test_data
    params:
      allowed_request_paths: '/*'
      client_timeout: 1
      connect_timeout: 1
      max_retries: 1
    acceleration:
      enabled: true
      refresh_mode: caching
      engine: duckdb
      mode: memory
      refresh_check_interval: 5s
      params:
        duckdb_file: swr_test.db
        caching_ttl: 5s
        caching_stale_while_revalidate_ttl: 30s
      refresh_sql: SELECT * FROM test_data
```
