### PR TITLE
fix: Disable Cayenne HashJoin rewriter optimizer

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -294,11 +294,6 @@ impl DataFusionBuilder {
                 Arc::new(Box::new(track_bytes_processed)),
             )));
 
-        #[cfg(not(windows))]
-        {
-            state = state.with_physical_optimizer_rule(Arc::new(CayenneJoinRewriter::new()));
-        }
-
         let mut state = state.build();
 
         if let Err(e) = datafusion_functions_json::register_all(&mut state) {

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -29,8 +29,6 @@ use crate::config::ClusterConfig;
 use crate::{dataaccelerator::AcceleratorEngineRegistry, datafusion::SPICE_SCP_SCHEMA};
 use crate::{metrics::telemetry::track_bytes_processed, status};
 use cache::Caching;
-#[cfg(not(windows))]
-use cayenne::optimizer_rules::CayenneJoinRewriter;
 use datafusion::{
     catalog::{CatalogProvider, MemoryCatalogProvider},
     execution::{

--- a/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_append_cron_schedule_after_one.snap
+++ b/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_append_cron_schedule_after_one.snap
@@ -15,4 +15,5 @@ expression: pretty
 | 8  | Lisa Taylor  | 29  | San Diego    | 88    |
 | 9  | Chris Martin | 37  | Dallas       | 79    |
 | 10 | Anna Garcia  | 41  | San Jose     | 90    |
+| 11 | Spaceman     | 29  | LEO          | 100   |
 +----+--------------+-----+--------------+-------+

--- a/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_append_cron_schedule_after_one.snap
+++ b/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_append_cron_schedule_after_one.snap
@@ -15,5 +15,4 @@ expression: pretty
 | 8  | Lisa Taylor  | 29  | San Diego    | 88    |
 | 9  | Chris Martin | 37  | Dallas       | 79    |
 | 10 | Anna Garcia  | 41  | San Jose     | 90    |
-| 11 | Spaceman     | 29  | LEO          | 100   |
 +----+--------------+-----+--------------+-------+


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Removes the optimizer rule that replaces `HashJoin`s for Cayenne with `ExactLeftAccumulator`s, as they are not sufficiently stable.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
