### PR TITLE
CI: Fix E2E models dispatch

### DIFF
--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Resolve run metadata
         id: resolve
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          INPUT_RUN_ID: ${{ inputs.run_id }}
         with:
           script: |
             let run;


### PR DESCRIPTION
If kicked off from workflow dispatch, it can't resolve the run_id without this change. I was able to kick off this job:
https://github.com/spiceai/spiceai/actions/runs/20066035195