### PR TITLE
Use separate Tokio runtime for SWR refreshes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13235,6 +13235,7 @@ name = "runtime-async"
 version = "1.10.1-unstable"
 dependencies = [
  "futures",
+ "libc",
  "num_cpus",
  "snafu",
  "tokio",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -268,10 +268,15 @@ pub async fn run(args: Args) -> Result<()> {
 
             rt.datafusion().set_cpu_runtime(cpu_runtime);
 
-            // Create a dedicated refresh runtime for acceleration refresh workers.
-            // This isolates refresh workloads from query execution to prevent large refresh
-            // operations from impacting query latency.
-            let refresh_runtime = ManagedTokioRuntime::try_new()
+            // Create a dedicated refresh runtime for acceleration refresh workers and
+            // stale-while-revalidate background cache refresh tasks. This isolates refresh
+            // workloads from query execution to prevent large refresh operations from
+            // impacting query latency.
+            // Uses low thread priority to minimize impact on latency-sensitive operations.
+            let refresh_runtime = ManagedTokioRuntime::builder()
+                .with_low_priority()
+                .with_thread_name("refresh-worker")
+                .build()
                 .boxed()
                 .context(UnableToInitializeDatafusionTokioRuntimeSnafu)?;
 

--- a/crates/runtime-async/Cargo.toml
+++ b/crates/runtime-async/Cargo.toml
@@ -14,3 +14,6 @@ futures.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 snafu.workspace = true
 num_cpus.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/runtime-async/src/lib.rs
+++ b/crates/runtime-async/src/lib.rs
@@ -70,14 +70,91 @@ impl ManagedTokioRuntime {
     ///
     /// Returns [`Error::RuntimeCreation`] if the Tokio runtime cannot be constructed.
     pub fn try_new() -> Result<Self> {
+        Self::builder().build()
+    }
+
+    /// Create a builder for configuring the runtime.
+    #[must_use]
+    pub fn builder() -> ManagedTokioRuntimeBuilder {
+        ManagedTokioRuntimeBuilder::new()
+    }
+
+    /// Return a handle suitable for spawning tasks
+    #[must_use]
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+/// Builder for [`ManagedTokioRuntime`] with configuration options.
+pub struct ManagedTokioRuntimeBuilder {
+    low_priority: bool,
+    thread_name: Option<String>,
+}
+
+impl Default for ManagedTokioRuntimeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ManagedTokioRuntimeBuilder {
+    /// Create a new builder with default settings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            low_priority: false,
+            thread_name: None,
+        }
+    }
+
+    /// Set worker threads to run at lower priority (nice value 10 on Unix).
+    /// This is useful for background tasks that shouldn't compete with latency-sensitive work.
+    #[must_use]
+    pub fn with_low_priority(mut self) -> Self {
+        self.low_priority = true;
+        self
+    }
+
+    /// Set a custom thread name prefix for worker threads.
+    #[must_use]
+    pub fn with_thread_name(mut self, name: impl Into<String>) -> Self {
+        self.thread_name = Some(name.into());
+        self
+    }
+
+    /// Build the runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeCreation`] if the Tokio runtime cannot be constructed.
+    pub fn build(self) -> Result<ManagedTokioRuntime> {
         let cpu_cores = num_cpus::get();
         let worker_threads = std::cmp::max(cpu_cores.saturating_sub(1), 1);
 
-        let runtime = tokio::runtime::Builder::new_multi_thread()
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder
             // Reserve one core for the primary Tokio runtime handling HTTP and control-plane work.
             .worker_threads(worker_threads)
-            .enable_all()
-            .build()?;
+            .enable_all();
+
+        if let Some(name) = &self.thread_name {
+            builder.thread_name(name);
+        }
+
+        // Set low priority on worker threads if requested (Unix only)
+        #[cfg(unix)]
+        if self.low_priority {
+            builder.on_thread_start(|| {
+                // Set nice value to 10 (lower priority than default 0, range is -20 to 19)
+                // SAFETY: setpriority is safe to call with PRIO_PROCESS and 0 (current thread)
+                unsafe {
+                    libc::setpriority(libc::PRIO_PROCESS, 0, 10);
+                }
+            });
+        }
+
+        let runtime = builder.build()?;
         let handle = runtime.handle().clone();
         let notify_shutdown = Arc::new(Notify::new());
         let notify_shutdown_captured = Arc::clone(&notify_shutdown);
@@ -90,17 +167,11 @@ impl ManagedTokioRuntime {
             // Note: runtime is dropped here
         });
 
-        Ok(Self {
+        Ok(ManagedTokioRuntime {
             handle,
             notify_shutdown,
             thread_join_handle: Some(thread_join_handle),
         })
-    }
-
-    /// Return a handle suitable for spawning tasks
-    #[must_use]
-    pub fn handle(&self) -> &Handle {
-        &self.handle
     }
 }
 

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -530,9 +530,11 @@ impl Query {
         let sql_owned = sql.to_string();
         let plan_owned = plan.cloned();
 
-        // Spawn a detached task for background revalidation
-        // Use optionally_get_with to ensure only one revalidation per key runs concurrently
-        tokio::spawn(async move {
+        // Get optional dedicated refresh runtime, fall back to current runtime if not configured
+        let refresh_runtime = df.refresh_runtime().cloned();
+
+        // Build the background task
+        let background_task = async move {
             // optionally_get_with provides automatic single-in-flight: if another task
             // is already running for this key, this will return None immediately
             let result = locks
@@ -617,7 +619,16 @@ impl Query {
                 );
                 cache::metrics::sql_results::STALE_WHILE_REVALIDATE_SKIPPED.add(1, &[]);
             }
-        });
+        };
+
+        // Spawn on dedicated refresh runtime if configured, otherwise use current runtime.
+        // Using the dedicated refresh runtime isolates SWR background work from user-facing
+        // query processing, preventing latency spikes when many cache entries become stale.
+        if let Some(runtime) = refresh_runtime {
+            runtime.spawn(background_task);
+        } else {
+            tokio::spawn(background_task);
+        }
     }
 
     pub(super) fn wrap_stream_with_cache(


### PR DESCRIPTION
## 📝 Summary

Moves the background refreshes that happen as part of the SQL Results Cache SWR implementation onto the same Tokio runtime that acceleration refreshes happen on. The thread priority of the refresh pool is lowered to prioritize the main thread pools.

Prior to this change, under heavy load with all queries hitting the results cache, Spice would drop in performance whenever a bunch of SWR tasks were triggered:

<img width="1417" height="922" alt="Pasted image 20251211175446" src="https://github.com/user-attachments/assets/a15f204d-ae51-4e12-85d2-1f170affaef7" />

After this change, the drop in performance is still noticeable but is much improved from before:

<img width="1417" height="922" alt="Pasted image 20251211175604" src="https://github.com/user-attachments/assets/83571523-3935-41d2-9150-d7f951e24c34" />
