### PR TITLE
Restore deprecated open-telemetry flag in spiced

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -124,6 +124,15 @@ pub struct Args {
     #[arg(long, value_name = "BIND_ADDRESS", help_heading = "Metrics")]
     pub metrics: Option<SocketAddr>,
 
+    /// Deprecated OpenTelemetry bind address (no effect).
+    #[arg(
+        long = "open_telemetry",
+        value_name = "OPEN_TELEMETRY_BIND_ADDRESS",
+        default_value = "127.0.0.1:50052",
+        action
+    )]
+    pub open_telemetry_bind_address: SocketAddr,
+
     /// Print the version and exit.
     #[arg(long)]
     pub version: bool,

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -124,6 +124,19 @@ pub struct Args {
     #[arg(long, value_name = "BIND_ADDRESS", help_heading = "Metrics")]
     pub metrics: Option<SocketAddr>,
 
+    /// Deprecated OpenTelemetry bind address (no effect).
+    #[arg(
+        long = "open-telemetry",
+        aliases = [
+            "open_telemetry",
+            "open-telemetry-bind-address",
+            "open_telemetry_bind_address"
+        ],
+        value_name = "BIND_ADDRESS",
+        help_heading = "Metrics"
+    )]
+    pub open_telemetry_bind_address: Option<SocketAddr>,
+
     /// Print the version and exit.
     #[arg(long)]
     pub version: bool,
@@ -187,6 +200,12 @@ pub struct Args {
 
 pub async fn run(args: Args) -> Result<()> {
     let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());
+
+    if args.open_telemetry_bind_address.is_some() {
+        tracing::warn!(
+            "`--open-telemetry` is deprecated and has no effect; it will be removed in a future version"
+        );
+    }
 
     let spicepod_path = args
         .spicepod

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -124,19 +124,6 @@ pub struct Args {
     #[arg(long, value_name = "BIND_ADDRESS", help_heading = "Metrics")]
     pub metrics: Option<SocketAddr>,
 
-    /// Deprecated OpenTelemetry bind address (no effect).
-    #[arg(
-        long = "open-telemetry",
-        aliases = [
-            "open_telemetry",
-            "open-telemetry-bind-address",
-            "open_telemetry_bind_address"
-        ],
-        value_name = "BIND_ADDRESS",
-        help_heading = "Metrics"
-    )]
-    pub open_telemetry_bind_address: Option<SocketAddr>,
-
     /// Print the version and exit.
     #[arg(long)]
     pub version: bool,
@@ -196,16 +183,13 @@ pub struct Args {
     /// Overrides for the runtime configuration (--set-runtime key1.subkey=value1)
     #[arg(long, action = ArgAction::Append, value_parser = parse_set_string)]
     pub set_runtime: Vec<(String, String)>,
+
+    #[arg(skip)]
+    pub open_telemetry_deprecated: bool,
 }
 
 pub async fn run(args: Args) -> Result<()> {
     let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());
-
-    if args.open_telemetry_bind_address.is_some() {
-        tracing::warn!(
-            "`--open-telemetry` is deprecated and has no effect; it will be removed in a future version"
-        );
-    }
 
     let spicepod_path = args
         .spicepod
@@ -279,6 +263,12 @@ pub async fn run(args: Args) -> Result<()> {
     )
     .await
     .context(UnableToInitializeTracingSnafu)?;
+
+    if args.open_telemetry_deprecated {
+        tracing::warn!(
+            "`--open_telemetry` is deprecated and has no effect; it will be removed in a future version"
+        );
+    }
 
     // Log spicepod load error now that tracing is initialized
     if let Some(err) = spicepod_load_error {

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -59,7 +59,7 @@ const fn get_allocator_name() -> Option<&'static str> {
 fn main() {
     let matches = spiced::Args::command().get_matches();
     let open_telemetry_deprecated =
-        matches.value_source("open_telemetry") == Some(ValueSource::CommandLine);
+        matches.value_source("open_telemetry_bind_address") == Some(ValueSource::CommandLine);
     let mut args = spiced::Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
     args.open_telemetry_deprecated = open_telemetry_deprecated;
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use clap::Parser;
+use clap::parser::ValueSource;
+use clap::{CommandFactory, FromArgMatches};
 use opentelemetry::global;
 use rustls::crypto::{self, CryptoProvider};
 use telemetry::noop::NoopMeterProvider;
@@ -56,7 +57,11 @@ const fn get_allocator_name() -> Option<&'static str> {
 }
 
 fn main() {
-    let args = spiced::Args::parse();
+    let matches = spiced::Args::command().get_matches();
+    let open_telemetry_deprecated =
+        matches.value_source("open_telemetry") == Some(ValueSource::CommandLine);
+    let mut args = spiced::Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+    args.open_telemetry_deprecated = open_telemetry_deprecated;
 
     if args.version {
         println!("{}", get_version_string());

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -40,14 +40,6 @@ pub struct Config {
     )]
     pub flight_bind_address: SocketAddr,
 
-    #[arg(
-        long = "open_telemetry",
-        value_name = "OPEN_TELEMETRY_BIND_ADDRESS",
-        default_value = "127.0.0.1:50052",
-        action
-    )]
-    pub open_telemetry_bind_address: SocketAddr,
-
     /// All cluster related arguments
     #[cfg(feature = "cluster")]
     #[clap(flatten)]
@@ -66,7 +58,6 @@ impl Config {
         Self {
             http_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8090),
             flight_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051),
-            open_telemetry_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50052),
             #[cfg(feature = "cluster")]
             cluster: ClusterConfig::default(),
         }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -40,6 +40,14 @@ pub struct Config {
     )]
     pub flight_bind_address: SocketAddr,
 
+    #[arg(
+        long = "open_telemetry",
+        value_name = "OPEN_TELEMETRY_BIND_ADDRESS",
+        default_value = "127.0.0.1:50052",
+        action
+    )]
+    pub open_telemetry_bind_address: SocketAddr,
+
     /// All cluster related arguments
     #[cfg(feature = "cluster")]
     #[clap(flatten)]
@@ -58,6 +66,7 @@ impl Config {
         Self {
             http_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8090),
             flight_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051),
+            open_telemetry_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50052),
             #[cfg(feature = "cluster")]
             cluster: ClusterConfig::default(),
         }


### PR DESCRIPTION
## Summary
- add deprecated `--open_telemetry` flag to spiced for backward compatibility
- log a warning when the flag is provided
- accept legacy flag aliases to avoid helm/chart breakage
