### PR TITLE
use 'max_message_size' in flight service too

### DIFF
--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -463,7 +463,7 @@ pub async fn start(
 
     let service = Service::new(endpoint_auth.flight_basic_auth.as_ref().map(Arc::clone));
 
-    let decoding_message_size = app
+    let flight_message_size = app
         .as_ref()
         .and_then(|a| a.runtime.flight.clone())
         .and_then(|f| f.max_message_size_bytes().transpose())
@@ -472,11 +472,15 @@ pub async fn start(
             message: format!(
                 "Failed to parse spicepod value 'runtime.flight.max_message_size': {e}"
             ),
-        })?
-        .unwrap_or(flight_client::MAX_DECODING_MESSAGE_SIZE);
+        })?;
 
-    let spice_flight_service =
-        FlightServiceServer::new(service).max_decoding_message_size(decoding_message_size);
+    let spice_flight_service = FlightServiceServer::new(service)
+        .max_decoding_message_size(
+            flight_message_size.unwrap_or(flight_client::MAX_DECODING_MESSAGE_SIZE),
+        )
+        .max_encoding_message_size(
+            flight_message_size.unwrap_or(flight_client::MAX_ENCODING_MESSAGE_SIZE),
+        );
 
     let mut server = Server::builder();
 

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -462,8 +462,21 @@ pub async fn start(
     }
 
     let service = Service::new(endpoint_auth.flight_basic_auth.as_ref().map(Arc::clone));
-    let spice_flight_service = FlightServiceServer::new(service)
-        .max_decoding_message_size(flight_client::MAX_DECODING_MESSAGE_SIZE);
+
+    let decoding_message_size = app
+        .as_ref()
+        .and_then(|a| a.runtime.flight.clone())
+        .and_then(|f| f.max_message_size_bytes().transpose())
+        .transpose()
+        .map_err(|e| Error::InsecureConfiguration {
+            message: format!(
+                "Failed to parse spicepod value 'runtime.flight.max_message_size': {e}"
+            ),
+        })?
+        .unwrap_or(flight_client::MAX_DECODING_MESSAGE_SIZE);
+
+    let spice_flight_service =
+        FlightServiceServer::new(service).max_decoding_message_size(decoding_message_size);
 
     let mut server = Server::builder();
 


### PR DESCRIPTION
## 📝 Summary
`spiced` as a flight service sets 100MiB as the maximum size of messages to decode. Should honour `runtime.flight.max_message_size`. 

## 🔗 Related
- Relates to #8651 
