### PR TITLE
Follow-up improvements and bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,6 +5493,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-dynamodbstreams",
  "futures",
+ "humantime",
  "serde",
  "snafu",
  "tokio",

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -90,6 +90,7 @@ impl DynamoDBTableProvider {
     /// # Errors
     ///
     /// Returns an error if the table cannot be accessed or metadata cannot be fetched.
+    #[allow(clippy::too_many_argumentsi)]
     pub async fn try_new(
         sdk_config: SdkConfig,
         table_name: Arc<str>,

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -102,8 +102,7 @@ impl DynamoDBTableProvider {
         ready_lag: Duration,
     ) -> Result<Self, Error> {
         let db_client = Arc::new(DbClient::new(&sdk_config));
-        #[expect(unsafe_code)]
-        let buffer_size = unsafe { NonZeroUsize::new_unchecked(1) };
+        let buffer_size = NonZeroUsize::new(1).unwrap_or_else(|| unreachable!("1 is safe"));
         let streams_client = Arc::new(
             StreamsClient::builder(sdk_config, table_name.to_string())
                 .interval(Some(scan_interval))

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -90,7 +90,7 @@ impl DynamoDBTableProvider {
     /// # Errors
     ///
     /// Returns an error if the table cannot be accessed or metadata cannot be fetched.
-    #[allow(clippy::too_many_argumentsi)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new(
         sdk_config: SdkConfig,
         table_name: Arc<str>,

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -61,6 +61,7 @@ use futures::pin_mut;
 use futures::stream::{self, BoxStream, StreamExt};
 use snafu::prelude::*;
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 use std::{any::Any, collections::HashMap, fmt, sync::Arc};
@@ -75,6 +76,7 @@ pub struct DynamoDBTableProvider {
     unnest_depth: Option<usize>,
     config_partitions: Option<usize>,
     table_total_item_count: Option<i64>,
+    pub ready_lag: Duration,
 }
 
 type DynamoDBItemStream =
@@ -83,6 +85,11 @@ type DynamoDBItemStream =
 const DEFAULT_PARTITIONS: usize = 8;
 
 impl DynamoDBTableProvider {
+    /// Creates a new `DynamoDB` table provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table cannot be accessed or metadata cannot be fetched.
     pub async fn try_new(
         sdk_config: SdkConfig,
         table_name: Arc<str>,
@@ -91,12 +98,15 @@ impl DynamoDBTableProvider {
         config_partitions: Option<usize>,
         stream_poll_interval_ms: u64,
         time_format: String,
+        ready_lag: Duration,
     ) -> Result<Self, Error> {
         let db_client = Arc::new(DbClient::new(&sdk_config));
+        #[expect(unsafe_code)]
+        let buffer_size = unsafe { NonZeroUsize::new_unchecked(1) };
         let streams_client = Arc::new(
             StreamsClient::builder(sdk_config, table_name.to_string())
                 .interval(Some(Duration::from_millis(stream_poll_interval_ms)))
-                // .buffer(NonZeroUsize::new(1).unwrap())
+                .buffer(buffer_size)
                 .build(),
         );
 
@@ -147,6 +157,7 @@ impl DynamoDBTableProvider {
             unnest_depth,
             config_partitions,
             table_total_item_count,
+            ready_lag,
         })
     }
 

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -90,7 +90,7 @@ impl DynamoDBTableProvider {
     /// # Errors
     ///
     /// Returns an error if the table cannot be accessed or metadata cannot be fetched.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn try_new(
         sdk_config: SdkConfig,
         table_name: Arc<str>,

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -96,7 +96,7 @@ impl DynamoDBTableProvider {
         unnest_depth: Option<usize>,
         schema_infer_max_records: i32,
         config_partitions: Option<usize>,
-        stream_poll_interval_ms: u64,
+        scan_interval: Duration,
         time_format: String,
         ready_lag: Duration,
     ) -> Result<Self, Error> {
@@ -105,7 +105,7 @@ impl DynamoDBTableProvider {
         let buffer_size = unsafe { NonZeroUsize::new_unchecked(1) };
         let streams_client = Arc::new(
             StreamsClient::builder(sdk_config, table_name.to_string())
-                .interval(Some(Duration::from_millis(stream_poll_interval_ms)))
+                .interval(Some(scan_interval))
                 .buffer(buffer_size)
                 .build(),
         );

--- a/crates/dynamodb-streams/Cargo.toml
+++ b/crates/dynamodb-streams/Cargo.toml
@@ -18,3 +18,4 @@ tracing.workspace = true
 futures.workspace = true
 serde.workspace = true
 util = { path = "../util" }
+humantime.workspace = true

--- a/crates/dynamodb-streams/src/client.rs
+++ b/crates/dynamodb-streams/src/client.rs
@@ -104,12 +104,15 @@ impl Client {
             .sdk_client
             .get_stream_arn(self.table_name.clone())
             .await?;
+
         let state = initialize_state_from_checkpoint(
             stream_arn.clone(),
             &checkpoint,
             Arc::clone(&self.sdk_client),
         )
         .await?;
+
+        tracing::debug!("Stream initialized from checkpoint: {:#?}", state);
 
         let (tx, rx) = mpsc::channel(self.buffer);
 
@@ -125,7 +128,6 @@ impl Client {
             sender: tx,
             client: Arc::clone(&self.sdk_client),
             retry_strategy,
-            idle_timeout: None,
         };
 
         tokio::spawn(async move {

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -22,6 +22,7 @@ use futures::{Stream, future::join_all};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::task::{Context, Poll};
 use std::time::SystemTime;
 use tokio::{
@@ -38,9 +39,6 @@ pub struct DynamodbStreamProducer {
     pub sender: mpsc::Sender<StreamResult>,
     pub client: Arc<SDKClient>,
     pub retry_strategy: RetryBackoff,
-    /// Duration after which a shard is considered idle and excluded from watermark calculation.
-    /// If None, all shards are included in watermark calculation regardless of activity.
-    pub idle_timeout: Option<Duration>,
 }
 
 pub struct DynamoDBStreamBatch {
@@ -103,10 +101,7 @@ impl DynamodbStreamProducer {
             }
         }
 
-        Ok((
-            combine_shard_batches(&poll_results, self.idle_timeout),
-            had_transient_error,
-        ))
+        Ok((combine_shard_batches(&poll_results), had_transient_error))
     }
 
     async fn initialize_shards_iterators(&mut self) -> Result<()> {
@@ -162,7 +157,12 @@ impl DynamodbStreamProducer {
 
                     if had_transient_error {
                         // Transient error occurred during collection - apply backoff
-                        if let Some(duration) = backoff.next_backoff() {
+                        if let Some(mut duration) = backoff.next_backoff() {
+                            // Avoid sleeping for more than 60 seconds
+                            if duration > Duration::from_secs(60) {
+                                duration = Duration::from_secs(1);
+                                backoff.reset();
+                            }
                             tokio::time::sleep(duration).await;
                         } else {
                             // Backoff exhausted - transient errors persisted too long
@@ -188,12 +188,7 @@ impl DynamodbStreamProducer {
     }
 }
 
-fn combine_shard_batches(
-    poll_results: &[ShardPollResult],
-    idle_timeout: Option<Duration>,
-) -> DynamoDBStreamBatch {
-    let now = SystemTime::now();
-
+fn combine_shard_batches(poll_results: &[ShardPollResult]) -> DynamoDBStreamBatch {
     // Collect records, checkpoints and watermarks
     let mut records = Vec::new();
     let mut shard_watermarks = Vec::new();
@@ -219,45 +214,16 @@ fn combine_shard_batches(
             // Shards that produced records and those that failed are always eligible
             PollOutcome::Records { .. } | PollOutcome::Failed => true,
 
-            // Shards that produced no records are NOT eligible if they have been idle for longer than the idle_timeout
-            PollOutcome::Empty => {
-                if let Some(last_produced_at) = shard_result.last_produced_at {
-                    match idle_timeout {
-                        Some(timeout) => {
-                            let elapsed = now
-                                .duration_since(last_produced_at)
-                                .unwrap_or(Duration::ZERO);
-                            let is_idle = shard_result.outcome.is_empty() && elapsed > timeout;
-
-                            if is_idle {
-                                tracing::trace!(
-                                    "Shard {} excluded from watermark (idle for {:?}, timeout: {:?})",
-                                    shard_result.shard_id,
-                                    elapsed,
-                                    timeout
-                                );
-                            }
-
-                            !is_idle
-                        }
-                        None => true,
-                    }
-                } else {
-                    tracing::debug!(
-                        "Shard {} excluded from watermark (never produced records)",
-                        shard_result.shard_id
-                    );
-                    false
-                }
-            }
+            // Shards that produced no records are NOT eligible as there's no lag
+            PollOutcome::Empty => false,
         };
 
         // If eligible, include its current_watermark
         if is_eligible && let Some(watermark) = shard_result.current_watermark {
-            tracing::debug!(
-                "Shard {} included in watermark: {:?}",
+            tracing::trace!(
+                "Shard {} included in watermark: {}",
                 shard_result.shard_id,
-                watermark
+                humantime::format_rfc3339(watermark),
             );
             shard_watermarks.push(watermark);
         }

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -22,7 +22,6 @@ use futures::{Stream, future::join_all};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::task::{Context, Poll};
 use std::time::SystemTime;
 use tokio::{
@@ -91,7 +90,7 @@ impl DynamodbStreamProducer {
         // 4. Discover new shards
         // If permanent error is encountered, it is surfaced to the client.
         match self.client.get_all_shards(&self.stream_arn).await {
-            Ok(shards) => self.state.add_discovered(shards)?,
+            Ok(shards) => self.state.add_discovered(&shards)?,
             Err(e) => {
                 if !e.is_retriable() {
                     return Err(e);

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -19,7 +19,7 @@ use crate::{Error, MissingStaringSequenceNumberSnafu, Result};
 use aws_sdk_dynamodbstreams::primitives::DateTime;
 use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use snafu::OptionExt;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -237,8 +237,8 @@ impl StreamState {
     }
 
     /// Add discovered shards, returns shard IDs that need initialization
-    pub fn add_discovered(&mut self, shards: Vec<ApiShard>) -> Result<()> {
-        for shard in shards.clone() {
+    pub fn add_discovered(&mut self, shards: &[ApiShard]) -> Result<()> {
+        for shard in shards.iter().cloned() {
             let shard_id = shard.shard_id.clone();
 
             // If we've seen this shard before, skip it entirely
@@ -479,7 +479,7 @@ pub fn datetime_to_system_time(dt: DateTime) -> SystemTime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aws_sdk_dynamodbstreams::types::{Shard, StreamRecord};
+    use aws_sdk_dynamodbstreams::types::StreamRecord;
 
     impl StreamState {
         #[must_use]
@@ -1141,7 +1141,7 @@ mod tests {
         #[test]
         fn test_add_discovered_empty_list() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
-            state.add_discovered(vec![]).expect("result");
+            state.add_discovered(&[]).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1156,7 +1156,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, None)];
 
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1179,7 +1179,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, Some("999"))];
 
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             // Closed shards are ignored
             assert_eq!(state.active.len(), 0);
@@ -1221,7 +1221,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1262,7 +1262,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -1304,7 +1304,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1354,7 +1354,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             // Should not change existing active shard
             assert_eq!(state.active.len(), 1);
@@ -1401,7 +1401,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1447,7 +1447,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1492,7 +1492,7 @@ mod tests {
                 create_api_shard("child-2", Some("nonexistent"), None), // Should go to initializing
             ];
 
-            state.add_discovered(shards).expect("result");
+            state.add_discovered(&shards).expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1594,7 +1594,7 @@ mod tests {
             create_api_shard("shard-A", None, Some("100")),
         ];
 
-        state.add_discovered(discovered).expect("result");
+        state.add_discovered(&discovered).expect("result");
 
         assert!(
             !state.initializing.contains_key("shard-A"),
@@ -2201,7 +2201,7 @@ mod tests {
 
             // Discover initial shard
             state
-                .add_discovered(vec![create_api_shard("shard-1", None, None)])
+                .add_discovered(&[create_api_shard("shard-1", None, None)])
                 .expect("result");
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -2261,7 +2261,7 @@ mod tests {
 
             // Discover parent and child
             state
-                .add_discovered(vec![
+                .add_discovered(&[
                     create_api_shard("parent", None, None),
                     create_api_shard("child", Some("parent"), None),
                 ])
@@ -2322,7 +2322,7 @@ mod tests {
 
             // Add three generations
             state
-                .add_discovered(vec![
+                .add_discovered(&[
                     create_api_shard("gen1", None, None),
                     create_api_shard("gen2", Some("gen1"), None),
                     create_api_shard("gen3", Some("gen2"), None),
@@ -2386,7 +2386,7 @@ mod tests {
 
             // Parent splits into two children
             state
-                .add_discovered(vec![
+                .add_discovered(&[
                     create_api_shard("parent", None, None),
                     create_api_shard("child-a", Some("parent"), None),
                     create_api_shard("child-b", Some("parent"), None),
@@ -2451,7 +2451,7 @@ mod tests {
 
             // Add initial shard
             state
-                .add_discovered(vec![create_api_shard("shard-1", None, None)])
+                .add_discovered(&[create_api_shard("shard-1", None, None)])
                 .expect("result");
             state.mark_active("shard-1".to_string(), "iter-1".to_string());
 
@@ -2461,7 +2461,7 @@ mod tests {
 
             // Rediscover same shard - should be ignored
             state
-                .add_discovered(vec![create_api_shard("shard-1", None, None)])
+                .add_discovered(&[create_api_shard("shard-1", None, None)])
                 .expect("result");
 
             assert_eq!(state.active.len(), 1);
@@ -2597,7 +2597,7 @@ mod tests {
 
             // Two independent parent-child chains
             state
-                .add_discovered(vec![
+                .add_discovered(&[
                     create_api_shard("parent-1", None, None),
                     create_api_shard("parent-2", None, None),
                     create_api_shard("child-1", Some("parent-1"), None),

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -19,7 +19,7 @@ use crate::{Error, MissingStaringSequenceNumberSnafu, Result};
 use aws_sdk_dynamodbstreams::primitives::DateTime;
 use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use snafu::OptionExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -29,7 +29,6 @@ pub struct ActiveShard {
     pub parent_shard_id: Option<String>,
     pub iterator: String,
     pub last_checkpoint: ShardCheckpoint,
-    pub last_produced_at: Option<SystemTime>,
     pub current_watermark: Option<SystemTime>,
 }
 
@@ -42,10 +41,6 @@ impl ActiveShard {
         self.last_checkpoint = checkpoint;
     }
 
-    pub fn update_produced_at(&mut self) {
-        self.last_produced_at = Some(SystemTime::now());
-    }
-
     pub fn update_watermark(&mut self, watermark: SystemTime) {
         self.current_watermark = Some(watermark);
     }
@@ -56,7 +51,6 @@ pub struct InitializingShard {
     pub shard_id: String,
     pub parent_shard_id: Option<String>,
     pub last_checkpoint: ShardCheckpoint,
-    pub last_produced_at: Option<SystemTime>,
     pub current_watermark: Option<SystemTime>,
 }
 
@@ -65,6 +59,13 @@ pub struct BlockedShard {
     pub shard_id: String,
     pub parent_shard_id: Option<String>,
     pub last_checkpoint: ShardCheckpoint,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct HistoricalShard {
+    pub shard_id: String,
+    pub parent_shard_id: Option<String>,
+    pub created_at: SystemTime,
 }
 
 #[derive(Debug)]
@@ -77,13 +78,14 @@ pub struct StreamState {
     initializing: HashMap<String, InitializingShard>,
     // Shards that are blocked by their parent
     blocked: HashMap<String, BlockedShard>,
+    // All shards that have ever been seen in the stream.
+    historical: HashMap<String, HistoricalShard>,
 }
 
 pub struct ShardPollResult {
     pub shard_id: String,
     pub outcome: PollOutcome,
     pub last_checkpoint: ShardCheckpoint,
-    pub last_produced_at: Option<SystemTime>,
     pub current_watermark: Option<SystemTime>,
 }
 
@@ -91,12 +93,6 @@ pub enum PollOutcome {
     Records { records: Vec<Record> },
     Empty,
     Failed,
-}
-
-impl PollOutcome {
-    pub fn is_empty(&self) -> bool {
-        matches!(self, PollOutcome::Empty)
-    }
 }
 
 impl StreamState {
@@ -120,16 +116,12 @@ impl StreamState {
             });
         };
         let mut current_checkpoint = shard.last_checkpoint.clone();
-        let mut current_last_produced_at = shard.last_produced_at;
         let mut current_watermark = shard.current_watermark;
 
         // First update watermark and checkpoint if possible
         if !records.is_empty()
             && let Some(shard) = self.active.get_mut(shard_id)
         {
-            shard.update_produced_at();
-            current_last_produced_at = shard.last_produced_at;
-
             // Update watermark
             let max_event_time = records
                 .iter()
@@ -171,6 +163,7 @@ impl StreamState {
                 shard.update_iterator(iter);
             }
         } else {
+            tracing::debug!("Removing shard from active shards: {}", shard_id);
             self.active.remove(shard_id);
             self.promote_children(shard_id);
         }
@@ -185,7 +178,6 @@ impl StreamState {
             shard_id: shard_id.to_string(),
             outcome,
             last_checkpoint: current_checkpoint,
-            last_produced_at: current_last_produced_at,
             current_watermark,
         })
     }
@@ -202,7 +194,6 @@ impl StreamState {
             shard_id: shard_id.to_string(),
             outcome: PollOutcome::Failed,
             last_checkpoint: shard.last_checkpoint.clone(),
-            last_produced_at: shard.last_produced_at,
             current_watermark: shard.current_watermark,
         };
 
@@ -239,7 +230,6 @@ impl StreamState {
                     shard_id: shard_id.to_string(),
                     parent_shard_id: active_shard.parent_shard_id,
                     last_checkpoint: active_shard.last_checkpoint,
-                    last_produced_at: active_shard.last_produced_at,
                     current_watermark: active_shard.current_watermark,
                 },
             );
@@ -248,17 +238,22 @@ impl StreamState {
 
     /// Add discovered shards, returns shard IDs that need initialization
     pub fn add_discovered(&mut self, shards: Vec<ApiShard>) -> Result<()> {
-        for shard in shards {
+        for shard in shards.clone() {
             let shard_id = shard.shard_id.clone();
 
-            // At each iteration we will get all currently non-expired shards
-            // Only subset of them we haven't seen before
-            if self.active.contains_key(&shard_id)
-                || self.blocked.contains_key(&shard_id)
-                || self.initializing.contains_key(&shard_id)
-            {
+            // If we've seen this shard before, skip it entirely
+            if self.historical.contains_key(&shard_id) {
                 continue;
             }
+
+            self.historical.insert(
+                shard_id.clone(),
+                HistoricalShard {
+                    shard_id: shard_id.clone(),
+                    parent_shard_id: shard.parent_shard_id.clone(),
+                    created_at: SystemTime::now(),
+                },
+            );
 
             // Shards in DynamoDB Streams have a parent-child relationship.
             // Until we exhausted the parent shard, we don't want to read from its children.
@@ -276,6 +271,9 @@ impl StreamState {
                 shard.parent_shard_id,
                 blocked
             );
+
+            tracing::debug!("Current state: {:#?}", self);
+            tracing::debug!("Discovered shards: {:#?}", shards);
 
             let checkpoint = ShardCheckpoint {
                 sequence_number: shard
@@ -302,7 +300,6 @@ impl StreamState {
                         shard_id: shard_id.clone(),
                         parent_shard_id: shard.parent_shard_id.clone(),
                         last_checkpoint: checkpoint,
-                        last_produced_at: None,
                         current_watermark: None,
                     },
                 );
@@ -315,11 +312,11 @@ impl StreamState {
     /// Move shard from initializing to active with its iterator
     pub fn mark_active(&mut self, shard_id: String, iterator: String) {
         if let Some(pending) = self.initializing.remove(&shard_id) {
+            tracing::debug!("Adding shard as active: {:?}", pending);
             let active = ActiveShard {
                 shard_id: shard_id.clone(),
                 parent_shard_id: pending.parent_shard_id,
                 last_checkpoint: pending.last_checkpoint,
-                last_produced_at: pending.last_produced_at,
                 current_watermark: pending.current_watermark,
                 iterator,
             };
@@ -358,7 +355,6 @@ impl StreamState {
                     shard_id: shard_id.to_string(),
                     parent_shard_id: shard.parent_shard_id,
                     last_checkpoint: shard.last_checkpoint,
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -375,7 +371,32 @@ pub async fn initialize_state_from_checkpoint(
         active: HashMap::new(),
         blocked: HashMap::new(),
         initializing: HashMap::new(),
+        historical: HashMap::new(),
     };
+
+    let all_shards = sdk_client.get_all_shards(&stream_arn).await?;
+
+    // Build parent->children map
+    let mut parent_map: HashMap<String, Vec<String>> = HashMap::new();
+    for shard in &all_shards {
+        if let Some(parent) = &shard.parent_shard_id {
+            parent_map
+                .entry(parent.clone())
+                .or_default()
+                .push(shard.shard_id.clone());
+        }
+    }
+
+    for shard in &all_shards {
+        state.historical.insert(
+            shard.shard_id.clone(),
+            HistoricalShard {
+                shard_id: shard.shard_id.clone(),
+                parent_shard_id: shard.parent_shard_id.clone(),
+                created_at: SystemTime::now(),
+            },
+        );
+    }
 
     for (shard_id, shard_checkpoint) in checkpoint.leaf_shards() {
         let iterator_type = match shard_checkpoint.position {
@@ -393,7 +414,7 @@ pub async fn initialize_state_from_checkpoint(
             .await?;
 
         tracing::debug!(
-            "Initialized shard from checkpoint: id={}, parent={:?}",
+            "Initialized active shard from checkpoint: id={}, parent={:?}",
             shard_id,
             shard_checkpoint.parent_id
         );
@@ -403,14 +424,50 @@ pub async fn initialize_state_from_checkpoint(
             parent_shard_id: shard_checkpoint.parent_id.clone(),
             iterator,
             last_checkpoint: shard_checkpoint.clone(),
-            last_produced_at: None,
             current_watermark: None,
         };
 
         state.active.insert(shard_id.to_string(), shard);
+
+        // Recursively add all descendants to blocked
+        add_all_descendants_to_blocked(&mut state, shard_id, &parent_map, &all_shards)?;
     }
 
     Ok(state)
+}
+
+fn add_all_descendants_to_blocked(
+    state: &mut StreamState,
+    parent_id: &str,
+    parent_map: &HashMap<String, Vec<String>>,
+    all_shards: &[ApiShard],
+) -> Result<()> {
+    if let Some(children) = parent_map.get(parent_id) {
+        for child_id in children {
+            if let Some(child) = all_shards.iter().find(|s| &s.shard_id == child_id) {
+                state.blocked.insert(
+                    child_id.clone(),
+                    BlockedShard {
+                        shard_id: child_id.clone(),
+                        parent_shard_id: child.parent_shard_id.clone(),
+                        last_checkpoint: ShardCheckpoint {
+                            sequence_number: child
+                                .starting_sequence_number
+                                .clone()
+                                .context(MissingStaringSequenceNumberSnafu)?,
+                            parent_id: child.parent_shard_id.clone(),
+                            updated_at: SystemTime::now(),
+                            position: CheckpointPosition::At,
+                        },
+                    },
+                );
+
+                add_all_descendants_to_blocked(state, child_id, parent_map, all_shards)?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn datetime_to_system_time(dt: DateTime) -> SystemTime {
@@ -420,10 +477,9 @@ pub fn datetime_to_system_time(dt: DateTime) -> SystemTime {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use aws_sdk_dynamodbstreams::types::StreamRecord;
+    use aws_sdk_dynamodbstreams::types::{Shard, StreamRecord};
 
     impl StreamState {
         #[must_use]
@@ -432,6 +488,7 @@ mod tests {
                 active: HashMap::new(),
                 blocked: HashMap::new(),
                 initializing: HashMap::new(),
+                historical: HashMap::new(),
             }
         }
     }
@@ -494,7 +551,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -546,7 +602,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -585,7 +640,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -626,7 +680,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -670,7 +723,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -706,7 +758,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -765,7 +816,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -826,7 +876,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -845,15 +894,14 @@ mod tests {
             // Verify watermark is max timestamp (1010)
             assert!(result.current_watermark.is_some());
             let expected_watermark = datetime_to_system_time(DateTime::from_secs(1010));
-            assert_eq!(result.current_watermark.unwrap(), expected_watermark);
-
-            // Verify last_produced_at is set
-            assert!(result.last_produced_at.is_some());
+            assert_eq!(
+                result.current_watermark.expect("result"),
+                expected_watermark
+            );
 
             // Verify active shard state
-            let shard = state.active.get("shard-1").unwrap();
-            assert_eq!(shard.current_watermark.unwrap(), expected_watermark);
-            assert!(shard.last_produced_at.is_some());
+            let shard = state.active.get("shard-1").expect("result");
+            assert_eq!(shard.current_watermark.expect("result"), expected_watermark);
             assert_eq!(shard.last_checkpoint.sequence_number, "102");
         }
 
@@ -873,7 +921,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -889,16 +936,12 @@ mod tests {
             // Watermark should still be None
             assert!(result.current_watermark.is_none());
 
-            // But last_produced_at should be set
-            assert!(result.last_produced_at.is_some());
-
             // Checkpoint should be updated
             assert_eq!(result.last_checkpoint.sequence_number, "100");
 
             // Verify active shard
-            let shard = state.active.get("shard-1").unwrap();
+            let shard = state.active.get("shard-1").expect("result");
             assert!(shard.current_watermark.is_none());
-            assert!(shard.last_produced_at.is_some());
         }
 
         #[test]
@@ -918,7 +961,6 @@ mod tests {
                         updated_at: old_checkpoint_time,
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -943,7 +985,7 @@ mod tests {
             }
 
             // Verify active shard kept old checkpoint
-            let shard = state.active.get("shard-1").unwrap();
+            let shard = state.active.get("shard-1").expect("result");
             assert_eq!(shard.last_checkpoint.sequence_number, "99");
         }
 
@@ -964,7 +1006,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -990,12 +1031,9 @@ mod tests {
             // Should have watermark
             assert!(result.current_watermark.is_some());
             assert_eq!(
-                result.current_watermark.unwrap(),
+                result.current_watermark.expect("result"),
                 datetime_to_system_time(base_time)
             );
-
-            // Should have last_produced_at
-            assert!(result.last_produced_at.is_some());
 
             // Shard should be removed
             assert!(!state.active.contains_key("shard-1"));
@@ -1005,7 +1043,6 @@ mod tests {
         fn test_handle_poll_result_exhausted_empty_records() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let old_watermark = datetime_to_system_time(DateTime::from_secs(1000));
-            let old_produced_at = SystemTime::now();
 
             state.active.insert(
                 "shard-1".to_string(),
@@ -1019,7 +1056,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: Some(old_produced_at),
                     current_watermark: Some(old_watermark),
                 },
             );
@@ -1033,10 +1069,9 @@ mod tests {
             // Should be empty
             assert!(matches!(result.outcome, PollOutcome::Empty));
 
-            // Should preserve old checkpoint, watermark, last_produced_at
+            // Should preserve old checkpoint and watermark
             assert_eq!(result.last_checkpoint.sequence_number, "99");
-            assert_eq!(result.current_watermark.unwrap(), old_watermark);
-            assert_eq!(result.last_produced_at.unwrap(), old_produced_at);
+            assert_eq!(result.current_watermark.expect("result"), old_watermark);
 
             // Shard should be removed
             assert!(!state.active.contains_key("shard-1"));
@@ -1059,7 +1094,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1080,9 +1114,8 @@ mod tests {
                 Some("parent-1".to_string())
             );
             assert_eq!(shard.last_checkpoint.position, CheckpointPosition::After);
-            assert!(shard.last_produced_at.is_some());
             assert_eq!(
-                shard.current_watermark.unwrap(),
+                shard.current_watermark.expect("result"),
                 datetime_to_system_time(base_time)
             );
         }
@@ -1108,7 +1141,7 @@ mod tests {
         #[test]
         fn test_add_discovered_empty_list() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
-            state.add_discovered(vec![]).unwrap();
+            state.add_discovered(vec![]).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1123,7 +1156,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, None)];
 
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1146,7 +1179,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, Some("999"))];
 
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             // Closed shards are ignored
             assert_eq!(state.active.len(), 0);
@@ -1183,13 +1216,12 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1230,7 +1262,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -1267,13 +1299,12 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1297,6 +1328,14 @@ mod tests {
         #[test]
         fn test_add_discovered_ignores_existing_active_shard() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            state.historical.insert(
+                "shard-1".to_string(),
+                HistoricalShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    created_at: SystemTime::now(),
+                },
+            );
 
             state.active.insert(
                 "shard-1".to_string(),
@@ -1310,13 +1349,12 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             // Should not change existing active shard
             assert_eq!(state.active.len(), 1);
@@ -1339,6 +1377,14 @@ mod tests {
         #[test]
         fn test_add_discovered_ignores_existing_pending_shard() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            state.historical.insert(
+                "shard-1".to_string(),
+                HistoricalShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    created_at: SystemTime::now(),
+                },
+            );
 
             state.blocked.insert(
                 "shard-1".to_string(),
@@ -1355,7 +1401,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1376,6 +1422,14 @@ mod tests {
         #[test]
         fn test_add_discovered_ignores_existing_initializing_shard() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
+            state.historical.insert(
+                "shard-1".to_string(),
+                HistoricalShard {
+                    shard_id: "shard-1".to_string(),
+                    parent_shard_id: None,
+                    created_at: SystemTime::now(),
+                },
+            );
 
             state.initializing.insert(
                 "shard-1".to_string(),
@@ -1388,13 +1442,12 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1428,7 +1481,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1440,7 +1492,7 @@ mod tests {
                 create_api_shard("child-2", Some("nonexistent"), None), // Should go to initializing
             ];
 
-            state.add_discovered(shards).unwrap();
+            state.add_discovered(shards).expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1493,6 +1545,67 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_ancestor_not_detected_after_child_expires() {
+        let mut state = StreamState::new("test-stream".to_string());
+
+        state.historical.insert(
+            "shard-A".to_string(),
+            HistoricalShard {
+                shard_id: "shard-A".to_string(),
+                parent_shard_id: None,
+                created_at: SystemTime::now(),
+            },
+        );
+        state.historical.insert(
+            "shard-B".to_string(),
+            HistoricalShard {
+                shard_id: "shard-B".to_string(),
+                parent_shard_id: Some("shard-A".to_string()),
+                created_at: SystemTime::now(),
+            },
+        );
+
+        // Shard-B (child) is active, has parent Shard-A (ancestor)
+        state.active.insert(
+            "shard-B".to_string(),
+            ActiveShard {
+                shard_id: "shard-B".to_string(),
+                parent_shard_id: Some("shard-A".to_string()),
+                iterator: "iter-B".to_string(),
+                last_checkpoint: ShardCheckpoint {
+                    sequence_number: "200".to_string(),
+                    parent_id: Some("shard-A".to_string()),
+                    updated_at: SystemTime::now(),
+                    position: CheckpointPosition::After,
+                },
+                current_watermark: None,
+            },
+        );
+
+        // Shard-B expires - handle_poll_result with None iterator removes it and adds to expired
+        state
+            .handle_poll_result("shard-B", None, vec![])
+            .expect("result");
+
+        // Discovery returns both shard-A and shard-B
+        let discovered = vec![
+            create_api_shard("shard-A", None, Some("100")),
+            create_api_shard("shard-A", None, Some("100")),
+        ];
+
+        state.add_discovered(discovered).expect("result");
+
+        assert!(
+            !state.initializing.contains_key("shard-A"),
+            "shard-A is an ancestor of expired shard-B and should be skipped"
+        );
+        assert!(
+            !state.initializing.contains_key("shard-B"),
+            "shard-A is an ancestor of expired shard-B and should be skipped"
+        );
+    }
+
     mod mark_active {
         use super::*;
 
@@ -1511,7 +1624,6 @@ mod tests {
                     },
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: Some("parent".to_string()),
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1550,7 +1662,6 @@ mod tests {
                     },
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1637,7 +1748,6 @@ mod tests {
                     },
                     shard_id: "shard-1".to_string(),
                     parent_shard_id: None,
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1652,7 +1762,6 @@ mod tests {
                     },
                     shard_id: "shard-2".to_string(),
                     parent_shard_id: Some("parent".to_string()),
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1855,7 +1964,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -1948,7 +2056,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -2044,7 +2151,6 @@ mod tests {
                     },
                     shard_id: "parent".to_string(),
                     parent_shard_id: None,
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -2096,7 +2202,7 @@ mod tests {
             // Discover initial shard
             state
                 .add_discovered(vec![create_api_shard("shard-1", None, None)])
-                .unwrap();
+                .expect("result");
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 1);
@@ -2123,7 +2229,7 @@ mod tests {
                 Some("iter-2".to_string()),
                 vec![create_record("100")],
             );
-            batch.unwrap();
+            batch.expect("result");
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 0);
@@ -2159,7 +2265,7 @@ mod tests {
                     create_api_shard("parent", None, None),
                     create_api_shard("child", Some("parent"), None),
                 ])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -2185,7 +2291,7 @@ mod tests {
 
             // Exhaust parent
             let batch = state.handle_poll_result("parent", None, vec![create_record("100")]);
-            batch.unwrap();
+            batch.expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -2221,7 +2327,7 @@ mod tests {
                     create_api_shard("gen2", Some("gen1"), None),
                     create_api_shard("gen3", Some("gen2"), None),
                 ])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2239,7 +2345,7 @@ mod tests {
             // Exhaust gen1
             state
                 .handle_poll_result("gen1", None, vec![create_record("100")])
-                .unwrap();
+                .expect("result");
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
             assert_eq!(state.initializing.len(), 1);
@@ -2255,7 +2361,7 @@ mod tests {
             // Exhaust gen2
             state
                 .handle_poll_result("gen2", None, vec![create_record("200")])
-                .unwrap();
+                .expect("result");
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 1);
@@ -2285,7 +2391,7 @@ mod tests {
                     create_api_shard("child-a", Some("parent"), None),
                     create_api_shard("child-b", Some("parent"), None),
                 ])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2303,7 +2409,7 @@ mod tests {
             // Exhaust parent
             state
                 .handle_poll_result("parent", None, vec![create_record("100")])
-                .unwrap();
+                .expect("result");
 
             // Both children should now be initializing
             assert_eq!(state.active.len(), 0);
@@ -2346,7 +2452,7 @@ mod tests {
             // Add initial shard
             state
                 .add_discovered(vec![create_api_shard("shard-1", None, None)])
-                .unwrap();
+                .expect("result");
             state.mark_active("shard-1".to_string(), "iter-1".to_string());
 
             assert_eq!(state.active.len(), 1);
@@ -2356,7 +2462,7 @@ mod tests {
             // Rediscover same shard - should be ignored
             state
                 .add_discovered(vec![create_api_shard("shard-1", None, None)])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 0);
@@ -2387,7 +2493,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -2474,7 +2579,6 @@ mod tests {
                         updated_at: SystemTime::now(),
                         position: CheckpointPosition::After,
                     },
-                    last_produced_at: None,
                     current_watermark: None,
                 },
             );
@@ -2499,7 +2603,7 @@ mod tests {
                     create_api_shard("child-1", Some("parent-1"), None),
                     create_api_shard("child-2", Some("parent-2"), None),
                 ])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2515,7 +2619,7 @@ mod tests {
             // Exhaust parent-1
             state
                 .handle_poll_result("parent-1", None, vec![create_record("100")])
-                .unwrap();
+                .expect("result");
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -92,13 +92,12 @@ impl RefreshTask {
                         .await
                     {
                         Ok(()) => {
-                            if let Some(ready_sender) = ready_sender.as_ref() {
-                                ready_sender.notify_waiters();
-                            }
-                            initial_load_completed.store(true, Ordering::Relaxed);
-
                             // Mark the dataset as ready if possible
                             if change_envelope.is_dataset_ready() {
+                                initial_load_completed.store(true, Ordering::Relaxed);
+                                if let Some(ready_sender) = ready_sender.as_ref() {
+                                    ready_sender.notify_waiters();
+                                }
                                 self.update_component_status(status::ComponentStatus::Ready)
                                     .await;
                             }
@@ -164,8 +163,7 @@ impl RefreshTask {
 
         let sub_batches = group_into_sub_batches(&change_batch);
 
-        // TODO: Should be trace
-        tracing::info!(
+        tracing::trace!(
             "Processing append/change stream batch: dataset={}, rows={}, sub-batches={}",
             self.dataset_name,
             change_batch.record.num_rows(),
@@ -211,12 +209,7 @@ impl RefreshTask {
         let indices_array = UInt32Array::from(
             row_indices
                 .iter()
-                .map(|&i| {
-                    u32::try_from(i).unwrap_or_else(|_| {
-                        tracing::error!("Index {i} doesn't fit in u32, using 0");
-                        0
-                    })
-                })
+                .filter_map(|&i| u32::try_from(i).ok())
                 .collect::<Vec<_>>(),
         );
 

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -59,7 +59,6 @@ impl DynamoDBFactory {
 
 const DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR: &str = "10";
 const SEGMENTS_AUTO_STR: &str = "auto";
-const DEFAULT_STREAM_POLL_INTERVAL_MS_STR: &str = "0";
 const DEFAULT_TIME_FORMAT: &str = "2006-01-02T15:04:05.000Z07:00";
 
 const PARAMETERS: &[ParameterSpec] = &[
@@ -85,9 +84,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("scan_segments")
         .description("Number of segments. 'auto' by default.")
         .default(SEGMENTS_AUTO_STR),
-    ParameterSpec::runtime("stream_poll_interval_ms")
+    ParameterSpec::runtime("scan_interval")
         .description("Interval in milliseconds between polling for new records in a DynamoDB stream.")
-        .default(DEFAULT_STREAM_POLL_INTERVAL_MS_STR),
+        .default("0s"),
     ParameterSpec::runtime("time_format")
         .description("Go-style time format used for parsing/formatting timestamps")
         .default(DEFAULT_TIME_FORMAT),
@@ -160,13 +159,13 @@ impl DataConnector for DynamoDB {
             .and_then(|v| v.parse::<i32>().ok())
             .unwrap_or(10);
 
-        let stream_poll_interval_ms = self
+        let scan_interval = self
             .params
-            .get("stream_poll_interval_ms")
+            .get("scan_interval")
             .expose()
             .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(0);
+            .and_then(|v| fundu::parse_duration(v).ok())
+            .unwrap_or(Duration::from_secs(0));
 
         let unnest_depth = match self.params.get("unnest_depth").expose() {
             ExposedParamLookup::Present(unnest_depth_str) => Some(usize::from_str(unnest_depth_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
@@ -238,7 +237,7 @@ impl DataConnector for DynamoDB {
             unnest_depth,
             schema_infer_max_records,
             config_segments,
-            stream_poll_interval_ms,
+            scan_interval,
             time_format.to_string(),
             ready_lag,
         )

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -28,7 +28,7 @@ use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitEr
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
-use dynamodb_streams::checkpoint::Checkpoint;
+use dynamodb_streams::Checkpoint;
 use futures::stream::{self, StreamExt};
 use runtime_parameters::ExposedParamLookup;
 use snafu::ResultExt;
@@ -59,7 +59,7 @@ impl DynamoDBFactory {
 
 const DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR: &str = "10";
 const SEGMENTS_AUTO_STR: &str = "auto";
-const DEFAULT_STREAM_POLL_INTERVAL_MS_STR: &str = "200";
+const DEFAULT_STREAM_POLL_INTERVAL_MS_STR: &str = "0";
 const DEFAULT_TIME_FORMAT: &str = "2006-01-02T15:04:05.000Z07:00";
 
 const PARAMETERS: &[ParameterSpec] = &[
@@ -91,6 +91,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("time_format")
         .description("Go-style time format used for parsing/formatting timestamps")
         .default(DEFAULT_TIME_FORMAT),
+    ParameterSpec::runtime("ready_lag")
+        .description("When using Streams, once tables reaches this lag, it will be reported as Ready")
+        .default("2s"),
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {
@@ -125,10 +128,11 @@ impl DataConnector for DynamoDB {
         self
     }
 
+    #[expect(clippy::too_many_lines)]
     async fn read_provider(
         &self,
         dataset: &Dataset,
-    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+    ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
         let table_name = dataset.path();
 
         let config = initiate_config_with_credentials(
@@ -162,7 +166,7 @@ impl DataConnector for DynamoDB {
             .expose()
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(200);
+            .unwrap_or(0);
 
         let unnest_depth = match self.params.get("unnest_depth").expose() {
             ExposedParamLookup::Present(unnest_depth_str) => Some(usize::from_str(unnest_depth_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
@@ -220,6 +224,14 @@ impl DataConnector for DynamoDB {
             });
         }
 
+        let ready_lag = self
+            .params
+            .get("ready_lag")
+            .expose()
+            .ok()
+            .and_then(|v| fundu::parse_duration(v).ok())
+            .unwrap_or(Duration::from_secs(2));
+
         let provider = DynamoDBTableProvider::try_new(
             config,
             Arc::from(table_name),
@@ -228,6 +240,7 @@ impl DataConnector for DynamoDB {
             config_segments,
             stream_poll_interval_ms,
             time_format.to_string(),
+            ready_lag,
         )
         .await
         .map_err(|e| DataConnectorError::UnableToGetReadProvider {
@@ -248,7 +261,6 @@ impl DataConnector for DynamoDB {
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
-        let acceptable_lag = Duration::from_secs(10);
 
         Some(Box::pin(
             stream::once(async move {
@@ -258,7 +270,7 @@ impl DataConnector for DynamoDB {
                     .as_any()
                     .downcast_ref::<DynamoDBTableProvider>()?;
 
-                let acceptable_lag = acceptable_lag;
+                let acceptable_lag = dynamodb_ref.ready_lag;
                 let dataset_name = dataset.name.clone();
                 let dataset_name_2 = dataset_name.clone();
                 let dataset_name_3 = dataset_name.clone();
@@ -277,19 +289,29 @@ impl DataConnector for DynamoDB {
                         .ok()?
                         .map(move |msg| {
                             msg.map(|change_batch| {
-                                tracing::info!("Bootstrapping DynamoDB table: table_name={}, records={}", dataset_name.clone(), change_batch.record.num_rows());
+                                tracing::info!("Bootstrapping DynamoDB table {}, records={}", dataset_name.clone(), change_batch.record.num_rows());
                                 // Bootstrap stream doesn't commit changes and doesn't mark dataset as ready
                                 ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch, false)
                             })
                         });
+
+                    let checkpoint_cloned = checkpoint.clone();
+                    let dynamodb_sys_cloned = Arc::clone(&dynamodb_sys);
 
                     // Attach changes stream from initial checkpoint to bootstrap stream
                     Some(
                         bootstrap_stream
                             .chain(
                                 stream::once(async move {
-                                    tracing::info!("Bootstrapping DynamoDB table complete, starting changes stream. \
-                                        Note it will take some time for table to catch up: table_name={}", dataset_name_2);
+                                    tracing::info!("Bootstrapping DynamoDB table {} complete, starting changes stream. \
+                                        Table will be marked as Ready once stream lag reaches < '{}'",
+                                        dataset_name_2, humantime::format_duration(acceptable_lag));
+
+                                    let committer = DynamoDBStreamCommitter::new(dynamodb_sys_cloned, checkpoint_cloned);
+                                    if let Err(err) = committer.commit() {
+                                        tracing::error!("Failed to commit bootstrap checkpoint: {:?}", err);
+                                    }
+
                                     stream::empty()
                                 })
                                 .flatten()
@@ -299,7 +321,6 @@ impl DataConnector for DynamoDB {
                                     Arc::clone(&dynamodb),
                                     Arc::clone(&dynamodb_sys),
                                     checkpoint,
-                                    true,
                                     acceptable_lag,
                                     dataset_name_3.clone(),
                                 ))
@@ -315,7 +336,6 @@ impl DataConnector for DynamoDB {
                             Arc::clone(&dynamodb),
                             Arc::clone(&dynamodb_sys),
                             checkpoint,
-                            false,
                             acceptable_lag,
                             dataset_name_4.clone(),
                         ))
@@ -356,7 +376,7 @@ async fn load_or_initialize_checkpoint(
         match serde_json::from_str::<Checkpoint>(&metadata.checkpoint_data) {
             Ok(checkpoint) => {
                 tracing::info!(
-                    "Found existing checkpoint for DynamoDB Stream, resuming from checkpoint: table_name={}",
+                    "Found existing checkpoint for DynamoDB table {}, resuming from checkpoint",
                     dataset_name
                 );
                 Some((false, checkpoint))
@@ -372,7 +392,7 @@ async fn load_or_initialize_checkpoint(
         }
     } else {
         tracing::info!(
-            "No existing checkpoint found, starting from bootstrap: table_name={}",
+            "No existing checkpoint found for table {}, starting from bootstrap",
             dataset_name
         );
         get_latest_checkpoint(dynamodb).await.map(|cp| (true, cp))
@@ -396,27 +416,12 @@ async fn changes_stream_from_checkpoint(
     dynamodb: Arc<DynamoDBTableProvider>,
     dynamodb_sys: Arc<DynamoDBSys>,
     checkpoint: Checkpoint,
-    from_bootstrap: bool,
     acceptable_lag: Duration,
     dataset_name: TableReference,
 ) -> Option<ChangesStream> {
-    // If this is an initial checkpoint(from_bootstrap=true), commit it immediately.
-    // This checkpoint is inclusive and in case of failure stream will restart from the current position, not next.
-    if from_bootstrap {
-        tracing::debug!(
-            "Committing bootstrap checkpoint: table_name={}",
-            dataset_name
-        );
-        let committer = DynamoDBStreamCommitter::new(Arc::clone(&dynamodb_sys), checkpoint.clone());
-        if let Err(err) = committer.commit() {
-            tracing::error!("Failed to commit bootstrap checkpoint: {:?}", err);
-        }
-    }
-
     tracing::debug!(
-        "Starting DynamoDB stream from checkpoint: table_name={}, from_bootstrap={}, checkpoint={:?}",
+        "Starting DynamoDB stream from checkpoint: table_name={}, checkpoint={:?}",
         dataset_name,
-        from_bootstrap,
         checkpoint,
     );
 
@@ -428,14 +433,14 @@ async fn changes_stream_from_checkpoint(
                         let lag = watermark
                             .and_then(|v| SystemTime::now().duration_since(v).ok());
 
-                        // TODO: should be trace
-                        tracing::info!(
-                            "Processing DynamoDB Streams batch: table_name={}, watermark={}, lag={}, records={}",
+                        tracing::debug!(
+                            "Processing DynamoDB Streams batch: table_name={}, watermark={}, lag={}, shards={}, records={}",
                             dataset_name,
                             watermark
                                 .map_or_else(|| "-".to_string(), |w| humantime::format_rfc3339(w).to_string()),
                             lag
                                 .map_or_else(|| "-".to_string(), |l| humantime::format_duration(l).to_string()),
+                            checkpoint.shards.len(),
                             change_batch.record.num_rows(),
                         );
 
@@ -486,7 +491,7 @@ impl DynamoDBStreamCommitter {
 
 impl CommitChange for DynamoDBStreamCommitter {
     fn commit(&self) -> Result<(), CommitError> {
-        tracing::debug!("Committing DynamoDB checkpoint: {:?}", self.checkpoint);
+        tracing::trace!("Committing DynamoDB checkpoint: {:?}", self.checkpoint);
 
         let checkpoint_json = serde_json::to_string(&self.checkpoint).map_err(|e| {
             CommitError::UnableToCommitChange {


### PR DESCRIPTION
## 📝 Summary

1. Removed shards that returned no records from watermark calculation
2. Moved persisting bootstrap checkpoint into a separate step
4. Fixed a bug of not skipping shards that are ancestors of active shards during discovery
5. Set default size of channel buffer to 1
6. Made default polling interval 0 instead of 200 (waiting is done by channel blocking)
7. Fixed a bug of not ignoring ancestor after its child has been removed from active

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7880

## 🚨 Breaking Changes

## 📚 Docs

Will be done in https://github.com/spiceai/spiceai/issues/8033

