### PR TITLE
Modify cluster arguments to spiced for UX review

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -35,7 +35,7 @@ use otel_arrow::OtelArrowExporter;
 #[cfg(feature = "cluster")]
 use runtime::cluster::ResolvedClusterConfig;
 #[cfg(feature = "cluster")]
-use runtime::config::ClusterMode;
+use runtime::config::ClusterRole;
 use runtime::config::Config as RuntimeConfig;
 use runtime::datafusion::DataFusion;
 use runtime::podswatcher::PodsWatcher;
@@ -361,11 +361,18 @@ pub async fn run(args: Args) -> Result<()> {
 
 async fn build_app(args: &Args) -> Result<(Option<Arc<App>>, Option<app::Error>)> {
     #[cfg(feature = "cluster")]
-    if matches!(args.runtime.cluster.mode, Some(ClusterMode::Executor)) {
-        tracing::info!(
-            "Starting as a cluster executor, without a Spicepod. The runtime will initialize its components upon joining the cluster."
-        );
-        return Ok((Some(Arc::new(App::default())), None));
+    {
+        // Check for explicit executor role OR implicit executor role (scheduler_address set without explicit role)
+        let is_executor = matches!(args.runtime.cluster.role, Some(ClusterRole::Executor))
+            || (args.runtime.cluster.role.is_none()
+                && args.runtime.cluster.scheduler_address.is_some());
+
+        if is_executor {
+            tracing::info!(
+                "Starting as a cluster executor, without a Spicepod. The runtime will initialize its components upon joining the cluster."
+            );
+            return Ok((Some(Arc::new(App::default())), None));
+        }
     }
 
     let spicepod_path = args

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use crate::Error::{FailedToStartClusterExecutor, FailedToStartClusterScheduler};
 use crate::cluster::datafusion::datafusion_and_cluster_physical_optimizers;
-use crate::config::{ClusterConfig, ClusterMode};
+use crate::config::{ClusterConfig, ClusterRole};
 use crate::dataconnector::listing;
 use crate::dataconnector::parameters::ConnectorParamsBuilder;
 use crate::status::ComponentStatus;
@@ -139,9 +139,9 @@ impl ResolvedClusterConfig {
     pub fn try_new(config: ClusterConfig) -> std::io::Result<Self> {
         // Cluster mode requires mTLS - all certificate files must be specified
         let tls_config = match (
-            &config.cluster_ca_certificate_file,
-            &config.cluster_certificate_file,
-            &config.cluster_key_file,
+            &config.node_mtls_ca_certificate_file,
+            &config.node_mtls_certificate_file,
+            &config.node_mtls_key_file,
         ) {
             (Some(ca_path), Some(cert_path), Some(key_path)) => {
                 Some(ClusterTlsConfig::try_new(ca_path, cert_path, key_path)?)
@@ -150,30 +150,33 @@ impl ResolvedClusterConfig {
             _ => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mTLS requires all of: --cluster-ca-certificate-file, --cluster-certificate-file, --cluster-key-file",
+                    "Cluster mTLS requires all of: --node-mtls-ca-certificate-file, --node-mtls-certificate-file, --node-mtls-key-file",
                 ));
             }
         };
 
-        // Validate cluster mode requirements
-        if config.mode.is_some() {
+        // Determine effective cluster role (explicit or implicit from scheduler_address)
+        let is_cluster_role = config.role.is_some() || config.scheduler_address.is_some();
+
+        // Validate cluster role requirements
+        if is_cluster_role {
             if tls_config.is_none() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires mTLS. Specify all of: --cluster-ca-certificate-file, --cluster-certificate-file, --cluster-key-file",
+                    "Cluster mode requires mTLS. Specify all of: --node-mtls-ca-certificate-file, --node-mtls-certificate-file, --node-mtls-key-file",
                 ));
             }
-            if config.cluster_advertise_address.is_none() {
+            if config.node_advertise_address.is_none() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires --cluster-advertise-address",
+                    "Multi-node clusters require --node-advertise-address. Set this to the hostname or IP address other cluster nodes can use to reach this node.",
                 ));
             }
         }
 
         // Pre-compute scheduler URL from advertise address
         let scheduler_url = config
-            .cluster_advertise_address
+            .node_advertise_address
             .as_ref()
             .map(|addr| format!("https://{addr}"));
 
@@ -184,22 +187,38 @@ impl ResolvedClusterConfig {
         })
     }
 
