### PR TITLE
Add snapshot interval for acceleration snapshots

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -294,6 +294,7 @@ pub struct Builder {
     snapshot_behavior: SnapshotBehavior,
     snapshot_local_path: Option<PathBuf>,
     snapshots_trigger_threshold: Option<i64>,
+    snapshots_create_interval: Option<Duration>,
     metrics: Option<Metrics>,
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
@@ -335,6 +336,7 @@ impl Builder {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             snapshots_trigger_threshold: None,
+            snapshots_create_interval: None,
             metrics: None,
             cpu_runtime: None,
             io_runtime,
@@ -475,10 +477,12 @@ impl Builder {
         snapshot_behavior: SnapshotBehavior,
         snapshot_path: Option<PathBuf>,
         snapshots_trigger_threshold: Option<i64>,
+        snapshots_create_interval: Option<Duration>,
     ) -> &mut Self {
         self.snapshot_behavior = snapshot_behavior;
         self.snapshot_local_path = snapshot_path;
         self.snapshots_trigger_threshold = snapshots_trigger_threshold;
+        self.snapshots_create_interval = snapshots_create_interval;
         self
     }
 
@@ -632,6 +636,7 @@ impl Builder {
             self.snapshot_behavior,
             self.snapshot_local_path.clone(),
             self.snapshots_trigger_threshold,
+            self.snapshots_create_interval,
         );
 
         if let Some(ref resource_monitor) = self.resource_monitor {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -469,6 +469,8 @@ pub struct Refresher {
     snapshot_behavior: SnapshotBehavior,
     snapshot_local_path: Option<PathBuf>,
     snapshots_trigger_threshold: Option<i64>,
+    snapshots_create_interval: Option<Duration>,
+    snapshot_interval_task: Option<tokio::task::JoinHandle<()>>,
 
     initial_load_completed: Arc<AtomicBool>,
     disable_federation: bool,
@@ -526,6 +528,8 @@ impl Refresher {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             snapshots_trigger_threshold: None,
+            snapshots_create_interval: None,
+            snapshot_interval_task: None,
             metrics: None,
             cpu_runtime,
             io_runtime,
@@ -584,10 +588,12 @@ impl Refresher {
         snapshot_behavior: SnapshotBehavior,
         snapshot_path: Option<PathBuf>,
         snapshots_trigger_threshold: Option<i64>,
+        snapshots_create_interval: Option<Duration>,
     ) -> &mut Self {
         self.snapshot_behavior = snapshot_behavior;
         self.snapshot_local_path = snapshot_path;
         self.snapshots_trigger_threshold = snapshots_trigger_threshold;
+        self.snapshots_create_interval = snapshots_create_interval;
         self
     }
 
@@ -677,7 +683,11 @@ impl Refresher {
             ),
             _ => None,
         }
-        .flatten();
+        .flatten()
+        .map(Arc::new);
+
+        let checkpointer = self.checkpointer.clone();
+        let federated_schema = self.federated.schema();
 
         let mut on_start_refresh_external = match (acceleration_refresh_mode, time_column) {
             (AccelerationRefreshMode::Disabled, _) => return Ok(None),
@@ -688,6 +698,14 @@ impl Refresher {
                 _,
             ) => receiver,
             (AccelerationRefreshMode::Changes(stream), _) => {
+                let snapshot_interval_task = spawn_snapshot_interval_task(
+                    self.snapshots_create_interval,
+                    checkpointer.clone(),
+                    snapshot_manager.clone(),
+                    dataset_name.clone(),
+                    Arc::clone(&federated_schema),
+                );
+                self.snapshot_interval_task = snapshot_interval_task;
                 return Ok(Some(self.start_changes_stream(stream, snapshot_manager)));
             }
         };
@@ -726,15 +744,20 @@ impl Refresher {
         let refresh = Arc::clone(&self.refresh);
 
         let caching = self.caching.clone();
-        let checkpointer = self.checkpointer.clone();
-
         let refresh_check_interval = self.refresh.read().await.check_interval;
         let max_jitter = self.refresh.read().await.max_jitter;
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
 
         let synchronize_with = self.synchronize_with.clone();
-        let federated_schema = self.federated.schema();
+        let snapshot_interval_task = spawn_snapshot_interval_task(
+            self.snapshots_create_interval,
+            checkpointer.clone(),
+            snapshot_manager.clone(),
+            dataset_name.clone(),
+            Arc::clone(&federated_schema),
+        );
+        self.snapshot_interval_task = snapshot_interval_task;
 
         // Spawns a tasks that both periodically refreshes the dataset, and upon request, will manually refresh the dataset.
         // The `select!` block handle waiting on both
@@ -862,7 +885,7 @@ impl Refresher {
     fn start_changes_stream(
         &mut self,
         changes_stream: ChangesStream,
-        snapshot_manager: Option<SnapshotManager>,
+        snapshot_manager: Option<Arc<SnapshotManager>>,
     ) -> tokio::task::JoinHandle<()> {
         let checkpointer = self.checkpointer.clone();
 
@@ -916,10 +939,58 @@ impl Refresher {
 type SnapshotCallback =
     Arc<Mutex<Box<dyn FnMut() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>>>;
 
+fn spawn_snapshot_interval_task(
+    snapshots_create_interval: Option<Duration>,
+    checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
+    snapshot_manager: Option<Arc<SnapshotManager>>,
+    dataset_name: TableReference,
+    federated_schema: Arc<Schema>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let interval = snapshots_create_interval?;
+    let checkpointer = checkpointer?;
+    let snapshot_manager = snapshot_manager?;
+
+    tracing::info!(
+        "Snapshots for dataset {dataset_name} will be created every {}s",
+        interval.as_secs()
+    );
+
+    Some(tokio::spawn(async move {
+        let mut initial_delay = interval;
+        if let Ok(Some(last_checkpoint_time)) = checkpointer.last_checkpoint_time().await
+            && let Ok(elapsed) = SystemTime::now().duration_since(last_checkpoint_time)
+        {
+            if elapsed < interval {
+                initial_delay = interval - elapsed;
+            } else {
+                initial_delay = Duration::from_secs(0);
+            }
+        }
+
+        if !initial_delay.is_zero() {
+            sleep(initial_delay).await;
+        }
+
+        loop {
+            if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
+                tracing::warn!("Failed to checkpoint dataset {dataset_name}: {e}");
+            } else if let Err(e) = snapshot_manager.create_snapshot(&federated_schema).await {
+                let dataset_label = dataset_name.to_string();
+                snapshot_metrics::record_snapshot_failure(&dataset_label);
+                tracing::warn!("Failed to create snapshot for dataset {dataset_name}: {e}");
+            } else {
+                tracing::info!("Successfully created snapshot for dataset {dataset_name}");
+            }
+
+            sleep(interval).await;
+        }
+    }))
+}
+
 fn create_periodic_snapshot_callback(
     snapshots_trigger_threshold: Option<i64>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
-    snapshot_manager: Option<SnapshotManager>,
+    snapshot_manager: Option<Arc<SnapshotManager>>,
     dataset_name: &TableReference,
     federated_schema: Arc<Schema>,
 ) -> Option<SnapshotCallback> {
@@ -927,7 +998,6 @@ fn create_periodic_snapshot_callback(
 
     match (checkpointer, snapshot_manager) {
         (Some(checkpointer), Some(snapshot_manager)) => {
-            let snapshot_manager = Arc::new(snapshot_manager);
             let dataset_name = dataset_name.clone();
 
             tracing::info!(
@@ -987,6 +1057,9 @@ impl Drop for Refresher {
     fn drop(&mut self) {
         if let Some(mut refresh_task_runner) = self.refresh_task_runner.take() {
             refresh_task_runner.abort();
+        }
+        if let Some(task) = self.snapshot_interval_task.take() {
+            task.abort();
         }
     }
 }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -360,6 +360,8 @@ pub struct Acceleration {
     pub snapshot_behavior: SnapshotBehavior,
 
     pub snapshots_trigger_threshold: Option<i64>,
+
+    pub snapshots_create_interval: Option<Duration>,
 }
 
 impl Acceleration {
@@ -458,6 +460,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
 
         let disable_federation = parse_is_query_federation_disabled(&mut params)?;
         let snapshots_trigger_threshold = parse_snapshots_trigger_threshold(&mut params)?;
+        let snapshots_create_interval = parse_snapshots_create_interval(&mut params)?;
 
         let caching_ttl = parse_caching_ttl(&mut params)?;
         let caching_stale_while_revalidate_ttl =
@@ -518,6 +521,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             partition_by: acceleration.partition_by,
             snapshot_behavior: SnapshotBehavior::disabled(),
             snapshots_trigger_threshold,
+            snapshots_create_interval,
         })
     }
 }
@@ -555,6 +559,7 @@ impl Default for Acceleration {
             partition_by: vec![],
             snapshot_behavior: SnapshotBehavior::Disabled,
             snapshots_trigger_threshold: None,
+            snapshots_create_interval: None,
         }
     }
 }
@@ -598,6 +603,44 @@ fn parse_snapshots_trigger_threshold(
         }
     } else {
         Ok(None)
+    }
+}
+
+#[expect(clippy::result_large_err)]
+fn parse_snapshots_create_interval(
+    params: &mut Option<Params>,
+) -> Result<Option<Duration>, crate::Error> {
+    let Some(params) = params else {
+        return Ok(None);
+    };
+    let Some(value) = params.data.remove("snapshots_create_interval") else {
+        return Ok(None);
+    };
+
+    match value {
+        spicepod::param::ParamValue::String(s) => {
+            let interval =
+                fundu::parse_duration(&s).map_err(|e| crate::Error::InvalidSpicepodDataset {
+                    source: super::Error::UnableToParseFieldAsDuration {
+                        source: e,
+                        field: "snapshots_create_interval".into(),
+                    },
+                })?;
+            if interval.is_zero() {
+                return Err(crate::Error::InvalidAccelerationConfiguration {
+                    source:
+                        "Invalid 'snapshots_create_interval' param value: duration must be greater than zero."
+                            .into(),
+                });
+            }
+            Ok(Some(interval))
+        }
+        _ => Err(crate::Error::InvalidAccelerationConfiguration {
+            source: format!(
+                "Invalid 'snapshots_create_interval' param value: {value:?}. Expected a duration string."
+            )
+            .into(),
+        }),
     }
 }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1212,6 +1212,7 @@ impl DataFusion {
                 acceleration_settings.snapshot_behavior.clone(),
                 Some(snapshot_path),
                 acceleration_settings.snapshots_trigger_threshold,
+                acceleration_settings.snapshots_create_interval,
             );
         }
 


### PR DESCRIPTION
## Summary
- add `snapshots_create_interval` acceleration param and parse duration
- schedule periodic snapshots in refresher for all refresh modes
- wire interval through accelerated table builder

Tested on the following Spicepod using localpod synchronized acceleration for an HTTP connector:

```yaml
version: v1
kind: Spicepod
name: time_server

snapshots:
  enabled: true
  location: s3://spiceai-acceleration-snapshots-seoul/251209-time-server/
  bootstrap_on_failure_behavior: warn
  params:
    s3_auth: iam_role

datasets:
  - from: http://localhost:7400
    name: time_file
    time_column: fetched_at
    params:
      request_query_filters: enabled
      request_body_filters: enabled
      allowed_request_paths: /**/**
      max_retries: 0
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
      refresh_mode: caching
      retention_check_enabled: false
      retention_period: 1m
      retention_check_interval: 10s
      snapshots: enabled
      params:
        snapshots_create_interval: 60s # new parameter
        caching_ttl: 600s
        caching_stale_while_revalidate_ttl: 600s
        caching_stale_if_error: enabled
        duckdb_file: time.db
  - from: localpod:time_file
    name: time
    acceleration:
      enabled: true
      engine: duckdb
      refresh_mode: caching
```