### PR TITLE
Overwrite branch name in 'push-snap-changes' as input parameter

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Title for the PR created in this action'
     required: false
     default: 'fix: Update test snapshots'
+  branch:
+    description: 'Branch name to push changes to. If not provided, generates a unique branch name.'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -30,20 +34,31 @@ runs:
     - name: Upload benchmark snapshots to branch
       shell: bash
       run: |
-        BRANCH_ID=${{ github.run_id }}
-        BRANCH_NAME="snapshot-update/${BRANCH_ID}"
+        if [[ -n "${{ inputs.branch }}" ]]; then
+          BRANCH_NAME="${{ inputs.branch }}"
+        else
+          BRANCH_ID=${{ github.run_id }}
+          BRANCH_NAME="snapshot-update/${BRANCH_ID}"
+        fi
 
         git config --global user.name 'Spice Snapshot Update Bot'
         git config --global user.email 'spiceaibot@spice.ai'
-        git checkout -b ${BRANCH_NAME}
+        
+        if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
+          echo "Branch ${BRANCH_NAME} already exists, checking it out"
+          git fetch origin ${BRANCH_NAME}
+          git checkout ${BRANCH_NAME}
+          git pull origin ${BRANCH_NAME}
+        else
+          echo "Creating new branch ${BRANCH_NAME}"
+          git checkout -b ${BRANCH_NAME}
+        fi
+        
         git add '*.snap'
         if git diff --cached --quiet; then
           echo "No changes to commit"
         else
           git commit -m "fix: Update the test snapshots"
-          if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
-            git pull --rebase origin ${BRANCH_NAME}
-          fi
           git push origin ${BRANCH_NAME}
 
           PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -155,6 +155,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-ai-udf:
     name: Test AI UDF
@@ -244,6 +245,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-hf:
     name: Test Huggingface Models
@@ -292,6 +294,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-local:
     name: Test Local Models
@@ -334,6 +337,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-bedrock:
     name: Test Bedrock Models
@@ -368,6 +372,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-workers:
     name: Test Workers
@@ -408,6 +413,7 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}
 
   test-search:
     name: Test Search
@@ -450,3 +456,4 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -70,3 +70,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: 'fix: Update Search integration test snapshots'
+          branch: ${{ github.event_name == 'schedule' && 'snapshot-update/search-integration' || (github.ref_name != 'trunk' && github.ref_name || '') }}


### PR DESCRIPTION
## 📝 Summary
- Several GH actions use `push-snap-changes` to publish snapshot changes when run at cron intervals. Currently,  consecutive runs make separate PRs, even if a previous run's PR remains open. 
- This PR enables updating the current open PR with any new snapshots changes.