### PR TITLE
Rename --insecure to --allow-insecure-connections to be consistent with existing naming

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -163,10 +163,10 @@ impl ResolvedClusterConfig {
 
         // Validate cluster role requirements
         if is_cluster_role {
-            if tls_config.is_none() && !config.insecure {
+            if tls_config.is_none() && !config.allow_insecure_connections {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Cluster mode requires mTLS configuration or the --insecure flag. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --insecure.",
+                    "Cluster mode requires mTLS configuration or the --allow-insecure-connections flag. Provide --node-mtls-ca-certificate-file, --node-mtls-certificate-file, and --node-mtls-key-file, or use --allow-insecure-connections.",
                 ));
             }
             if config.node_advertise_address.is_none() {
@@ -259,7 +259,7 @@ impl ResolvedClusterConfig {
     /// Returns whether this node allows insecure cluster communication.
     #[must_use]
     pub fn insecure(&self) -> bool {
-        self.config.insecure
+        self.config.allow_insecure_connections
     }
 
     /// Returns the client TLS config for connecting to other cluster nodes.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -258,7 +258,7 @@ impl ResolvedClusterConfig {
 
     /// Returns whether this node allows insecure cluster communication.
     #[must_use]
-    pub fn insecure(&self) -> bool {
+    pub fn allow_insecure_connections(&self) -> bool {
         self.config.allow_insecure_connections
     }
 

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -75,11 +75,12 @@ pub async fn start_internal_cluster_server(
         tracing::info!("Cluster mTLS enabled for internal cluster server");
     } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires the --insecure flag".to_string(),
+            message: "Cluster mode without mTLS requires the --allow-insecure-connections flag"
+                .to_string(),
         });
     } else {
         tracing::warn!(
-            "Cluster mTLS disabled for internal cluster server (--insecure flag is set)"
+            "Cluster mTLS disabled for internal cluster server (--allow-insecure-connections flag is set)"
         );
     }
 
@@ -119,7 +120,7 @@ pub async fn start_internal_cluster_server(
 
 /// Starts the executor Ballista Flight server used for receiving query fragments.
 ///
-/// mTLS is optional when `--insecure` is used.
+/// mTLS is optional when `--allow-insecure-connections` is used.
 pub async fn start_executor_flight_server(
     bind_address: std::net::SocketAddr,
     rt: Arc<Runtime>,
@@ -134,10 +135,13 @@ pub async fn start_executor_flight_server(
         tracing::info!("Cluster mTLS enabled for executor flight server");
     } else if !rt.df.cluster_config.insecure() {
         return Err(Error::InsecureConfiguration {
-            message: "Cluster mode without mTLS requires the --insecure flag".to_string(),
+            message: "Cluster mode without mTLS requires the --allow-insecure-connections flag"
+                .to_string(),
         });
     } else {
-        tracing::warn!("Cluster mTLS disabled for executor flight server (--insecure flag is set)");
+        tracing::warn!(
+            "Cluster mTLS disabled for executor flight server (--allow-insecure-connections flag is set)"
+        );
     }
 
     // Executor: serve only BallistaFlightService for receiving query fragments.

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -73,7 +73,7 @@ pub async fn start_internal_cluster_server(
         server = server_with_cluster_mtls(server, tls_config)
             .map_err(|source| Error::UnableToConfigureTls { source })?;
         tracing::info!("Cluster mTLS enabled for internal cluster server");
-    } else if !rt.df.cluster_config.insecure() {
+    } else if !rt.df.cluster_config.allow_insecure_connections() {
         return Err(Error::InsecureConfiguration {
             message: "Cluster mode without mTLS requires the --allow-insecure-connections flag"
                 .to_string(),
@@ -133,7 +133,7 @@ pub async fn start_executor_flight_server(
         server = server_with_cluster_mtls(server, tls_config)
             .map_err(|source| Error::UnableToConfigureTls { source })?;
         tracing::info!("Cluster mTLS enabled for executor flight server");
-    } else if !rt.df.cluster_config.insecure() {
+    } else if !rt.df.cluster_config.allow_insecure_connections() {
         return Err(Error::InsecureConfiguration {
             message: "Cluster mode without mTLS requires the --allow-insecure-connections flag"
                 .to_string(),

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -118,8 +118,8 @@ pub struct ClusterConfig {
     pub node_mtls_key_file: Option<String>,
 
     /// Allow insecure cluster communication without mTLS. WARNING: Only use this flag in development or testing environments and never in production.
-    #[arg(long = "insecure", default_value_t = false, action = ArgAction::SetTrue)]
-    pub insecure: bool,
+    #[arg(long = "allow-insecure-connections", default_value_t = false, action = ArgAction::SetTrue)]
+    pub allow_insecure_connections: bool,
 
     /// The URL of the scheduler service. Required for executors to join a cluster.
     /// If set, --role executor is implied and can be omitted.
@@ -142,7 +142,7 @@ impl Default for ClusterConfig {
             node_mtls_ca_certificate_file: None,
             node_mtls_certificate_file: None,
             node_mtls_key_file: None,
-            insecure: false,
+            allow_insecure_connections: false,
             scheduler_address: None,
             node_advertise_address: None,
         }


### PR DESCRIPTION
This pull request updates the configuration and related logic for allowing insecure cluster communication by renaming the `--insecure` flag and its associated code references to `--allow-insecure-connections`. This change improves clarity and makes it explicit that insecure connections should only be used for development or testing. All related error messages, function names, and documentation are updated to reflect this new flag.

Configuration and CLI changes:

* Renamed the `insecure` field in the `ClusterConfig` struct to `allow_insecure_connections`, and updated the CLI flag from `--insecure` to `--allow-insecure-connections` for enabling insecure cluster communication.
* Updated the default implementation of `ClusterConfig` to set `allow_insecure_connections` instead of `insecure`.

Code and logic updates:

* Updated all logic in `ResolvedClusterConfig` and related server startup functions to use `allow_insecure_connections` instead of `insecure`, including method and variable names. [[1]](diffhunk://#diff-e1e370f29e5ce7149cc9537e6d7888599ae17e3a4332c9f3f1991a950d37bb30L166-R169) [[2]](diffhunk://#diff-e1e370f29e5ce7149cc9537e6d7888599ae17e3a4332c9f3f1991a950d37bb30L261-R262) [[3]](diffhunk://#diff-b36a6746c621869f9b2583ead3f0af9cc99a5a231ba6d83fa265ed9b7ef914deL76-R83) [[4]](diffhunk://#diff-b36a6746c621869f9b2583ead3f0af9cc99a5a231ba6d83fa265ed9b7ef914deL135-R144)
* Updated error messages and warnings throughout the codebase to reference `--allow-insecure-connections` instead of `--insecure`, making it clear which flag is required for insecure operation. [[1]](diffhunk://#diff-b36a6746c621869f9b2583ead3f0af9cc99a5a231ba6d83fa265ed9b7ef914deL76-R83) [[2]](diffhunk://#diff-b36a6746c621869f9b2583ead3f0af9cc99a5a231ba6d83fa265ed9b7ef914deL135-R144)

Documentation:

* Updated documentation comments to refer to `--allow-insecure-connections` instead of `--insecure`, clarifying the purpose and usage of the flag.