### PR TITLE
Increase GitHub rate limit buffer to 100 requests

### DIFF
--- a/crates/runtime/src/dataconnector/github/rate_limit.rs
+++ b/crates/runtime/src/dataconnector/github/rate_limit.rs
@@ -21,6 +21,8 @@ use reqwest::header::HeaderMap;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 
+const GITHUB_RATE_LIMIT_BUFFER: i32 = 100;
+
 #[derive(Debug)]
 pub struct GitHubRateLimiter {
     // Track API response headers rate limits
@@ -149,7 +151,7 @@ impl RateLimiter for GitHubRateLimiter {
                 }
                 RateLimitInfo::Primary(primary) => {
                     // GitHub GraphQL requests consume more than 1 rate-limit unit, so add some buffer to ensure the proper handling
-                    if primary.remaining <= 5 {
+                    if primary.remaining <= GITHUB_RATE_LIMIT_BUFFER {
                         let now = Utc::now();
                         if now < primary.reset_time {
                             let wait_duration = (primary.reset_time - now)


### PR DESCRIPTION
## 📝 Summary

Increase GitHub rate limit buffer from 5 to 100 remaining requests. 

Justification: Complex GraphQL requests used for pulls and issues with nested fields might consume more than 5 requests from the limit.