### PR TITLE
Build a local docker image from an existing Spice binary

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY .spiced-local-tmp /usr/local/bin/spiced
+
+RUN chmod +x /usr/local/bin/spiced
+
+EXPOSE 8090 50051
+
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/spiced"]

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,12 @@ docker-run:
 	docker stop spiceai && docker rm spiceai || true
 	docker run --name spiceai -p 8090:8090 -p 50051:50051 spiceai-rust:local-dev
 
+.PHONY: docker-local
+docker-local:
+	cp ~/.spice/bin/spiced .spiced-local-tmp
+	docker build -f Dockerfile.local -t spiceai.org/spiceai:local .
+	rm .spiced-local-tmp
+
 .PHONY: deps-licenses
 dep-licenses:
 	@cargo install cargo-license --quiet


### PR DESCRIPTION
## 📝 Summary

Adds a Makefile target `make docker-local` that will copy an existing `spiced` binary at `~/.spice/bin/spiced` into an Ubuntu docker container. This makes it faster to iterate on K8s images since the incremental build cache is already present for local builds.

Note: This would only work on Linux host machines - copying a Darwin binary into a Linux container won't work.