### PR TITLE
DDB Streams Integration Test + Memory Acceleration + Improved Warning

### DIFF
--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -136,6 +136,9 @@ pub fn process_batch(
             (Some(event_name), Some(dynamodb)) => match event_name {
                 OperationType::Insert | OperationType::Modify => {
                     let Some(item) = &dynamodb.new_image else {
+                        tracing::warn!(
+                            "No new_image in DynamoDB Streams record. Make sure stream is configured with either NewImage or NewAndOldImages. https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html#Streams.Enabling"
+                        );
                         continue;
                     };
                     let streams_item = streams_to_dynamodb_item(item.clone());

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -192,6 +192,7 @@ gethostname.workspace = true
 anyhow.workspace = true
 async-graphql = "7.0.17"
 async-graphql-axum = "7.0.16"
+aws-credential-types = { workspace = true, features = ["hardcoded-credentials"] }
 azure_core = "0.30.1"
 azure_storage = "0.21.0"
 azure_storage_blobs = "0.21.0"

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -298,15 +298,6 @@ impl AcceleratorEngineRegistry {
         external_table_builder =
             external_table_builder.upsert_options(acceleration_settings.upsert_options());
 
-        println!(
-            "acceleration_settings.table_constraints: {:#?}",
-            acceleration_settings.table_constraints(Arc::clone(&schema))
-        );
-        println!(
-            "acceleration_settings.on_conflict: {:#?}",
-            acceleration_settings.on_conflict
-        );
-
         match acceleration_settings.table_constraints(Arc::clone(&schema)) {
             Ok(Some(constraints)) => {
                 if !constraints.is_empty() {
@@ -345,8 +336,6 @@ impl AcceleratorEngineRegistry {
             partition_by_expressions(&acceleration_settings.partition_by, &ctx, &df_schema)
                 .map_err(|e| Error::AccelerationCreationFailed { source: e.into() })?
         };
-
-        println!("external_table.options: {:#?}", external_table.options);
 
         let table_provider = accelerator
             .create_external_table(external_table, source, partition_by)
@@ -472,7 +461,6 @@ impl AcceleratorExternalTableBuilder {
 
     #[must_use]
     pub fn on_conflict(mut self, on_conflict: OnConflict) -> Self {
-        println!("on_conflict: {on_conflict:?}");
         self.on_conflict = Some(on_conflict);
         self
     }
@@ -491,7 +479,6 @@ impl AcceleratorExternalTableBuilder {
 
     #[must_use]
     pub fn constraints(mut self, constraints: Constraints) -> Self {
-        println!("constraints: {constraints:?}");
         self.constraints = Some(constraints);
         self
     }
@@ -543,8 +530,6 @@ impl AcceleratorExternalTableBuilder {
             let indexes_option_str = Acceleration::hashmap_to_option_string(&self.indexes);
             options.insert("indexes".to_string(), indexes_option_str);
         }
-
-        println!("self.on_conflict: {:?}", self.on_conflict);
 
         if let Some(on_conflict) = self.on_conflict {
             let on_conflict_str = on_conflict.to_string();

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -298,6 +298,15 @@ impl AcceleratorEngineRegistry {
         external_table_builder =
             external_table_builder.upsert_options(acceleration_settings.upsert_options());
 
+        println!(
+            "acceleration_settings.table_constraints: {:#?}",
+            acceleration_settings.table_constraints(Arc::clone(&schema))
+        );
+        println!(
+            "acceleration_settings.on_conflict: {:#?}",
+            acceleration_settings.on_conflict
+        );
+
         match acceleration_settings.table_constraints(Arc::clone(&schema)) {
             Ok(Some(constraints)) => {
                 if !constraints.is_empty() {
@@ -336,6 +345,8 @@ impl AcceleratorEngineRegistry {
             partition_by_expressions(&acceleration_settings.partition_by, &ctx, &df_schema)
                 .map_err(|e| Error::AccelerationCreationFailed { source: e.into() })?
         };
+
+        println!("external_table.options: {:#?}", external_table.options);
 
         let table_provider = accelerator
             .create_external_table(external_table, source, partition_by)
@@ -461,6 +472,7 @@ impl AcceleratorExternalTableBuilder {
 
     #[must_use]
     pub fn on_conflict(mut self, on_conflict: OnConflict) -> Self {
+        println!("on_conflict: {on_conflict:?}");
         self.on_conflict = Some(on_conflict);
         self
     }
@@ -479,6 +491,7 @@ impl AcceleratorExternalTableBuilder {
 
     #[must_use]
     pub fn constraints(mut self, constraints: Constraints) -> Self {
+        println!("constraints: {constraints:?}");
         self.constraints = Some(constraints);
         self
     }
@@ -530,6 +543,8 @@ impl AcceleratorExternalTableBuilder {
             let indexes_option_str = Acceleration::hashmap_to_option_string(&self.indexes);
             options.insert("indexes".to_string(), indexes_option_str);
         }
+
+        println!("self.on_conflict: {:?}", self.on_conflict);
 
         if let Some(on_conflict) = self.on_conflict {
             let on_conflict_str = on_conflict.to_string();

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -100,7 +100,7 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("When using Streams, once tables reaches this lag, it will be reported as Ready")
         .default("2s"),
     ParameterSpec::runtime("endpoint_url")
-        .description("")
+        .description("Custom endpoint URL for DynamoDB. Useful for development and testing.")
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -100,7 +100,7 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("When using Streams, once tables reaches this lag, it will be reported as Ready")
         .default("2s"),
     ParameterSpec::runtime("endpoint_url")
-        .description("Custom endpoint URL for DynamoDB. Useful for development and testing.")
+        .description("Custom endpoint URL for testing or using DynamoDB-compatible services (e.g., DynamoDB Local).")
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -98,6 +98,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("ready_lag")
         .description("When using Streams, once tables reaches this lag, it will be reported as Ready")
         .default("2s"),
+    ParameterSpec::runtime("endpoint_url")
+        .description("")
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {
@@ -140,7 +142,7 @@ impl DataConnector for DynamoDB {
     ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
         let table_name = dataset.path();
 
-        let config = initiate_config_with_credentials(
+        let mut config_loader = initiate_config_with_credentials(
             "DynamoDBTableProvider",
             "aws_region",
             "aws_access_key_id",
@@ -153,9 +155,13 @@ impl DataConnector for DynamoDB {
             dataconnector: "dynamodb".to_string(),
             connector_component: ConnectorComponent::from(dataset),
             message: message.to_string(),
-        })?
-        .load()
-        .await;
+        })?;
+
+        if let Some(endpoint_url) = self.params.get("endpoint_url").expose().ok() {
+            config_loader = config_loader.endpoint_url(endpoint_url.to_string());
+        }
+
+        let config = config_loader.load().await;
 
         let schema_infer_max_records = self
             .params
@@ -288,7 +294,11 @@ impl DataConnector for DynamoDB {
                 let dataset_name_3 = dataset_name.clone();
                 let dataset_name_4 = dataset_name.clone();
                 let dynamodb = Arc::new(dynamodb_ref.clone());
-                let dynamodb_sys = initialize_dynamodb_sys(&dataset).await?;
+                let dynamodb_sys = Arc::new(if dataset.is_file_accelerated() {
+                    initialize_dynamodb_sys(&dataset).await
+                } else {
+                    None
+                });
 
                 let (should_bootstrap, checkpoint) =
                     load_or_initialize_checkpoint(&dynamodb, &dynamodb_sys, &dataset_name).await?;
@@ -369,9 +379,9 @@ impl DataConnector for DynamoDB {
     }
 }
 
-async fn initialize_dynamodb_sys(dataset: &Dataset) -> Option<Arc<DynamoDBSys>> {
+async fn initialize_dynamodb_sys(dataset: &Dataset) -> Option<DynamoDBSys> {
     match DynamoDBSys::try_new(dataset, OpenOption::OpenExisting).await {
-        Ok(sys) => Some(Arc::new(sys)),
+        Ok(sys) => Some(sys),
         Err(err) => {
             tracing::error!(
                 "Failed to initialize DynamoDBSys for checkpoint persistence: table={} - {:?}",
@@ -386,24 +396,28 @@ async fn initialize_dynamodb_sys(dataset: &Dataset) -> Option<Arc<DynamoDBSys>> 
 /// Loads checkpoint from `DynamoDBSys`, or initializes a new checkpoint if none exists.
 async fn load_or_initialize_checkpoint(
     dynamodb: &Arc<DynamoDBTableProvider>,
-    dynamodb_sys: &Arc<DynamoDBSys>,
+    dynamodb_sys: &Arc<Option<DynamoDBSys>>,
     dataset_name: &TableReference,
 ) -> Option<(bool, Checkpoint)> {
-    let existing_checkpoint = dynamodb_sys.get().await;
-
-    if let Some(metadata) = existing_checkpoint {
-        match serde_json::from_str::<Checkpoint>(&metadata.checkpoint_data) {
-            Ok(checkpoint) => Some((false, checkpoint)),
-            Err(err) => {
-                tracing::warn!(
-                    "Failed to deserialize checkpoint, falling back to bootstrap: table_name={} - {:?}",
-                    dataset_name,
-                    err
-                );
-                get_latest_checkpoint(dynamodb, dataset_name)
-                    .await
-                    .map(|cp| (true, cp))
+    if let Some(ref dynamodb_sys) = **dynamodb_sys {
+        if let Some(metadata) = dynamodb_sys.get().await {
+            match serde_json::from_str::<Checkpoint>(&metadata.checkpoint_data) {
+                Ok(checkpoint) => Some((false, checkpoint)),
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to deserialize checkpoint, falling back to bootstrap: table_name={} - {:?}",
+                        dataset_name,
+                        err
+                    );
+                    get_latest_checkpoint(dynamodb, dataset_name)
+                        .await
+                        .map(|cp| (true, cp))
+                }
             }
+        } else {
+            get_latest_checkpoint(dynamodb, dataset_name)
+                .await
+                .map(|cp| (true, cp))
         }
     } else {
         get_latest_checkpoint(dynamodb, dataset_name)
@@ -436,7 +450,7 @@ async fn get_latest_checkpoint(
 
 async fn changes_stream_from_checkpoint(
     dynamodb: Arc<DynamoDBTableProvider>,
-    dynamodb_sys: Arc<DynamoDBSys>,
+    dynamodb_sys: Arc<Option<DynamoDBSys>>,
     checkpoint: Checkpoint,
     acceptable_lag: Duration,
     dataset_name: TableReference,
@@ -563,13 +577,13 @@ impl CommitChange for NoOpCommitter {
 }
 
 pub struct DynamoDBStreamCommitter {
-    dynamodb_sys: Arc<DynamoDBSys>,
+    dynamodb_sys: Arc<Option<DynamoDBSys>>,
     checkpoint: Checkpoint,
 }
 
 impl DynamoDBStreamCommitter {
     #[must_use]
-    pub fn new(dynamodb_sys: Arc<DynamoDBSys>, checkpoint: Checkpoint) -> Self {
+    pub fn new(dynamodb_sys: Arc<Option<DynamoDBSys>>, checkpoint: Checkpoint) -> Self {
         Self {
             dynamodb_sys,
             checkpoint,
@@ -591,15 +605,18 @@ impl CommitChange for DynamoDBStreamCommitter {
             checkpoint_data: checkpoint_json,
         };
 
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.dynamodb_sys.upsert(&metadata).await.map_err(|e| {
-                    CommitError::UnableToCommitChange {
-                        source: Box::new(e),
-                    }
+        match self.dynamodb_sys.as_ref() {
+            Some(dynamodb_sys) => tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    dynamodb_sys.upsert(&metadata).await.map_err(|e| {
+                        CommitError::UnableToCommitChange {
+                            source: Box::new(e),
+                        }
+                    })
                 })
-            })
-        })
+            }),
+            None => Ok(()),
+        }
     }
 }
 

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::component::ComponentType;
 use crate::component::dataset::Dataset;
+use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::metrics::{MetricSpec, MetricType, MetricsProvider, ObserveMetricCallback};
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, DynamoDBSys};
@@ -140,6 +141,17 @@ impl DataConnector for DynamoDB {
         &self,
         dataset: &Dataset,
     ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
+        if let Some(acceleration) = &dataset.acceleration {
+            if let Some(refresh_mode) = acceleration.refresh_mode {
+                if matches!(refresh_mode, RefreshMode::Changes) && !acceleration.enabled {
+                    tracing::warn!(
+                        "DynamoDB dataset {} is configured for changes stream, but acceleration is disabled. Enable acceleration to use DynamoDB Streams",
+                        dataset.name
+                    );
+                }
+            }
+        }
+
         let table_name = dataset.path();
 
         let mut config_loader = initiate_config_with_credentials(
@@ -297,6 +309,7 @@ impl DataConnector for DynamoDB {
                 let dynamodb_sys = Arc::new(if dataset.is_file_accelerated() {
                     initialize_dynamodb_sys(&dataset).await
                 } else {
+                    tracing::warn!("Dataset {dataset_name} is not file-accelerated. DynamoDB Streams checkpoints will not be persisted.");
                     None
                 });
 

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -141,15 +141,15 @@ impl DataConnector for DynamoDB {
         &self,
         dataset: &Dataset,
     ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
-        if let Some(acceleration) = &dataset.acceleration {
-            if let Some(refresh_mode) = acceleration.refresh_mode {
-                if matches!(refresh_mode, RefreshMode::Changes) && !acceleration.enabled {
-                    tracing::warn!(
-                        "DynamoDB dataset {} is configured for changes stream, but acceleration is disabled. Enable acceleration to use DynamoDB Streams",
-                        dataset.name
-                    );
-                }
-            }
+        if let Some(acceleration) = &dataset.acceleration
+            && let Some(refresh_mode) = acceleration.refresh_mode
+            && matches!(refresh_mode, RefreshMode::Changes)
+            && !acceleration.enabled
+        {
+            tracing::warn!(
+                "DynamoDB dataset {} is configured for changes stream, but acceleration is disabled. Enable acceleration to use DynamoDB Streams",
+                dataset.name
+            );
         }
 
         let table_name = dataset.path();

--- a/crates/runtime/tests/dynamodb/mod.rs
+++ b/crates/runtime/tests/dynamodb/mod.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+mod streams;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test1.snap
+++ b/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test1.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/dynamodb/streams.rs
+expression: formatted
+---
++------+--------+---------+
+| id   | name   | version |
++------+--------+---------+
+| id-0 | Item 0 | 0       |
+| id-1 | Item 1 | 1       |
+| id-2 | Item 2 | 2       |
+| id-3 | Item 3 | 3       |
+| id-4 | Item 4 | 4       |
++------+--------+---------+

--- a/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test2.snap
+++ b/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test2.snap
@@ -1,0 +1,15 @@
+---
+source: crates/runtime/tests/dynamodb/streams.rs
+expression: formatted
+---
++------+--------+---------+
+| id   | name   | version |
++------+--------+---------+
+| id-0 | Item 0 | 0       |
+| id-1 | Item 1 | 1       |
+| id-2 | Item 2 | 2       |
+| id-3 | Item 3 | 3       |
+| id-4 | Item 4 | 4       |
+| id-5 | Item 5 | 5       |
+| id-6 | Item 6 | 6       |
++------+--------+---------+

--- a/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test3.snap
+++ b/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__test3.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/dynamodb/streams.rs
+expression: formatted
+---
++------+--------+---------+
+| id   | name   | version |
++------+--------+---------+
+| id-0 | Item 0 | 0       |
+| id-1 | Item 1 | 1       |
+| id-2 | Item 2 | 2       |
+| id-3 | Item 3 | 3       |
+| id-4 | Item 4 | 4       |
+| id-5 | Item 5 | 5       |
+| id-6 | Item 6 | 6       |
+| id-7 | Item 7 | 7       |
+| id-8 | Item 8 | 8       |
+| id-9 | Item 9 | 9       |
++------+--------+---------+

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use crate::docker::{ContainerRunnerBuilder, RunningContainer};
 use crate::utils::{runtime_ready_check, test_request_context};
-use crate::{configure_test_datafusion, init_tracing, run_query_and_check_results};
+use crate::{configure_test_datafusion, init_tracing};
 use app::AppBuilder;
 use async_graphql::futures_util::TryStreamExt;
 use aws_config::{BehaviorVersion, Region, SdkConfig, retry::RetryConfig};
@@ -40,7 +40,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::instrument;
-use util::retry;
 
 const DYNAMODB_DOCKER_CONTAINER: &str = "runtime-integration-test-dynamodb";
 const PORT: u16 = 8001;

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -241,10 +241,10 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
             )
             .await?;
 
-            // running_container.remove().await.map_err(|e| {
-            //     tracing::error!("running_container.remove: {e}");
-            //     anyhow::Error::msg(e.to_string())
-            // })?;
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
 
             Ok(())
         })

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -187,11 +187,7 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
 
             let app = AppBuilder::new("dynamodb_integration_test")
                 .with_dataset(make_dynamodb_dataset(
-                    table_name,
-                    PORT,
-                    access_key,
-                    secret_key,
-                    true,
+                    table_name, PORT, access_key, secret_key, true,
                 ))
                 .with_results_cache(ResultsCache {
                     enabled: false,

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -1,6 +1,21 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 use crate::docker::{ContainerRunnerBuilder, RunningContainer};
 use crate::utils::{runtime_ready_check, test_request_context};
-use crate::{ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results};
+use crate::{configure_test_datafusion, init_tracing, run_query_and_check_results};
 use app::AppBuilder;
 use async_graphql::futures_util::TryStreamExt;
 use aws_config::{BehaviorVersion, Region, SdkConfig, retry::RetryConfig};
@@ -14,7 +29,7 @@ use aws_sdk_dynamodb::{
 };
 use bollard::secret::HealthConfig;
 use runtime::Runtime;
-use spicepod::acceleration::{Mode, OnConflictBehavior, RefreshMode};
+use spicepod::acceleration::RefreshMode;
 use spicepod::component::caching::ResultsCache;
 use spicepod::{
     acceleration::Acceleration, component::dataset::Dataset, param::Params as DatasetParams,
@@ -25,8 +40,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::instrument;
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
-use util::{RetryError, retry};
+use util::retry;
 
 const DYNAMODB_DOCKER_CONTAINER: &str = "runtime-integration-test-dynamodb";
 const PORT: u16 = 8001;
@@ -102,7 +116,7 @@ async fn create_table(client: &Client, table_name: &str) {
                 .attribute_name("id")
                 .attribute_type(ScalarAttributeType::S)
                 .build()
-                .unwrap(),
+                .expect("Attribute definition created"),
         )
         .table_name(table_name)
         .key_schema(
@@ -110,7 +124,7 @@ async fn create_table(client: &Client, table_name: &str) {
                 .attribute_name("id")
                 .key_type(KeyType::Hash)
                 .build()
-                .unwrap(),
+                .expect("Key schema element created"),
         )
         .billing_mode(BillingMode::PayPerRequest)
         .stream_specification(
@@ -118,7 +132,7 @@ async fn create_table(client: &Client, table_name: &str) {
                 .stream_enabled(true)
                 .stream_view_type(StreamViewType::NewAndOldImages)
                 .build()
-                .unwrap(),
+                .expect("Stream specification created"),
         )
         .send()
         .await
@@ -227,10 +241,10 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
             )
             .await?;
 
-            running_container.remove().await.map_err(|e| {
-                tracing::error!("running_container.remove: {e}");
-                anyhow::Error::msg(e.to_string())
-            })?;
+            // running_container.remove().await.map_err(|e| {
+            //     tracing::error!("running_container.remove: {e}");
+            //     anyhow::Error::msg(e.to_string())
+            // })?;
 
             Ok(())
         })

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -153,13 +153,11 @@ fn get_client(port: u16, access_key: &str, secret_key: &str) -> Client {
 
 async fn insert_rows(client: &Client, table_name: &str, range: Range<usize>) {
     for i in range {
-        let id = format!("id-{}", i);
-
         client
             .put_item()
             .table_name(table_name)
-            .item("id", AttributeValue::S(id))
-            .item("name", AttributeValue::S(format!("Item {}", i)))
+            .item("id", AttributeValue::S(format!("id-{i}")))
+            .item("name", AttributeValue::S(format!("Item {i}")))
             .item("version", AttributeValue::N(i.to_string()))
             .send()
             .await
@@ -181,7 +179,7 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
         .scope(async {
             let running_container = start_dynamodb_docker_container(PORT).await?;
 
-            let client = get_client(PORT, &access_key, &secret_key);
+            let client = get_client(PORT, access_key, secret_key);
 
             create_table(&client, table_name).await;
             insert_rows(&client, "test_table", 0..5).await;
@@ -191,8 +189,8 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
                 .with_dataset(make_dynamodb_dataset(
                     table_name,
                     PORT,
-                    &access_key,
-                    &secret_key,
+                    access_key,
+                    secret_key,
                     true,
                 ))
                 .with_results_cache(ResultsCache {
@@ -202,7 +200,7 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
                 .build();
 
             configure_test_datafusion();
-            let mut rt = Runtime::builder().with_app(app).build().await;
+            let rt = Runtime::builder().with_app(app).build().await;
 
             let cloned_rt = Arc::new(rt.clone());
 

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -1,0 +1,251 @@
+use crate::docker::{ContainerRunnerBuilder, RunningContainer};
+use crate::utils::{runtime_ready_check, test_request_context};
+use crate::{ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results};
+use app::AppBuilder;
+use async_graphql::futures_util::TryStreamExt;
+use aws_config::{BehaviorVersion, Region, SdkConfig, retry::RetryConfig};
+use aws_credential_types::{Credentials, provider::SharedCredentialsProvider};
+use aws_sdk_dynamodb::{
+    Client,
+    types::{
+        AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+        ScalarAttributeType, StreamSpecification, StreamViewType,
+    },
+};
+use bollard::secret::HealthConfig;
+use runtime::Runtime;
+use spicepod::acceleration::{Mode, OnConflictBehavior, RefreshMode};
+use spicepod::component::caching::ResultsCache;
+use spicepod::{
+    acceleration::Acceleration, component::dataset::Dataset, param::Params as DatasetParams,
+};
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::instrument;
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::{RetryError, retry};
+
+const DYNAMODB_DOCKER_CONTAINER: &str = "runtime-integration-test-dynamodb";
+const PORT: u16 = 8001;
+
+#[instrument]
+pub async fn start_dynamodb_docker_container(
+    port: u16,
+) -> Result<RunningContainer<'static>, anyhow::Error> {
+    let container_name = format!("{DYNAMODB_DOCKER_CONTAINER}-{port}");
+    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
+    let running_container = ContainerRunnerBuilder::new(container_name)
+        .image("amazon/dynamodb-local:latest".to_string())
+        .add_port_binding(8000, port)
+        .healthcheck(HealthConfig {
+            test: Some(vec![
+                "CMD-SHELL".to_string(),
+                "curl -s http://localhost:8000 | grep -q 'MissingAuthenticationToken' || exit 1"
+                    .to_string(),
+            ]),
+            interval: Some(2_000_000_000), // 2 seconds
+            timeout: Some(10_000_000_000), // 10 seconds
+            retries: Some(15),
+            start_period: Some(10_000_000_000), // 10 seconds
+            start_interval: None,
+        })
+        .build()?
+        .run(None)
+        .await?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+    Ok(running_container)
+}
+
+pub fn make_dynamodb_dataset(
+    table_name: &str,
+    port: u16,
+    access_key: &str,
+    secret_key: &str,
+    accelerated: bool,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("dynamodb:{table_name}"), table_name.to_string());
+    let params = HashMap::from([
+        (
+            "dynamodb_aws_access_key_id".to_string(),
+            access_key.to_string(),
+        ),
+        (
+            "dynamodb_aws_secret_access_key".to_string(),
+            secret_key.to_string(),
+        ),
+        ("dynamodb_aws_region".to_string(), "us-east-1".to_string()),
+        (
+            "endpoint_url".to_string(),
+            format!("http://localhost:{port}"),
+        ),
+    ]);
+    dataset.params = Some(DatasetParams::from_string_map(params));
+    if accelerated {
+        dataset.acceleration = Some(Acceleration {
+            enabled: true,
+            // engine: Some("duckdb".to_string()),
+            // mode: Mode::File,
+            refresh_mode: Some(RefreshMode::Changes),
+            // refresh_mode: Some(RefreshMode::Full),
+            // on_conflict: HashMap::from([("id".to_string(), OnConflictBehavior::Upsert)]),
+            ..Acceleration::default()
+        });
+    }
+    dataset
+}
+
+async fn create_table(client: &Client, table_name: &str) {
+    client
+        .create_table()
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("Table created");
+}
+
+fn get_client(port: u16, access_key: &str, secret_key: &str) -> Client {
+    let config = SdkConfig::builder()
+        .endpoint_url(format!("http://localhost:{port}"))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::from_keys(
+            access_key, secret_key, None,
+        )))
+        .retry_config(RetryConfig::standard().with_max_attempts(5))
+        .behavior_version(BehaviorVersion::latest())
+        .region(Some(Region::from_static("us-east-1")))
+        .build();
+    Client::new(&config)
+}
+
+async fn insert_rows(client: &Client, table_name: &str, range: Range<usize>) {
+    for i in range {
+        let id = format!("id-{}", i);
+
+        client
+            .put_item()
+            .table_name(table_name)
+            .item("id", AttributeValue::S(id))
+            .item("name", AttributeValue::S(format!("Item {}", i)))
+            .item("version", AttributeValue::N(i.to_string()))
+            .send()
+            .await
+            .expect("Failed to insert item");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_streams() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,dynamodb_streams=debug,info",
+    ));
+
+    let table_name = "test_table";
+    let access_key = "foo";
+    let secret_key = "bar";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT).await?;
+
+            let client = get_client(PORT, &access_key, &secret_key);
+
+            create_table(&client, table_name).await;
+            insert_rows(&client, "test_table", 0..5).await;
+
+            let app = AppBuilder::new("dynamodb_integration_test")
+                .with_dataset(make_dynamodb_dataset(
+                    table_name,
+                    PORT,
+                    &access_key,
+                    &secret_key,
+                    true,
+                ))
+                .with_results_cache(ResultsCache {
+                    enabled: false,
+                    ..Default::default()
+                })
+                .build();
+
+            configure_test_datafusion();
+            let mut rt = Runtime::builder().with_app(app).build().await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+            sleep(Duration::from_secs(2)).await;
+
+            let query_result = rt
+                .datafusion()
+                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let data = query_result.data.try_collect::<Vec<_>>().await?;
+            println!("Result: {data:#?}");
+
+            insert_rows(&client, "test_table", 5..7).await;
+            sleep(Duration::from_secs(2)).await;
+            let query_result = rt
+                .datafusion()
+                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let data = query_result.data.try_collect::<Vec<_>>().await?;
+            println!("Result2: {data:#?}");
+
+            insert_rows(&client, "test_table", 7..10).await;
+            sleep(Duration::from_secs(2)).await;
+            let query_result = rt
+                .datafusion()
+                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let data = query_result.data.try_collect::<Vec<_>>().await?;
+            println!("Result3: {data:#?}");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -87,11 +87,7 @@ pub fn make_dynamodb_dataset(
     if accelerated {
         dataset.acceleration = Some(Acceleration {
             enabled: true,
-            // engine: Some("duckdb".to_string()),
-            // mode: Mode::File,
             refresh_mode: Some(RefreshMode::Changes),
-            // refresh_mode: Some(RefreshMode::Full),
-            // on_conflict: HashMap::from([("id".to_string(), OnConflictBehavior::Upsert)]),
             ..Acceleration::default()
         });
     }
@@ -176,6 +172,7 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
 
             create_table(&client, table_name).await;
             insert_rows(&client, "test_table", 0..5).await;
+            sleep(Duration::from_secs(2)).await;
 
             let app = AppBuilder::new("dynamodb_integration_test")
                 .with_dataset(make_dynamodb_dataset(
@@ -205,40 +202,30 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
 
             runtime_ready_check(&rt).await;
             sleep(Duration::from_secs(2)).await;
-
-            let query_result = rt
-                .datafusion()
-                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
-                .build()
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))?;
-            let data = query_result.data.try_collect::<Vec<_>>().await?;
-            println!("Result: {data:#?}");
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "test1",
+            )
+            .await?;
 
             insert_rows(&client, "test_table", 5..7).await;
             sleep(Duration::from_secs(2)).await;
-            let query_result = rt
-                .datafusion()
-                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
-                .build()
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))?;
-            let data = query_result.data.try_collect::<Vec<_>>().await?;
-            println!("Result2: {data:#?}");
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "test2",
+            )
+            .await?;
 
             insert_rows(&client, "test_table", 7..10).await;
             sleep(Duration::from_secs(2)).await;
-            let query_result = rt
-                .datafusion()
-                .query_builder(&format!("SELECT * FROM {table_name} ORDER BY id"))
-                .build()
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))?;
-            let data = query_result.data.try_collect::<Vec<_>>().await?;
-            println!("Result3: {data:#?}");
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "test3",
+            )
+            .await?;
 
             running_container.remove().await.map_err(|e| {
                 tracing::error!("running_container.remove: {e}");
@@ -248,4 +235,25 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
             Ok(())
         })
         .await
+}
+
+async fn run_and_snapshot_query(
+    rt: &Runtime,
+    query: &str,
+    test_name: &str,
+) -> Result<(), anyhow::Error> {
+    let query_result = rt
+        .datafusion()
+        .query_builder(query)
+        .build()
+        .run()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    let data = query_result.data.try_collect::<Vec<_>>().await?;
+
+    let formatted = arrow::util::pretty::pretty_format_batches(&data)
+        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+    insta::assert_snapshot!(test_name, formatted);
+    Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

1. Added integration test for DynamoDB Streams by using dockerized dynamodb
  * New `endpoint_url` for DynamoDB Connector which allows to point it to local instance
2. Added support for in-memory acceleration (feature parity with kafka/debezium)
3. Added warning for cases:
  * `refresh_mode: changes` with disabled acceleration: `DynamoDB dataset X is configured for changes stream, but acceleration is disabled. Enable acceleration to use DynamoDB Streams`
  * In-memory acceleration: `Dataset X is not file-accelerated. DynamoDB Streams checkpoints will not be persisted.`
  * No `new_image`: `No new_image in DynamoDB Streams record. Make sure stream is configured with either NewImage or NewAndOldImages. https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html#Streams.Enabling`

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7880