### PR TITLE
Fix kafka warning when `security.protocol` is set to `PLAINTEXT`

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -385,8 +385,11 @@ impl KafkaConsumer {
             // Don't automatically store offsets the library provides to us - we will store them after processing explicitly
             // This is what gives us the "at least once" semantics
             .set("enable.auto.offset.store", "false")
-            .set("security.protocol", &kafka_config.security_protocol)
-            .set("sasl.mechanism", &kafka_config.sasl_mechanism);
+            .set("security.protocol", &kafka_config.security_protocol);
+
+        if kafka_config.security_protocol.to_lowercase() != "plaintext" {
+            config.set("sasl.mechanism", &kafka_config.sasl_mechanism);
+        }
 
         if let Some(sasl_username) = &kafka_config.sasl_username {
             config.set("sasl.username", sasl_username);


### PR DESCRIPTION
## 📝 Summary

Ignore `sasl.mechanism` when `security.protocol` is set to `PLAINTEXT`. 

This seems to be the only way to suppress warnings like:
```
WARN librdkafka: librdkafka: CONFWARN [thrd:app]: Configuration property `sasl.mechanism` 
  set to `SCRAM-SHA-512` but `security.protocol` is not configured for SASL: recommend setting 
  `security.protocol` to SASL_SSL or SASL_PLAINTEXT
```

Closes https://github.com/spiceai/spiceai/issues/8288


