### PR TITLE
Fix `testoperator_dispatch.yaml`

### DIFF
--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -123,11 +123,15 @@ runs:
         minio_endpoint: ${{ inputs.minio_endpoint }}
         os: ${{ steps.detect-os.outputs.os }}
 
+    - name: Set up make
+      uses: ./.github/actions/setup-make
+      with:
+        os: ${{ steps.detect-os.outputs.os }}
+
     - name: Build spicepod-validator
       if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-validator.outputs.cache-hit != 'true')
       shell: bash
-      run: |
-        cargo build -p spicepod-validator --release
+      run: make build-validator
       env:
         RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}

--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -124,6 +124,7 @@ runs:
         os: ${{ steps.detect-os.outputs.os }}
 
     - name: Set up make
+      if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-validator.outputs.cache-hit != 'true')
       uses: ./.github/actions/setup-make
       with:
         os: ${{ steps.detect-os.outputs.os }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Set up make
-        uses: ./.github/actions/setup-make
-
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:
@@ -80,7 +77,11 @@ jobs:
           minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Build spicepod validator
-        run: make build-validator
+        uses: ./.github/actions/build-spicepod-validator
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Validate spicepods - TPCH - SF1
         run: |

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - name: Set up make
+        uses: ./.github/actions/setup-make
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:


### PR DESCRIPTION
Started using makefile target for building testoperator in #8426. But `testoperator_dispatch.yml` did not have `make` installed.

Successful dispatch CI run: https://github.com/spiceai/spiceai/actions/runs/20649099857/job/59290861516#step:7:217