### PR TITLE
fix: Avoid double hashing cache key

### DIFF
--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -196,15 +196,17 @@ mod tests {
     #[test]
     fn test_passthrough_hasher() {
         // validate that `write_u64` and `write` produce the same hash result from a u64 input
-        let mut hasher1 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
-        hasher1.write_u64(42);
-        let hash1 = hasher1.finish();
+        let hash1 = PassthroughHashBuilder::new(RandomState::default()).hash_one(42);
         assert_eq!(hash1, 42);
 
-        let mut hasher2 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
-        42.hash(&mut hasher2);
-        let hash2 = hasher2.finish();
+        // explicitly allow this rule, because we're validating that the builtin u64 hash -> .write_u64() path works as expected
+        #[expect(clippy::manual_hash_one)]
+        {
+            let mut hasher2 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
+            42.hash(&mut hasher2);
+            let hash2 = hasher2.finish();
 
-        assert_eq!(hash1, hash2);
+            assert_eq!(hash1, hash2);
+        }
     }
 }

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -136,37 +136,49 @@ impl RawCacheKey {
     }
 }
 
-/// A hasher that simply passes through u64 values as-is.
+/// A hash builder that builds a hasher which simply passes through u64 values as-is.
 /// This is useful to reduce hashing overhead when we already have a u64 hash key, as returned from `CacheKey::as_raw_key()`.
-#[derive(Copy, Clone, Default)]
-pub(crate) struct PassthroughHashBuilder;
-impl BuildHasher for PassthroughHashBuilder {
-    type Hasher = PassthroughHasher;
+#[derive(Copy, Clone)]
+pub(crate) struct PassthroughHashBuilder<T: BuildHasher + Clone + Send + Sync + 'static> {
+    hasher: T,
+}
 
-    fn build_hasher(&self) -> Self::Hasher {
-        PassthroughHasher { hash: 0 }
+impl<T: BuildHasher + Clone + Send + Sync + 'static> PassthroughHashBuilder<T> {
+    pub(crate) fn new(hasher: T) -> Self {
+        Self { hasher }
     }
 }
 
-pub(crate) struct PassthroughHasher {
-    hash: u64,
+impl<T: BuildHasher + Clone + Send + Sync + 'static> BuildHasher for PassthroughHashBuilder<T> {
+    type Hasher = PassthroughHasher<T>;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        PassthroughHasher {
+            hash: 0,
+            hasher: self.hasher.clone(),
+        }
+    }
 }
 
-impl Hasher for PassthroughHasher {
+pub(crate) struct PassthroughHasher<T: BuildHasher + Clone + Send + Sync + 'static> {
+    hash: u64,
+    hasher: T,
+}
+
+impl<T: BuildHasher + Clone + Send + Sync + 'static> Hasher for PassthroughHasher<T> {
     fn finish(&self) -> u64 {
         self.hash
     }
 
