### PR TITLE
Fix IMAGE_TAG assignment for Docker compatibility

### DIFF
--- a/.github/workflows/e2e_test_release_install_helm.yml
+++ b/.github/workflows/e2e_test_release_install_helm.yml
@@ -131,7 +131,7 @@ jobs:
             echo "Using latest release version: $RELEASE_VERSION"
             # remove prefix 'v' from RELEASE_VERSION. (i.e. v1.10.1 -> 1.10.1). 
             IMAGE_TAG="${RELEASE_VERSION#v}-models"
-            echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+            echo "version=${RELEASE_VERSION#v}" >> $GITHUB_OUTPUT
             echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
             echo "source=github-release" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/e2e_test_release_install_helm.yml
+++ b/.github/workflows/e2e_test_release_install_helm.yml
@@ -129,8 +129,8 @@ jobs:
             # Get latest release tag from GitHub
             RELEASE_VERSION=$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" -H "Authorization: token $GITHUB_TOKEN" | jq -r '.tag_name')
             echo "Using latest release version: $RELEASE_VERSION"
-            # Replace '+' with '-' for Docker image tag compatibility (Kubernetes doesn't allow + in image tags)
-            IMAGE_TAG="${RELEASE_VERSION}-models"
+            # remove prefix 'v' from RELEASE_VERSION. (i.e. v1.10.1 -> 1.10.1). 
+            IMAGE_TAG="${RELEASE_VERSION#v}-models"
             echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
             echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
             echo "source=github-release" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e_test_release_install_helm.yml
+++ b/.github/workflows/e2e_test_release_install_helm.yml
@@ -277,7 +277,7 @@ jobs:
           # Test simple SQL query
           RESPONSE=$(curl -s -X POST http://localhost:8090/v1/sql \
             -H "Content-Type: application/json" \
-            -d '{"query": "SELECT 1 as test"}')
+            -d '{"sql": "SELECT 1 as test", "parameters": {}}')
           
           echo "Query response: $RESPONSE"
           
@@ -314,7 +314,7 @@ jobs:
           helm upgrade spice-test ./deploy/chart \
             --namespace spice-system \
             --set image.repository=ghcr.io/spiceai/spiceai \
-            --set image.tag=${{ steps.chart-version.outputs.version }}+models \
+            --set image.tag=${{ steps.chart-version.outputs.version }}-models \
             --set replicaCount=1 \
             --set service.type=ClusterIP \
             --wait \


### PR DESCRIPTION
Updated IMAGE_TAG assignment to remove 'v' prefix from RELEASE_VERSION.

## 📝 Summary
 - See failing https://github.com/spiceai/spiceai/actions/runs/20287105014/job/58263899023