### PR TITLE
Remove 'tract-core' dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13194,7 +13194,6 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tract-core",
  "turso",
  "twox-hash",
  "url",
@@ -13325,7 +13324,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "tract-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9526,7 +9526,6 @@ dependencies = [
  "spicepod",
  "tokio",
  "tracing",
- "tract-core",
  "tract-onnx",
  "util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,6 @@ tracing = "0.1.43"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-tract-core = "0.22.0"
 turso = "0.3.0"
 twox-hash = "2.1.2"
 url = "2.5"

--- a/crates/model_components/Cargo.toml
+++ b/crates/model_components/Cargo.toml
@@ -26,7 +26,6 @@ snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
-tract-core = "0.22.0"
 tract-onnx = "0.22.0"
 util = { path = "../util" }
 

--- a/crates/model_components/Cargo.toml
+++ b/crates/model_components/Cargo.toml
@@ -26,7 +26,7 @@ snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
-tract-core.workspace = true
+tract-core = "0.22.0"
 tract-onnx = "0.22.0"
 util = { path = "../util" }
 

--- a/crates/model_components/src/modelruntime/tract.rs
+++ b/crates/model_components/src/modelruntime/tract.rs
@@ -28,7 +28,6 @@ use snafu::prelude::*;
 use std::sync::Arc;
 
 use crate::modelformat::onnx;
-use tract_core::tract_data::itertools::Itertools;
 use tract_onnx::prelude::*;
 
 pub struct Tract {
@@ -104,7 +103,7 @@ impl Runnable for Model {
 
             let schema = first_record.schema();
             let fields = schema.fields();
-            let mut data: Vec<Vec<f64>> = fields.iter().map(|_| Vec::new()).collect_vec();
+            let mut data: Vec<Vec<f64>> = fields.iter().map(|_| Vec::new()).collect::<Vec<_>>();
 
             let [_, lookback_size, num_variates] = this.try_get_input_shape()?;
 
@@ -127,7 +126,7 @@ impl Runnable for Model {
                         let Some(float_col) = a.as_any().downcast_ref::<Float64Array>() else {
                             return;
                         };
-                        let col = float_col.into_iter().flatten().collect_vec();
+                        let col = float_col.into_iter().flatten().collect::<Vec<_>>();
                         let end_idx: usize =
                             std::cmp::min(lookback_size - data[i].len(), col.len());
                         data[i].append(&mut col[..end_idx].to_vec());
@@ -138,7 +137,7 @@ impl Runnable for Model {
                 .enumerate()
                 .filter(|(i, _)| schema.field(*i).name() != "ts") //: (usize, ArrayRef)
                 .map(|(_, x)| x.clone())
-                .collect_vec();
+                .collect::<Vec<_>>();
 
             if inp.len() != num_variates {
                 return Err(Box::new(Error::TractError {
@@ -152,7 +151,7 @@ impl Runnable for Model {
 
             let small_vec: Tensor = tract_ndarray::Array3::from_shape_vec(
                 (1, lookback_size, num_variates),
-                inp.into_iter().concat(),
+                inp.into_iter().flatten().collect(),
             )
             .map_err(|_| Error::ShapeError {
                 source: ndarray::ShapeError::from_kind(ndarray::ErrorKind::IncompatibleShape),
@@ -172,7 +171,7 @@ impl Runnable for Model {
                 .context(TractSnafu)?
                 .iter()
                 .copied()
-                .collect_vec();
+                .collect::<Vec<_>>();
 
             let record_batch = RecordBatch::try_new(
                 Arc::new(return_schema),

--- a/crates/runtime-datafusion-udfs/Cargo.toml
+++ b/crates/runtime-datafusion-udfs/Cargo.toml
@@ -21,7 +21,6 @@ runtime-request-context = { path = "../runtime-request-context" }
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tract-core.workspace = true
 
 [dev-dependencies]
 async-stream.workspace = true

--- a/crates/runtime-datafusion-udfs/src/truncate.rs
+++ b/crates/runtime-datafusion-udfs/src/truncate.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use std::num::TryFromIntError;
+use std::ops::{Add, Rem, Sub};
 use std::sync::Arc;
 
 use arrow::array::{
@@ -30,7 +31,6 @@ use datafusion::logical_expr::{
 };
 use datafusion::scalar::ScalarValue;
 use snafu::{ResultExt, Snafu, ensure};
-use tract_core::num_traits::Num;
 
 // Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
 const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
@@ -239,7 +239,11 @@ fn compute_truncate_scalar(
 
 fn truncate_numeric<V, W>(v: V, w: W) -> Result<V, TruncateError>
 where
-    V: Num + Copy + TryFrom<W, Error = TryFromIntError>,
+    V: Rem<Output = V>
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Copy
+        + TryFrom<W, Error = TryFromIntError>,
 {
     let w = V::try_from(w).context(WidthCastingFailedSnafu)?;
     Ok(v - (((v % w) + w) % w))

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -173,7 +173,6 @@ tower-http.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true
-tract-core.workspace = true
 turso = { workspace = true, optional = true }
 twox-hash.workspace = true
 url.workspace = true

--- a/crates/runtime/src/http/v1/catalogs.rs
+++ b/crates/runtime/src/http/v1/catalogs.rs
@@ -31,7 +31,6 @@ use mediatype::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tract_core::tract_data::itertools::Itertools;
 
 use super::{Format, convert_entry_to_csv};
 
@@ -115,7 +114,7 @@ pub(crate) async fn get(
             from: d.from.clone(),
             name: d.name.clone(),
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     let mut format = Format::Json;
     if let Some(accept) = accept

--- a/crates/runtime/src/http/v1/inference.rs
+++ b/crates/runtime/src/http/v1/inference.rs
@@ -32,7 +32,6 @@ use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
-use tract_core::tract_data::itertools::Itertools;
 
 #[derive(Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -291,13 +290,12 @@ async fn run_inference(
         Ok(inference_result) => {
             if let Some(column_data) = inference_result.column_by_name("y") {
                 if let Some(array) = column_data.as_any().downcast_ref::<Float32Array>() {
-                    let result = array.values().iter().copied().collect_vec();
                     return PredictResponse {
                         status: PredictStatus::Success,
                         error_message: None,
                         model_name,
                         model_version: Some(modelsource::version(&model.from)),
-                        prediction: Some(result),
+                        prediction: Some(array.values().to_vec()),
                         duration_ms: start_time.elapsed().as_millis(),
                     };
                 }


### PR DESCRIPTION
## 📝 Summary
With a few changes, we don't need `tract-core`: 
 - Don't use `tract_core::collect_vec` when `.collect::<Vec<_>>()` is sufficient.
 - Don't use `tract_core::num` for trait definition when specific `std::ops::*` traits are sufficient.