### PR TITLE
Append tests: add support for `with_retention_data` to dispatch

### DIFF
--- a/.github/workflows/testoperator_run_append.yml
+++ b/.github/workflows/testoperator_run_append.yml
@@ -64,6 +64,11 @@ on:
         required: false
         type: boolean
         default: false
+      with_retention_data:
+        description: 'Include additional data to test retention behavior'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-append:
@@ -138,7 +143,8 @@ jobs:
             --load-interval ${{ github.event.inputs.load_interval }} \
             --load-steps ${{ github.event.inputs.load_steps }} \
             ${{ github.event.inputs.query_overrides != '' && format('--query-overrides {0}', github.event.inputs.query_overrides) || '' }} \
-            ${{ github.event.inputs.with_conflict_data == 'true' && '--with-conflict-data' || '' }}
+            ${{ github.event.inputs.with_conflict_data == 'true' && '--with-conflict-data' || '' }} \
+            ${{ github.event.inputs.with_retention_data == 'true' && '--with-retention-data' || '' }}
         env:
           S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
           S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY }}

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
@@ -17,9 +17,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: c_custkey
-      on_conflict:
-        c_custkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -34,9 +31,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: '(l_orderkey, l_linenumber)'
-      on_conflict:
-        '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -51,9 +45,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: n_nationkey
-      on_conflict:
-        n_nationkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -68,9 +59,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: o_orderkey
-      on_conflict:
-        o_orderkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -85,9 +73,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: p_partkey
-      on_conflict:
-        p_partkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -102,9 +87,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: '(ps_partkey, ps_suppkey)'
-      on_conflict:
-        '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -119,9 +101,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: r_regionkey
-      on_conflict:
-        r_regionkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
@@ -136,9 +115,7 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: s_suppkey
-      on_conflict:
-        s_suppkey: upsert
       retention_check_enabled: true
       retention_check_interval: *retention_check_interval
       retention_period: *retention_period
+

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
@@ -1,0 +1,142 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-cayenne[file]-append_retention_period
+
+refresh_check_interval: &refresh_check_interval 30s
+
+datasets:
+  - from: file:customer.parquet
+    name: customer
+    time_format: timestamptz
+    time_column: c_created_at
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: c_custkey
+      on_conflict:
+        c_custkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:lineitem.parquet
+    name: lineitem
+    time_column: l_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(l_orderkey, l_linenumber)'
+      on_conflict:
+        '(l_orderkey, l_linenumber)': upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:nation.parquet
+    name: nation
+    time_column: n_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:orders.parquet
+    name: orders
+    time_column: o_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: o_orderkey
+      on_conflict:
+        o_orderkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:part.parquet
+    name: part
+    time_column: p_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: p_partkey
+      on_conflict:
+        p_partkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:partsupp.parquet
+    name: partsupp
+    time_column: ps_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(ps_partkey, ps_suppkey)'
+      on_conflict:
+        '(ps_partkey, ps_suppkey)': upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:region.parquet
+    name: region
+    time_column: r_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d
+
+  - from: file:supplier.parquet
+    name: supplier
+    time_column: s_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: s_suppkey
+      on_conflict:
+        s_suppkey: upsert
+      retention_check_enabled: true
+      retention_check_interval: 30s
+      retention_period: 1d

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
@@ -3,6 +3,8 @@ kind: Spicepod
 name: file[parquet]-cayenne[file]-append_retention_period
 
 refresh_check_interval: &refresh_check_interval 30s
+retention_check_interval: &retention_check_interval 30s
+retention_period: &retention_period 1d
 
 datasets:
   - from: file:customer.parquet
@@ -19,8 +21,8 @@ datasets:
       on_conflict:
         c_custkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:lineitem.parquet
     name: lineitem
@@ -36,8 +38,8 @@ datasets:
       on_conflict:
         '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:nation.parquet
     name: nation
@@ -53,8 +55,8 @@ datasets:
       on_conflict:
         n_nationkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:orders.parquet
     name: orders
@@ -70,8 +72,8 @@ datasets:
       on_conflict:
         o_orderkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:part.parquet
     name: part
@@ -87,8 +89,8 @@ datasets:
       on_conflict:
         p_partkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:partsupp.parquet
     name: partsupp
@@ -104,8 +106,8 @@ datasets:
       on_conflict:
         '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:region.parquet
     name: region
@@ -121,8 +123,8 @@ datasets:
       on_conflict:
         r_regionkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:supplier.parquet
     name: supplier
@@ -138,5 +140,5 @@ datasets:
       on_conflict:
         s_suppkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
