### PR TITLE
fix: Use a GitHub rate controller per auth context

### DIFF
--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -62,7 +62,7 @@ use std::num::NonZeroU32;
 use std::sync::LazyLock;
 use std::{any::Any, future::Future, pin::Pin, str::FromStr, sync::Arc, time::Duration};
 use token_provider::{StaticTokenProvider, TokenProvider};
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::{Mutex, RwLock, Semaphore};
 use url::Url;
 
 use super::{
@@ -83,7 +83,20 @@ mod workflows;
 static GITHUB_CONCURRENCY_LIMITS: LazyLock<Mutex<HashMap<String, Arc<Semaphore>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-static GLOBAL_GITHUB_RATE_CONTROLLER: LazyLock<Arc<RateController>> = LazyLock::new(|| {
+static GITHUB_AUTH_CONTEXT_RATE_CONTROLLERS: LazyLock<
+    RwLock<HashMap<String, Arc<RateController>>>,
+> = LazyLock::new(|| RwLock::new(HashMap::new()));
+static UNAUTHENTICATED_AUTH_CONTEXT: &str = "unauthenticated";
+
+async fn get_github_auth_context_rate_controller(auth_context: String) -> Arc<RateController> {
+    let rate_controllers = GITHUB_AUTH_CONTEXT_RATE_CONTROLLERS.read().await;
+    if let Some(controller) = rate_controllers.get(&auth_context) {
+        return Arc::clone(controller);
+    }
+
+    drop(rate_controllers);
+    let mut rate_controllers = GITHUB_AUTH_CONTEXT_RATE_CONTROLLERS.write().await;
+
     // GitHub secondary rate limit for GraphQL is 2000 points per minute
     let Some(secondary_quota_per_minute) = NonZeroU32::new(2000) else {
         unreachable!("2000 is non-zero");
@@ -102,8 +115,11 @@ static GLOBAL_GITHUB_RATE_CONTROLLER: LazyLock<Arc<RateController>> = LazyLock::
             Duration::from_millis(10),
         ));
 
-    rate_controller.build()
-});
+    let controller = rate_controller.build();
+    rate_controllers.insert(auth_context.clone(), Arc::clone(&controller));
+
+    controller
+}
 
 const GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 10;
 
@@ -325,7 +341,7 @@ impl Github {
         }
     }
 
