### PR TITLE
Percent-encode Kubernetes secret name path segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13415,6 +13415,7 @@ dependencies = [
  "indexmap 2.12.1",
  "keyring",
  "logos",
+ "percent-encoding",
  "prost 0.13.5",
  "rand 0.9.2",
  "reqwest",

--- a/crates/runtime-secrets/Cargo.toml
+++ b/crates/runtime-secrets/Cargo.toml
@@ -21,6 +21,7 @@ snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tracing.workspace = true
 tokio = { workspace = true, features = ["sync"] }
+percent-encoding.workspace = true
 flight_client = { optional = true, path = "../flight_client" }
 arrow-flight = { optional = true, workspace = true }
 runtime-proto = { optional = true, path = "../runtime-proto" }

--- a/crates/runtime-secrets/src/stores/kubernetes.rs
+++ b/crates/runtime-secrets/src/stores/kubernetes.rs
@@ -18,7 +18,12 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use base64::{Engine, engine::general_purpose};
-use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+
+/// Characters that must be percent-encoded in Kubernetes secret names to prevent path traversal.
+/// This encodes control characters plus `/` and `\` to prevent path traversal attacks,
+/// while preserving safe characters like `-`, `_`, and `.` that are valid in secret names.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS.add(b'/').add(b'\\');
 use reqwest;
 use secrecy::SecretString;
 use snafu::{ResultExt, Snafu};
@@ -69,7 +74,7 @@ struct KubernetesClient {
 }
 
 fn secret_url(namespace: &str, secret_name: &str) -> String {
-    let encoded_secret_name = utf8_percent_encode(secret_name, NON_ALPHANUMERIC);
+    let encoded_secret_name = utf8_percent_encode(secret_name, PATH_SEGMENT_ENCODE_SET);
     format!("{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{encoded_secret_name}")
 }
 

--- a/crates/runtime-secrets/src/stores/kubernetes.rs
+++ b/crates/runtime-secrets/src/stores/kubernetes.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use base64::{Engine, engine::general_purpose};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest;
 use secrecy::SecretString;
 use snafu::{ResultExt, Snafu};
@@ -123,8 +124,10 @@ impl KubernetesClient {
             return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
-        let url =
-            format!("{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{secret_name}");
+        let encoded_secret_name = utf8_percent_encode(secret_name, NON_ALPHANUMERIC);
+        let url = format!(
+            "{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{encoded_secret_name}"
+        );
 
         let kubernetes_secret = client
             .get(url.clone())

--- a/crates/runtime-secrets/src/stores/kubernetes.rs
+++ b/crates/runtime-secrets/src/stores/kubernetes.rs
@@ -68,6 +68,11 @@ struct KubernetesClient {
     namespace: Option<String>,
 }
 
+fn secret_url(namespace: &str, secret_name: &str) -> String {
+    let encoded_secret_name = utf8_percent_encode(secret_name, NON_ALPHANUMERIC);
+    format!("{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{encoded_secret_name}")
+}
+
 impl KubernetesClient {
     fn new() -> Self {
         Self {
@@ -124,10 +129,7 @@ impl KubernetesClient {
             return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
-        let encoded_secret_name = utf8_percent_encode(secret_name, NON_ALPHANUMERIC);
-        let url = format!(
-            "{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{encoded_secret_name}"
-        );
+        let url = secret_url(namespace, secret_name);
 
         let kubernetes_secret = client
             .get(url.clone())
@@ -213,5 +215,22 @@ impl SecretStore for KubernetesSecretStore {
             }
             Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::secret_url;
+
+    #[test]
+    fn secret_url_encodes_secret_name() {
+        let url = secret_url("default", "../configmaps/sensitive");
+        assert!(url.ends_with("secrets/..%2Fconfigmaps%2Fsensitive"));
+    }
+
+    #[test]
+    fn secret_url_handles_regular_name_without_changes() {
+        let url = secret_url("default", "my-secret");
+        assert!(url.ends_with("secrets/my-secret"));
     }
 }


### PR DESCRIPTION
## Summary
`percent-encode` the Kubernetes secret name when constructing the API URL to avoid potential path traversal. This isn't possible to trigger in the current codebase since the `secret_name` comes from the `spicepod.yaml` directly, but this gives us some extra defense in depth in case we re-use this for anything else in the future where the secret name may not be trusted.
