### PR TITLE
Clear the in-flight revalidations cache after a revalidation has completed.

### DIFF
--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -622,7 +622,7 @@ func runRemoteSearchREPL(cmd *cobra.Command, rtcontext *context.RuntimeContext, 
 		// Check cache status header
 		cacheStatus := resp.Header.Get("Search-Results-Cache-Status")
 		cachedStr := ""
-		if cacheStatus == "HIT" {
+		if cacheStatus == "HIT" || cacheStatus == "STALE" {
 			cachedStr = " (cached)"
 		}
 

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -747,7 +747,7 @@ func runHTTPREPL(cmd *cobra.Command, ctx *rtcontext.RuntimeContext, httpEndpoint
 		// Check cache status header
 		cacheStatus := resp.Header.Get("Results-Cache-Status")
 		cachedStr := ""
-		if cacheStatus == "HIT" {
+		if cacheStatus == "HIT" || cacheStatus == "STALE" {
 			cachedStr = " (cached)"
 		}
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -578,7 +578,9 @@ pub async fn get_records(
         .metadata()
         .get("results-cache-status")
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|s| s.to_lowercase().starts_with("hit"));
+        .is_some_and(|s| {
+            s.to_lowercase().starts_with("hit") || s.to_lowercase().starts_with("stale")
+        });
 
     let stream = response.into_inner();
 

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -607,6 +607,8 @@ impl Query {
 
             if result == Some(()) {
                 // This task was the one that ran the revalidation
+                // Remove the single-flight guard so future stale hits can trigger another refresh
+                locks.invalidate(&cache_key_u64).await;
             } else {
                 // Another task is already revalidating this key
                 tracing::debug!(


### PR DESCRIPTION
## 📝 Summary

When the results cache was configured with an SWR ttl, i.e.:

```yaml
runtime:
  caching:
    sql_results:
      enabled: true
      item_ttl: 20s
      stale_while_revalidate_ttl: 10s
```

The first revalidation would succeed, but subsequent revalidations would not trigger.

The reason was because we are using a separate Moka cache for tracking the in-flight requests, but setting a TTL of 5 minutes on those entries without also clearing them after the revalidation completed. So this meant we were stuck in a state where Spice wouldn't trigger revalidations because it thought there was already an in-progress request, whereas that request has already completed but didn't clear the entry.

Also fixed the REPLs to show `(cached)` even for SWR entries.