### PR TITLE
Add a check to validate that results cache SWR and caching accelerator SWR are not both set.

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -278,7 +278,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid configuration detected for dataset {dataset_name}. Setting both `caching_stale_while_revalidate_ttl` on a dataset with a `refresh_mode: caching` acceleration and `stale_while_revalidate_ttl` on the runtime SQL results cache is unsupported. Remove one of those parameters and retry."
+        "Conflicting stale-while-revalidate settings for dataset {dataset_name}. When using `refresh_mode: caching`, set either acceleration `caching_stale_while_revalidate_ttl` or results cache `stale_while_revalidate_ttl`, but not both.
     ))]
     ConflictingStaleWhileRevalidateConfig { dataset_name: String },
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1163,15 +1163,14 @@ impl DataFusion {
             if acceleration_settings
                 .caching_stale_while_revalidate_ttl
                 .is_some()
+                && let Some(results_cache) = &self.caching.results
             {
-                if let Some(results_cache) = &self.caching.results {
-                    ensure!(
-                        results_cache.stale_while_revalidate_ttl().is_none(),
-                        ConflictingStaleWhileRevalidateConfigSnafu {
-                            dataset_name: dataset.name.to_string(),
-                        }
-                    );
-                }
+                ensure!(
+                    results_cache.stale_while_revalidate_ttl().is_none(),
+                    ConflictingStaleWhileRevalidateConfigSnafu {
+                        dataset_name: dataset.name.to_string(),
+                    }
+                );
             }
 
             accelerated_table_builder.caching_ttl(acceleration_settings.caching_ttl);

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -277,6 +277,11 @@ pub enum Error {
         connector: String,
     },
 
+    #[snafu(display(
+        "Invalid configuration detected for dataset {dataset_name}. Setting both `caching_stale_while_revalidate_ttl` on a dataset with a `refresh_mode: caching` acceleration and `stale_while_revalidate_ttl` on the runtime SQL results cache is unsupported. Remove one of those parameters and retry."
+    ))]
+    ConflictingStaleWhileRevalidateConfig { dataset_name: String },
+
     #[snafu(display("Unable to retrieve underlying table provider from federation"))]
     UnableToRetrieveTableFromFederation { table_name: String },
 
@@ -1154,6 +1159,21 @@ impl DataFusion {
 
         // For caching mode, set the TTL (max_age) and stale_while_revalidate from params
         if refresh_mode == RefreshMode::Caching {
+            // Check for conflicting stale_while_revalidate configuration
+            if acceleration_settings
+                .caching_stale_while_revalidate_ttl
+                .is_some()
+            {
+                if let Some(results_cache) = &self.caching.results {
+                    ensure!(
+                        results_cache.stale_while_revalidate_ttl().is_none(),
+                        ConflictingStaleWhileRevalidateConfigSnafu {
+                            dataset_name: dataset.name.to_string(),
+                        }
+                    );
+                }
+            }
+
             accelerated_table_builder.caching_ttl(acceleration_settings.caching_ttl);
             accelerated_table_builder.caching_stale_while_revalidate_ttl(
                 acceleration_settings.caching_stale_while_revalidate_ttl,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -278,7 +278,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Conflicting stale-while-revalidate settings for dataset {dataset_name}. When using `refresh_mode: caching`, set either acceleration `caching_stale_while_revalidate_ttl` or results cache `stale_while_revalidate_ttl`, but not both.
+        "Conflicting stale-while-revalidate settings for dataset {dataset_name}. When using `refresh_mode: caching`, set either acceleration `caching_stale_while_revalidate_ttl` or results cache `stale_while_revalidate_ttl`, but not both."
     ))]
     ConflictingStaleWhileRevalidateConfig { dataset_name: String },
 


### PR DESCRIPTION
## 📝 Summary

Shows the following error message when a configuration is detected that sets both results cache SWR and the caching accelerator SWR:

> Invalid configuration detected for dataset {dataset_name}. Setting both `caching_stale_while_revalidate_ttl` on a dataset with a `refresh_mode: caching` acceleration and `stale_while_revalidate_ttl` on the runtime SQL results cache is unsupported. Remove one of those parameters and retry.
