### PR TITLE
Remove the `clippy::too_many_lines` lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ lint-rust:
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
 		-Aclippy::large_futures \
+		-Aclippy::too_many_lines \
 		-Dclippy::equatable_if_let \
 		-Dclippy::needless_collect \
 		-Dclippy::redundant_clone \
@@ -101,6 +102,7 @@ lint-rust:
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
 		-Aclippy::large_futures \
+		-Aclippy::too_many_lines \
 		-Dclippy::equatable_if_let \
 		-Dclippy::needless_collect \
 		-Dclippy::redundant_clone \
@@ -120,6 +122,7 @@ lint-rust-fix:
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
 		-Aclippy::large_futures \
+		-Aclippy::too_many_lines \
 		-Dclippy::equatable_if_let \
 		-Dclippy::needless_collect \
 		-Dclippy::redundant_clone \
@@ -134,6 +137,7 @@ lint-rust-fix:
 		-Dclippy::clone_on_ref_ptr \
 		-Aclippy::module_name_repetitions \
 		-Aclippy::large_futures \
+		-Aclippy::too_many_lines \
 		-Dclippy::equatable_if_let \
 		-Dclippy::needless_collect \
 		-Dclippy::redundant_clone \

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -183,7 +183,6 @@ pub struct Args {
     pub set_runtime: Vec<(String, String)>,
 }
 
