### PR TITLE
fix: Pin CUDA build actions to commits

### DIFF
--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -60,7 +60,7 @@ runs:
 
     - name: Install CUDA Toolkit (Linux)
       if: ${{ inputs.target_os != 'windows'}}
-      uses: Jimver/cuda-toolkit@v0.2.21
+      uses: Jimver/cuda-toolkit@8022558310ea543e35132143092835585f60e628 # v0.2.21
       id: cuda-toolkit-linux
       with:
         cuda: ${{ inputs.cuda-version }}
@@ -71,7 +71,7 @@ runs:
 
     - name: Install CUDA Toolkit (Windows)
       if: ${{ inputs.target_os == 'windows'}}
-      uses: Jimver/cuda-toolkit@v0.2.21
+      uses: Jimver/cuda-toolkit@8022558310ea543e35132143092835585f60e628 # v0.2.21
       id: cuda-toolkit-windows
       with:
         cuda: ${{ inputs.cuda-version }}
@@ -94,14 +94,14 @@ runs:
 
     - name: Upload artifact
       if: matrix.target.target_os != 'windows'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}
         path: spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz
 
     - name: Upload artifact
       if: matrix.target.target_os == 'windows'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}
         path: spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Pins the actions used in the CUDA build to specific commits as required by security settings.