@@ -1,0 +1,134 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-cayenne[file]-append_retention_sql
+
+refresh_check_interval: &refresh_check_interval 30s
+
+datasets:
+  - from: file:customer.parquet
+    name: customer
+    time_column: c_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: c_custkey
+      on_conflict:
+        c_custkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM customer WHERE c_custkey >=  1000000000
+
+  - from: file:lineitem.parquet
+    name: lineitem
+    time_column: l_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(l_orderkey, l_linenumber)'
+      on_conflict:
+        '(l_orderkey, l_linenumber)': upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM lineitem WHERE l_orderkey >=  1000000000
+
+  - from: file:nation.parquet
+    name: nation
+    time_column: n_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM nation WHERE n_nationkey >=  1000000000
+
+  - from: file:orders.parquet
+    name: orders
+    time_column: o_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: o_orderkey
+      on_conflict:
+        o_orderkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM orders WHERE o_orderkey >=  1000000000
+
+  - from: file:part.parquet
+    name: part
+    time_column: p_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: p_partkey
+      on_conflict:
+        p_partkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM part WHERE p_partkey >=  1000000000
+
+  - from: file:partsupp.parquet
+    name: partsupp
+    time_column: ps_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: '(ps_partkey, ps_suppkey)'
+      on_conflict:
+        '(ps_partkey, ps_suppkey)': upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM partsupp WHERE ps_partkey >=  1000000000
+
+  - from: file:region.parquet
+    name: region
+    time_column: r_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM region WHERE r_regionkey >=  1000000000
+
+  - from: file:supplier.parquet
+    name: supplier
+    time_column: s_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      primary_key: s_suppkey
+      on_conflict:
+        s_suppkey: upsert
+      retention_check_enabled: true
+      retention_sql: DELETE FROM supplier WHERE s_suppkey >=  1000000000

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
@@ -15,9 +15,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: c_custkey
-      on_conflict:
-        c_custkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM customer WHERE c_custkey >=  1000000000
 
@@ -31,9 +28,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: '(l_orderkey, l_linenumber)'
-      on_conflict:
-        '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM lineitem WHERE l_orderkey >=  1000000000
 
@@ -47,9 +41,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: n_nationkey
-      on_conflict:
-        n_nationkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM nation WHERE n_nationkey >=  1000000000
 
@@ -63,9 +54,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: o_orderkey
-      on_conflict:
-        o_orderkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM orders WHERE o_orderkey >=  1000000000
 
@@ -79,9 +67,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: p_partkey
-      on_conflict:
-        p_partkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM part WHERE p_partkey >=  1000000000
 
@@ -95,9 +80,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: '(ps_partkey, ps_suppkey)'
-      on_conflict:
-        '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM partsupp WHERE ps_partkey >=  1000000000
 
@@ -111,9 +93,6 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: r_regionkey
-      on_conflict:
-        r_regionkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM region WHERE r_regionkey >=  1000000000
 
@@ -127,8 +106,5 @@ datasets:
       mode: file
       refresh_mode: append
       refresh_check_interval: *refresh_check_interval
-      primary_key: s_suppkey
-      on_conflict:
-        s_suppkey: upsert
       retention_check_enabled: true
       retention_sql: DELETE FROM supplier WHERE s_suppkey >=  1000000000

--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
@@ -3,6 +3,8 @@ kind: Spicepod
 name: file[parquet]-duckdb[file]-append_retention_period
 
 refresh_check_interval: &refresh_check_interval 30s
+retention_check_interval: &retention_check_interval 30s
+retention_period: &retention_period 1d
 
 datasets:
   - from: file:customer.parquet
@@ -19,8 +21,8 @@ datasets:
       on_conflict:
         c_custkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:lineitem.parquet
     name: lineitem
@@ -36,8 +38,8 @@ datasets:
       on_conflict:
         '(l_orderkey, l_linenumber)': upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:nation.parquet
     name: nation
@@ -53,8 +55,8 @@ datasets:
       on_conflict:
         n_nationkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:orders.parquet
     name: orders
@@ -104,8 +106,8 @@ datasets:
       on_conflict:
         '(ps_partkey, ps_suppkey)': upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:region.parquet
     name: region
@@ -121,8 +123,8 @@ datasets:
       on_conflict:
         r_regionkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
 
   - from: file:supplier.parquet
     name: supplier
@@ -138,5 +140,6 @@ datasets:
       on_conflict:
         s_suppkey: upsert
       retention_check_enabled: true
-      retention_check_interval: 30s
-      retention_period: 1d
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
@@ -1,0 +1,5 @@
+tests:
+  append:
+    spicepod_path: accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+    query_set: tpch
+    with_retention_data: true

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
@@ -1,0 +1,5 @@
+tests:
+  append:
+    spicepod_path: accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
+    query_set: tpch
+    with_retention_data: true

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
@@ -1,0 +1,5 @@
+tests:
+  append:
+    spicepod_path: accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+    query_set: tpch
+    with_retention_data: true

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
@@ -1,0 +1,5 @@
+tests:
+  append:
+    spicepod_path: accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
+    query_set: tpch
+    with_retention_data: true

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -178,6 +178,8 @@ pub struct AppendArgs {
     pub load_steps: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub with_conflict_data: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub with_retention_data: Option<bool>,
 }
 
 impl<'de> Deserialize<'de> for LoadArgs {


### PR DESCRIPTION
## 📝 Summary

1. Add support for `with_retention_data` to dispatch and `testoperator_run_append.yml` workflow
2. Add dispatch configurations for retention tests (`duckdb` and `cayenne`)

## 🔗 Related

Part of 
- https://github.com/spiceai/spiceai/issues/8251

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
