### PR TITLE
fix(cluster): initialize secrets before object stores in executor

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -191,14 +191,16 @@ pub async fn initialize_cluster_executor(
             .boxed()
             .context(FailedToStartClusterExecutorSnafu)?;
         rt.status.update_cluster("executor", ComponentStatus::Ready);
-        executor_bind_object_stores(Arc::clone(&rt)).await?;
 
+        // Initialize secrets first so they're available for object store configuration
         executor_bind_app(
             &rt,
             rt.config.cluster.scheduler_url.to_string(),
             executor_id,
         )
         .await?;
+
+        executor_bind_object_stores(Arc::clone(&rt)).await?;
 
         executor_poll_loop
             .await


### PR DESCRIPTION
## 📝 Summary

In clustered mode, executor queries against datasets using secrets (e.g., Delta Lake with S3 credentials) fail with 403 Forbidden errors.

The executor's startup sequence called `executor_bind_object_stores()` **before** `executor_bind_app()`. Object stores need to resolve secret patterns like `${secrets:DELTA_LAKE_AWS_ACCESS_KEY_ID}`, but the `SchedulerRPCSecretStore` (which fetches secrets from the scheduler via the `ExpandSecret` Flight action) is only initialized in `executor_bind_app()`.

Result: secrets resolved to empty strings, S3 requests were unauthenticated.


Solution: Reorder executor initialization:
1. `executor_bind_app()` — initializes `SchedulerRPCSecretStore`
2. `executor_bind_object_stores()` — can now resolve secrets via RPC


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