-#[expect(clippy::too_many_lines)]
 pub async fn run(args: Args) -> Result<()> {
     let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -331,7 +331,6 @@ impl AppBuilder {
         Self::build_from_spicepod(spicepod_root, Spicepod::base_path(&path)).await
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn build_from_spicepod(spicepod: Spicepod, path: impl Into<PathBuf>) -> Result<App> {
         let path = path.into();
         let secrets = spicepod.secrets.clone();

--- a/crates/arrow_sql_gen/src/clickhouse.rs
+++ b/crates/arrow_sql_gen/src/clickhouse.rs
@@ -131,7 +131,6 @@ macro_rules! handle_primitive_nullable_type {
 /// # Errors
 ///
 /// Returns an error if there is a failure in converting the rows to a `RecordBatch`.
-#[expect(clippy::too_many_lines)]
 pub fn block_to_arrow<T: ColumnType>(block: &Block<T>) -> Result<RecordBatch> {
     let mut arrow_fields: Vec<Option<Field>> = Vec::new();
     let mut arrow_columns_builders: Vec<Option<Box<dyn ArrayBuilder>>> = Vec::new();

--- a/crates/arrow_tools/src/format.rs
+++ b/crates/arrow_tools/src/format.rs
@@ -38,7 +38,6 @@ pub enum FormatOperation {
     TruncateListLength(usize),
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) fn format_column_data(
     column: ArrayRef,
     field: &Arc<Field>,

--- a/crates/cayenne/tests/integration_test.rs
+++ b/crates/cayenne/tests/integration_test.rs
@@ -32,7 +32,6 @@ use std::sync::Arc;
 // Generate test variants for each backend
 test_with_backends!(test_cayenne_basic_workflow_impl);
 
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_basic_workflow_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -632,7 +631,6 @@ async fn test_cayenne_statistics_impl(
 // Generate test variants for each backend
 test_with_backends!(test_cayenne_core_data_types_impl);
 
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_core_data_types_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -906,7 +904,6 @@ test_with_backends!(test_cayenne_sorted_insert_impl);
 /// 1. Data is sorted after retention filters and before listing table refresh
 /// 2. Sorting operates on the complete corpus after retention
 /// 3. Zone maps have optimal (non-overlapping) min/max ranges
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_sorted_insert_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/cayenne/tests/overwrite_test.rs
+++ b/crates/cayenne/tests/overwrite_test.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use tempfile::TempDir;
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n🧪 Testing INSERT OVERWRITE functionality...");
 

--- a/crates/cayenne/tests/partition_chunking_test.rs
+++ b/crates/cayenne/tests/partition_chunking_test.rs
@@ -30,7 +30,6 @@ use std::sync::Arc;
 // Generate test variants for each backend
 test_with_backends!(test_partitioned_table_with_chunking_impl);
 
-#[expect(clippy::too_many_lines)]
 async fn test_partitioned_table_with_chunking_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -316,7 +315,6 @@ async fn test_partitioned_table_with_large_chunks_impl(
 // Generate test variants for timestamp partitioning test
 test_with_backends!(test_timestamp_partition_with_date_part_impl);
 
-#[expect(clippy::too_many_lines)]
 async fn test_timestamp_partition_with_date_part_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/cayenne/tests/partition_pruning_test.rs
+++ b/crates/cayenne/tests/partition_pruning_test.rs
@@ -67,7 +67,6 @@ fn sanitize_file_paths(plan: &str) -> String {
 /// 2. Inserts data across multiple partitions
 /// 3. Queries with partition filters and validates EXPLAIN plan shows pruning
 /// 4. Validates that only relevant partitions are scanned
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_pruning_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -365,7 +364,6 @@ test_with_backends!(test_cayenne_bucket_partitioning_impl);
 /// 1. Bucket partitioning works correctly
 /// 2. Filters are still pushed down to partitions (since each bucket contains multiple values)
 /// 3. Partition pruning works for filters on the bucketed column
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_bucket_partitioning_impl(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -528,7 +528,6 @@ pub(crate) fn check_and_filter_unique_constraint<S: std::hash::BuildHasher + Def
 ///
 /// # Visibility
 /// This function is public for benchmarking purposes.
-#[expect(clippy::too_many_lines)]
 pub(crate) fn extract_primary_keys_str(
     batch: &RecordBatch,
     pk_indices_ordered: &[usize],

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -180,7 +180,6 @@ pub fn append_value_to_struct_builder(
 }
 
 #[expect(clippy::cast_possible_truncation)]
-#[expect(clippy::too_many_lines)]
 fn append_field_value_to_builder(
     field_value: &serde_json::Value,
     field: &Arc<Field>,

--- a/crates/data_components/src/debezium/tests/mod.rs
+++ b/crates/data_components/src/debezium/tests/mod.rs
@@ -27,7 +27,6 @@ use crate::debezium::{arrow::convert_fields_to_arrow_schema, change_event::Chang
 use super::arrow::to_record_batch;
 
 #[test]
-#[expect(clippy::too_many_lines)]
 fn parse_arrow_schema() {
     let change_event_json = include_str!("./all_types.json");
 

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -423,7 +423,6 @@ impl TableProvider for DeltaTable {
         Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn scan(
         &self,
         state: &dyn Session,
@@ -961,7 +960,6 @@ fn to_delta_kernel_binary_expression(
 }
 
 #[expect(clippy::cast_sign_loss)]
-#[expect(clippy::too_many_lines)]
 fn to_delta_kernel_scalar(scalar: ScalarValue) -> Option<Scalar> {
     match scalar {
         ScalarValue::Int8(Some(v)) => Some(Scalar::Byte(v)),
@@ -1136,7 +1134,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     #[expect(clippy::similar_names)]
     fn test_to_delta_kernel_expr() {
         // Test basic column reference
@@ -1287,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_to_delta_kernel_scalar() {
         // Test string scalar
         let scalar = ScalarValue::Utf8(Some("test".to_string()));

--- a/crates/data_components/src/dynamodb/arrow.rs
+++ b/crates/data_components/src/dynamodb/arrow.rs
@@ -73,7 +73,6 @@ pub fn append_item_to_struct_builder(
     Ok(())
 }
 
-#[expect(clippy::too_many_lines)]
 fn append_value_to_builder(
     builder: &mut dyn ArrayBuilder,
     value: Option<&AttributeValue>,

--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -325,7 +325,6 @@ impl GithubRestClient {
     }
 
     #[expect(clippy::too_many_arguments)]
-    #[expect(clippy::too_many_lines)]
     #[expect(clippy::missing_panics_doc)]
     #[expect(clippy::expect_used)]
     pub async fn fetch_files(

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -814,7 +814,6 @@ impl GraphQLClient {
         })
     }
 
-    #[expect(clippy::too_many_lines)]
     pub(crate) async fn execute(
         &self,
         query: &mut GraphQLQuery,

--- a/crates/data_components/src/mssql/convert.rs
+++ b/crates/data_components/src/mssql/convert.rs
@@ -49,7 +49,6 @@ macro_rules! handle_primitive_type {
     }};
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<RecordBatch> {
     let mut arrow_columns_builders: Vec<Box<dyn ArrayBuilder>> = Vec::new();
     let mut mssql_types: Vec<ColumnType> = Vec::new();

--- a/crates/data_components/src/oracle/convert.rs
+++ b/crates/data_components/src/oracle/convert.rs
@@ -135,7 +135,6 @@ macro_rules! handle_primitive_type {
     };
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<RecordBatch> {
     let mut arrow_columns_builders = vec![];
     for field in schema.fields() {

--- a/crates/data_components/src/s3_vectors/partition.rs
+++ b/crates/data_components/src/s3_vectors/partition.rs
@@ -207,7 +207,6 @@ fn to_stable_string(exprs: &[Expr]) -> Result<String, Error> {
         .join(PARTS_SEPARATOR))
 }
 
-#[expect(clippy::too_many_lines)]
 fn stable_expr_string(expr: &Expr) -> Result<String, Error> {
     Ok(match expr {
         Expr::Column(col) => {

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -1034,7 +1034,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn scan_plan_with_partitioned_index_spilling() -> Result<(), Box<dyn std::error::Error>> {
         let mock_client = Arc::new(MockClient::new());
         let bucket_name = "test-bucket";

--- a/crates/data_components/src/sharepoint/client.rs
+++ b/crates/data_components/src/sharepoint/client.rs
@@ -151,7 +151,6 @@ enum DrivePtr {
 }
 
 /// Resolves a `DrivePtr` into a `DriveId`. This ensures that the `DriveId` is unique and can be used to fetch drive items.
-#[expect(clippy::too_many_lines)]
 async fn resolve_drive_ptr(
     client: Arc<GraphClient>,
     drive: &PublicDrivePtr,

--- a/crates/dataformat-json/src/source.rs
+++ b/crates/dataformat-json/src/source.rs
@@ -176,7 +176,6 @@ impl FileOpener for SpiceJsonOpener {
     /// are applied to determine which lines to read:
     /// 1. The first line of the partition is the line in which the index of the first character >= `start`.
     /// 2. The last line of the partition is the line in which the byte at position `end - 1` resides.
-    #[expect(clippy::too_many_lines)]
     fn open(&self, file_meta: FileMeta, _file: PartitionedFile) -> Result<FileOpenFuture> {
         let store = Arc::clone(&self.object_store);
         let base_flattened_schema = Arc::clone(&self.base_flattened_schema);

--- a/crates/datafusion-optimizer-rules/src/physical_plan/duckdb/intermediate_index_cte.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/duckdb/intermediate_index_cte.rs
@@ -114,7 +114,6 @@ impl DuckDBIntermediateIndexMaterializationOptimizer {
 
     /// Given the SELECT component of a statement and bound `DuckDB` indexes, attempt to build a
     /// materialized CTE with filters _only_ on index columns
-    #[expect(clippy::too_many_lines)]
     fn build_cte(
         select: &Select,
         indexes: &[(ColumnReference, IndexType)],
@@ -457,7 +456,6 @@ mod tests {
 
     #[test]
     #[expect(clippy::type_complexity)]
-    #[expect(clippy::too_many_lines)]
     fn test_rewrite_statement() {
         let test_cases: Vec<(&str, Vec<(ColumnReference, IndexType)>, Option<&str>)> = vec![
             // core query we want to optimize

--- a/crates/flightrepl/src/completer.rs
+++ b/crates/flightrepl/src/completer.rs
@@ -172,7 +172,6 @@ fn suggest_tables(
 impl Completer for EditorHelper {
     type Candidate = Pair;
 
-    #[expect(clippy::too_many_lines)]
     fn complete(
         &self,
         line: &str,

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -233,7 +233,6 @@ impl Highlighter for EditorHelper {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 #[expect(clippy::missing_errors_doc)]
 pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Error>> {
     let mut repl_flight_endpoint = repl_config.repl_flight_endpoint;

--- a/crates/google-genai/examples/function_calling.rs
+++ b/crates/google-genai/examples/function_calling.rs
@@ -33,7 +33,6 @@ fn get_current_weather(location: &str, unit: Option<&str>) -> String {
     )
 }
 
-#[expect(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =

--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -259,7 +259,6 @@ pub struct MessageDelta {
 ///  | Tool packets have no out of order protection            | Provides numbering for out of order tool packets        |
 ///  +---------------------------------------------------------+---------------------------------------------------------+
 ///
-#[expect(clippy::too_many_lines)]
 pub fn transform_stream(
     stream: Pin<
         Box<dyn Stream<Item = Result<MessageCreateStreamResponse, AnthropicStreamError>> + Send>,

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -119,7 +119,6 @@ impl BedrockConverse {
     /// Convert [`ChatCompletionRequestMessage`] that are neither [`ChatCompletionRequestMessage::System`] or [`ChatCompletionRequestMessage::Developer`] into the Bedrock equivalent [`Message`] format.
     ///
     /// Other enum variants will be ignored.
-    #[expect(clippy::too_many_lines)]
     fn convert_non_system_messages(
         msgs: Vec<ChatCompletionRequestMessage>,
     ) -> Result<Vec<Message>, BuildError> {
@@ -478,7 +477,6 @@ impl BedrockConverse {
         })
     }
 
-    #[expect(clippy::too_many_lines)]
     fn process_stream(
         model: &str,
         input_stream: EventReceiver<ConverseStreamOutputPacket, ConverseStreamOutputError>,

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -317,7 +317,6 @@ pub fn message_to_content(message: &ChatCompletionRequestMessage) -> String {
 
 /// Convert a structured [`ChatCompletionRequestMessage`] to the mistral.rs compatible [`RequestMessage`] type.
 #[must_use]
-#[expect(clippy::too_many_lines)]
 pub fn message_to_mistral(
     message: &ChatCompletionRequestMessage,
 ) -> IndexMap<String, MessageContent> {

--- a/crates/model_components/src/modelsource/huggingface.rs
+++ b/crates/model_components/src/modelsource/huggingface.rs
@@ -30,7 +30,6 @@ pub struct Huggingface {}
 
 #[async_trait]
 impl ModelSource for Huggingface {
-    #[expect(clippy::too_many_lines)]
     async fn pull(&self, params: Arc<HashMap<String, SecretString>>) -> super::Result<String> {
         let name = params
             .get("name")

--- a/crates/model_components/src/modelsource/spiceai.rs
+++ b/crates/model_components/src/modelsource/spiceai.rs
@@ -34,7 +34,6 @@ use regex::Regex;
 
 #[async_trait]
 impl ModelSource for SpiceAI {
-    #[expect(clippy::too_many_lines)]
     async fn pull(&self, params: Arc<HashMap<String, SecretString>>) -> super::Result<String> {
         let name = params
             .get("name")

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -583,7 +583,6 @@ impl SnapshotManager {
     ///
     /// - If the local acceleration file cannot be opened or read.
     /// - If communicating with the backing object store fails at any stage of the upload.
-    #[expect(clippy::too_many_lines)]
     pub async fn create_snapshot(
         &self,
         schema: &SchemaRef,
@@ -988,7 +987,6 @@ impl SnapshotManager {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn download_snapshot_entry(
         &self,
         entry: &SnapshotEntry,
@@ -1149,7 +1147,6 @@ impl SnapshotManager {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn update_metadata_after_upload(
         &self,
         location: &ObjectPath,

--- a/crates/runtime-object-store/src/registry/mod.rs
+++ b/crates/runtime-object-store/src/registry/mod.rs
@@ -261,7 +261,6 @@ impl SpiceObjectStoreRegistry {
     }
 
     // Splitting up this function wouldn't make much sense as it's all used to create the ObjectStore
-    #[expect(clippy::too_many_lines)]
     fn prepare_azure_object_store(
         &self,
         url: &Url,

--- a/crates/runtime-object-store/src/store/sftp.rs
+++ b/crates/runtime-object-store/src/store/sftp.rs
@@ -140,7 +140,6 @@ impl ObjectStore for SFTPObjectStore {
         unimplemented!()
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn get_opts(
         &self,
         location: &Path,

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -139,7 +139,6 @@ impl ExecutionPlan for PartitionerExec {
         )))
     }
 
-    #[expect(clippy::too_many_lines)]
     fn execute(
         &self,
         partition: usize,

--- a/crates/runtime-table-partition/src/provider/pruning.rs
+++ b/crates/runtime-table-partition/src/provider/pruning.rs
@@ -190,7 +190,6 @@ fn evaluate_expr(
 }
 
 /// Evaluates if a filter expression excludes a partition value based on the partition-by expression.
-#[expect(clippy::too_many_lines)]
 pub(crate) fn prune_partition(
     filters: &[Expr],
     partition_by: &Expr,
@@ -455,7 +454,6 @@ fn evaluate_inequality(
 
 /// Special handler for bucket inequality that needs access to all filters to determine bounded ranges.
 /// This is called from `prune_partition` when we detect a bucket expression.
-#[expect(clippy::too_many_lines)]
 fn evaluate_bucket_inequality(
     filters: &[Expr],
     col: &Column,
@@ -1296,7 +1294,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_prune_partition_date_trunc() -> Result<(), DataFusionError> {
         let schema = Schema::new(vec![Field::new(
             "date",

--- a/crates/runtime-table-partition/tests/partition_table_provider.rs
+++ b/crates/runtime-table-partition/tests/partition_table_provider.rs
@@ -409,7 +409,6 @@ async fn test_explain_plan_filtering() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_bucket_in_list_plan_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
@@ -532,7 +531,6 @@ async fn test_bucket_in_list_plan_filtering() -> Result<(), Box<dyn std::error::
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_truncate_in_list_plan_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -973,7 +973,6 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         )))
     }
 
-    #[expect(clippy::too_many_lines)]
     fn execute(
         &self,
         partition: usize,

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -496,7 +496,6 @@ impl Builder {
     }
 
     /// Build the accelerated table
-    #[expect(clippy::too_many_lines)]
     pub async fn build(self) -> AcceleratedTableBuilderResult<AcceleratedTable> {
         if self.refresh.mode != RefreshMode::Changes && self.changes_stream.is_some() {
             return ExpectedChangesModeForChangesStreamSnafu.fail();

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -629,7 +629,6 @@ impl Refresher {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     pub(crate) async fn start(
         &mut self,
         acceleration_refresh_mode: AccelerationRefreshMode,
@@ -1292,7 +1291,6 @@ mod tests {
         );
     }
 
-    #[expect(clippy::too_many_lines)]
     #[tokio::test]
     async fn test_refresh_append_batch_for_iso8601() {
         async fn test(
@@ -1444,7 +1442,6 @@ mod tests {
         .await;
     }
 
-    #[expect(clippy::too_many_lines)]
     #[tokio::test]
     async fn test_refresh_append_batch_for_timestamp() {
         async fn test(
@@ -1624,7 +1621,6 @@ mod tests {
         .await;
     }
 
-    #[expect(clippy::too_many_lines)]
     #[tokio::test]
     async fn test_refresh_append_batch_for_timestamp_with_more_complicated_structs() {
         async fn test(
@@ -2069,7 +2065,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_startup_next_refresh() {
         struct TestCase {
             description: &'static str,
@@ -2234,7 +2229,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_startup_next_refresh_wait_time() {
         struct TestCase {
             description: &'static str,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -369,7 +369,6 @@ impl RefreshTask {
         })
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn run_once(&self, refresh: &Refresh) -> Result<(), RetryError<super::Error>> {
         self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -146,7 +146,6 @@ impl RuntimeBuilder {
         self
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn build(self) -> Runtime {
         // Initialize DataFusion tracer for span context propagation across async boundaries
         if let Err(e) = tracers::init_datafusion_tracer() {

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -133,7 +133,6 @@ impl CatalogConnector for Databricks {
         self
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn refreshable_catalog_provider(
         self: Arc<Self>,
         runtime: Arc<Runtime>,

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -64,7 +64,6 @@ pub async fn initialize_cluster_scheduler(rt: &Arc<Runtime>) -> crate::Result<()
 
 /// Creates a Ballista executor, binds it to the `Runtime` handle, and returns its configured
 /// work loop as a future
-#[expect(clippy::too_many_lines)]
 pub async fn initialize_cluster_executor(
     rt: Arc<Runtime>,
 ) -> crate::Result<impl Future<Output = crate::Result<()>>> {

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -382,7 +382,6 @@ impl Acceleration {
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
     type Error = crate::Error;
 
-    #[expect(clippy::too_many_lines)]
     fn try_from(
         acceleration: spicepod_acceleration::Acceleration,
     ) -> std::result::Result<Self, Self::Error> {

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -195,7 +195,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_validate_identifier() {
         // Valid identifiers
         validate_identifier("valid_identifier").expect("should validate successfully");

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -616,7 +616,6 @@ impl DataAccelerator for CayenneAccelerator {
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     /// Cayenne supports file mode and can optionally partition data.
-    #[expect(clippy::too_many_lines)]
     async fn create_external_table(
         &self,
         cmd: CreateExternalTable,

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -770,7 +770,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn retention_sql_fails_with_internal_tables() {
         use datafusion_table_providers::duckdb::DuckDB;
         use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
@@ -932,7 +931,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     #[expect(clippy::unreadable_literal)]
     async fn test_round_trip_duckdb() {
         let schema = Arc::new(Schema::new(vec![
@@ -1176,7 +1174,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_retention_sql_with_duckdb_accelerator() {
         use tempfile::TempDir;
 

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -494,7 +494,6 @@ mod tests {
     use std::collections::HashMap;
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_tables_mode_partitioned_duckdb_accelerator() {
         // Ensure no previous database version exists
         let test_db_path = "./test_table.db";

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/sink.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/sink.rs
@@ -109,7 +109,6 @@ impl DataSink for DuckDBPartitionedDataSink {
         &self.schema
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn write_all(
         &self,
         mut data: SendableRecordBatchStream,

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -164,7 +164,6 @@ pub enum OpenOption {
     OpenExisting,
 }
 
-#[expect(clippy::too_many_lines)]
 async fn acceleration_connection(
     source: &dyn AccelerationSource,
     open_option: OpenOption,

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -508,7 +508,6 @@ impl DataAccelerator for TursoAccelerator {
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
-    #[expect(clippy::too_many_lines)]
     async fn create_external_table(
         &self,
         cmd: CreateExternalTable,
@@ -1297,7 +1296,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_timestamp_unit_conversion() {
         // Test that timestamps are correctly converted between different units
         // All timestamps are stored as milliseconds in Turso, but should be

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -136,7 +136,6 @@ impl DataConnector for DynamoDB {
         self
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -795,7 +795,6 @@ fn parse_github_path(path: &str) -> Option<GitHubPathComponents<'_>> {
 }
 
 #[async_trait]
-#[expect(clippy::too_many_lines)]
 impl DataConnector for Github {
     fn as_any(&self) -> &dyn Any {
         self

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -114,7 +114,6 @@ impl IcebergDataConnector {
         })
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn create_iceberg_table_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -854,7 +854,6 @@ pub trait ListingTableConnector: DataConnector {
         ))
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn create_listing_table(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -345,7 +345,6 @@ impl MetricsProvider for MySQLMetricsProvider {
         METRICS
     }
 
-    #[expect(clippy::too_many_lines)]
     fn callback_to_observe_metric(
         &self,
         metric: &MetricSpec,

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -446,7 +446,6 @@ mod tests {
     use crate::component::dataset::builder::DatasetBuilder;
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_spice_dataset_path() {
         let tests = vec![
             (

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -244,7 +244,6 @@ impl DataFusionBuilder {
     ///
     /// Panics if the `DataFusion` instance cannot be built due to errors in registering functions or schemas.
     #[must_use]
-    #[expect(clippy::too_many_lines)]
     pub fn build(self) -> DataFusion {
         let mut config = self.config;
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -974,7 +974,6 @@ impl DataFusion {
         Ok(())
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn create_accelerated_table(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -266,7 +266,6 @@ impl Query {
         Ok(QueryResult::new(stream, cache_status))
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn run_internal(self, request_context: Arc<RequestContext>) -> Result<QueryResult> {
         crate::metrics::telemetry::track_query_count(&request_context.to_dimensions());
 

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -207,7 +207,6 @@ impl Query {
         )
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn try_get_cached_result<'a>(
         df: &Arc<DataFusion>,
         request_context: &Arc<RequestContext>,
@@ -699,7 +698,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_get_plan_or_cached_cache_miss_and_hit() {
         let df = prepare_runtime(Some(SQLResultsCacheConfig {
             item_ttl: Some("10m".to_string()),
@@ -1122,7 +1120,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_stale_while_revalidate_complete_lifecycle() {
         // This test validates the complete stale-while-revalidate lifecycle:
         // 1. Initial cache population
@@ -1352,7 +1349,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_stale_while_revalidate_with_client_supplied_cache_key() {
         // Configure cache with short TTL and stale-while-revalidate
         let df = prepare_runtime(Some(SQLResultsCacheConfig {
@@ -1516,7 +1512,6 @@ mod tests {
             .await;
     }
 
-    #[expect(clippy::too_many_lines)]
     #[tokio::test]
     async fn test_single_in_flight_revalidation() {
         // This test validates that concurrent stale-while-revalidate requests

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -84,7 +84,6 @@ macro_rules! ensure_no_expr {
     };
 }
 
-#[expect(clippy::too_many_lines)]
 pub fn validate_refresh_sql(
     expected_table: TableReference,
     refresh_sql: &str,

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -493,7 +493,6 @@ pub(super) fn get_vectors_in_process(
 ///                          | [[0, 10], [10, 21]]           |
 ///                          +-------------------------------+
 /// ```
-#[expect(clippy::too_many_lines)]
 async fn get_vectors_with_chunker(
     arr: impl Iterator<Item = Option<&str>>,
     chunker: Arc<dyn Chunker>,

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -34,7 +34,6 @@ use runtime_request_context::{AsyncMarker, RequestContext};
 
 use super::{Service, metrics};
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn handle(
     flight_svc: &Service,
     request: Request<Streaming<FlightData>>,

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -657,7 +657,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn test_parameter_binding_with_plan_caching() {
         use crate::dataaccelerator::AcceleratorEngineRegistry;
         use crate::datafusion::builder::DataFusionBuilder;

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -443,7 +443,6 @@ fn is_address_in_use_error(err: &tonic::transport::Error) -> bool {
 /// # Panics
 /// If running in clustered mode, will panic unless TLS is configured or user manually overrides
 /// this safety check, as RPC will transmit sensitive information to executors.
-#[expect(clippy::too_many_lines)]
 pub async fn start(
     bind_address: std::net::SocketAddr,
     app: Option<Arc<App>>,

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -198,7 +198,6 @@ const DEFAULT_REQUEST_BODY_LIMIT: usize = 128 * 1024 * 1024; // 128 MiB
 const MCP_REQUEST_BODY_LIMIT: usize = 32 * 1024 * 1024; // 32 MiB
 const HEALTH_REQUEST_BODY_LIMIT: usize = 128 * 1024; // 128 KiB
 
-#[expect(clippy::too_many_lines)]
 pub(crate) fn routes(
     rt: &Arc<Runtime>,
     config: Arc<config::Config>,

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -290,7 +290,6 @@ pub(crate) async fn post(
     }
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn handle_nsql_query(
     rt: Arc<Runtime>,
     context: Arc<RequestContext>,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -303,7 +303,6 @@ impl Runtime {
         .await;
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn register_loaded_dataset(
         self: Arc<Self>,
         ds: Arc<Dataset>,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -625,7 +625,6 @@ impl Runtime {
     /// The future returned by this function drives the individual server futures and will only return once the servers are shutdown.
     ///
     /// It is recommended to start the servers in parallel to loading the Runtime components to speed up startup.
-    #[expect(clippy::too_many_lines)]
     pub async fn start_servers(
         self: Arc<Self>,
         config: Config,
@@ -871,7 +870,6 @@ impl Runtime {
     ///
     /// The future returned by this function will not resolve until all components have been loaded and marked as ready.
     /// This includes waiting for the first refresh of any accelerated tables to complete.
-    #[expect(clippy::too_many_lines)]
     pub async fn load_components(self: Arc<Self>) {
         Arc::clone(&self).set_components_initializing().await;
 

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -186,7 +186,6 @@ fn model2vec(
 }
 
 #[cfg(feature = "bedrock")]
-#[expect(clippy::too_many_lines)]
 async fn bedrock(
     model_id: Option<String>,
     params: &HashMap<String, SecretString>,

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -607,7 +607,6 @@ impl Stream for CustomStream {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 fn make_a_stream(
     span: Span,
     request_context: Arc<RequestContext>,

--- a/crates/runtime/src/model/tool_use_responses.rs
+++ b/crates/runtime/src/model/tool_use_responses.rs
@@ -427,7 +427,6 @@ impl Stream for CustomResponseStream {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 fn make_responses_stream(
     span: Span,
     request_context: Arc<RequestContext>,

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -252,7 +252,6 @@ macro_rules! append_value {
     };
 }
 
-#[expect(clippy::too_many_lines)]
 fn number_data_points_to_record_batch(
     metric: &str,
     data_points: &Vec<NumberDataPoint>,

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -66,7 +66,6 @@ use crate::{
 ///
 /// Also verifies:
 /// - Cache hit: subsequent queries with same filters are served from cache
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_filter_propagation() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some(
@@ -199,7 +198,6 @@ async fn test_caching_mode_filter_propagation() -> Result<(), anyhow::Error> {
 ///
 /// For production use with `DuckDB` or Cayenne accelerators, multi-filter caching
 /// works correctly with upsert behavior.
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_multi_filter_limitation() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some(
@@ -413,7 +411,6 @@ async fn test_caching_mode_multi_filter_limitation() -> Result<(), anyhow::Error
 /// 4. Query with filter B → cache hit → served from cache (no HTTP fetch)
 ///
 /// Uses `DuckDB` accelerator which supports upsert-based multi-filter caching.
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_multi_filter_ideal() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some(
@@ -630,7 +627,6 @@ async fn test_caching_mode_multi_filter_ideal() -> Result<(), anyhow::Error> {
 ///
 /// NOTE: Currently SQLite/Cayenne caching mode has similar issues to `DuckDB` - queries return empty results.
 /// Investigation needed. Test runs when sqlite feature is enabled but is currently failing.
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "sqlite")]
 async fn test_caching_mode_multi_filter_cayenne() -> Result<(), anyhow::Error> {
@@ -1251,7 +1247,6 @@ async fn test_caching_mode_empty_results() -> Result<(), anyhow::Error> {
 /// Test background refresh triggered on cache miss.
 /// Verifies that when data is not in the cache, a background refresh is triggered
 /// to populate the cache asynchronously after returning the federated data.
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_background_refresh_on_miss() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some(
@@ -1402,7 +1397,6 @@ async fn test_caching_mode_background_refresh_on_miss() -> Result<(), anyhow::Er
 /// the test can query stale data, it overwrites with fresh data. The proper fix would
 /// be to implement "delete-where + insert" for background refresh to only update
 /// specific rows.
-#[expect(clippy::too_many_lines)]
 #[ignore = "Background refresh uses InsertOp::Overwrite which replaces all data - needs delete-where + insert for row-level updates"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::Error> {
@@ -1595,7 +1589,6 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
 /// 2. Data becomes stale after TTL
 /// 3. Periodic refresh task (based on `refresh_check_interval`) updates stale data automatically
 /// 4. Old data beyond `retention_period` is evicted from cache
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_caching_mode_interval_refresh_with_retention() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some(

--- a/crates/runtime/tests/acceleration/checkpoint_turso.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_turso.rs
@@ -140,7 +140,6 @@ async fn test_acceleration_turso_checkpoint() -> Result<(), anyhow::Error> {
 }
 
 /// Helper function to convert libsql query results to Arrow `RecordBatches`
-#[expect(clippy::too_many_lines)]
 async fn query_to_record_batches(
     conn: &Connection,
     query: &str,

--- a/crates/runtime/tests/acceleration/cron.rs
+++ b/crates/runtime/tests/acceleration/cron.rs
@@ -71,7 +71,6 @@ async fn snapshot_names_from_runtime(name: &str, rt: &Arc<Runtime>, dataset_name
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_cron_schedule_creates() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
@@ -154,7 +153,6 @@ async fn test_cron_schedule_creates() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_multiple_cron_schedule_creates() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
@@ -301,7 +299,6 @@ datasets:
       refresh_cron: \"* * * * * *\" # every minute
 ";
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cron_reload() -> Result<(), anyhow::Error> {
     let _ = rustls::crypto::CryptoProvider::install_default(
@@ -436,7 +433,6 @@ async fn test_cron_reload() -> Result<(), anyhow::Error> {
 const NAMES_TIMESTAMPED_CSV: &str = include_str!("data/names_timestamped.csv");
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_append_cron_schedule() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
@@ -536,7 +532,6 @@ async fn test_append_cron_schedule() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_cron_view() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/acceleration/on_conflict.rs
+++ b/crates/runtime/tests/acceleration/on_conflict.rs
@@ -34,7 +34,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use super::get_params;
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_acceleration_on_conflict() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/acceleration/partition_by_cayenne.rs
+++ b/crates/runtime/tests/acceleration/partition_by_cayenne.rs
@@ -251,7 +251,6 @@ async fn test_cayenne_partition_by_bucket() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
 #[ignore = "Data duplication issue with multiple partition expressions - needs investigation"]
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_multiple_expressions() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 
@@ -395,7 +394,6 @@ async fn test_cayenne_partition_by_multiple_expressions() -> Result<(), anyhow::
 /// 4. Data with NULL partition values can be queried correctly
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_bucket_with_nulls() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 
@@ -553,7 +551,6 @@ async fn test_cayenne_partition_by_bucket_with_nulls() -> Result<(), anyhow::Err
 /// This test verifies NULL handling specifically for numeric partition columns
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_bucket_numeric_nulls() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 
@@ -712,7 +709,6 @@ async fn test_cayenne_partition_by_bucket_numeric_nulls() -> Result<(), anyhow::
 /// 3. Physical plans show correct partition structure with month-based partitions
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(not(target_os = "windows"))]
-#[expect(clippy::too_many_lines)]
 async fn test_cayenne_partition_by_date_part() -> Result<(), anyhow::Error> {
     let _tracing = crate::init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -25,7 +25,6 @@ use spicepod::{component::dataset::Dataset, param::Params};
 use crate::{init_tracing, utils::test_request_context};
 
 #[cfg(feature = "postgres")]
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error> {
     use crate::configure_test_datafusion;

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -50,7 +50,6 @@ fn get_dataset(from: &str, name: &str, path: &str) -> Dataset {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/clickbench/q8.rs
+++ b/crates/runtime/tests/clickbench/q8.rs
@@ -17,7 +17,6 @@ limitations under the License.
 const Q8_QUERY: &str = r#"SELECT "AdvEngineID", COUNT(*) FROM hits WHERE "AdvEngineID" <> 0 GROUP BY "AdvEngineID" ORDER BY COUNT(*) DESC;"#;
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_clickbench_q8() -> Result<(), anyhow::Error> {
     super::test_clickbench_query(Q8_QUERY).await
 }

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -237,7 +237,6 @@ async fn duckdb_order_by_special_cases() -> Result<(), String> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn duckdb_regexp() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
@@ -362,7 +361,6 @@ async fn duckdb_regexp() -> Result<(), String> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_duckdb_settings_persist() -> Result<(), String> {
     use spicepod::param::Params;
     use std::collections::HashMap;
@@ -507,7 +505,6 @@ async fn test_duckdb_settings_persist() -> Result<(), String> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_duckdb_all_settings() -> Result<(), String> {
     use spicepod::param::Params;
     use std::collections::HashMap;

--- a/crates/runtime/tests/dynamodb/mod.rs
+++ b/crates/runtime/tests/dynamodb/mod.rs
@@ -622,7 +622,6 @@ pub async fn get_dynamodb_client() -> Result<aws_sdk_dynamodb::Client, anyhow::E
     Ok(client)
 }
 
-#[expect(clippy::too_many_lines)]
 #[expect(dead_code)]
 async fn init_test_table(table_name: &str) -> Result<(), anyhow::Error> {
     let client = get_dynamodb_client().await?;

--- a/crates/runtime/tests/github/mod.rs
+++ b/crates/runtime/tests/github/mod.rs
@@ -86,7 +86,6 @@ fn make_github_dataset(
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn test_github_issues() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/iceberg_api/mod.rs
+++ b/crates/runtime/tests/iceberg_api/mod.rs
@@ -38,7 +38,6 @@ pub fn get_s3_dictionary_dataset(name: &str) -> Dataset {
     )
 }
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_iceberg_api_get_table_schema() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/metadata/mod.rs
+++ b/crates/runtime/tests/metadata/mod.rs
@@ -48,7 +48,6 @@ pub fn get_s3_hive_partitioned_dataset(
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn s3_metadata_columns() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -186,7 +186,6 @@ mod search {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
-    #[expect(clippy::too_many_lines)]
     async fn huggingface_test_search() -> Result<(), anyhow::Error> {
         let app = AppBuilder::new("text-to-sql")
             .with_dataset(item_tpcds_dataset_w_embeddings(

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -142,7 +142,6 @@ pub(crate) mod search {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn hybrid_w_vector_engine() -> Result<(), anyhow::Error> {
         let mut app = AppBuilder::new("search_app").with_embedding(get_model_to_vec_embeddings(
             "minishlab/potion-base-2M",
@@ -541,7 +540,6 @@ pub(crate) mod search {
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
     async fn metadata_columns() -> Result<(), anyhow::Error> {
         let mut app = AppBuilder::new("search_app").with_embedding(get_model_to_vec_embeddings(
             "minishlab/potion-base-2M",

--- a/crates/runtime/tests/mssql/mod.rs
+++ b/crates/runtime/tests/mssql/mod.rs
@@ -34,7 +34,6 @@ use tracing::instrument;
 const MSSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-types-mssql";
 const MSSQL_PORT: u16 = 11433;
 
-#[expect(clippy::too_many_lines)]
 #[instrument]
 async fn init_mssql_db(port: u16) -> Result<(), anyhow::Error> {
     let mut config = tiberius::Config::new();

--- a/crates/runtime/tests/mysql/federation.rs
+++ b/crates/runtime/tests/mysql/federation.rs
@@ -163,7 +163,6 @@ async fn mysql_federation_push_down() -> Result<(), String> {
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/mysql/mod.rs
+++ b/crates/runtime/tests/mysql/mod.rs
@@ -40,7 +40,6 @@ const MYSQL_PORT1: u16 = 13316;
 const MYSQL_PORT2: u16 = 13317;
 const MYSQL_PORT3: u16 = 13318;
 
-#[expect(clippy::too_many_lines)]
 #[instrument]
 async fn init_mysql_db(port: u16) -> Result<(), anyhow::Error> {
     let pool = get_mysql_conn(port)?;

--- a/crates/runtime/tests/oracle/mod.rs
+++ b/crates/runtime/tests/oracle/mod.rs
@@ -35,7 +35,6 @@ use tracing::instrument;
 const ORACLE_DOCKER_CONTAINER: &str = "runtime-integration-test-oracle";
 const ORACLE_PORT: u16 = 15210;
 
-#[expect(clippy::too_many_lines)]
 #[instrument]
 async fn init_oracle_db(port: u16) -> Result<(), anyhow::Error> {
     let connector = oracle_connector::new(

--- a/crates/runtime/tests/ready_state/mod.rs
+++ b/crates/runtime/tests/ready_state/mod.rs
@@ -491,7 +491,6 @@ fn get_federated_dataset(
     dataset
 }
 
-#[expect(clippy::too_many_lines)]
 async fn run_ready_state_test(
     is_native: bool,
     ready_state: ReadyState,

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -144,7 +144,6 @@ async fn get_accelerator(rt: &Runtime, table_name: &str) -> Result<Arc<dyn Table
 }
 
 #[tokio::test]
-#[expect(clippy::too_many_lines)]
 async fn mysql_refresh_retries() -> Result<(), String> {
     test_request_context()
         .scope(async {

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -238,7 +238,6 @@ async fn test_retention_sql() -> Result<(), anyhow::Error> {
         .await
 }
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_duckdb_append_refresh_preserves_timestamptz() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -1010,7 +1010,6 @@ async fn snapshot_int_test6_concurrent_snapshot_writes_retry() -> Result<()> {
         .await
 }
 
-#[expect(clippy::too_many_lines)]
 #[cfg(feature = "duckdb")]
 #[tokio::test]
 async fn snapshot_int_test7_respects_current_snapshot_metadata_selection() -> Result<()> {

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -37,7 +37,6 @@ use tonic_health::pb::health_client::HealthClient;
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/view/mod.rs
+++ b/crates/runtime/tests/view/mod.rs
@@ -33,7 +33,6 @@ use crate::{
 };
 
 #[cfg(feature = "duckdb")]
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn accelerated_view_duckdb() -> Result<(), anyhow::Error> {
     use datafusion_table_providers::sql::db_connection_pool::{
@@ -476,7 +475,6 @@ async fn test_multiple_views_same_dataset() -> Result<(), anyhow::Error> {
         .await
 }
 
-#[expect(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_view_sql_validation() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/s3_vectors_metadata_filter/src/datafusion.rs
+++ b/crates/s3_vectors_metadata_filter/src/datafusion.rs
@@ -593,7 +593,6 @@ mod tests {
     use datafusion::sql::unparser::{Unparser, dialect::DefaultDialect};
 
     #[test]
-    #[expect(clippy::too_many_lines)]
     fn test_valid_datafusion_expressions() {
         let columns = vec![
             "genre".to_string(),

--- a/crates/search/src/generation/text_search/util.rs
+++ b/crates/search/src/generation/text_search/util.rs
@@ -90,7 +90,6 @@ macro_rules! downcast_array {
     };
 }
 
-#[expect(clippy::too_many_lines)]
 pub fn array_to_terms(field: Field, arr: &ArrayRef) -> Result<Vec<Term>, ArrowError> {
     let mut terms = Vec::with_capacity(arr.len());
 

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -226,7 +226,6 @@ impl SearchIndex for ChunkedSearchIndex {
     /// | 116 | Do planning and scheduling mean the                  | 0        | [0, 35]   | textbook_reasoning |
     /// | 116 | same thing? (Yes | No)                               | 0        | [35, 57]  | textbook_reasoning |
     /// +-----+------------------------------------------------------+----------|-----------|--------------------+
-    #[expect(clippy::too_many_lines)]
     async fn write(
         &self,
         record: RecordBatch,

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -512,7 +512,6 @@ impl QueryOverrides {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 #[must_use]
 pub fn get_tpch_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
     let queries = generate_tpch_queries!(

--- a/crates/test-framework/src/queries/parameterized/mod.rs
+++ b/crates/test-framework/src/queries/parameterized/mod.rs
@@ -57,7 +57,6 @@ impl ParameterValue {
 
 /// Defines parameters for TPC-H queries. Values are extracted from the original TPC-H queries,
 /// with their values replaced with $1 parameters in the `/parameterized/` TPC-H files.
-#[expect(clippy::too_many_lines)]
 #[must_use]
 pub fn add_tpch_parameters(queries: Vec<Query>) -> Vec<Query> {
     queries

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -241,7 +241,6 @@ macro_rules! downcast_and_stringify_ts {
 /// - If the function fails to downcast the array to the expected type (e.g., if the array's type is
 ///   mismatched), it will return an error.
 /// - If the array's data type is not supported for conversion, `None` is returned.
-#[expect(clippy::too_many_lines)]
 pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<String>> {
     if array.len() <= index {
         return Err(anyhow!("Index out of bounds: {index} >= {}", array.len()));

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -250,7 +250,6 @@ impl SpiceTestQueryWorker {
         validation::validate_tpch_query(query, actual_batches)
     }
 
-    #[expect(clippy::too_many_lines)]
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
             let query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>> = Arc::new(DashMap::new());
@@ -528,7 +527,6 @@ impl SpiceTestQueryWorker {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     async fn execute_flight(
         &self,
         query: &Query,

--- a/crates/util/src/time_format.rs
+++ b/crates/util/src/time_format.rs
@@ -72,7 +72,6 @@ pub fn parse_datetime(input: &str, go_format: &str) -> Option<ParsedDateTime> {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 fn convert_go_format_to_rust(go_format: &str) -> Option<String> {
     if go_format.is_empty() {
         return None;

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -66,7 +66,6 @@ fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::R
     Ok(())
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let (app, start_request) = get_app_and_start_request(&args.common).await?;
     let mut spiced_instance = SpicedInstance::start(start_request).await?;

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -24,7 +24,6 @@ use test_framework::{
 
 use crate::args::dispatch::{DispatchArgs, DispatchTestFile, DispatchTests, WorkflowArgs};
 
-#[expect(clippy::too_many_lines)]
 pub async fn dispatch(args: DispatchArgs) -> Result<()> {
     if !args.path.is_dir() && !args.path.is_file() {
         return Err(anyhow::anyhow!("Path must be a directory or a file"));

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -36,7 +36,6 @@ use test_framework::{
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     if args.test_args.common.concurrency < 2 {
         return Err(anyhow::anyhow!(

--- a/tools/testoperator/src/commands/search/mod.rs
+++ b/tools/testoperator/src/commands/search/mod.rs
@@ -36,7 +36,6 @@ use test_framework::{
 };
 use tokio::time::sleep;
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
     let (app, start_request) = get_app_and_start_request(&args.common).await?;
 


### PR DESCRIPTION
## 📝 Summary

Removes the Clippy pedantic lint `too_many_lines` since it isn't very useful in our codebase (as evidenced by the number of times we suppress it).