### PR TITLE
Serialize acceleration snapshots with refresh writes

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -180,7 +180,7 @@ impl CacheRefreshHelper {
         accelerator: Arc<dyn TableProvider>,
         dataset_name: &str,
         ttl: Duration,
-        accelerator_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> DataFusionResult<usize> {
         let ctx = SessionContext::new();
         let state = ctx.state();
@@ -238,7 +238,7 @@ impl CacheRefreshHelper {
             let federated = Arc::clone(&federated);
             let accelerator = Arc::clone(&accelerator);
             let dataset_name = dataset_name.to_string();
-            let accelerator_mutex = Arc::clone(&accelerator_mutex);
+            let accelerator_write_mutex = Arc::clone(&accelerator_write_mutex);
 
             async move {
                 tracing::debug!(
@@ -257,7 +257,7 @@ impl CacheRefreshHelper {
                 let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
                 // Acquire the mutex to protect accelerator operations
-                let lock_guard = accelerator_mutex.lock().await;
+                let lock_guard = accelerator_write_mutex.lock().await;
 
                 // Upsert this specific cache entry - removes rows matching the filters
                 // and adds the new data, preserving other cache entries.
@@ -712,7 +712,7 @@ impl CacheRefreshHelper {
     ///   when the upstream source returns an error instead of propagating the error.
     /// * `expired_batches` - The expired cached data to serve if `stale_if_error` is enabled and
     ///   the source returns an error.
-    /// * `accelerator_mutex` - Mutex to protect concurrent access to the accelerator.
+    /// * `accelerator_write_mutex` - Mutex to protect concurrent access to the accelerator.
     /// * `synchronized_children` - Child accelerators that should also receive the cached data.
     #[expect(clippy::too_many_arguments)]
     async fn handle_cache_miss(
@@ -725,7 +725,7 @@ impl CacheRefreshHelper {
         is_expired: bool,
         stale_if_error: bool,
         expired_batches: Option<Vec<RecordBatch>>,
-        accelerator_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
         synchronized_children: SynchronizedChildren,
     ) -> SendableRecordBatchStream {
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
@@ -739,7 +739,7 @@ impl CacheRefreshHelper {
                 );
 
                 // Acquire the mutex to protect accelerator operations
-                let lock_guard = accelerator_mutex.lock().await;
+                let lock_guard = accelerator_write_mutex.lock().await;
 
                 // Store in accelerator for future queries
                 let store_result = if is_expired {
@@ -843,7 +843,7 @@ impl CacheRefreshHelper {
         stale_while_revalidate: Option<Duration>,
         io_runtime: &Handle,
         schema: SchemaRef,
-        accelerator_mutex: &Arc<Mutex<()>>,
+        accelerator_write_mutex: &Arc<Mutex<()>>,
         filters: &[Expr],
         in_flight_revalidations: &InFlightRevalidations,
     ) -> SendableRecordBatchStream {
@@ -904,7 +904,7 @@ impl CacheRefreshHelper {
                         let federated_clone = Arc::clone(federated);
                         let accelerator_clone = Arc::clone(accelerator);
                         let dataset_name_clone = dataset_name.to_string();
-                        let accelerator_mutex_clone = Arc::clone(accelerator_mutex);
+                        let accelerator_write_mutex_clone = Arc::clone(accelerator_write_mutex);
                         let in_flight_clone = Arc::clone(in_flight_revalidations);
 
                         io_runtime.spawn(async move {
@@ -916,7 +916,7 @@ impl CacheRefreshHelper {
                                 accelerator_clone,
                                 &dataset_name_clone,
                                 max_age,
-                                accelerator_mutex_clone,
+                                accelerator_write_mutex_clone,
                             )
                             .await;
 
@@ -978,7 +978,7 @@ pub struct CachingAccelerationScanExec {
     projection: Option<Vec<usize>>,
     limit: Option<usize>,
     /// Mutex to protect concurrent access to the accelerator during cache operations
-    accelerator_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     /// Tracks in-flight revalidation requests to avoid duplicate upstream requests during SWR window
     in_flight_revalidations: InFlightRevalidations,
     /// Child accelerators that should receive cached data when this parent stores new cache entries
@@ -999,7 +999,7 @@ impl CachingAccelerationScanExec {
         filters: Vec<Expr>,
         projection: Option<Vec<usize>>,
         limit: Option<usize>,
-        accelerator_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
         in_flight_revalidations: InFlightRevalidations,
         synchronized_children: SynchronizedChildren,
     ) -> Self {
@@ -1025,7 +1025,7 @@ impl CachingAccelerationScanExec {
             filters,
             projection,
             limit,
-            accelerator_mutex,
+            accelerator_write_mutex,
             in_flight_revalidations,
             synchronized_children,
         }
@@ -1085,7 +1085,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
             self.filters.clone(),
             self.projection.clone(),
             self.limit,
-            Arc::clone(&self.accelerator_mutex),
+            Arc::clone(&self.accelerator_write_mutex),
             Arc::clone(&self.in_flight_revalidations),
             Arc::clone(&self.synchronized_children),
         )))
@@ -1115,7 +1115,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         let stale_while_revalidate = self.stale_while_revalidate;
         let stale_if_error = self.stale_if_error;
         let io_runtime = self.io_runtime.clone();
-        let accelerator_mutex = Arc::clone(&self.accelerator_mutex);
+        let accelerator_write_mutex = Arc::clone(&self.accelerator_write_mutex);
         let in_flight_revalidations = Arc::clone(&self.in_flight_revalidations);
         let synchronized_children = Arc::clone(&self.synchronized_children);
 
@@ -1185,7 +1185,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             true, // is_expired = true, will upsert
                             stale_if_error,
                             expired_batches,
-                            Arc::clone(&accelerator_mutex),
+                            Arc::clone(&accelerator_write_mutex),
                             Arc::clone(&synchronized_children),
                         )
                         .await;
@@ -1202,7 +1202,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     stale_while_revalidate,
                     &io_runtime,
                     Arc::clone(&schema_clone),
-                    &accelerator_mutex,
+                    &accelerator_write_mutex,
                     &filters,
                     &in_flight_revalidations,
                 )
@@ -1222,7 +1222,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     false, // is_expired = false, will insert (append)
                     false, // stale_if_error = false, no expired data to fall back to
                     None,  // no expired batches
-                    accelerator_mutex,
+                    accelerator_write_mutex,
                     synchronized_children,
                 )
                 .await

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -977,7 +977,7 @@ pub struct CachingAccelerationScanExec {
     filters: Vec<Expr>,
     projection: Option<Vec<usize>>,
     limit: Option<usize>,
-    /// Mutex to protect concurrent access to the accelerator during cache operations
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations
     accelerator_write_mutex: Arc<Mutex<()>>,
     /// Tracks in-flight revalidation requests to avoid duplicate upstream requests during SWR window
     in_flight_revalidations: InFlightRevalidations,

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -232,7 +232,7 @@ pub struct AcceleratedTable {
     cache_stale_if_error: bool,
     io_runtime: Handle,
     /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator
-    cache_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     /// Tracks in-flight revalidation requests to avoid duplicate upstream requests during SWR window
     in_flight_revalidations: caching::InFlightRevalidations,
 }
@@ -603,8 +603,8 @@ impl Builder {
         validate_refresh_data_window(&self.refresh, &self.dataset_name, &self.federated.schema());
         let refresh_mode = self.refresh.mode;
         let refresh_params = Arc::new(RwLock::new(self.refresh));
-        // Create the cache mutex early so it can be shared between the Refresher and the AcceleratedTable.
-        let cache_mutex: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+        // Create the accelerator write mutex early so it can be shared between the Refresher and the AcceleratedTable.
+        let accelerator_write_mutex: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
         // Create the in-flight revalidations tracker to avoid duplicate upstream requests during SWR window.
         let in_flight_revalidations: caching::InFlightRevalidations =
             Arc::new(Mutex::new(std::collections::HashSet::new()));
@@ -617,7 +617,7 @@ impl Builder {
             Arc::clone(&self.accelerator),
             self.cpu_runtime.clone(),
             self.io_runtime.clone(),
-            Arc::clone(&cache_mutex),
+            Arc::clone(&accelerator_write_mutex),
         );
         refresher.caching(&self.caching);
         refresher.checkpointer(self.checkpointer);
@@ -736,7 +736,7 @@ impl Builder {
             cache_stale_while_revalidate_ttl: self.caching_stale_while_revalidate_ttl,
             cache_stale_if_error: self.caching_stale_if_error,
             io_runtime: self.io_runtime,
-            cache_mutex,
+            accelerator_write_mutex,
             in_flight_revalidations,
         })
     }
@@ -987,7 +987,7 @@ impl TableProvider for AcceleratedTable {
                     filters.to_vec(),
                     projection.cloned(),
                     limit,
-                    Arc::clone(&self.cache_mutex),
+                    Arc::clone(&self.accelerator_write_mutex),
                     Arc::clone(&self.in_flight_revalidations),
                     Arc::clone(&self.synchronized_children),
                 ))

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -231,7 +231,7 @@ pub struct AcceleratedTable {
     cache_stale_while_revalidate_ttl: Option<Duration>,
     cache_stale_if_error: bool,
     io_runtime: Handle,
-    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations
     accelerator_write_mutex: Arc<Mutex<()>>,
     /// Tracks in-flight revalidation requests to avoid duplicate upstream requests during SWR window
     in_flight_revalidations: caching::InFlightRevalidations,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -481,7 +481,7 @@ pub struct Refresher {
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
     /// Shared with `CachingAccelerationScanExec`.
-    cache_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -507,7 +507,7 @@ impl Refresher {
         accelerator: Arc<dyn TableProvider>,
         cpu_runtime: Option<Handle>,
         io_runtime: Handle,
-        cache_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -534,7 +534,7 @@ impl Refresher {
             cpu_runtime,
             io_runtime,
             resource_monitor: None,
-            cache_mutex,
+            accelerator_write_mutex,
         }
     }
 
@@ -702,7 +702,7 @@ impl Refresher {
                     self.snapshots_create_interval,
                     checkpointer.clone(),
                     snapshot_manager.clone(),
-                    Arc::clone(&self.cache_mutex),
+                    Arc::clone(&self.accelerator_write_mutex),
                     dataset_name.clone(),
                     Arc::clone(&federated_schema),
                 );
@@ -719,7 +719,7 @@ impl Refresher {
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
             self.io_runtime.clone(),
-            Arc::clone(&self.cache_mutex),
+            Arc::clone(&self.accelerator_write_mutex),
         )
         .with_disable_federation(self.disable_federation);
 
@@ -747,7 +747,7 @@ impl Refresher {
         let caching = self.caching.clone();
         let refresh_check_interval = self.refresh.read().await.check_interval;
         let max_jitter = self.refresh.read().await.max_jitter;
-        let snapshot_mutex = Arc::clone(&self.cache_mutex);
+        let snapshot_mutex = Arc::clone(&self.accelerator_write_mutex);
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
 
@@ -756,7 +756,7 @@ impl Refresher {
             self.snapshots_create_interval,
             checkpointer.clone(),
             snapshot_manager.clone(),
-            Arc::clone(&self.cache_mutex),
+            Arc::clone(&self.accelerator_write_mutex),
             dataset_name.clone(),
             Arc::clone(&federated_schema),
         );
@@ -895,13 +895,13 @@ impl Refresher {
         snapshot_manager: Option<Arc<SnapshotManager>>,
     ) -> tokio::task::JoinHandle<()> {
         let checkpointer = self.checkpointer.clone();
-        let accelerator_mutex = Arc::clone(&self.cache_mutex);
+        let accelerator_write_mutex = Arc::clone(&self.accelerator_write_mutex);
 
         let on_batch_process_callback = create_periodic_snapshot_callback(
             self.snapshots_trigger_threshold,
             checkpointer,
             snapshot_manager,
-            accelerator_mutex,
+            accelerator_write_mutex,
             &self.dataset_name,
             self.federated.schema(),
         );
@@ -914,7 +914,7 @@ impl Refresher {
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
                 self.io_runtime.clone(),
-                Arc::clone(&self.cache_mutex),
+                Arc::clone(&self.accelerator_write_mutex),
             )
             .with_disable_federation(self.disable_federation)
             .with_cpu_runtime(self.cpu_runtime.clone())
@@ -952,7 +952,7 @@ fn spawn_snapshot_interval_task(
     snapshots_create_interval: Option<Duration>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     snapshot_manager: Option<Arc<SnapshotManager>>,
-    accelerator_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     dataset_name: TableReference,
     federated_schema: Arc<Schema>,
 ) -> Option<tokio::task::JoinHandle<()>> {
@@ -982,7 +982,7 @@ fn spawn_snapshot_interval_task(
         }
 
         loop {
-            let _lock_guard = accelerator_mutex.lock().await;
+            let _lock_guard = accelerator_write_mutex.lock().await;
             if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
                 tracing::warn!("Failed to checkpoint dataset {dataset_name}: {e}");
             } else if let Err(e) = snapshot_manager.create_snapshot(&federated_schema).await {
@@ -1002,7 +1002,7 @@ fn create_periodic_snapshot_callback(
     snapshots_trigger_threshold: Option<i64>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     snapshot_manager: Option<Arc<SnapshotManager>>,
-    accelerator_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     dataset_name: &TableReference,
     federated_schema: Arc<Schema>,
 ) -> Option<SnapshotCallback> {
@@ -1022,7 +1022,7 @@ fn create_periodic_snapshot_callback(
             let callback = Arc::new(Mutex::new(Box::new(move || {
                 let checkpointer = Arc::clone(&checkpointer);
                 let snapshot_manager = Arc::clone(&snapshot_manager);
-                let accelerator_mutex = Arc::clone(&accelerator_mutex);
+                let accelerator_write_mutex = Arc::clone(&accelerator_write_mutex);
                 let batches_processed = Arc::clone(&batches_processed);
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
@@ -1036,7 +1036,7 @@ fn create_periodic_snapshot_callback(
 
                         tracing::debug!("Creating snapshot for changes stream: {}", dataset_name);
 
-                        let _lock_guard = accelerator_mutex.lock().await;
+                        let _lock_guard = accelerator_write_mutex.lock().await;
                         if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
                             tracing::warn!("Failed to checkpoint dataset {dataset_name}: {e}");
                             return;

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -444,7 +444,7 @@ impl Default for Refresh {
     }
 }
 
-pub(crate) enum AccelerationRefreshMode {
+pub enum AccelerationRefreshMode {
     Disabled,
     Full(Receiver<Option<RefreshOverrides>>),
     Append(Receiver<Option<RefreshOverrides>>),
@@ -498,7 +498,7 @@ impl std::fmt::Debug for Refresher {
 
 impl Refresher {
     #[expect(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
         federated: Arc<FederatedTable>,
@@ -635,7 +635,7 @@ impl Refresher {
         }
     }
 
-    pub(crate) async fn start(
+    pub async fn start(
         &mut self,
         acceleration_refresh_mode: AccelerationRefreshMode,
     ) -> super::Result<Option<tokio::task::JoinHandle<()>>> {
@@ -702,6 +702,7 @@ impl Refresher {
                     self.snapshots_create_interval,
                     checkpointer.clone(),
                     snapshot_manager.clone(),
+                    Arc::clone(&self.cache_mutex),
                     dataset_name.clone(),
                     Arc::clone(&federated_schema),
                 );
@@ -746,6 +747,7 @@ impl Refresher {
         let caching = self.caching.clone();
         let refresh_check_interval = self.refresh.read().await.check_interval;
         let max_jitter = self.refresh.read().await.max_jitter;
+        let snapshot_mutex = Arc::clone(&self.cache_mutex);
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
 
@@ -754,6 +756,7 @@ impl Refresher {
             self.snapshots_create_interval,
             checkpointer.clone(),
             snapshot_manager.clone(),
+            Arc::clone(&self.cache_mutex),
             dataset_name.clone(),
             Arc::clone(&federated_schema),
         );
@@ -817,7 +820,11 @@ impl Refresher {
                             }
 
                             if let Some(checkpointer) = &checkpointer {
-                                match (checkpointer.checkpoint(&federated_schema).await, snapshot_manager.as_ref()) {
+                                let _lock_guard = snapshot_mutex.lock().await;
+                                match (
+                                    checkpointer.checkpoint(&federated_schema).await,
+                                    snapshot_manager.as_ref(),
+                                ) {
                                     (Ok(()), Some(snapshot_manager)) => {
                                         if let Err(e) = snapshot_manager
                                             .create_snapshot(&federated_schema)
@@ -888,11 +895,13 @@ impl Refresher {
         snapshot_manager: Option<Arc<SnapshotManager>>,
     ) -> tokio::task::JoinHandle<()> {
         let checkpointer = self.checkpointer.clone();
+        let accelerator_mutex = Arc::clone(&self.cache_mutex);
 
         let on_batch_process_callback = create_periodic_snapshot_callback(
             self.snapshots_trigger_threshold,
             checkpointer,
             snapshot_manager,
+            accelerator_mutex,
             &self.dataset_name,
             self.federated.schema(),
         );
@@ -943,6 +952,7 @@ fn spawn_snapshot_interval_task(
     snapshots_create_interval: Option<Duration>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     snapshot_manager: Option<Arc<SnapshotManager>>,
+    accelerator_mutex: Arc<Mutex<()>>,
     dataset_name: TableReference,
     federated_schema: Arc<Schema>,
 ) -> Option<tokio::task::JoinHandle<()>> {
@@ -972,6 +982,7 @@ fn spawn_snapshot_interval_task(
         }
 
         loop {
+            let _lock_guard = accelerator_mutex.lock().await;
             if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
                 tracing::warn!("Failed to checkpoint dataset {dataset_name}: {e}");
             } else if let Err(e) = snapshot_manager.create_snapshot(&federated_schema).await {
@@ -991,6 +1002,7 @@ fn create_periodic_snapshot_callback(
     snapshots_trigger_threshold: Option<i64>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     snapshot_manager: Option<Arc<SnapshotManager>>,
+    accelerator_mutex: Arc<Mutex<()>>,
     dataset_name: &TableReference,
     federated_schema: Arc<Schema>,
 ) -> Option<SnapshotCallback> {
@@ -1010,6 +1022,7 @@ fn create_periodic_snapshot_callback(
             let callback = Arc::new(Mutex::new(Box::new(move || {
                 let checkpointer = Arc::clone(&checkpointer);
                 let snapshot_manager = Arc::clone(&snapshot_manager);
+                let accelerator_mutex = Arc::clone(&accelerator_mutex);
                 let batches_processed = Arc::clone(&batches_processed);
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
@@ -1023,6 +1036,7 @@ fn create_periodic_snapshot_callback(
 
                         tracing::debug!("Creating snapshot for changes stream: {}", dataset_name);
 
+                        let _lock_guard = accelerator_mutex.lock().await;
                         if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
                             tracing::warn!("Failed to checkpoint dataset {dataset_name}: {e}");
                             return;

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -479,7 +479,7 @@ pub struct Refresher {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
-    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations
     /// Shared with `CachingAccelerationScanExec`.
     accelerator_write_mutex: Arc<Mutex<()>>,
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -117,7 +117,7 @@ pub struct RefreshTaskBuilder {
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     /// Mutex to protect concurrent access to the accelerator during cache operations.
-    accelerator_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
 }
 
@@ -130,7 +130,7 @@ impl RefreshTaskBuilder {
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
-        accelerator_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -144,7 +144,7 @@ impl RefreshTaskBuilder {
             cpu_runtime: None,
             io_runtime,
             resource_monitor: None,
-            accelerator_mutex,
+            accelerator_write_mutex,
             on_stream_batch_process_callback: None,
         }
     }
@@ -238,7 +238,7 @@ impl RefreshTaskBuilder {
             cpu_runtime: self.cpu_runtime,
             io_runtime: self.io_runtime,
             resource_monitor: self.resource_monitor,
-            accelerator_mutex: self.accelerator_mutex,
+            accelerator_write_mutex: self.accelerator_write_mutex,
             on_stream_batch_process_callback: self.on_stream_batch_process_callback,
         }
     }
@@ -259,7 +259,7 @@ pub struct RefreshTask {
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     /// Mutex to protect concurrent access to the accelerator during cache operations.
-    accelerator_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
 }
 
@@ -291,7 +291,7 @@ impl RefreshTask {
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
-        accelerator_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> RefreshTaskBuilder {
         RefreshTaskBuilder::new(
             runtime_status,
@@ -300,7 +300,7 @@ impl RefreshTask {
             federated_source,
             accelerator,
             io_runtime,
-            accelerator_mutex,
+            accelerator_write_mutex,
         )
     }
 
@@ -706,7 +706,7 @@ impl RefreshTask {
         let sink_lock = self.sink.read().await;
         let sink = &*sink_lock;
 
-        let _lock_guard = self.accelerator_mutex.lock().await;
+        let _lock_guard = self.accelerator_write_mutex.lock().await;
         if let Err(e) = sink.insert_into(record_batch_stream, overwrite).await {
             self.set_refresh_status(sql, status::ComponentStatus::Error)
                 .await;
@@ -825,7 +825,7 @@ impl RefreshTask {
             Arc::clone(&self.accelerator),
             self.dataset_name.to_string().as_str(),
             ttl,
-            Arc::clone(&self.accelerator_mutex),
+            Arc::clone(&self.accelerator_write_mutex),
         )
         .await
         .map_err(|e| RetryError::permanent(super::Error::FailedToRefreshDataset { source: e }))?;

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -116,7 +116,7 @@ pub struct RefreshTaskBuilder {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
-    /// Mutex to protect concurrent access to the accelerator during cache operations.
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
 }
@@ -258,7 +258,7 @@ pub struct RefreshTask {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
-    /// Mutex to protect concurrent access to the accelerator during cache operations.
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -706,6 +706,7 @@ impl RefreshTask {
         let sink_lock = self.sink.read().await;
         let sink = &*sink_lock;
 
+        let _lock_guard = self.accelerator_mutex.lock().await;
         if let Err(e) = sink.insert_into(record_batch_stream, overwrite).await {
             self.set_refresh_status(sql, status::ComponentStatus::Error)
                 .await;

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -239,7 +239,7 @@ impl RefreshTask {
             Box::pin(stream::once(async move { Ok(selected_batch) })),
         ));
 
-        let _lock_guard = self.accelerator_mutex.lock().await;
+        let _lock_guard = self.accelerator_write_mutex.lock().await;
         let insert_plan = self
             .accelerator
             .insert_into(
@@ -286,7 +286,7 @@ impl RefreshTask {
             all_where_exprs.extend(delete_where_exprs);
         }
 
-        let _lock_guard = self.accelerator_mutex.lock().await;
+        let _lock_guard = self.accelerator_write_mutex.lock().await;
         let delete_plan = deletion_provider
             .delete_from(&session_state, &all_where_exprs)
             .await

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -239,6 +239,7 @@ impl RefreshTask {
             Box::pin(stream::once(async move { Ok(selected_batch) })),
         ));
 
+        let _lock_guard = self.accelerator_mutex.lock().await;
         let insert_plan = self
             .accelerator
             .insert_into(
@@ -249,7 +250,6 @@ impl RefreshTask {
             .await
             .map_err(find_datafusion_root)
             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
-
         collect(insert_plan, ctx.task_ctx())
             .await
             .map_err(find_datafusion_root)
@@ -286,12 +286,12 @@ impl RefreshTask {
             all_where_exprs.extend(delete_where_exprs);
         }
 
+        let _lock_guard = self.accelerator_mutex.lock().await;
         let delete_plan = deletion_provider
             .delete_from(&session_state, &all_where_exprs)
             .await
             .map_err(find_datafusion_root)
             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
-
         collect(delete_plan, ctx.task_ctx())
             .await
             .map_err(find_datafusion_root)

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -54,7 +54,7 @@ pub struct RefreshTaskRunnerBuilder {
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
     /// Shared with `CachingAccelerationScanExec`.
-    cache_mutex: Arc<Mutex<()>>,
+    accelerator_write_mutex: Arc<Mutex<()>>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -68,7 +68,7 @@ impl RefreshTaskRunnerBuilder {
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
-        cache_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_status,
@@ -83,7 +83,7 @@ impl RefreshTaskRunnerBuilder {
             cpu_runtime: None,
             io_runtime,
             resource_monitor: None,
-            cache_mutex,
+            accelerator_write_mutex,
         }
     }
 
@@ -130,7 +130,7 @@ impl RefreshTaskRunnerBuilder {
             self.federated_source,
             self.accelerator,
             self.io_runtime,
-            self.cache_mutex,
+            self.accelerator_write_mutex,
         )
         .with_disable_federation(self.disable_federation)
         .with_metrics(self.metrics);
@@ -184,7 +184,7 @@ impl RefreshTaskRunner {
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
         io_runtime: Handle,
-        cache_mutex: Arc<Mutex<()>>,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> RefreshTaskRunnerBuilder {
         RefreshTaskRunnerBuilder::new(
             runtime_status,
@@ -194,7 +194,7 @@ impl RefreshTaskRunner {
             refresh,
             accelerator,
             io_runtime,
-            cache_mutex,
+            accelerator_write_mutex,
         )
     }
 

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -52,7 +52,7 @@ pub struct RefreshTaskRunnerBuilder {
     cpu_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
-    /// Mutex to protect concurrent cache operations (insert, upsert) to the accelerator.
+    /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     /// Shared with `CachingAccelerationScanExec`.
     accelerator_write_mutex: Arc<Mutex<()>>,
 }

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -43,6 +43,8 @@ mod query_push_down;
 mod refresh;
 #[cfg(feature = "duckdb")]
 mod single_instance_duckdb;
+#[cfg(feature = "snapshots")]
+mod snapshot_mutex;
 
 pub(crate) fn get_params(mode: &Mode, file: Option<String>, engine: &str) -> Option<Params> {
     let param_name = format!("{engine}_file",);

--- a/crates/runtime/tests/acceleration/snapshot_mutex.rs
+++ b/crates/runtime/tests/acceleration/snapshot_mutex.rs
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use data_components::arrow::write::MemTable;
+use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
+use runtime::Runtime;
+use runtime::accelerated_table::refresh::{AccelerationRefreshMode, Refresh, Refresher};
+use runtime::component::dataset::acceleration::RefreshMode;
+use runtime::federated_table::FederatedTable;
+use runtime::status;
+use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
+use runtime_acceleration::snapshot::SnapshotBehavior as RuntimeSnapshotBehavior;
+use spicepod::component::snapshot::Snapshots;
+use tokio::sync::{Mutex, RwLock, mpsc};
+
+use crate::init_tracing;
+
+struct MockCheckpointer;
+
+#[async_trait]
+impl DatasetCheckpointer for MockCheckpointer {
+    async fn exists(&self) -> bool {
+        true
+    }
+
+    async fn checkpoint(
+        &self,
+        _schema: &arrow::datatypes::SchemaRef,
+    ) -> runtime_acceleration::dataset_checkpoint::Result<()> {
+        Ok(())
+    }
+
+    async fn get_schema(
+        &self,
+    ) -> runtime_acceleration::dataset_checkpoint::Result<Option<arrow::datatypes::SchemaRef>> {
+        Ok(None)
+    }
+
+    async fn last_checkpoint_time(
+        &self,
+    ) -> runtime_acceleration::dataset_checkpoint::Result<Option<SystemTime>> {
+        Ok(None)
+    }
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}_{nanos}"))
+}
+
+async fn count_files(root: &Path) -> anyhow::Result<usize> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut count = 0usize;
+
+    while let Some(dir) = pending.pop() {
+        let Ok(mut entries) = tokio::fs::read_dir(&dir).await else {
+            continue;
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                pending.push(path);
+            } else {
+                count += 1;
+            }
+        }
+    }
+
+    Ok(count)
+}
+
+#[tokio::test]
+async fn test_snapshot_interval_serializes_with_accelerator_writes() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let temp_root = unique_temp_dir("snapshot_mutex");
+    let snapshot_dir = temp_root.join("snapshots");
+    let local_snapshot_file = temp_root.join("acceleration.db");
+
+    tokio::fs::create_dir_all(&snapshot_dir).await?;
+    tokio::fs::write(&local_snapshot_file, b"snapshot-data").await?;
+
+    let snapshots = Snapshots {
+        enabled: true,
+        location: Some(format!("file://{}", snapshot_dir.display())),
+        ..Snapshots::default()
+    };
+
+    let runtime = Runtime::builder().build().await;
+    let snapshot_behavior = RuntimeSnapshotBehavior::create_only(
+        Arc::new(snapshots),
+        runtime.secrets_weak(),
+        runtime.tokio_io_runtime(),
+    );
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int32Array::from(vec![1]))],
+    )?;
+
+    let mem_table: Arc<dyn TableProvider> =
+        Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![batch]])?);
+    let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&mem_table)));
+    let accelerator_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int32Array::from(vec![1]))],
+    )?;
+    let accelerator: Arc<dyn TableProvider> =
+        Arc::new(MemTable::try_new(schema, vec![vec![accelerator_batch]])?);
+
+    let refresh = Refresh::new(RefreshMode::Full);
+    let cache_mutex = Arc::new(Mutex::new(()));
+
+    let mut refresher = Refresher::new(
+        status::RuntimeStatus::new(),
+        TableReference::bare("snapshot_mutex_test"),
+        federated,
+        Some("mem_table".to_string()),
+        Arc::new(RwLock::new(refresh)),
+        accelerator,
+        None,
+        runtime.tokio_io_runtime(),
+        Arc::clone(&cache_mutex),
+    );
+
+    refresher.checkpointer(Some(Arc::new(MockCheckpointer)));
+    refresher.with_snapshot_behavior(
+        snapshot_behavior,
+        Some(local_snapshot_file.clone()),
+        None,
+        Some(Duration::from_millis(200)),
+    );
+
+    let (_start_refresh, on_start_refresh) = mpsc::channel(1);
+    let refresh_handle = refresher
+        .start(AccelerationRefreshMode::Full(on_start_refresh))
+        .await?;
+
+    let lock_guard = cache_mutex.lock().await;
+    tokio::time::sleep(Duration::from_millis(450)).await;
+
+    let locked_count = count_files(&snapshot_dir).await?;
+    assert_eq!(
+        locked_count, 0,
+        "Snapshots should not be created while the accelerator mutex is held."
+    );
+    drop(lock_guard);
+
+    let snapshot_wait = tokio::time::timeout(Duration::from_secs(3), async move {
+        loop {
+            if count_files(&snapshot_dir).await? > 0 {
+                return Ok::<(), anyhow::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    snapshot_wait.map_err(|_| anyhow::anyhow!("Timed out waiting for snapshot creation"))??;
+
+    if let Some(handle) = refresh_handle {
+        handle.abort();
+    }
+    drop(refresher);
+
+    tokio::fs::remove_dir_all(&temp_root).await?;
+
+    Ok(())
+}

--- a/crates/runtime/tests/acceleration/snapshot_mutex.rs
+++ b/crates/runtime/tests/acceleration/snapshot_mutex.rs
@@ -139,7 +139,7 @@ async fn test_snapshot_interval_serializes_with_accelerator_writes() -> anyhow::
         Arc::new(MemTable::try_new(schema, vec![vec![accelerator_batch]])?);
 
     let refresh = Refresh::new(RefreshMode::Full);
-    let cache_mutex = Arc::new(Mutex::new(()));
+    let accelerator_write_mutex = Arc::new(Mutex::new(()));
 
     let mut refresher = Refresher::new(
         status::RuntimeStatus::new(),
@@ -150,7 +150,7 @@ async fn test_snapshot_interval_serializes_with_accelerator_writes() -> anyhow::
         accelerator,
         None,
         runtime.tokio_io_runtime(),
-        Arc::clone(&cache_mutex),
+        Arc::clone(&accelerator_write_mutex),
     );
 
     refresher.checkpointer(Some(Arc::new(MockCheckpointer)));
@@ -166,7 +166,7 @@ async fn test_snapshot_interval_serializes_with_accelerator_writes() -> anyhow::
         .start(AccelerationRefreshMode::Full(on_start_refresh))
         .await?;
 
-    let lock_guard = cache_mutex.lock().await;
+    let lock_guard = accelerator_write_mutex.lock().await;
     tokio::time::sleep(Duration::from_millis(450)).await;
 
     let locked_count = count_files(&snapshot_dir).await?;


### PR DESCRIPTION
## Summary
- serialize snapshot creation with accelerator writes using the shared mutex - this prevents a potential race condition brought up by @krinart where the acceleration could be written to in between the checkpoint and the snapshot creation.
- add an integration test that asserts snapshots wait on the mutex
