### PR TITLE
Make cluster mTLS optional with insecure flag

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -63,9 +63,6 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity
 use url::Url;
 use uuid::Uuid;
 
-type SchedulerEndpointOverride =
-    Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
-
 pub mod datafusion;
 mod servers;
 mod service;
@@ -166,7 +163,7 @@ impl ResolvedClusterConfig {
             if tls_config.is_none() && !config.insecure_node {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode without mTLS requires --insecure-node. Specify all of: --node-mtls-ca-certificate-file, --node-mtls-certificate-file, --node-mtls-key-file or pass --insecure-node",
+                    "Cluster mode requires mTLS configuration unless --insecure-node is specified. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure-node to skip mTLS.",
                 ));
             }
             if config.node_advertise_address.is_none() {
@@ -344,11 +341,11 @@ pub async fn initialize_cluster_executor(
     let scheduler_endpoint = if let Some(tls_config) = client_tls_config.clone() {
         scheduler_endpoint
             .tls_config(tls_config)
-            .boxed()
             .context(FailedToStartClusterExecutorSnafu)?
     } else {
         scheduler_endpoint
     };
+    let scheduler_endpoint = scheduler_endpoint.boxed();
 
     let scheduler_connection =
         scheduler_endpoint
@@ -501,6 +498,9 @@ pub async fn initialize_cluster_executor(
 async fn create_scheduler_server(
     rt: &Arc<Runtime>,
 ) -> crate::Result<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>> {
+    type SchedulerEndpointOverride =
+        Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
+
     let bind_addr = rt.df.cluster_config.node_bind_address();
 
     // Bind Spice Datafusion configuration incl SpiceQueryPlanner as bound in `DataFusionBuilder`
@@ -574,9 +574,11 @@ async fn create_cluster_service_client(
     if let Some(tls_config) = client_tls_config {
         endpoint = endpoint
             .tls_config(tls_config)
-            .boxed()
             .context(FailedToStartClusterExecutorSnafu)?;
     }
+    let endpoint = endpoint
+        .boxed()
+        .context(FailedToStartClusterExecutorSnafu)?;
 
     let channel = endpoint
         .connect()

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -63,6 +63,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity
 use url::Url;
 use uuid::Uuid;
 
+type SchedulerEndpointOverride =
+    Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
+
 pub mod datafusion;
 mod servers;
 mod service;
@@ -163,7 +166,7 @@ impl ResolvedClusterConfig {
             if tls_config.is_none() && !config.insecure {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires mTLS configuration unless --insecure is specified. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure to skip mTLS.",
+                    "Cluster mode requires mTLS configuration or the --insecure flag. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure.",
                 ));
             }
             if config.node_advertise_address.is_none() {
@@ -499,9 +502,6 @@ pub async fn initialize_cluster_executor(
 async fn create_scheduler_server(
     rt: &Arc<Runtime>,
 ) -> crate::Result<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>> {
-    type SchedulerEndpointOverride =
-        Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
-
     let bind_addr = rt.df.cluster_config.node_bind_address();
 
     // Bind Spice Datafusion configuration incl SpiceQueryPlanner as bound in `DataFusionBuilder`

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -341,11 +341,12 @@ pub async fn initialize_cluster_executor(
     let scheduler_endpoint = if let Some(tls_config) = client_tls_config.clone() {
         scheduler_endpoint
             .tls_config(tls_config)
-            .context(FailedToStartClusterExecutorSnafu)?
+            .map_err(|e| FailedToStartClusterExecutor {
+                source: Box::new(e),
+            })?
     } else {
         scheduler_endpoint
     };
-    let scheduler_endpoint = scheduler_endpoint.boxed();
 
     let scheduler_connection =
         scheduler_endpoint
@@ -574,11 +575,10 @@ async fn create_cluster_service_client(
     if let Some(tls_config) = client_tls_config {
         endpoint = endpoint
             .tls_config(tls_config)
-            .context(FailedToStartClusterExecutorSnafu)?;
+            .map_err(|e| FailedToStartClusterExecutor {
+                source: Box::new(e),
+            })?;
     }
-    let endpoint = endpoint
-        .boxed()
-        .context(FailedToStartClusterExecutorSnafu)?;
 
     let channel = endpoint
         .connect()

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -63,6 +63,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity
 use url::Url;
 use uuid::Uuid;
 
+type SchedulerEndpointOverride =
+    Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
+
 pub mod datafusion;
 mod servers;
 mod service;
@@ -120,7 +123,7 @@ impl ClusterTlsConfig {
 #[derive(Debug, Default)]
 pub struct ResolvedClusterConfig {
     config: ClusterConfig,
-    /// Cached cluster TLS config for mTLS (required when cluster mode is enabled).
+    /// Cached cluster TLS config for mTLS when configured.
     tls_config: Option<ClusterTlsConfig>,
     /// Pre-computed scheduler URL string for Ballista configuration.
     scheduler_url: Option<String>,
@@ -137,7 +140,7 @@ impl ResolvedClusterConfig {
     /// - Cluster mode is set but advertise address is not specified
     /// - Certificate files cannot be read
     pub fn try_new(config: ClusterConfig) -> std::io::Result<Self> {
-        // Cluster mode requires mTLS - all certificate files must be specified
+        // Cluster mTLS configuration must be complete when provided
         let tls_config = match (
             &config.node_mtls_ca_certificate_file,
             &config.node_mtls_certificate_file,
@@ -160,10 +163,10 @@ impl ResolvedClusterConfig {
 
         // Validate cluster role requirements
         if is_cluster_role {
-            if tls_config.is_none() {
+            if tls_config.is_none() && !config.insecure_node {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires mTLS. Specify all of: --node-mtls-ca-certificate-file, --node-mtls-certificate-file, --node-mtls-key-file",
+                    "Cluster mode without mTLS requires --insecure-node. Specify all of: --node-mtls-ca-certificate-file, --node-mtls-certificate-file, --node-mtls-key-file or pass --insecure-node",
                 ));
             }
             if config.node_advertise_address.is_none() {
@@ -175,10 +178,15 @@ impl ResolvedClusterConfig {
         }
 
         // Pre-compute scheduler URL from advertise address
+        let scheme = if tls_config.is_some() {
+            "https"
+        } else {
+            "http"
+        };
         let scheduler_url = config
             .node_advertise_address
             .as_ref()
-            .map(|addr| format!("https://{addr}"));
+            .map(|addr| format!("{scheme}://{addr}"));
 
         Ok(Self {
             config,
@@ -242,6 +250,18 @@ impl ResolvedClusterConfig {
         self.tls_config.as_ref()
     }
 
+    /// Returns whether cluster mTLS is enabled.
+    #[must_use]
+    pub fn tls_enabled(&self) -> bool {
+        self.tls_config.is_some()
+    }
+
+    /// Returns whether this node allows insecure cluster communication.
+    #[must_use]
+    pub fn insecure_node(&self) -> bool {
+        self.config.insecure_node
+    }
+
     /// Returns the client TLS config for connecting to other cluster nodes.
     #[must_use]
     pub fn client_tls_config(&self) -> Option<&ClientTlsConfig> {
@@ -293,26 +313,23 @@ pub async fn initialize_cluster_executor(
         });
     };
 
-    // mTLS is required for cluster mode
-    let Some(client_tls_config) = rt.df.cluster_config.client_tls_config().cloned() else {
-        return Err(FailedToStartClusterExecutor {
-            source: "Cluster mode requires mTLS configuration"
-                .to_string()
-                .into(),
-        });
-    };
-
+    let client_tls_config = rt.df.cluster_config.client_tls_config().cloned();
+    let tls_enabled = client_tls_config.is_some();
     let config_producer_tls = client_tls_config.clone();
 
     // Configure mTLS for executor-to-executor gRPC connections (e.g., shuffle fetch)
     let config_producer: ConfigProducer = Arc::new(move || {
-        SessionConfig::new_with_ballista()
+        let mut config = SessionConfig::new_with_ballista()
             .with_option_extension(SpiceClusterConfig::default())
-            .with_ballista_use_tls(true)
-            .with_ballista_override_create_grpc_client_endpoint({
-                let tls_config = config_producer_tls.clone();
+            .with_ballista_use_tls(tls_enabled);
+
+        if let Some(tls_config) = config_producer_tls.clone() {
+            config = config.with_ballista_override_create_grpc_client_endpoint({
                 Arc::new(move |ep| ep.tls_config(tls_config.clone()).boxed())
-            })
+            });
+        }
+
+        config
     });
 
     let work_dir = rt
@@ -323,10 +340,15 @@ pub async fn initialize_cluster_executor(
 
     let scheduler_endpoint = create_grpc_client_endpoint(scheduler_url.to_string())
         .boxed()
-        .context(FailedToStartClusterExecutorSnafu)?
-        .tls_config(client_tls_config.clone())
-        .boxed()
         .context(FailedToStartClusterExecutorSnafu)?;
+    let scheduler_endpoint = if let Some(tls_config) = client_tls_config.clone() {
+        scheduler_endpoint
+            .tls_config(tls_config)
+            .boxed()
+            .context(FailedToStartClusterExecutorSnafu)?
+    } else {
+        scheduler_endpoint
+    };
 
     let scheduler_connection =
         scheduler_endpoint
@@ -485,12 +507,10 @@ async fn create_scheduler_server(
     let current_context = Arc::clone(&rt.df.ctx);
     let io_runtime = rt.tokio_io_runtime();
 
-    // mTLS is required for cluster mode
-    let Some(client_tls_config) = rt.df.cluster_config.client_tls_config().cloned() else {
-        return Err(FailedToStartClusterScheduler {
-            source: "Cluster mode requires mTLS configuration".into(),
-        });
-    };
+    let client_tls_config = rt.df.cluster_config.client_tls_config().cloned();
+    let override_create_grpc_client_endpoint: Option<SchedulerEndpointOverride> = client_tls_config
+        .clone()
+        .map(|tls_config| Arc::new(move |ep: Endpoint| ep.tls_config(tls_config.clone())) as _);
 
     let scheduler_config = SchedulerConfig {
         bind_host: bind_addr.ip().to_string(),
@@ -519,9 +539,7 @@ async fn create_scheduler_server(
                     .build(),
             )
         })),
-        override_create_grpc_client_endpoint: Some(Arc::new(move |ep| {
-            ep.tls_config(client_tls_config.clone())
-        })),
+        override_create_grpc_client_endpoint,
         ..Default::default()
     };
 
@@ -547,15 +565,18 @@ async fn create_scheduler_server(
 /// Creates a gRPC client for the scheduler's internal cluster service.
 async fn create_cluster_service_client(
     scheduler_url: &Url,
-    client_tls_config: ClientTlsConfig,
+    client_tls_config: Option<ClientTlsConfig>,
 ) -> crate::Result<ClusterServiceClient<Channel>> {
     let endpoint_url = scheduler_url.to_string();
-    let endpoint = Endpoint::from_shared(endpoint_url.clone())
-        .boxed()
-        .context(FailedToStartClusterExecutorSnafu)?
-        .tls_config(client_tls_config)
+    let mut endpoint = Endpoint::from_shared(endpoint_url.clone())
         .boxed()
         .context(FailedToStartClusterExecutorSnafu)?;
+    if let Some(tls_config) = client_tls_config {
+        endpoint = endpoint
+            .tls_config(tls_config)
+            .boxed()
+            .context(FailedToStartClusterExecutorSnafu)?;
+    }
 
     let channel = endpoint
         .connect()
@@ -606,7 +627,7 @@ impl runtime_secrets::ClusterSecretExpander for ClusterSecretExpanderImpl {
 async fn executor_bind_app(
     rt: &Arc<Runtime>,
     executor_id: String,
-    client_tls_config: ClientTlsConfig,
+    client_tls_config: Option<ClientTlsConfig>,
 ) -> crate::Result<()> {
     let Some(scheduler_url) = rt.df.cluster_config.scheduler_address() else {
         return Err(FailedToStartClusterExecutor {

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -160,10 +160,10 @@ impl ResolvedClusterConfig {
 
         // Validate cluster role requirements
         if is_cluster_role {
-            if tls_config.is_none() && !config.insecure_node {
+            if tls_config.is_none() && !config.insecure {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires mTLS configuration unless --insecure-node is specified. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure-node to skip mTLS.",
+                    "Cluster mode requires mTLS configuration unless --insecure is specified. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure to skip mTLS.",
                 ));
             }
             if config.node_advertise_address.is_none() {
@@ -255,8 +255,8 @@ impl ResolvedClusterConfig {
 
     /// Returns whether this node allows insecure cluster communication.
     #[must_use]
-    pub fn insecure_node(&self) -> bool {
-        self.config.insecure_node
+    pub fn insecure(&self) -> bool {
+        self.config.insecure
     }
 
     /// Returns the client TLS config for connecting to other cluster nodes.

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -75,10 +75,10 @@ pub async fn start_internal_cluster_server(
         tracing::info!("Cluster mTLS enabled for internal cluster server");
     } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires --insecure".to_string(),
+            message: "Cluster mode without mTLS requires the --insecure flag".to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for internal cluster server due to --insecure");
+        tracing::warn!("Cluster mTLS disabled for internal cluster server (--insecure flag is set)");
     }
 
     let scheduler_grpc_server = SchedulerGrpcServer::from_arc(scheduler)
@@ -132,10 +132,10 @@ pub async fn start_executor_flight_server(
         tracing::info!("Cluster mTLS enabled for executor flight server");
     } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires --insecure".to_string(),
+            message: "Cluster mode without mTLS requires the --insecure flag".to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for executor flight server due to --insecure");
+        tracing::warn!("Cluster mTLS disabled for executor flight server (--insecure flag is set)");
     }
 
     // Executor: serve only BallistaFlightService for receiving query fragments.

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -50,7 +50,6 @@ fn server_with_cluster_mtls(
 /// - `ClusterServiceServer`: Spice-specific RPCs (`GetAppDefinition`, `ExpandSecret`)
 ///
 /// This server should only be started when running in scheduler mode.
-/// mTLS is required and enforced, requiring client certificates.
 pub async fn start_internal_cluster_server(
     rt: Arc<Runtime>,
     shutdown_signal: Option<CancellationToken>,
@@ -67,17 +66,20 @@ pub async fn start_internal_cluster_server(
         return Err(Error::ClusterSchedulerNotInitialized {});
     };
 
-    // mTLS is required for cluster mode
-    let Some(tls_config) = rt.df.cluster_config.tls_config() else {
+    let tls_config = rt.df.cluster_config.tls_config();
+    let mut server = Server::builder();
+
+    if let Some(tls_config) = tls_config {
+        server = server_with_cluster_mtls(server, tls_config)
+            .map_err(|source| Error::UnableToConfigureTls { source })?;
+        tracing::info!("Cluster mTLS enabled for internal cluster server");
+    } else if !rt.df.cluster_config.insecure_node() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode requires mTLS configuration".to_string(),
+            message: "Cluster mode without mTLS requires --insecure-node".to_string(),
         });
-    };
-
-    let mut server = server_with_cluster_mtls(Server::builder(), tls_config)
-        .map_err(|source| Error::UnableToConfigureTls { source })?;
-
-    tracing::info!("Cluster mTLS enabled for internal cluster server");
+    } else {
+        tracing::warn!("Cluster mTLS disabled for internal cluster server due to --insecure-node");
+    }
 
     let scheduler_grpc_server = SchedulerGrpcServer::from_arc(scheduler)
         .max_decoding_message_size(usize::MAX)
@@ -115,23 +117,26 @@ pub async fn start_internal_cluster_server(
 
 /// Starts the executor Ballista Flight server used for receiving query fragments.
 ///
-/// mTLS is required and enforced, requiring client certificates.
+/// mTLS is optional when `--insecure-node` is used.
 pub async fn start_executor_flight_server(
     bind_address: std::net::SocketAddr,
     rt: Arc<Runtime>,
     shutdown_signal: Option<CancellationToken>,
 ) -> ClusterServerResult<()> {
-    // mTLS is required for cluster mode
-    let Some(tls_config) = rt.df.cluster_config.tls_config() else {
+    let tls_config = rt.df.cluster_config.tls_config();
+    let mut server = Server::builder();
+
+    if let Some(tls_config) = tls_config {
+        server = server_with_cluster_mtls(server, tls_config)
+            .map_err(|source| Error::UnableToConfigureTls { source })?;
+        tracing::info!("Cluster mTLS enabled for executor flight server");
+    } else if !rt.df.cluster_config.insecure_node() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode requires mTLS configuration".to_string(),
+            message: "Cluster mode without mTLS requires --insecure-node".to_string(),
         });
-    };
-
-    let mut server = server_with_cluster_mtls(Server::builder(), tls_config)
-        .map_err(|source| Error::UnableToConfigureTls { source })?;
-
-    tracing::info!("Cluster mTLS enabled for executor flight server");
+    } else {
+        tracing::warn!("Cluster mTLS disabled for executor flight server due to --insecure-node");
+    }
 
     // Executor: serve only BallistaFlightService for receiving query fragments.
     // No OTel service needed on executors.

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -78,7 +78,9 @@ pub async fn start_internal_cluster_server(
             message: "Cluster mode without mTLS requires the --insecure flag".to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for internal cluster server (--insecure flag is set)");
+        tracing::warn!(
+            "Cluster mTLS disabled for internal cluster server (--insecure flag is set)"
+        );
     }
 
     let scheduler_grpc_server = SchedulerGrpcServer::from_arc(scheduler)

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -73,12 +73,12 @@ pub async fn start_internal_cluster_server(
         server = server_with_cluster_mtls(server, tls_config)
             .map_err(|source| Error::UnableToConfigureTls { source })?;
         tracing::info!("Cluster mTLS enabled for internal cluster server");
-    } else if !rt.df.cluster_config.insecure_node() {
+    } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires --insecure-node".to_string(),
+            message: "Cluster mode without mTLS requires --insecure".to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for internal cluster server due to --insecure-node");
+        tracing::warn!("Cluster mTLS disabled for internal cluster server due to --insecure");
     }
 
     let scheduler_grpc_server = SchedulerGrpcServer::from_arc(scheduler)
@@ -117,7 +117,7 @@ pub async fn start_internal_cluster_server(
 
 /// Starts the executor Ballista Flight server used for receiving query fragments.
 ///
-/// mTLS is optional when `--insecure-node` is used.
+/// mTLS is optional when `--insecure` is used.
 pub async fn start_executor_flight_server(
     bind_address: std::net::SocketAddr,
     rt: Arc<Runtime>,
@@ -130,12 +130,12 @@ pub async fn start_executor_flight_server(
         server = server_with_cluster_mtls(server, tls_config)
             .map_err(|source| Error::UnableToConfigureTls { source })?;
         tracing::info!("Cluster mTLS enabled for executor flight server");
-    } else if !rt.df.cluster_config.insecure_node() {
+    } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires --insecure-node".to_string(),
+            message: "Cluster mode without mTLS requires --insecure".to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for executor flight server due to --insecure-node");
+        tracing::warn!("Cluster mTLS disabled for executor flight server due to --insecure");
     }
 
     // Executor: serve only BallistaFlightService for receiving query fragments.

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use clap::ValueEnum;
+use clap::{ArgAction, ValueEnum};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[cfg(feature = "cluster")]
@@ -117,6 +117,10 @@ pub struct ClusterConfig {
     #[arg(long = "node-mtls-key-file", value_name = "NODE_MTLS_KEY_FILE")]
     pub node_mtls_key_file: Option<String>,
 
+    /// Allow insecure cluster communication without mTLS.
+    #[arg(long = "insecure-node", default_value_t = false, action = ArgAction::SetTrue)]
+    pub insecure_node: bool,
+
     /// The URL of the scheduler service. Required for executors to join a cluster.
     /// If set, --role executor is implied and can be omitted.
     #[arg(long = "scheduler-address", value_name = "SCHEDULER_ADDRESS")]
@@ -138,6 +142,7 @@ impl Default for ClusterConfig {
             node_mtls_ca_certificate_file: None,
             node_mtls_certificate_file: None,
             node_mtls_key_file: None,
+            insecure_node: false,
             scheduler_address: None,
             node_advertise_address: None,
         }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -117,7 +117,7 @@ pub struct ClusterConfig {
     #[arg(long = "node-mtls-key-file", value_name = "NODE_MTLS_KEY_FILE")]
     pub node_mtls_key_file: Option<String>,
 
-    /// Allow insecure cluster communication without mTLS.
+    /// Allow insecure cluster communication without mTLS. WARNING: Only use this flag in development or testing environments and never in production.
     #[arg(long = "insecure", default_value_t = false, action = ArgAction::SetTrue)]
     pub insecure: bool,
 

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -118,8 +118,8 @@ pub struct ClusterConfig {
     pub node_mtls_key_file: Option<String>,
 
     /// Allow insecure cluster communication without mTLS.
-    #[arg(long = "insecure-node", default_value_t = false, action = ArgAction::SetTrue)]
-    pub insecure_node: bool,
+    #[arg(long = "insecure", default_value_t = false, action = ArgAction::SetTrue)]
+    pub insecure: bool,
 
     /// The URL of the scheduler service. Required for executors to join a cluster.
     /// If set, --role executor is implied and can be omitted.
@@ -142,7 +142,7 @@ impl Default for ClusterConfig {
             node_mtls_ca_certificate_file: None,
             node_mtls_certificate_file: None,
             node_mtls_key_file: None,
-            insecure_node: false,
+            insecure: false,
             scheduler_address: None,
             node_advertise_address: None,
         }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -182,27 +182,21 @@ impl Query {
             });
         };
 
-        // TLS is always required for cluster mode
-        let client_tls_config = self
-            .df
-            .cluster_config
-            .client_tls_config()
-            .cloned()
-            .ok_or_else(|| Error::UnableToExecuteQuery {
-                source: datafusion::error::DataFusionError::Configuration(
-                    "Cluster mode requires mTLS configuration".to_string(),
-                ),
-            })?;
+        let client_tls_config = self.df.cluster_config.client_tls_config().cloned();
+        let tls_enabled = client_tls_config.is_some();
 
-        let cfg = self
+        let mut cfg = self
             .df
             .ctx
             .copied_config()
             .with_ballista_logical_extension_codec(SpiceLogicalCodec::new_codec())
-            .with_ballista_override_create_grpc_client_endpoint(Arc::new(move |ep| {
-                ep.tls_config(client_tls_config.clone()).boxed()
-            }))
-            .with_ballista_use_tls(true);
+            .with_ballista_use_tls(tls_enabled);
+
+        if let Some(tls_config) = client_tls_config {
+            cfg = cfg.with_ballista_override_create_grpc_client_endpoint(Arc::new(move |ep| {
+                ep.tls_config(tls_config.clone()).boxed()
+            }));
+        }
 
         let query_planner: BallistaQueryPlanner<LogicalPlanNode> =
             BallistaQueryPlanner::with_local_planner(


### PR DESCRIPTION
Allow configuring distributed cluster mode without mTLS by passing `--insecure`

This makes it easier to configure clusters for dev/test scenarios.