-    pub(crate) fn create_graphql_client(
+    pub(crate) async fn create_graphql_client(
         &self,
         tbl: &Arc<dyn GitHubTableArgs>,
     ) -> std::result::Result<GraphQLClient, Box<dyn std::error::Error + Send + Sync>> {
@@ -337,6 +353,13 @@ impl Github {
             .token
             .as_ref()
             .map(|token| Arc::clone(token) as Arc<dyn TokenProvider>);
+
+        let auth_context = token.as_ref().map_or_else(
+            || UNAUTHENTICATED_AUTH_CONTEXT.to_string(),
+            |t| t.dyn_hash(),
+        );
+
+        let rate_controller = get_github_auth_context_rate_controller(auth_context).await;
 
         let client = default_spice_client("application/json").boxed()?;
 
@@ -351,7 +374,7 @@ impl Github {
         .with_schema(gql_client_params.schema)
         .with_rate_limiter(Some(Arc::clone(&self.rate_limiter) as Arc<dyn RateLimiter>))
         .with_semaphore(Some(Arc::clone(&self.semaphore)))
-        .with_rate_controller(Some(Arc::clone(&GLOBAL_GITHUB_RATE_CONTROLLER)))
+        .with_rate_controller(Some(rate_controller))
         .build(client)
         .boxed()
     }
@@ -384,7 +407,7 @@ impl Github {
         context: Option<Arc<dyn GraphQLContext>>,
         health_check_query_string: String,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        let client = self.create_graphql_client(&table_args).context(
+        let client = self.create_graphql_client(&table_args).await.context(
             super::UnableToGetReadProviderSnafu {
                 dataconnector: "github".to_string(),
                 connector_component: table_args.get_component(),

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -18,6 +18,8 @@ limitations under the License.
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use snafu::prelude::*;
+use std::hash::Hasher;
+use std::hash::{DefaultHasher, Hash};
 use std::time::Duration;
 use std::{fmt, sync::Arc};
 use token_provider::{Result, TokenProvider};
@@ -47,6 +49,13 @@ pub struct DatabricksM2MTokenProvider {
     rx: watch::Receiver<SecretString>,
 
     _handle: Arc<JoinHandle<()>>,
+}
+
+impl Hash for DatabricksM2MTokenProvider {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.endpoint.hash(state);
+        self.client_id.hash(state);
+    }
 }
 
 impl fmt::Debug for DatabricksM2MTokenProvider {
@@ -139,6 +148,12 @@ impl DatabricksM2MTokenProvider {
 impl TokenProvider for DatabricksM2MTokenProvider {
     fn get_token(&self) -> String {
         self.rx.borrow().expose_secret().to_string()
+    }
+
+    fn dyn_hash(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish().to_string()
     }
 
     fn subscribe(&self) -> Option<watch::Receiver<String>> {
@@ -239,6 +254,13 @@ pub struct DatabricksU2MTokenProvider {
     client_id: String,
 }
 
+impl Hash for DatabricksU2MTokenProvider {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.endpoint.hash(state);
+        self.client_id.hash(state);
+    }
+}
+
 impl fmt::Debug for DatabricksU2MTokenProvider {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DatabricksU2MTokenProvider")
@@ -272,6 +294,12 @@ impl TokenProvider for DatabricksU2MTokenProvider {
         }
 
         String::new()
+    }
+
+    fn dyn_hash(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish().to_string()
     }
 }
 

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -18,8 +18,7 @@ limitations under the License.
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use snafu::prelude::*;
-use std::hash::Hasher;
-use std::hash::{DefaultHasher, Hash};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 use std::{fmt, sync::Arc};
 use token_provider::{Result, TokenProvider};

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -78,8 +78,8 @@ pub struct GitHubAppTokenProvider {
 
 impl Hash for GitHubAppTokenProvider {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Only hash non-sensitive identifiers; do not include the private key.
         self.app_client_id.hash(state);
-        self.private_key.hash(state);
         self.installation_id.hash(state);
     }
 }

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -17,6 +17,7 @@ limitations under the License.
 
 use std::{
     fmt,
+    hash::DefaultHasher,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -26,6 +27,8 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
+use std::hash::Hash;
+use std::hash::Hasher;
 use token_provider::{Result, TokenProvider};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -73,6 +76,14 @@ pub struct GitHubAppTokenProvider {
     _handle: Arc<JoinHandle<()>>,
 }
 
+impl Hash for GitHubAppTokenProvider {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.app_client_id.hash(state);
+        self.private_key.hash(state);
+        self.installation_id.hash(state);
+    }
+}
+
 impl std::fmt::Debug for GitHubAppTokenProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GitHubAppTokenProvider")
@@ -86,6 +97,12 @@ impl std::fmt::Debug for GitHubAppTokenProvider {
 impl TokenProvider for GitHubAppTokenProvider {
     fn get_token(&self) -> String {
         self.rx.borrow().expose_secret().to_string()
+    }
+
+    fn dyn_hash(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish().to_string()
     }
 
     fn subscribe(&self) -> Option<watch::Receiver<String>> {

--- a/crates/token_provider/src/lib.rs
+++ b/crates/token_provider/src/lib.rs
@@ -39,7 +39,7 @@ pub trait TokenProvider: Send + Sync + Debug {
     /// Returns a hash representing the configuration of this token provider.
     /// Token providers with the same configuration should return the same hash.
     ///
-    /// This is used instead of implenting Hash directly on the trait object, as Hash is not dyn-compatible.
+    /// This is used instead of implementing Hash directly on the trait object, as Hash is not dyn-compatible.
     fn dyn_hash(&self) -> String;
 
     /// Returns a `watch::Receiver` of new tokens, if the provider supports refresh.

--- a/crates/token_provider/src/lib.rs
+++ b/crates/token_provider/src/lib.rs
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 use std::sync::Arc;
-use std::{fmt::Debug, hash::{DefaultHasher, Hash, Hasher}};
+use std::{
+    fmt::Debug,
+    hash::{DefaultHasher, Hash, Hasher},
+};
 
 use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;

--- a/crates/token_provider/src/lib.rs
+++ b/crates/token_provider/src/lib.rs
@@ -15,12 +15,10 @@ limitations under the License.
 */
 
 use std::sync::Arc;
-use std::{fmt::Debug, hash::DefaultHasher};
+use std::{fmt::Debug, hash::{DefaultHasher, Hash, Hasher}};
 
 use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
-use std::hash::Hash;
-use std::hash::Hasher;
 use tokio::sync::watch;
 
 pub mod registry;

--- a/crates/token_provider/src/lib.rs
+++ b/crates/token_provider/src/lib.rs
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::fmt::Debug;
 use std::sync::Arc;
+use std::{fmt::Debug, hash::DefaultHasher};
 
 use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
+use std::hash::Hash;
+use std::hash::Hasher;
 use tokio::sync::watch;
 
 pub mod registry;
@@ -36,6 +38,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub trait TokenProvider: Send + Sync + Debug {
     fn get_token(&self) -> String;
 
+    /// Returns a hash representing the configuration of this token provider.
+    /// Token providers with the same configuration should return the same hash.
+    ///
+    /// This is used instead of implenting Hash directly on the trait object, as Hash is not dyn-compatible.
+    fn dyn_hash(&self) -> String;
+
     /// Returns a `watch::Receiver` of new tokens, if the provider supports refresh.
     ///
     /// The default implementation gives no updates.
@@ -46,6 +54,12 @@ pub trait TokenProvider: Send + Sync + Debug {
 
 pub struct StaticTokenProvider {
     token: Arc<SecretString>,
+}
+
+impl Hash for StaticTokenProvider {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.token.expose_secret().hash(state);
+    }
 }
 
 impl std::fmt::Debug for StaticTokenProvider {
@@ -68,5 +82,11 @@ impl StaticTokenProvider {
 impl TokenProvider for StaticTokenProvider {
     fn get_token(&self) -> String {
         self.token.expose_secret().to_string()
+    }
+
+    fn dyn_hash(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish().to_string()
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Builds a GitHub rate controller for each auth context (e.g. static token, app/installation instance, etc)
* Adds a simple `dyn_hash` method on `TokenProvider` as `Hash` is not dyn-compatible
