### PR TITLE
Append Tests: add support for retention testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,8 +86,9 @@
         "--duration",
         "240",
         "--with-conflict-data",
+        "--with-retention-data",
         "-p",
-        "./test/spicepods/tpch/sf1/accelerated/append/file_duckdb_file_on_conflict_upsert.yaml"
+        "./test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml"
       ],
       "env": {},
       "cwd": "${workspaceFolder}",

--- a/crates/test-framework/src/spicetest/append/mod.rs
+++ b/crates/test-framework/src/spicetest/append/mod.rs
@@ -52,6 +52,7 @@ pub struct NotStarted {
     load_interval: Option<Duration>,
     load_steps: Option<u16>,
     with_conflict_data: bool,
+    with_retention_test_data: bool,
 }
 
 impl NotStarted {
@@ -108,6 +109,12 @@ impl NotStarted {
         self
     }
 
+    #[must_use]
+    pub fn with_retention_test_data(mut self, with_retention_test_data: bool) -> Self {
+        self.with_retention_test_data = with_retention_test_data;
+        self
+    }
+
     pub fn get_tempdir_path(&self) -> Result<&PathBuf> {
         self.tempdir_path
             .as_ref()
@@ -154,7 +161,8 @@ impl SpiceTest<NotStarted> {
             self.state.query_set.clone(),
             self.state.get_tempdir_path()?.clone(),
         )
-        .with_conflict_data(self.state.with_conflict_data);
+        .with_conflict_data(self.state.with_conflict_data)
+        .with_retention_test_data(self.state.with_retention_test_data);
 
         if let Some(load_interval) = self.state.load_interval {
             append_config = append_config.with_load_interval(load_interval);

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -30,11 +30,15 @@ use super::AppendableSource;
 
 // Large offset for retention test data primary keys to avoid conflicts with real data.
 // TPC-H SF=1 generates max ~6M rows, so 1 billion offset is safe.
-// Cleanup options:
-//   - By key range: DELETE FROM {table} WHERE {pk_column} >= 1000000000
-//   - By timestamp: DELETE FROM {table} WHERE {timestamp_column} <= TIMESTAMP '2025-01-01'
 const TEMP_DATA_KEY_OFFSET: i64 = 1_000_000_000;
-const RETENTION_TIMESTAMP: &str = "TIMESTAMP '2025-01-01 00:00:00'";
+
+// Retention timestamp: NOW() - 1 day + 1 minute
+// With retention_period=1d, this data will expire ~1 minute after insertion.
+// On first refresh, there's no max timestamp so ALL data is loaded (including this old data).
+// Retention should be configured to 1 day for tests using this data.
+// Using TIMESTAMPTZ to ensure timezone is preserved.
+const RETENTION_TIMESTAMP_EXPR: &str =
+    "(current_timestamp - INTERVAL '1 day' + INTERVAL '1 minute')::TIMESTAMPTZ";
 
 /// TPC-H table name to primary key column mapping for retention data offset.
 const TPCH_PRIMARY_KEYS: &[(&str, &str)] = &[
@@ -56,12 +60,87 @@ fn tpch_primary_key(table_name: &str) -> Option<&'static str> {
         .map(|(_, pk)| *pk)
 }
 
-/// Generates SQL for TPC-H append data generation.
+/// Generates SQL for TPC-H initial setup (step 0).
+/// Unlike `generate_tpch_sql`, this creates fresh tables rather than appending to existing ones.
+fn generate_tpch_setup_sql(
+    load_steps: u16,
+    generate_retention_data: bool,
+    tables: &[TableWithTimeColumn],
+    temp_directory: &Path,
+) -> String {
+    let mut sql = format!(
+        "INSTALL tpch;
+         LOAD tpch;
+         BEGIN;
+         CALL dbgen(sf=1, children={load_steps}, step=0);\n"
+    );
+
+    // Generate retention test data during initial setup so it's included in first load
+    if generate_retention_data {
+        writeln!(
+            &mut sql,
+            "CALL dbgen(sf=1, children={load_steps}, step=0, suffix='_retention');"
+        )
+        .ok();
+    }
+
+    for TableWithTimeColumn { name, column } in tables {
+        let parquet_path = temp_directory.join(format!("{name}.parquet"));
+
+        // Add timestamp column with current timestamp for main data
+        writeln!(
+            &mut sql,
+            "ALTER TABLE {name} ADD COLUMN {column} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;"
+        )
+        .ok();
+
+        // Retention test data: offset primary keys + old timestamp for deletion testing
+        if generate_retention_data {
+            writeln!(
+                sql,
+                "ALTER TABLE {name}_retention ADD COLUMN {column} TIMESTAMPTZ;"
+            )
+            .ok();
+            // Offset primary keys and set old timestamp in single UPDATE
+            if let Some(pk_col) = tpch_primary_key(name) {
+                writeln!(
+                    sql,
+                    "UPDATE {name}_retention SET {pk_col} = {pk_col} + {TEMP_DATA_KEY_OFFSET}, {column} = {RETENTION_TIMESTAMP_EXPR};"
+                )
+                .ok();
+            } else {
+                writeln!(
+                    sql,
+                    "UPDATE {name}_retention SET {column} = {RETENTION_TIMESTAMP_EXPR};"
+                )
+                .ok();
+            }
+
+            writeln!(
+                sql,
+                "INSERT INTO {name} SELECT * FROM {name}_retention;
+                DROP TABLE {name}_retention;"
+            )
+            .ok();
+        }
+
+        writeln!(
+            &mut sql,
+            "COPY {name} TO '{}' (FORMAT 'parquet');",
+            parquet_path.to_string_lossy()
+        )
+        .ok();
+    }
+
+    sql += "COMMIT;";
+    sql
+}
+
+/// Generates SQL for TPC-H append data generation (step 1+).
 fn generate_tpch_sql(
     load_steps: u16,
     load_index: u16,
     generate_conflict_data: bool,
-    generate_retention_data: bool,
     tables: &[TableWithTimeColumn],
     temp_directory: &Path,
 ) -> String {
@@ -82,23 +161,13 @@ fn generate_tpch_sql(
         .ok();
     }
 
-    // Generate retention test data: data with OFFSET primary keys and old timestamps
-    if generate_retention_data {
-        let next_step = load_index + 1;
-        writeln!(
-            &mut sql,
-            "CALL dbgen(sf=1, children={load_steps}, step={next_step}, suffix='_retention');"
-        )
-        .ok();
-    }
-
     for TableWithTimeColumn { name, column } in tables {
         let parquet_path = temp_directory.join(format!("{name}.parquet"));
 
         // Insert the current step's data with current timestamp
         write!(
             &mut sql,
-            "ALTER TABLE {name}_new ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+            "ALTER TABLE {name}_new ADD COLUMN {column} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
                          INSERT INTO {name} SELECT * FROM {name}_new;
                          DROP TABLE {name}_new;\n"
         )
@@ -106,29 +175,9 @@ fn generate_tpch_sql(
 
         // Conflict data: same primary keys, will be handled by ON CONFLICT
         if generate_conflict_data {
-            write!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+            write!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
                              INSERT INTO {name} SELECT * FROM {name}_conflict;
                              DROP TABLE {name}_conflict;\n").ok();
-        }
-
-        // Retention test data: offset primary keys + old timestamp for deletion testing
-        if generate_retention_data {
-            writeln!(&mut sql, "ALTER TABLE {name}_retention ADD COLUMN {column} TIMESTAMP DEFAULT {RETENTION_TIMESTAMP};").ok();
-
-            if let Some(pk_col) = tpch_primary_key(name) {
-                writeln!(
-                    &mut sql,
-                    "UPDATE {name}_retention SET {pk_col} = {pk_col} + {TEMP_DATA_KEY_OFFSET};"
-                )
-                .ok();
-            }
-
-            writeln!(
-                &mut sql,
-                "INSERT INTO {name} SELECT * FROM {name}_retention;
-                               DROP TABLE {name}_retention;"
-            )
-            .ok();
         }
 
         writeln!(
@@ -214,29 +263,50 @@ impl AppendableSource for FileAppendableSource {
         let load_steps = config.load_steps;
         let tables = self.tables.clone();
         let temp_directory = config.temp_directory.clone();
+        let generate_retention_data = config.with_retention_data;
 
         tokio::task::spawn_blocking(move || {
             let dest_conn = Connection::open(&dest_db_file)?;
-            println!("Loading initial data for {query_set} benchmark suite");
+            println!("Loading initial data for {query_set} benchmark suite (with retention: {generate_retention_data})");
             match query_set {
                 QuerySet::Tpch => {
-                    let mut sql = format!(
-                        "INSTALL tpch;
-                         LOAD tpch;
-                         BEGIN;
-                         CALL dbgen(sf=1, children={load_steps}, step=0);\n"
+                    let sql = generate_tpch_setup_sql(
+                        load_steps,
+                        generate_retention_data,
+                        &tables,
+                        &temp_directory,
                     );
-
-                    for TableWithTimeColumn { name, column } in &tables {
-                        let parquet_path = temp_directory.join(format!("{name}.parquet"));
-                        write!(&mut sql,
-                                    "ALTER TABLE {name} ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
-                             COPY {name} TO '{}' (FORMAT 'parquet');\n", parquet_path.to_string_lossy()).ok();
-                    }
-
-                    sql += "COMMIT;";
-
                     dest_conn.execute_batch(&sql)?;
+
+                    // Debug: verify retention data was generated
+                    if generate_retention_data {
+                        for table in &tables {
+                            let pk_col = tpch_primary_key(&table.name).unwrap_or("rowid");
+                            let query = format!(
+                                "SELECT COUNT(*) as total, \
+                                 SUM(CASE WHEN {pk} >= {offset} THEN 1 ELSE 0 END) as retention_count, \
+                                 CAST(MIN({col}) AS VARCHAR) as min_ts \
+                                 FROM {name}",
+                                name = table.name,
+                                col = table.column,
+                                pk = pk_col,
+                                offset = TEMP_DATA_KEY_OFFSET,
+                            );
+                            if let Ok(mut stmt) = dest_conn.prepare(&query) {
+                                if let Ok(mut rows) = stmt.query([]) {
+                                    if let Ok(Some(row)) = rows.next() {
+                                        let total: i64 = row.get(0).unwrap_or(0);
+                                        let retention: i64 = row.get(1).unwrap_or(0);
+                                        let min_ts: Option<String> = row.get(2).ok();
+                                        println!(
+                                            "[setup-debug] {}: total={}, retention={}, min_ts={:?}",
+                                            table.name, total, retention, min_ts
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 QuerySet::Tpcds => {
                     let mut setup_sql = "INSTALL tpcds;
@@ -291,23 +361,15 @@ impl AppendableSource for FileAppendableSource {
         let generate_conflict_test_data =
             config.with_conflict_data && load_index < config.load_steps - 1;
 
-        // If retention testing is enabled, generate additional data with offset primary keys
-        // and far-future timestamps that can be deleted by retention policies
-        let generate_retention_test_data = config.with_retention_data;
-
         println!(
-            "Loading append data (with conflict data: {generate_conflict_test_data}, with retention test data: {generate_retention_test_data}) {query_set} benchmark suite - {load_index}/{load_steps}",
+            "Loading append data (with conflict: {generate_conflict_test_data}) {query_set} benchmark suite - {load_index}/{load_steps}",
             query_set = config.query_set,
             load_steps = config.load_steps,
             load_index = load_index + 1, // display index is 1-based
         );
 
-        if (generate_conflict_test_data || generate_retention_test_data)
-            && !matches!(config.query_set, QuerySet::Tpch)
-        {
-            anyhow::bail!(
-                "Generating conflict or retention test data is only supported for TPC-H datasets"
-            );
+        if generate_conflict_test_data && !matches!(config.query_set, QuerySet::Tpch) {
+            anyhow::bail!("Generating conflict test data is only supported for TPC-H datasets");
         }
 
         let dest_db_file = self.dest_db_file.clone();
@@ -324,7 +386,6 @@ impl AppendableSource for FileAppendableSource {
                     load_steps,
                     load_index,
                     generate_conflict_test_data,
-                    generate_retention_test_data,
                     &tables,
                     &temp_directory,
                 ),
@@ -336,6 +397,7 @@ impl AppendableSource for FileAppendableSource {
             };
 
             dest_conn.execute_batch(&sql)?;
+
             Ok::<(), anyhow::Error>(())
         })
         .await

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -277,36 +277,6 @@ impl AppendableSource for FileAppendableSource {
                         &temp_directory,
                     );
                     dest_conn.execute_batch(&sql)?;
-
-                    // Debug: verify retention data was generated
-                    if generate_retention_data {
-                        for table in &tables {
-                            let pk_col = tpch_primary_key(&table.name).unwrap_or("rowid");
-                            let query = format!(
-                                "SELECT COUNT(*) as total, \
-                                 SUM(CASE WHEN {pk} >= {offset} THEN 1 ELSE 0 END) as retention_count, \
-                                 CAST(MIN({col}) AS VARCHAR) as min_ts \
-                                 FROM {name}",
-                                name = table.name,
-                                col = table.column,
-                                pk = pk_col,
-                                offset = TEMP_DATA_KEY_OFFSET,
-                            );
-                            if let Ok(mut stmt) = dest_conn.prepare(&query) {
-                                if let Ok(mut rows) = stmt.query([]) {
-                                    if let Ok(Some(row)) = rows.next() {
-                                        let total: i64 = row.get(0).unwrap_or(0);
-                                        let retention: i64 = row.get(1).unwrap_or(0);
-                                        let min_ts: Option<String> = row.get(2).ok();
-                                        println!(
-                                            "[setup-debug] {}: total={}, retention={}, min_ts={:?}",
-                                            table.name, total, retention, min_ts
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
                 QuerySet::Tpcds => {
                     let mut setup_sql = "INSTALL tpcds;

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use duckdb::Connection;
@@ -27,6 +27,154 @@ use crate::{
 };
 
 use super::AppendableSource;
+
+// Large offset for retention test data primary keys to avoid conflicts with real data.
+// TPC-H SF=1 generates max ~6M rows, so 1 billion offset is safe.
+// Cleanup options:
+//   - By key range: DELETE FROM {table} WHERE {pk_column} >= 1000000000
+//   - By timestamp: DELETE FROM {table} WHERE {timestamp_column} <= TIMESTAMP '2025-01-01'
+const TEMP_DATA_KEY_OFFSET: i64 = 1_000_000_000;
+const RETENTION_TIMESTAMP: &str = "TIMESTAMP '2025-01-01 00:00:00'";
+
+/// TPC-H table name to primary key column mapping for retention data offset.
+const TPCH_PRIMARY_KEYS: &[(&str, &str)] = &[
+    ("customer", "c_custkey"),
+    ("orders", "o_orderkey"),
+    ("lineitem", "l_orderkey"),
+    ("part", "p_partkey"),
+    ("partsupp", "ps_partkey"),
+    ("supplier", "s_suppkey"),
+    ("nation", "n_nationkey"),
+    ("region", "r_regionkey"),
+];
+
+/// Returns the primary key column for a TPC-H table, if known.
+fn tpch_primary_key(table_name: &str) -> Option<&'static str> {
+    TPCH_PRIMARY_KEYS
+        .iter()
+        .find(|(t, _)| *t == table_name)
+        .map(|(_, pk)| *pk)
+}
+
+/// Generates SQL for TPC-H append data generation.
+fn generate_tpch_sql(
+    load_steps: u16,
+    load_index: u16,
+    generate_conflict_data: bool,
+    generate_retention_data: bool,
+    tables: &[TableWithTimeColumn],
+    temp_directory: &Path,
+) -> String {
+    let mut sql = format!(
+        "INSTALL tpch;
+         LOAD tpch;
+         BEGIN;
+         CALL dbgen(sf=1, children={load_steps}, step={load_index}, suffix='_new');\n"
+    );
+
+    // Generate conflict data: next step's data with SAME primary keys (will conflict on refresh)
+    if generate_conflict_data {
+        let next_step = load_index + 1;
+        writeln!(
+            &mut sql,
+            "CALL dbgen(sf=1, children={load_steps}, step={next_step}, suffix='_conflict');"
+        )
+        .ok();
+    }
+
+    // Generate retention test data: data with OFFSET primary keys and old timestamps
+    if generate_retention_data {
+        let next_step = load_index + 1;
+        writeln!(
+            &mut sql,
+            "CALL dbgen(sf=1, children={load_steps}, step={next_step}, suffix='_retention');"
+        )
+        .ok();
+    }
+
+    for TableWithTimeColumn { name, column } in tables {
+        let parquet_path = temp_directory.join(format!("{name}.parquet"));
+
+        // Insert the current step's data with current timestamp
+        write!(
+            &mut sql,
+            "ALTER TABLE {name}_new ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                         INSERT INTO {name} SELECT * FROM {name}_new;
+                         DROP TABLE {name}_new;\n"
+        )
+        .ok();
+
+        // Conflict data: same primary keys, will be handled by ON CONFLICT
+        if generate_conflict_data {
+            write!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                             INSERT INTO {name} SELECT * FROM {name}_conflict;
+                             DROP TABLE {name}_conflict;\n").ok();
+        }
+
+        // Retention test data: offset primary keys + old timestamp for deletion testing
+        if generate_retention_data {
+            writeln!(&mut sql, "ALTER TABLE {name}_retention ADD COLUMN {column} TIMESTAMP DEFAULT {RETENTION_TIMESTAMP};").ok();
+
+            if let Some(pk_col) = tpch_primary_key(name) {
+                writeln!(
+                    &mut sql,
+                    "UPDATE {name}_retention SET {pk_col} = {pk_col} + {TEMP_DATA_KEY_OFFSET};"
+                )
+                .ok();
+            }
+
+            writeln!(
+                &mut sql,
+                "INSERT INTO {name} SELECT * FROM {name}_retention;
+                               DROP TABLE {name}_retention;"
+            )
+            .ok();
+        }
+
+        writeln!(
+            &mut sql,
+            "COPY {name} TO '{}' (FORMAT 'parquet');",
+            parquet_path.to_string_lossy()
+        )
+        .ok();
+    }
+
+    sql += "COMMIT;";
+    sql
+}
+
+/// Generates SQL for TPC-DS append data generation.
+fn generate_tpcds_sql(load_steps: u16, load_index: u16, tables: &[TableWithTimeColumn]) -> String {
+    let mut sql = "BEGIN;\n".to_string();
+
+    for TableWithTimeColumn { name, column } in tables {
+        write!(
+            &mut sql,
+            "INSERT INTO {name} SELECT *, CURRENT_TIMESTAMP AS {column}
+                         FROM {name}_gen
+                         LIMIT (SELECT COUNT(*) / {load_steps} FROM {name}_gen)
+                         OFFSET (SELECT COUNT(*) / {load_steps} * {load_index} FROM {name}_gen);
+                         COPY {name} TO '{name}.parquet' (FORMAT 'parquet');\n"
+        )
+        .ok();
+    }
+
+    sql += "COMMIT;";
+    sql
+}
+
+/// Generates SQL for `ClickBench` append data generation.
+fn generate_clickbench_sql(load_steps: u16, load_index: u16) -> String {
+    format!(
+        "BEGIN;
+         INSERT INTO hits_delayed SELECT *, CURRENT_TIMESTAMP AS created_at
+         FROM hits
+         LIMIT (SELECT COUNT(*) / {load_steps} FROM hits)
+         OFFSET (SELECT COUNT(*) / {load_steps} * {load_index} FROM hits);
+         COPY hits_delayed TO 'hits_delayed.parquet' (FORMAT 'parquet');
+         COMMIT;"
+    )
+}
 
 pub(crate) struct FileAppendableSource {
     dest_db_file: PathBuf,
@@ -143,12 +291,24 @@ impl AppendableSource for FileAppendableSource {
         let generate_conflict_test_data =
             config.with_conflict_data && load_index < config.load_steps - 1;
 
+        // If retention testing is enabled, generate additional data with offset primary keys
+        // and far-future timestamps that can be deleted by retention policies
+        let generate_retention_test_data = config.with_retention_data;
+
         println!(
-            "Loading append data (with conflict data: {generate_conflict_test_data})  {query_set} benchmark suite - {load_index}/{load_steps}",
+            "Loading append data (with conflict data: {generate_conflict_test_data}, with retention test data: {generate_retention_test_data}) {query_set} benchmark suite - {load_index}/{load_steps}",
             query_set = config.query_set,
             load_steps = config.load_steps,
             load_index = load_index + 1, // display index is 1-based
         );
+
+        if (generate_conflict_test_data || generate_retention_test_data)
+            && !matches!(config.query_set, QuerySet::Tpch)
+        {
+            anyhow::bail!(
+                "Generating conflict or retention test data is only supported for TPC-H datasets"
+            );
+        }
 
         let dest_db_file = self.dest_db_file.clone();
         let query_set = config.query_set.clone();
@@ -159,74 +319,23 @@ impl AppendableSource for FileAppendableSource {
         tokio::task::spawn_blocking(move || {
             let dest_conn = Connection::open(&dest_db_file)?;
 
-            match query_set {
-                QuerySet::Tpch => {
-                    let mut sql = format!(
-                        "INSTALL tpch;
-                         LOAD tpch;
-                         BEGIN;
-                         CALL dbgen(sf=1, children={load_steps}, step={load_index}, suffix='_new');\n"
-                    );
-
-                    if generate_conflict_test_data {
-                        let next_step = load_index + 1;
-                        writeln!(&mut sql, "CALL dbgen(sf=1, children={load_steps}, step={next_step}, suffix='_conflict');").ok();
-                    }
-
-                    for TableWithTimeColumn { name, column } in &tables {
-                        let parquet_path = temp_directory.join(format!("{name}.parquet"));
-
-                        // Insert the current step's data
-                        write!(&mut sql, "ALTER TABLE {name}_new ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
-                                         INSERT INTO {name} SELECT * FROM {name}_new;
-                                         DROP TABLE {name}_new;\n").ok();
-
-                        if generate_conflict_test_data {
-                            write!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
-                                             INSERT INTO {name} SELECT * FROM {name}_conflict;
-                                             DROP TABLE {name}_conflict;\n").ok();
-                        }
-
-                        writeln!(&mut sql, "COPY {name} TO '{}' (FORMAT 'parquet');", parquet_path.to_string_lossy()).ok();
-                    }
-
-                    sql += "COMMIT;";
-
-                    dest_conn.execute_batch(&sql)?;
+            let sql = match query_set {
+                QuerySet::Tpch => generate_tpch_sql(
+                    load_steps,
+                    load_index,
+                    generate_conflict_test_data,
+                    generate_retention_test_data,
+                    &tables,
+                    &temp_directory,
+                ),
+                QuerySet::Tpcds => generate_tpcds_sql(load_steps, load_index, &tables),
+                QuerySet::Clickbench => generate_clickbench_sql(load_steps, load_index),
+                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch => {
+                    unimplemented!("Appendable file source is not implemented for Scenario or Parameterized query sets")
                 }
-                QuerySet::Tpcds => {
-                    let mut sql = "BEGIN;\n".to_string();
+            };
 
-                    if generate_conflict_test_data {
-                        anyhow::bail!("Generating data for on_conflict testing for TPCDS is not supported");
-                    }
-
-                    for TableWithTimeColumn { name, column } in &tables {
-                        write!(&mut sql, "INSERT INTO {name} SELECT *, CURRENT_TIMESTAMP AS {column}
-                                         FROM {name}_gen
-                                         LIMIT (SELECT COUNT(*) / {load_steps} FROM {name}_gen)
-                                         OFFSET (SELECT COUNT(*) / {load_steps} * {load_index} FROM {name}_gen);
-                                         COPY {name} TO '{name}.parquet' (FORMAT 'parquet');\n").ok();
-                    }
-
-                    sql += "COMMIT;";
-
-                    dest_conn.execute_batch(&sql)?;
-                }
-                QuerySet::Clickbench => {
-                    let sql = format!("BEGIN;
-                                       INSERT INTO hits_delayed SELECT *, CURRENT_TIMESTAMP AS created_at
-                                       FROM hits
-                                       LIMIT (SELECT COUNT(*) / {load_steps} FROM hits)
-                                       OFFSET (SELECT COUNT(*) / {load_steps} * {load_index} FROM hits);
-                                       COPY hits_delayed TO 'hits_delayed.parquet' (FORMAT 'parquet');
-                                       COMMIT;");
-
-                    dest_conn.execute_batch(&sql)?;
-                }
-                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch => unimplemented!("Appendable file source is not implemented for Scenario or Parameterized TPC-H query sets"),
-            }
-
+            dest_conn.execute_batch(&sql)?;
             Ok::<(), anyhow::Error>(())
         })
         .await

--- a/crates/test-framework/src/spicetest/append/worker.rs
+++ b/crates/test-framework/src/spicetest/append/worker.rs
@@ -33,6 +33,7 @@ pub(crate) struct AppendConfig {
     pub(crate) load_interval: Duration,
     pub(crate) temp_directory: PathBuf,
     pub(crate) with_conflict_data: bool,
+    pub(crate) with_retention_data: bool,
 }
 
 impl AppendConfig {
@@ -44,6 +45,7 @@ impl AppendConfig {
             load_interval: Duration::from_secs(60 * 4),
             temp_directory,
             with_conflict_data: false,
+            with_retention_data: false,
         }
     }
 
@@ -59,6 +61,11 @@ impl AppendConfig {
 
     pub fn with_conflict_data(mut self, with_conflict_data: bool) -> Self {
         self.with_conflict_data = with_conflict_data;
+        self
+    }
+
+    pub fn with_retention_test_data(mut self, with_retention_test_data: bool) -> Self {
+        self.with_retention_data = with_retention_test_data;
         self
     }
 }

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append.yaml
@@ -5,6 +5,7 @@ datasets:
   - from: file:customer.parquet
     name: customer
     time_column: c_created_at
+    time_format: timestamptz
     acceleration: &acceleration
       enabled: true
       engine: cayenne
@@ -14,28 +15,35 @@ datasets:
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration: *acceleration

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_upsert.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_upsert.yaml
@@ -8,6 +8,7 @@ datasets:
   - from: file:customer.parquet
     name: customer
     time_column: c_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -21,6 +22,7 @@ datasets:
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -34,6 +36,7 @@ datasets:
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -47,6 +50,7 @@ datasets:
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -60,6 +64,7 @@ datasets:
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -73,6 +78,7 @@ datasets:
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -86,6 +92,7 @@ datasets:
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne
@@ -99,6 +106,7 @@ datasets:
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: cayenne

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append.yaml
@@ -5,6 +5,7 @@ datasets:
   - from: file:customer.parquet
     name: customer
     time_column: c_created_at
+    time_format: timestamptz
     acceleration: &acceleration
       enabled: true
       engine: duckdb
@@ -14,28 +15,35 @@ datasets:
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration: *acceleration
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration: *acceleration

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
@@ -1,0 +1,126 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-duckdb[file]-append_retention_sql
+
+refresh_check_interval: &refresh_check_interval 30s
+
+datasets:
+  - from: file:customer.parquet
+    name: customer
+    time_column: c_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: c_custkey
+      on_conflict:
+        c_custkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:lineitem.parquet
+    name: lineitem
+    time_column: l_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(l_orderkey, l_linenumber)'
+      on_conflict:
+        '(l_orderkey, l_linenumber)': upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:nation.parquet
+    name: nation
+    time_column: n_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:orders.parquet
+    name: orders
+    time_column: o_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: o_orderkey
+      on_conflict:
+        o_orderkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:part.parquet
+    name: part
+    time_column: p_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: p_partkey
+      on_conflict:
+        p_partkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:partsupp.parquet
+    name: partsupp
+    time_column: ps_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(ps_partkey, ps_suppkey)'
+      on_conflict:
+        '(ps_partkey, ps_suppkey)': upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:region.parquet
+    name: region
+    time_column: r_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d
+
+  - from: file:supplier.parquet
+    name: supplier
+    time_column: s_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: s_suppkey
+      on_conflict:
+        s_suppkey: upsert
+      retention_check_enabled: true
+      retention_period: 1d

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
@@ -1,12 +1,13 @@
 version: v1
 kind: Spicepod
-name: file[parquet]-duckdb[file]-append_retention_sql
+name: file[parquet]-duckdb[file]-append_retention_period
 
 refresh_check_interval: &refresh_check_interval 30s
 
 datasets:
   - from: file:customer.parquet
     name: customer
+    time_format: timestamptz
     time_column: c_created_at
     acceleration:
       enabled: true
@@ -18,12 +19,13 @@ datasets:
       on_conflict:
         c_custkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -34,12 +36,13 @@ datasets:
       on_conflict:
         '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -50,12 +53,13 @@ datasets:
       on_conflict:
         n_nationkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -66,12 +70,13 @@ datasets:
       on_conflict:
         o_orderkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -82,12 +87,13 @@ datasets:
       on_conflict:
         p_partkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -98,12 +104,13 @@ datasets:
       on_conflict:
         '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -114,12 +121,13 @@ datasets:
       on_conflict:
         r_regionkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d
 
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -130,5 +138,5 @@ datasets:
       on_conflict:
         s_suppkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 15s
+      retention_check_interval: 30s
       retention_period: 1d

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
@@ -18,6 +18,7 @@ datasets:
       on_conflict:
         c_custkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:lineitem.parquet
@@ -33,6 +34,7 @@ datasets:
       on_conflict:
         '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:nation.parquet
@@ -48,6 +50,7 @@ datasets:
       on_conflict:
         n_nationkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:orders.parquet
@@ -63,6 +66,7 @@ datasets:
       on_conflict:
         o_orderkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:part.parquet
@@ -78,6 +82,7 @@ datasets:
       on_conflict:
         p_partkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:partsupp.parquet
@@ -93,6 +98,7 @@ datasets:
       on_conflict:
         '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:region.parquet
@@ -108,6 +114,7 @@ datasets:
       on_conflict:
         r_regionkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d
 
   - from: file:supplier.parquet
@@ -123,4 +130,5 @@ datasets:
       on_conflict:
         s_suppkey: upsert
       retention_check_enabled: true
+      retention_check_interval: 15s
       retention_period: 1d

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
@@ -1,0 +1,126 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-duckdb[file]-append_retention_sql
+
+refresh_check_interval: &refresh_check_interval 30s
+
+datasets:
+  - from: file:customer.parquet
+    name: customer
+    time_column: c_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: c_custkey
+      on_conflict:
+        c_custkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM customer WHERE c_custkey >=  1000000000
+
+  - from: file:lineitem.parquet
+    name: lineitem
+    time_column: l_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(l_orderkey, l_linenumber)'
+      on_conflict:
+        '(l_orderkey, l_linenumber)': upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM lineitem WHERE l_orderkey >=  1000000000
+
+  - from: file:nation.parquet
+    name: nation
+    time_column: n_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM nation WHERE n_nationkey >=  1000000000
+
+  - from: file:orders.parquet
+    name: orders
+    time_column: o_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: o_orderkey
+      on_conflict:
+        o_orderkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM orders WHERE o_orderkey >=  1000000000
+
+  - from: file:part.parquet
+    name: part
+    time_column: p_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: p_partkey
+      on_conflict:
+        p_partkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM part WHERE p_partkey >=  1000000000
+
+  - from: file:partsupp.parquet
+    name: partsupp
+    time_column: ps_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(ps_partkey, ps_suppkey)'
+      on_conflict:
+        '(ps_partkey, ps_suppkey)': upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM partsupp WHERE ps_partkey >=  1000000000
+
+  - from: file:region.parquet
+    name: region
+    time_column: r_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM region WHERE r_regionkey >=  1000000000
+
+  - from: file:supplier.parquet
+    name: supplier
+    time_column: s_created_at
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: s_suppkey
+      on_conflict:
+        s_suppkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM supplier WHERE s_suppkey >=  1000000000

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
@@ -8,6 +8,7 @@ datasets:
   - from: file:customer.parquet
     name: customer
     time_column: c_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -23,6 +24,7 @@ datasets:
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -38,6 +40,7 @@ datasets:
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -53,6 +56,7 @@ datasets:
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -68,6 +72,7 @@ datasets:
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -83,6 +88,7 @@ datasets:
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -98,6 +104,7 @@ datasets:
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -113,6 +120,7 @@ datasets:
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_upsert.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_upsert.yaml
@@ -8,6 +8,7 @@ datasets:
   - from: file:customer.parquet
     name: customer
     time_column: c_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -21,6 +22,7 @@ datasets:
   - from: file:lineitem.parquet
     name: lineitem
     time_column: l_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -34,6 +36,7 @@ datasets:
   - from: file:nation.parquet
     name: nation
     time_column: n_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -47,6 +50,7 @@ datasets:
   - from: file:orders.parquet
     name: orders
     time_column: o_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -60,6 +64,7 @@ datasets:
   - from: file:part.parquet
     name: part
     time_column: p_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -73,6 +78,7 @@ datasets:
   - from: file:partsupp.parquet
     name: partsupp
     time_column: ps_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -86,6 +92,7 @@ datasets:
   - from: file:region.parquet
     name: region
     time_column: r_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb
@@ -99,6 +106,7 @@ datasets:
   - from: file:supplier.parquet
     name: supplier
     time_column: s_created_at
+    time_format: timestamptz
     acceleration:
       enabled: true
       engine: duckdb

--- a/tools/testoperator/src/args/append.rs
+++ b/tools/testoperator/src/args/append.rs
@@ -34,4 +34,8 @@ pub struct AppendTestArgs {
     /// Include additional conflict data to test ON CONFLICT upsert behavior during append operations
     #[arg(long)]
     pub(crate) with_conflict_data: bool,
+
+    /// Include additional data with offset primary keys and outdated timestamps to test retention deletion policies
+    #[arg(long)]
+    pub(crate) with_retention_data: bool,
 }

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -59,7 +59,8 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
             .with_tempdir_path(start_request.get_tempdir_path())
             .with_load_interval(Duration::from_secs(args.load_interval))
             .with_load_steps(args.load_steps)
-            .with_conflict_data(args.with_conflict_data),
+            .with_conflict_data(args.with_conflict_data)
+            .with_retention_test_data(args.with_retention_data),
     )
     .with_progress_bars(!args.test_args.common.disable_progress_bars)
     .start_appending()


### PR DESCRIPTION
## 📝 Summary

1. Append Tests: add support for retention testing:
 - Use `TIMESTAMPTZ` for TPC-H to respect time zone information and enable proper retention testing - configure timestamp data for retention as `timestamp: NOW() - 1 day + 1 minute` so it is initially loaded and expected to be removed after 1 minute.
 - Setup tests to generate retention data with temeztamp and large ids so it can be used for both `retention_sql` and `retention_period` verification
3. Add `file[parquet]-duckdb[file]-append_retention_sql` and `file[parquet]-duckdb[file]-append_retention_sql` test configurations

## 🔗 Related

Implements https://github.com/spiceai/spiceai/issues/8412
Part of https://github.com/spiceai/spiceai/issues/8251

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
