### PR TITLE
test-operator: fix metrics reporting

### DIFF
--- a/crates/test-framework/src/telemetry/mod.rs
+++ b/crates/test-framework/src/telemetry/mod.rs
@@ -50,8 +50,21 @@ pub struct Telemetry {
 }
 
 impl Telemetry {
+    /// Create telemetry with empty resource.
+    /// Use `set_resource()` later to set the actual resource before calling `emit()`.
     #[must_use]
-    pub fn new(resource: &Resource, api_key_name: &str) -> Self {
+    pub fn new(api_key_name: &str) -> Self {
+        let resource = Resource::builder_empty().build();
+        Self::new_with_resource(&resource, api_key_name)
+    }
+
+    /// Create telemetry with a resource provided upfront.
+    ///
+    /// Use this when the resource attributes are already available at creation time.
+    /// For most cases, prefer `new()` + `set_resource()` to ensure telemetry is initialized
+    /// before any metrics calls.
+    #[must_use]
+    pub fn new_with_resource(resource: &Resource, api_key_name: &str) -> Self {
         let reader = InitialReader::default();
 
         let provider = SdkMeterProvider::builder()
@@ -59,12 +72,10 @@ impl Telemetry {
             .with_reader(reader.clone())
             .build();
 
-        let setup = if METER_PROVIDER_ONCE.set(Arc::new(provider)).is_err() {
+        let setup = METER_PROVIDER_ONCE.set(Arc::new(provider)).is_ok();
+        if !setup {
             println!("Telemetry disabled");
-            false
-        } else {
-            true
-        };
+        }
 
         Self {
             reader,
@@ -75,6 +86,14 @@ impl Telemetry {
                 .as_deref()
                 .map(|key| SecretString::new(key.into())),
         }
+    }
+
+    /// Set the resource to be used when emitting metrics.
+    ///
+    /// Call this after collecting all the resource attributes (e.g., `spiced_version`, `commit_sha`)
+    /// but before calling `emit()`.
+    pub fn set_resource(&mut self, resource: Resource) {
+        self.resource = resource;
     }
 
     pub async fn emit(&self) -> Result<()> {
@@ -102,6 +121,11 @@ impl Telemetry {
             };
 
             self.reader.collect(&mut rm)?;
+
+            // Replace the resource from the provider with our potentially deferred resource.
+            // The provider was initialized with an empty resource, but we set the
+            // actual resource later via set_resource() once all attributes are known.
+            rm.resource = self.resource.clone();
 
             telemetry_exporter
                 .export(&mut rm)

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -173,7 +173,6 @@ impl TestStatus {
 }
 
 /// Builder for emitting append test metrics.
-#[derive(Default)]
 struct AppendTestMetrics {
     app_name: String,
     spiced_version: Option<String>,
@@ -183,14 +182,23 @@ struct AppendTestMetrics {
     branch_name: Option<String>,
     max_memory: Option<f64>,
     median_memory: Option<f64>,
+    telemetry: Telemetry,
 }
 
 impl AppendTestMetrics {
     fn new(app_name: impl Into<String>, query_set: impl Into<String>) -> Self {
+        let telemetry = Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY");
+
         Self {
             app_name: app_name.into(),
             query_set: query_set.into(),
-            ..Self::default()
+            telemetry,
+            spiced_version: None,
+            testoperator_commit_sha: None,
+            spiced_commit_sha: None,
+            branch_name: None,
+            max_memory: None,
+            median_memory: None,
         }
     }
 
@@ -221,7 +229,7 @@ impl AppendTestMetrics {
     }
 
     /// Emit metrics and telemetry for the test result.
-    async fn emit(self, test_status: TestStatus) -> anyhow::Result<()> {
+    async fn emit(mut self, test_status: TestStatus) -> anyhow::Result<()> {
         let resource = Resource::builder_empty()
             .with_attributes(vec![
                 KeyValue::new("service.name", "testoperator"),
@@ -249,6 +257,8 @@ impl AppendTestMetrics {
             ])
             .build();
 
+        self.telemetry.set_resource(resource);
+
         crate::metrics::STATUS.record(test_status.to_u64(), &[]);
 
         if let Some(max_mem) = self.max_memory {
@@ -258,8 +268,7 @@ impl AppendTestMetrics {
             crate::metrics::MEDIAN_MEMORY_USAGE.record(median_mem * 1024.0, &[]);
         }
 
-        let telemetry = Telemetry::new(&resource, "SPICEAI_BENCHMARK_METRICS_KEY");
-        telemetry.emit().await
+        self.telemetry.emit().await
     }
 }
 

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -81,6 +81,11 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         .await?;
 
     let ready_wait_duration = ready_wait_start.elapsed();
+
+    // Create telemetry early before any metrics calls (e.g., HealthMonitor)
+    // Resource will be set later with set_resource() before emit()
+    let mut telemetry = Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY");
+
     let health_monitor = HealthMonitor::spawn()?;
 
     // Start metrics scraper if enabled
@@ -138,7 +143,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         ])
         .build();
 
-    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
+    telemetry.set_resource(benchmark_resource);
 
     let mut failures = Vec::new();
     for query in &metrics.metrics {

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -111,6 +111,11 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+
+    // Create telemetry early before any metrics calls (e.g., HealthMonitor)
+    // Resource will be set later with set_resource() before emit()
+    let mut telemetry = Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY");
+
     let health_monitor = HealthMonitor::spawn()?;
 
     println!("Executing {eval} eval benchmark for model {model}. It might take several minutes...");
@@ -186,7 +191,7 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
         ])
         .build();
 
-    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
+    telemetry.set_resource(benchmark_resource);
 
     let attributes = vec![
         KeyValue::new("model_name", model.to_string()),

--- a/tools/testoperator/src/commands/search/mod.rs
+++ b/tools/testoperator/src/commands/search/mod.rs
@@ -71,6 +71,11 @@ pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+
+    // Create telemetry early before any metrics calls (e.g., HealthMonitor)
+    // Resource will be set later with set_resource() before emit()
+    let mut telemetry = Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY");
+
     let health_monitor = HealthMonitor::spawn()?;
 
     let index_finished_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
@@ -137,7 +142,7 @@ pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
         ])
         .build();
 
-    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
+    telemetry.set_resource(benchmark_resource);
 
     crate::metrics::TEST_DURATION
         .record(u64::try_from((finished_at - started_at).as_millis())?, &[]);


### PR DESCRIPTION
## 📝 Summary

Ensure benchmark metrics always initialize telemetry before first metric recording

1. Add a deferred `Telemetry::new()` + `set_resource` path so the meter provider is initialized before any `crate::metrics::*` calls (e.g., HealthMonitor metrics), preventing the `Telemetry disabled` issue.
1. Refactor `append/bench/search/evals` commands to create telemetry up front, capture resources later


Example test run: https://github.com/spiceai/spiceai/actions/runs/20012455223

## 🔗 Related

Fixes
 - https://github.com/spiceai/spiceai/issues/8434

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
