### PR TITLE
feat: testoperator: OTLP streaming metrics / connect to existing instance / infinite mode / query timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15727,6 +15727,7 @@ dependencies = [
  "nix",
  "octocrab",
  "opentelemetry 0.29.1",
+ "opentelemetry-otlp",
  "opentelemetry_sdk 0.29.0",
  "otel-arrow",
  "rand 0.9.2",
@@ -15764,6 +15765,7 @@ dependencies = [
  "spiceai",
  "test-framework",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -29,6 +29,7 @@ indicatif = "0.18.0"
 insta.workspace = true
 octocrab = "0.47.0"
 opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 otel-arrow = { path = "../../crates/otel-arrow" }
 rand.workspace = true

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -49,7 +49,13 @@ impl Display for SpicedVersion {
 }
 
 pub enum SpicedInstance {
+    /// Connect to an existing local spiced instance at default ports
     Existing,
+    /// Connect to an external spiced instance at custom URLs
+    External {
+        flight_url: String,
+        http_base_url: String,
+    },
     Owned {
         child: Child,
         tempdir: TempDir,
@@ -127,6 +133,38 @@ impl SpicedInstance {
     #[must_use]
     pub fn empty() -> Self {
         Self::Existing
+    }
+
+    /// Create an instance that connects to an external spiced at the given Flight URL.
+    ///
+    /// The HTTP base URL is derived from the Flight URL by replacing the port with 8090,
+    /// or can be explicitly provided.
+    #[must_use]
+    pub fn external(flight_url: impl Into<String>) -> Self {
+        let flight_url = flight_url.into();
+        // Derive HTTP URL from Flight URL by replacing port
+        // e.g., "http://localhost:50051" -> "http://localhost:8090"
+        let http_base_url = if let Some(last_colon) = flight_url.rfind(':') {
+            format!("{}:8090", &flight_url[..last_colon])
+        } else {
+            format!("{flight_url}:8090")
+        };
+        Self::External {
+            flight_url,
+            http_base_url,
+        }
+    }
+
+    /// Create an instance with explicit Flight and HTTP URLs.
+    #[must_use]
+    pub fn external_with_http(
+        flight_url: impl Into<String>,
+        http_base_url: impl Into<String>,
+    ) -> Self {
+        Self::External {
+            flight_url: flight_url.into(),
+            http_base_url: http_base_url.into(),
+        }
     }
 
     /// Start a spiced instance
@@ -227,8 +265,13 @@ impl SpicedInstance {
             spice_client = spice_client.cache_control("no-cache");
         }
 
+        let flight_url = match self {
+            Self::External { flight_url, .. } => flight_url.as_str(),
+            Self::Existing | Self::Owned { .. } => FLIGHT_URL,
+        };
+
         let spice_client = spice_client
-            .flight_url(FLIGHT_URL)
+            .flight_url(flight_url)
             .user_agent("spice-test-framework/1.0")
             .build()
             .await
@@ -248,6 +291,15 @@ impl SpicedInstance {
             .build()?)
     }
 
+    /// Get the HTTP base URL for this instance
+    #[must_use]
+    pub fn http_base_url(&self) -> &str {
+        match self {
+            Self::External { http_base_url, .. } => http_base_url.as_str(),
+            Self::Existing | Self::Owned { .. } => HTTP_BASE_URL,
+        }
+    }
+
     /// Wait for the spiced instance to be ready
     ///
     /// # Errors
@@ -256,7 +308,8 @@ impl SpicedInstance {
     pub async fn wait_for_ready(&mut self, timeout: Duration) -> Result<()> {
         // Wait for the spiced instance to be ready by polling the `/v1/ready` endpoint
         let client = self.http_client()?;
-        let ready_url = format!("{HTTP_BASE_URL}{READY_ENDPOINT}");
+        let http_base = self.http_base_url().to_string();
+        let ready_url = format!("{http_base}{READY_ENDPOINT}");
         if !wait_until_true(timeout, || async {
             let response = client.get(&ready_url).send().await;
             match response {
@@ -280,7 +333,7 @@ impl SpicedInstance {
         let Ok(client) = self.http_client() else {
             return false;
         };
-        let ready_url = format!("{HTTP_BASE_URL}{READY_ENDPOINT}");
+        let ready_url = format!("{}{READY_ENDPOINT}", self.http_base_url());
         let response = client.get(&ready_url).send().await;
         match response {
             Ok(response) => response.status().is_success(),

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -26,11 +26,13 @@ use crate::{
         ThroughputMetrics, system_time_to_unix_epoch_ms,
     },
     queries::Query,
+    telemetry::streaming::QueryMetricEvent,
 };
 use anyhow::Result;
 use arrow::array::RecordBatch;
 use futures::future::join_all;
 use indicatif::{MultiProgress, ProgressBar};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use super::{SpiceTest, TestCompleted, TestNotStarted, TestState};
@@ -41,6 +43,7 @@ pub(crate) use worker::{SpiceTestQueryWorker, SpiceTestQueryWorkerResult};
 pub enum EndCondition {
     Duration(Duration),
     QuerySetCompleted(usize),
+    Unlimited,
 }
 
 impl Default for EndCondition {
@@ -55,6 +58,7 @@ impl EndCondition {
         match self {
             EndCondition::Duration(duration) => start.elapsed() >= *duration,
             EndCondition::QuerySetCompleted(count) => query_set_count >= *count,
+            EndCondition::Unlimited => false,
         }
     }
 }
@@ -71,6 +75,8 @@ pub struct NotStarted {
     http_client: bool,
     validation_data: Option<HashMap<Arc<str>, Vec<RecordBatch>>>,
     reference_schema: Option<String>,
+    streaming_metrics_sender: Option<mpsc::Sender<QueryMetricEvent>>,
+    query_duration_threshold: Option<Duration>,
 }
 
 impl NotStarted {
@@ -136,6 +142,18 @@ impl NotStarted {
         self.reference_schema = reference_schema;
         self
     }
+
+    #[must_use]
+    pub fn with_streaming_metrics(mut self, sender: mpsc::Sender<QueryMetricEvent>) -> Self {
+        self.streaming_metrics_sender = Some(sender);
+        self
+    }
+
+    #[must_use]
+    pub fn with_query_duration_threshold(mut self, threshold: Option<Duration>) -> Self {
+        self.query_duration_threshold = threshold;
+        self
+    }
 }
 
 pub type SpiceTestQueryWorkers = Vec<JoinHandle<Result<SpiceTestQueryWorkerResult>>>;
@@ -147,6 +165,7 @@ pub struct Running {
     query_count: usize,
     parallel_count: usize,
     end_condition: EndCondition,
+    shutdown_token: tokio_util::sync::CancellationToken,
 }
 pub struct Completed {
     pub(crate) query_durations: BTreeMap<Arc<str>, Vec<Duration>>,
@@ -182,6 +201,10 @@ impl SpiceTest<NotStarted> {
             EndCondition::QuerySetCompleted(count) => {
                 ProgressBar::new((self.state.query_set.len() * count) as u64)
             }
+            EndCondition::Unlimited => {
+                // For unlimited tests, use a spinner-style progress bar
+                ProgressBar::new_spinner()
+            }
         }
     }
 
@@ -201,6 +224,7 @@ impl SpiceTest<NotStarted> {
         };
 
         let http_client = self.get_spiced()?.http_client()?;
+        let shutdown_token = tokio_util::sync::CancellationToken::new();
 
         let mut query_workers = Vec::new();
         for id in 0..self.state.parallel_count {
@@ -213,7 +237,8 @@ impl SpiceTest<NotStarted> {
             .with_explain_plan_snapshot(self.explain_plan_snapshot)
             .with_results_snapshot(self.results_snapshot_predicate)
             .with_validate(self.state.validate)
-            .with_scale_factor(self.state.scale_factor);
+            .with_scale_factor(self.state.scale_factor)
+            .with_shutdown_token(shutdown_token.clone());
 
             if let Some(multi) = &multi {
                 worker = worker.with_progress_bar(multi.add(self.get_new_progress_bar()));
@@ -237,6 +262,14 @@ impl SpiceTest<NotStarted> {
                 worker = worker.with_reference_schema(Some(reference_schema.clone()));
             }
 
+            if let Some(sender) = &self.state.streaming_metrics_sender {
+                worker = worker.with_streaming_metrics(sender.clone());
+            }
+
+            if let Some(threshold) = self.state.query_duration_threshold {
+                worker = worker.with_query_duration_threshold(threshold);
+            }
+
             query_workers.push(worker.start());
         }
 
@@ -255,12 +288,22 @@ impl SpiceTest<NotStarted> {
                 query_count: self.state.query_count,
                 parallel_count: self.state.parallel_count,
                 end_condition: self.state.end_condition,
+                shutdown_token,
             },
         })
     }
 }
 
 impl SpiceTest<Running> {
+    #[must_use]
+    pub fn cancellation_token(&self) -> tokio_util::sync::CancellationToken {
+        self.state.shutdown_token.clone()
+    }
+
+    pub fn cancel(&self) {
+        self.state.shutdown_token.cancel();
+    }
+
     pub async fn wait(self) -> Result<SpiceTest<Completed>> {
         let mut query_durations = BTreeMap::new();
         let mut query_iteration_durations = BTreeMap::new();
@@ -377,6 +420,11 @@ impl SpiceTest<Completed> {
             EndCondition::Duration(_) => {
                 return Err(anyhow::anyhow!(
                     "Throughput metric calculation for duration-based tests is not supported. Use a QuerySetCompleted test instead."
+                ));
+            }
+            EndCondition::Unlimited => {
+                return Err(anyhow::anyhow!(
+                    "Throughput metric calculation is not supported for unlimited tests."
                 ));
             }
             EndCondition::QuerySetCompleted(count) => f64::from(u32::try_from(count)?),

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -27,9 +27,12 @@ use dashmap::DashMap;
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use spiceai::{Client as SpiceClient, SpiceClientError};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::constants::{HTTP_BASE_URL, SQL_ENDPOINT};
+use crate::telemetry::streaming::QueryMetricEvent;
 
 use crate::{
     metrics::QueryStatus,
@@ -59,6 +62,11 @@ pub(crate) struct SpiceTestQueryWorker {
     skip_row_count_validation: HashSet<String>,
     /// Whether to validate row counts between HTTP and Flight endpoints, and check for zero rows
     validate_row_counts: bool,
+    shutdown_token: CancellationToken,
+    /// Optional sender for streaming query metrics to OTLP
+    streaming_metrics_sender: Option<mpsc::Sender<QueryMetricEvent>>,
+    /// Duration threshold - queries exceeding this are marked as failed in streaming metrics
+    query_duration_threshold: Option<Duration>,
 }
 
 pub struct SpiceTestQueryWorkerResult {
@@ -120,6 +128,9 @@ impl SpiceTestQueryWorker {
             reference_schema: None,
             skip_row_count_validation: default_row_count_validation_skip_queries(),
             validate_row_counts: true,
+            shutdown_token: CancellationToken::new(),
+            streaming_metrics_sender: None,
+            query_duration_threshold: None,
         }
     }
 
@@ -138,8 +149,23 @@ impl SpiceTestQueryWorker {
         self
     }
 
+    pub fn with_shutdown_token(mut self, shutdown_token: CancellationToken) -> Self {
+        self.shutdown_token = shutdown_token;
+        self
+    }
+
     pub fn with_validate(mut self, validate: bool) -> Self {
         self.validate = validate;
+        self
+    }
+
+    pub fn with_streaming_metrics(mut self, sender: mpsc::Sender<QueryMetricEvent>) -> Self {
+        self.streaming_metrics_sender = Some(sender);
+        self
+    }
+
+    pub fn with_query_duration_threshold(mut self, threshold: Duration) -> Self {
+        self.query_duration_threshold = Some(threshold);
         self
     }
 
@@ -179,6 +205,29 @@ impl SpiceTestQueryWorker {
         self
     }
 
+    /// Send a query metric event to the streaming exporter if configured.
+    /// If a duration threshold is set and the query exceeds it, it will be marked as a timeout failure.
+    fn send_streaming_metric(&self, query_name: &str, duration: Duration, success: bool) {
+        let Some(sender) = &self.streaming_metrics_sender else {
+            return;
+        };
+
+        // Check if duration exceeds threshold - if so, mark as timeout failure
+        let exceeded_threshold =
+            success && self.query_duration_threshold.is_some_and(|t| duration > t);
+
+        let event = if exceeded_threshold {
+            QueryMetricEvent::with_failure(query_name.to_string(), duration, self.id, "timeout")
+        } else if success {
+            QueryMetricEvent::new(query_name.to_string(), duration, true, self.id)
+        } else {
+            QueryMetricEvent::with_failure(query_name.to_string(), duration, self.id, "error")
+        };
+
+        // Non-blocking send - if channel is full, we drop the metric
+        let _ = sender.try_send(event);
+    }
+
     /// Validate query results against expected data
     /// Uses TPCH validation for TPCH queries, custom validation data for scenario queries
     fn validate_query_results(
@@ -216,9 +265,11 @@ impl SpiceTestQueryWorker {
             let start = Instant::now();
 
             match self.end_condition {
-                EndCondition::Duration(_) => {
-                    // For Duration-based end condition, keep running queries in sequence
-                    while !self.end_condition.is_met(&start, query_set_count) {
+                EndCondition::Duration(_) | EndCondition::Unlimited => {
+                    // For Duration-based or Unlimited end condition, keep running queries in sequence
+                    while !self.shutdown_token.is_cancelled()
+                        && !self.end_condition.is_met(&start, query_set_count)
+                    {
                         if self.progress_bar.is_none() && self.id == 0 {
                             println!(
                                 "Worker {} - Query set count: {} - Elapsed time: {:?}",
@@ -251,6 +302,9 @@ impl SpiceTestQueryWorker {
                     // For QuerySetCompleted, run each query target_count times before moving to next
                     let start = SystemTime::now();
                     for query in &self.query_set {
+                        if self.shutdown_token.is_cancelled() {
+                            break;
+                        }
                         if self.validate && query.name.contains("simple") {
                             continue; // skip validation for simple TPCH queries, because they are not part of the spec
                         }
@@ -507,6 +561,9 @@ impl SpiceTestQueryWorker {
                         limited_records.clear();
                         validation_records.clear();
                     } else {
+                        let duration = query_start.elapsed();
+                        // Send streaming metric for failed Flight query
+                        self.send_streaming_metric(&query.name, duration, false);
                         eprintln!(
                             "{} FAIL - Worker {} - Query '{}' failed: {}",
                             chrono::Utc::now(),
@@ -673,6 +730,9 @@ impl SpiceTestQueryWorker {
         }
 
         let duration = query_start.elapsed();
+
+        // Send streaming metric for real-time OTLP export
+        self.send_streaming_metric(&query.name, duration, true);
 
         query_durations
             .entry(Arc::clone(&query.name))

--- a/crates/test-framework/src/telemetry/mod.rs
+++ b/crates/test-framework/src/telemetry/mod.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+pub mod streaming;
+
 use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
 use anyhow::Result;
 
@@ -27,6 +30,7 @@ use opentelemetry_sdk::{
     metrics::{SdkMeterProvider, data::ResourceMetrics},
 };
 
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use secrecy::SecretString;
 use telemetry::exporter::TelemetryExporterBuilder;
 pub use telemetry::meter::{METER_PROVIDER, METER_PROVIDER_ONCE};
@@ -42,11 +46,23 @@ pub static ENDPOINT: LazyLock<Arc<str>> = LazyLock::new(|| {
 
 pub static METER: LazyLock<Meter> = LazyLock::new(|| METER_PROVIDER.meter("benchmarks_telemetry"));
 
+#[derive(Debug, Clone)]
+pub struct OtlpExporterConfig {
+    pub endpoint: Arc<str>,
+    pub headers: Vec<(String, String)>,
+    pub timeout: Duration,
+}
+
+enum TelemetryBackend {
+    Arrow { api_key: Option<SecretString> },
+    Otlp(OtlpExporterConfig),
+}
+
 pub struct Telemetry {
     reader: InitialReader,
     resource: Resource,
     setup: bool,
-    api_key: Option<SecretString>,
+    backend: TelemetryBackend,
 }
 
 impl Telemetry {
@@ -77,14 +93,39 @@ impl Telemetry {
             println!("Telemetry disabled");
         }
 
+        let api_key = std::env::var(api_key_name)
+            .ok()
+            .as_deref()
+            .map(|key| SecretString::new(key.into()));
+
         Self {
             reader,
             resource: resource.clone(),
             setup,
-            api_key: std::env::var(api_key_name)
-                .ok()
-                .as_deref()
-                .map(|key| SecretString::new(key.into())),
+            backend: TelemetryBackend::Arrow { api_key },
+        }
+    }
+
+    #[must_use]
+    pub fn with_otlp(config: OtlpExporterConfig) -> Self {
+        let resource = Resource::builder_empty().build();
+        let reader = InitialReader::default();
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(resource.clone())
+            .with_reader(reader.clone())
+            .build();
+
+        let setup = METER_PROVIDER_ONCE.set(Arc::new(provider)).is_ok();
+        if !setup {
+            println!("Telemetry disabled");
+        }
+
+        Self {
+            reader,
+            resource,
+            setup,
+            backend: TelemetryBackend::Otlp(config),
         }
     }
 
@@ -101,40 +142,62 @@ impl Telemetry {
             return Ok(());
         }
 
-        if let Some(api_key) = &self.api_key {
-            println!("Emitting to exporter at {}", *ENDPOINT);
-            let telemetry_exporter = otel_arrow::OtelArrowExporter::new(
-                TelemetryExporterBuilder::new()
-                    .with_credentials(flight_client::Credentials::Bearer {
-                        token: api_key.clone().into(),
-                        prefix: false,
-                    })
-                    .with_service_name("benchmarks_telemetry".into())
-                    .with_endpoint(Arc::clone(&ENDPOINT))
-                    .build()
-                    .await?,
-            );
+        match &self.backend {
+            TelemetryBackend::Arrow { api_key } => {
+                if let Some(api_key) = api_key {
+                    println!("Emitting to exporter at {}", *ENDPOINT);
+                    let telemetry_exporter = otel_arrow::OtelArrowExporter::new(
+                        TelemetryExporterBuilder::new()
+                            .with_credentials(flight_client::Credentials::Bearer {
+                                token: api_key.clone().into(),
+                                prefix: false,
+                            })
+                            .with_service_name("benchmarks_telemetry".into())
+                            .with_endpoint(Arc::clone(&ENDPOINT))
+                            .build()
+                            .await?,
+                    );
 
-            let mut rm = ResourceMetrics {
-                resource: self.resource.clone(),
-                scope_metrics: vec![],
-            };
+                    let mut rm = ResourceMetrics {
+                        resource: self.resource.clone(),
+                        scope_metrics: vec![],
+                    };
 
-            self.reader.collect(&mut rm)?;
+                    self.reader.collect(&mut rm)?;
 
-            // Replace the resource from the provider with our potentially deferred resource.
-            // The provider was initialized with an empty resource, but we set the
-            // actual resource later via set_resource() once all attributes are known.
-            rm.resource = self.resource.clone();
+                    // Replace the resource from the provider with our potentially deferred resource.
+                    // The provider was initialized with an empty resource, but we set the
+                    // actual resource later via set_resource() once all attributes are known.
+                    rm.resource = self.resource.clone();
 
-            telemetry_exporter
-                .export(&mut rm)
-                .await
-                .unwrap_or_else(|err| {
-                    println!("Failed to export initial telemetry: {err:?}");
-                });
-        } else {
-            println!("No API key provided, telemetry is disabled");
+                    telemetry_exporter
+                        .export(&mut rm)
+                        .await
+                        .unwrap_or_else(|err| {
+                            println!("Failed to export initial telemetry: {err:?}");
+                        });
+                } else {
+                    println!("No API key provided, telemetry is disabled");
+                }
+            }
+            TelemetryBackend::Otlp(config) => {
+                let mut rm = ResourceMetrics {
+                    resource: self.resource.clone(),
+                    scope_metrics: vec![],
+                };
+                self.reader.collect(&mut rm)?;
+                rm.resource = self.resource.clone();
+
+                let exporter = MetricExporter::builder()
+                    .with_tonic()
+                    .with_timeout(config.timeout)
+                    .with_endpoint(config.endpoint.as_ref())
+                    .build()?;
+                exporter
+                    .export(&mut rm)
+                    .await
+                    .unwrap_or_else(|err| println!("Failed to export OTLP telemetry: {err:?}"));
+            }
         }
 
         Ok(())

--- a/crates/test-framework/src/telemetry/streaming.rs
+++ b/crates/test-framework/src/telemetry/streaming.rs
@@ -1,0 +1,225 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Streaming OTLP metrics exporter for real-time query metrics.
+//!
+//! This module provides incremental metrics export during test execution,
+//! allowing correlation with other system metrics in real-time.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use opentelemetry::metrics::{Histogram, Meter, MeterProvider as _};
+use opentelemetry::{KeyValue, global};
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// A query metric event to be exported
+#[derive(Debug, Clone)]
+pub struct QueryMetricEvent {
+    pub query_name: Arc<str>,
+    pub duration_ms: f64,
+    pub success: bool,
+    pub worker_id: usize,
+    /// Reason for failure, if any (e.g., "error", "timeout")
+    pub failure_reason: Option<String>,
+}
+
+impl QueryMetricEvent {
+    /// Create a new query metric event
+    #[must_use]
+    pub fn new(query_name: String, duration: Duration, success: bool, worker_id: usize) -> Self {
+        Self {
+            query_name: Arc::from(query_name),
+            duration_ms: duration.as_secs_f64() * 1000.0,
+            success,
+            worker_id,
+            failure_reason: None,
+        }
+    }
+
+    /// Create a new query metric event with a failure reason
+    #[must_use]
+    pub fn with_failure(
+        query_name: String,
+        duration: Duration,
+        worker_id: usize,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            query_name: Arc::from(query_name),
+            duration_ms: duration.as_secs_f64() * 1000.0,
+            success: false,
+            worker_id,
+            failure_reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Streaming OTLP exporter that sends query metrics in real-time
+pub struct StreamingOtlpExporter {
+    tx: mpsc::Sender<QueryMetricEvent>,
+    handle: JoinHandle<()>,
+    shutdown_token: CancellationToken,
+}
+
+impl StreamingOtlpExporter {
+    /// Spawn a new streaming OTLP exporter with the given endpoint.
+    ///
+    /// Metrics will be exported periodically (every 5 seconds).
+    #[must_use]
+    pub fn spawn(endpoint: String) -> Self {
+        // Use a bounded channel to avoid unbounded memory growth
+        let (tx, rx) = mpsc::channel(10_000);
+        let shutdown_token = CancellationToken::new();
+
+        let handle = tokio::spawn(Self::exporter_task(rx, endpoint, shutdown_token.clone()));
+
+        Self {
+            tx,
+            handle,
+            shutdown_token,
+        }
+    }
+
+    /// Get a sender that can be cloned and passed to workers
+    #[must_use]
+    pub fn sender(&self) -> mpsc::Sender<QueryMetricEvent> {
+        self.tx.clone()
+    }
+
+    async fn exporter_task(
+        mut rx: mpsc::Receiver<QueryMetricEvent>,
+        endpoint: String,
+        shutdown_token: CancellationToken,
+    ) {
+        // Build the OTLP exporter
+        let exporter = match MetricExporter::builder()
+            .with_tonic()
+            .with_timeout(Duration::from_secs(10))
+            .with_endpoint(&endpoint)
+            .build()
+        {
+            Ok(exp) => exp,
+            Err(e) => {
+                eprintln!("Failed to create streaming OTLP exporter: {e}");
+                return;
+            }
+        };
+
+        // Create a periodic reader that exports every 5 seconds
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(5))
+            .build();
+
+        let resource = Resource::builder()
+            .with_service_name("testoperator-streaming")
+            .build();
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(resource)
+            .with_reader(reader)
+            .build();
+
+        // Set as global provider for this task
+        global::set_meter_provider(provider.clone());
+
+        let meter: Meter = provider.meter("testoperator-streaming");
+        let query_duration_histogram: Histogram<f64> = meter
+            .f64_histogram("testoperator.streaming.query.duration_ms")
+            .with_description("Query execution duration in milliseconds (streaming)")
+            .with_unit("ms")
+            .build();
+
+        let query_count = meter
+            .u64_counter("testoperator.streaming.query.count")
+            .with_description("Total number of queries executed (streaming)")
+            .build();
+
+        let query_success_count = meter
+            .u64_counter("testoperator.streaming.query.success_count")
+            .with_description("Number of successful queries (streaming)")
+            .build();
+
+        let query_failure_count = meter
+            .u64_counter("testoperator.streaming.query.failure_count")
+            .with_description("Number of failed queries (streaming)")
+            .build();
+
+        println!("Streaming OTLP metrics exporter started (endpoint: {endpoint})");
+
+        loop {
+            tokio::select! {
+                Some(event) = rx.recv() => {
+                    let mut attributes = vec![
+                        KeyValue::new("query_name", event.query_name.to_string()),
+                        KeyValue::new("worker_id", event.worker_id.to_string()),
+                        KeyValue::new("success", event.success.to_string()),
+                    ];
+                    if let Some(reason) = &event.failure_reason {
+                        attributes.push(KeyValue::new("failure_reason", reason.clone()));
+                    }
+
+                    query_duration_histogram.record(event.duration_ms, &attributes);
+                    query_count.add(1, &attributes);
+
+                    if event.success {
+                        query_success_count.add(1, &attributes);
+                    } else {
+                        query_failure_count.add(1, &attributes);
+                    }
+                }
+                () = shutdown_token.cancelled() => {
+                    println!("Streaming OTLP metrics exporter shutting down");
+                    // Drain any remaining events
+                    while let Ok(event) = rx.try_recv() {
+                        let mut attributes = vec![
+                            KeyValue::new("query_name", event.query_name.to_string()),
+                            KeyValue::new("worker_id", event.worker_id.to_string()),
+                            KeyValue::new("success", event.success.to_string()),
+                        ];
+                        if let Some(reason) = &event.failure_reason {
+                            attributes.push(KeyValue::new("failure_reason", reason.clone()));
+                        }
+                        query_duration_histogram.record(event.duration_ms, &attributes);
+                        query_count.add(1, &attributes);
+                        if event.success {
+                            query_success_count.add(1, &attributes);
+                        } else {
+                            query_failure_count.add(1, &attributes);
+                        }
+                    }
+
+                    // Force a final flush
+                    if let Err(e) = provider.force_flush() {
+                        eprintln!("Failed to flush streaming metrics: {e}");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Shutdown the exporter and wait for the background task to complete
+    pub async fn shutdown(self) {
+        self.shutdown_token.cancel();
+        let _ = self.handle.await;
+    }
+}

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -19,6 +19,7 @@ serde_yaml.workspace = true
 spiceai.workspace = true
 test-framework = { path = "../../crates/test-framework" }
 tokio.workspace = true
+tokio-util.workspace = true
 
 [features]
 default = ["append"]

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -9,10 +9,11 @@ While a test is executing, `testoperator` continuously probes the `/health` and 
 ## Common Options
 
 - `-p, --spicepod-path <SPICEPOD_PATH>`: Path to the `spicepod.yaml` file.
-- `-s, --spiced-path <SPICED_PATH>`: Path to the `spiced` binary.
+- `-s, --spiced-path <SPICED_PATH>`: Path to the `spiced` binary, or URL to an already-running spiced instance's Flight endpoint (e.g., `http://localhost:50051` to connect to an external instance).
 - `-d, --data-dir <DATA_DIR>`: An optional data directory to symlink into the `spiced` instance.
 - `--ready-wait <WAIT TIME>`: How long to wait before spiced is ready.
 - `--disable-progress-bars`: Disable progress bars during the test.
+- `--otlp-endpoint <URL>` / `--otlp-header KEY=VALUE`: Export metrics to an OTLP collector over the standard OTLP protocol instead of the default Arrow exporter. Repeat `--otlp-header` to add multiple headers (e.g., auth tokens).
 
 ## Use cases
 
@@ -141,6 +142,8 @@ testoperator run throughput -p ./benchmarks/file_tpch.yaml -s spiced -d ./.data 
 A load test replicates a throughput test, but instead of running for a set number of query executions (2 by default for throughput tests) load tests run for a specified duration. A load test uses the same command options as a throughput test, with the additional options:
 
 - `--duration <SECONDS>`: The duration of the load test to run in seconds.
+- `--run-until-stopped`: Continue the load phase until manually interrupted (Ctrl+C). Warm-up and baseline still use `--duration` to size their runs.
+- `--mark-query-failed-if-exceeds <DURATION>`: Mark queries as failed if they exceed this duration threshold (e.g., "500ms", "2s"). Useful for identifying slow queries that should be treated as failures in metrics.
 
 A load test will match the specified duration as a best-effort. A load test will never be shorter than the specified duration, but can be longer than the specified duration if there are running queries when the end duration is passed. For example, a `--duration 10` is specified but a query that takes 60 seconds runs. The load test will end after the query finishes, taking 60 seconds instead of 10.
 

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -89,6 +89,16 @@ pub struct DatasetTestArgs {
     /// Whether to add HTTP clients for the test
     #[arg(long)]
     pub(crate) http_clients: bool,
+
+    /// Random parameter set count for parameterized queries (tests with different random parameters each run).
+    /// If not specified or 0, fixed parameters are used (no randomization).
+    #[arg(long)]
+    pub(crate) random_param_set_count: Option<usize>,
+
+    /// Mark queries as failed if they exceed this duration threshold (e.g., "500ms", "2s").
+    /// Useful for identifying slow queries that should be treated as failures in metrics.
+    #[arg(long, value_parser = parse_duration)]
+    pub(crate) mark_query_failed_if_exceeds: Option<std::time::Duration>,
 }
 
 #[derive(Clone, ValueEnum, Debug, Deserialize, Serialize)]
@@ -253,4 +263,37 @@ pub struct LoadTestArgs {
 
     #[arg(long)]
     pub(crate) no_error: bool,
+
+    /// Run until manually interrupted; disables duration-based stopping for the load phase
+    #[arg(long)]
+    pub(crate) run_until_stopped: bool,
+}
+
+/// Parse a duration string like "500ms", "2s", "1m" into a `Duration`
+fn parse_duration(s: &str) -> Result<std::time::Duration, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("duration cannot be empty".to_string());
+    }
+
+    // Find where the numeric part ends
+    let num_end = s
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(s.len());
+
+    let (num_str, unit) = s.split_at(num_end);
+    let num: f64 = num_str
+        .parse()
+        .map_err(|_| format!("invalid number: {num_str}"))?;
+
+    let multiplier = match unit.trim().to_lowercase().as_str() {
+        "ms" | "millis" | "milliseconds" => 1.0,
+        "s" | "sec" | "secs" | "second" | "seconds" | "" => 1000.0,
+        "m" | "min" | "mins" | "minute" | "minutes" => 60_000.0,
+        _ => return Err(format!("unknown time unit: {unit}")),
+    };
+
+    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let millis = (num * multiplier) as u64;
+    Ok(std::time::Duration::from_millis(millis))
 }

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 
 mod http;
 pub use http::{HttpConsistencyTestArgs, HttpOverheadTestArgs, HttpTestArgs};
@@ -87,9 +87,10 @@ pub struct CommonArgs {
     #[arg(long, default_value = "1")]
     pub(crate) concurrency: usize,
 
-    /// Path to the spiced binary
+    /// Path to the spiced binary, or URL to an already-running spiced instance's Flight endpoint
+    /// (e.g., `http://localhost:50051` to connect to an external instance)
     #[arg(short, long, default_value = "spiced")]
-    pub(crate) spiced_path: PathBuf,
+    pub(crate) spiced_path: String,
 
     /// The number of seconds to wait for the spiced instance to become ready
     #[arg(long, default_value = "30")]
@@ -114,4 +115,33 @@ pub struct CommonArgs {
     /// Whether to enable scraping spiced metrics (automatically enables --metrics for spiced)
     #[arg(long)]
     pub(crate) scrape_spiced_metrics: bool,
+
+    /// OTLP metrics collector endpoint (HTTP or gRPC). If unset, falls back to Arrow telemetry.
+    #[arg(long)]
+    pub(crate) otlp_endpoint: Option<String>,
+
+    /// Additional OTLP headers in key=value form. Can be repeated.
+    #[arg(long, value_parser = parse_key_val, action = ArgAction::Append, requires = "otlp_endpoint", value_name = "KEY=VALUE")]
+    pub(crate) otlp_header: Vec<(String, String)>,
+}
+
+impl CommonArgs {
+    /// Check if `spiced_path` is a URL to an external instance
+    #[must_use]
+    pub fn is_external_instance(&self) -> bool {
+        self.spiced_path.starts_with("http://") || self.spiced_path.starts_with("https://")
+    }
+
+    /// Get the spiced path as a `PathBuf` (only valid when not an external instance)
+    #[must_use]
+    pub fn spiced_path_buf(&self) -> PathBuf {
+        PathBuf::from(&self.spiced_path)
+    }
+}
+
+fn parse_key_val(s: &str) -> Result<(String, String), String> {
+    let pos = s
+        .find('=')
+        .ok_or_else(|| "expected KEY=VALUE formatted header".to_string())?;
+    Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -36,7 +36,6 @@ use test_framework::{
         SpiceTest,
         datasets::{EndCondition, NotStarted},
     },
-    telemetry::Telemetry,
     tokio_util::sync::CancellationToken,
     utils::{observe_memory, recursively_get_dir_size},
 };
@@ -84,7 +83,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     // Create telemetry early before any metrics calls (e.g., HealthMonitor)
     // Resource will be set later with set_resource() before emit()
-    let mut telemetry = Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY");
+    let mut telemetry = super::create_telemetry(&args.common);
 
     let health_monitor = HealthMonitor::spawn()?;
 

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -15,23 +15,26 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{
-    args::LoadTestArgs, health::HealthMonitor, spiced_metrics::MetricsScraper, wait_test_and_memory,
-};
+use crate::{args::LoadTestArgs, health::HealthMonitor, spiced_metrics::MetricsScraper};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
+    app::AppBuilder,
     arrow::util::pretty::print_batches,
     metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics, StatisticsCollector},
     opentelemetry::KeyValue,
+    opentelemetry_sdk::Resource,
     spiced::SpicedInstance,
+    spicepod::Spicepod,
     spicetest::{
         SpiceTest,
         datasets::{EndCondition, NotStarted},
     },
-    tokio_util::sync::CancellationToken,
+    telemetry::streaming::StreamingOtlpExporter,
     utils::observe_memory,
 };
+use tokio::signal;
+use tokio_util::sync::CancellationToken;
 
 #[expect(clippy::too_many_lines)]
 pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
@@ -41,12 +44,32 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         ));
     }
 
-    let (app, start_request) = get_app_and_start_request(&args.test_args.common).await?;
-    let mut spiced_instance = SpicedInstance::start(start_request).await?;
+    // Check if connecting to an external instance or starting a new one
+    let (app, mut spiced_instance) = if args.test_args.common.is_external_instance() {
+        println!(
+            "Connecting to external spiced instance at: {}",
+            args.test_args.common.spiced_path
+        );
+        let spicepod = Spicepod::load_exact(args.test_args.common.spicepod_path.clone()).await?;
+        let app = AppBuilder::new(spicepod.name.clone())
+            .with_spicepod(spicepod)
+            .build();
+        let instance = SpicedInstance::external(&args.test_args.common.spiced_path);
+        (app, instance)
+    } else {
+        let (app, start_request) = get_app_and_start_request(&args.test_args.common).await?;
+        let instance = SpicedInstance::start(start_request).await?;
+        (app, instance)
+    };
 
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.test_args.common.ready_wait))
         .await?;
+
+    // Create telemetry early before any metrics calls (e.g., HealthMonitor)
+    // Resource will be set later with set_resource() before emit()
+    let mut telemetry = super::create_telemetry(&args.test_args.common);
+
     let health_monitor = HealthMonitor::spawn()?;
 
     // Start metrics scraper if enabled
@@ -109,21 +132,43 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     print_batches(&records)?;
     let spiced_instance = test.end()?;
     let memory_token = CancellationToken::new();
-    let memory_readings = spiced_instance.process()?.watch_memory(&memory_token);
+    // Memory monitoring is only available for owned spiced instances (not external)
+    let memory_readings = spiced_instance
+        .process()
+        .ok()
+        .map(|p| p.watch_memory(&memory_token));
 
     // load test
     println!("Running load test");
 
-    let (query_set, test_builder) = super::build_test_with_validation(
-        &args.test_args,
-        NotStarted::new()
-            .with_parallel_count(args.test_args.common.concurrency)
-            .with_end_condition(EndCondition::Duration(Duration::from_secs(
-                args.test_args.common.duration,
-            )))
-            .with_disable_caching(args.test_args.disable_caching)
-            .with_http_client(args.test_args.http_clients),
-    )?;
+    let load_end_condition = if args.run_until_stopped {
+        EndCondition::Unlimited
+    } else {
+        EndCondition::Duration(Duration::from_secs(args.test_args.common.duration))
+    };
+
+    // Create streaming OTLP exporter if OTLP endpoint is configured
+    let streaming_exporter = args
+        .test_args
+        .common
+        .otlp_endpoint
+        .as_ref()
+        .map(|endpoint| StreamingOtlpExporter::spawn(endpoint.clone()));
+
+    let mut test_builder = NotStarted::new()
+        .with_parallel_count(args.test_args.common.concurrency)
+        .with_end_condition(load_end_condition)
+        .with_disable_caching(args.test_args.disable_caching)
+        .with_http_client(args.test_args.http_clients)
+        .with_query_duration_threshold(args.test_args.mark_query_failed_if_exceeds);
+
+    // Add streaming metrics sender if exporter is configured
+    if let Some(exporter) = &streaming_exporter {
+        test_builder = test_builder.with_streaming_metrics(exporter.sender());
+    }
+
+    let (query_set, test_builder) =
+        super::build_test_with_validation(&args.test_args, test_builder)?;
 
     // Use the same query overrides that were applied in build_test_with_validation
     let query_overrides = args
@@ -138,12 +183,59 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         .with_progress_bars(!args.test_args.common.disable_progress_bars)
         .start()
         .await?;
+    let shutdown_token = throughput_test.cancellation_token();
+    let test_future = throughput_test.wait();
+    tokio::pin!(test_future);
+    let test = match tokio::select! {
+        res = &mut test_future => res,
+        _ = signal::ctrl_c() => {
+            println!("Interrupt received, stopping load test...");
+            shutdown_token.cancel();
+            test_future.await
+        }
+    } {
+        Ok(test) => test,
+        Err(e) => {
+            if let Some(readings) = memory_readings {
+                let _ = observe_memory(memory_token, readings).await;
+            }
+            return Err(e);
+        }
+    };
+    let _test_durations = test.get_query_durations().statistical_set()?;
 
-    let test = wait_test_and_memory!(throughput_test, memory_token, memory_readings);
-    let test_durations = test.get_query_durations().clone();
+    // Get all query durations for overall statistics before ending the test
+    let all_durations = test.get_query_durations().clone();
+
     let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Load)?;
     let mut spiced_instance = test.end()?;
-    let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;
+    let (max_memory, _median_memory) = if let Some(readings) = memory_readings {
+        observe_memory(memory_token, readings).await?
+    } else {
+        println!("Memory monitoring not available for external spiced instances");
+        (0.0, 0.0)
+    };
+
+    // Set up telemetry for load test metrics
+    let commit_sha = metrics.commit_sha.clone();
+    let spiced_version = metrics.spiced_version.clone();
+    let spicepod = args.test_args.common.spicepod_path.display().to_string();
+
+    telemetry.set_resource(
+        Resource::builder()
+            .with_attribute(KeyValue::new("test", "load"))
+            .with_attribute(KeyValue::new("commit_sha", commit_sha.clone()))
+            .with_attribute(KeyValue::new("spiced_version", spiced_version.clone()))
+            .with_attribute(KeyValue::new("spicepod", spicepod.clone()))
+            .build(),
+    );
+
+    let attributes = [
+        KeyValue::new("test", "load"),
+        KeyValue::new("commit_sha", commit_sha),
+        KeyValue::new("spiced_version", spiced_version),
+        KeyValue::new("spicepod", spicepod),
+    ];
 
     println!("Baseline metrics:");
     let baseline_records = baseline_metrics.build_records()?;
@@ -156,9 +248,15 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     let health_report = health_monitor.stop().await;
 
     // Stop and process metrics scraper if enabled
-    let attributes = vec![KeyValue::new("test", "load")];
     super::process_spiced_metrics(metrics_scraper, args.test_args.common.metrics, &attributes)
         .await;
+
+    // Shutdown streaming exporter before emitting final telemetry
+    if let Some(exporter) = streaming_exporter {
+        exporter.shutdown().await;
+    }
+
+    telemetry.emit().await?;
 
     spiced_instance.stop()?;
     let health_report = health_report?;
@@ -171,7 +269,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
             continue;
         };
 
-        let Some(duration) = test_durations.get(&query.name) else {
+        let Some(duration) = all_durations.get(&query.name) else {
             return Err(anyhow::anyhow!(
                 "Query {} not found in test durations",
                 query.name

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use crate::args::{DatasetTestArgs, QuerySetLoader};
+use crate::args::{CommonArgs, DatasetTestArgs, QuerySetLoader};
 use test_framework::{
     anyhow,
     app::{App, AppBuilder},
@@ -25,6 +25,7 @@ use test_framework::{
     spicepod::Spicepod,
     spicepod_utils::from_app,
     spicetest::datasets::NotStarted,
+    telemetry::{OtlpExporterConfig, Telemetry},
 };
 
 #[cfg(feature = "append")]
@@ -41,7 +42,18 @@ pub(crate) mod throughput;
 mod util;
 pub(crate) type RowCounts = BTreeMap<Arc<str>, usize>;
 
-use crate::args::CommonArgs;
+#[must_use]
+pub(crate) fn create_telemetry(common: &CommonArgs) -> Telemetry {
+    if let Some(endpoint) = &common.otlp_endpoint {
+        return Telemetry::with_otlp(OtlpExporterConfig {
+            endpoint: endpoint.clone().into(),
+            headers: common.otlp_header.clone(),
+            timeout: Duration::from_secs(10),
+        });
+    }
+
+    Telemetry::new("SPICEAI_BENCHMARK_METRICS_KEY")
+}
 
 /// Build a test configuration with validation data if applicable
 ///
@@ -103,7 +115,7 @@ pub(crate) async fn get_app_and_start_request(
     spicepod.dependencies = vec![];
     let app = app_builder.build();
 
-    let mut start_request = StartRequest::new(args.spiced_path.clone(), from_app(app.clone()))?;
+    let mut start_request = StartRequest::new(args.spiced_path_buf(), from_app(app.clone()))?;
 
     if let Some(ref data_dir) = args.data_dir {
         start_request = start_request.with_data_dir(data_dir.clone());


### PR DESCRIPTION
## 📝 Summary

Implements some improvements to the `testoperator` that I found useful when debugging some performance issues in Spice.

- `testoperator load` now allows connecting to an external instance with the `--spiced-path` parameter, i.e. `--spiced-path http://localhost:50051`
- `testoperator load` has a new `--run-until-stopped` flag that will keep the load test running until it is manually stopped.
- `testoperator load` has a new `--mark-query-failed-if-exceeds` flag that will mark queries as having failed if they exceed some threshold (i.e. `--mark-query-failed-if-exceeds 500ms`)
- `testoperator load` has a new `--otlp-endpoint` flag that will stream metrics to an OpenTelemetry collector in real-time while the test is in progress, instead of waiting until the end of a test to emit metrics.
