### PR TITLE
Watermarks support for DynamoDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13052,6 +13052,7 @@ dependencies = [
  "hf-hub",
  "http 1.4.0",
  "http-body-util",
+ "humantime",
  "hyper 1.8.1",
  "hyper-util",
  "iceberg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ graphql-parser = "0.4.0"
 hf-hub = { version = "0.4", features = ["tokio"] }
 http = "1.3.1"
 httpdate = "1.0"
+humantime = "2.1.0"
 iceberg = "0.7.0"
 iceberg-catalog-glue = "0.7.0"
 iceberg-catalog-rest = "0.7.0"

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -91,7 +91,11 @@ pub struct ChangeEnvelope {
 
 impl ChangeEnvelope {
     #[must_use]
-    pub fn new(change_committer: Box<dyn CommitChange + Send>, change_batch: ChangeBatch, is_dataset_ready: bool) -> Self {
+    pub fn new(
+        change_committer: Box<dyn CommitChange + Send>,
+        change_batch: ChangeBatch,
+        is_dataset_ready: bool,
+    ) -> Self {
         Self {
             change_committer,
             change_batch,
@@ -105,7 +109,11 @@ impl ChangeEnvelope {
 
     #[must_use]
     pub fn into_parts(self) -> (Box<dyn CommitChange + Send>, ChangeBatch, bool) {
-        (self.change_committer, self.change_batch, self.is_dataset_ready)
+        (
+            self.change_committer,
+            self.change_batch,
+            self.is_dataset_ready,
+        )
     }
 
     #[must_use]
@@ -117,10 +125,11 @@ impl ChangeEnvelope {
         Self {
             change_committer,
             change_batch,
-            is_dataset_ready
+            is_dataset_ready,
         }
     }
 
+    #[must_use]
     pub fn is_dataset_ready(&self) -> bool {
         self.is_dataset_ready
     }

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -86,14 +86,16 @@ pub trait CommitChange {
 pub struct ChangeEnvelope {
     change_committer: Box<dyn CommitChange + Send>,
     pub change_batch: ChangeBatch,
+    is_dataset_ready: bool,
 }
 
 impl ChangeEnvelope {
     #[must_use]
-    pub fn new(change_committer: Box<dyn CommitChange + Send>, change_batch: ChangeBatch) -> Self {
+    pub fn new(change_committer: Box<dyn CommitChange + Send>, change_batch: ChangeBatch, is_dataset_ready: bool) -> Self {
         Self {
             change_committer,
             change_batch,
+            is_dataset_ready,
         }
     }
 
@@ -102,19 +104,25 @@ impl ChangeEnvelope {
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (Box<dyn CommitChange + Send>, ChangeBatch) {
-        (self.change_committer, self.change_batch)
+    pub fn into_parts(self) -> (Box<dyn CommitChange + Send>, ChangeBatch, bool) {
+        (self.change_committer, self.change_batch, self.is_dataset_ready)
     }
 
     #[must_use]
     pub fn from_parts(
         change_committer: Box<dyn CommitChange + Send>,
         change_batch: ChangeBatch,
+        is_dataset_ready: bool,
     ) -> Self {
         Self {
             change_committer,
             change_batch,
+            is_dataset_ready
         }
+    }
+
+    pub fn is_dataset_ready(&self) -> bool {
+        self.is_dataset_ready
     }
 }
 

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -102,7 +102,7 @@ impl DebeziumKafka {
 
                 let val = msg.value();
                 changes::to_change_batch(&schema, &pk, val)
-                    .map(|rb| ChangeEnvelope::new(Box::new(msg), rb))
+                    .map(|rb| ChangeEnvelope::new(Box::new(msg), rb, true))
                     .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
             });
 

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -64,7 +64,6 @@ use std::collections::HashSet;
 use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 use std::{any::Any, collections::HashMap, fmt, sync::Arc};
-use std::num::NonZeroUsize;
 
 #[derive(Debug, Clone)]
 pub struct DynamoDBTableProvider {
@@ -268,8 +267,12 @@ impl DynamoDBTableProvider {
     pub async fn stream_from_checkpoint(
         &self,
         checkpoint: Checkpoint,
-    ) -> Result<BoxStream<'static, Result<(ChangeBatch, Checkpoint, Option<SystemTime>), crate::cdc::StreamError>>>
-    {
+    ) -> Result<
+        BoxStream<
+            'static,
+            Result<(ChangeBatch, Checkpoint, Option<SystemTime>), crate::cdc::StreamError>,
+        >,
+    > {
         let table_schema = Arc::clone(self.table_schema.schema());
         let primary_keys = self.table_schema.primary_keys().clone();
         let unnest_depth = self.unnest_depth;

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -55,16 +55,16 @@ use datafusion::{
     },
     prelude::Expr,
 };
-use dynamodb_streams::Client as StreamsClient;
-use dynamodb_streams::checkpoint::Checkpoint;
+use dynamodb_streams::{Checkpoint, Client as StreamsClient};
 use futures::Stream;
 use futures::pin_mut;
 use futures::stream::{self, BoxStream, StreamExt};
 use snafu::prelude::*;
 use std::collections::HashSet;
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use std::{any::Any, collections::HashMap, fmt, sync::Arc};
+use std::num::NonZeroUsize;
 
 #[derive(Debug, Clone)]
 pub struct DynamoDBTableProvider {
@@ -97,6 +97,7 @@ impl DynamoDBTableProvider {
         let streams_client = Arc::new(
             StreamsClient::builder(sdk_config, table_name.to_string())
                 .interval(Some(Duration::from_millis(stream_poll_interval_ms)))
+                // .buffer(NonZeroUsize::new(1).unwrap())
                 .build(),
         );
 
@@ -267,7 +268,7 @@ impl DynamoDBTableProvider {
     pub async fn stream_from_checkpoint(
         &self,
         checkpoint: Checkpoint,
-    ) -> Result<BoxStream<'static, Result<(ChangeBatch, Checkpoint), crate::cdc::StreamError>>>
+    ) -> Result<BoxStream<'static, Result<(ChangeBatch, Checkpoint, Option<SystemTime>), crate::cdc::StreamError>>>
     {
         let table_schema = Arc::clone(self.table_schema.schema());
         let primary_keys = self.table_schema.primary_keys().clone();

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -32,6 +32,7 @@ use snafu::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 #[derive(Debug, Snafu)]
 pub enum StreamError {
@@ -121,7 +122,7 @@ pub fn process_batch(
     primary_keys: &[String],
     unnest_depth: Option<usize>,
     time_format: &str,
-) -> Result<(ChangeBatch, Checkpoint), StreamError> {
+) -> Result<(ChangeBatch, Checkpoint, Option<SystemTime>), StreamError> {
     let batch = batch.context(FailedToReceiveMessageSnafu)?;
     let records = batch.records;
 
@@ -213,7 +214,7 @@ pub fn process_batch(
     let change_batch =
         ChangeBatch::try_new(record_batch).context(FailedToCreateChangeBatchSnafu)?;
 
-    Ok((change_batch, batch.checkpoint))
+    Ok((change_batch, batch.checkpoint, batch.watermark))
 }
 
 fn streams_to_dynamodb_item(

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -297,6 +297,7 @@ mod tests {
             checkpoint: Checkpoint {
                 shards: HashMap::default(),
             },
+            watermark: None,
         })
     }
 
@@ -329,7 +330,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify the batch has 1 row
             assert_eq!(change_batch.record.num_rows(), 1);
@@ -365,7 +367,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify the batch has 1 row
             assert_eq!(change_batch.record.num_rows(), 1);
@@ -397,7 +400,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify the batch has 1 row
             assert_eq!(change_batch.record.num_rows(), 1);
@@ -422,7 +426,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Empty batch should produce 0 rows
             assert_eq!(change_batch.record.num_rows(), 0);
@@ -464,7 +469,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Should have 3 rows
             assert_eq!(change_batch.record.num_rows(), 3);
@@ -530,7 +536,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify we can extract primary keys (should be empty)
             let pks = change_batch.primary_keys(0);
@@ -553,7 +560,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Should skip the record and produce 0 rows
             assert_eq!(change_batch.record.num_rows(), 0);
@@ -579,7 +587,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Should skip the record and produce 0 rows
             assert_eq!(change_batch.record.num_rows(), 0);
@@ -605,7 +614,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Should skip the record and produce 0 rows
             assert_eq!(change_batch.record.num_rows(), 0);
@@ -637,7 +647,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify primary keys
             let pks = change_batch.primary_keys(0);
@@ -674,7 +685,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Should only process the valid record
             assert_eq!(change_batch.record.num_rows(), 1);
@@ -706,7 +718,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify primary keys can be extracted
             let extracted_pks = change_batch.primary_keys(0);
@@ -739,7 +752,8 @@ mod tests {
                 TIME_FORMAT,
             );
 
-            let (change_batch, _checkpoint) = result.expect("Should create change envelope");
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
 
             // Verify data can be extracted
             let data_batch = change_batch.data(0);

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -540,7 +540,7 @@ impl Kafka {
 
                 // Wrap the record batch to emulate a change event
                 cdc::wrap_data_as_change_batch(&schema, &rb)
-                    .map(|rb| ChangeEnvelope::new(Box::new(msg), rb))
+                    .map(|rb| ChangeEnvelope::new(Box::new(msg), rb, true))
                     .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
             });
 

--- a/crates/dynamodb-streams/src/checkpoint.rs
+++ b/crates/dynamodb-streams/src/checkpoint.rs
@@ -26,7 +26,7 @@ use std::time::SystemTime;
 /// since no records have been processed yet.
 ///
 /// Exclusive (`After`) checkpoint is returned as part of `StreamResult`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ShardCheckpoint {
     pub sequence_number: String,
     pub parent_id: Option<String>, // Root shards don't have parents

--- a/crates/dynamodb-streams/src/client.rs
+++ b/crates/dynamodb-streams/src/client.rs
@@ -121,6 +121,7 @@ impl Client {
                 .method(BackoffMethod::Fibonacci)
                 .max_retries(Some(3))
                 .build(),
+            idle_timeout: None,
         };
 
         tokio::spawn(async move {

--- a/crates/dynamodb-streams/src/lib.rs
+++ b/crates/dynamodb-streams/src/lib.rs
@@ -23,7 +23,7 @@ mod stream_state;
 
 pub use checkpoint::Checkpoint;
 pub use client::Client;
-pub use stream::{DynamodbStream, DynamoDBStreamBatch};
+pub use stream::{DynamoDBStreamBatch, DynamodbStream};
 
 pub type StreamResult = Result<DynamoDBStreamBatch, Error>;
 

--- a/crates/dynamodb-streams/src/lib.rs
+++ b/crates/dynamodb-streams/src/lib.rs
@@ -21,9 +21,9 @@ mod client_sdk;
 mod stream;
 mod stream_state;
 
-pub use crate::stream_state::DynamoDBStreamBatch;
+pub use checkpoint::Checkpoint;
 pub use client::Client;
-pub use stream::DynamodbStream;
+pub use stream::{DynamodbStream, DynamoDBStreamBatch};
 
 pub type StreamResult = Result<DynamoDBStreamBatch, Error>;
 
@@ -46,4 +46,7 @@ pub enum Error {
         "Failed to initialize checkpoint due to empty starting_sequence_number in one of the open shards"
     ))]
     FailedToInitializeCheckpoint,
+
+    #[snafu(display("Unexpected shard id: {shard_id}"))]
+    UnexpectedShardId { shard_id: String },
 }

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -15,14 +15,15 @@ limitations under the License.
 */
 use crate::checkpoint::Checkpoint;
 use crate::client_sdk::SDKClient;
-use crate::stream_state::{DynamoDBStreamBatch, ShardPollResult, StreamState};
+use crate::stream_state::{PollOutcome, ShardPollResult, StreamState};
 use crate::{Error, Result, StreamResult};
-use aws_sdk_dynamodbstreams::types::ShardIteratorType;
+use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use futures::{Stream, future::join_all};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::SystemTime;
 use tokio::{
     sync::mpsc,
     time::{Duration, sleep},
@@ -37,11 +38,20 @@ pub struct DynamodbStreamProducer {
     pub sender: mpsc::Sender<StreamResult>,
     pub client: Arc<SDKClient>,
     pub retry_strategy: RetryBackoff,
+    /// Duration after which a shard is considered idle and excluded from watermark calculation.
+    /// If None, all shards are included in watermark calculation regardless of activity.
+    pub idle_timeout: Option<Duration>,
+}
+
+pub struct DynamoDBStreamBatch {
+    pub records: Vec<Record>,
+    pub checkpoint: Checkpoint,
+    pub watermark: Option<SystemTime>,
 }
 
 impl DynamodbStreamProducer {
     async fn collect(&mut self) -> Result<DynamoDBStreamBatch> {
-        let mut batches = Vec::new();
+        let mut poll_results = Vec::new();
 
         // 1. Initialize shards that require iterators
         self.initialize_shards_iterators().await;
@@ -66,19 +76,26 @@ impl DynamodbStreamProducer {
 
         // 3. Process poll results
         for (shard_id, result) in results {
-            match result {
+            let poll_result = match result {
                 Ok((next_iter, records)) => {
-                    if let Some(batch) =
-                        self.state.handle_poll_result(&shard_id, next_iter, records)
-                    {
-                        batches.push(batch);
+                    match self.state.handle_poll_result(&shard_id, next_iter, records) {
+                        Some(result) => result,
+                        None => {
+                            return Err(Error::UnexpectedShardId {shard_id})
+                        },
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Shard poll failed: shard_id={}, {}", shard_id, e);
-                    self.handle_failed_shard(&shard_id, &e);
+                    match self.state.handle_poll_error(&shard_id, e) {
+                        Some(result) => result,
+                        None => {
+                            return Err(Error::UnexpectedShardId {shard_id})
+                        },
+                    }
+
                 }
-            }
+            };
+            poll_results.push(poll_result);
         }
 
         // 4. Discover new shards
@@ -86,18 +103,7 @@ impl DynamodbStreamProducer {
             self.state.add_discovered(shards);
         }
 
-        Ok(combine_shard_batches(batches))
-    }
-
-    fn handle_failed_shard(&mut self, shard_id: &str, error: &Error) {
-        let is_expired_iterator = error.to_string().contains("ExpiredIterator")
-            || error.to_string().contains("TrimmedDataAccess");
-
-        if is_expired_iterator {
-            tracing::warn!("Iterator expired for shard {}, will reinitialize", shard_id);
-
-            self.state.reinitialize_shard(shard_id);
-        }
+        Ok(combine_shard_batches(poll_results, self.idle_timeout))
     }
 
     async fn initialize_shards_iterators(&mut self) {
@@ -163,20 +169,93 @@ impl DynamodbStreamProducer {
     }
 }
 
-fn combine_shard_batches(batches: Vec<ShardPollResult>) -> DynamoDBStreamBatch {
+fn combine_shard_batches(
+    poll_results: Vec<ShardPollResult>,
+    idle_timeout: Option<Duration>,
+) -> DynamoDBStreamBatch {
+    let now = SystemTime::now();
+
+    // Collect records, checkpoints and watermarks
     let mut records = Vec::new();
+    let mut shard_watermarks = Vec::new();
     let mut shards_checkpoints = HashMap::new();
 
-    for batch in batches {
-        records.extend(batch.records);
-        shards_checkpoints.insert(batch.shard_id, batch.checkpoint);
+    for shard_result in &poll_results {
+        // Collect records
+        if let PollOutcome::Records { records: shard_records } = &shard_result.outcome {
+            records.extend(shard_records.clone());
+        }
+
+        // Collect checkpoints
+        shards_checkpoints.insert(shard_result.shard_id.clone(), shard_result.last_checkpoint.clone());
+
+        // Check eligibility for watermark
+        let is_eligible = match shard_result.outcome {
+            // Shards that produced records and those that failed are always eligible
+            PollOutcome::Records { .. } | PollOutcome::Failed => true,
+
+            // Shards that produced no records are NOT eligible if they have been idle for longer than the idle_timeout
+            PollOutcome::Empty => {
+                match shard_result.last_produced_at {
+                    Some(last_produced_at) => {
+                        match idle_timeout {
+                            Some(timeout) => {
+                                let elapsed = now.duration_since(last_produced_at).unwrap_or(Duration::ZERO);
+                                let is_idle = shard_result.outcome.is_empty() && elapsed > timeout;
+
+                                if is_idle {
+                                    tracing::debug!(
+                                        "Shard {} excluded from watermark (idle for {:?}, timeout: {:?})",
+                                        shard_result.shard_id,
+                                        elapsed,
+                                        timeout
+                                    );
+                                }
+
+                                !is_idle
+                            }
+                            None => true,
+                        }
+                    }
+                    None => {
+                        tracing::debug!(
+                        "Shard {} excluded from watermark (never produced records)",
+                        shard_result.shard_id
+                    );
+                        false
+                    }
+                }
+            }
+        };
+
+        // If eligible, include its current_watermark
+        if is_eligible {
+            if let Some(watermark) = shard_result.current_watermark {
+                tracing::debug!(
+                    "Shard {} included in watermark: {:?}",
+                    shard_result.shard_id,
+                    watermark
+                );
+                shard_watermarks.push(watermark);
+            }
+        }
     }
+
+    let watermark = if shard_watermarks.is_empty() {
+        tracing::trace!("No eligible shards with watermarks, watermark is None");
+        None
+    } else {
+        let min_watermark = shard_watermarks.into_iter().min();
+        tracing::trace!("Calculated watermark: {:?}", min_watermark);
+        min_watermark
+    };
 
     DynamoDBStreamBatch {
         records,
         checkpoint: Checkpoint {
             shards: shards_checkpoints,
         },
+        watermark,
     }
 }
 

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -80,20 +80,13 @@ impl DynamodbStreamProducer {
                 Ok((next_iter, records)) => {
                     match self.state.handle_poll_result(&shard_id, next_iter, records) {
                         Some(result) => result,
-                        None => {
-                            return Err(Error::UnexpectedShardId {shard_id})
-                        },
+                        None => return Err(Error::UnexpectedShardId { shard_id }),
                     }
                 }
-                Err(e) => {
-                    match self.state.handle_poll_error(&shard_id, e) {
-                        Some(result) => result,
-                        None => {
-                            return Err(Error::UnexpectedShardId {shard_id})
-                        },
-                    }
-
-                }
+                Err(e) => match self.state.handle_poll_error(&shard_id, &e) {
+                    Some(result) => result,
+                    None => return Err(Error::UnexpectedShardId { shard_id }),
+                },
             };
             poll_results.push(poll_result);
         }
@@ -103,7 +96,7 @@ impl DynamodbStreamProducer {
             self.state.add_discovered(shards);
         }
 
-        Ok(combine_shard_batches(poll_results, self.idle_timeout))
+        Ok(combine_shard_batches(&poll_results, self.idle_timeout))
     }
 
     async fn initialize_shards_iterators(&mut self) {
@@ -170,7 +163,7 @@ impl DynamodbStreamProducer {
 }
 
 fn combine_shard_batches(
-    poll_results: Vec<ShardPollResult>,
+    poll_results: &[ShardPollResult],
     idle_timeout: Option<Duration>,
 ) -> DynamoDBStreamBatch {
     let now = SystemTime::now();
@@ -180,14 +173,20 @@ fn combine_shard_batches(
     let mut shard_watermarks = Vec::new();
     let mut shards_checkpoints = HashMap::new();
 
-    for shard_result in &poll_results {
+    for shard_result in poll_results {
         // Collect records
-        if let PollOutcome::Records { records: shard_records } = &shard_result.outcome {
+        if let PollOutcome::Records {
+            records: shard_records,
+        } = &shard_result.outcome
+        {
             records.extend(shard_records.clone());
         }
 
         // Collect checkpoints
-        shards_checkpoints.insert(shard_result.shard_id.clone(), shard_result.last_checkpoint.clone());
+        shards_checkpoints.insert(
+            shard_result.shard_id.clone(),
+            shard_result.last_checkpoint.clone(),
+        );
 
         // Check eligibility for watermark
         let is_eligible = match shard_result.outcome {
@@ -196,48 +195,45 @@ fn combine_shard_batches(
 
             // Shards that produced no records are NOT eligible if they have been idle for longer than the idle_timeout
             PollOutcome::Empty => {
-                match shard_result.last_produced_at {
-                    Some(last_produced_at) => {
-                        match idle_timeout {
-                            Some(timeout) => {
-                                let elapsed = now.duration_since(last_produced_at).unwrap_or(Duration::ZERO);
-                                let is_idle = shard_result.outcome.is_empty() && elapsed > timeout;
+                if let Some(last_produced_at) = shard_result.last_produced_at {
+                    match idle_timeout {
+                        Some(timeout) => {
+                            let elapsed = now
+                                .duration_since(last_produced_at)
+                                .unwrap_or(Duration::ZERO);
+                            let is_idle = shard_result.outcome.is_empty() && elapsed > timeout;
 
-                                if is_idle {
-                                    tracing::debug!(
-                                        "Shard {} excluded from watermark (idle for {:?}, timeout: {:?})",
-                                        shard_result.shard_id,
-                                        elapsed,
-                                        timeout
-                                    );
-                                }
-
-                                !is_idle
+                            if is_idle {
+                                tracing::debug!(
+                                    "Shard {} excluded from watermark (idle for {:?}, timeout: {:?})",
+                                    shard_result.shard_id,
+                                    elapsed,
+                                    timeout
+                                );
                             }
-                            None => true,
+
+                            !is_idle
                         }
+                        None => true,
                     }
-                    None => {
-                        tracing::debug!(
+                } else {
+                    tracing::debug!(
                         "Shard {} excluded from watermark (never produced records)",
                         shard_result.shard_id
                     );
-                        false
-                    }
+                    false
                 }
             }
         };
 
         // If eligible, include its current_watermark
-        if is_eligible {
-            if let Some(watermark) = shard_result.current_watermark {
-                tracing::debug!(
-                    "Shard {} included in watermark: {:?}",
-                    shard_result.shard_id,
-                    watermark
-                );
-                shard_watermarks.push(watermark);
-            }
+        if is_eligible && let Some(watermark) = shard_result.current_watermark {
+            tracing::debug!(
+                "Shard {} included in watermark: {:?}",
+                shard_result.shard_id,
+                watermark
+            );
+            shard_watermarks.push(watermark);
         }
     }
 

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -18,24 +18,35 @@ use crate::client_sdk::{ApiShard, SDKClient};
 use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use aws_sdk_dynamodbstreams::primitives::DateTime;
+use crate::Error;
 
-#[derive(Debug)]
-pub struct DynamoDBStreamBatch {
-    pub records: Vec<Record>,
-    pub checkpoint: Checkpoint,
-}
-
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ActiveShard {
     pub shard_id: String,
     pub parent_shard_id: Option<String>,
     pub iterator: String,
+    pub last_checkpoint: ShardCheckpoint,
+    pub last_produced_at: Option<SystemTime>,
+    pub current_watermark: Option<SystemTime>,
 }
 
 impl ActiveShard {
-    pub fn set_iterator(&mut self, new_iterator: String) {
+    pub fn update_iterator(&mut self, new_iterator: String) {
         self.iterator = new_iterator;
+    }
+
+    pub fn update_checkpoint(&mut self, checkpoint: ShardCheckpoint) {
+        self.last_checkpoint = checkpoint;
+    }
+
+    pub fn update_produced_at(&mut self) {
+        self.last_produced_at = Some(SystemTime::now());
+    }
+
+    pub fn update_watermark(&mut self, watermark: SystemTime) {
+        self.current_watermark = Some(watermark);
     }
 }
 
@@ -55,24 +66,26 @@ pub struct StreamState {
 
 pub struct ShardPollResult {
     pub shard_id: String,
-    pub records: Vec<Record>,
-    pub checkpoint: ShardCheckpoint,
+    pub outcome: PollOutcome,
+    pub last_checkpoint: ShardCheckpoint,
+    pub last_produced_at: Option<SystemTime>,
+    pub current_watermark: Option<SystemTime>,
 }
 
-/// Manages shard lifecycle across three states to maintain parent-child ordering guarantees.
-///
-/// State Transitions:
-/// - Active: Shards with iterators, ready to poll for records
-/// - Pending: Shards blocked by active/initializing parents (respects lineage order)
-/// - Initializing: Shards awaiting iterator initialization from AWS
-///
-/// Flow:
-/// 1. Discovered shards enter `pending` if parent exists, otherwise `initializing`
-/// 2. `initializing` → `active` when iterator obtained
-/// 3. When parent exhausts, children move `pending` → `initializing`
-/// 4. Failed polls can move `active` → `initializing` for fresh iterator
-///
-/// This ensures parent shards are fully consumed before children begin processing.
+pub enum PollOutcome {
+    Records {
+        records: Vec<Record>,
+    },
+    Empty,
+    Failed,
+}
+
+impl PollOutcome {
+    pub fn is_empty(&self) -> bool {
+        matches!(self, PollOutcome::Empty)
+    }
+}
+
 impl StreamState {
     pub fn get_active_shards(&self) -> impl Iterator<Item = &ActiveShard> {
         self.active.values()
@@ -88,47 +101,105 @@ impl StreamState {
         new_iterator: Option<String>,
         records: Vec<Record>,
     ) -> Option<ShardPollResult> {
-        tracing::debug!(
-            "Processing shard poll: shard_id={:?}, new_iterator={:?}, records_num={:?}",
-            shard_id,
-            new_iterator,
-            records.len()
-        );
+        let shard = self.active.get(shard_id)?;
+        let mut current_checkpoint = shard.last_checkpoint.clone();
+        let mut current_last_produced_at = shard.last_produced_at;
+        let mut current_watermark = shard.current_watermark;
 
-        let parent_id = self.active.get(shard_id)?.parent_shard_id.clone();
+        // Update checkpoint and watermark first if possible
+        if !records.is_empty() {
+            if let Some(shard) = self.active.get_mut(shard_id) {
+                shard.update_produced_at();
+                current_last_produced_at = shard.last_produced_at;
 
+                // Update watermark
+                let max_event_time = records
+                    .iter()
+                    .filter_map(|r| r.dynamodb.as_ref()?.approximate_creation_date_time)
+                    .max()
+                    .map(datetime_to_system_time);
+
+                if let Some(event_time) = max_event_time {
+                    shard.update_watermark(event_time);
+                    current_watermark = shard.current_watermark;
+                }
+
+                // Update checkpoint
+                let sequence_number = records
+                    .last()
+                    .and_then(|r| r.dynamodb.as_ref())
+                    .and_then(|db| db.sequence_number.clone());
+
+                if let Some(seq) = sequence_number {
+                    let checkpoint = ShardCheckpoint {
+                        sequence_number: seq,
+                        parent_id: shard.parent_shard_id.clone(),
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    };
+                    shard.update_checkpoint(checkpoint.clone());
+                    current_checkpoint = checkpoint;
+                } else {
+                    tracing::warn!(
+                        "Missing sequence number for shard {}, keeping previous checkpoint",
+                        shard_id
+                    );
+                }
+            }
+        }
+
+        // Check if shard is exhausted and can be removed
         if let Some(iter) = new_iterator {
-            self.active.get_mut(shard_id)?.set_iterator(iter);
+            if let Some(shard) = self.active.get_mut(shard_id) {
+                shard.update_iterator(iter);
+            }
         } else {
             self.active.remove(shard_id);
             self.promote_children(shard_id);
         }
 
-        if records.is_empty() {
-            return None;
-        }
-
-        let last_seq_opt = records.last()?.clone().dynamodb?.sequence_number;
-        tracing::debug!(
-            "Shard latest sequence number: shard_id={:?}, seq_number={:?}",
-            shard_id,
-            last_seq_opt
-        );
-        if last_seq_opt.is_none() {
-            tracing::error!("Missing sequence number: shard_id={}", shard_id);
-        }
-        let last_seq = last_seq_opt?;
+        let outcome = if records.is_empty() {
+            PollOutcome::Empty
+        } else {
+            PollOutcome::Records { records }
+        };
 
         Some(ShardPollResult {
             shard_id: shard_id.to_string(),
-            records,
-            checkpoint: ShardCheckpoint {
-                sequence_number: last_seq,
-                parent_id,
-                updated_at: SystemTime::now(),
-                position: CheckpointPosition::After,
-            },
+            outcome,
+            last_checkpoint: current_checkpoint,
+            last_produced_at: current_last_produced_at,
+            current_watermark,
         })
+    }
+
+    pub fn handle_poll_error(
+        &mut self,
+        shard_id: &str,
+        error: Error,
+    ) -> Option<ShardPollResult> {
+        tracing::error!("Poll error for shard {}: {}", shard_id, error);
+
+        let shard = self.active.get(shard_id)?;
+
+        // Capture current state
+        let result = ShardPollResult {
+            shard_id: shard_id.to_string(),
+            outcome: PollOutcome::Failed,
+            last_checkpoint: shard.last_checkpoint.clone(),
+            last_produced_at: shard.last_produced_at,
+            current_watermark: shard.current_watermark,
+        };
+
+        let is_expired_iterator = error.to_string().contains("ExpiredIterator")
+            || error.to_string().contains("TrimmedDataAccess");
+
+        if is_expired_iterator {
+            tracing::warn!("Iterator expired for shard {}, marking for reinitialization", shard_id);
+            self.reinitialize_shard(shard_id);
+        }
+
+        Some(result)
     }
 
     pub fn reinitialize_shard(&mut self, shard_id: &str) {
@@ -185,16 +256,26 @@ impl StreamState {
     /// Move shard from initializing to active with its iterator
     pub fn mark_active(&mut self, shard_id: String, iterator: String) {
         if let Some(pending) = self.initializing.remove(&shard_id) {
+            // Create initial checkpoint with empty sequence number for newly discovered shards
+            let initial_checkpoint = ShardCheckpoint {
+                sequence_number: String::new(),
+                parent_id: pending.parent_shard_id.clone(),
+                updated_at: SystemTime::now(),
+                position: CheckpointPosition::After,
+            };
+
             let active = ActiveShard {
                 shard_id: shard_id.clone(),
                 parent_shard_id: pending.parent_shard_id,
                 iterator,
+                last_checkpoint: initial_checkpoint,
+                last_produced_at: None,
+                current_watermark: None,
             };
             self.active.insert(shard_id, active);
         }
     }
 
-    /// Promote children of exhausted parent, returns shard IDs that need initialization
     fn promote_children(&mut self, parent_id: &str) {
         let to_promote: Vec<String> = self
             .pending
@@ -257,6 +338,9 @@ pub async fn initialize_state_from_checkpoint(
                     shard_id: shard_id.to_string(),
                     parent_shard_id: shard_checkpoint.parent_id.clone(),
                     iterator,
+                    last_checkpoint: shard_checkpoint.clone(),
+                    last_produced_at: None,
+                    current_watermark: None,
                 };
 
                 state.active.insert(shard_id.to_string(), shard);
@@ -293,10 +377,21 @@ async fn start_children_from_trim_horizon(
                 .await
             {
                 Ok(Some(iterator)) => {
+                    // Create initial checkpoint with empty sequence number
+                    let initial_checkpoint = ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: Some(parent_id.to_string()),
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    };
+
                     let shard = ActiveShard {
                         shard_id: child.shard_id.clone(),
                         parent_shard_id: Some(parent_id.to_string()),
                         iterator,
+                        last_checkpoint: initial_checkpoint,
+                        last_produced_at: None,
+                        current_watermark: None,
                     };
                     state.active.insert(child.shard_id.clone(), shard);
                 }
@@ -312,6 +407,13 @@ async fn start_children_from_trim_horizon(
 
     Ok(())
 }
+
+pub fn datetime_to_system_time(dt: DateTime) -> SystemTime {
+    let secs = dt.secs();
+    let subsec_nanos = dt.subsec_nanos();
+    UNIX_EPOCH + Duration::new(secs as u64, subsec_nanos)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,6 +483,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "old-iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -391,29 +501,29 @@ mod tests {
             );
 
             assert!(result.is_some());
-            let batch = result.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "shard-1");
-            assert_eq!(batch.records.len(), 1);
-            assert_eq!(batch.checkpoint.sequence_number, "123");
-            assert_eq!(batch.checkpoint.parent_id, None);
-            assert_eq!(batch.checkpoint.position, CheckpointPosition::After);
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "shard-1");
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 1);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+            assert_eq!(result.last_checkpoint.sequence_number, "123");
+            assert_eq!(result.last_checkpoint.parent_id, None);
+            assert_eq!(result.last_checkpoint.position, CheckpointPosition::After);
 
             // Check complete state
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "new-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "new-iter");
         }
 
         #[test]
@@ -425,16 +535,28 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
             let result = state.handle_poll_result("shard-1", None, vec![create_record("123")]);
 
             assert!(result.is_some());
-            let batch = result.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "shard-1");
-            assert_eq!(batch.records.len(), 1);
-            assert_eq!(batch.checkpoint.sequence_number, "123");
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "shard-1");
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 1);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+            assert_eq!(result.last_checkpoint.sequence_number, "123");
 
             // Check complete state - shard should be removed
             assert_eq!(state.active.len(), 0);
@@ -452,29 +574,36 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), vec![]);
 
-            assert!(result.is_none());
+            assert!(result.is_some());
+            if let Some(result) = result {
+                assert!(matches!(result.outcome, PollOutcome::Empty));
+            }
 
             // Iterator should still be updated even though no records
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "new-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "new-iter");
         }
 
         #[test]
@@ -486,6 +615,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -495,24 +632,22 @@ mod tests {
                 vec![create_record_without_seq()],
             );
 
-            assert!(result.is_none());
+            assert!(result.is_some());
+            // When sequence number is missing, the record is still returned
+            // but the checkpoint is not updated
 
-            // State should be updated even though result is None
+            // State should be updated
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "new-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "new-iter");
         }
 
         #[test]
@@ -524,6 +659,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -533,7 +676,9 @@ mod tests {
                 vec![create_record_without_dynamodb()],
             );
 
-            assert!(result.is_none());
+            assert!(result.is_some());
+            // When dynamodb field is missing, the record is still returned
+            // but the checkpoint is not updated
 
             // State should be updated
             assert_eq!(state.active.len(), 1);
@@ -550,6 +695,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: Some("parent-1".to_string()),
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: Some("parent-1".to_string()),
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -562,29 +715,29 @@ mod tests {
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
 
             assert!(result.is_some());
-            let batch = result.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "shard-1");
-            assert_eq!(batch.records.len(), 3);
-            assert_eq!(batch.checkpoint.sequence_number, "102");
-            assert_eq!(batch.checkpoint.parent_id, Some("parent-1".to_string()));
-            assert_eq!(batch.checkpoint.position, CheckpointPosition::After);
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "shard-1");
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 3);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+            assert_eq!(result.last_checkpoint.sequence_number, "102");
+            assert_eq!(result.last_checkpoint.parent_id, Some("parent-1".to_string()));
+            assert_eq!(result.last_checkpoint.position, CheckpointPosition::After);
 
             // Verify complete state
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: Some("parent-1".to_string()),
-                    iterator: "new-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, Some("parent-1".to_string()));
+            assert_eq!(active_shard.iterator, "new-iter");
         }
 
         #[test]
@@ -598,6 +751,14 @@ mod tests {
                     shard_id: "parent".to_string(),
                     parent_shard_id: None,
                     iterator: "iter-parent".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -614,9 +775,9 @@ mod tests {
             let result = state.handle_poll_result("parent", None, vec![create_record("100")]);
 
             assert!(result.is_some());
-            let batch = result.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "parent");
-            assert_eq!(batch.checkpoint.sequence_number, "100");
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "parent");
+            assert_eq!(result.last_checkpoint.sequence_number, "100");
 
             // Verify complete state after exhaustion
             assert_eq!(state.active.len(), 0);
@@ -637,6 +798,289 @@ mod tests {
                     parent_shard_id: Some("parent".to_string()),
                 }
             );
+        }
+
+        #[test]
+        fn test_handle_poll_result_updates_watermark() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "99".to_string(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
+                },
+            );
+
+            let records = vec![
+                create_record_with_timestamp("100", DateTime::from_secs(1000)),
+                create_record_with_timestamp("101", DateTime::from_secs(1010)), // Latest
+                create_record_with_timestamp("102", DateTime::from_secs(1005)),
+            ];
+
+            let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
+
+            assert!(result.is_some());
+            let result = result.unwrap();
+
+            // Verify watermark is max timestamp (1010)
+            assert!(result.current_watermark.is_some());
+            let expected_watermark = datetime_to_system_time(DateTime::from_secs(1010));
+            assert_eq!(result.current_watermark.unwrap(), expected_watermark);
+
+            // Verify last_produced_at is set
+            assert!(result.last_produced_at.is_some());
+
+            // Verify active shard state
+            let shard = state.active.get("shard-1").unwrap();
+            assert_eq!(shard.current_watermark.unwrap(), expected_watermark);
+            assert!(shard.last_produced_at.is_some());
+            assert_eq!(shard.last_checkpoint.sequence_number, "102");
+        }
+
+        #[test]
+        fn test_handle_poll_result_watermark_not_updated_without_timestamps() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "99".to_string(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
+                },
+            );
+
+            // Records without approximate_creation_date_time
+            let records = vec![create_record("100")]; // Assuming this creates without timestamp
+
+            let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
+
+            assert!(result.is_some());
+            let result = result.unwrap();
+
+            // Watermark should still be None
+            assert!(result.current_watermark.is_none());
+
+            // But last_produced_at should be set
+            assert!(result.last_produced_at.is_some());
+
+            // Checkpoint should be updated
+            assert_eq!(result.last_checkpoint.sequence_number, "100");
+
+            // Verify active shard
+            let shard = state.active.get("shard-1").unwrap();
+            assert!(shard.current_watermark.is_none());
+            assert!(shard.last_produced_at.is_some());
+        }
+
+        #[test]
+        fn test_handle_poll_result_missing_sequence_keeps_old_checkpoint() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            let old_checkpoint_time = SystemTime::now();
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "99".to_string(),
+                        parent_id: None,
+                        updated_at: old_checkpoint_time,
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
+                },
+            );
+
+            let result = state.handle_poll_result(
+                "shard-1",
+                Some("new-iter".to_string()),
+                vec![create_record_without_seq()],
+            );
+
+            assert!(result.is_some());
+            let result = result.unwrap();
+
+            // Checkpoint sequence should be unchanged
+            assert_eq!(result.last_checkpoint.sequence_number, "99");
+
+            // But records should still be returned
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 1);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+
+            // Verify active shard kept old checkpoint
+            let shard = state.active.get("shard-1").unwrap();
+            assert_eq!(shard.last_checkpoint.sequence_number, "99");
+        }
+
+        #[test]
+        fn test_handle_poll_result_exhausted_with_watermark() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            let base_time = DateTime::from_secs(2000);
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "99".to_string(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
+                },
+            );
+
+            let records = vec![create_record_with_timestamp("100", base_time)];
+
+            // Shard exhausted (new_iterator = None) but has final records
+            let result = state.handle_poll_result("shard-1", None, records);
+
+            assert!(result.is_some());
+            let result = result.unwrap();
+
+            // Should have records
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 1);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+
+            // Should have updated checkpoint
+            assert_eq!(result.last_checkpoint.sequence_number, "100");
+
+            // Should have watermark
+            assert!(result.current_watermark.is_some());
+            assert_eq!(
+                result.current_watermark.unwrap(),
+                datetime_to_system_time(base_time)
+            );
+
+            // Should have last_produced_at
+            assert!(result.last_produced_at.is_some());
+
+            // Shard should be removed
+            assert!(!state.active.contains_key("shard-1"));
+        }
+
+        #[test]
+        fn test_handle_poll_result_exhausted_empty_records() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            let old_watermark = datetime_to_system_time(DateTime::from_secs(1000));
+            let old_produced_at = SystemTime::now();
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "99".to_string(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: Some(old_produced_at),
+                    current_watermark: Some(old_watermark),
+                },
+            );
+
+            // Shard exhausted with no records
+            let result = state.handle_poll_result("shard-1", None, vec![]);
+
+            assert!(result.is_some());
+            let result = result.unwrap();
+
+            // Should be empty
+            assert!(matches!(result.outcome, PollOutcome::Empty));
+
+            // Should preserve old checkpoint, watermark, last_produced_at
+            assert_eq!(result.last_checkpoint.sequence_number, "99");
+            assert_eq!(result.current_watermark.unwrap(), old_watermark);
+            assert_eq!(result.last_produced_at.unwrap(), old_produced_at);
+
+            // Shard should be removed
+            assert!(!state.active.contains_key("shard-1"));
+        }
+
+        #[test]
+        fn test_handle_poll_result_verifies_all_shard_fields() {
+            let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            let base_time = DateTime::from_secs(3000);
+
+            state.active.insert(
+                "shard-1".to_string(),
+                ActiveShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: Some("parent-1".to_string()),
+                    iterator: "old-iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: "50".to_string(),
+                        parent_id: Some("parent-1".to_string()),
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
+                },
+            );
+
+            let records = vec![create_record_with_timestamp("100", base_time)];
+            let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
+
+            assert!(result.is_some());
+
+            // Verify active shard has ALL fields updated correctly
+            let shard = state.active.get("shard-1").expect("shard should exist");
+            assert_eq!(shard.shard_id, "shard-1");
+            assert_eq!(shard.parent_shard_id, Some("parent-1".to_string()));
+            assert_eq!(shard.iterator, "new-iter");
+            assert_eq!(shard.last_checkpoint.sequence_number, "100");
+            assert_eq!(shard.last_checkpoint.parent_id, Some("parent-1".to_string()));
+            assert_eq!(shard.last_checkpoint.position, CheckpointPosition::After);
+            assert!(shard.last_produced_at.is_some());
+            assert_eq!(
+                shard.current_watermark.unwrap(),
+                datetime_to_system_time(base_time)
+            );
+        }
+
+        // Helper function to create record with timestamp
+        fn create_record_with_timestamp(seq: &str, timestamp: DateTime) -> Record {
+            Record::builder()
+                .dynamodb(StreamRecord::builder()
+                    .sequence_number(seq.to_string())
+                    .approximate_creation_date_time(timestamp).build())
+                .build()
         }
     }
 
@@ -713,6 +1157,14 @@ mod tests {
                     shard_id: "parent".to_string(),
                     parent_shard_id: None,
                     iterator: "iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -821,6 +1273,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
                     iterator: "original-iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -836,17 +1296,13 @@ mod tests {
             assert!(!state.pending.contains_key("shard-1"));
             assert!(!state.initializing.contains_key("shard-1"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "original-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "original-iter");
         }
 
         #[test]
@@ -929,6 +1385,14 @@ mod tests {
                     shard_id: "parent-1".to_string(),
                     parent_shard_id: None,
                     iterator: "iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -1019,17 +1483,13 @@ mod tests {
             assert!(!state.pending.contains_key("shard-1"));
             assert!(state.active.contains_key("shard-1"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "iterator-1".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(active_shard.iterator, "iterator-1");
         }
 
         #[test]
@@ -1051,17 +1511,13 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
 
             assert!(state.active.contains_key("shard-1"));
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iterator-1".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "iterator-1");
         }
 
         #[test]
@@ -1139,29 +1595,21 @@ mod tests {
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iter-1".to_string(),
-                }
-            );
+            let shard1 = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(shard1.shard_id, "shard-1");
+            assert_eq!(shard1.parent_shard_id, None);
+            assert_eq!(shard1.iterator, "iter-1");
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-2")
-                    .expect("shard-2 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-2".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "iter-2".to_string(),
-                }
-            );
+            let shard2 = state
+                .active
+                .get("shard-2")
+                .expect("shard-2 should be in active");
+            assert_eq!(shard2.shard_id, "shard-2");
+            assert_eq!(shard2.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(shard2.iterator, "iter-2");
         }
     }
 
@@ -1319,6 +1767,14 @@ mod tests {
                     shard_id: "grandparent".to_string(),
                     parent_shard_id: None,
                     iterator: "iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -1400,6 +1856,14 @@ mod tests {
                     shard_id: "parent".to_string(),
                     parent_shard_id: None,
                     iterator: "iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -1541,17 +2005,13 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
             assert!(state.active.contains_key("shard-1"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iter-1".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "iter-1");
 
             // Poll with records
             let batch = state.handle_poll_result(
@@ -1564,24 +2024,20 @@ mod tests {
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iter-2".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "iter-2");
 
             // Exhaust shard
-            let batch = state.handle_poll_result("shard-1", None, vec![create_record("101")]);
-            assert!(batch.is_some());
-            let batch = batch.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "shard-1");
-            assert_eq!(batch.checkpoint.sequence_number, "101");
+            let result = state.handle_poll_result("shard-1", None, vec![create_record("101")]);
+            assert!(result.is_some());
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "shard-1");
+            assert_eq!(result.last_checkpoint.sequence_number, "101");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.pending.len(), 0);
@@ -1613,17 +2069,13 @@ mod tests {
             assert!(state.active.contains_key("parent"));
             assert!(state.pending.contains_key("child"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("parent")
-                    .expect("parent should be in active"),
-                &ActiveShard {
-                    shard_id: "parent".to_string(),
-                    parent_shard_id: None,
-                    iterator: "parent-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("parent")
+                .expect("parent should be in active");
+            assert_eq!(active_shard.shard_id, "parent");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "parent-iter");
 
             // Exhaust parent
             let batch = state.handle_poll_result("parent", None, vec![create_record("100")]);
@@ -1643,17 +2095,13 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
             assert!(state.active.contains_key("child"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("child")
-                    .expect("child should be in active"),
-                &ActiveShard {
-                    shard_id: "child".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "child-iter".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("child")
+                .expect("child should be in active");
+            assert_eq!(active_shard.shard_id, "child");
+            assert_eq!(active_shard.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(active_shard.iterator, "child-iter");
         }
 
         #[test]
@@ -1708,14 +2156,10 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
             assert!(state.active.contains_key("gen3"));
 
-            assert_eq!(
-                state.active.get("gen3").expect("gen3 should be in active"),
-                &ActiveShard {
-                    shard_id: "gen3".to_string(),
-                    parent_shard_id: Some("gen2".to_string()),
-                    iterator: "iter3".to_string(),
-                }
-            );
+            let active_shard = state.active.get("gen3").expect("gen3 should be in active");
+            assert_eq!(active_shard.shard_id, "gen3");
+            assert_eq!(active_shard.parent_shard_id, Some("gen2".to_string()));
+            assert_eq!(active_shard.iterator, "iter3");
         }
 
         #[test]
@@ -1762,29 +2206,21 @@ mod tests {
             assert!(state.active.contains_key("child-a"));
             assert!(state.active.contains_key("child-b"));
 
-            assert_eq!(
-                state
-                    .active
-                    .get("child-a")
-                    .expect("child-a should be in active"),
-                &ActiveShard {
-                    shard_id: "child-a".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "iter-a".to_string(),
-                }
-            );
+            let child_a = state
+                .active
+                .get("child-a")
+                .expect("child-a should be in active");
+            assert_eq!(child_a.shard_id, "child-a");
+            assert_eq!(child_a.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(child_a.iterator, "iter-a");
 
-            assert_eq!(
-                state
-                    .active
-                    .get("child-b")
-                    .expect("child-b should be in active"),
-                &ActiveShard {
-                    shard_id: "child-b".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "iter-b".to_string(),
-                }
-            );
+            let child_b = state
+                .active
+                .get("child-b")
+                .expect("child-b should be in active");
+            assert_eq!(child_b.shard_id, "child-b");
+            assert_eq!(child_b.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(child_b.iterator, "iter-b");
         }
 
         #[test]
@@ -1806,17 +2242,13 @@ mod tests {
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iter-1".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, None);
+            assert_eq!(active_shard.iterator, "iter-1");
         }
 
         #[test]
@@ -1829,6 +2261,14 @@ mod tests {
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: Some("parent".to_string()),
                     iterator: "iter-1".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: Some("parent".to_string()),
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -1840,32 +2280,32 @@ mod tests {
                 create_record("104"),
             ];
 
-            let batch = state.handle_poll_result("shard-1", Some("iter-2".to_string()), records);
+            let result = state.handle_poll_result("shard-1", Some("iter-2".to_string()), records);
 
-            assert!(batch.is_some());
-            let batch = batch.expect("Expected batch to be Some");
-            assert_eq!(batch.shard_id, "shard-1");
-            assert_eq!(batch.records.len(), 5);
-            assert_eq!(batch.checkpoint.sequence_number, "104");
-            assert_eq!(batch.checkpoint.parent_id, Some("parent".to_string()));
-            assert_eq!(batch.checkpoint.position, CheckpointPosition::After);
+            assert!(result.is_some());
+            let result = result.expect("Expected result to be Some");
+            assert_eq!(result.shard_id, "shard-1");
+            if let PollOutcome::Records { records } = result.outcome {
+                assert_eq!(records.len(), 5);
+            } else {
+                panic!("Expected PollOutcome::Records");
+            }
+            assert_eq!(result.last_checkpoint.sequence_number, "104");
+            assert_eq!(result.last_checkpoint.parent_id, Some("parent".to_string()));
+            assert_eq!(result.last_checkpoint.position, CheckpointPosition::After);
 
             // Verify state
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.pending.len(), 0);
             assert_eq!(state.initializing.len(), 0);
 
-            assert_eq!(
-                state
-                    .active
-                    .get("shard-1")
-                    .expect("shard-1 should be in active"),
-                &ActiveShard {
-                    shard_id: "shard-1".to_string(),
-                    parent_shard_id: Some("parent".to_string()),
-                    iterator: "iter-2".to_string(),
-                }
-            );
+            let active_shard = state
+                .active
+                .get("shard-1")
+                .expect("shard-1 should be in active");
+            assert_eq!(active_shard.shard_id, "shard-1");
+            assert_eq!(active_shard.parent_shard_id, Some("parent".to_string()));
+            assert_eq!(active_shard.iterator, "iter-2");
         }
 
         #[test]
@@ -1906,6 +2346,14 @@ mod tests {
                     shard_id: "parent".to_string(),
                     parent_shard_id: None,
                     iterator: "iter".to_string(),
+                    last_checkpoint: ShardCheckpoint {
+                        sequence_number: String::new(),
+                        parent_id: None,
+                        updated_at: SystemTime::now(),
+                        position: CheckpointPosition::After,
+                    },
+                    last_produced_at: None,
+                    current_watermark: None,
                 },
             );
 
@@ -1974,17 +2422,13 @@ mod tests {
                 }
             );
 
-            assert_eq!(
-                state
-                    .active
-                    .get("parent-2")
-                    .expect("parent-2 should be in active"),
-                &ActiveShard {
-                    shard_id: "parent-2".to_string(),
-                    parent_shard_id: None,
-                    iterator: "iter2".to_string(),
-                }
-            );
+            let parent2 = state
+                .active
+                .get("parent-2")
+                .expect("parent-2 should be in active");
+            assert_eq!(parent2.shard_id, "parent-2");
+            assert_eq!(parent2.parent_shard_id, None);
+            assert_eq!(parent2.iterator, "iter2");
         }
     }
 }

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -13,14 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+use crate::Error;
 use crate::checkpoint::{Checkpoint, CheckpointPosition, ShardCheckpoint};
 use crate::client_sdk::{ApiShard, SDKClient};
+use aws_sdk_dynamodbstreams::primitives::DateTime;
 use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use aws_sdk_dynamodbstreams::primitives::DateTime;
-use crate::Error;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ActiveShard {
@@ -73,9 +73,7 @@ pub struct ShardPollResult {
 }
 
 pub enum PollOutcome {
-    Records {
-        records: Vec<Record>,
-    },
+    Records { records: Vec<Record> },
     Empty,
     Failed,
 }
@@ -106,45 +104,45 @@ impl StreamState {
         let mut current_last_produced_at = shard.last_produced_at;
         let mut current_watermark = shard.current_watermark;
 
-        // Update checkpoint and watermark first if possible
-        if !records.is_empty() {
-            if let Some(shard) = self.active.get_mut(shard_id) {
-                shard.update_produced_at();
-                current_last_produced_at = shard.last_produced_at;
+        // First update watermark and checkpoint if possible
+        if !records.is_empty()
+            && let Some(shard) = self.active.get_mut(shard_id)
+        {
+            shard.update_produced_at();
+            current_last_produced_at = shard.last_produced_at;
 
-                // Update watermark
-                let max_event_time = records
-                    .iter()
-                    .filter_map(|r| r.dynamodb.as_ref()?.approximate_creation_date_time)
-                    .max()
-                    .map(datetime_to_system_time);
+            // Update watermark
+            let max_event_time = records
+                .iter()
+                .filter_map(|r| r.dynamodb.as_ref()?.approximate_creation_date_time)
+                .max()
+                .map(datetime_to_system_time);
 
-                if let Some(event_time) = max_event_time {
-                    shard.update_watermark(event_time);
-                    current_watermark = shard.current_watermark;
-                }
+            if let Some(event_time) = max_event_time {
+                shard.update_watermark(event_time);
+                current_watermark = shard.current_watermark;
+            }
 
-                // Update checkpoint
-                let sequence_number = records
-                    .last()
-                    .and_then(|r| r.dynamodb.as_ref())
-                    .and_then(|db| db.sequence_number.clone());
+            // Update checkpoint
+            let sequence_number = records
+                .last()
+                .and_then(|r| r.dynamodb.as_ref())
+                .and_then(|db| db.sequence_number.clone());
 
-                if let Some(seq) = sequence_number {
-                    let checkpoint = ShardCheckpoint {
-                        sequence_number: seq,
-                        parent_id: shard.parent_shard_id.clone(),
-                        updated_at: SystemTime::now(),
-                        position: CheckpointPosition::After,
-                    };
-                    shard.update_checkpoint(checkpoint.clone());
-                    current_checkpoint = checkpoint;
-                } else {
-                    tracing::warn!(
-                        "Missing sequence number for shard {}, keeping previous checkpoint",
-                        shard_id
-                    );
-                }
+            if let Some(seq) = sequence_number {
+                let checkpoint = ShardCheckpoint {
+                    sequence_number: seq,
+                    parent_id: shard.parent_shard_id.clone(),
+                    updated_at: SystemTime::now(),
+                    position: CheckpointPosition::After,
+                };
+                shard.update_checkpoint(checkpoint.clone());
+                current_checkpoint = checkpoint;
+            } else {
+                tracing::warn!(
+                    "Missing sequence number for shard {}, keeping previous checkpoint",
+                    shard_id
+                );
             }
         }
 
@@ -173,11 +171,7 @@ impl StreamState {
         })
     }
 
-    pub fn handle_poll_error(
-        &mut self,
-        shard_id: &str,
-        error: Error,
-    ) -> Option<ShardPollResult> {
+    pub fn handle_poll_error(&mut self, shard_id: &str, error: &Error) -> Option<ShardPollResult> {
         tracing::error!("Poll error for shard {}: {}", shard_id, error);
 
         let shard = self.active.get(shard_id)?;
@@ -195,7 +189,10 @@ impl StreamState {
             || error.to_string().contains("TrimmedDataAccess");
 
         if is_expired_iterator {
-            tracing::warn!("Iterator expired for shard {}, marking for reinitialization", shard_id);
+            tracing::warn!(
+                "Iterator expired for shard {}, marking for reinitialization",
+                shard_id
+            );
             self.reinitialize_shard(shard_id);
         }
 
@@ -411,10 +408,11 @@ async fn start_children_from_trim_horizon(
 pub fn datetime_to_system_time(dt: DateTime) -> SystemTime {
     let secs = dt.secs();
     let subsec_nanos = dt.subsec_nanos();
-    UNIX_EPOCH + Duration::new(secs as u64, subsec_nanos)
+    UNIX_EPOCH + Duration::new(secs.try_into().unwrap_or(0), subsec_nanos)
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use aws_sdk_dynamodbstreams::types::StreamRecord;
@@ -723,7 +721,10 @@ mod tests {
                 panic!("Expected PollOutcome::Records");
             }
             assert_eq!(result.last_checkpoint.sequence_number, "102");
-            assert_eq!(result.last_checkpoint.parent_id, Some("parent-1".to_string()));
+            assert_eq!(
+                result.last_checkpoint.parent_id,
+                Some("parent-1".to_string())
+            );
             assert_eq!(result.last_checkpoint.position, CheckpointPosition::After);
 
             // Verify complete state
@@ -1065,7 +1066,10 @@ mod tests {
             assert_eq!(shard.parent_shard_id, Some("parent-1".to_string()));
             assert_eq!(shard.iterator, "new-iter");
             assert_eq!(shard.last_checkpoint.sequence_number, "100");
-            assert_eq!(shard.last_checkpoint.parent_id, Some("parent-1".to_string()));
+            assert_eq!(
+                shard.last_checkpoint.parent_id,
+                Some("parent-1".to_string())
+            );
             assert_eq!(shard.last_checkpoint.position, CheckpointPosition::After);
             assert!(shard.last_produced_at.is_some());
             assert_eq!(
@@ -1077,9 +1081,12 @@ mod tests {
         // Helper function to create record with timestamp
         fn create_record_with_timestamp(seq: &str, timestamp: DateTime) -> Record {
             Record::builder()
-                .dynamodb(StreamRecord::builder()
-                    .sequence_number(seq.to_string())
-                    .approximate_creation_date_time(timestamp).build())
+                .dynamodb(
+                    StreamRecord::builder()
+                        .sequence_number(seq.to_string())
+                        .approximate_creation_date_time(timestamp)
+                        .build(),
+                )
                 .build()
         }
     }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -71,6 +71,7 @@ graphql-parser.workspace = true
 headers-accept = "0.1.3"
 http.workspace = true
 http-body-util = "0.1.3"
+humantime = { workspace = true, optional = true }
 hyper = "1.7.0"
 hyper-util = { version = "0.1.17", features = ["service"] }
 iceberg.workspace = true
@@ -249,7 +250,7 @@ delta_lake = ["data_components/delta_lake"]
 dev = ["openapi", "otel-arrow/dev", "mcp"]
 dremio = []
 duckdb = ["dep:duckdb", "db_connection_pool/duckdb", "data_components/duckdb", "datafusion-optimizer-rules/duckdb"]
-dynamodb = ["dep:aws-sdk-dynamodb", "data_components/dynamodb", "dep:dynamodb-streams"]
+dynamodb = ["dep:aws-sdk-dynamodb", "data_components/dynamodb", "dep:dynamodb-streams", "dep:humantime"]
 extended_tests = []
 flightsql = ["data_components/flightsql"]
 ftp = ["runtime-object-store/ftp"]

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -95,9 +95,11 @@ impl RefreshTask {
                             }
                             initial_load_completed.store(true, Ordering::Relaxed);
 
-                            // Mark the dataset as ready after the first message is received. This covers both streaming append and CDC modes.
-                            self.update_component_status(status::ComponentStatus::Ready)
-                                .await;
+                            // Mark the dataset as ready if possible
+                            if change_envelope.is_dataset_ready() {
+                                self.update_component_status(status::ComponentStatus::Ready)
+                                    .await;
+                            }
 
                             if let Err(e) = change_envelope.commit()
                                 && !self.runtime_status.is_shutdown()
@@ -160,7 +162,8 @@ impl RefreshTask {
 
         let sub_batches = group_into_sub_batches(&change_batch);
 
-        tracing::trace!(
+        // TODO: Should be trace
+        tracing::info!(
             "Processing append/change stream batch: dataset={}, rows={}, sub-batches={}",
             self.dataset_name,
             change_batch.record.num_rows(),

--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -56,7 +56,11 @@ pub async fn index_change_envelope(
     let new_change_batch = replace_change_batch_data(&batches[0], &batch)
         .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-    Ok(ChangeEnvelope::new(change_committer, new_change_batch, is_dataset_ready))
+    Ok(ChangeEnvelope::new(
+        change_committer,
+        new_change_batch,
+        is_dataset_ready,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -43,7 +43,7 @@ pub async fn index_change_envelope(
         e
     })?;
 
-    let (change_committer, batch) = envelope.into_parts();
+    let (change_committer, batch, is_dataset_ready) = envelope.into_parts();
     let mut batches = vec![batch.data_batch()];
 
     for index in &indexes.0 {
@@ -56,7 +56,7 @@ pub async fn index_change_envelope(
     let new_change_batch = replace_change_batch_data(&batches[0], &batch)
         .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-    Ok(ChangeEnvelope::new(change_committer, new_change_batch))
+    Ok(ChangeEnvelope::new(change_committer, new_change_batch, is_dataset_ready))
 }
 
 #[cfg(test)]
@@ -205,7 +205,7 @@ mod tests {
         let change_batch = wrap_data_as_change_batch(&data_batch.schema(), &data_batch)
             .expect("Failed to create change batch");
         let committer = Box::new(MockCommitChange);
-        ChangeEnvelope::new(committer, change_batch)
+        ChangeEnvelope::new(committer, change_batch, true)
     }
 
     #[tokio::test]
@@ -304,7 +304,7 @@ mod tests {
         let change_batch = wrap_data_as_change_batch(&data_batch.schema(), &data_batch)
             .expect("Failed to create change batch");
         let committer = Box::new(MockCommitChange);
-        let envelope = ChangeEnvelope::new(committer, change_batch);
+        let envelope = ChangeEnvelope::new(committer, change_batch, true);
 
         let table_provider = Arc::new(MockTableProvider);
         let index = Arc::new(MockIndex::new("test_index"));

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -248,7 +248,7 @@ impl DataConnector for DynamoDB {
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
-        let acceptable_lag = Duration::from_secs(10800);
+        let acceptable_lag = Duration::from_secs(10);
 
         Some(Box::pin(
             stream::once(async move {

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -27,14 +27,14 @@ use async_trait::async_trait;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError};
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
 use dynamodb_streams::checkpoint::Checkpoint;
 use futures::stream::{self, StreamExt};
 use runtime_parameters::ExposedParamLookup;
 use snafu::ResultExt;
 use std::str::FromStr;
-use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 use std::time::{Duration, SystemTime};
-use datafusion::sql::TableReference;
+use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 use util::time_format::is_valid_format;
 
 #[derive(Debug)]
@@ -258,7 +258,7 @@ impl DataConnector for DynamoDB {
                     .as_any()
                     .downcast_ref::<DynamoDBTableProvider>()?;
 
-                let acceptable_lag = acceptable_lag.clone();
+                let acceptable_lag = acceptable_lag;
                 let dataset_name = dataset.name.clone();
                 let dataset_name_2 = dataset_name.clone();
                 let dataset_name_3 = dataset_name.clone();
@@ -371,7 +371,10 @@ async fn load_or_initialize_checkpoint(
             }
         }
     } else {
-        tracing::info!("No existing checkpoint found, starting from bootstrap: table_name={}", dataset_name);
+        tracing::info!(
+            "No existing checkpoint found, starting from bootstrap: table_name={}",
+            dataset_name
+        );
         get_latest_checkpoint(dynamodb).await.map(|cp| (true, cp))
     }
 }
@@ -400,7 +403,10 @@ async fn changes_stream_from_checkpoint(
     // If this is an initial checkpoint(from_bootstrap=true), commit it immediately.
     // This checkpoint is inclusive and in case of failure stream will restart from the current position, not next.
     if from_bootstrap {
-        tracing::debug!("Committing bootstrap checkpoint: table_name={}", dataset_name);
+        tracing::debug!(
+            "Committing bootstrap checkpoint: table_name={}",
+            dataset_name
+        );
         let committer = DynamoDBStreamCommitter::new(Arc::clone(&dynamodb_sys), checkpoint.clone());
         if let Err(err) = committer.commit() {
             tracing::error!("Failed to commit bootstrap checkpoint: {:?}", err);
@@ -420,19 +426,16 @@ async fn changes_stream_from_checkpoint(
                 .map(move |msg| {
                     msg.map(|(change_batch, checkpoint, watermark)| {
                         let lag = watermark
-                            .map(|v| SystemTime::now().duration_since(v).ok())
-                            .flatten();
+                            .and_then(|v| SystemTime::now().duration_since(v).ok());
 
                         // TODO: should be trace
                         tracing::info!(
                             "Processing DynamoDB Streams batch: table_name={}, watermark={}, lag={}, records={}",
                             dataset_name,
                             watermark
-                                .map(|w| humantime::format_rfc3339(w).to_string())
-                                .unwrap_or_else(|| "-".to_string()),
+                                .map_or_else(|| "-".to_string(), |w| humantime::format_rfc3339(w).to_string()),
                             lag
-                                .map(|l| humantime::format_duration(l).to_string())
-                                .unwrap_or_else(|| "-".to_string()),
+                                .map_or_else(|| "-".to_string(), |l| humantime::format_duration(l).to_string()),
                             change_batch.record.num_rows(),
                         );
 
@@ -442,7 +445,7 @@ async fn changes_stream_from_checkpoint(
                                 checkpoint,
                             )),
                             change_batch,
-                            lag.map_or(false, |l| l < acceptable_lag),
+                            lag.is_some_and(|l| l < acceptable_lag),
                         )
                     })
                 })

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -33,6 +33,8 @@ use runtime_parameters::ExposedParamLookup;
 use snafu::ResultExt;
 use std::str::FromStr;
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
+use std::time::{Duration, SystemTime};
+use datafusion::sql::TableReference;
 use util::time_format::is_valid_format;
 
 #[derive(Debug)]
@@ -246,6 +248,7 @@ impl DataConnector for DynamoDB {
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
+        let acceptable_lag = Duration::from_secs(10800);
 
         Some(Box::pin(
             stream::once(async move {
@@ -255,11 +258,16 @@ impl DataConnector for DynamoDB {
                     .as_any()
                     .downcast_ref::<DynamoDBTableProvider>()?;
 
+                let acceptable_lag = acceptable_lag.clone();
+                let dataset_name = dataset.name.clone();
+                let dataset_name_2 = dataset_name.clone();
+                let dataset_name_3 = dataset_name.clone();
+                let dataset_name_4 = dataset_name.clone();
                 let dynamodb = Arc::new(dynamodb_ref.clone());
                 let dynamodb_sys = initialize_dynamodb_sys(&dataset).await?;
 
                 let (should_bootstrap, checkpoint) =
-                    load_or_initialize_checkpoint(&dynamodb, &dynamodb_sys).await?;
+                    load_or_initialize_checkpoint(&dynamodb, &dynamodb_sys, &dataset_name).await?;
 
                 if should_bootstrap {
                     // Initialize bootstrap stream
@@ -267,10 +275,11 @@ impl DataConnector for DynamoDB {
                         .bootstrap_stream()
                         .await
                         .ok()?
-                        .map(|msg| {
+                        .map(move |msg| {
                             msg.map(|change_batch| {
-                                // Bootstrap stream doesn't commit changes
-                                ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch)
+                                tracing::info!("Bootstrapping DynamoDB table: table_name={}, records={}", dataset_name.clone(), change_batch.record.num_rows());
+                                // Bootstrap stream doesn't commit changes and doesn't mark dataset as ready
+                                ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch, false)
                             })
                         });
 
@@ -278,11 +287,21 @@ impl DataConnector for DynamoDB {
                     Some(
                         bootstrap_stream
                             .chain(
+                                stream::once(async move {
+                                    tracing::info!("Bootstrapping DynamoDB table complete, starting changes stream. \
+                                        Note it will take some time for table to catch up: table_name={}", dataset_name_2);
+                                    stream::empty()
+                                })
+                                .flatten()
+                            )
+                            .chain(
                                 stream::once(changes_stream_from_checkpoint(
                                     Arc::clone(&dynamodb),
                                     Arc::clone(&dynamodb_sys),
                                     checkpoint,
                                     true,
+                                    acceptable_lag,
+                                    dataset_name_3.clone(),
                                 ))
                                 .filter_map(|opt| async move { opt })
                                 .flatten(),
@@ -297,6 +316,8 @@ impl DataConnector for DynamoDB {
                             Arc::clone(&dynamodb_sys),
                             checkpoint,
                             false,
+                            acceptable_lag,
+                            dataset_name_4.clone(),
                         ))
                         .filter_map(|opt| async move { opt })
                         .flatten()
@@ -314,7 +335,8 @@ async fn initialize_dynamodb_sys(dataset: &Dataset) -> Option<Arc<DynamoDBSys>> 
         Ok(sys) => Some(Arc::new(sys)),
         Err(err) => {
             tracing::error!(
-                "Failed to initialize DynamoDBSys for checkpoint persistence: {:?}",
+                "Failed to initialize DynamoDBSys for checkpoint persistence: table={} - {:?}",
+                dataset.name,
                 err
             );
             None
@@ -326,6 +348,7 @@ async fn initialize_dynamodb_sys(dataset: &Dataset) -> Option<Arc<DynamoDBSys>> 
 async fn load_or_initialize_checkpoint(
     dynamodb: &Arc<DynamoDBTableProvider>,
     dynamodb_sys: &Arc<DynamoDBSys>,
+    dataset_name: &TableReference,
 ) -> Option<(bool, Checkpoint)> {
     let existing_checkpoint = dynamodb_sys.get().await;
 
@@ -333,20 +356,22 @@ async fn load_or_initialize_checkpoint(
         match serde_json::from_str::<Checkpoint>(&metadata.checkpoint_data) {
             Ok(checkpoint) => {
                 tracing::info!(
-                    "Found existing checkpoint for DynamoDB Stream, resuming from checkpoint"
+                    "Found existing checkpoint for DynamoDB Stream, resuming from checkpoint: table_name={}",
+                    dataset_name
                 );
                 Some((false, checkpoint))
             }
             Err(err) => {
                 tracing::warn!(
-                    "Failed to deserialize checkpoint, falling back to bootstrap: {:?}",
+                    "Failed to deserialize checkpoint, falling back to bootstrap: table_name={} - {:?}",
+                    dataset_name,
                     err
                 );
                 get_latest_checkpoint(dynamodb).await.map(|cp| (true, cp))
             }
         }
     } else {
-        tracing::info!("No existing checkpoint found, starting from bootstrap");
+        tracing::info!("No existing checkpoint found, starting from bootstrap: table_name={}", dataset_name);
         get_latest_checkpoint(dynamodb).await.map(|cp| (true, cp))
     }
 }
@@ -369,11 +394,13 @@ async fn changes_stream_from_checkpoint(
     dynamodb_sys: Arc<DynamoDBSys>,
     checkpoint: Checkpoint,
     from_bootstrap: bool,
+    acceptable_lag: Duration,
+    dataset_name: TableReference,
 ) -> Option<ChangesStream> {
     // If this is an initial checkpoint(from_bootstrap=true), commit it immediately.
     // This checkpoint is inclusive and in case of failure stream will restart from the current position, not next.
     if from_bootstrap {
-        tracing::debug!("Committing bootstrap checkpoint");
+        tracing::debug!("Committing bootstrap checkpoint: table_name={}", dataset_name);
         let committer = DynamoDBStreamCommitter::new(Arc::clone(&dynamodb_sys), checkpoint.clone());
         if let Err(err) = committer.commit() {
             tracing::error!("Failed to commit bootstrap checkpoint: {:?}", err);
@@ -381,7 +408,8 @@ async fn changes_stream_from_checkpoint(
     }
 
     tracing::debug!(
-        "Starting DynamoDB stream from checkpoint: from_bootstrap={}, checkpoint={:?}",
+        "Starting DynamoDB stream from checkpoint: table_name={}, from_bootstrap={}, checkpoint={:?}",
+        dataset_name,
         from_bootstrap,
         checkpoint,
     );
@@ -390,13 +418,31 @@ async fn changes_stream_from_checkpoint(
         Ok(stream) => Some(
             stream
                 .map(move |msg| {
-                    msg.map(|(change_batch, checkpoint)| {
+                    msg.map(|(change_batch, checkpoint, watermark)| {
+                        let lag = watermark
+                            .map(|v| SystemTime::now().duration_since(v).ok())
+                            .flatten();
+
+                        // TODO: should be trace
+                        tracing::info!(
+                            "Processing DynamoDB Streams batch: table_name={}, watermark={}, lag={}, records={}",
+                            dataset_name,
+                            watermark
+                                .map(|w| humantime::format_rfc3339(w).to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                            lag
+                                .map(|l| humantime::format_duration(l).to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                            change_batch.record.num_rows(),
+                        );
+
                         ChangeEnvelope::new(
                             Box::new(DynamoDBStreamCommitter::new(
                                 Arc::clone(&dynamodb_sys),
                                 checkpoint,
                             )),
                             change_batch,
+                            lag.map_or(false, |l| l < acceptable_lag),
                         )
                     })
                 })

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -409,7 +409,7 @@ pub fn subscribe_to_append_stream(
                             DecodedPayload::None | DecodedPayload::Schema(_) => {},
                             DecodedPayload::RecordBatch(batch) => {
                                 match ChangeBatch::try_new(batch).map(|rb| {
-                                    ChangeEnvelope::new(Box::new(SpiceAIChangeCommiter {}), rb)
+                                    ChangeEnvelope::new(Box::new(SpiceAIChangeCommiter {}), rb, true)
                                 }) {
                                     Ok(change_batch) => yield Ok(change_batch),
                                     Err(e) => {

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -182,7 +182,11 @@ impl EmbeddingConnector {
         let new_change_batch = replace_change_batch_data(&embedded_batch, &batch)
             .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-        Ok(ChangeEnvelope::new(change_committer, new_change_batch, is_dataset_ready))
+        Ok(ChangeEnvelope::new(
+            change_committer,
+            new_change_batch,
+            is_dataset_ready,
+        ))
     }
 }
 

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -154,7 +154,7 @@ impl EmbeddingConnector {
             e
         })?;
 
-        let (change_committer, batch) = envelope.into_parts();
+        let (change_committer, batch, is_dataset_ready) = envelope.into_parts();
         let data_batch = batch.data_batch();
 
         let embeddings = compute_additional_embedding_columns(
@@ -182,7 +182,7 @@ impl EmbeddingConnector {
         let new_change_batch = replace_change_batch_data(&embedded_batch, &batch)
             .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-        Ok(ChangeEnvelope::new(change_committer, new_change_batch))
+        Ok(ChangeEnvelope::new(change_committer, new_change_batch, is_dataset_ready))
     }
 }
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -13,7 +13,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono.workspace = true
 ctrlc = "3.5"
 futures.workspace = true
-humantime = "2.1.0"
+humantime.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }


### PR DESCRIPTION
## 📝 Summary

1. Watermark calculation in `dynamodb-streams:
  * Each shard has: 
      * `last_produced_at: Option<SystemTime>` # time when it emitted message(s) last time, until then `None`
      * `current_watermark: Option<SystemTime>` # current max event time seen in this shard
  * When building a batch:
      * Find non-idle shards: (`now() - last_produced_at < idle_timeout`)
      * Find `min(current_watermark)` for non-idle shards
2. Added `is_dataset_ready` to `ChangeEnvelope`
  * Always `true` for kafka/debezium
  * For DynamoDB hardcoded as `10 seconds` (Will update in the follow up PR based on UX review)


## 🔗 Related

https://github.com/spiceai/spiceai/issues/7880
Closes https://github.com/spiceai/spiceai/issues/8031

## 🚨 Breaking Changes

## 📚 Docs

Will be done in https://github.com/spiceai/spiceai/issues/8033