### PR TITLE
Vortex file format for object store

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -40,6 +40,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::parquet::arrow::async_reader::ObjectVersionType;
 use datafusion::physical_plan::empty::EmptyExec;
+#[cfg(feature = "vortex")]
 use datafusion_datasource::file_format::FileFormatFactory;
 use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
@@ -540,7 +541,7 @@ pub trait ListingTableConnector: DataConnector {
                 extension.unwrap_or(".jsonl".to_string()),
             )),
             #[cfg(feature = "vortex")]
-            (Some("vortex"), _) | (None, Some("vortex"))=> Ok((
+            (Some("vortex"), _) | (None, Some("vortex")) => Ok((
                 Some(VortexFormatFactory::new().default()),
                 extension.unwrap_or(".vortex".to_string()),
             )),
@@ -552,7 +553,6 @@ pub trait ListingTableConnector: DataConnector {
             )),
             (Some(format), _) => Ok((None, format!(".{format}"))),
             (_, _) => Err(
-
                     crate::dataconnector::DataConnectorError::InvalidConfiguration {
                         dataconnector: format!("{self}"),
                         message: "The required 'file_format' parameter is missing. Ensure the parameter is provided, and try again.".to_string(),

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -40,6 +40,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::parquet::arrow::async_reader::ObjectVersionType;
 use datafusion::physical_plan::empty::EmptyExec;
+use datafusion_datasource::file_format::FileFormatFactory;
 use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::{PartitionedFile, metadata::MetadataColumn};
@@ -47,6 +48,8 @@ use futures::TryStreamExt;
 use object_store::{ObjectMeta, ObjectStore, path::Path};
 use snafu::prelude::*;
 use url::Url;
+#[cfg(feature = "vortex")]
+use vortex_datafusion::VortexFormatFactory;
 
 use crate::Runtime;
 use crate::accelerated_table::AcceleratedTable;
@@ -536,6 +539,11 @@ pub trait ListingTableConnector: DataConnector {
                 Some(self.get_jsonl_format(dataset, params)?),
                 extension.unwrap_or(".jsonl".to_string()),
             )),
+            #[cfg(feature = "vortex")]
+            (Some("vortex"), _) | (None, Some("vortex"))=> Ok((
+                Some(VortexFormatFactory::new().default()),
+                extension.unwrap_or(".vortex".to_string()),
+            )),
             (Some("parquet"), _) | (None, Some("parquet"))=> Ok((
                 Some(Arc::new(
                     ParquetFormat::default().with_options(self.get_table_parquet_options(dataset).await?),
@@ -544,6 +552,7 @@ pub trait ListingTableConnector: DataConnector {
             )),
             (Some(format), _) => Ok((None, format!(".{format}"))),
             (_, _) => Err(
+
                     crate::dataconnector::DataConnectorError::InvalidConfiguration {
                         dataconnector: format!("{self}"),
                         message: "The required 'file_format' parameter is missing. Ensure the parameter is provided, and try again.".to_string(),


### PR DESCRIPTION
## 📝 Summary
Enables using vortex as file for any object_store data connector.

```yaml
datasets:
  - from: file:./data/wiki_en/compact
    name: vortex.compact
    params:
      file_format: vortex

  - from: file:./data/wiki_en/parquet
    name: parquet
    params:
      file_format: parquet

```