### PR TITLE
fix: Eagerly drop cached records for results larger than max

### DIFF
--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -48,6 +48,11 @@ pub fn to_cached_record_batch_stream(
             if records_size < cache_max_size && let Ok(batch) = &batch_result {
                 records.push(batch.clone());
                 records_size += batch.get_array_memory_size();
+            } else if records.len() > 0 && records_size >= cache_max_size {
+                // eagerly clear the cached records, as this result won't be cached anyway
+                // this allows some memory reclamation if the stream is very large
+                records.clear();
+                records.shrink_to_fit();
             }
 
             yield batch_result;

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -48,7 +48,7 @@ pub fn to_cached_record_batch_stream(
             if records_size < cache_max_size && let Ok(batch) = &batch_result {
                 records.push(batch.clone());
                 records_size += batch.get_array_memory_size();
-            } else if records.len() > 0 && records_size >= cache_max_size {
+            } else if !records.is_empty() && records_size >= cache_max_size {
                 // eagerly clear the cached records, as this result won't be cached anyway
                 // this allows some memory reclamation if the stream is very large
                 records.clear();


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Reduces the memory usage of large result streams when the cache max size is also large (e.g. a `4GiB` max cache size) by dropping and resizing the records array after it is detected to be too large to cache.
