### PR TITLE
Fixes for testoperator.

### DIFF
--- a/.github/workflows/testoperator_build_and_release.yml
+++ b/.github/workflows/testoperator_build_and_release.yml
@@ -1,4 +1,4 @@
-name: testoperator_build_and_release
+name: Build testoperator binary and Docker Image
 
 on:
   push:

--- a/.github/workflows/testoperator_build_and_release.yml
+++ b/.github/workflows/testoperator_build_and_release.yml
@@ -34,6 +34,13 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Build testoperator
         uses: ./.github/actions/build-testoperator
         with:

--- a/crates/test-framework/src/spicetest/text_to_sql/mod.rs
+++ b/crates/test-framework/src/spicetest/text_to_sql/mod.rs
@@ -78,6 +78,7 @@ impl SpiceTest<NotStarted> {
             .await
             .context("Failed to create Spice client")?;
         let http_client = spiced_instance.http_client()?;
+        let http_base_url = spiced_instance.http_base_url().to_string();
 
         Ok(SpiceTest {
             name: self.name,
@@ -89,7 +90,13 @@ impl SpiceTest<NotStarted> {
             results_snapshot_predicate: self.results_snapshot_predicate,
             state: Running {
                 workers: vec![
-                    TextToSqlWorker::new(http_client, spice_client, self.state.config).start(),
+                    TextToSqlWorker::new(
+                        http_client,
+                        http_base_url,
+                        spice_client,
+                        self.state.config,
+                    )
+                    .start(),
                 ],
             },
         })

--- a/crates/test-framework/src/spicetest/text_to_sql/worker.rs
+++ b/crates/test-framework/src/spicetest/text_to_sql/worker.rs
@@ -27,8 +27,6 @@ use reqwest::Client;
 use serde_json::json;
 use tokio::task::JoinHandle;
 
-use crate::constants::HTTP_BASE_URL;
-
 #[derive(Debug, Clone)]
 pub struct TextToSqlRequest {
     pub id: String,
@@ -98,6 +96,7 @@ pub struct TextToSqlResult {
 
 pub(crate) struct TextToSqlWorker {
     http_client: Client,
+    http_base_url: String,
     spice_client: spiceai::Client,
     config: TextToSqlConfig,
 }
@@ -105,11 +104,13 @@ pub(crate) struct TextToSqlWorker {
 impl TextToSqlWorker {
     pub fn new(
         http_client: Client,
+        http_base_url: impl Into<String>,
         spice_client: spiceai::Client,
         config: TextToSqlConfig,
     ) -> Self {
         Self {
             http_client,
+            http_base_url: http_base_url.into(),
             spice_client,
             config,
         }
@@ -126,7 +127,7 @@ impl TextToSqlWorker {
             for (index, request) in self.config.requests.into_iter().enumerate() {
                 let start = Instant::now();
 
-                let url = format!("{HTTP_BASE_URL}/v1/nsql");
+                let url = format!("{}/v1/nsql", self.http_base_url);
                 let body = json!({
                     "query": request.question,
                     "model": request.model,


### PR DESCRIPTION
## 📝 Summary
Several fixes needed for testoperator CI and testoperator run text-to-sql
- Install Minio in `.github/workflows/testoperator_build_and_release.yml`.
- Use the correct base HTTP url for `testoperator run text-to-sql`.
- Rename the `testoperator_build_and_release.yml` `.name`. 