### PR TITLE
Proper batch commit for kafka/debezium

### DIFF
--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::kafka::MessageBatchCommitter;
 use crate::{
     cdc::{self, ChangeEnvelope, ChangesStream},
     debezium::{
@@ -99,6 +100,7 @@ impl DebeziumKafka {
     pub fn stream_changes(&self) -> ChangesStream {
         let schema = Arc::clone(&self.schema);
         let primary_keys = self.primary_keys.clone();
+        let consumer = self.consumer;
         let stream = self
             .consumer
             .stream_json::<ChangeEventKey, ChangeEvent>()
@@ -124,11 +126,9 @@ impl DebeziumKafka {
                 let rb = changes::vector_to_change_batch(&schema, &pk, &changes)
                     .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))?;
 
-                let Some(last_msg) = messages.pop() else {
-                    unreachable!("checked non-empty above");
-                };
+                let committer = MessageBatchCommitter::from_messages(consumer, &messages);
 
-                Ok(ChangeEnvelope::new(Box::new(last_msg), rb, true))
+                Ok(ChangeEnvelope::new(Box::new(committer), rb, true))
             });
 
         Box::pin(stream)

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -113,7 +113,7 @@ impl DebeziumKafka {
                     return Err(cdc::StreamError::Kafka(Error::EmptyBatch));
                 }
 
-                let mut messages: Vec<_> = msgs
+                let messages: Vec<_> = msgs
                     .into_iter()
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(cdc::StreamError::Kafka)?;

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -311,6 +311,12 @@ impl KafkaConsumer {
         })
     }
 
+    pub fn store_offset(&self, topic: &str, partition: i32, offset: i64) -> Result<()> {
+        self.consumer
+            .store_offset(topic, partition, offset)
+            .context(UnableToCommitMessageSnafu)
+    }
+
     pub fn restart_topic(&self, topic: &str) -> Result<()> {
         let mut assignment = self
             .consumer
@@ -599,7 +605,7 @@ impl Kafka {
                 let schema = Arc::clone(&schema);
 
                 // Collect all successful messages, fail on first error
-                let mut messages: Vec<_> = msgs
+                let messages: Vec<_> = msgs
                     .into_iter()
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(cdc::StreamError::Kafka)?;

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -35,6 +35,7 @@ use rdkafka::{
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use snafu::prelude::*;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use std::{any::Any, sync::Arc};
@@ -368,6 +369,8 @@ impl KafkaConsumer {
     }
 
     fn create(group_id: String, kafka_config: &KafkaConfig) -> Result<Self> {
+        tracing::debug!("Using kafka group_id: {}", group_id);
+
         let (_, version) = get_rdkafka_version();
         tracing::debug!("rd_kafka_version: {}", version);
 
@@ -470,6 +473,18 @@ impl<'a, K, V> KafkaMessage<'a, K, V> {
         &self.value
     }
 
+    pub fn topic(&self) -> &str {
+        self.msg.topic()
+    }
+
+    pub fn partition(&self) -> i32 {
+        self.msg.partition()
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.msg.offset()
+    }
+
     pub fn mark_processed(&self) -> Result<()> {
         self.consumer
             .store_offset_from_message(&self.msg)
@@ -482,6 +497,51 @@ impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
         self.mark_processed()
             .boxed()
             .map_err(|e| cdc::CommitError::UnableToCommitChange { source: e })?;
+        Ok(())
+    }
+}
+
+pub struct MessageBatchCommitter {
+    consumer: &'static KafkaConsumer,
+    offsets: Vec<(String, i32, i64)>,
+}
+
+impl MessageBatchCommitter {
+    pub fn from_messages<K, V>(
+        consumer: &'static KafkaConsumer,
+        messages: &[KafkaMessage<'_, K, V>],
+    ) -> Self {
+        let mut max_offsets: HashMap<(String, i32), i64> = HashMap::new();
+
+        for msg in messages {
+            let key = (msg.topic().to_string(), msg.partition());
+            max_offsets
+                .entry(key)
+                .and_modify(|existing| {
+                    if msg.offset() > *existing {
+                        *existing = msg.offset();
+                    }
+                })
+                .or_insert(msg.offset());
+        }
+
+        let offsets = max_offsets
+            .into_iter()
+            .map(|((topic, partition), offset)| (topic, partition, offset))
+            .collect();
+
+        Self { consumer, offsets }
+    }
+}
+
+impl CommitChange for MessageBatchCommitter {
+    fn commit(&self) -> Result<(), CommitError> {
+        for (topic, partition, offset) in &self.offsets {
+            self.consumer
+                .store_offset(topic, *partition, *offset)
+                .boxed()
+                .map_err(|e| CommitError::UnableToCommitChange { source: e })?;
+        }
         Ok(())
     }
 }
@@ -530,6 +590,7 @@ impl Kafka {
     pub fn stream_changes(&self) -> ChangesStream {
         let schema = Arc::clone(&self.schema);
         let flatten_json = self.flatten_json.clone();
+        let consumer = self.consumer;
         let stream = self
             .consumer
             .stream_json::<serde_json::Value, serde_json::Value>()
@@ -553,12 +614,9 @@ impl Kafka {
                     &schema,
                 );
 
-                // Take the last message for the envelope
-                let Some(last_msg) = messages.pop() else {
-                    unreachable!("checked non-empty above");
-                };
+                let committer = MessageBatchCommitter::from_messages(consumer, &messages);
 
-                change_batch.map(|rb| ChangeEnvelope::new(Box::new(last_msg), rb, true))
+                change_batch.map(|rb| ChangeEnvelope::new(Box::new(committer), rb, true))
             });
 
         Box::pin(stream)


### PR DESCRIPTION
## 📝 Summary

The initial implementation of batching for kafka/debezium had a bug where we would only commit last message from batch, which ignores the fact that batch may contain messages from different partitions.

Now we collect all partitions/offsets from batch and properly commit them.