### PR TITLE
fix: Add warning when multiple partitions are defined for the same table

### DIFF
--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -113,6 +113,12 @@ impl PartitionTableProvider {
         schema: SchemaRef,
     ) -> Result<Self, Error> {
         let num_partition_by = partition_by.len();
+        if num_partition_by > 1 {
+            tracing::warn!(
+                "Multiple 'partition_by' expressions are not yet supported. Only the first expression will be used for partitioning."
+            );
+        }
+
         let partition_by = partition_by
             .pop()
             .context(PartitionByViolationSnafu { num_partition_by })?;

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -115,12 +115,12 @@ impl PartitionTableProvider {
         let num_partition_by = partition_by.len();
         if num_partition_by > 1 {
             tracing::warn!(
-                "Multiple 'partition_by' expressions are not yet supported. Only the first expression will be used for partitioning."
+                "Multiple 'partition_by' expressions are not yet supported. Only the last expression will be used for partitioning."
             );
         }
 
         let partition_by = partition_by
-            .first()
+            .pop()
             .context(PartitionByViolationSnafu { num_partition_by })?;
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
 

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -120,7 +120,7 @@ impl PartitionTableProvider {
         }
 
         let partition_by = partition_by
-            .pop()
+            .first()
             .context(PartitionByViolationSnafu { num_partition_by })?;
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
 

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -762,7 +762,7 @@ impl DataAccelerator for CayenneAccelerator {
             // Non-partitioned table - return base provider directly
             Ok(cayenne_table)
         } else {
-            let partition_by_first = partition_by.first().cloned().ok_or_else(|| {
+            let partition_by_last = partition_by.last().cloned().ok_or_else(|| {
                 Box::new(Error::PartitionByRequired) as Box<dyn std::error::Error + Send + Sync>
             })?;
 
@@ -813,7 +813,7 @@ impl DataAccelerator for CayenneAccelerator {
             let creator = Arc::new(CayennePartitionCreator::new(
                 table_name,
                 PathBuf::from(&dir_path),
-                partition_by_first,
+                partition_by_last,
                 Arc::clone(&arrow_schema),
                 catalog,
                 table_metadata.table_id,

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -287,8 +287,8 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         self.is_initialized.store(false, Ordering::Release);
 
-        let partition_by_first = partition_by
-            .first()
+        let partition_by_last = partition_by
+            .last()
             .context(PartitionByRequiredSnafu)?
             .clone();
 
@@ -302,7 +302,7 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         let creator = Arc::new(DuckDBPartitionCreator::new(
             partition_dir(source),
             cmd,
-            partition_by_first,
+            partition_by_last,
             Arc::clone(&schema),
         ));
         let table_provider =

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -185,8 +185,8 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
         source: Option<&dyn AccelerationSource>,
         partition_by: Vec<PartitionedBy>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        let partition_by_first = partition_by
-            .first()
+        let partition_by_last = partition_by
+            .last()
             .context(super::PartitionByRequiredSnafu)?
             .clone();
 
@@ -202,7 +202,7 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
             DuckDBPartitionCreator::new(
                 self.get_shared_pool(source).await?,
                 cmd.clone(),
-                partition_by_first,
+                partition_by_last,
                 Arc::clone(&schema),
                 &self.duckdb_factory,
             )


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a warning log when multiple `partition_by` are defined

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Raised https://github.com/spiceai/spiceai/issues/8539 for tracking

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
