### PR TITLE
DuckDB agg pushdown: gate behind accelerator parameter

### DIFF
--- a/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
@@ -87,8 +87,8 @@ impl DuckDBAggregateLogicalPushdown {
             Some("duckdb")
         ) && schema_meta
             .get(SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY)
-            .map_or("disabled".to_string(), |p| p.to_lowercase())
-            == "enabled";
+            .map_or("disabled", |p| p.as_str())
+            .eq_ignore_ascii_case("enabled");
         Ok(should_optimize)
     }
 

--- a/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
@@ -12,6 +12,8 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, LazyLock};
 
 pub(crate) const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
+pub(crate) const SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY: &str =
+    "spice.optimizer.duckdb_aggregate_pushdown";
 
 // https://duckdb.org/docs/stable/sql/functions/aggregates
 // https://datafusion.apache.org/user-guide/sql/aggregate_functions.html
@@ -72,17 +74,24 @@ impl DuckDBAggregateLogicalPushdown {
         Arc::new(Self {})
     }
 
-    fn is_duckdb_provider(scan: &TableScan) -> Result<bool> {
+    fn should_optimize(scan: &TableScan) -> Result<bool> {
         let provider = source_as_provider(&scan.source)?;
 
-        Ok(matches!(
-            provider
-                .schema()
-                .metadata
+        let schema = provider.schema();
+        let schema_meta = schema.metadata();
+
+        let should_optimize = matches!(
+            schema_meta
                 .get(SPICE_ACCELERATOR_METADATA_KEY)
                 .map(String::as_str),
             Some("duckdb")
-        ))
+        ) && matches!(
+            schema_meta
+                .get(SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY)
+                .map(|p| p.parse::<bool>().unwrap_or(false)),
+            Some(true)
+        );
+        Ok(should_optimize)
     }
 
     /// If this aggregate's root scan is from a `DuckDB` accelerated source, with supported expressions,
@@ -108,7 +117,7 @@ impl DuckDBAggregateLogicalPushdown {
         let mut found = false;
 
         let _ = plan.apply(|p| match p {
-            LogicalPlan::TableScan(table_scan) if Self::is_duckdb_provider(table_scan)? => {
+            LogicalPlan::TableScan(table_scan) if Self::should_optimize(table_scan)? => {
                 found = true;
                 Ok(TreeNodeRecursion::Stop)
             }
@@ -262,7 +271,8 @@ impl UserDefinedLogicalNodeCore for DuckDBAggregatePushdownNode {
 mod tests {
     use crate::concrete;
     use crate::logical_plan::duckdb::aggregate_pushdown::{
-        DuckDBAggregateLogicalPushdown, DuckDBAggregatePushdownNode, SPICE_ACCELERATOR_METADATA_KEY,
+        DuckDBAggregateLogicalPushdown, DuckDBAggregatePushdownNode,
+        SPICE_ACCELERATOR_METADATA_KEY, SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY,
     };
     use datafusion::catalog::MemTable;
     use datafusion::common::Result;
@@ -298,6 +308,11 @@ mod tests {
         metadata.insert(
             SPICE_ACCELERATOR_METADATA_KEY.to_string(),
             "duckdb".to_string(),
+        );
+
+        metadata.insert(
+            SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
+            "true".to_string(),
         );
 
         let schema = df.schema().inner().as_ref().clone().with_metadata(metadata);

--- a/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
@@ -85,12 +85,11 @@ impl DuckDBAggregateLogicalPushdown {
                 .get(SPICE_ACCELERATOR_METADATA_KEY)
                 .map(String::as_str),
             Some("duckdb")
-        ) && matches!(
-            schema_meta
-                .get(SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY)
-                .map(|p| p.parse::<bool>().unwrap_or(false)),
-            Some(true)
-        );
+        ) && schema_meta
+            .get(SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY)
+            .map(|p| p.to_lowercase())
+            .unwrap_or("disabled".to_string())
+            == "enabled";
         Ok(should_optimize)
     }
 
@@ -312,7 +311,7 @@ mod tests {
 
         metadata.insert(
             SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
-            "true".to_string(),
+            "enabled".to_string(),
         );
 
         let schema = df.schema().inner().as_ref().clone().with_metadata(metadata);

--- a/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/logical_plan/duckdb/aggregate_pushdown.rs
@@ -87,8 +87,7 @@ impl DuckDBAggregateLogicalPushdown {
             Some("duckdb")
         ) && schema_meta
             .get(SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY)
-            .map(|p| p.to_lowercase())
-            .unwrap_or("disabled".to_string())
+            .map_or("disabled".to_string(), |p| p.to_lowercase())
             == "enabled";
         Ok(should_optimize)
     }

--- a/crates/google-genai/examples/function_calling.rs
+++ b/crates/google-genai/examples/function_calling.rs
@@ -33,7 +33,7 @@ fn get_current_weather(location: &str, unit: Option<&str>) -> String {
     )
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -69,6 +69,8 @@ pub(crate) mod settings;
 
 pub(crate) const DEFAULT_MIN_IDLE_CONNECTIONS: u32 = 10;
 pub(crate) const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
+pub(crate) const SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY: &str =
+    "spice.optimizer.duckdb_aggregate_pushdown";
 
 use super::upsert_dedup;
 
@@ -301,6 +303,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ),
     ParameterSpec::runtime("on_refresh_recompute_statistics"),
     ParameterSpec::runtime("partitioned_write_buffer"),
+    ParameterSpec::runtime("aggregate_pushdown_optimization"),
 ];
 
 #[async_trait]
@@ -548,6 +551,18 @@ pub(crate) async fn create_table_provider(
         SPICE_ACCELERATOR_METADATA_KEY.to_string(),
         "duckdb".to_string(),
     );
+
+    if cmd
+        .options
+        .get("aggregate_pushdown_optimization")
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(false)
+    {
+        schema_metadata.insert(
+            SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
+            "true".to_string(),
+        );
+    }
 
     let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
         write_provider,

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -555,7 +555,8 @@ pub(crate) async fn create_table_provider(
     let agg_pushdown_optimization = cmd
         .options
         .get("aggregate_pushdown_optimization")
-        .map_or("disabled".to_string(), |v| v.to_lowercase());
+        .map_or("disabled", |v| v.as_str())
+        .to_lowercase();
 
     schema_metadata.insert(
         SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -555,12 +555,11 @@ pub(crate) async fn create_table_provider(
     let agg_pushdown_optimization = cmd
         .options
         .get("aggregate_pushdown_optimization")
-        .map(|v| v.to_lowercase())
-        .unwrap_or("disabled".to_string());
+        .map_or("disabled".to_string(), |v| v.to_lowercase());
 
     schema_metadata.insert(
         SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
-        agg_pushdown_optimization.to_string(),
+        agg_pushdown_optimization,
     );
 
     let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -552,17 +552,16 @@ pub(crate) async fn create_table_provider(
         "duckdb".to_string(),
     );
 
-    if cmd
+    let agg_pushdown_optimization = cmd
         .options
         .get("aggregate_pushdown_optimization")
-        .and_then(|v| v.parse::<bool>().ok())
-        .unwrap_or(false)
-    {
-        schema_metadata.insert(
-            SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
-            "true".to_string(),
-        );
-    }
+        .map(|v| v.to_lowercase())
+        .unwrap_or("disabled".to_string());
+
+    schema_metadata.insert(
+        SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY.to_string(),
+        agg_pushdown_optimization.to_string(),
+    );
 
     let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
         write_provider,


### PR DESCRIPTION
## 📝 Summary

To enable DuckDB agg pushdown, you must now specify `aggregate_pushdown_optimization: enabled` as shown below:
```yaml
version: v1
kind: Spicepod
name: my_spicepod

datasets:
  - from: file://test_data.parquet
    name: tdata
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
      params:
        query_federation: disabled
        aggregate_pushdown_optimization: enabled # disabled
```

## 🚨 Breaking Changes

n/a, not released yet

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
