### PR TITLE
fix: Remove unused Cayenne parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,19 +3014,8 @@ dependencies = [
  "util",
  "uuid 1.18.1",
  "vortex",
- "vortex-alp",
- "vortex-array",
- "vortex-bytebool",
  "vortex-datafusion",
- "vortex-datetime-parts",
- "vortex-decimal-byte-parts",
- "vortex-fastlanes",
- "vortex-fsst",
- "vortex-runend",
- "vortex-sequence",
  "vortex-session",
- "vortex-sparse",
- "vortex-zigzag",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,20 +289,10 @@ util = { path = "crates/util" }
 uuid = "1"
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
 vortex = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-alp = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 vortex-array = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-bytebool = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-datetime-parts = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-decimal-byte-parts = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-fastlanes = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-fsst = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-runend = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-sequence = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 vortex-session = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-sparse = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
-vortex-zigzag = { git = "https://github.com/spiceai/vortex", rev = "c279ace2ebe54eee109c760930621979cff6372f" }
 x509-certificate = "0.25.0"
 # TODO: Switch to official crate once spice-rs is released
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "0ca5a48dae189bc4297350cba7265e9c6036188b" }

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -35,22 +35,11 @@ snafu = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 tracing = { workspace = true }
 turso = { workspace = true, optional = true }
+util = { path = "../util" }
 uuid = { workspace = true, features = ["v7"] }
 vortex = { workspace = true }
-vortex-alp = { workspace = true }
-vortex-array = { workspace = true }
-vortex-bytebool = { workspace = true }
 vortex-datafusion = { workspace = true }
-vortex-datetime-parts = { workspace = true }
-vortex-decimal-byte-parts = { workspace = true }
-vortex-fastlanes = { workspace = true }
-vortex-fsst = { workspace = true }
-vortex-runend = { workspace = true }
-vortex-sequence = { workspace = true }
 vortex-session = { workspace = true }
