### PR TITLE
Show user-friendly error on empty DDB table

### DIFF
--- a/crates/data_components/src/dynamodb/mod.rs
+++ b/crates/data_components/src/dynamodb/mod.rs
@@ -82,4 +82,7 @@ pub enum Error {
 
     #[snafu(display("Failed to Bootstrap DynamoDB Table: {source}"))]
     FailedToBootstrapTable { source: DataFusionError },
+
+    #[snafu(display("DynamoDB table {table_name} is empty"))]
+    EmptyTable { table_name: String },
 }

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 use super::{
-    DescribeTableSnafu, Error, FailedToBootstrapTableSnafu, FailedToInitializeCheckpointSnafu,
-    FailedToInitializeStreamSnafu, Result, ScanSnafu, TableDoesNotExistSnafu,
-    TableStatusIsNotActiveSnafu,
+    DescribeTableSnafu, EmptyTableSnafu, Error, FailedToBootstrapTableSnafu,
+    FailedToInitializeCheckpointSnafu, FailedToInitializeStreamSnafu, Result, ScanSnafu,
+    TableDoesNotExistSnafu, TableStatusIsNotActiveSnafu,
 };
 use crate::cdc::ChangeBatch;
 use crate::dynamodb::arrow::dynamodb_items_to_arrow;
@@ -227,6 +227,12 @@ impl DynamoDBTableProvider {
             .context(ScanSnafu)?
             .items()
             .to_vec();
+
+        if items.is_empty() {
+            return Err(Error::EmptyTable {
+                table_name: table_name.to_string(),
+            });
+        }
 
         let (unnested_items, flattened_fields) = match unnest_depth {
             None => (items, HashSet::new()),

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 use super::{
-    DescribeTableSnafu, EmptyTableSnafu, Error, FailedToBootstrapTableSnafu,
-    FailedToInitializeCheckpointSnafu, FailedToInitializeStreamSnafu, Result, ScanSnafu,
-    TableDoesNotExistSnafu, TableStatusIsNotActiveSnafu,
+    DescribeTableSnafu, Error, FailedToBootstrapTableSnafu, FailedToInitializeCheckpointSnafu,
+    FailedToInitializeStreamSnafu, Result, ScanSnafu, TableDoesNotExistSnafu,
+    TableStatusIsNotActiveSnafu,
 };
 use crate::cdc::ChangeBatch;
 use crate::dynamodb::arrow::dynamodb_items_to_arrow;


### PR DESCRIPTION
## 📝 Summary

We rely on table not being empty for schema inference. Show user-friendly error when table is empty:
```
WARN runtime::init::dataset: Failed to load the dataset viktor_test_empty_table (dynamodb). DynamoDB table viktor_test_empty_table is empty
```

Closes https://github.com/spiceai/spiceai/issues/8583
