### PR TITLE
ci: Upload artifacts to MinIO eagerly after each build step

### DIFF
--- a/.github/actions/upload-to-minio/action.yml
+++ b/.github/actions/upload-to-minio/action.yml
@@ -1,0 +1,42 @@
+name: Upload to MinIO
+description: 'Setup MinIO client and upload a file to MinIO'
+
+inputs:
+  minio_endpoint:
+    description: 'MinIO endpoint'
+    required: true
+    type: string
+  minio_access_key:
+    description: 'MinIO access key'
+    required: true
+    type: string
+  minio_secret_key:
+    description: 'MinIO secret key'
+    required: true
+    type: string
+  source_path:
+    description: 'Path to the file to upload'
+    required: true
+    type: string
+  destination_path:
+    description: 'Destination path in MinIO (e.g., spice-minio/bucket/path/)'
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install MinIO client
+      shell: bash
+      run: |
+        if ! command -v mc &> /dev/null; then
+          sudo apt update && sudo apt install wget -y
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
+        fi
+        mc alias set spice-minio ${{ inputs.minio_endpoint }} ${{ inputs.minio_access_key }} ${{ inputs.minio_secret_key }}
+
+    - name: Upload to MinIO
+      shell: bash
+      run: |
+        mc cp ${{ inputs.source_path }} ${{ inputs.destination_path }}

--- a/.github/actions/upload-to-minio/action.yml
+++ b/.github/actions/upload-to-minio/action.yml
@@ -39,4 +39,8 @@ runs:
     - name: Upload to MinIO
       shell: bash
       run: |
-        mc cp ${{ inputs.source_path }} ${{ inputs.destination_path }}
+        if [ -f "${{ inputs.source_path }}" ]; then
+          mc cp ${{ inputs.source_path }} ${{ inputs.destination_path }}
+        else
+          echo "File ${{ inputs.source_path }} not found, skipping upload"
+        fi

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -239,6 +239,16 @@ jobs:
           name: spiced.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: spiced.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
+      - name: Upload spiced to Minio
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64' && contains(matrix.target.tags, 'default')
+        uses: ./.github/actions/upload-to-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          source_path: spiced_linux_x86_64.tar.gz
+          destination_path: spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
+
       ## Models flavor
       - name: Build spiced (models)
         if: contains(matrix.target.tags, 'models')
@@ -279,6 +289,16 @@ jobs:
           name: spiced.exe_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: spiced.exe_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
+      - name: Upload spiced_models to Minio
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64' && contains(matrix.target.tags, 'models')
+        uses: ./.github/actions/upload-to-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          source_path: spiced_models_linux_x86_64.tar.gz
+          destination_path: spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
+
       ## ODBC + Models flavor - for now, assume ODBC only builds with models because this binary is only used for internal testing.
       - name: Build spiced (odbc,models)
         if: matrix.target.target_os != 'windows' && contains(matrix.target.tags, 'odbc') && contains(matrix.target.tags, 'models')
@@ -301,6 +321,16 @@ jobs:
         with:
           name: spiced_odbc_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: spiced_odbc_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
+
+      - name: Upload spiced_odbc_models to Minio
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64' && contains(matrix.target.tags, 'odbc') && contains(matrix.target.tags, 'models')
+        uses: ./.github/actions/upload-to-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          source_path: spiced_odbc_models_linux_x86_64.tar.gz
+          destination_path: spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
 
       ## Models + metal flavor
       - name: Build spiced (models)
@@ -363,33 +393,15 @@ jobs:
           name: spice.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: spice.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
-      # Publish Linux x86_64 binaries to MinIO
-      - name: Setup MinIO
-        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64'
-        uses: ./.github/actions/setup-minio
+      - name: Upload spice CLI to Minio
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64' && contains(matrix.target.tags, 'default')
+        uses: ./.github/actions/upload-to-minio
         with:
           minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
           minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-
-      - name: Upload artifacts to Minio
-        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64'
-        run: |
-          if [ -f "spiced_linux_x86_64.tar.gz" ]; then
-            mc cp spiced_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
-          fi;
-
-          if [ -f "spiced_models_linux_x86_64.tar.gz" ]; then
-            mc cp spiced_models_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
-          fi;
-
-          if [ -f "spiced_odbc_models_linux_x86_64.tar.gz" ]; then
-            mc cp spiced_odbc_models_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ github.sha }}/
-          fi;
-
-          if [ -f "spice_linux_x86_64.tar.gz" ]; then
-            mc cp spice_linux_x86_64.tar.gz spice-minio/artifacts/spice/linux-x86_64/${{ github.sha }}/
-          fi;
+          source_path: spice_linux_x86_64.tar.gz
+          destination_path: spice-minio/artifacts/spice/linux-x86_64/${{ github.sha }}/
 
   publish:
     name: Publish ${{ matrix.target_os }}-${{ matrix.target_arch }} binaries


### PR DESCRIPTION
Instead of waiting for all build flavors to complete before uploading to MinIO in the `build_and_release` workflow, upload each artifact immediately after it's built. This makes artifacts available sooner and ensures earlier artifacts are uploaded even if later builds fail.

- Add upload-to-minio composite action that handles setup and upload
- Upload spiced, spiced_models, spiced_odbc_models, and spice CLI individually after each is built
- Remove batch upload step at end of build job

Test run: https://github.com/spiceai/spiceai/actions/runs/20324171659