### PR TITLE
Align object-store vortex with runtime feature flagging

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -314,8 +314,8 @@ turso = [
 ]
 [target.'cfg(not(windows))'.dependencies]
 cayenne = { path = "../cayenne", features = ["turso"] }
-vortex = { workspace = true, optional = true }
-vortex-datafusion = { workspace = true, optional = true }
+vortex.workspace = true
+vortex-datafusion.workspace = true
 
 [[bench]]
 harness = false

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -312,8 +312,6 @@ turso = [
     "data_components/turso",
     "dep:rusqlite",
 ]
-vortex = ["dep:vortex-datafusion", "dep:vortex"]
-
 [target.'cfg(not(windows))'.dependencies]
 cayenne = { path = "../cayenne", features = ["turso"] }
 vortex = { workspace = true, optional = true }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -40,8 +40,6 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::parquet::arrow::async_reader::ObjectVersionType;
 use datafusion::physical_plan::empty::EmptyExec;
-#[cfg(feature = "vortex")]
-use datafusion_datasource::file_format::FileFormatFactory;
 use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::{PartitionedFile, metadata::MetadataColumn};
@@ -49,8 +47,10 @@ use futures::TryStreamExt;
 use object_store::{ObjectMeta, ObjectStore, path::Path};
 use snafu::prelude::*;
 use url::Url;
-#[cfg(feature = "vortex")]
-use vortex_datafusion::VortexFormatFactory;
+#[cfg(not(windows))]
+use {
+    datafusion_datasource::file_format::FileFormatFactory, vortex_datafusion::VortexFormatFactory,
+};
 
 use crate::Runtime;
 use crate::accelerated_table::AcceleratedTable;
@@ -541,7 +541,7 @@ pub trait ListingTableConnector: DataConnector {
                 Some(self.get_jsonl_format(dataset, params)?),
                 extension.unwrap_or(".jsonl".to_string()),
             )),
-            #[cfg(feature = "vortex")]
+            #[cfg(not(windows))]
             (Some("vortex"), _) | (None, Some("vortex")) => Ok((
                 Some(VortexFormatFactory::new().default()),
                 extension.unwrap_or(".vortex".to_string()),


### PR DESCRIPTION
## 📝 Summary
- `runtime` crate has vortex enabled by default (except windows).  Enable vortex file support for object store by default too. 