### PR TITLE
Remove `spicepod-validator` cargo build from `build-dev` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ build: build-cli build-runtime
 build-dev:
 	export DEV=true; make -C bin/spice
 	export DEV=true; make -C bin/spiced
-	cargo build --profile dev -p spicepod-validator
 
 .PHONY: ci
 ci:


### PR DESCRIPTION
Remove cargo build command from build-dev target. This is never used and slows down all builds. 
