### PR TITLE
Add Spice test operator improvements

### DIFF
--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -51,11 +51,6 @@ on:
           - 'databricks-catalog'
           - 'spicecloud'
           - 'iceberg-hadoop'
-      ready_wait:
-        description: 'How long (in seconds) to wait for spiced to start'
-        required: true
-        default: '30'
-        type: string
       runner_type:
         description: 'Runner type'
         required: true
@@ -64,16 +59,20 @@ on:
         options:
           - 'spiceai-dev-runners'
           - 'spiceai-dev-large-runners'
-      concurrency_count:
+      concurrency:
         description: 'How many concurrent client connections to use?'
         required: true
         default: '8'
         type: string
-      scale_factor:
-        description: 'Scale factor for the benchmark'
+      random_param_set_count:
+        description: 'Number of random parameter sets to generate for parameterized queries (optional)'
         required: false
         type: string
-        default: '1'
+      http_clients:
+        description: 'Use HTTP clients for the test?'
+        required: false
+        type: boolean
+        default: false
       scrape_spiced_metrics:
         description: 'Scrape Prometheus metrics from spiced during the test'
         required: false
@@ -93,7 +92,7 @@ jobs:
         run: |
           query_set="${{ github.event.inputs.query_set }}"
           query_set="${query_set%%\[*\]*}"
-          SPICEPOD_PATH="./test/spicepods/${query_set}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
+          SPICEPOD_PATH="./test/spicepods/${query_set}/sf1/${{ github.event.inputs.spicepod_path }}"
           echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
 
       - name: Validate spicepod file exists
@@ -147,6 +146,11 @@ jobs:
             echo "MYSQL_DB=tpch_sf1" >> $GITHUB_ENV
           fi
 
+      - name: Install OpenMP runtime library
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgomp1
+
       - name: Run the load test - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
@@ -156,11 +160,14 @@ jobs:
             -p ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }} \
             -d /opt/spiced/data \
             --query-set ${{ github.event.inputs.query_set }} \
-            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --ready-wait 900 \
             --disable-progress-bars \
             --duration ${{ github.event.inputs.duration }} \
-            --concurrency ${{ github.event.inputs.concurrency_count }} \
-            ${{ github.event.inputs.scrape_spiced_metrics == 'true' && '--scrape-spiced-metrics' || '' }}
+            --concurrency ${{ github.event.inputs.concurrency }} \
+            ${{ github.event.inputs.random_param_set_count && format('--random-param-set-count {0}', github.event.inputs.random_param_set_count) || '' }} \
+            ${{ github.event.inputs.http_clients == 'true' && '--http-clients' || '' }} \
+            ${{ github.event.inputs.scrape_spiced_metrics == 'true' && '--scrape-spiced-metrics' || '' }} \
+            --metrics
         env:
           S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT}}
           S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY}}
@@ -193,6 +200,7 @@ jobs:
           DREMIO_PASSWORD: ${{ secrets.SPICE_DREMIO_PASSWORD}}
           MONGODB_HOST: ${{ secrets.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
 
       - name: Run the load test (with overrides) - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides != '' }}
@@ -203,12 +211,15 @@ jobs:
             -p ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }} \
             -d /opt/spiced/data \
             --query-set ${{ github.event.inputs.query_set }} \
-            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --ready-wait 900 \
             --disable-progress-bars \
             --duration ${{ github.event.inputs.duration }} \
             --query-overrides ${{ github.event.inputs.query_overrides }} \
-            --concurrency ${{ github.event.inputs.concurrency_count }} \
-            ${{ github.event.inputs.scrape_spiced_metrics == 'true' && '--scrape-spiced-metrics' || '' }}
+            --concurrency ${{ github.event.inputs.concurrency }} \
+            ${{ github.event.inputs.random_param_set_count && format('--random-param-set-count {0}', github.event.inputs.random_param_set_count) || '' }} \
+            ${{ github.event.inputs.http_clients == 'true' && '--http-clients' || '' }} \
+            ${{ github.event.inputs.scrape_spiced_metrics == 'true' && '--scrape-spiced-metrics' || '' }} \
+            --metrics
         env:
           S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT}}
           S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY}}