-vortex-sparse = { workspace = true }
-vortex-zigzag = { workspace = true }
-util = { path = "../util" }
 # Force aegis to use pure-rust implementation for ARM64 builds to avoid C compilation issues
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
 aegis = { version = "0.9.3", default-features = false, features = [

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -128,7 +128,6 @@ pub struct PartitionStats {
 
 /// Configuration for Vortex encodings to optimize compression and performance.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[expect(clippy::struct_excessive_bools)]
 pub struct VortexConfig {
     /// Footer cache size in MB
     pub footer_cache_mb: usize,

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -130,22 +130,6 @@ pub struct PartitionStats {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct VortexConfig {
-    /// Enable ALP (Adaptive Lossless Precision) encoding for numeric columns
-    pub enable_alp: bool,
-    /// Enable FSST (Fast String Suffix Trie) encoding for string columns
-    pub enable_fsst: bool,
-    /// Enable `BitPacking` encoding for integer columns
-    pub enable_bitpacking: bool,
-    /// Enable Delta encoding for sequential data
-    pub enable_delta: bool,
-    /// Enable Run-Length Encoding (RLE)
-    pub enable_rle: bool,
-    /// Enable Dictionary encoding for low-cardinality columns
-    pub enable_dict: bool,
-    /// Enable Frame-of-Reference (FOR) encoding
-    pub enable_for: bool,
-    /// Enable `ZigZag` encoding for signed integers
-    pub enable_zigzag: bool,
     /// Footer cache size in MB
     pub footer_cache_mb: usize,
     /// Segment cache size in MB
@@ -162,23 +146,6 @@ pub struct VortexConfig {
 impl Default for VortexConfig {
     fn default() -> Self {
         Self {
-            // Enable encodings optimized for read performance
-            // ALP: Excellent for floating-point queries (SIMD-friendly decompression)
-            enable_alp: true,
-            // FSST: Fast string decompression, good for string-heavy workloads
-            enable_fsst: true,
-            // BitPacking: Very fast SIMD decompression for integers
-            enable_bitpacking: true,
-            // Delta: Disable for reads - requires sequential decompression
-            enable_delta: false,
-            // RLE: Enable for low-cardinality/repeated values (very fast scans)
-            enable_rle: true,
-            // Dictionary: Enable for low-cardinality columns (fast lookups)
-            enable_dict: true,
-            // FOR: Fast integer decompression, SIMD-friendly
-            enable_for: true,
-            // ZigZag: Minimal overhead, keep enabled for signed integers
-            enable_zigzag: true,
             // Larger caches improve read performance
             footer_cache_mb: 128,
             segment_cache_mb: 256,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -48,7 +48,9 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::{Arc, RwLock};
 use tokio::task;
+use vortex::VortexSessionDefault;
 use vortex_datafusion::VortexFormat;
+use vortex_session::VortexSession;
 
 /// Cayenne table provider that reads from Vortex virtual files.
 ///
@@ -132,58 +134,6 @@ impl CayenneTableProvider {
         url_str
     }
 
-    /// Create a configured `VortexSession` with selected encodings for hardware acceleration.
-    ///
-    /// This method registers only the encodings that are enabled in the configuration,
-    /// allowing fine-grained control over compression vs performance tradeoffs.
-    fn create_vortex_session(
-        config: &crate::metadata::VortexConfig,
-    ) -> vortex_session::VortexSession {
-        use vortex::VortexSessionDefault;
-        use vortex_session::VortexSession;
-
-        // Use default session which registers all encodings
-        // Note: If all encodings are enabled, this is optimal. Otherwise, the overhead
-        // of unused encodings is minimal compared to the complexity of custom registration.
-        // Future enhancement: Vortex may provide API for selective encoding registration.
-        let session = VortexSession::default();
-
-        // Log which encodings are configured to be used
-        let mut enabled = Vec::new();
-        if config.enable_alp {
-            enabled.push("ALP (SIMD numeric compression)");
-        }
-        if config.enable_fsst {
-            enabled.push("FSST (SIMD string compression)");
-        }
-        if config.enable_bitpacking {
-            enabled.push("BitPacking (SIMD integer compression)");
-        }
-        if config.enable_delta {
-            enabled.push("Delta");
-        }
-        if config.enable_rle {
-            enabled.push("RLE");
-        }
-        if config.enable_dict {
-            enabled.push("Dictionary");
-        }
-        if config.enable_for {
-            enabled.push("FOR");
-        }
-        if config.enable_zigzag {
-            enabled.push("ZigZag");
-        }
-
-        if enabled.is_empty() {
-            tracing::warn!("All Cayenne Vortex encodings disabled - using canonical encoding only");
-        } else {
-            tracing::info!("Cayenne Vortex encodings enabled: {}", enabled.join(", "));
-        }
-
-        session
-    }
-
     /// Create a new `ListingTable` for a snapshot directory.
     ///
     /// # Arguments
@@ -208,7 +158,7 @@ impl CayenneTableProvider {
             })?;
 
         // Create a configured Vortex session with selected encodings
-        let vortex_session = Self::create_vortex_session(vortex_config);
+        let vortex_session = VortexSession::default();
 
         // Configure VortexFormat with hardware-optimized settings
         let vortex_opts = vortex_datafusion::VortexOptions {

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use super::{AccelerationSource, DataAccelerator};
-use crate::component::dataset::acceleration::{Engine, Mode, RefreshMode};
+use crate::component::dataset::acceleration::{Acceleration, Engine, Mode, RefreshMode};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
@@ -226,6 +226,14 @@ impl Default for CayenneAccelerator {
     }
 }
 
+fn parse_usize(acceleration: &Acceleration, key: &str, default: usize) -> usize {
+    acceleration
+        .params
+        .get(key)
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
 impl CayenneAccelerator {
     #[must_use]
     pub fn new() -> Self {
@@ -303,40 +311,21 @@ impl CayenneAccelerator {
         let mut config = cayenne::metadata::VortexConfig::default();
 
         if let Some(acceleration) = source.acceleration() {
-            // Helper to get enabled/disabled parameter with default
-            let get_enabled = |key: &str, default: bool| -> bool {
-                acceleration
-                    .params
-                    .get(key)
-                    .map_or(default, |v| util::parse_enabled(v))
-            };
-
-            // Helper to parse usize parameter
-            let parse_usize = |key: &str, default: usize| -> usize {
-                acceleration
-                    .params
-                    .get(key)
-                    .and_then(|v| v.parse::<usize>().ok())
-                    .unwrap_or(default)
-            };
-
-            // Parse encoding options - use VortexConfig defaults if not specified
-            config.enable_alp = get_enabled("cayenne_alp", config.enable_alp);
-            config.enable_fsst = get_enabled("cayenne_fsst", config.enable_fsst);
-            config.enable_bitpacking = get_enabled("cayenne_bitpacking", config.enable_bitpacking);
-            config.enable_delta = get_enabled("cayenne_delta", config.enable_delta);
-            config.enable_rle = get_enabled("cayenne_rle", config.enable_rle);
-            config.enable_dict = get_enabled("cayenne_dict", config.enable_dict);
-            config.enable_for = get_enabled("cayenne_for", config.enable_for);
-            config.enable_zigzag = get_enabled("cayenne_zigzag", config.enable_zigzag);
-
             // Parse cache options - use VortexConfig defaults if not specified
-            config.footer_cache_mb = parse_usize("cayenne_footer_cache_mb", config.footer_cache_mb);
-            config.segment_cache_mb =
-                parse_usize("cayenne_segment_cache_mb", config.segment_cache_mb);
+            config.footer_cache_mb = parse_usize(
+                acceleration,
+                "cayenne_footer_cache_mb",
+                config.footer_cache_mb,
+            );
+            config.segment_cache_mb = parse_usize(
+                acceleration,
+                "cayenne_segment_cache_mb",
+                config.segment_cache_mb,
+            );
 
             // Parse file size options
             config.target_vortex_file_size_mb = parse_usize(
+                acceleration,
                 "cayenne_target_file_size_mb",
                 config.target_vortex_file_size_mb,
             );
@@ -351,15 +340,7 @@ impl CayenneAccelerator {
             }
 
             tracing::debug!(
-                "Cayenne Vortex config: ALP={}, FSST={}, BitPacking={}, Delta={}, RLE={}, Dict={}, FOR={}, ZigZag={}, footer_cache={}MB, segment_cache={}MB, target_file_size={}MB, sort_columns={:?}",
-                config.enable_alp,
-                config.enable_fsst,
-                config.enable_bitpacking,
-                config.enable_delta,
-                config.enable_rle,
-                config.enable_dict,
-                config.enable_for,
-                config.enable_zigzag,
+                "Cayenne Vortex config: footer_cache={}MB, segment_cache={}MB, target_file_size={}MB, sort_columns={:?}",
                 config.footer_cache_mb,
                 config.segment_cache_mb,
                 config.target_vortex_file_size_mb,
@@ -507,37 +488,12 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("unsupported_type_action")
         .description("How to handle data types not natively supported by Cayenne (internally using Vortex format) (Time32, Time64, Duration, Interval, Map, etc.). Options: 'string' (convert schema to Utf8, default - requires data source to provide string data), 'error' (fail on unsupported types), 'warn' (include in schema, may fail on insert), 'ignore' (skip unsupported fields)")
         .default("string"),
-    // Vortex encoding configuration for hardware acceleration
-    ParameterSpec::component("cayenne_alp")
-        .description("Enable Adaptive Lossless Precision (ALP) encoding for numeric columns. Provides 5-10x compression with SIMD decompression on ARM64 (NEON) and x86_64 (AVX2/AVX-512). Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_fsst")
-        .description("Enable Fast String Suffix Trie (FSST) encoding for string columns. Provides 2-5x compression with SIMD acceleration. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_bitpacking")
-        .description("Enable BitPacking encoding for integer columns. Provides SIMD-optimized integer unpacking, especially effective on ARM64 with NEON. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_delta")
-        .description("Enable Delta encoding for sorted/sequential numeric data. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_rle")
-        .description("Enable Run-Length Encoding (RLE) for data with repeated values. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_dict")
-        .description("Enable Dictionary encoding for low-cardinality columns. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_for")
-        .description("Enable Frame-of-Reference (FOR) encoding for integer columns with small ranges. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_zigzag")
-        .description("Enable ZigZag encoding for signed integers. Options: 'enabled' (default), 'disabled'")
-        .default("enabled"),
-    ParameterSpec::component("cayenne_footer_cache_mb")
+    ParameterSpec::component("footer_cache_mb")
         .description("Size of the in-memory Vortex footer cache in MB. Larger values improve query performance for repeated scans. Default: 64 MB")
         .default("64"),
-    ParameterSpec::component("cayenne_segment_cache_mb")
-        .description("Size of the in-memory Vortex segment cache in MB. Set > 0 to cache decompressed data segments. Default: 0 (disabled)")
-        .default("0"),
+    ParameterSpec::component("segment_cache_mb")
+        .description("Size of the in-memory Vortex segment cache in MB. Set > 0 to cache decompressed data segments. Default: 32 MB")
+        .default("32"),
     ParameterSpec::component("sort_columns")
         .description("Comma-separated list of columns to sort data by during inserts (e.g., 'timestamp,user_id')."),
 ];

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -489,11 +489,11 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("How to handle data types not natively supported by Cayenne (internally using Vortex format) (Time32, Time64, Duration, Interval, Map, etc.). Options: 'string' (convert schema to Utf8, default - requires data source to provide string data), 'error' (fail on unsupported types), 'warn' (include in schema, may fail on insert), 'ignore' (skip unsupported fields)")
         .default("string"),
     ParameterSpec::component("footer_cache_mb")
-        .description("Size of the in-memory Vortex footer cache in MB. Larger values improve query performance for repeated scans. Default: 64 MB")
-        .default("64"),
+        .description("Size of the in-memory Vortex footer cache in MB. Larger values improve query performance for repeated scans. Default: 128 MB")
+        .default("128"),
     ParameterSpec::component("segment_cache_mb")
-        .description("Size of the in-memory Vortex segment cache in MB. Set > 0 to cache decompressed data segments. Default: 32 MB")
-        .default("32"),
+        .description("Size of the in-memory Vortex segment cache in MB. Set > 0 to cache decompressed data segments. Default: 256 MB")
+        .default("256"),
     ParameterSpec::component("sort_columns")
         .description("Comma-separated list of columns to sort data by during inserts (e.g., 'timestamp,user_id')."),
 ];

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -630,11 +630,11 @@ pub async fn get_data(
         df = df.filter(filter).map_err(find_datafusion_root)?;
     }
 
-    if tracing::enabled!(Level::DEBUG)
+    if tracing::enabled!(Level::TRACE)
         && let Ok(explained) = df.clone().explain(false, false)
         && let Ok(explained) = explained.to_string().await
     {
-        tracing::debug!("Data refresh plan for {}:\n{}", table_name, explained);
+        tracing::trace!("Data refresh plan for {}:\n{}", table_name, explained);
     }
 
     let sql = Unparser::default()


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Removes Cayenne parameters that have no actual effect.
* Removes vortex dependencies that are unused.
* Aligns the footer and segment cache defaults with the actual defaults from `VortexConfig`.
* Makes the data accelerator refresh plan output a `Level::TRACE` output instead of `Level::DEBUG`, as it is quite verbose.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #8039
