### PR TITLE
Increase Helm install timeout from 5m to 10m

### DIFF
--- a/.github/workflows/e2e_test_release_install_helm.yml
+++ b/.github/workflows/e2e_test_release_install_helm.yml
@@ -164,7 +164,7 @@ jobs:
             --set replicaCount=1 \
             --set service.type=ClusterIP \
             --wait \
-            --timeout 5m
+            --timeout 10m
 
       # Install Spice using Helm (from GitHub release)
       - name: Install Spice with Helm (GitHub release)


### PR DESCRIPTION
## 📝 Summary
 - timeout failures in CI: https://github.com/spiceai/spiceai/actions/runs/20287105014/workflow