### PR TITLE
Upgrade to Turso v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5650,7 +5650,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6128,7 +6128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6403,7 +6403,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8048,7 +8048,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8667,7 +8667,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10678,7 +10678,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12769,7 +12769,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14578,7 +14578,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14591,7 +14591,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15765,7 +15765,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -16235,7 +16235,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -18189,10 +18188,10 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.3.0"
-source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c670345a51c5df2ebb0a582c9af67dea98192c8fd82ca2c50aca34b342bf0c10"
 dependencies = [
- "mimalloc",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
@@ -18201,8 +18200,9 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.3.0"
-source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5a3044961c822886d08cbc94f5519524213b877f65fb66ab70133ed3c0a36d"
 dependencies = [
  "aegis",
  "aes 0.8.4",
@@ -18249,8 +18249,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.3.0"
-source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c744b2d657542911d6b1708f8aa2f047601cc0d452af8cd2d7f8fb1c05d40730"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -18259,8 +18260,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.3.0"
-source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4631f270381e6153833ab491b42fca3a1dbaad0f657a12ea1d676dec8f71e7b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18269,8 +18271,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.3.0"
-source = "git+https://github.com/spiceai/turso?rev=5c4d14d298869fe5ea296163b3241d6963a2e87d#5c4d14d298869fe5ea296163b3241d6963a2e87d"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64ae3d49b989ed156abe143ae0244d0f239f67fc42da72806369a567f295750"
 dependencies = [
  "bitflags 2.10.0",
  "miette",
@@ -19718,7 +19721,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ tracing = "0.1.43"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-turso = "0.3.0"
+turso = { version = "0.3.2", default-features = false, features = ["experimental_indexes"] }
 twox-hash = "2.1.2"
 url = "2.5"
 util = { path = "crates/util" }
@@ -381,9 +381,5 @@ arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "37d844b
 arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "37d844b382204821a5a5e082e1248edb7d35bdf0" } # spiceai-56
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "37d844b382204821a5a5e082e1248edb7d35bdf0" } # spiceai-56
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "37d844b382204821a5a5e082e1248edb7d35bdf0" }      # spiceai-56
-
-# Note: Turso's bindings/rust/src/lib.rs defines #[global_allocator] which conflicts with spiced's allocator
-# We need to fork and remove the global allocator or patch it out
-turso = { git = "https://github.com/spiceai/turso", rev = "5c4d14d298869fe5ea296163b3241d6963a2e87d" }
 
 object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "f0a772cd49d2ebb1f19f487ccd93d705f48dc891" }

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_data_filter.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_data_filter.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: value@2 > 500
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: value@2 > 500

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_range_filter.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_range_filter.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 >= 3 AND id@0 <= 7
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 >= 3 AND id@0 <= 7

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_with_filter.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_with_filter.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 > 5
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 > 5

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_with_filter.snap.new
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__bucket_partition_with_filter.snap.new
@@ -1,7 +1,8 @@
 ---
 source: crates/cayenne/tests/partition_pruning_test.rs
+assertion_line: 456
 expression: explain_plan
 ---
 CayenneAccelerationExec
   SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 > 3 AND value@2 < 700
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 > 5

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__data_filter_only.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__data_filter_only.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: value@2 > 400
+CayenneAccelerationExec
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: value@2 > 400
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__partition_and_data_filter.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__partition_and_data_filter.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-west-1 AND value@2 > 300
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-west-1 AND value@2 > 300

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_in_list.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_in_list.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-east-1 OR region@1 = eu-west-1
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-east-1 OR region@1 = eu-west-1

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_us_east_1.snap
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_us_east_1.snap
@@ -2,5 +2,6 @@
 source: crates/cayenne/tests/partition_pruning_test.rs
 expression: explain_plan
 ---
-SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-  DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-east-1
+CayenneAccelerationExec
+  SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-east-1

--- a/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_us_east_1.snap.new
+++ b/crates/cayenne/tests/snapshots/partition_pruning_test__partition_filter_us_east_1.snap.new
@@ -1,7 +1,8 @@
 ---
 source: crates/cayenne/tests/partition_pruning_test.rs
+assertion_line: 160
 expression: explain_plan
 ---
 CayenneAccelerationExec
   SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
-    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, name, value], file_type=vortex, predicate: id@0 > 3 AND value@2 < 700
+    DataSourceExec: file_groups={1 group: [[<TEMP_PATH>/<FILE>.vortex]]}, projection=[id, region, value], file_type=vortex, predicate: region@1 = us-east-1


### PR DESCRIPTION
This pull request updates the Turso dependency configuration and refreshes snapshot test outputs for partition pruning in the Cayenne engine. The most notable changes are the switch to a newer Turso crate version with specific features enabled, removal of a workaround for Turso's global allocator, and updated test snapshots reflecting the use of `CayenneAccelerationExec` in query plans.

**Dependency updates:**

* Updated the `turso` crate in `Cargo.toml` to version `0.3.2`, disabled default features, and enabled the `experimental_indexes` feature for more control and access to experimental functionality.
* Removed the previous Turso git dependency and related comments about allocator conflicts, indicating the issue is resolved or no longer relevant.

**Test snapshot updates (partition pruning):**

* Refreshed snapshot files for various partition pruning scenarios to include `CayenneAccelerationExec` nodes in the query plan, reflecting improvements or changes in query acceleration and execution. [[1]](diffhunk://#diff-3bd2b4633814c96714d894bc6b8b9d14299145ebaddf1f5004947d63b8ec2f7aR5) [[2]](diffhunk://#diff-4130726ec3dbb3cf1bbcd328e88af45c27f8c473c36afae47489775788b37befR5) [[3]](diffhunk://#diff-a3dd0cdc30190e23ee56a3f03fab1a0ef9192d42fc876e9369924e91b7ed0af8R5) [[4]](diffhunk://#diff-7c5655ab084ff164ebf2fd8eb081becaade752615e237d087a8a594bb2d68165R5) [[5]](diffhunk://#diff-da44a279129a167fa08361b8a6a934b1e3d0066d4e4e22d1dff1c8c5fe21ebbaL5-R7) [[6]](diffhunk://#diff-7300be43508e785de0c45817979aceb7ce1f6cd3f4b5ec22086ad00604679caaR5) [[7]](diffhunk://#diff-f031f03900ecf040afcc6f980bc2df0aab58f77cf9272273b6c8571043f6bf88R5) [[8]](diffhunk://#diff-8c30034422ae0a38a33ddaee1a1af5f69c11673095153849fd8fdaffcf50f579R5)
* Added new snapshot files for specific partition pruning tests, providing more granular assertions and documentation of query plan changes. [[1]](diffhunk://#diff-06179b96b3316dcae2178d04f97580f440d9c7d531a4821b7943fdf0da0c6ba0R1-R8) [[2]](diffhunk://#diff-1b12faa1ff737065d91689b77e60f9c0cc087b1b29e7b35c7b1add64fbf24e3eR1-R8)