### PR TITLE
Align `make lint-rust-fix` with `make lint-rust`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,19 +112,36 @@ lint-rust:
 lint-rust-fix:
 	cargo fmt --all
 	## All except metal, cuda
-	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,cluster --workspace -- \
+	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --lib --bins --fix --allow-dirty --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,cluster --workspace -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
 		-Dclippy::expect_used \
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
+		-Aclippy::large_futures \
 		-Dclippy::equatable_if_let \
 		-Dclippy::needless_collect \
 		-Dclippy::redundant_clone \
 		-Dclippy::todo \
 		-Dclippy::assertions_on_result_states \
 		-Dclippy::allow_attributes
+	cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --tests --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,cluster --workspace -- \
+		-Dwarnings \
+		-Dclippy::pedantic \
+		-Dclippy::unwrap_used \
+		-Aclippy::expect_used \
+		-Dclippy::clone_on_ref_ptr \
+		-Aclippy::module_name_repetitions \
+		-Aclippy::large_futures \
+		-Dclippy::equatable_if_let \
+		-Dclippy::needless_collect \
+		-Dclippy::redundant_clone \
+		-Dclippy::todo \
+		-Dclippy::assertions_on_result_states \
+		-Dclippy::allow_attributes \
+		-Aunfulfilled_lint_expectations
+
 
 lint-go:
 	go vet ./...


### PR DESCRIPTION
## 📝 Summary
 - Make the fix command the same config as the CI checks.
 - Also reduces warning noise/bloat locally when running `make lint-rust-fix`.