### PR TITLE
warning if column is defined in spicepod but is non-existant

### DIFF
--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -54,6 +54,16 @@ pub async fn wrap_table_as_index(
     inner_table_provider: Arc<dyn TableProvider>,
     vector_store: &VectorStore,
 ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    let schema = inner_table_provider.schema();
+    for c in columns {
+        if schema.column_with_name(&c.name).is_none() {
+            tracing::warn!(
+                "The table {} is configured with column {} in the spicepod, but the column is not in the table's schema",
+                tbl.to_string(),
+                c.name
+            );
+        }
+    }
     #[cfg(not(feature = "s3_vectors"))]
     let _ = (
         ctx,

--- a/crates/runtime/src/search/full_text/table.rs
+++ b/crates/runtime/src/search/full_text/table.rs
@@ -36,6 +36,16 @@ pub(crate) fn add_full_text_search_to_table(
     columns: &[Column],
     tbl: &TableReference,
 ) -> Result<IndexedTableProvider, Box<dyn std::error::Error + Send + Sync>> {
+    let schema = inner_table_provider.schema();
+    for c in columns {
+        if schema.column_with_name(&c.name).is_none() {
+            tracing::warn!(
+                "The table {} is configured with column {} in the spicepod, but the column is not in the table's schema",
+                tbl.to_string(),
+                c.name
+            );
+        }
+    }
     let Some(FullTextSearchDatasetConfig {
         index_store,
         index_path,


### PR DESCRIPTION
## 📝 Summary
- Warn if `spicepod.yaml` contains dataset/view with `.column[].name` not in the underlying `TableProvider`.

Resolves #8341 