### PR TITLE
Fix column projection order mismatch with location metadata columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "futures",
  "log",
@@ -4645,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-compression",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4761,12 +4761,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 
 [[package]]
 name = "datafusion-execution"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4844,7 +4844,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4868,7 +4868,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4914,7 +4914,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
  "datafusion-physical-expr-common",
  "itertools 0.14.0",
  "log",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4939,14 +4939,14 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
  "datafusion-functions-window-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "chrono",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5128,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5221,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b645aa11f67bf2921d3c6701344a172972e81611#b645aa11f67bf2921d3c6701344a172972e81611"
+source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "futures",
  "log",
@@ -4645,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-compression",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4761,12 +4761,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 
 [[package]]
 name = "datafusion-execution"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4844,7 +4844,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc)",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4868,7 +4868,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4914,7 +4914,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc)",
  "datafusion-physical-expr-common",
  "itertools 0.14.0",
  "log",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4939,14 +4939,14 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
  "datafusion-functions-window-common",
- "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c)",
+ "datafusion-macros 50.3.0 (git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "chrono",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5128,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5221,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "50.3.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c#cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=10b5cc5da1a4796eedefde3f079dd14768e483cc#10b5cc5da1a4796eedefde3f079dd14768e483cc"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,25 +312,25 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                       # spiceai/spiceai-50
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                # spiceai/spiceai-50
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }        # spiceai/spiceai-50
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }            # spiceai/spiceai-50
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }    # spiceai/spiceai-50
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }             # spiceai/spiceai-50
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                  # spiceai/spiceai-50
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }           # spiceai/spiceai-50
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }             # spiceai/spiceai-50
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }         # spiceai/spiceai-50
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" } # spiceai/spiceai-50
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }  # spiceai/spiceai-50
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }         # spiceai/spiceai-50
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                 # spiceai/spiceai-50
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }          # spiceai/spiceai-50
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                   # spiceai/spiceai-50
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }                       # spiceai/spiceai-50
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }               # spiceai/spiceai-50
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }                # spiceai/spiceai-50
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }        # spiceai/spiceai-50
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }            # spiceai/spiceai-50
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }    # spiceai/spiceai-50
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }             # spiceai/spiceai-50
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }                  # spiceai/spiceai-50
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }           # spiceai/spiceai-50
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }             # spiceai/spiceai-50
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }         # spiceai/spiceai-50
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" } # spiceai/spiceai-50
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }  # spiceai/spiceai-50
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }         # spiceai/spiceai-50
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }                 # spiceai/spiceai-50
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }          # spiceai/spiceai-50
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }               # spiceai/spiceai-50
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }               # spiceai/spiceai-50
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "10b5cc5da1a4796eedefde3f079dd14768e483cc" }                   # spiceai/spiceai-50
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c9363befa430a53c471fc18a811ea0769e631114" } # spiceai
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,25 +312,25 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }                       # spiceai/spiceai-50
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }               # spiceai/spiceai-50
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }                # spiceai/spiceai-50
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }        # spiceai/spiceai-50
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }            # spiceai/spiceai-50
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }    # spiceai/spiceai-50
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }             # spiceai/spiceai-50
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }                  # spiceai/spiceai-50
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }           # spiceai/spiceai-50
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }             # spiceai/spiceai-50
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }         # spiceai/spiceai-50
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" } # spiceai/spiceai-50
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }  # spiceai/spiceai-50
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }         # spiceai/spiceai-50
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }                 # spiceai/spiceai-50
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }          # spiceai/spiceai-50
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }               # spiceai/spiceai-50
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }               # spiceai/spiceai-50
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b645aa11f67bf2921d3c6701344a172972e81611" }                   # spiceai/spiceai-50
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                       # spiceai/spiceai-50
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                # spiceai/spiceai-50
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }        # spiceai/spiceai-50
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }            # spiceai/spiceai-50
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }    # spiceai/spiceai-50
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }             # spiceai/spiceai-50
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                  # spiceai/spiceai-50
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }           # spiceai/spiceai-50
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }             # spiceai/spiceai-50
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }         # spiceai/spiceai-50
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" } # spiceai/spiceai-50
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }  # spiceai/spiceai-50
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }         # spiceai/spiceai-50
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                 # spiceai/spiceai-50
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }          # spiceai/spiceai-50
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }               # spiceai/spiceai-50
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "cc3cdc46bb0c40b0548acbf9eeb8b14605ecee8c" }                   # spiceai/spiceai-50
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c9363befa430a53c471fc18a811ea0769e631114" } # spiceai
 

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -79,6 +79,12 @@ struct LocationPruningListingTable {
     inner: Arc<ListingTable>,
     object_store: Arc<dyn ObjectStore>,
     table_path: ListingTableUrl,
+    /// The original file schema from the `ListingTable`, containing only columns
+    /// physically stored in data files. This must be stored separately because
+    /// `ListingTable` doesn't expose its `file_schema` field publicly, and we cannot
+    /// reliably reconstruct it from `table_schema` when partition columns also
+    /// appear in the file (causing duplicates in `table_schema`).
+    file_schema: SchemaRef,
 }
 
 impl LocationPruningListingTable {
@@ -86,11 +92,13 @@ impl LocationPruningListingTable {
         inner: Arc<ListingTable>,
         object_store: Arc<dyn ObjectStore>,
         table_path: ListingTableUrl,
+        file_schema: SchemaRef,
     ) -> Self {
         Self {
             inner,
             object_store,
             table_path,
+            file_schema,
         }
     }
 
@@ -111,29 +119,7 @@ impl LocationPruningListingTable {
     }
 
     fn file_schema(&self) -> Arc<Schema> {
-        let table_schema = self.inner.schema();
-        let partition_cols: HashSet<&str> = self
-            .partition_column_types()
-            .iter()
-            .map(|(name, _)| name.as_str())
-            .collect();
-        let metadata_cols: HashSet<&str> = self
-            .metadata_columns()
-            .iter()
-            .map(MetadataColumn::name)
-            .collect();
-
-        let fields: Vec<_> = table_schema
-            .fields()
-            .iter()
-            .filter(|field| {
-                let name = field.name().as_str();
-                !partition_cols.contains(name) && !metadata_cols.contains(name)
-            })
-            .cloned()
-            .collect();
-
-        Arc::new(Schema::new(fields))
+        Arc::clone(&self.file_schema)
     }
 
     fn collect_partition_values(&self, meta: &ObjectMeta) -> Option<Vec<ScalarValue>> {
@@ -999,6 +985,9 @@ pub trait ListingTableConnector: DataConnector {
             expanded_schema
         };
 
+        // Keep a reference to the file schema for LocationPruningListingTable
+        let file_schema = Arc::clone(&final_schema);
+
         let config = ListingTableConfig::new(table_path.clone())
             .with_listing_options(options)
             .with_schema(final_schema);
@@ -1044,8 +1033,12 @@ pub trait ListingTableConnector: DataConnector {
             .any(|c| matches!(c, MetadataColumn::Location(_)));
 
         if has_location_metadata {
-            let wrapped =
-                LocationPruningListingTable::new(table_arc, Arc::clone(&object_store), table_path);
+            let wrapped = LocationPruningListingTable::new(
+                table_arc,
+                Arc::clone(&object_store),
+                table_path,
+                file_schema,
+            );
             Ok(Arc::new(wrapped))
         } else {
             Ok(table_arc)
@@ -1457,6 +1450,7 @@ async fn parquet_page_index_options(runtime: &Runtime) -> ParquetPageIndexOption
 
 #[cfg(test)]
 mod tests {
+    use arrow::array::RecordBatch;
     use chrono::{TimeZone, Utc};
     use datafusion_table_providers::util::secrets::to_secret_map;
     use futures::StreamExt;
@@ -1932,6 +1926,7 @@ mod tests {
                 .object_store(&table_path)
                 .expect("object store"),
             table_path.clone(),
+            file_schema,
         );
 
         let filters = vec![datafusion_expr::col("location").eq(datafusion_expr::lit(
@@ -1950,6 +1945,200 @@ mod tests {
                 .list_called
                 .load(std::sync::atomic::Ordering::SeqCst),
             "Listing should not be invoked when location predicates are present"
+        );
+    }
+
+    /// Regression test for issue where SELECT with metadata columns (like `location`)
+    /// appearing before partition columns in the projection would fail with
+    /// "column types must match schema types" error.
+    ///
+    /// The root cause was in `DataFusion`'s `ExtendedColumnProjector::project()` which
+    /// inserted partition columns first, then metadata columns, without accounting
+    /// for index position shifts when metadata columns had lower schema indices
+    /// than partition columns.
+    ///
+    /// For example, with schema [compression, day, location] where:
+    /// - compression is a file column (index 0)
+    /// - day is a partition column (index 1)
+    /// - location is a metadata column (index 2)
+    ///
+    /// `SELECT location, day, compression` would request projection [2, 1, 0] which
+    /// maps to output positions [0, 1, 2]. The old code would:
+    /// 1. Insert partition column `day` at position 1 → [compression, day]
+    /// 2. Insert metadata column `location` at position 0 → [location, compression, day]
+    ///
+    /// But the correct output should be [location, day, compression].
+    #[tokio::test]
+    async fn test_location_metadata_column_projection_order() {
+        use datafusion::parquet::arrow::ArrowWriter;
+        use tempfile::TempDir;
+
+        // Create temp directory with hive-partitioned parquet files
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let partition_dir = temp_dir.path().join("day=2025-01-01");
+        std::fs::create_dir_all(&partition_dir).expect("create partition dir");
+
+        // Create a simple parquet file with one column (the partition column comes from path)
+        let file_schema = Arc::new(Schema::new(vec![Field::new(
+            "compression",
+            arrow_schema::DataType::Utf8,
+            true,
+        )]));
+
+        let compression_array = arrow::array::StringArray::from(vec!["gzip"]);
+        let batch =
+            RecordBatch::try_new(Arc::clone(&file_schema), vec![Arc::new(compression_array)])
+                .expect("create batch");
+
+        let parquet_path = partition_dir.join("data.parquet");
+        let file = std::fs::File::create(&parquet_path).expect("create parquet file");
+        let mut writer =
+            ArrowWriter::try_new(file, Arc::clone(&file_schema), None).expect("create writer");
+        writer.write(&batch).expect("write batch");
+        writer.close().expect("close writer");
+
+        // Set up DataFusion with the listing table
+        let ctx = SessionContext::new();
+        let table_url = format!("file://{}/", temp_dir.path().display());
+        let store_url = Url::parse(&table_url).expect("parse url");
+        let table_path = ListingTableUrl::parse(&table_url).expect("parse listing url");
+
+        // Register the local filesystem object store
+        let object_store = object_store::local::LocalFileSystem::new();
+        ctx.runtime_env()
+            .register_object_store(&store_url, Arc::new(object_store));
+
+        // Create listing options with partition columns and location metadata
+        let file_format = Arc::new(ParquetFormat::default());
+        let options = ListingOptions::new(file_format)
+            .with_file_extension(".parquet")
+            .with_table_partition_cols(vec![("day".to_string(), arrow_schema::DataType::Utf8)])
+            .with_metadata_cols(vec![MetadataColumn::Location(Some(
+                table_url.clone().into(),
+            ))]);
+
+        // Note: We only provide the file schema here. The ListingTable automatically
+        // adds partition columns (day) and metadata columns (location) to form the
+        // full table schema.
+        let listing = ListingTable::try_new(
+            ListingTableConfig::new(table_path.clone())
+                .with_listing_options(options)
+                .with_schema(Arc::clone(&file_schema)),
+        )
+        .expect("create listing table");
+
+        let provider = LocationPruningListingTable::new(
+            Arc::new(listing),
+            ctx.runtime_env()
+                .object_store(&table_path)
+                .expect("object store"),
+            table_path,
+            file_schema,
+        );
+
+        ctx.register_table("test_table", Arc::new(provider))
+            .expect("register table");
+
+        // Test 1: SELECT with location first (this was failing before the fix)
+        let df = ctx
+            .sql("SELECT location, day, compression FROM test_table")
+            .await
+            .expect("execute query");
+
+        let batches: Vec<RecordBatch> = df.collect().await.expect("collect results");
+        assert_eq!(batches.len(), 1, "should have one batch");
+
+        let result = &batches[0];
+        assert_eq!(result.num_columns(), 3, "should have 3 columns");
+        assert_eq!(result.num_rows(), 1, "should have 1 row");
+
+        // Verify column order is correct
+        assert_eq!(
+            result.schema().field(0).name(),
+            "location",
+            "first column should be location"
+        );
+        assert_eq!(
+            result.schema().field(1).name(),
+            "day",
+            "second column should be day"
+        );
+        assert_eq!(
+            result.schema().field(2).name(),
+            "compression",
+            "third column should be compression"
+        );
+
+        // Verify data types are correct
+        let location_col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("location should be string array");
+        let day_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("day should be string array");
+        let compression_col = result
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("compression should be string array");
+
+        // Verify values
+        assert!(
+            location_col
+                .value(0)
+                .contains("day=2025-01-01/data.parquet"),
+            "location should contain file path, got: {}",
+            location_col.value(0)
+        );
+        assert_eq!(day_col.value(0), "2025-01-01", "day should be 2025-01-01");
+        assert_eq!(
+            compression_col.value(0),
+            "gzip",
+            "compression should be gzip"
+        );
+
+        // Test 2: SELECT with just location and day (was causing panic before fix)
+        let df = ctx
+            .sql("SELECT location, day FROM test_table")
+            .await
+            .expect("execute query");
+
+        let batches: Vec<RecordBatch> = df.collect().await.expect("collect results");
+        assert_eq!(batches.len(), 1, "should have one batch");
+        assert_eq!(batches[0].num_columns(), 2, "should have 2 columns");
+        assert_eq!(
+            batches[0].schema().field(0).name(),
+            "location",
+            "first column should be location"
+        );
+        assert_eq!(
+            batches[0].schema().field(1).name(),
+            "day",
+            "second column should be day"
+        );
+
+        // Test 3: SELECT with reversed order (day, location) - should also work
+        let df = ctx
+            .sql("SELECT day, location FROM test_table")
+            .await
+            .expect("execute query");
+
+        let batches: Vec<RecordBatch> = df.collect().await.expect("collect results");
+        assert_eq!(batches.len(), 1, "should have one batch");
+        assert_eq!(batches[0].num_columns(), 2, "should have 2 columns");
+        assert_eq!(
+            batches[0].schema().field(0).name(),
+            "day",
+            "first column should be day"
+        );
+        assert_eq!(
+            batches[0].schema().field(1).name(),
+            "location",
+            "second column should be location"
         );
     }
 


### PR DESCRIPTION
## 📝 Summary

When querying with columns in a different order than the schema (e.g.,  SELECT location, day, size FROM raw_email), the ExtendedColumnProjector in the DataFusion fork would incorrectly project columns, causing 'column types must match schema types' errors.

The fix ensures column projection respects the requested projection order rather than assuming schema order.

Includes regression test test_location_metadata_column_projection_order.

## 🔗 Related

- Depends on https://github.com/spiceai/datafusion/pull/120