+    // moka generates an internal UUID v4 for bucket IDs, which is a string
+    // it re-uses the provided hash builder for hashing the value of the UUID, which is used to target a bucket segment
+    // as a result, even though our keys are always u64, we also need to support hashing arbitrary byte slices (strings)
+    //
+    // to support this need, we fallback to the generic hash builder for non-u64 inputs
     fn write(&mut self, bytes: &[u8]) {
-        // support .write() for implementations that still use `v.hash()` from the build hasher
-        // assume the input is always a u64 in bytes
-        if bytes.len() == 8 {
-            let mut arr = [0u8; 8];
-            arr.copy_from_slice(bytes);
-            self.hash = u64::from_ne_bytes(arr);
-        } else {
-            unimplemented!("PassthroughHasher only supports writing u64 values");
-        }
+        let mut hasher = self.hasher.build_hasher();
+        hasher.write(bytes);
+        self.hash = hasher.finish();
     }
 
     fn write_u64(&mut self, i: u64) {
@@ -176,18 +188,20 @@ impl Hasher for PassthroughHasher {
 
 #[cfg(test)]
 mod tests {
+    use std::hash::RandomState;
+
     use super::*;
 
     #[test]
     fn test_passthrough_hasher() {
         // validate that `write_u64` and `write` produce the same hash result from a u64 input
-        let mut hasher1 = PassthroughHashBuilder::default().build_hasher();
+        let mut hasher1 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
         hasher1.write_u64(42);
         let hash1 = hasher1.finish();
         assert_eq!(hash1, 42);
 
-        let mut hasher2 = PassthroughHashBuilder::default().build_hasher();
-        hasher2.write(&42u64.to_ne_bytes());
+        let mut hasher2 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
+        42.hash(&mut hasher2);
         let hash2 = hasher2.finish();
 
         assert_eq!(hash1, hash2);

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -174,7 +174,7 @@ impl<T: BuildHasher + Clone + Send + Sync + 'static> Hasher for PassthroughHashe
     // it re-uses the provided hash builder for hashing the value of the UUID, which is used to target a bucket segment
     // as a result, even though our keys are always u64, we also need to support hashing arbitrary byte slices (strings)
     //
-    // to support this need, we fallback to the generic hash builder for non-u64 inputs
+    // to support this need, we fallback to the hash builder from the generic type for non-u64 inputs
     fn write(&mut self, bytes: &[u8]) {
         let mut hasher = self.hasher.build_hasher();
         hasher.write(bytes);

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -193,20 +193,20 @@ mod tests {
 
     use super::*;
 
+    // explicitly allow this rule, because we're validating that the builtin u64 hash -> .write_u64() path works as expected
+    #[expect(clippy::manual_hash_one)]
     #[test]
     fn test_passthrough_hasher() {
         // validate that `write_u64` and `write` produce the same hash result from a u64 input
-        let hash1 = PassthroughHashBuilder::new(RandomState::default()).hash_one(42);
+        let mut hasher1 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
+        hasher1.write_u64(42);
+        let hash1 = hasher1.finish();
         assert_eq!(hash1, 42);
 
-        // explicitly allow this rule, because we're validating that the builtin u64 hash -> .write_u64() path works as expected
-        #[expect(clippy::manual_hash_one)]
-        {
-            let mut hasher2 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
-            42.hash(&mut hasher2);
-            let hash2 = hasher2.finish();
+        let mut hasher2 = PassthroughHashBuilder::new(RandomState::default()).build_hasher();
+        42u64.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
 
-            assert_eq!(hash1, hash2);
-        }
+        assert_eq!(hash1, hash2);
     }
 }

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -149,25 +149,28 @@ impl<T: BuildHasher + Clone + Send + Sync + 'static> PassthroughHashBuilder<T> {
     }
 }
 
-impl<T: BuildHasher + Clone + Send + Sync + 'static> BuildHasher for PassthroughHashBuilder<T> {
-    type Hasher = PassthroughHasher<T>;
+impl<T: BuildHasher + Clone + Send + Sync + 'static> BuildHasher for PassthroughHashBuilder<T>
+where
+    <T as BuildHasher>::Hasher: Send + Sync + 'static,
+{
+    type Hasher = PassthroughHasher<T::Hasher>;
 
     fn build_hasher(&self) -> Self::Hasher {
         PassthroughHasher {
-            hash: 0,
-            hasher: self.hasher.clone(),
+            hash: None,
+            hasher: self.hasher.build_hasher(),
         }
     }
 }
 
-pub(crate) struct PassthroughHasher<T: BuildHasher + Clone + Send + Sync + 'static> {
-    hash: u64,
+pub(crate) struct PassthroughHasher<T: Hasher + Send + Sync + 'static> {
+    hash: Option<u64>,
     hasher: T,
 }
 
-impl<T: BuildHasher + Clone + Send + Sync + 'static> Hasher for PassthroughHasher<T> {
+impl<T: Hasher + Send + Sync + 'static> Hasher for PassthroughHasher<T> {
     fn finish(&self) -> u64 {
-        self.hash
+        self.hash.unwrap_or_else(|| self.hasher.finish())
     }
 
     // moka generates an internal UUID v4 for bucket IDs, which is a string
@@ -176,13 +179,11 @@ impl<T: BuildHasher + Clone + Send + Sync + 'static> Hasher for PassthroughHashe
     //
     // to support this need, we fallback to the hash builder from the generic type for non-u64 inputs
     fn write(&mut self, bytes: &[u8]) {
-        let mut hasher = self.hasher.build_hasher();
-        hasher.write(bytes);
-        self.hash = hasher.finish();
+        self.hasher.write(bytes);
     }
 
     fn write_u64(&mut self, i: u64) {
-        self.hash = i;
+        self.hash = Some(i);
     }
 }
 

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -132,5 +133,63 @@ impl RawCacheKey {
     #[must_use]
     pub fn as_u64(&self) -> u64 {
         self.0
+    }
+}
+
+/// A hasher that simply passes through u64 values as-is.
+/// This is useful to reduce hashing overhead when we already have a u64 hash key, as returned from `CacheKey::as_raw_key()`.
+#[derive(Copy, Clone, Default)]
+pub(crate) struct PassthroughHashBuilder;
+impl BuildHasher for PassthroughHashBuilder {
+    type Hasher = PassthroughHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        PassthroughHasher { hash: 0 }
+    }
+}
+
+pub(crate) struct PassthroughHasher {
+    hash: u64,
+}
+
+impl Hasher for PassthroughHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        // support .write() for implementations that still use `v.hash()` from the build hasher
+        // assume the input is always a u64 in bytes
+        if bytes.len() == 8 {
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(bytes);
+            self.hash = u64::from_ne_bytes(arr);
+        } else {
+            unimplemented!("PassthroughHasher only supports writing u64 values");
+        }
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.hash = i;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_passthrough_hasher() {
+        // validate that `write_u64` and `write` produce the same hash result from a u64 input
+        let mut hasher1 = PassthroughHashBuilder::default().build_hasher();
+        hasher1.write_u64(42);
+        let hash1 = hasher1.finish();
+        assert_eq!(hash1, 42);
+
+        let mut hasher2 = PassthroughHashBuilder::default().build_hasher();
+        hasher2.write(&42u64.to_ne_bytes());
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
     }
 }

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -138,7 +138,7 @@ impl RawCacheKey {
 
 /// A hash builder that builds a hasher which simply passes through u64 values as-is.
 /// This is useful to reduce hashing overhead when we already have a u64 hash key, as returned from `CacheKey::as_raw_key()`.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub(crate) struct PassthroughHashBuilder<T: BuildHasher + Clone + Send + Sync + 'static> {
     hasher: T,
 }

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -138,7 +138,7 @@ pub enum HashBuilder {
 }
 
 impl std::hash::BuildHasher for HashBuilder {
-    type Hasher = Box<dyn Hasher>;
+    type Hasher = Box<dyn Hasher + Send + Sync + 'static>;
 
     fn build_hasher(&self) -> Self::Hasher {
         match self {

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -41,7 +41,8 @@ use std::time::{Duration, Instant};
 // 'static is required by a bound from moka::Cache
 pub struct LruCache<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
 > {
     cache: Cache<u64, V, PassthroughHashBuilder<T>>,
     hasher: T,
@@ -55,8 +56,9 @@ pub struct LruCache<
 
 impl<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> Display for LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> Display for LruCache<V, T, H>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -70,8 +72,9 @@ impl<
 
 impl<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> std::fmt::Debug for LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> std::fmt::Debug for LruCache<V, T, H>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LruCache")
@@ -93,7 +96,7 @@ impl<
 /// - If the specified `item_ttl` cannot be parsed as a valid duration.
 pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static>(
     cache_config: &CacheConfig,
-) -> Result<Arc<LruCache<V, HashBuilder>>> {
+) -> Result<Arc<LruCache<V, HashBuilder, Box<dyn Hasher + Send + Sync + 'static>>>> {
     let cache_max_size: u64 = match &cache_config.max_size {
         Some(cache_max_size) => Byte::parse_str(cache_max_size, true)
             .context(super::FailedToParseCacheMaxSizeSnafu)?
@@ -121,16 +124,15 @@ pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'sta
 
 impl<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> LruCache<V, T, H>
 {
     #[must_use]
-    pub fn new(
-        cache_max_size: u64,
-        ttl: Duration,
-        hasher: T,
-        caching_policy: CachingPolicy,
-    ) -> Self {
+    pub fn new(cache_max_size: u64, ttl: Duration, hasher: T, caching_policy: CachingPolicy) -> Self
+    where
+        <T as BuildHasher>::Hasher: Send + Sync + 'static,
+    {
         let moka_eviction_policy = match caching_policy {
             CachingPolicy::Lru => moka::policy::EvictionPolicy::lru(),
             CachingPolicy::TinyLfu => moka::policy::EvictionPolicy::tiny_lfu(),
@@ -183,8 +185,9 @@ impl<
 
 impl<
     V: Sizeable + AsTableRefs + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> LruCache<V, T, H>
 {
     pub fn as_tabled_provider(self: Arc<Self>) -> Arc<dyn TabledCacheProvider<V> + Send + Sync> {
         self
@@ -193,8 +196,9 @@ impl<
 
 impl<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> HashProvider for LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> HashProvider for LruCache<V, T, H>
 {
     fn hasher(&self) -> Box<dyn Hasher> {
         Box::new(self.hasher.build_hasher())
@@ -204,8 +208,9 @@ impl<
 #[async_trait]
 impl<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> CacheProvider<V> for LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> CacheProvider<V> for LruCache<V, T, H>
 {
     async fn get_raw_key(&self, key: &u64) -> Option<V> {
         V::record_request();
@@ -296,8 +301,9 @@ impl<
 #[async_trait]
 impl<
     V: Sizeable + AsTableRefs + CacheMetrics + Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
-> TabledCacheProvider<V> for LruCache<V, T>
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> TabledCacheProvider<V> for LruCache<V, T, H>
 {
     fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
         let table_name = match &table_ref {
@@ -385,11 +391,15 @@ mod tests {
     #[rstest]
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
+    #[case::xxhash32(twox_hash::xxhash32::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_put_and_get<T: BuildHasher + Clone + Send + Sync + 'static>(
+    async fn test_cache_put_and_get<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
         #[case] hasher: T,
     ) {
-        let cache: LruCache<CachedQueryResult, _> =
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
@@ -412,9 +422,15 @@ mod tests {
     #[rstest]
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
+    #[case::xxhash32(twox_hash::xxhash32::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_miss<T: BuildHasher + Clone + Send + Sync + 'static>(#[case] hasher: T) {
-        let cache: LruCache<CachedQueryResult, _> =
+    async fn test_cache_miss<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
+        #[case] hasher: T,
+    ) {
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let key = CacheKey::Query("nonexistent_query", None).as_raw_key(cache.hasher());
 
@@ -429,11 +445,15 @@ mod tests {
     #[rstest]
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
+    #[case::xxhash32(twox_hash::xxhash32::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_invalidate_for_table<T: BuildHasher + Clone + Send + Sync + 'static>(
+    async fn test_cache_invalidate_for_table<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
         #[case] hasher: T,
     ) {
-        let cache: LruCache<CachedQueryResult, _> =
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let table_ref = TableReference::Bare {
             table: Arc::from("test_table"),
@@ -468,13 +488,15 @@ mod tests {
     #[rstest]
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
+    #[case::xxhash32(twox_hash::xxhash32::RandomState::default())]
     #[tokio::test]
     async fn test_search_cache_invalidate_for_table<
-        T: BuildHasher + Clone + Send + Sync + 'static,
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
     >(
         #[case] hasher: T,
     ) {
-        let cache: LruCache<CachedSearchResult, _> =
+        let cache: LruCache<CachedSearchResult, _, _> =
             LruCache::new(10, Duration::from_secs(60), hasher, CachingPolicy::Lru);
         let table_ref = TableReference::Bare {
             table: Arc::from("test_table"),
@@ -514,7 +536,7 @@ mod tests {
     async fn test_cache_ttl(#[case] hashing_algo: HashingAlgorithm) {
         let hasher = get_hash_builder(hashing_algo).expect("Failed to get hash builder");
 
-        let cache: LruCache<CachedQueryResult, _> =
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_millis(100), hasher, CachingPolicy::Lru);
         let key = || CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
@@ -549,7 +571,7 @@ mod tests {
     async fn test_cache_ttl_xhash(#[case] hashing_algo: HashingAlgorithm) {
         let hasher = get_hash_builder(hashing_algo).expect("Failed to get hash builder");
 
-        let cache: LruCache<CachedQueryResult, _> =
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_millis(100), hasher, CachingPolicy::Lru);
         let key = || CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
@@ -581,7 +603,7 @@ mod tests {
     #[tokio::test]
     async fn test_cache_with_caching_policy(#[case] caching_policy: CachingPolicy) {
         let hasher = RandomState::default();
-        let cache: LruCache<CachedQueryResult, _> =
+        let cache: LruCache<CachedQueryResult, _, _> =
             LruCache::new(10, Duration::from_secs(60), hasher, caching_policy);
 
         let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -21,6 +21,7 @@ use crate::HashProvider;
 use crate::Result;
 use crate::Sizeable;
 use crate::TabledCacheProvider;
+use crate::key::PassthroughHashBuilder;
 use crate::metrics::CacheMetrics;
 use crate::{CacheProvider, get_hash_builder};
 use async_trait::async_trait;
@@ -42,7 +43,7 @@ pub struct LruCache<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
     T: BuildHasher + Clone + Send + Sync + 'static,
 > {
-    cache: Cache<u64, V, T>,
+    cache: Cache<u64, V, PassthroughHashBuilder>,
     hasher: T,
     max_size: u64,
     metrics_last_reported_time: AtomicU64,
@@ -135,7 +136,7 @@ impl<
             CachingPolicy::TinyLfu => moka::policy::EvictionPolicy::tiny_lfu(),
         };
 
-        let cache: Cache<u64, V, T> = Cache::builder()
+        let cache: Cache<u64, V, PassthroughHashBuilder> = Cache::builder()
             .time_to_live(ttl)
             .weigher(|_key, value: &V| -> u32 {
                 let val: usize = value.get_memory_size();
@@ -161,7 +162,7 @@ impl<
                     V::record_eviction();
                 }
             })
-            .build_with_hasher(hasher.clone());
+            .build_with_hasher(PassthroughHashBuilder);
 
         LruCache {
             cache,

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -88,6 +88,8 @@ impl<
     }
 }
 
+type BuiltLruCache<V> = LruCache<V, HashBuilder, Box<dyn Hasher + Send + Sync + 'static>>;
+
 /// Builds an LRU cache provider from the given configuration.
 ///
 /// # Errors
@@ -96,7 +98,7 @@ impl<
 /// - If the specified `item_ttl` cannot be parsed as a valid duration.
 pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static>(
     cache_config: &CacheConfig,
-) -> Result<Arc<LruCache<V, HashBuilder, Box<dyn Hasher + Send + Sync + 'static>>>> {
+) -> Result<Arc<BuiltLruCache<V>>> {
     let cache_max_size: u64 = match &cache_config.max_size {
         Some(cache_max_size) => Byte::parse_str(cache_max_size, true)
             .context(super::FailedToParseCacheMaxSizeSnafu)?

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -43,7 +43,7 @@ pub struct LruCache<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
     T: BuildHasher + Clone + Send + Sync + 'static,
 > {
-    cache: Cache<u64, V, PassthroughHashBuilder>,
+    cache: Cache<u64, V, PassthroughHashBuilder<T>>,
     hasher: T,
     max_size: u64,
     metrics_last_reported_time: AtomicU64,
@@ -136,7 +136,7 @@ impl<
             CachingPolicy::TinyLfu => moka::policy::EvictionPolicy::tiny_lfu(),
         };
 
-        let cache: Cache<u64, V, PassthroughHashBuilder> = Cache::builder()
+        let cache: Cache<u64, V, PassthroughHashBuilder<T>> = Cache::builder()
             .time_to_live(ttl)
             .weigher(|_key, value: &V| -> u32 {
                 let val: usize = value.get_memory_size();
@@ -162,7 +162,7 @@ impl<
                     V::record_eviction();
                 }
             })
-            .build_with_hasher(PassthroughHashBuilder);
+            .build_with_hasher(PassthroughHashBuilder::new(hasher.clone()));
 
         LruCache {
             cache,

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -34,7 +34,7 @@ pub struct SimpleCache<
     V: Clone + Send + Sync + 'static,
     T: BuildHasher + Clone + Send + Sync + 'static,
 > {
-    cache: Cache<u64, V, PassthroughHashBuilder>,
+    cache: Cache<u64, V, PassthroughHashBuilder<T>>,
     hasher: T,
     max_size: u64,
     ttl: Duration,
@@ -68,11 +68,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
     SimpleCache<V, T>
 {
     pub fn new(cache_max_size: u64, ttl: Duration, hasher: T) -> Self {
-        let cache: Cache<u64, V, PassthroughHashBuilder> = Cache::builder()
+        let cache: Cache<u64, V, PassthroughHashBuilder<T>> = Cache::builder()
             .time_to_live(ttl)
             .max_capacity(cache_max_size)
             .support_invalidation_closures()
-            .build_with_hasher(PassthroughHashBuilder);
+            .build_with_hasher(PassthroughHashBuilder::new(hasher.clone()));
 
         SimpleCache {
             cache,

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -32,7 +32,8 @@ use std::time::Duration;
 // 'static is required by a bound from moka::Cache
 pub struct SimpleCache<
     V: Clone + Send + Sync + 'static,
-    T: BuildHasher + Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
 > {
     cache: Cache<u64, V, PassthroughHashBuilder<T>>,
     hasher: T,
@@ -40,8 +41,11 @@ pub struct SimpleCache<
     ttl: Duration,
 }
 
-impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static> Display
-    for SimpleCache<V, T>
+impl<
+    V: Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> Display for SimpleCache<V, T, H>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -53,8 +57,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
     }
 }
 
-impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    std::fmt::Debug for SimpleCache<V, T>
+impl<
+    V: Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> std::fmt::Debug for SimpleCache<V, T, H>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SimpleCache")
@@ -64,8 +71,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
     }
 }
 
-impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    SimpleCache<V, T>
+impl<
+    V: Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> SimpleCache<V, T, H>
 {
     pub fn new(cache_max_size: u64, ttl: Duration, hasher: T) -> Self {
         let cache: Cache<u64, V, PassthroughHashBuilder<T>> = Cache::builder()
@@ -83,16 +93,22 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
     }
 }
 
-impl<V: AsTableRefs + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    SimpleCache<V, T>
+impl<
+    V: AsTableRefs + Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> SimpleCache<V, T, H>
 {
     pub fn as_tabled_provider(self: Arc<Self>) -> Arc<dyn TabledCacheProvider<V> + Send + Sync> {
         self
     }
 }
 
-impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static> HashProvider
-    for SimpleCache<V, T>
+impl<
+    V: Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> HashProvider for SimpleCache<V, T, H>
 {
     fn hasher(&self) -> Box<dyn Hasher> {
         Box::new(self.hasher.build_hasher())
@@ -100,8 +116,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
 }
 
 #[async_trait]
-impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    CacheProvider<V> for SimpleCache<V, T>
+impl<
+    V: Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> CacheProvider<V> for SimpleCache<V, T, H>
 {
     async fn get_raw_key(&self, key: &u64) -> Option<V> {
         self.cache.get(key).await
@@ -135,8 +154,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
 }
 
 #[async_trait]
-impl<V: AsTableRefs + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    TabledCacheProvider<V> for SimpleCache<V, T>
+impl<
+    V: AsTableRefs + Clone + Send + Sync + 'static,
+    T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    H: Hasher + Send + Sync + 'static,
+> TabledCacheProvider<V> for SimpleCache<V, T, H>
 {
     fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
         let table_name = match &table_ref {
@@ -198,10 +220,13 @@ mod tests {
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_put_and_get<T: BuildHasher + Clone + Send + Sync + 'static>(
+    async fn test_cache_put_and_get<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
         #[case] hasher: T,
     ) {
-        let cache: SimpleCache<CachedQueryResult, _> =
+        let cache: SimpleCache<CachedQueryResult, _, _> =
             SimpleCache::new(10, Duration::from_secs(60), hasher);
         let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;
@@ -225,8 +250,13 @@ mod tests {
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_miss<T: BuildHasher + Clone + Send + Sync + 'static>(#[case] hasher: T) {
-        let cache: SimpleCache<CachedQueryResult, _> =
+    async fn test_cache_miss<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
+        #[case] hasher: T,
+    ) {
+        let cache: SimpleCache<CachedQueryResult, _, _> =
             SimpleCache::new(10, Duration::from_secs(60), hasher);
         let key = CacheKey::Query("nonexistent_query", None).as_raw_key(cache.hasher());
 
@@ -242,10 +272,13 @@ mod tests {
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_invalidate_all<T: BuildHasher + Clone + Send + Sync + 'static>(
+    async fn test_cache_invalidate_all<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
         #[case] hasher: T,
     ) {
-        let cache: SimpleCache<CachedQueryResult, _> =
+        let cache: SimpleCache<CachedQueryResult, _, _> =
             SimpleCache::new(10, Duration::from_secs(60), hasher);
         let result = create_test_cached_result().await;
 
@@ -276,8 +309,13 @@ mod tests {
     #[case::siphash(RandomState::default())]
     #[case::ahash(ahash::RandomState::default())]
     #[tokio::test]
-    async fn test_cache_ttl<T: BuildHasher + Clone + Send + Sync + 'static>(#[case] hasher: T) {
-        let cache: SimpleCache<CachedQueryResult, _> =
+    async fn test_cache_ttl<
+        H: Hasher + Send + Sync + 'static,
+        T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
+    >(
+        #[case] hasher: T,
+    ) {
+        let cache: SimpleCache<CachedQueryResult, _, _> =
             SimpleCache::new(10, Duration::from_millis(100), hasher);
         let key = || CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
         let result = create_test_cached_result().await;

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::key::PassthroughHashBuilder;
 use crate::{
     AsTableRefs, CacheProvider, FailedToInvalidateCacheSnafu, HashProvider, Result,
     TabledCacheProvider,
@@ -33,7 +34,7 @@ pub struct SimpleCache<
     V: Clone + Send + Sync + 'static,
     T: BuildHasher + Clone + Send + Sync + 'static,
 > {
-    cache: Cache<u64, V, T>,
+    cache: Cache<u64, V, PassthroughHashBuilder>,
     hasher: T,
     max_size: u64,
     ttl: Duration,
@@ -67,11 +68,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
     SimpleCache<V, T>
 {
     pub fn new(cache_max_size: u64, ttl: Duration, hasher: T) -> Self {
-        let cache: Cache<u64, V, T> = Cache::builder()
+        let cache: Cache<u64, V, PassthroughHashBuilder> = Cache::builder()
             .time_to_live(ttl)
             .max_capacity(cache_max_size)
             .support_invalidation_closures()
-            .build_with_hasher(hasher.clone());
+            .build_with_hasher(PassthroughHashBuilder);
 
         SimpleCache {
             cache,


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Introduces a `PassthroughHashBuilder` to implement a `BuildHasher` which performs no hashing - returning the provided `u64` value as the hash instead
* Sets the `PassthroughHashBuilder` as the hasher for the inner `Cache<_, _, T>` on the moka caches, as we provide a pre-hashed `u64` key for retrieving/inserting values into the moka cache

This has resulted in some neat performance improvements:
* 24% RPS and 99.9th latency improvement
* 20% average latency improvement

Run details from `oha`:

```md
# Before

Summary:
  Success rate: 100.00%
  Total:        30001.4585 ms
  Slowest:      35.2598 ms
  Fastest:      0.1617 ms
  Average:      1.3643 ms
  Requests/sec: 36540.0236

  Total data:   25.09 MiB
  Size/request: 24 B
  Size/sec:     856.39 KiB

Response time histogram:
   0.162 ms [1]       |
   3.672 ms [1068267] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   7.181 ms [26789]   |
  10.691 ms [556]     |
  14.201 ms [47]      |
  17.711 ms [116]     |
  21.221 ms [106]     |
  24.730 ms [98]      |
  28.240 ms [198]     |
  31.750 ms [31]      |
  35.260 ms [20]      |

Response time distribution:
  10.00% in 0.6332 ms
  25.00% in 0.8047 ms
  50.00% in 1.0971 ms
  75.00% in 1.6294 ms
  90.00% in 2.4214 ms
  95.00% in 3.0613 ms
  99.00% in 4.4545 ms
  99.90% in 7.3338 ms
  99.99% in 26.6988 ms

# After PassthroughHashBuilder

+24% RPS
+20% average latency improvement
+24% 99.9th percentile latency improvement

Summary:
  Success rate: 100.00%
  Total:        30000.7916 ms
  Slowest:      33.7960 ms
  Fastest:      0.1311 ms
  Average:      1.0913 ms
  Requests/sec: 45643.9289

  Total data:   31.34 MiB
  Size/request: 24 B
  Size/sec:     1.04 MiB

Response time histogram:
   0.131 ms [1]       |
   3.498 ms [1350949] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   6.864 ms [17447]   |
  10.231 ms [373]     |
  13.597 ms [38]      |
  16.964 ms [9]       |
  20.330 ms [0]       |
  23.697 ms [0]       |
  27.063 ms [216]     |
  30.429 ms [270]     |
  33.796 ms [14]      |

Response time distribution:
  10.00% in 0.5364 ms
  25.00% in 0.6678 ms
  50.00% in 0.8788 ms
  75.00% in 1.2627 ms
  90.00% in 1.8794 ms
  95.00% in 2.4154 ms
  99.00% in 3.7209 ms
  99.90% in 5.8902 ms
  99.99% in 28.0463 ms
```
