### PR TITLE
Move OTel ingestion to Flight port, remove separate OTel port 50052

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ Example output will be shown as follows:
 2025-01-20T19:26:10.679716Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-01-20T19:26:10.679786Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-20T19:26:10.680140Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-20T19:26:10.682080Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-20T19:26:10.879126Z  INFO runtime::init::results_cache: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s
 ```
 

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -95,6 +95,5 @@ func init() {
 	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://127.0.0.1:50051")
 	runCmd.Flags().String(constants.HttpEndpointKeyFlag, "", "Specifies the runtime HTTP endpoint. Defaults to http://127.0.0.1:8090")
 	runCmd.Flags().String("metrics-endpoint", "", "Specifies the runtime Prometheus metrics endpoint. Defaults to http://127.0.0.1:9090")
-	runCmd.Flags().String("open-telemetry-endpoint", "", "Specifies the runtime OpenTelemetry endpoint. Defaults to http://127.0.0.1:50052")
 	sqlCmd.Flags().String("captured-output", "truncated", "Specifies the captured output setting for task history. [possible values: truncated, none]. Default: truncated")
 }

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -693,18 +693,10 @@ func (c *RuntimeContext) configureMetricsFlag(args []string) []string {
 	return args
 }
 
-func (c *RuntimeContext) configureOpenTelemetryEndpoint(args []string) []string {
-	if otelEndpoint, err := c.flags.GetString("open-telemetry-endpoint"); err == nil && otelEndpoint != "" {
-		args = appendIfAbsent(args, "--open_telemetry", otelEndpoint)
-	}
-	return args
-}
-
 func (c *RuntimeContext) configureEndpoints(args []string) []string {
 	args = c.configureFlightFlag(args)
 	args = appendIfAbsent(args, "--http", c.HttpSocketAddress())
 	args = c.configureMetricsFlag(args)
-	args = c.configureOpenTelemetryEndpoint(args)
 	return args
 }
 

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -40,15 +40,6 @@ pub struct Config {
     )]
     pub flight_bind_address: SocketAddr,
 
-    /// Configure runtime OpenTelemetry address.
-    #[arg(
-        long = "open_telemetry",
-        value_name = "OPEN_TELEMETRY_BIND_ADDRESS",
-        default_value = "127.0.0.1:50052",
-        action
-    )]
-    pub open_telemetry_bind_address: SocketAddr,
-
     /// All cluster related arguments
     #[cfg(feature = "cluster")]
     #[clap(flatten)]
@@ -67,7 +58,6 @@ impl Config {
         Self {
             http_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8090),
             flight_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051),
-            open_telemetry_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50052),
             #[cfg(feature = "cluster")]
             cluster: ClusterConfig::default(),
         }
@@ -82,12 +72,6 @@ impl Config {
     #[must_use]
     pub fn with_flight_bind_address(mut self, bind_addr: SocketAddr) -> Self {
         self.flight_bind_address = bind_addr;
-        self
-    }
-
-    #[must_use]
-    pub fn with_open_telemetry_bind_address(mut self, bind_addr: SocketAddr) -> Self {
-        self.open_telemetry_bind_address = bind_addr;
         self
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -26,6 +26,7 @@ use crate::datafusion::DataFusion;
 use crate::datafusion::error::{SpiceExternalError, find_datafusion_root};
 use crate::datafusion::query::{self, QueryBuilder};
 use crate::dataupdate::DataUpdate;
+use crate::opentelemetry::create_metrics_service;
 use crate::tls::TlsConfig;
 use crate::{Runtime, metrics as runtime_metrics};
 use app::App;
@@ -485,6 +486,9 @@ pub async fn start(
         .layer(BasicAuthLayer::new(endpoint_auth.flight_basic_auth))
         .into_inner();
 
+    // Create the OpenTelemetry MetricsService
+    let otel_service = create_metrics_service(rt.datafusion());
+
     let mut server = server
         .layer(RequestContextLayer::new(app, rt.datafusion(), rt.secrets()))
         .layer(WriteRateLimitLayer::new(RateLimiter::direct(
@@ -493,7 +497,9 @@ pub async fn start(
         .layer(auth_layer);
 
     #[cfg(not(feature = "cluster"))]
-    let server = server.add_service(spice_flight_service);
+    let server = server
+        .add_service(spice_flight_service)
+        .add_service(otel_service);
 
     #[cfg(feature = "cluster")]
     let server = match rt.config.cluster.mode {
@@ -512,15 +518,20 @@ pub async fn start(
             server
                 .add_service(spice_flight_service)
                 .add_service(scheduler_grpc_server)
+                .add_service(otel_service)
         }
         Some(ClusterMode::Executor) => {
             let executor_flight = FlightServiceServer::new(BallistaFlightService::new())
                 .max_decoding_message_size(usize::MAX)
                 .max_encoding_message_size(usize::MAX);
 
-            server.add_service(executor_flight)
+            server
+                .add_service(executor_flight)
+                .add_service(otel_service)
         }
-        _ => server.add_service(spice_flight_service),
+        _ => server
+            .add_service(spice_flight_service)
+            .add_service(otel_service),
     };
 
     // If running an executor, we may have resolved another port to bind if 50051 is taken

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -112,7 +112,7 @@ pub(crate) async fn get(
         },
         ConnectionDetails {
             name: "flight",
-            status: flight_status.clone(),
+            status: flight_status,
             endpoint: flight_url.clone(),
         },
         ConnectionDetails {

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -17,8 +17,6 @@ use csv::Writer;
 use flight_client::{Credentials, FlightClient};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
-use tonic::transport::Channel;
-use tonic_health::{ServingStatus, pb::health_client::HealthClient};
 
 use axum::{
     Extension, Json,
@@ -104,6 +102,7 @@ pub(crate) async fn get(
 ) -> Response {
     let cfg = cfg.as_ref();
     let flight_url = cfg.flight_bind_address.to_string();
+    let flight_status = get_flight_status(&flight_url).await;
 
     let details = vec![
         ConnectionDetails {
@@ -113,8 +112,8 @@ pub(crate) async fn get(
         },
         ConnectionDetails {
             name: "flight",
-            status: get_flight_status(&flight_url).await,
-            endpoint: flight_url,
+            status: flight_status.clone(),
+            endpoint: flight_url.clone(),
         },
         ConnectionDetails {
             name: "metrics",
@@ -130,24 +129,11 @@ pub(crate) async fn get(
                 None => ComponentStatus::Disabled,
             },
         },
+        // OpenTelemetry is served on the same gRPC port as Flight
         ConnectionDetails {
             name: "opentelemetry",
-            status: match get_opentelemetry_status(
-                cfg.open_telemetry_bind_address.to_string().as_str(),
-            )
-            .await
-            {
-                Ok(status) => status,
-                Err(e) => {
-                    tracing::error!(
-                        "Error getting opentelemetry status from {}: {}",
-                        cfg.open_telemetry_bind_address,
-                        e
-                    );
-                    ComponentStatus::Error
-                }
-            },
-            endpoint: cfg.open_telemetry_bind_address.to_string(),
+            status: flight_status,
+            endpoint: flight_url,
         },
     ];
 
@@ -196,27 +182,6 @@ async fn get_metrics_status(
 ) -> Result<ComponentStatus, Box<dyn std::error::Error>> {
     let resp = reqwest::get(format!("http://{metrics_addr}/health")).await?;
     if resp.status().is_success() && resp.text().await? == "OK" {
-        Ok(ComponentStatus::Ready)
-    } else {
-        Ok(ComponentStatus::Error)
-    }
-}
-async fn get_opentelemetry_status(
-    addr: &str,
-) -> Result<ComponentStatus, Box<dyn std::error::Error>> {
-    let channel = Channel::from_shared(format!("http://{addr}"))?
-        .connect()
-        .await?;
-
-    let mut client = HealthClient::new(channel);
-
-    let resp = client
-        .check(tonic_health::pb::HealthCheckRequest {
-            service: String::new(),
-        })
-        .await?;
-
-    if resp.into_inner().status == ServingStatus::Serving as i32 {
         Ok(ComponentStatus::Ready)
     } else {
         Ok(ComponentStatus::Error)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -148,9 +148,6 @@ pub enum Error {
     #[snafu(display("Unable to start Flight server: {source}"))]
     UnableToStartFlightServer { source: flight::Error },
 
-    #[snafu(display("Unable to start OpenTelemetry server: {source}"))]
-    UnableToStartOpenTelemetryServer { source: opentelemetry::Error },
-
     #[snafu(display("Unknown data source: {data_source}"))]
     UnknownDataSource { data_source: String },
 
@@ -436,7 +433,6 @@ const CLUSTER_EXECUTOR: &str = "cluster_executor";
 const HTTP_SERVER: &str = "http_server";
 const METRICS_SERVER: &str = "metrics_server";
 const FLIGHT_SERVER: &str = "flight_server";
-const OPENTELEMETRY_SERVER: &str = "opentelemetry_server";
 const PODS_WATCHER: &str = "pods_watcher";
 const COMPONENTS_INITIAL_LOAD: &str = "components_initial_load";
 
@@ -754,30 +750,6 @@ impl Runtime {
             })
             .await;
 
-        // Start OpenTelemetry server
-        let opentelemetry_graceful_shutdown = CancellationToken::new();
-        let df_ref = Arc::clone(&self.df);
-        let cloned_tls_config = tls_config.clone();
-        let grpc_auth = endpoint_auth.grpc_auth.clone();
-
-        let opentelemetry_future = self
-            .start_runtime_task(
-                OPENTELEMETRY_SERVER,
-                Some(opentelemetry_graceful_shutdown.clone()),
-                async move {
-                    opentelemetry::start(
-                        config.open_telemetry_bind_address,
-                        df_ref,
-                        cloned_tls_config,
-                        grpc_auth,
-                        Some(opentelemetry_graceful_shutdown),
-                    )
-                    .await
-                    .context(UnableToStartOpenTelemetryServerSnafu)
-                },
-            )
-            .await;
-
         if let Some(tls_config) = tls_config {
             match tls_config.subject_name() {
                 Some(subject_name) => {
@@ -805,7 +777,6 @@ impl Runtime {
             http_future,
             flight_future,
             metrics_future,
-            opentelemetry_future,
             pods_watcher_future,
             shutdown_signal_future
         ) {

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -558,7 +558,7 @@ fn append_null(
     }
 }
 
-/// Creates the OpenTelemetry MetricsService server that can be added to a gRPC server.
+/// Creates the OpenTelemetry `MetricsService` server that can be added to a gRPC server.
 ///
 /// This is used to add OpenTelemetry metrics ingestion to the Flight gRPC server.
 #[must_use]

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use arrow::array::ArrayBuilder;
@@ -35,41 +34,29 @@ use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsPartialSucc
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse;
 use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsService;
-use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsServiceServer;
+pub use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsServiceServer;
 use opentelemetry_proto::tonic::common::v1::KeyValue;
 use opentelemetry_proto::tonic::common::v1::any_value;
 use opentelemetry_proto::tonic::metrics::v1::DataPointFlags;
 use opentelemetry_proto::tonic::metrics::v1::NumberDataPoint;
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
-use runtime_auth::GrpcAuth;
-use runtime_auth::layer::grpc::make_interceptor;
-use secrecy::ExposeSecret;
 use snafu::prelude::*;
-use tokio_util::sync::CancellationToken;
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tonic::async_trait;
 use tonic::codec::CompressionEncoding;
-use tonic::service::InterceptorLayer;
-use tonic::transport::{Identity, Server, ServerTlsConfig};
-use tonic_health::pb::health_server::Health;
-use tonic_health::pb::health_server::HealthServer;
 
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
 use crate::dataupdate::UpdateType;
-use crate::tls::TlsConfig;
 use crate::{tracers::OnceTracer, warn_once};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to serve: {source}"))]
-    UnableToServe { source: tonic::transport::Error },
-
     #[snafu(display("Failed to build record batch from OpenTelemetry metrics: {source}"))]
     FailedToBuildRecordBatch { source: arrow::error::ArrowError },
 
@@ -95,14 +82,6 @@ pub enum Error {
         "First data point for metric {metric} has no value and therefore is not valid for establishing schema"
     ))]
     FirstMetricDataPointHasNoValue { metric: String },
-
-    #[snafu(display("Unable to configure TLS on the Flight server: {source}"))]
-    UnableToConfigureTls { source: tonic::transport::Error },
-
-    #[snafu(display(
-        "Address {addr} is already in use by another process. Either stop the existing process or change the address: https://spiceai.org/docs/cli/reference/run"
-    ))]
-    AddressAlreadyInUse { addr: String },
 }
 
 const VALUE_COLUMN_NAME: &str = "value";
@@ -202,14 +181,6 @@ impl MetricsService for Service {
             partial_success,
         }))
     }
-}
-
-async fn create_health_service() -> HealthServer<impl Health> {
-    let (health_reporter, health_service) = tonic_health::server::health_reporter();
-    health_reporter
-        .set_serving::<MetricsServiceServer<Service>>()
-        .await;
-    health_service
 }
 
 pub fn metric_data_to_record_batch(
@@ -587,67 +558,14 @@ fn append_null(
     }
 }
 
-pub async fn start(
-    bind_address: SocketAddr,
-    datafusion: Arc<DataFusion>,
-    tls_config: Option<Arc<TlsConfig>>,
-    grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
-    shutdown_signal: Option<CancellationToken>,
-) -> Result<()> {
+/// Creates the OpenTelemetry MetricsService server that can be added to a gRPC server.
+///
+/// This is used to add OpenTelemetry metrics ingestion to the Flight gRPC server.
+#[must_use]
+pub fn create_metrics_service(datafusion: Arc<DataFusion>) -> MetricsServiceServer<Service> {
     let service = Service {
         datafusion,
         once_tracer: OnceTracer::new(),
     };
-    let svc = MetricsServiceServer::new(service).accept_compressed(CompressionEncoding::Gzip);
-
-    tracing::info!("Spice Runtime OpenTelemetry listening on {bind_address}");
-
-    let mut server = Server::builder();
-
-    if let Some(ref tls_config) = tls_config {
-        let server_tls_config = ServerTlsConfig::new().identity(Identity::from_pem(
-            tls_config.cert.expose_secret(),
-            tls_config.key.expose_secret(),
-        ));
-        server = server
-            .tls_config(server_tls_config)
-            .context(UnableToConfigureTlsSnafu)?;
-    }
-
-    let server = server
-        .layer(InterceptorLayer::new(make_interceptor(grpc_auth)))
-        .add_service(create_health_service().await)
-        .add_service(svc);
-
-    if let Some(token) = shutdown_signal {
-        server
-            .serve_with_shutdown(bind_address, token.cancelled())
-            .await
-    } else {
-        server.serve(bind_address).await
-    }
-    .map_err(|e| {
-        if is_address_in_use_error(&e) {
-            Error::AddressAlreadyInUse {
-                addr: bind_address.to_string(),
-            }
-        } else {
-            Error::UnableToServe { source: e }
-        }
-    })?;
-
-    tracing::debug!("Spice Runtime OpenTelemetry stopped");
-
-    Ok(())
-}
-
-fn is_address_in_use_error(err: &tonic::transport::Error) -> bool {
-    let mut source: Option<&dyn std::error::Error> = Some(err);
-    while let Some(e) = source {
-        if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
-            return io_err.kind() == std::io::ErrorKind::AddrInUse;
-        }
-        source = e.source();
-    }
-    false
+    MetricsServiceServer::new(service).accept_compressed(CompressionEncoding::Gzip)
 }

--- a/crates/runtime/tests/cors/mod.rs
+++ b/crates/runtime/tests/cors/mod.rs
@@ -43,33 +43,34 @@ async fn test_enabled_cors_endpoints() -> Result<(), anyhow::Error> {
             let mut rng = rand::rng();
             let http_port: u16 = rng.random_range(50000..60000);
             let flight_port: u16 = http_port + 1;
-            let otel_port: u16 = http_port + 2;
-            let metrics_port: u16 = http_port + 3;
+            let metrics_port: u16 = http_port + 2;
 
             tracing::debug!(
-                "CORS Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+                "CORS Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
             );
 
             let api_config = Config::new()
                 .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-                .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
-            let rt = Arc::new(Runtime::builder()
-                .with_app(
-                    AppBuilder::new("test")
-                        .with_cors_config(CorsConfig {
-                            enabled: true,
-                            allowed_origins: vec!["*".to_string()],
-                        })
-                        .build(),
-                )
-                .build()
-                .await);
+            let rt = Arc::new(
+                Runtime::builder()
+                    .with_app(
+                        AppBuilder::new("test")
+                            .with_cors_config(CorsConfig {
+                                enabled: true,
+                                allowed_origins: vec!["*".to_string()],
+                            })
+                            .build(),
+                    )
+                    .build()
+                    .await,
+            );
 
             // Start the servers
             tokio::spawn(async move {
-                Box::pin(Arc::clone(&rt).start_servers(api_config, None, EndpointAuth::no_auth())).await
+                Box::pin(Arc::clone(&rt).start_servers(api_config, None, EndpointAuth::no_auth()))
+                    .await
             });
 
             let http_client = reqwest::Client::builder().build()?;
@@ -105,73 +106,81 @@ async fn test_enabled_cors_endpoints() -> Result<(), anyhow::Error> {
             assert_eq!(cors_allow_methods_header, "GET,POST,PATCH,OPTIONS");
 
             Ok(())
-        }).await
+        })
+        .await
 }
 
 #[tokio::test]
 async fn test_disabled_cors_endpoints() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
-    test_request_context().scope(async {
-        let span = tracing::info_span!("test_disabled_cors_endpoints");
-        let _span_guard = span.enter();
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_disabled_cors_endpoints");
+            let _span_guard = span.enter();
 
-        let mut rng = rand::rng();
-        let http_port: u16 = rng.random_range(50000..60000);
-        let flight_port: u16 = http_port + 1;
-        let otel_port: u16 = http_port + 2;
-        let metrics_port: u16 = http_port + 3;
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let metrics_port: u16 = http_port + 2;
 
-        tracing::debug!(
-            "CORS Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-        );
+            tracing::debug!(
+                "CORS Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
+            );
 
-        let api_config = Config::new()
-            .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-            .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-            .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
-        // Default cors config is disabled
-        let rt = Arc::new(Runtime::builder()
-            .with_app(AppBuilder::new("test").build())
-            .build()
-            .await);
+            // Default cors config is disabled
+            let rt = Arc::new(
+                Runtime::builder()
+                    .with_app(AppBuilder::new("test").build())
+                    .build()
+                    .await,
+            );
 
-        // Start the servers
-        tokio::spawn(async move {
-            Box::pin(Arc::clone(&rt).start_servers(api_config, None, EndpointAuth::no_auth())).await
-        });
+            // Start the servers
+            tokio::spawn(async move {
+                Box::pin(Arc::clone(&rt).start_servers(api_config, None, EndpointAuth::no_auth()))
+                    .await
+            });
 
-        let http_client = reqwest::Client::builder().build()?;
+            let http_client = reqwest::Client::builder().build()?;
 
-        // Wait for the servers to start
-        tracing::info!("Waiting for servers to start...");
-        wait_until_true(Duration::from_secs(10), || async {
-            http_client
-                .get(format!("http://localhost:{http_port}/health"))
-                .send()
-                .await
-                .is_ok()
+            // Wait for the servers to start
+            tracing::info!("Waiting for servers to start...");
+            wait_until_true(Duration::from_secs(10), || async {
+                http_client
+                    .get(format!("http://localhost:{http_port}/health"))
+                    .send()
+                    .await
+                    .is_ok()
+            })
+            .await;
+
+            let http_url = format!("http://127.0.0.1:{http_port}/health");
+            let request_builder = http_client.request(http::Method::OPTIONS, &http_url);
+            let response = request_builder.send().await.expect("valid response");
+            assert!(response.status().is_success());
+            tracing::info!("HTTP health check passed");
+
+            // Verify that the CORS headers are set
+            assert!(
+                response
+                    .headers()
+                    .get("access-control-allow-origin")
+                    .is_none()
+            );
+
+            assert!(
+                response
+                    .headers()
+                    .get("access-control-allow-methods")
+                    .is_none()
+            );
+
+            Ok(())
         })
-        .await;
-
-        let http_url = format!("http://127.0.0.1:{http_port}/health");
-        let request_builder = http_client.request(http::Method::OPTIONS, &http_url);
-        let response = request_builder.send().await.expect("valid response");
-        assert!(response.status().is_success());
-        tracing::info!("HTTP health check passed");
-
-        // Verify that the CORS headers are set
-        assert!(response
-            .headers()
-            .get("access-control-allow-origin")
-            .is_none());
-
-        assert!(response
-            .headers()
-            .get("access-control-allow-methods")
-            .is_none());
-
-        Ok(())
-    }).await
+        .await
 }

--- a/crates/runtime/tests/endpoint_auth/flight.rs
+++ b/crates/runtime/tests/endpoint_auth/flight.rs
@@ -38,93 +38,93 @@ const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 async fn test_flight_auth() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
-    test_request_context().scope(async {
-        let span = tracing::info_span!("test_flight_auth");
-        let _span_guard = span.enter();
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_flight_auth");
+            let _span_guard = span.enter();
 
-        let mut rng = rand::rng();
-        let http_port: u16 = rng.random_range(50000..60000);
-        let flight_port: u16 = http_port + 1;
-        let otel_port: u16 = http_port + 2;
-        let metrics_port: u16 = http_port + 3;
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let metrics_port: u16 = http_port + 2;
 
-        tracing::debug!(
-            "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-        );
+            tracing::debug!(
+                "Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
+            );
 
-        let api_config = Config::new()
-            .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-            .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-            .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
-        let registry = prometheus::Registry::new();
+            let registry = prometheus::Registry::new();
 
-        let app = app::AppBuilder::new("test_app").build();
+            let app = app::AppBuilder::new("test_app").build();
 
-        let rt = Runtime::builder()
-            .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
-            .with_app(app)
-            .build()
+            let rt = Runtime::builder()
+                .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
+                .with_app(app)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            let api_key_auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid")]))
+                as Arc<dyn FlightBasicAuth + Send + Sync>;
+
+            // Start the servers
+            tokio::spawn(async move {
+                Box::pin(Arc::clone(&cloned_rt).start_servers(
+                    api_config,
+                    None,
+                    EndpointAuth::default().with_flight_basic_auth(api_key_auth),
+                ))
+                .await
+            });
+
+            // Wait for the servers to start
+            tracing::info!("Waiting for servers to start...");
+            wait_until_true(Duration::from_secs(10), || async {
+                reqwest::get(format!("http://localhost:{http_port}/health"))
+                    .await
+                    .is_ok()
+            })
             .await;
 
-        let cloned_rt = Arc::new(rt.clone());
-
-        let api_key_auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid")]))
-            as Arc<dyn FlightBasicAuth + Send + Sync>;
-
-        // Start the servers
-        tokio::spawn(async move {
-            Box::pin(Arc::clone(&cloned_rt).start_servers(
-                api_config,
-                None,
-                EndpointAuth::default().with_flight_basic_auth(api_key_auth),
-            ))
-            .await
-        });
-
-        // Wait for the servers to start
-        tracing::info!("Waiting for servers to start...");
-        wait_until_true(Duration::from_secs(10), || async {
-            reqwest::get(format!("http://localhost:{http_port}/health"))
+            let channel = Channel::from_shared(format!("http://localhost:{flight_port}"))?
+                .connect()
                 .await
-                .is_ok()
-        })
-        .await;
+                .expect("to connect to flight endpoint");
+            let client = FlightServiceClient::new(channel);
 
-        let channel = Channel::from_shared(format!("http://localhost:{flight_port}"))?
-            .connect()
+            let result = flightrepl::get_records(
+                client.clone(),
+                "SELECT 1",
+                Some(&"valid".to_string()),
+                &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
+                cache_control::CacheControl::Cache,
+            )
+            .await;
+            result.expect("should succeed with valid API key");
+
+            let Err(e) = flightrepl::get_records(
+                client,
+                "SELECT 1",
+                None,
+                &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
+                cache_control::CacheControl::Cache,
+            )
             .await
-            .expect("to connect to flight endpoint");
-        let client = FlightServiceClient::new(channel);
-
-        let result = flightrepl::get_records(
-            client.clone(),
-            "SELECT 1",
-            Some(&"valid".to_string()),
-            &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
-            cache_control::CacheControl::Cache,
-        )
-        .await;
-        result.expect("should succeed with valid API key");
-
-        let Err(e) = flightrepl::get_records(
-            client,
-            "SELECT 1",
-            None,
-            &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
-            cache_control::CacheControl::Cache,
-        )
-        .await
-        else {
-            panic!("expected error");
-        };
-        match e {
-            FlightError::Tonic(status) => {
-                assert_eq!(status.code(), tonic::Code::Unauthenticated);
+            else {
+                panic!("expected error");
+            };
+            match e {
+                FlightError::Tonic(status) => {
+                    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+                }
+                _ => panic!("expected tonic error"),
             }
-            _ => panic!("expected tonic error"),
-        }
 
-        Ok(())
-    }).await
+            Ok(())
+        })
+        .await
 }

--- a/crates/runtime/tests/endpoint_auth/http.rs
+++ b/crates/runtime/tests/endpoint_auth/http.rs
@@ -38,123 +38,123 @@ async fn test_http_auth() -> Result<(), anyhow::Error> {
         rustls::crypto::aws_lc_rs::default_provider(),
     );
 
-    test_request_context().scope(async {
-        let span = tracing::info_span!("test_http_auth");
-        let _span_guard = span.enter();
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_http_auth");
+            let _span_guard = span.enter();
 
-        let mut rng = rand::rng();
-        let http_port: u16 = rng.random_range(50000..60000);
-        let flight_port: u16 = http_port + 1;
-        let otel_port: u16 = http_port + 2;
-        let metrics_port: u16 = http_port + 3;
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let metrics_port: u16 = http_port + 2;
 
-        tracing::debug!(
-            "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-        );
+            tracing::debug!(
+                "Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
+            );
 
-        let api_config = Config::new()
-            .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-            .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-            .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
-        let registry = prometheus::Registry::new();
+            let registry = prometheus::Registry::new();
 
-        let app = app::AppBuilder::new("test_app").build();
+            let app = app::AppBuilder::new("test_app").build();
 
-        let rt = Runtime::builder()
-            .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
-            .with_app(app)
-            .build()
+            let rt = Runtime::builder()
+                .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
+                .with_app(app)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            let api_key_auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid")]))
+                as Arc<dyn HttpAuth + Send + Sync>;
+
+            // Start the servers
+            tokio::spawn(async move {
+                Box::pin(Arc::clone(&cloned_rt).start_servers(
+                    api_config,
+                    None,
+                    EndpointAuth::default().with_http_auth(api_key_auth),
+                ))
+                .await
+            });
+
+            let http_client = reqwest::Client::builder().build()?;
+
+            // Wait for the servers to start
+            tracing::info!("Waiting for servers to start...");
+            wait_until_true(Duration::from_secs(10), || async {
+                http_client
+                    .get(format!("http://localhost:{http_port}/health"))
+                    .send()
+                    .await
+                    .is_ok()
+            })
             .await;
 
-        let cloned_rt = Arc::new(rt.clone());
-
-        let api_key_auth =
-            Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid")])) as Arc<dyn HttpAuth + Send + Sync>;
-
-        // Start the servers
-        tokio::spawn(async move {
-            Box::pin(Arc::clone(&cloned_rt).start_servers(
-                api_config,
-                None,
-                EndpointAuth::default().with_http_auth(api_key_auth),
-            ))
-            .await
-        });
-
-        let http_client = reqwest::Client::builder().build()?;
-
-        // Wait for the servers to start
-        tracing::info!("Waiting for servers to start...");
-        wait_until_true(Duration::from_secs(10), || async {
-            http_client
-                .get(format!("http://localhost:{http_port}/health"))
+            // HTTP is not authenticated
+            let http_url = format!("http://127.0.0.1:{http_port}/health");
+            let response = http_client
+                .get(&http_url)
                 .send()
                 .await
-                .is_ok()
+                .expect("valid response");
+            assert!(response.status().is_success());
+            tracing::info!("HTTP health check passed");
+
+            // Ready API is not authenticated
+            let http_url = format!("http://127.0.0.1:{http_port}/v1/ready");
+            let response = http_client
+                .get(&http_url)
+                .send()
+                .await
+                .expect("valid response");
+            assert!(response.status().is_success());
+            tracing::info!("HTTP health check passed");
+
+            // Metrics API is not authenticated
+            let metrics_url = format!("http://127.0.0.1:{metrics_port}/");
+            let response = http_client
+                .get(&metrics_url)
+                .send()
+                .await
+                .expect("valid response");
+            assert!(response.status().is_success());
+            tracing::info!("Metrics health check passed");
+
+            // v1/status is authenticated
+            let status_url = format!("http://127.0.0.1:{http_port}/v1/status?format=json");
+            let response = http_client
+                .get(&status_url)
+                .send()
+                .await
+                .expect("valid response");
+            assert!(!response.status().is_success());
+            assert_eq!(response.status().as_u16(), 401);
+
+            // Test valid API key
+            let response = http_client
+                .get(&status_url)
+                .header("x-api-key", "valid")
+                .send()
+                .await
+                .expect("valid response");
+            assert!(response.status().is_success());
+            assert_eq!(response.status().as_u16(), 200);
+
+            // Test invalid API key
+            let response = http_client
+                .get(&status_url)
+                .header("x-api-key", "invalid")
+                .send()
+                .await
+                .expect("valid response");
+            assert!(!response.status().is_success());
+            assert_eq!(response.status().as_u16(), 401);
+
+            Ok(())
         })
-        .await;
-
-        // HTTP is not authenticated
-        let http_url = format!("http://127.0.0.1:{http_port}/health");
-        let response = http_client
-            .get(&http_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success());
-        tracing::info!("HTTP health check passed");
-
-        // Ready API is not authenticated
-        let http_url = format!("http://127.0.0.1:{http_port}/v1/ready");
-        let response = http_client
-            .get(&http_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success());
-        tracing::info!("HTTP health check passed");
-
-        // Metrics API is not authenticated
-        let metrics_url = format!("http://127.0.0.1:{metrics_port}/");
-        let response = http_client
-            .get(&metrics_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success());
-        tracing::info!("Metrics health check passed");
-
-        // v1/status is authenticated
-        let status_url = format!("http://127.0.0.1:{http_port}/v1/status?format=json");
-        let response = http_client
-            .get(&status_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(!response.status().is_success());
-        assert_eq!(response.status().as_u16(), 401);
-
-        // Test valid API key
-        let response = http_client
-            .get(&status_url)
-            .header("x-api-key", "valid")
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success());
-        assert_eq!(response.status().as_u16(), 200);
-
-        // Test invalid API key
-        let response = http_client
-            .get(&status_url)
-            .header("x-api-key", "invalid")
-            .send()
-            .await
-            .expect("valid response");
-        assert!(!response.status().is_success());
-        assert_eq!(response.status().as_u16(), 401);
-
-        Ok(())
-    }).await
+        .await
 }

--- a/crates/runtime/tests/flight/mod.rs
+++ b/crates/runtime/tests/flight/mod.rs
@@ -59,17 +59,13 @@ async fn start_spice_test_app(
     let mut rng = rand::rng();
     let http_port: u16 = rng.random_range(50000..60000);
     let flight_port: u16 = http_port + 1;
-    let otel_port: u16 = http_port + 2;
-    let metrics_port: u16 = http_port + 3;
+    let metrics_port: u16 = http_port + 2;
 
-    tracing::debug!(
-        "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-    );
+    tracing::debug!("Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}");
 
     let api_config = Config::new()
         .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-        .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
     let registry = prometheus::Registry::new();
 

--- a/crates/runtime/tests/iceberg_api/mod.rs
+++ b/crates/runtime/tests/iceberg_api/mod.rs
@@ -54,16 +54,14 @@ async fn test_iceberg_api_get_table_schema() -> Result<(), anyhow::Error> {
             let mut rng = rand::rng();
             let http_port: u16 = rng.random_range(50000..60000);
             let flight_port: u16 = http_port + 1;
-            let otel_port: u16 = http_port + 2;
 
             tracing::debug!(
-                "Iceberg API Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}"
+                "Iceberg API Ports: http: {http_port}, flight: {flight_port}"
             );
 
             let api_config = Config::new()
                 .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-                .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
             let app = app::AppBuilder::new("test_app")
                 .with_dataset(get_s3_dictionary_dataset("dictionary_example"))

--- a/crates/runtime/tests/management/mod.rs
+++ b/crates/runtime/tests/management/mod.rs
@@ -154,17 +154,13 @@ async fn create_data_export_endpoint() -> Result<DataExportEndpoint, anyhow::Err
     let mut rng = rand::rng();
     let http_port: u16 = rng.random_range(50000..60000);
     let flight_port: u16 = http_port + 1;
-    let otel_port: u16 = http_port + 2;
-    let metrics_port: u16 = http_port + 3;
+    let metrics_port: u16 = http_port + 2;
 
-    tracing::debug!(
-        "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-    );
+    tracing::debug!("Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}");
 
     let api_config = Config::new()
         .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-        .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
     let app = AppBuilder::new("management_sink_app").build();
 

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -145,18 +145,16 @@ pub(crate) fn create_api_bindings_config() -> Config {
     let mut rng = rand::rng();
     let http_port: u16 = rng.random_range(50000..60000);
     let flight_port: u16 = http_port + 1;
-    let otel_port: u16 = http_port + 2;
-    let metrics_port: u16 = http_port + 3;
+    let metrics_port: u16 = http_port + 2;
 
     let localhost: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
     let api_config = Config::new()
         .with_http_bind_address(SocketAddr::new(localhost, http_port))
-        .with_flight_bind_address(SocketAddr::new(localhost, flight_port))
-        .with_open_telemetry_bind_address(SocketAddr::new(localhost, otel_port));
+        .with_flight_bind_address(SocketAddr::new(localhost, flight_port));
 
     tracing::debug!(
-        "Created api bindings configuration: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+        "Created api bindings configuration: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
     );
 
     api_config

--- a/crates/runtime/tests/shutdown/mod.rs
+++ b/crates/runtime/tests/shutdown/mod.rs
@@ -59,17 +59,15 @@ async fn runtime_shutdown_timeout_force() -> Result<(), anyhow::Error> {
             let mut rng = rand::rng();
             let http_port: u16 = rng.random_range(50000..60000);
             let flight_port: u16 = http_port + 1;
-            let otel_port: u16 = http_port + 2;
-            let metrics_port: u16 = http_port + 3;
+            let metrics_port: u16 = http_port + 2;
 
             tracing::debug!(
-                "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+                "Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
             );
 
             let api_config = runtime::config::Config::new()
                 .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-                .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
             let app = AppBuilder::new("lineitem")
                 .with_dataset(get_s3_dataset(
@@ -149,17 +147,15 @@ async fn runtime_shutdown_timeout_grace() -> Result<(), anyhow::Error> {
             let mut rng = rand::rng();
             let http_port: u16 = rng.random_range(50000..60000);
             let flight_port: u16 = http_port + 1;
-            let otel_port: u16 = http_port + 2;
-            let metrics_port: u16 = http_port + 3;
+            let metrics_port: u16 = http_port + 2;
 
             tracing::debug!(
-                "Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+                "Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
             );
 
             let api_config = runtime::config::Config::new()
                 .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-                .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
 
             let app = AppBuilder::new("lineitem")
                 .with_dataset(get_s3_dataset(

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -33,7 +33,6 @@ use prost::Message;
 use rand::Rng;
 use runtime::{Runtime, auth::EndpointAuth, config::Config, tls::TlsConfig};
 use tonic::transport::Channel;
-use tonic_health::pb::health_client::HealthClient;
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
@@ -45,132 +44,125 @@ async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
         rustls::crypto::aws_lc_rs::default_provider(),
     );
 
-    test_request_context().scope(async {
-        let span = tracing::info_span!("test_tls_endpoints");
-        let _span_guard = span.enter();
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_tls_endpoints");
+            let _span_guard = span.enter();
 
-        let mut rng = rand::rng();
-        let http_port: u16 = rng.random_range(50000..60000);
-        let flight_port: u16 = http_port + 1;
-        let otel_port: u16 = http_port + 2;
-        let metrics_port: u16 = http_port + 3;
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let metrics_port: u16 = http_port + 2;
 
-        tracing::debug!(
-            "TLS Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
-        );
+            tracing::debug!(
+                "TLS Ports: http: {http_port}, flight: {flight_port}, metrics: {metrics_port}"
+            );
 
-        let cert_bytes = include_bytes!("../../../../test/tls/spiced_cert.pem").to_vec();
-        let key_bytes = include_bytes!("../../../../test/tls/spiced_key.pem").to_vec();
+            let cert_bytes = include_bytes!("../../../../test/tls/spiced_cert.pem").to_vec();
+            let key_bytes = include_bytes!("../../../../test/tls/spiced_key.pem").to_vec();
 
-        let api_config = Config::new()
-            .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
-            .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
-            .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
-        let tls_config = TlsConfig::try_new(cert_bytes.clone(), key_bytes).expect("valid TlsConfig");
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
+            let tls_config =
+                TlsConfig::try_new(cert_bytes.clone(), key_bytes).expect("valid TlsConfig");
 
-        let registry = prometheus::Registry::new();
-        let app = app::AppBuilder::new("test_app").build();
+            let registry = prometheus::Registry::new();
+            let app = app::AppBuilder::new("test_app").build();
 
-        let rt = Arc::new(Runtime::builder()
-            .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
-            .with_app(app)
-            .build()
-            .await);
+            let rt = Arc::new(
+                Runtime::builder()
+                    .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
+                    .with_app(app)
+                    .build()
+                    .await,
+            );
 
-        // Start the servers
-        tokio::spawn(async move {
-            Box::pin(Arc::clone(&rt).start_servers(
-                api_config,
-                Some(Arc::new(tls_config)),
-                EndpointAuth::no_auth(),
-            ))
-            .await
-        });
+            // Start the servers
+            tokio::spawn(async move {
+                Box::pin(Arc::clone(&rt).start_servers(
+                    api_config,
+                    Some(Arc::new(tls_config)),
+                    EndpointAuth::no_auth(),
+                ))
+                .await
+            });
 
-        // Connect to the servers with TLS
-        let root_cert_bytes = include_bytes!("../../../../test/tls/spiced_root_cert.pem").to_vec();
-        let root_cert_reqwest =
-            reqwest::tls::Certificate::from_pem(&root_cert_bytes).expect("valid certificate");
-        let http_client = reqwest::Client::builder()
-            .use_rustls_tls()
-            .tls_built_in_root_certs(false)
-            .add_root_certificate(root_cert_reqwest)
-            .build()?;
+            // Connect to the servers with TLS
+            let root_cert_bytes =
+                include_bytes!("../../../../test/tls/spiced_root_cert.pem").to_vec();
+            let root_cert_reqwest =
+                reqwest::tls::Certificate::from_pem(&root_cert_bytes).expect("valid certificate");
+            let http_client = reqwest::Client::builder()
+                .use_rustls_tls()
+                .tls_built_in_root_certs(false)
+                .add_root_certificate(root_cert_reqwest)
+                .build()?;
 
-        // Wait for the servers to start
-        tracing::info!("Waiting for servers to start...");
-        wait_until_true(Duration::from_secs(10), || async {
-            http_client
-                .get(format!("https://127.0.0.1:{http_port}/health"))
+            // Wait for the servers to start
+            tracing::info!("Waiting for servers to start...");
+            wait_until_true(Duration::from_secs(10), || async {
+                http_client
+                    .get(format!("https://127.0.0.1:{http_port}/health"))
+                    .send()
+                    .await
+                    .is_ok()
+            })
+            .await;
+
+            // HTTP
+            let http_url = format!("https://127.0.0.1:{http_port}/health");
+            let response = http_client
+                .get(&http_url)
                 .send()
                 .await
-                .is_ok()
-        })
-        .await;
+                .expect("valid response");
+            assert!(
+                response.status().is_success(),
+                "HTTP health check failed: {}",
+                response.status()
+            );
+            tracing::info!("HTTP health check passed");
 
-        // HTTP
-        let http_url = format!("https://127.0.0.1:{http_port}/health");
-        let response = http_client
-            .get(&http_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success(), "HTTP health check failed: {}", response.status());
-        tracing::info!("HTTP health check passed");
+            // METRICS
+            let metrics_url = format!("https://127.0.0.1:{metrics_port}/health");
+            let response = http_client
+                .get(&metrics_url)
+                .send()
+                .await
+                .expect("valid response");
+            assert!(response.status().is_success());
+            tracing::info!("Metrics health check passed");
 
-        // METRICS
-        let metrics_url = format!("https://127.0.0.1:{metrics_port}/health");
-        let response = http_client
-            .get(&metrics_url)
-            .send()
-            .await
-            .expect("valid response");
-        assert!(response.status().is_success());
-        tracing::info!("Metrics health check passed");
-
-        // FLIGHT (GRPC)
-        let root_cert_tonic = tonic::transport::Certificate::from_pem(&root_cert_bytes);
-        let channel = Channel::from_shared(format!("https://127.0.0.1:{flight_port}"))?
-            .tls_config(
-                tonic::transport::ClientTlsConfig::new().ca_certificate(root_cert_tonic.clone()),
-            )
-            .expect("valid tls config")
-            .connect()
-            .await
-            .expect("to connect to flight port");
-
-        let mut client = FlightServiceClient::new(channel);
-        let sql_command = CommandStatementQuery {
-            query: "show tables".to_string(),
-            transaction_id: None,
-        };
-        let sql_command_bytes = sql_command.as_any().encode_to_vec();
-
-        let request = FlightDescriptor::new_cmd(sql_command_bytes);
-        let _ = client
-            .get_flight_info(request)
-            .await
-            .expect("valid response");
-        tracing::info!("Flight (GRPC) health check passed");
-
-        // OpenTelemetry (GRPC)
-        let root_cert_tonic = tonic::transport::Certificate::from_pem(&root_cert_bytes);
-        let otel_channel =
-            tonic::transport::Channel::from_shared(format!("https://127.0.0.1:{otel_port}"))?
-                .tls_config(tonic::transport::ClientTlsConfig::new().ca_certificate(root_cert_tonic))
+            // FLIGHT (GRPC)
+            let root_cert_tonic = tonic::transport::Certificate::from_pem(&root_cert_bytes);
+            let channel = Channel::from_shared(format!("https://127.0.0.1:{flight_port}"))?
+                .tls_config(
+                    tonic::transport::ClientTlsConfig::new()
+                        .ca_certificate(root_cert_tonic.clone()),
+                )
                 .expect("valid tls config")
                 .connect()
                 .await
-                .expect("to connect to otel port");
-        let mut health_client = HealthClient::new(otel_channel);
-        health_client
-            .check(tonic_health::pb::HealthCheckRequest {
-                service: String::new(),
-            })
-            .await
-            .expect("valid response");
-        tracing::info!("OpenTelemetry (GRPC) health check passed");
+                .expect("to connect to flight port");
 
-        Ok(())
-    }).await
+            let mut client = FlightServiceClient::new(channel);
+            let sql_command = CommandStatementQuery {
+                query: "show tables".to_string(),
+                transaction_id: None,
+            };
+            let sql_command_bytes = sql_command.as_any().encode_to_vec();
+
+            let request = FlightDescriptor::new_cmd(sql_command_bytes);
+            let _ = client
+                .get_flight_info(request)
+                .await
+                .expect("valid response");
+            tracing::info!("Flight (GRPC) health check passed");
+
+            // OpenTelemetry is now served on the same gRPC port as Flight (50051)
+
+            Ok(())
+        })
+        .await
 }

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -65,9 +65,7 @@ spec:
               "--metrics",
               "0.0.0.0:9090",
               "--flight",
-              "0.0.0.0:50051",
-              "--open_telemetry",
-              "0.0.0.0:50052"
+              "0.0.0.0:50051"
             ]
           env:
             {{- if .Values.additionalEnv }}
@@ -80,8 +78,6 @@ spec:
               name: metrics
             - containerPort: 50051
               name: flight
-            - containerPort: 50052
-              name: otel
           livenessProbe:
             httpGet:
               path: /health

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -28,8 +28,6 @@ spec:
       name: metrics
     - port: 50051
       name: flight
-    - port: 50052
-      name: otel
     {{- end }}
   selector:
     {{- if .Values.service.selector }}

--- a/tools/otelpublisher/src/main.rs
+++ b/tools/otelpublisher/src/main.rs
@@ -38,7 +38,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "OTEL_ENDPOINT",
-        default_value = "http://localhost:50052"
+        default_value = "http://localhost:50051"
     )]
     pub otel_endpoint: String,
 
@@ -61,8 +61,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let tls_root_certificate = std::fs::read(tls_root_certificate_file)?;
         let tls_root_certificate = tonic::transport::Certificate::from_pem(tls_root_certificate);
         let client_tls_config = ClientTlsConfig::new().ca_certificate(tls_root_certificate);
-        if otel_endpoint == "http://localhost:50052" {
-            otel_endpoint = "https://localhost:50052".to_string();
+        if otel_endpoint == "http://localhost:50051" {
+            otel_endpoint = "https://localhost:50051".to_string();
         }
         Channel::from_shared(otel_endpoint)?
             .tls_config(client_tls_config)?


### PR DESCRIPTION
## 📝 Summary

Moves the OpenTelemetry metrics ingestion service from being on its own port to being bundled with the flight service on port 50051.

This simplifies `spiced` by removing an extra port that it listens on.

## 🚨 Breaking Changes

This is a breaking change, but currently there are no known usages of the OpenTelemetry metrics ingestion endpoint.

## 📚 Docs

- https://github.com/spiceai/docs/pull/1270
