### PR TITLE
Fix minio for ai benchmark CI

### DIFF
--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -17,7 +17,7 @@ inputs:
   os:
     description: 'Operating system to install MinIO for'
     required: false
-    default: 'linux' # 'linux', 'windows', 'macos'
+    default: 'linux' # 'linux', 'windows', 'darwin'
     type: string
 
 runs:
@@ -33,7 +33,7 @@ runs:
 
     - name: Install MinIO on macOS
       shell: bash
-      if: ${{ inputs.os == 'macos' }}
+      if: ${{ inputs.os == 'darwin' }}
       run: |
         brew update
         brew install wget

--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -17,7 +17,7 @@ inputs:
   os:
     description: 'Operating system to install MinIO for'
     required: false
-    default: 'linux' # 'linux', 'windows', 'darwin'
+    default: 'linux' # 'linux', 'darwin'
     type: string
 
 runs:
@@ -37,14 +37,6 @@ runs:
       run: |
         brew update
         brew install minio/stable/mc
-
-    - name: Install MinIO on Windows
-      shell: pwsh
-      if: ${{ inputs.os == 'windows' }}
-      run: |
-        Invoke-WebRequest https://dl.min.io/client/mc/release/windows-amd64/mc.exe -OutFile "C:\Program Files\mc.exe"
-        Set-ExecutionPolicy RemoteSigned -Scope Process
-        $env:PATH += ";C:\Program Files"
 
     - name: Set MinIO alias
       shell: bash

--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -14,13 +14,41 @@ inputs:
     description: 'MinIO secret key'
     required: true
     type: string
+  os:
+    description: 'Operating system to install MinIO for'
+    required: false
+    default: 'linux' # 'linux', 'windows', 'macos'
+    type: string
+
 runs:
   using: 'composite'
   steps:
-    - name: Install MinIO
+    - name: Install MinIO on Linux
       shell: bash
+      if: ${{ inputs.os == 'linux' }}
       run: |
         sudo apt update && sudo apt install wget -y
         sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
         sudo chmod +x /usr/local/bin/mc
+
+    - name: Install MinIO on macOS
+      shell: bash
+      if: ${{ inputs.os == 'macos' }}
+      run: |
+        brew update
+        brew install wget
+        wget https://dl.min.io/client/mc/release/darwin-amd64/mc -O /usr/local/bin/mc
+        chmod +x /usr/local/bin/mc
+
+    - name: Install MinIO on Windows
+      shell: pwsh
+      if: ${{ inputs.os == 'windows' }}
+      run: |
+        Invoke-WebRequest https://dl.min.io/client/mc/release/windows-amd64/mc.exe -OutFile "C:\Program Files\mc.exe"
+        Set-ExecutionPolicy RemoteSigned -Scope Process
+        $env:PATH += ";C:\Program Files"
+
+    - name: Set MinIO alias
+      shell: bash
+      run: |
         mc alias set spice-minio ${{ inputs.minio_endpoint }} ${{ inputs.minio_access_key }} ${{ inputs.minio_secret_key }}

--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -36,9 +36,7 @@ runs:
       if: ${{ inputs.os == 'darwin' }}
       run: |
         brew update
-        brew install wget
-        wget https://dl.min.io/client/mc/release/darwin-amd64/mc -O /usr/local/bin/mc
-        chmod +x /usr/local/bin/mc
+        brew install minio/stable/mc
 
     - name: Install MinIO on Windows
       shell: pwsh

--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -32,19 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-      - name: Install MinIO
-        uses: ./.github/actions/setup-minio
-        with:
-          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          os: darwin # Since `runs-on: 'spiceai-macos'`
-
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
         with:
           install_to_system_path: 'false'
           upload_artifact: 'true'
+          force_rebuild: 'true'
+          download_from_minio: 'false'
 
   build-spiced:
     name: Build spiced

--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -32,6 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          os: darwin # Since `runs-on: 'spiceai-macos'`
+
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
         with:


### PR DESCRIPTION
## 📝 Summary
- Remove minio from ai nsql eval benchmark.
- Also make `actions/setup-minio` compatible for macOS. 
- [x] [ai benchmark (nsql)](https://github.com/spiceai/spiceai/actions/workflows/ai_benchmark_nsql.yml) run
