### PR TITLE
dont build 'spicepod-validator' on 'make install'

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -76,7 +76,7 @@ jobs:
           minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Build spicepod validator
-        run: cargo build --release -p spicepod-validator
+        run: make build-validator
 
       - name: Validate spicepods - TPCH - SF1
         run: |

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-validator:
 	cargo build --release -p spicepod-validator
 
 .PHONY: build
-build: build-cli build-runtime build-validator
+build: build-cli build-runtime
 
 .PHONY: build-dev
 build-dev:


### PR DESCRIPTION
## 📝 Summary
We shouldn't build `spicepod-validator` anytime we just need a `spiced`. This is frequently in CI, but also for local development.