@@ -241,3 +252,4 @@ jobs:
           DREMIO_PASSWORD: ${{ secrets.SPICE_DREMIO_PASSWORD}}
           MONGODB_HOST: ${{ secrets.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -101,7 +101,10 @@ async fn test_cayenne_with_partitioned_tpch() -> Result<(), String> {
 
             runtime_ready_check_with_timeout(&rt, Duration::from_secs(300)).await;
 
-            let queries = QuerySet::Tpch.get_queries(None);
+            let queries = QuerySet::Tpch
+                .get_queries(None, None, None)
+                .await
+                .expect("to get queries");
 
             let queries = vec![
                 queries.get(1).expect("TPCH q2 missing"),

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 app = { path = "../app" }
-arrow = { workspace = true, features = ["prettyprint"] }
+arrow = { workspace = true, features = ["prettyprint", "chrono-tz"] }
 arrow-json.workspace = true
 async-openai.workspace = true
 async-trait.workspace = true

--- a/crates/test-framework/src/gh_utils/mod.rs
+++ b/crates/test-framework/src/gh_utils/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use octocrab::actions::ActionsHandler;
+use octocrab::{Octocrab, actions::ActionsHandler};
 use serde_json::Value;
 
 /// Represents a GitHub workflow to be dispatched
@@ -58,6 +58,29 @@ impl GitHubWorkflow {
         .await?;
 
         Ok(())
+    }
+
+    /// Returns the number of active workflow runs for this workflow.
+    ///
+    /// Active runs include workflows that are either queued or currently in progress.
+    ///
+    /// Notes:
+    /// - This method retrieves **only the first page** of results, with a maximum of **100 runs** (`per_page(100)` limit).
+    pub async fn active_runs_count(&self, octo: &Octocrab) -> anyhow::Result<usize> {
+        let page = octo
+            .workflows(&self.org, &self.repo)
+            .list_runs(&self.workflow_file)
+            .per_page(100)
+            .send()
+            .await?;
+
+        let active_runs = page
+            .items
+            .into_iter()
+            .filter(|run| matches!(run.status.as_str(), "queued" | "in_progress" | "waiting"))
+            .count();
+
+        Ok(active_runs)
     }
 }
 

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -18,8 +18,12 @@ use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use arrow::array::RecordBatch;
 use parameterized::{ParameterValue, add_tpch_parameters};
+use serde::{Deserialize, Serialize};
 
-use crate::flight::{PreparedStatementParamColumn, create_param_batch};
+use crate::{
+    flight::{PreparedStatementParamColumn, create_param_batch},
+    spiced::SpicedInstance,
+};
 
 pub mod parameterized;
 pub mod scenario;
@@ -119,6 +123,7 @@ macro_rules! add_tpcds_query_overrides {
         }
     }
 }
+
 macro_rules! generate_clickbench_queries {
   ( $( $i:literal ),* ) => {
       vec![
@@ -147,7 +152,7 @@ macro_rules! generate_clickbench_query_overrides {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Query {
     pub name: Arc<str>,
     pub sql: Arc<str>,
@@ -182,6 +187,34 @@ impl Query {
 
             create_param_batch(columns)
         })
+    }
+
+    /// Converts parameterized SQL to raw SQL with parameters substituted as literals
+    /// for use with endpoints that don't support parameterized queries.
+    #[must_use]
+    pub fn to_sql_with_inlined_params(&self) -> Arc<str> {
+        match &self.parameters {
+            Some(params) if !params.is_empty() => {
+                let mut sql = self.sql.as_ref().to_string();
+
+                // Handle different parameter formats
+                if sql.contains('?') {
+                    // Positional format: replace ? with actual values
+                    for param in params {
+                        sql = sql.replacen('?', &param.to_sql_literal(), 1);
+                    }
+                } else {
+                    // Named format: replace $1, $2, etc. with actual values
+                    for (i, param) in params.iter().enumerate() {
+                        let placeholder = format!("${}", i + 1);
+                        sql = sql.replace(&placeholder, &param.to_sql_literal());
+                    }
+                }
+
+                sql.into()
+            }
+            _ => Arc::clone(&self.sql),
+        }
     }
 
     /// Rewrite table references in the query to use a reference schema.
@@ -249,7 +282,8 @@ impl Query {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum QuerySet {
     #[default]
     Tpch,
@@ -258,6 +292,7 @@ pub enum QuerySet {
     ParameterizedTpch,
     /// Scenario query set loaded from a file
     Scenario {
+        #[serde(skip)]
         queries: Vec<Query>,
         scenario_set: scenario::ScenarioQuerySet,
     },
@@ -291,13 +326,18 @@ impl From<&(&'static str, u32)> for TableWithRowCount {
 }
 
 impl QuerySet {
-    #[must_use]
-    pub fn get_queries(&self, overrides: Option<QueryOverrides>) -> Vec<Query> {
+    #[expect(clippy::unused_async)]
+    pub async fn get_queries(
+        &self,
+        overrides: Option<QueryOverrides>,
+        _instance: Option<&SpicedInstance>,
+        _random_param_set_count: Option<usize>,
+    ) -> anyhow::Result<Vec<Query>> {
         match self {
-            QuerySet::Tpch => get_tpch_test_queries(overrides),
-            QuerySet::Tpcds => get_tpcds_test_queries(overrides),
-            QuerySet::Clickbench => get_clickbench_test_queries(overrides),
-            QuerySet::Scenario { queries, .. } => queries.clone(),
+            QuerySet::Tpch => Ok(get_tpch_test_queries(overrides)),
+            QuerySet::Tpcds => Ok(get_tpcds_test_queries(overrides)),
+            QuerySet::Clickbench => Ok(get_clickbench_test_queries(overrides)),
+            QuerySet::Scenario { queries, .. } => Ok(queries.clone()),
             QuerySet::ParameterizedTpch => {
                 let queries = generate_tpch_queries_override!(
                     "parameterized",
@@ -322,7 +362,7 @@ impl QuerySet {
                     q21 // q22 -- Invalid argument error: column types must match schema types, expected Float64 but found Decimal128(38, 10) at column index 7
                 );
 
-                add_tpch_parameters(queries)
+                Ok(add_tpch_parameters(queries))
             }
         }
     }
@@ -833,6 +873,81 @@ pub fn get_clickbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Que
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_to_sql_with_inlined_params_named_format() {
+        let mut query = Query::new(
+            "test_query".into(),
+            "SELECT * FROM table WHERE id = $1 AND name = $2 AND price > $3".into(),
+            false,
+        );
+        query.parameters = Some(vec![
+            ParameterValue::Number(123),
+            ParameterValue::String("test_name".into()),
+            ParameterValue::Float(99.99),
+        ]);
+
+        let result = query.to_sql_with_inlined_params();
+        assert_eq!(
+            result.as_ref(),
+            "SELECT * FROM table WHERE id = 123 AND name = 'test_name' AND price > 99.99"
+        );
+    }
+
+    #[test]
+    fn test_to_sql_with_inlined_params_positional_format() {
+        let mut query = Query::new(
+            "test_query".into(),
+            "SELECT * FROM table WHERE id = ? AND name = ? AND active = ?".into(),
+            false,
+        );
+        query.parameters = Some(vec![
+            ParameterValue::Number(456),
+            ParameterValue::String("positional_test".into()),
+            ParameterValue::Number(1),
+        ]);
+
+        let result = query.to_sql_with_inlined_params();
+        assert_eq!(
+            result.as_ref(),
+            "SELECT * FROM table WHERE id = 456 AND name = 'positional_test' AND active = 1"
+        );
+    }
+
+    #[test]
+    fn test_to_sql_with_inlined_params_string_escaping() {
+        let mut query = Query::new(
+            "test_query".into(),
+            "SELECT * FROM table WHERE comment = ?".into(),
+            false,
+        );
+        query.parameters = Some(vec![ParameterValue::String(
+            "It's a test with 'quotes'".into(),
+        )]);
+
+        let result = query.to_sql_with_inlined_params();
+        assert_eq!(
+            result.as_ref(),
+            "SELECT * FROM table WHERE comment = 'It''s a test with ''quotes'''"
+        );
+    }
+
+    #[test]
+    fn test_to_sql_with_inlined_params_no_parameters() {
+        let query = Query::new("test_query".into(), "SELECT * FROM table".into(), false);
+
+        let result = query.to_sql_with_inlined_params();
+        assert_eq!(result.as_ref(), "SELECT * FROM table");
+    }
+
+    #[test]
+    fn test_to_sql_with_inlined_params_empty_parameters() {
+        let mut query = Query::new("test_query".into(), "SELECT * FROM table".into(), false);
+        query.parameters = Some(vec![]);
+
+        let result = query.to_sql_with_inlined_params();
+        assert_eq!(result.as_ref(), "SELECT * FROM table");
+    }
 
     #[test]
     fn test_rewrite_simple_query() {

--- a/crates/test-framework/src/queries/parameterized/mod.rs
+++ b/crates/test-framework/src/queries/parameterized/mod.rs
@@ -22,7 +22,7 @@ use super::Query;
 
 // DataFusion has ParamValues which can define a list of `Vec<ScalarValue>`
 // This is a scaled down equivalent to the `ScalarValue` enum, but we don't want to import DataFusion just for this.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ParameterValue {
     String(Arc<str>),
     Number(i64),
@@ -51,6 +51,17 @@ impl ParameterValue {
                 let decimal_value = (*value * 1_000_000.0) as i128;
                 Arc::new(arrow::array::Decimal128Array::from(vec![decimal_value]))
             }
+        }
+    }
+
+    /// Converts the parameter value to a SQL literal string for use in queries
+    /// that don't support parameterized queries (e.g., HTTP endpoints).
+    #[must_use]
+    pub fn to_sql_literal(&self) -> String {
+        match self {
+            ParameterValue::String(s) => format!("'{}'", s.replace('\'', "''")),
+            ParameterValue::Number(n) => n.to_string(),
+            ParameterValue::Float(f) => f.to_string(),
         }
     }
 }

--- a/crates/test-framework/src/queries/scenario.rs
+++ b/crates/test-framework/src/queries/scenario.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use super::Query;
 
 /// A scenario query definition that can be loaded from a YAML file
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ScenarioQueryDefinition {
     /// Unique name for the query
     pub name: String,
@@ -37,7 +37,7 @@ pub struct ScenarioQueryDefinition {
 }
 
 /// Expected results for query validation
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum ExpectedResults {
     /// Path to a CSV file containing expected results
@@ -54,7 +54,7 @@ pub enum ExpectedResults {
 }
 
 /// A collection of scenario queries loaded from a file
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ScenarioQuerySet {
     /// Optional name for the query set
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -713,12 +713,14 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_correct_answer_wrong_type() {
+    #[tokio::test]
+    async fn test_correct_answer_wrong_type() {
         // Use the correct answer, but a different datatype
         // Q22 from CSV, cntrycode is Utf8. Query returns it as Int64
         let query = QuerySet::Tpch
-            .get_queries(None)
+            .get_queries(None, None, None)
+            .await
+            .expect("to get queries")
             .get(20)
             .expect("Should have q22")
             .clone();
@@ -798,11 +800,13 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_wrong_answers() {
+    #[tokio::test]
+    async fn test_wrong_answers() {
         // Use the wrong answer and validate it fails
         let query = QuerySet::Tpch
-            .get_queries(None)
+            .get_queries(None, None, None)
+            .await
+            .expect("to get queries")
             .get(20)
             .expect("Should have q22")
             .clone();

--- a/crates/test-framework/src/spicetest/append/mod.rs
+++ b/crates/test-framework/src/spicetest/append/mod.rs
@@ -23,7 +23,7 @@ use std::{
 
 use crate::{
     metrics::QueryStatus,
-    queries::{self, QueryOverrides, QuerySet},
+    queries::{self, QuerySet},
 };
 use anyhow::{Context, Result};
 use futures::future::join_all;
@@ -39,6 +39,7 @@ mod worker;
 use worker::{AppendConfig, AppendWorker};
 
 mod sources;
+use crate::queries::QueryOverrides;
 use sources::FileAppendableSource;
 
 #[derive(Default)]
@@ -67,16 +68,15 @@ impl NotStarted {
         self
     }
 
-    #[must_use]
-    pub fn with_query_set(
+    pub async fn with_query_set(
         mut self,
         query_set: QuerySet,
         overrides: Option<QueryOverrides>,
-    ) -> Self {
-        self.queries = query_set.get_queries(overrides);
+    ) -> Result<Self> {
+        self.queries = query_set.get_queries(overrides, None, None).await?;
         self.query_count = self.queries.len();
         self.query_set = query_set;
-        self
+        Ok(self)
     }
 
     #[must_use]

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -252,6 +252,12 @@ impl SpiceTestQueryWorker {
 
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
+            // Load test queries may be generated with multiple parameter sets, resulting in a large
+            // set of queries. To respect duration limits, we group queries by name and run one
+            // group at a time, cycling through each group's parameter variations.
+            // If queries are unique, it will result in a single query set and will be the same as usual
+            let query_sets = build_unique_query_sets(&self.query_set)?;
+
             let query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>> = Arc::new(DashMap::new());
 
             // Keeps track of the start and end time of each query iteration
@@ -278,11 +284,18 @@ impl SpiceTestQueryWorker {
                             );
                         }
 
+                        // Select the query set to use for this iteration
+                        let queries_to_run = {
+                            let set_index = query_set_count % query_sets.len();
+                            &query_sets[set_index]
+                        };
+
                         if !self
                             .run_query_set(
                                 Arc::clone(&query_durations),
                                 &mut query_statuses,
                                 &mut row_counts,
+                                queries_to_run,
                             )
                             .await?
                         {
@@ -433,8 +446,9 @@ impl SpiceTestQueryWorker {
         query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
         query_statuses: &mut BTreeMap<Arc<str>, QueryStatus>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
+        queries: &[Query],
     ) -> Result<bool> {
-        for query in &self.query_set {
+        for query in queries {
             let QueryRunResult {
                 connection_failed,
                 query_failure,
@@ -756,30 +770,27 @@ impl SpiceTestQueryWorker {
     ) -> Result<()> {
         if let Some(http_client) = self.http_client.as_ref() {
             let query_start = Instant::now();
+            let sql_text = query.to_sql_with_inlined_params();
             let sql_url = format!("{HTTP_BASE_URL}{SQL_ENDPOINT}");
             let http_response = http_client
                 .post(&sql_url)
                 .header("Accept", "application/vnd.spiceai.sql.v1+json")
-                .body(query.sql.to_string())
+                .body(sql_text.to_string())
                 .send()
                 .await?;
 
-            if !http_response.status().is_success() {
+            let status = http_response.status();
+            let response_text = http_response.text().await.unwrap_or_default();
+
+            if !status.is_success() {
                 eprintln!(
-                    "{} FAIL - Worker {} - Query '{}' HTTP request failed: {}",
+                    "{} FAIL - Worker {} - Query '{}' HTTP request failed: {status} - {response_text}",
                     chrono::Utc::now(),
                     self.id,
                     query.name,
-                    http_response.status()
                 );
-                return Err(anyhow::anyhow!(
-                    "Query HTTP request failed: {}",
-                    http_response.status()
-                ));
+                return Err(anyhow::anyhow!("Query HTTP request failed: {status}",));
             }
-
-            // Extract row count from response
-            let response_text = http_response.text().await?;
 
             let duration = query_start.elapsed();
 
@@ -925,4 +936,168 @@ fn default_row_count_validation_skip_queries() -> HashSet<String> {
     .iter()
     .map(std::string::ToString::to_string)
     .collect()
+}
+
+/// Build unique query sets by grouping queries by parameter index.
+/// Creates one query set per parameter variation, where each set contains
+/// one query of each type with the same parameter index.
+fn build_unique_query_sets(queries: &[Query]) -> Result<Vec<Vec<Query>>> {
+    use std::collections::HashMap;
+
+    // Group queries by name first
+    let mut groups: HashMap<Arc<str>, Vec<&Query>> = HashMap::new();
+    for query in queries {
+        groups
+            .entry(Arc::clone(&query.name))
+            .or_default()
+            .push(query);
+    }
+
+    // Validate that all groups have the same size
+    let mut expected_size = None;
+    for (name, query_group) in &groups {
+        let group_size = query_group.len();
+        match expected_size {
+            None => expected_size = Some(group_size),
+            Some(expected) if expected != group_size => {
+                return Err(anyhow::anyhow!(
+                    "Uneven parameter groups detected: query '{name}' has {group_size} parameters, expected {expected}"
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let num_variations = expected_size.unwrap_or(0);
+
+    // Create query sets by parameter index
+    let mut result = Vec::with_capacity(num_variations);
+
+    for param_index in 0..num_variations {
+        let mut query_set = Vec::with_capacity(groups.len());
+
+        for query_group in groups.values() {
+            if let Some(query) = query_group.get(param_index) {
+                query_set.push((*query).clone());
+            }
+        }
+
+        result.push(query_set);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::queries::parameterized::ParameterValue;
+
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_build_unique_query_sets_single_group() {
+        let queries = vec![
+            Query {
+                name: Arc::from("query1"),
+                sql: Arc::from("SELECT * FROM table WHERE id = ?"),
+                overridden: false,
+                parameters: Some(vec![ParameterValue::String("1".into())]),
+            },
+            Query {
+                name: Arc::from("query1"),
+                sql: Arc::from("SELECT * FROM table WHERE id = ?"),
+                overridden: false,
+                parameters: Some(vec![ParameterValue::String("2".into())]),
+            },
+        ];
+
+        let result = build_unique_query_sets(&queries).expect("Should succeed");
+
+        assert_eq!(
+            result.len(),
+            2,
+            "Should have two query sets (one per parameter)"
+        );
+        assert_eq!(result[0].len(), 1, "Each set should have one query");
+        assert_eq!(result[1].len(), 1, "Each set should have one query");
+    }
+
+    #[test]
+    fn test_build_unique_query_sets_multiple_groups() {
+        let queries = vec![
+            Query {
+                name: Arc::from("query1"),
+                sql: Arc::from("SELECT * FROM table1"),
+                overridden: false,
+                parameters: None,
+            },
+            Query {
+                name: Arc::from("query2"),
+                sql: Arc::from("SELECT * FROM table2"),
+                overridden: false,
+                parameters: None,
+            },
+            Query {
+                name: Arc::from("query1"),
+                sql: Arc::from("SELECT * FROM table1 WHERE id = ?"),
+                overridden: false,
+                parameters: Some(vec![ParameterValue::String("1".into())]),
+            },
+            Query {
+                name: Arc::from("query2"),
+                sql: Arc::from("SELECT * FROM table2 WHERE id = ?"),
+                overridden: false,
+                parameters: Some(vec![ParameterValue::String("2".into())]),
+            },
+        ];
+
+        let result = build_unique_query_sets(&queries).expect("Should succeed");
+
+        assert_eq!(
+            result.len(),
+            2,
+            "Should have two query sets (one per parameter)"
+        );
+        for group in &result {
+            assert_eq!(
+                group.len(),
+                2,
+                "Each set should have two queries (one per query type)"
+            );
+        }
+
+        // Verify each set contains one query of each type
+        let set1_names: Vec<&str> = result[0].iter().map(|q| q.name.as_ref()).collect();
+        let set2_names: Vec<&str> = result[1].iter().map(|q| q.name.as_ref()).collect();
+        assert!(set1_names.contains(&"query1") && set1_names.contains(&"query2"));
+        assert!(set2_names.contains(&"query1") && set2_names.contains(&"query2"));
+    }
+
+    #[test]
+    fn test_build_unique_query_sets_unique_names() {
+        let queries = vec![
+            Query {
+                name: Arc::from("query1"),
+                sql: Arc::from("SELECT * FROM table1"),
+                overridden: false,
+                parameters: None,
+            },
+            Query {
+                name: Arc::from("query2"),
+                sql: Arc::from("SELECT * FROM table2"),
+                overridden: false,
+                parameters: None,
+            },
+        ];
+
+        let result = build_unique_query_sets(&queries).expect("Should succeed");
+
+        assert_eq!(result.len(), 1, "Should have one query set");
+        assert_eq!(result[0].len(), 2, "Set should have both queries");
+
+        // Verify we have both query names in the single set
+        let names: Vec<&str> = result[0].iter().map(|q| q.name.as_ref()).collect();
+        assert!(names.contains(&"query1") && names.contains(&"query2"));
+    }
 }

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -175,6 +175,19 @@ impl From<QuerySetArg> for QuerySet {
     }
 }
 
+impl PartialEq<QuerySet> for QuerySetArg {
+    fn eq(&self, other: &QuerySet) -> bool {
+        matches!(
+            (self, other),
+            (QuerySetArg::Tpch, QuerySet::Tpch)
+                | (QuerySetArg::Tpcds, QuerySet::Tpcds)
+                | (QuerySetArg::Clickbench, QuerySet::Clickbench)
+                | (QuerySetArg::ParameterizedTpch, QuerySet::ParameterizedTpch)
+                | (QuerySetArg::Scenario, QuerySet::Scenario { .. })
+        )
+    }
+}
+
 pub trait QuerySetLoader {
     fn query_set(&self) -> &QuerySetArg;
     fn scenario_query_file(&self) -> Option<&PathBuf>;
@@ -197,6 +210,13 @@ pub trait QuerySetLoader {
             }
             query_set => Ok(QuerySet::from(query_set.clone())),
         }
+    }
+}
+
+impl DatasetTestArgs {
+    /// Load the query set, handling scenario query sets from files
+    pub fn load_query_set(&self) -> anyhow::Result<QuerySet> {
+        QuerySetLoader::load_query_set(self)
     }
 }
 

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use clap::{ArgAction, Parser, ValueEnum};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 use test_framework::TestType;
 
@@ -44,6 +44,13 @@ pub struct DispatchArgs {
 
     #[arg(long, default_value = "false", action = ArgAction::Set)]
     pub(crate) update_snapshots: bool,
+
+    #[arg(long, action = ArgAction::Set, default_value_t = false, default_missing_value = "true", num_args = 0..=1, require_equals = false)]
+    pub(crate) validate: bool,
+
+    /// Maximum number of concurrent workflow runs allowed
+    #[arg(long)]
+    pub(crate) max_concurrent: Option<usize>,
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
@@ -79,15 +86,22 @@ pub struct DispatchTestFile {
 
 /// Represents the tests that can be defined in a test file
 /// The tests correspond to the different workflows that can be dispatched
+/// Each test type can be defined as a single section or as an array of sections
 /// If a test is not defined, it will be skipped for that workflow
 #[derive(Debug, Clone, Deserialize)]
 pub struct DispatchTests {
-    pub bench: Option<BenchArgs>,
-    pub throughput: Option<BenchArgs>,
-    pub load: Option<LoadArgs>,
-    pub append: Option<AppendArgs>,
-    pub http_consistency: Option<HttpConsistencyArgs>,
-    pub http_overhead: Option<HttpOverheadArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub bench: Vec<BenchArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub throughput: Vec<BenchArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub load: Vec<LoadArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub append: Vec<AppendArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub http_consistency: Vec<HttpConsistencyArgs>,
+    #[serde(deserialize_with = "deserialize_single_or_vec", default)]
+    pub http_overhead: Vec<HttpOverheadArgs>,
 }
 
 /// Benchmark and throughput workflow arguments, defined in the test files
@@ -96,6 +110,7 @@ pub struct BenchArgs {
     pub spicepod_path: PathBuf,
     pub query_set: QuerySetArg,
     pub query_overrides: Option<QueryOverridesArg>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_wait: Option<u64>,
     pub runner_type: RunnerType,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,6 +124,25 @@ pub struct BenchArgs {
     pub scale_factor: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scrape_spiced_metrics: Option<bool>,
+}
+
+/// Custom deserializer that accepts either a single item or a vector of items
+fn deserialize_single_or_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum SingleOrVec<T> {
+        Single(T),
+        Vec(Vec<T>),
+    }
+
+    match SingleOrVec::deserialize(deserializer)? {
+        SingleOrVec::Single(single) => Ok(vec![single]),
+        SingleOrVec::Vec(vec) => Ok(vec),
+    }
 }
 
 #[expect(clippy::cast_possible_truncation)]
@@ -161,6 +195,12 @@ pub struct LoadArgs {
     #[serde(flatten)]
     pub bench_args: BenchArgs,
     pub duration: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub random_param_set_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_clients: Option<bool>,
 }
 
 /// Append workflow arguments, defined in the test files
@@ -192,6 +232,9 @@ impl<'de> Deserialize<'de> for LoadArgs {
             #[serde(flatten)]
             bench_args: BenchArgs,
             duration: Option<u64>,
+            concurrency: Option<u64>,
+            random_param_set_count: Option<usize>,
+            http_clients: Option<bool>,
         }
 
         let mut helper = LoadArgsHelper::deserialize(deserializer)?;
@@ -201,9 +244,21 @@ impl<'de> Deserialize<'de> for LoadArgs {
             helper.bench_args.scrape_spiced_metrics = Some(true);
         }
 
+        // Remove ready_wait parameter as it's not supported by testoperator_run_load workflow
+        if helper.bench_args.ready_wait.is_some() {
+            eprintln!(
+                "Warning: ready_wait parameter (spicepod_path = {}) is not supported by testoperator_run_load workflow and will be ignored",
+                helper.bench_args.spicepod_path.display()
+            );
+            helper.bench_args.ready_wait = None;
+        }
+
         Ok(LoadArgs {
             bench_args: helper.bench_args,
             duration: helper.duration,
+            concurrency: helper.concurrency,
+            random_param_set_count: helper.random_param_set_count,
+            http_clients: helper.http_clients,
         })
     }
 }
@@ -276,4 +331,162 @@ pub struct WorkflowArgs<T: Serialize> {
     #[serde(flatten)]
     pub specific_args: T,
     pub spiced_commit: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_framework::queries::QuerySet;
+
+    #[test]
+    fn test_single_section_deserialization() {
+        let yaml = "
+tests:
+  bench:
+    spicepod_path: s3[parquet]-turso[file].yaml
+    query_set: tpch
+    ready_wait: 300
+    runner_type: spiceai-dev-runners
+  load:
+    spicepod_path: s3[parquet]-turso[file].yaml
+    query_set: tpch
+    ready_wait: 300
+    runner_type: spiceai-dev-runners
+    concurrency: 128
+    duration: 1800
+    random_param_set_count: 1000
+";
+
+        let test_file: DispatchTestFile =
+            serde_yaml::from_str(yaml).expect("Failed to deserialize");
+
+        // Verify bench section (single item becomes vec with one element)
+        assert_eq!(test_file.tests.bench.len(), 1);
+        assert_eq!(
+            test_file.tests.bench[0].spicepod_path.to_string_lossy(),
+            "s3[parquet]-turso[file].yaml"
+        );
+        assert_eq!(test_file.tests.bench[0].query_set, QuerySet::Tpch);
+        assert_eq!(test_file.tests.bench[0].ready_wait, Some(300));
+
+        // Verify load section (single item becomes vec with one element)
+        assert_eq!(test_file.tests.load.len(), 1);
+        assert_eq!(
+            test_file.tests.load[0]
+                .bench_args
+                .spicepod_path
+                .to_string_lossy(),
+            "s3[parquet]-turso[file].yaml"
+        );
+        assert_eq!(test_file.tests.load[0].bench_args.query_set, QuerySet::Tpch);
+        assert_eq!(test_file.tests.load[0].bench_args.ready_wait, Some(300));
+        assert_eq!(test_file.tests.load[0].concurrency, Some(128));
+        assert_eq!(test_file.tests.load[0].duration, Some(1800));
+        assert_eq!(test_file.tests.load[0].random_param_set_count, Some(1000));
+
+        // Verify empty sections default to empty vectors
+        assert_eq!(test_file.tests.throughput.len(), 0);
+        assert_eq!(test_file.tests.http_consistency.len(), 0);
+        assert_eq!(test_file.tests.http_overhead.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_sections_deserialization() {
+        let yaml = "
+tests:
+  load:
+    - spicepod_path: s3[parquet]-turso[file].yaml
+      query_set: tpch
+      ready_wait: 300
+      runner_type: spiceai-dev-runners
+      concurrency: 128
+      duration: 1800
+      random_param_set_count: 1000
+    - spicepod_path: s3[parquet]-turso[file].yaml
+      query_set: tpch
+      ready_wait: 600
+      runner_type: spicehq-dev-large-runners
+      concurrency: 256
+      duration: 3600
+      random_param_set_count: 2000
+    - spicepod_path: different-spicepod.yaml
+      query_set: tpch
+      ready_wait: 120
+      runner_type: spiceai-dev-runners
+      concurrency: 64
+      duration: 900
+      random_param_set_count: 500
+";
+
+        let test_file: DispatchTestFile =
+            serde_yaml::from_str(yaml).expect("Failed to deserialize");
+
+        // Verify we have 3 load sections
+        assert_eq!(test_file.tests.load.len(), 3);
+
+        // Verify first load section
+        assert_eq!(
+            test_file.tests.load[0]
+                .bench_args
+                .spicepod_path
+                .to_string_lossy(),
+            "s3[parquet]-turso[file].yaml"
+        );
+        assert_eq!(test_file.tests.load[0].bench_args.query_set, QuerySet::Tpch);
+        assert_eq!(test_file.tests.load[0].bench_args.ready_wait, Some(300));
+        assert_eq!(test_file.tests.load[0].concurrency, Some(128));
+        assert_eq!(test_file.tests.load[0].duration, Some(1800));
+        assert_eq!(test_file.tests.load[0].random_param_set_count, Some(1000));
+
+        // Verify second load section
+        assert_eq!(
+            test_file.tests.load[1]
+                .bench_args
+                .spicepod_path
+                .to_string_lossy(),
+            "s3[parquet]-turso[file].yaml"
+        );
+        assert_eq!(test_file.tests.load[1].bench_args.query_set, QuerySet::Tpch);
+        assert_eq!(test_file.tests.load[1].bench_args.ready_wait, Some(600));
+        assert_eq!(test_file.tests.load[1].concurrency, Some(256));
+        assert_eq!(test_file.tests.load[1].duration, Some(3600));
+        assert_eq!(test_file.tests.load[1].random_param_set_count, Some(2000));
+
+        // Verify third load section
+        assert_eq!(
+            test_file.tests.load[2]
+                .bench_args
+                .spicepod_path
+                .to_string_lossy(),
+            "different-spicepod.yaml"
+        );
+        assert_eq!(test_file.tests.load[2].bench_args.query_set, QuerySet::Tpch);
+        assert_eq!(test_file.tests.load[2].bench_args.ready_wait, Some(120));
+        assert_eq!(test_file.tests.load[2].concurrency, Some(64));
+        assert_eq!(test_file.tests.load[2].duration, Some(900));
+        assert_eq!(test_file.tests.load[2].random_param_set_count, Some(500));
+
+        // Verify other sections are empty
+        assert_eq!(test_file.tests.bench.len(), 0);
+        assert_eq!(test_file.tests.throughput.len(), 0);
+        assert_eq!(test_file.tests.http_consistency.len(), 0);
+        assert_eq!(test_file.tests.http_overhead.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_sections_default_to_empty_vec() {
+        let yaml = "
+tests: {}
+";
+
+        let test_file: DispatchTestFile =
+            serde_yaml::from_str(yaml).expect("Failed to deserialize");
+
+        // All sections should default to empty vectors
+        assert_eq!(test_file.tests.bench.len(), 0);
+        assert_eq!(test_file.tests.throughput.len(), 0);
+        assert_eq!(test_file.tests.load.len(), 0);
+        assert_eq!(test_file.tests.http_consistency.len(), 0);
+        assert_eq!(test_file.tests.http_overhead.len(), 0);
+    }
 }

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -15,11 +15,7 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{
-    args::{AppendTestArgs, QuerySetLoader},
-    health::HealthMonitor,
-    wait_test_and_memory,
-};
+use crate::{args::AppendTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType,
@@ -62,6 +58,7 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
         app.name.clone(),
         NotStarted::new()
             .with_query_set(query_set.clone(), query_overrides)
+            .await?
             .with_parallel_count(1)
             .with_end_duration(Duration::from_secs(args.test_args.common.duration))
             .with_tempdir_path(start_request.get_tempdir_path())

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -105,7 +105,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
             .with_disable_caching(args.disable_caching)
             .with_scale_factor(args.scale_factor.unwrap_or(1.0))
             .with_http_client(args.http_clients),
-    )?;
+    )
+    .await?;
 
     let benchmark_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -14,15 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::time::Duration;
+
 use test_framework::{
     TestType,
     anyhow::{self, Result},
     gh_utils::{GitHubWorkflow, map_numbers_to_strings},
-    octocrab,
+    octocrab::{self, Octocrab},
     utils::scan_directory_for_yamls,
 };
 
-use crate::args::dispatch::{DispatchArgs, DispatchTestFile, DispatchTests, WorkflowArgs};
+use crate::args::dispatch::{DispatchArgs, DispatchTestFile, WorkflowArgs};
 
 pub async fn dispatch(args: DispatchArgs) -> Result<()> {
     if !args.path.is_dir() && !args.path.is_file() {
@@ -43,153 +45,202 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
         .iter()
         .map(|path| {
             let file = std::fs::File::open(path)?;
-            let tests: DispatchTestFile = serde_yaml::from_reader(file)?;
+            let tests: DispatchTestFile = serde_yaml::from_reader(file)
+                .map_err(|e| anyhow::anyhow!("Failed to parse {}: {e}", path.display()))?;
 
             Ok::<_, anyhow::Error>((path, tests))
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let total_tests = tests.len();
-    for (index, (path, test)) in tests.into_iter().enumerate() {
-        let mut payload = match (test_type, &test.tests) {
-            (
-                TestType::Benchmark,
-                DispatchTests {
-                    bench: Some(bench), ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: bench
-                        .clone()
-                        .with_update_snapshots(args.update_snapshots.into()),
-                    spiced_commit: args.spiced_commit.clone(),
-                })
+    // Collect all test instances for the selected test type
+    let mut tests_to_dispatch = Vec::new();
+
+    for (path, test_file) in tests {
+        match test_type {
+            TestType::Benchmark => {
+                for bench in &test_file.tests.bench {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: bench
+                                .clone()
+                                .with_update_snapshots(args.update_snapshots.into()),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
-            (
-                TestType::Throughput,
-                DispatchTests {
-                    throughput: Some(throughput),
-                    ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: throughput.clone(),
-                    spiced_commit: args.spiced_commit.clone(),
-                })
+            TestType::Load => {
+                for load in &test_file.tests.load {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: load.clone(),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
-            (
-                TestType::Load,
-                DispatchTests {
-                    load: Some(load), ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: load.clone(),
-                    spiced_commit: args.spiced_commit.clone(),
-                })
+            TestType::Throughput => {
+                for throughput in &test_file.tests.throughput {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: throughput.clone(),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
-            (
-                TestType::HttpConsistency,
-                DispatchTests {
-                    http_consistency: Some(consistency),
-                    ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: consistency,
-                    spiced_commit: args.spiced_commit.clone(),
-                })
+            TestType::HttpConsistency => {
+                for consistency in &test_file.tests.http_consistency {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: consistency.clone(),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
-            (
-                TestType::HttpOverhead,
-                DispatchTests {
-                    http_overhead: Some(overhead),
-                    ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: overhead,
-                    spiced_commit: args.spiced_commit.clone(),
-                })
+            TestType::HttpOverhead => {
+                for overhead in &test_file.tests.http_overhead {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: overhead.clone(),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
-            (
-                TestType::Append,
-                DispatchTests {
-                    append: Some(append),
-                    ..
-                },
-            ) => {
-                serde_json::json!(WorkflowArgs {
-                    specific_args: append.clone(),
-                    spiced_commit: args.spiced_commit.clone(),
-                })
-            }
-            (TestType::Benchmark, _) => {
-                println!(
-                    "Test file {} does not contain a benchmark test",
-                    path.display()
-                );
-                continue;
-            }
-            (TestType::Throughput, _) => {
-                println!(
-                    "Test file {} does not contain a throughput test",
-                    path.display()
-                );
-                continue;
-            }
-            (TestType::Load, _) => {
-                println!("Test file {} does not contain a load test", path.display());
-                continue;
-            }
-            (TestType::HttpConsistency, _) => {
-                println!(
-                    "Test file {} does not contain an HTTP consistency test",
-                    path.display()
-                );
-                continue;
-            }
-            (TestType::HttpOverhead, _) => {
-                println!(
-                    "Test file {} does not contain an HTTP overhead test",
-                    path.display()
-                );
-                continue;
-            }
-            (TestType::Append, _) => {
-                println!(
-                    "Test file {} does not contain an append test",
-                    path.display()
-                );
-                continue;
+            TestType::Append => {
+                for append in &test_file.tests.append {
+                    tests_to_dispatch.push((
+                        path,
+                        serde_json::json!(WorkflowArgs {
+                            specific_args: append.clone(),
+                            spiced_commit: args.spiced_commit.clone(),
+                        }),
+                    ));
+                }
             }
             _ => {
-                return Err(anyhow::anyhow!(
-                    "Test type {test_type} not supported for dispatching"
-                ));
+                println!("Test type {test_type} not supported for dispatching");
             }
-        };
+        }
+    }
 
+    if tests_to_dispatch.is_empty() {
+        println!("No tests found for test type {test_type}");
+        return Ok(());
+    }
+
+    let total_tests = tests_to_dispatch.len();
+    for (index, (path, mut payload)) in tests_to_dispatch.into_iter().enumerate() {
         payload = map_numbers_to_strings(payload);
 
         println!(
-            "{index}/{total_tests} - Dispatching {test_type} test from {}",
+            "{}/{} - Dispatching {test_type} test from {}",
+            index + 1,
+            total_tests,
             path.display(),
-            index = index + 1,
         );
-        GitHubWorkflow::new(
+
+        let workflow = GitHubWorkflow::new(
             "spiceai",
             "spiceai",
             test_type.workflow(),
             &args.workflow_commit,
-        )
-        .send(octo_client.actions(), Some(payload))
-        .await?;
+        );
+
+        match args.max_concurrent {
+            Some(max_concurrent) => {
+                // Dispatch workflow while waiting for an available slot, limiting to max_concurrent parallel runs
+                dispatch_workflow_with_concurrency(
+                    workflow,
+                    &octo_client,
+                    Some(payload),
+                    max_concurrent,
+                )
+                .await?;
+            }
+            None => {
+                // Dispatch workflow without concurrency limit
+                workflow.send(octo_client.actions(), Some(payload)).await?;
+            }
+        }
 
         // sleep to space out runs
         println!("Waiting for next run...");
         tokio::time::sleep(std::time::Duration::from_secs(80)).await;
     }
 
+    Ok(())
+}
+
+/// Dispatches the workflow, waiting until the number of active runs is below the limit
+/// or until the 30 minutes max wait time expires.
+///
+/// - `max_concurrent`: maximum number of active runs allowed
+async fn dispatch_workflow_with_concurrency(
+    workflow: GitHubWorkflow,
+    octo: &Octocrab,
+    input: Option<serde_json::Value>,
+    max_concurrent: usize,
+) -> Result<()> {
+    println!(
+        "Checking for available slot to run workflow (limit: {max_concurrent} concurrent runs)..."
+    );
+    if let Err(err) = wait_for_slot(
+        &workflow,
+        octo,
+        max_concurrent,
+        Duration::from_secs(1800), // 30 mins
+    )
+    .await
+    {
+        eprintln!("Error waiting for slot: {err}");
+    }
+
+    workflow.send(octo.actions(), input).await
+}
+
+/// Waits until the number of already queued runs is below the given limit,
+/// or until the timeout expires.
+///
+/// This is used to limit the number of concurrent workflow runs on GitHub Actions.
+/// - `max_concurrent`: maximum number of active runs allowed
+async fn wait_for_slot(
+    workflow: &GitHubWorkflow,
+    octo: &Octocrab,
+    max_concurrent: usize,
+    timeout: Duration,
+) -> Result<()> {
+    let start_time = std::time::Instant::now();
+
+    loop {
+        let num_active = workflow.active_runs_count(octo).await?;
+        if num_active < max_concurrent {
+            println!("✅ Dispatch slot available! Currently {num_active} active runs.");
+            break;
+        }
+
+        // Check if we've exceeded the maximum wait time
+        if start_time.elapsed() >= timeout {
+            return Err(anyhow::anyhow!(
+                "Timeout: waited {} seconds for available slot but {num_active} runs still active",
+                timeout.as_secs()
+            ));
+        }
+
+        let remaining_time = timeout.saturating_sub(start_time.elapsed());
+        println!(
+            "🕒 {num_active} run(s) already active — waiting for slot... ({} seconds remaining)",
+            remaining_time.as_secs()
+        );
+
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    }
     Ok(())
 }

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -81,16 +81,17 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     // warm up run
     println!("Performing warm up");
 
-    let (_query_set, test_builder) = super::build_test_with_validation(
+    let (baseline_query_set, test_builder) = super::build_test_with_validation(
         &args.test_args,
         NotStarted::new()
             .with_parallel_count(args.test_args.common.concurrency)
             .with_end_condition(EndCondition::QuerySetCompleted(1))
             .with_disable_caching(args.test_args.disable_caching)
             .with_http_client(args.test_args.http_clients),
-    )?;
+    )
+    .await?;
 
-    let warm_up = SpiceTest::new(app.name.clone(), test_builder)
+    let warm_up = SpiceTest::<NotStarted>::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
         .with_progress_bars(!args.test_args.common.disable_progress_bars)
         .start()
@@ -114,7 +115,8 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
             .with_end_condition(EndCondition::Duration(baseline_duration))
             .with_disable_caching(args.test_args.disable_caching)
             .with_http_client(args.test_args.http_clients),
-    )?;
+    )
+    .await?;
 
     let baseline_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
@@ -167,7 +169,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     }
 
     let (query_set, test_builder) =
-        super::build_test_with_validation(&args.test_args, test_builder)?;
+        super::build_test_with_validation(&args.test_args, test_builder).await?;
 
     // Use the same query overrides that were applied in build_test_with_validation
     let query_overrides = args
@@ -175,7 +177,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         .query_overrides
         .clone()
         .map(test_framework::queries::QueryOverrides::from);
-    let queries = query_set.get_queries(query_overrides);
+    let _queries = query_set.get_queries(query_overrides, None, None).await?;
 
     let throughput_test = SpiceTest::<NotStarted>::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
@@ -262,7 +264,13 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
 
     let mut test_passed = true;
     let mut yellow_measurements = 0;
-    for query in queries {
+
+    // Use baseline_queries that represent unique query names, otherwise the same failure
+    // could be reported multiple times for each parameterized query params set variation
+    for query in baseline_query_set
+        .get_queries(query_overrides, None, None)
+        .await?
+    {
         let Some(baseline_percentile) = baseline_percentiles.get(&query.name) else {
             // Query Failed, no percentile statistics recorded
             continue;

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use crate::args::{CommonArgs, DatasetTestArgs, QuerySetLoader};
+use crate::args::{CommonArgs, DatasetTestArgs};
 use test_framework::{
     anyhow,
     app::{App, AppBuilder},
@@ -65,7 +65,7 @@ pub(crate) fn create_telemetry(common: &CommonArgs) -> Telemetry {
 ///
 /// # Returns
 /// Tuple of (`QuerySet`, Vec<Query>, `NotStarted` builder)
-pub(crate) fn build_test_with_validation(
+pub(crate) async fn build_test_with_validation(
     args: &DatasetTestArgs,
     test_builder: NotStarted,
 ) -> anyhow::Result<(QuerySet, NotStarted)> {
@@ -74,7 +74,7 @@ pub(crate) fn build_test_with_validation(
         .query_overrides
         .clone()
         .map(test_framework::queries::QueryOverrides::from);
-    let queries = query_set.get_queries(query_overrides);
+    let queries = query_set.get_queries(query_overrides, None, None).await?;
 
     let mut test_builder = test_builder.with_query_set(queries);
 

--- a/tools/testoperator/src/commands/query/mod.rs
+++ b/tools/testoperator/src/commands/query/mod.rs
@@ -48,7 +48,9 @@ pub(crate) async fn run(args: &QueryArgs) -> anyhow::Result<RowCounts> {
         .query_overrides
         .clone()
         .map(test_framework::queries::QueryOverrides::from);
-    let queries = query_set.get_queries(query_overrides);
+    let queries = query_set
+        .get_queries(query_overrides, Some(&spiced_instance), None)
+        .await?;
 
     let mut test = NotStarted::new()
         .with_parallel_count(1)

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -55,7 +55,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_end_condition(EndCondition::QuerySetCompleted(6))
             .with_disable_caching(args.disable_caching)
             .with_http_client(args.http_clients),
-    )?;
+    )
+    .await?;
 
     let baseline_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
@@ -78,7 +79,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_end_condition(EndCondition::QuerySetCompleted(2))
             .with_disable_caching(args.disable_caching)
             .with_http_client(args.http_clients),
-    )?;
+    )
+    .await?;
 
     let throughput_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)


### PR DESCRIPTION
## 📝 Summary

Test operator Load tests:
 - Support for `http_clients` option,
 - `concurrency` param fix
 - Support for `random_param_set_count` param

Fixes `http_clients` when it is used for parametrized queries (inlining actual param value via `to_sql_with_inlined_params`)

Support for dispatch workflow concurrency to control max running benchmarks

Make `get_queries` more flexible allowing to generate test queries based on `SpicedInstance`

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
