### PR TITLE
Disable dataset health monitor for dynamic HTTP connector

### DIFF
--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -54,7 +54,7 @@ impl Databricks {
         let component_initialization =
             match DatabricksDataConnector::build_auth_credentials(&params.parameters) {
                 Ok(AuthCredentials::U2M(_)) => ComponentInitialization::OnTrigger,
-                _ => ComponentInitialization::OnStartup,
+                _ => ComponentInitialization::default(),
             };
 
         Arc::new(Self {

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -219,7 +219,7 @@ pub trait CatalogConnector: Send + Sync {
 
     /// Returns whether the catalog connector should be initialized on startup or on trigger.
     fn initialization(&self) -> ComponentInitialization {
-        ComponentInitialization::OnStartup
+        ComponentInitialization::default()
     }
 }
 

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -146,10 +146,16 @@ fn find_first_delimiter(from: &str) -> Option<(usize, usize)> {
 ///
 /// [`OnStartup`] indicates that the component should be initialized when runtime started.
 /// [`OnTrigger`] indicates that the component should be initialized when a specific trigger event occurs.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComponentInitialization {
-    OnStartup,
+    OnStartup(StartupOptions),
     OnTrigger,
+}
+
+impl Default for ComponentInitialization {
+    fn default() -> Self {
+        Self::OnStartup(StartupOptions::default())
+    }
 }
 
 impl ComponentInitialization {
@@ -157,6 +163,31 @@ impl ComponentInitialization {
     pub fn is_on_trigger(&self) -> bool {
         matches!(self, ComponentInitialization::OnTrigger)
     }
+
+    /// Returns whether the dataset health monitor should be enabled for this component.
+    #[must_use]
+    pub fn is_dataset_health_monitor_enabled(&self) -> bool {
+        match self {
+            ComponentInitialization::OnStartup(options) => {
+                options.dataset_health_monitor == DatasetHealthMonitor::Enabled
+            }
+            ComponentInitialization::OnTrigger => false,
+        }
+    }
+}
+
+/// Controls whether the dataset health monitor is enabled for a component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DatasetHealthMonitor {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+/// Options for components initialized on startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StartupOptions {
+    pub dataset_health_monitor: DatasetHealthMonitor,
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -118,7 +118,7 @@ impl Databricks {
         let auth_credentials = Self::build_auth_credentials(&params)?;
         let initialization = match auth_credentials {
             AuthCredentials::U2M(_) => ComponentInitialization::OnTrigger,
-            _ => ComponentInitialization::OnStartup,
+            _ => ComponentInitialization::default(),
         };
 
         match mode {
@@ -325,7 +325,7 @@ impl Databricks {
             read_provider,
 
             // Databricks spark connect doesn't support U2M, so no deferred loading
-            initialization: ComponentInitialization::OnStartup,
+            initialization: ComponentInitialization::default(),
         })
     }
 

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::component::ComponentInitialization;
 use crate::component::dataset::Dataset;
 use crate::component::dataset::acceleration::RefreshMode;
+use crate::component::{ComponentInitialization, DatasetHealthMonitor, StartupOptions};
 use crate::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, build_fragments,
 };
@@ -465,9 +465,11 @@ impl DataConnector for Https {
         // Non-structured HTTP endpoints (using HttpTableProvider) are dynamic datasets
         // that require filters to work properly, so skip health monitoring for them.
         if self.is_structured_format(dataset) {
-            ComponentInitialization::OnStartup
+            ComponentInitialization::default()
         } else {
-            ComponentInitialization::OnTrigger
+            ComponentInitialization::OnStartup(StartupOptions {
+                dataset_health_monitor: DatasetHealthMonitor::Disabled,
+            })
         }
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::ComponentInitialization;
 use crate::component::dataset::Dataset;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::dataconnector::listing::{
@@ -52,6 +53,47 @@ pub struct Https {
 impl std::fmt::Display for Https {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "https")
+    }
+}
+
+impl Https {
+    /// Determines if the dataset uses a structured file format (parquet, csv, etc.)
+    /// that would be handled by `ListingTableConnector` rather than `HttpTableProvider`.
+    fn is_structured_format(&self, dataset: &Dataset) -> bool {
+        let file_format = self
+            .params
+            .get("file_format")
+            .expose()
+            .ok()
+            .map_or_else(|| "auto".to_string(), str::to_ascii_lowercase);
+
+        // Check if explicitly configured as a structured format
+        if matches!(
+            file_format.as_str(),
+            "parquet" | "csv" | "tsv" | "arrow" | "avro"
+        ) {
+            return true;
+        }
+
+        // If file_format is "auto", try to detect from URL extension
+        if file_format == "auto"
+            && let Ok(url) = Url::parse(&dataset.from)
+            && let Some(mut path) = url.path_segments()
+            && let Some(last_segment) = path.next_back()
+        {
+            let extension = last_segment
+                .split('.')
+                .next_back()
+                .map(str::to_ascii_lowercase)
+                .unwrap_or_default();
+
+            return matches!(
+                extension.as_str(),
+                "parquet" | "csv" | "tsv" | "arrow" | "avro"
+            );
+        }
+
+        false
     }
 }
 
@@ -389,41 +431,9 @@ impl DataConnector for Https {
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
-        // Determine file format - default to "auto" if not specified
-        let file_format = self
-            .params
-            .get("file_format")
-            .expose()
-            .ok()
-            .map_or_else(|| "auto".to_string(), str::to_ascii_lowercase);
-
-        // For structured file formats (parquet, csv, arrow, avro), delegate to ListingTableConnector
-        // which properly handles file parsing with correct schemas
-        let mut is_structured_format = matches!(
-            file_format.as_str(),
-            "parquet" | "csv" | "tsv" | "arrow" | "avro"
-        );
-
-        // If file_format is "auto", try to detect from URL extension
-        if file_format == "auto"
-            && let Ok(url) = Url::parse(&dataset.from)
-            && let Some(mut path) = url.path_segments()
-            && let Some(last_segment) = path.next_back()
-        {
-            let extension = last_segment
-                .split('.')
-                .next_back()
-                .map(str::to_ascii_lowercase)
-                .unwrap_or_default();
-
-            is_structured_format = matches!(
-                extension.as_str(),
-                "parquet" | "csv" | "tsv" | "arrow" | "avro"
-            );
-        }
-
-        if is_structured_format {
-            // Use ListingTableConnector for file-based structured formats
+        if self.is_structured_format(dataset) {
+            // Use ListingTableConnector for file-based structured formats (parquet, csv, etc.)
+            // which properly handles file parsing with correct schemas
             let listing_connector =
                 HttpListingConnector::new(self.params.clone(), Handle::current());
             return listing_connector.read_provider(dataset).await;
@@ -449,6 +459,16 @@ impl DataConnector for Https {
 
         // For JSON API endpoints and other formats, use HttpTableProvider
         self.create_http_table_provider(dataset)
+    }
+
+    fn initialization_for_dataset(&self, dataset: &Dataset) -> ComponentInitialization {
+        // Non-structured HTTP endpoints (using HttpTableProvider) are dynamic datasets
+        // that require filters to work properly, so skip health monitoring for them.
+        if self.is_structured_format(dataset) {
+            ComponentInitialization::OnStartup
+        } else {
+            ComponentInitialization::OnTrigger
+        }
     }
 }
 

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -568,6 +568,15 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
     fn initialization(&self) -> ComponentInitialization {
         ComponentInitialization::OnStartup
     }
+
+    /// Returns whether the data connector should be initialized on startup or on trigger,
+    /// with dataset-specific logic.
+    ///
+    /// This method allows connectors to make initialization decisions based on the specific
+    /// dataset configuration. The default implementation delegates to `initialization()`.
+    fn initialization_for_dataset(&self, _dataset: &Dataset) -> ComponentInitialization {
+        self.initialization()
+    }
 }
 
 impl<T: DataConnector + Debug + 'static> MetricsProviderComponent for T {

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -566,7 +566,7 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
 
     /// Returns whether the data connector should be initialized on startup or on trigger.
     fn initialization(&self) -> ComponentInitialization {
-        ComponentInitialization::OnStartup
+        ComponentInitialization::default()
     }
 
     /// Returns whether the data connector should be initialized on startup or on trigger,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -380,7 +380,9 @@ impl Runtime {
                         self.df.results_cache_provider().is_some()
                     )
                 );
-                if !data_connector.initialization().is_on_trigger()
+                if !data_connector
+                    .initialization_for_dataset(&ds)
+                    .is_on_trigger()
                     && let Some(datasets_health_monitor) = &self.datasets_health_monitor
                     && let Err(err) = datasets_health_monitor.register_dataset(&ds).await
                 {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -380,9 +380,9 @@ impl Runtime {
                         self.df.results_cache_provider().is_some()
                     )
                 );
-                if !data_connector
+                if data_connector
                     .initialization_for_dataset(&ds)
-                    .is_on_trigger()
+                    .is_dataset_health_monitor_enabled()
                     && let Some(datasets_health_monitor) = &self.datasets_health_monitor
                     && let Err(err) = datasets_health_monitor.register_dataset(&ds).await
                 {


### PR DESCRIPTION
## 📝 Summary

By its nature, the HTTP connector when used with the dynamic `request_path` support doesn't make sense to test automatically for the automatic health check. If the root URL configured responds with a 404, then we get this log spam in Spice:

> 2025-12-08T02:18:50.806663Z  WARN runtime::datasets_health_monitor: Failed to verify the dataset time was available. Error during planning: HTTP client error (404): Not Found for url (http://localhost:7400/)

Skip the registration of the dynamic HTTP connector with the health monitor on startup.