### PR TITLE
Fixes for search integration test CI

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -4,6 +4,10 @@ inputs:
   token:
     description: 'GitHub token with permissions to push to the repository'
     required: true
+  title:
+    description: 'Title for the PR created in this action'
+    required: false
+    default: 'fix: Update test snapshots'
 runs:
   using: 'composite'
   steps:
@@ -47,7 +51,7 @@ runs:
             echo "PR already exists -> ${PR_URL}"
             exit 0
           else
-            gh pr create --title "fix: Update test snapshots" --body "Updates some test snapshots" --base trunk --head ${BRANCH_NAME} --label kind/bug
+            gh pr create --title "${{ inputs.title }}" --body "Updates some test snapshots" --base trunk --head ${BRANCH_NAME} --label kind/bug
           fi
         fi
       env:

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -40,10 +40,6 @@ jobs:
         with:
           os: 'darwin'
 
-      - name: Install Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
       - name: Set up API Keys
         run: |
           echo 'SPICE_OPENAI_API_KEY="${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}"' > .env
@@ -59,7 +55,7 @@ jobs:
             echo "Error: OpenAI API key is not defined."
             exit 1
           fi
-          cargo nextest run --test integration_models -p runtime --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
+          cargo insta test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
 
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule'

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -55,7 +55,7 @@ jobs:
             echo "Error: OpenAI API key is not defined."
             exit 1
           fi
-          cargo insta test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
+          cargo test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
 
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule'

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -69,3 +69,4 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          title: 'fix: Update Search integration test snapshots'

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -55,7 +55,14 @@ jobs:
             echo "Error: OpenAI API key is not defined."
             exit 1
           fi
-          cargo test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
+          cargo test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search || {
+            if [ "$INSTA_UPDATE" == "always" ]; then
+              echo "Warning: Tests failed but INSTA_UPDATE is enabled. Continuing."
+              exit 0
+            else
+              exit 1
+            fi
+          }
 
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule'


### PR DESCRIPTION
## 📝 Summary
 - Fix `integration tests (search)` so that when snapshots are updated, we don't fail before we upload snapshots changes. 
 - Also improve PR title for `push-snap-changes` action.