### PR TITLE
Use `Datafusion::Plan` over `Datafusion::Internal` for user-facing search errors.

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -116,7 +116,7 @@ impl VectorSearchTableFuncArgs {
         match (self.column.as_deref(), cfg) {
             (Some(col), Some(cfg)) => Ok((col.to_string(), cfg)),
             (Some(col), None) => Err(DataFusionError::Internal(format!(
-                "User function 'vector_search' is called on table '{}' that does not have a embedding index on '{col}' column. Index is on column(s): {}.",
+                "User function 'vector_search' is called on table '{}' that does not have a embedding index on '{col}' column. Index is on column(s): {}",
                 self.tbl,
                 embedded_columns
                     .keys()
@@ -360,7 +360,7 @@ impl VectorSearchTableFunc {
         } else {
             if vector_indexes.len() > 1 {
                 return Err(DataFusionError::Internal(format!(
-                    "User function 'vector_search' is called on table '{}' that has {} vector search columns. Must call 'vector_search' with column parameter, e.g. `vector_search(\"my table\", 'my query', my_embedded_col)`.",
+                    "User function 'vector_search' is called on table '{}' that has {} vector search columns. Must call 'vector_search' with column parameter, e.g. `vector_search(\"my table\", 'my query', my_embedded_col)`",
                     args.tbl,
                     vector_indexes.len()
                 )));

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -115,7 +115,7 @@ impl VectorSearchTableFuncArgs {
             .cloned();
         match (self.column.as_deref(), cfg) {
             (Some(col), Some(cfg)) => Ok((col.to_string(), cfg)),
-            (Some(col), None) => Err(DataFusionError::Internal(format!(
+            (Some(col), None) => Err(DataFusionError::Plan(format!(
                 "User function 'vector_search' is called on table '{}' that does not have a embedding index on '{col}' column. Index is on column(s): {}",
                 self.tbl,
                 embedded_columns
@@ -359,7 +359,7 @@ impl VectorSearchTableFunc {
                 .find(|idx| *idx.search_column() == *col)
         } else {
             if vector_indexes.len() > 1 {
-                return Err(DataFusionError::Internal(format!(
+                return Err(DataFusionError::Plan(format!(
                     "User function 'vector_search' is called on table '{}' that has {} vector search columns. Must call 'vector_search' with column parameter, e.g. `vector_search(\"my table\", 'my query', my_embedded_col)`",
                     args.tbl,
                     vector_indexes.len()

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -78,7 +78,7 @@ impl TextSearchTableFuncArgs {
         let TextSearchTableFuncArgs { column, tbl, .. } = &self;
         let col: String = if let Some(col) = column {
             if !search_fields.contains(col) {
-                return Err(DataFusionError::Internal(format!(
+                return Err(DataFusionError::Plan(format!(
                     "User function 'text_search' is called on table '{tbl}' that does not have a full text search index on '{col}' column. Index is on column(s): {}",
                     search_fields.join(", ")
                 )));
@@ -90,13 +90,13 @@ impl TextSearchTableFuncArgs {
             match (fields.next(), fields.next()) {
                 (Some(field), None) => field.clone(),
                 (Some(_), Some(_)) => {
-                    return Err(DataFusionError::Internal(format!(
+                    return Err(DataFusionError::Plan(format!(
                         "User function 'text_search' is called on table '{tbl}' that has {} full text search columns. Must call 'text_search' with column parameter, e.g. `text_search(\"my table\", 'my query', my_search_col)`",
                         search_fields.len()
                     )));
                 }
                 _ => {
-                    return Err(DataFusionError::Internal(format!(
+                    return Err(DataFusionError::Plan(format!(
                         "User function 'text_search' is called on table '{tbl}' that has no associated full text search index"
                     )));
                 }

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -79,7 +79,7 @@ impl TextSearchTableFuncArgs {
         let col: String = if let Some(col) = column {
             if !search_fields.contains(col) {
                 return Err(DataFusionError::Internal(format!(
-                    "User function 'text_search' is called on table '{tbl}' that does not have a full text search index on '{col}' column. Index is on column(s): {}.",
+                    "User function 'text_search' is called on table '{tbl}' that does not have a full text search index on '{col}' column. Index is on column(s): {}",
                     search_fields.join(", ")
                 )));
             }
@@ -91,13 +91,13 @@ impl TextSearchTableFuncArgs {
                 (Some(field), None) => field.clone(),
                 (Some(_), Some(_)) => {
                     return Err(DataFusionError::Internal(format!(
-                        "User function 'text_search' is called on table '{tbl}' that has {} full text search columns. Must call 'text_search' with column parameter, e.g. `text_search(\"my table\", 'my query', my_search_col)`.",
+                        "User function 'text_search' is called on table '{tbl}' that has {} full text search columns. Must call 'text_search' with column parameter, e.g. `text_search(\"my table\", 'my query', my_search_col)`",
                         search_fields.len()
                     )));
                 }
                 _ => {
                     return Err(DataFusionError::Internal(format!(
-                        "User function 'text_search' is called on table '{tbl}' that has no associated full text search index."
+                        "User function 'text_search' is called on table '{tbl}' that has no associated full text search index"
                     )));
                 }
             }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_wrong_column_error_response.snap
@@ -2,5 +2,4 @@
 source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'vector_search' is called on table 'spice.public.qs' that does not have a embedding index on 'answer' column. Index is on column(s): question..
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'vector_search' is called on table 'spice.public.qs' that does not have a embedding index on 'answer' column. Index is on column(s): question

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
@@ -3,4 +3,4 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer.
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
@@ -3,5 +3,5 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer..
+HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search_wrong_column_error_response.snap
@@ -3,5 +3,4 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that does not have a full text search index on 'question' column. Index is on column(s): answer.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search_wrong_column_error_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
+snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'vector_search' is called on table 'spice.public.qs' that does not have a embedding index on 'answer' column. Index is on column(s): question..
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'vector_search' is called on table 'spice.public.qs' that does not have a embedding index on 'answer' column. Index is on column(s): question

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
@@ -3,5 +3,4 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
@@ -3,5 +3,5 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`..
+HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error_without_column_error_response.snap
@@ -3,4 +3,4 @@ source: crates/runtime/tests/models/search.rs
 expression: err.to_string()
 snapshot_kind: text
 ---
-HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`.
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: User function 'text_search' is called on table 'spice.public.qs' that has 2 full text search columns. Must call 'text_search' with column parameter, e.g. `text_search("my table", 'my query', my_search_col)`


### PR DESCRIPTION
## 📝 Summary
- Prefer `Datafusion::Plan` over `Datafusion::Internal` when issue is user facing.
- For using facing messages using `Datafusion::Internal`, the inner message should not have a full stop.
```rust
DataFusionError::Internal(ref desc) => Cow::Owned(format!(
    "{desc}.\nThis issue was likely caused by a bug in DataFusion's code. \
    Please help us to resolve this by filing a bug report in our issue tracker: \
    https://github.com/apache/datafusion/issues"
)),
```
[source](https://github.com/apache/datafusion/blob/83736efc4ad8865019b0809ac9d87e63eabbe0a8/datafusion/common/src/error.rs#L575-L579).