-    /// Returns the cluster mode.
+    /// Returns the cluster role.
     #[must_use]
-    pub fn mode(&self) -> Option<&ClusterMode> {
-        self.config.mode.as_ref()
+    pub fn role(&self) -> Option<&ClusterRole> {
+        self.config.role.as_ref()
+    }
+
+    /// Returns the effective cluster role.
+    ///
+    /// This accounts for the implicit executor role: if `--scheduler-address` is set
+    /// but no explicit `--role` is specified, this returns `ClusterRole::Executor`.
+    #[must_use]
+    pub fn effective_role(&self) -> Option<ClusterRole> {
+        if let Some(role) = &self.config.role {
+            return Some(role.clone());
+        }
+        // If scheduler_address is set, implicitly assume executor role
+        if self.config.scheduler_address.is_some() {
+            return Some(ClusterRole::Executor);
+        }
+        None
     }
 
     /// Returns the cluster bind address.
     #[must_use]
-    pub fn cluster_address(&self) -> SocketAddr {
-        self.config.cluster_address
+    pub fn node_bind_address(&self) -> SocketAddr {
+        self.config.node_bind_address
     }
 
     /// Returns the scheduler URL (for executors).
     #[must_use]
-    pub fn cluster_scheduler_url(&self) -> Option<&Url> {
-        self.config.cluster_scheduler_url.as_ref()
+    pub fn scheduler_address(&self) -> Option<&Url> {
+        self.config.scheduler_address.as_ref()
     }
 
     /// Returns the scheduler URL as a string for use in Ballista configuration.
@@ -213,8 +232,8 @@ impl ResolvedClusterConfig {
 
     /// Returns the advertise address.
     #[must_use]
-    pub fn cluster_advertise_address(&self) -> Option<&str> {
-        self.config.cluster_advertise_address.as_deref()
+    pub fn node_advertise_address(&self) -> Option<&str> {
+        self.config.node_advertise_address.as_deref()
     }
 
     /// Returns the cluster TLS config if configured.
@@ -276,9 +295,9 @@ pub async fn initialize_cluster_executor(
         .unwrap_or(env::temp_dir().to_string_lossy().to_string());
 
     // Get scheduler URL - required for executors
-    let Some(scheduler_url) = rt.df.cluster_config.cluster_scheduler_url() else {
+    let Some(scheduler_url) = rt.df.cluster_config.scheduler_address() else {
         return Err(FailedToStartClusterExecutor {
-            source: "--cluster-scheduler-url is required for executor mode"
+            source: "--scheduler-address is required for executor mode"
                 .to_string()
                 .into(),
         });
@@ -347,7 +366,7 @@ pub async fn initialize_cluster_executor(
 
     // Determine the advertise host and port for executor registration
     let (advertise_host, advertise_port) = if let Some(advertise_addr) =
-        rt.df.cluster_config.cluster_advertise_address()
+        rt.df.cluster_config.node_advertise_address()
     {
         // Parse the advertise address (format: "host:port" or "[ipv6]:port")
         if let Ok(socket_addr) = advertise_addr.parse::<SocketAddr>() {
@@ -356,17 +375,15 @@ pub async fn initialize_cluster_executor(
             let port = port_part
                 .parse::<u16>()
                 .map_err(|_| FailedToStartClusterExecutor {
-                    source: format!(
-                        "Invalid port in --cluster-advertise-address: {advertise_addr}"
-                    )
-                    .into(),
+                    source: format!("Invalid port in --node-advertise-address: {advertise_addr}")
+                        .into(),
                 })?;
             let host = host_part.trim_matches(['[', ']']).to_string();
             (host, port)
         } else {
             return Err(FailedToStartClusterExecutor {
                     source: format!(
-                        "Invalid --cluster-advertise-address format: {advertise_addr}. Expected 'host:port' (IPv6 must be in [addr]:port form)"
+                        "Invalid --node-advertise-address format: {advertise_addr}. Expected 'host:port' (IPv6 must be in [addr]:port form)"
                     )
                     .into(),
                 });
@@ -453,7 +470,7 @@ pub async fn initialize_cluster_executor(
 async fn create_scheduler_server(
     rt: &Arc<Runtime>,
 ) -> crate::Result<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>> {
-    let bind_addr = rt.df.cluster_config.cluster_address();
+    let bind_addr = rt.df.cluster_config.node_bind_address();
 
     // Bind Spice Datafusion configuration incl SpiceQueryPlanner as bound in `DataFusionBuilder`
     let current_context = Arc::clone(&rt.df.ctx);
@@ -582,9 +599,9 @@ async fn executor_bind_app(
     executor_id: String,
     client_tls_config: ClientTlsConfig,
 ) -> crate::Result<()> {
-    let Some(scheduler_url) = rt.df.cluster_config.cluster_scheduler_url() else {
+    let Some(scheduler_url) = rt.df.cluster_config.scheduler_address() else {
         return Err(FailedToStartClusterExecutor {
-            source: "--cluster-scheduler-url is required for executor mode"
+            source: "--scheduler-address is required for executor mode"
                 .to_string()
                 .into(),
         });

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -55,7 +55,7 @@ pub async fn start_internal_cluster_server(
     rt: Arc<Runtime>,
     shutdown_signal: Option<CancellationToken>,
 ) -> ClusterServerResult<()> {
-    let bind_address = rt.df.cluster_config.cluster_address();
+    let bind_address = rt.df.cluster_config.node_bind_address();
 
     let Some(scheduler) = rt
         .df

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -47,7 +47,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
-pub enum ClusterMode {
+pub enum ClusterRole {
     Scheduler,
     Executor,
 }
@@ -85,68 +85,61 @@ impl Default for Config {
 #[cfg(feature = "cluster")]
 #[derive(Debug, Clone, clap::Parser)]
 pub struct ClusterConfig {
-    /// Configure cluster mode role
-    #[arg(
-        long = "cluster-mode",
-        value_name = "CLUSTER_MODE",
-        required = false,
-        action
-    )]
-    pub mode: Option<ClusterMode>,
+    /// Configure cluster node role: scheduler or executor
+    #[arg(long = "role", value_name = "ROLE", required = false, action)]
+    pub role: Option<ClusterRole>,
 
     /// The bind address for the internal cluster gRPC service.
     /// Used by both schedulers and executors.
     #[arg(
-        long = "cluster-address",
-        value_name = "CLUSTER_ADDRESS",
+        long = "node-bind-address",
+        value_name = "NODE_BIND_ADDRESS",
         default_value = "0.0.0.0:50052",
         action
     )]
-    pub cluster_address: SocketAddr,
+    pub node_bind_address: SocketAddr,
 
     /// The path to the CA certificate used to validate cluster node identities.
     #[arg(
-        long = "cluster-ca-certificate-file",
-        value_name = "CLUSTER_CA_CERTIFICATE_FILE"
+        long = "node-mtls-ca-certificate-file",
+        value_name = "NODE_MTLS_CA_CERTIFICATE_FILE"
     )]
-    pub cluster_ca_certificate_file: Option<String>,
+    pub node_mtls_ca_certificate_file: Option<String>,
 
     /// The path to the certificate file used for both server TLS and client mTLS.
     #[arg(
-        long = "cluster-certificate-file",
-        value_name = "CLUSTER_CERTIFICATE_FILE"
+        long = "node-mtls-certificate-file",
+        value_name = "NODE_MTLS_CERTIFICATE_FILE"
     )]
-    pub cluster_certificate_file: Option<String>,
+    pub node_mtls_certificate_file: Option<String>,
 
     /// The path to the private key file for the cluster certificate.
-    #[arg(long = "cluster-key-file", value_name = "CLUSTER_KEY_FILE")]
-    pub cluster_key_file: Option<String>,
+    #[arg(long = "node-mtls-key-file", value_name = "NODE_MTLS_KEY_FILE")]
+    pub node_mtls_key_file: Option<String>,
 
     /// The URL of the scheduler service. Required for executors to join a cluster.
-    #[arg(long = "cluster-scheduler-url", value_name = "CLUSTER_SCHEDULER_URL")]
-    pub cluster_scheduler_url: Option<Url>,
+    /// If set, --role executor is implied and can be omitted.
+    #[arg(long = "scheduler-address", value_name = "SCHEDULER_ADDRESS")]
+    pub scheduler_address: Option<Url>,
 
     /// The hostname and port that this node advertises to other cluster nodes.
     /// For schedulers: used as the URL for distributed query planning.
     /// For executors: used during registration to tell the scheduler how to contact this node.
-    #[arg(
-        long = "cluster-advertise-address",
-        value_name = "CLUSTER_ADVERTISE_ADDRESS"
-    )]
-    pub cluster_advertise_address: Option<String>,
+    #[arg(long = "node-advertise-address", value_name = "NODE_ADVERTISE_ADDRESS")]
+    pub node_advertise_address: Option<String>,
 }
 
 #[cfg(feature = "cluster")]
 impl Default for ClusterConfig {
     fn default() -> Self {
         Self {
-            mode: None,
-            cluster_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 50052),
-            cluster_ca_certificate_file: None,
-            cluster_certificate_file: None,
-            cluster_key_file: None,
-            cluster_scheduler_url: None,
-            cluster_advertise_address: None,
+            role: None,
+            node_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 50052),
+            node_mtls_ca_certificate_file: None,
+            node_mtls_certificate_file: None,
+            node_mtls_key_file: None,
+            scheduler_address: None,
+            node_advertise_address: None,
         }
     }
 }
@@ -154,20 +147,20 @@ impl Default for ClusterConfig {
 #[cfg(feature = "cluster")]
 impl ClusterConfig {
     #[must_use]
-    pub fn with_mode(mut self, mode: ClusterMode) -> Self {
-        self.mode = Some(mode);
+    pub fn with_role(mut self, role: ClusterRole) -> Self {
+        self.role = Some(role);
         self
     }
 
     #[must_use]
-    pub fn with_cluster_address(mut self, addr: SocketAddr) -> Self {
-        self.cluster_address = addr;
+    pub fn with_node_bind_address(mut self, addr: SocketAddr) -> Self {
+        self.node_bind_address = addr;
         self
     }
 
     #[must_use]
-    pub fn with_cluster_scheduler_url(mut self, url: Url) -> Self {
-        self.cluster_scheduler_url = Some(url);
+    pub fn with_scheduler_address(mut self, url: Url) -> Self {
+        self.scheduler_address = Some(url);
         self
     }
 }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -48,7 +48,7 @@ mod tracker;
 
 #[cfg(feature = "cluster")]
 use {
-    crate::config::ClusterMode,
+    crate::config::ClusterRole,
     crate::datafusion::builder::default_extension_planners,
     ballista_core::extension::{SessionConfigExt, SessionStateExt},
     ballista_core::planner::BallistaQueryPlanner,
@@ -170,14 +170,14 @@ impl Query {
 
     #[cfg(feature = "cluster")]
     fn get_session_state(&self) -> Result<SessionState> {
-        if !matches!(self.df.cluster_config.mode(), Some(ClusterMode::Scheduler)) {
+        if !matches!(self.df.cluster_config.role(), Some(ClusterRole::Scheduler)) {
             return Ok(self.df.ctx.state());
         }
 
         let Some(scheduler_url) = self.df.cluster_config.scheduler_url_string() else {
             return Err(Error::UnableToExecuteQuery {
                 source: datafusion::error::DataFusionError::Configuration(
-                    "Scheduler mode requires --cluster-advertise-address".to_string(),
+                    "Scheduler mode requires --node-advertise-address".to_string(),
                 ),
             });
         };

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -455,8 +455,8 @@ pub async fn start(
 ) -> Result<()> {
     #[cfg(feature = "cluster")]
     if matches!(
-        rt.config.cluster.mode,
-        Some(crate::config::ClusterMode::Executor)
+        rt.df.cluster_config.effective_role(),
+        Some(crate::config::ClusterRole::Executor)
     ) {
         return Err(Error::InsecureConfiguration {
             message:

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -47,7 +47,7 @@ use ::datafusion::sql::{TableReference, sqlparser};
 use app::App;
 
 #[cfg(feature = "cluster")]
-use {crate::Error::FailedToStartClusterExecutor, crate::config::ClusterMode};
+use {crate::Error::FailedToStartClusterExecutor, crate::config::ClusterRole};
 
 use builder::RuntimeBuilder;
 use cancellable_task::{CancellableTaskHandle, spawn_cancellable_task};
@@ -662,46 +662,48 @@ impl Runtime {
         )]
         type BoxedClusterFuture = std::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
         #[cfg(feature = "cluster")]
-        let maybe_cluster_future: Option<BoxedClusterFuture> = match self.config.cluster.mode {
-            Some(ClusterMode::Scheduler) => {
-                cluster::initialize_cluster_scheduler(&self).await?;
-                // Start internal cluster server for scheduler on separate port
-                let internal_server_shutdown = CancellationToken::new();
-                let self_ref = Arc::clone(&self);
-                let cloned_shutdown = internal_server_shutdown.clone();
-                let internal_server_fut = async move {
-                    cluster::start_internal_cluster_server(
-                        Arc::clone(&self_ref),
-                        Some(cloned_shutdown),
-                    )
-                    .await
-                    .context(UnableToStartClusterServerSnafu)
-                };
-                let self_for_task = Arc::clone(&self);
-                Some(Box::pin(
-                    self_for_task
-                        .start_runtime_task(
-                            CLUSTER_INTERNAL_SERVER,
-                            Some(internal_server_shutdown),
-                            internal_server_fut,
+        let maybe_cluster_future: Option<BoxedClusterFuture> =
+            match self.df.cluster_config.effective_role() {
+                Some(ClusterRole::Scheduler) => {
+                    cluster::initialize_cluster_scheduler(&self).await?;
+                    // Start internal cluster server for scheduler on separate port
+                    let internal_server_shutdown = CancellationToken::new();
+                    let self_ref = Arc::clone(&self);
+                    let cloned_shutdown = internal_server_shutdown.clone();
+                    let internal_server_fut = async move {
+                        cluster::start_internal_cluster_server(
+                            Arc::clone(&self_ref),
+                            Some(cloned_shutdown),
                         )
-                        .await,
-                ))
-            }
-            Some(ClusterMode::Executor) => {
-                let executor_fut = cluster::initialize_cluster_executor(Arc::clone(&self)).await?;
-                let self_ref = Arc::clone(&self);
-                Some(Box::pin(
-                    self_ref
-                        .start_runtime_task(CLUSTER_EXECUTOR, None, executor_fut)
-                        .await,
-                ))
-            }
-            _ => None,
-        };
+                        .await
+                        .context(UnableToStartClusterServerSnafu)
+                    };
+                    let self_for_task = Arc::clone(&self);
+                    Some(Box::pin(
+                        self_for_task
+                            .start_runtime_task(
+                                CLUSTER_INTERNAL_SERVER,
+                                Some(internal_server_shutdown),
+                                internal_server_fut,
+                            )
+                            .await,
+                    ))
+                }
+                Some(ClusterRole::Executor) => {
+                    let executor_fut =
+                        cluster::initialize_cluster_executor(Arc::clone(&self)).await?;
+                    let self_ref = Arc::clone(&self);
+                    Some(Box::pin(
+                        self_ref
+                            .start_runtime_task(CLUSTER_EXECUTOR, None, executor_fut)
+                            .await,
+                    ))
+                }
+                _ => None,
+            };
 
         #[cfg(feature = "cluster")]
-        if self.config.cluster.mode.is_some() {
+        if self.df.cluster_config.effective_role().is_some() {
             tracing::warn!(
                 "Distributed Query (Alpha) is in preview and should not be used in production."
             );
@@ -714,7 +716,7 @@ impl Runtime {
         #[cfg(feature = "cluster")]
         let flight_future: std::pin::Pin<
             Box<dyn Future<Output = Result<(), Error>> + Send>,
-        > = if self.config.cluster.mode == Some(ClusterMode::Executor) {
+        > = if self.df.cluster_config.effective_role() == Some(ClusterRole::Executor) {
             Box::pin(
                 self.start_runtime_task(FLIGHT_SERVER, Some(flight_shutdown.clone()), async move {
                     cluster::start_executor_flight_server(
@@ -776,7 +778,10 @@ impl Runtime {
 
         #[cfg(feature = "cluster")]
         // If this is an executor, we only need the shutdown signal and flight server
-        if matches!(self.config.cluster.mode, Some(ClusterMode::Executor)) {
+        if matches!(
+            self.df.cluster_config.effective_role(),
+            Some(ClusterRole::Executor)
+        ) {
             let Some(executor_future) = maybe_cluster_future else {
                 return Err(FailedToStartClusterExecutor {
                     source: "Executor work loop not bound. Report this bug on GitHub: https://github.com/spiceai/spiceai/issues"


### PR DESCRIPTION
## 📝 Summary

Renames several CLI arguments following a UX review:

- `--cluster-mode` -> `--role`
- `--cluster-address` -> `--node-bind-address`
- `--cluster-ca-certificate-file` -> `--node-mtls-ca-certificate-file`
- `--cluster-certificate-file` -> `--node-mtls-certificate-file`
- `--cluster-key-file` -> `--node-mtls-key-file`
- `--cluster-advertise-address` -> `--node-advertise-address`
- `--cluster-scheduler-url` -> `--scheduler-address`
  -  if set, then `--role executor` can be omitted.