### PR TITLE
cluster: validate --role argument

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -100,6 +100,10 @@ pub enum Error {
     #[snafu(display("Generic Error: {reason}"))]
     GenericError { reason: String },
 
+    #[cfg(feature = "cluster")]
+    #[snafu(display("Invalid cluster configuration: {source}"))]
+    InvalidClusterConfig { source: std::io::Error },
+
     #[snafu(display("Failed to apply the runtime overrides from `--set-runtime`. {reason}"))]
     FailedToApplyOverridesGeneric { reason: String },
 
@@ -248,8 +252,17 @@ pub async fn run(args: Args) -> Result<()> {
         .with_io_runtime(Handle::current());
 
     #[cfg(feature = "cluster")]
-    if let Ok(resolved_cluster_config) = resolved_cluster_config {
-        builder = builder.with_resolved_cluster_config(resolved_cluster_config);
+    match resolved_cluster_config {
+        Ok(resolved_cluster_config) => {
+            builder = builder.with_resolved_cluster_config(resolved_cluster_config);
+        }
+        Err(e) if args.runtime.cluster.role.is_some() => {
+            // If --role was explicitly specified, surface the configuration error
+            return Err(Error::InvalidClusterConfig { source: e });
+        }
+        Err(_) => {
+            // No explicit role specified, silently continue in standalone mode
+        }
     }
 
     if args.pods_watcher_enabled && args.spicepod.is_none() {


### PR DESCRIPTION
## 📝 Summary

When `spiced --role scheduler` is run without any other arguments, Spice starts up as if `--role` was not passed instead of returning a useful error that more arguments are required to enable cluster mode.

Now:

> ❯ spiced --role scheduler
2025-12-30T06:59:06.163159Z  INFO spiced: Starting runtime v1.11.0-unstable-build.7fe5b35ba+models
2025-12-30T06:59:06.163580Z ERROR spiced: Invalid cluster configuration: Cluster mode requires mTLS configuration or the --insecure flag. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure.