### PR TITLE
Move verbose tool init messages to trace

### DIFF
--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -64,7 +64,7 @@ impl Runtime {
         let mut tools_map = self.tools.write().await;
 
         tools_map.insert(name.clone(), Arc::clone(t).into());
-        tracing::debug!("Tool catalog {} ready to use", name.clone());
+        tracing::trace!("Tool catalog {} ready to use", name.clone());
         metrics::tools::COUNT.add(1, &[KeyValue::new("tool_catalog", name.clone())]);
         self.status
             .update_tool_catalog(&name, status::ComponentStatus::Ready);
@@ -75,7 +75,7 @@ impl Runtime {
         let mut tools_map = self.tools.write().await;
 
         tools_map.insert(name.clone(), t);
-        tracing::debug!("Tool {} ready to use", name.clone());
+        tracing::trace!("Tool {} ready to use", name.clone());
         metrics::tools::COUNT.add(1, &[KeyValue::new("tool", name.clone())]);
         self.status
             .update_tool(&name, status::ComponentStatus::Ready);


### PR DESCRIPTION
## 📝 Summary

The following messages are quite verbose and don't provide that much value.

> 2025-12-14T09:25:47.284632Z DEBUG runtime::init::tool: Tool catalog auto ready to use
2025-12-14T09:25:47.285020Z DEBUG runtime::init::tool: Tool catalog memory ready to use
2025-12-14T09:25:47.285164Z DEBUG runtime::init::tool: Tool list_datasets ready to use
2025-12-14T09:25:47.285380Z DEBUG runtime::init::tool: Tool search ready to use
2025-12-14T09:25:47.285458Z DEBUG runtime::init::tool: Tool table_schema ready to use
2025-12-14T09:25:47.285473Z DEBUG runtime::init::tool: Tool sql ready to use
2025-12-14T09:25:47.285486Z DEBUG runtime::init::tool: Tool get_readiness ready to use
2025-12-14T09:25:47.285622Z DEBUG runtime::init::tool: Tool sample_distinct_columns ready to use
2025-12-14T09:25:47.285826Z DEBUG runtime::init::tool: Tool load_memory ready to use
2025-12-14T09:25:47.285850Z DEBUG runtime::init::tool: Tool top_n_sample ready to use
2025-12-14T09:25:47.285865Z DEBUG runtime::init::tool: Tool store_memory ready to use
2025-12-14T09:25:47.285878Z DEBUG runtime::init::tool: Tool random_sample ready to use
