### PR TITLE
feat: Add scheduler-driven executor discovery via DNS SRV

### DIFF
--- a/crates/ns_lookup/src/lib.rs
+++ b/crates/ns_lookup/src/lib.rs
@@ -38,9 +38,78 @@ pub enum Error {
 
     #[snafu(display("Invalid endpoint (no port specified): {endpoint}"))]
     InvalidPort { endpoint: String },
+
+    #[snafu(display("Failed to perform SRV lookup for {name}: {message}"))]
+    SrvLookupFailed { name: String, message: String },
+
+    #[snafu(display("Failed to create DNS resolver: {message}"))]
+    ResolverCreationFailed { message: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Result of an SRV record lookup.
+#[derive(Debug, Clone)]
+pub struct SrvRecord {
+    /// The target hostname from the SRV record.
+    pub target: String,
+    /// The port from the SRV record.
+    pub port: u16,
+    /// The priority of the SRV record (lower is higher priority).
+    pub priority: u16,
+    /// The weight for load balancing among records with the same priority.
+    pub weight: u16,
+}
+
+/// Perform a DNS SRV lookup for the given service name.
+///
+/// This is useful for discovering services in Kubernetes headless services,
+/// where the SRV record returns the individual pod hostnames and ports.
+///
+/// # Arguments
+///
+/// * `name` - The DNS name to query for SRV records (e.g., `my-service.default.svc.cluster.local`)
+///
+/// # Returns
+///
+/// A vector of `SrvRecord` containing the discovered services.
+///
+/// # Errors
+///
+/// Returns an error if the DNS lookup fails.
+pub async fn lookup_srv(name: &str) -> Result<Vec<SrvRecord>> {
+    let resolver = Resolver::builder_tokio()
+        .map_err(|e| Error::ResolverCreationFailed {
+            message: e.to_string(),
+        })?
+        .build();
+
+    let srv_lookup = resolver
+        .srv_lookup(name)
+        .await
+        .map_err(|e| Error::SrvLookupFailed {
+            name: name.to_string(),
+            message: e.to_string(),
+        })?;
+
+    let records: Vec<SrvRecord> = srv_lookup
+        .iter()
+        .map(|srv| {
+            // Remove trailing dot from target hostname
+            let target = srv.target().to_string();
+            let target = target.trim_end_matches('.').to_string();
+
+            SrvRecord {
+                target,
+                port: srv.port(),
+                priority: srv.priority(),
+                weight: srv.weight(),
+            }
+        })
+        .collect();
+
+    Ok(records)
+}
 
 /// Verify NS lookup and TCP connect for the provided `endpoint`.
 ///

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -17,6 +17,31 @@ service ClusterService {
     rpc ExpandSecret(ExpandSecretRequest) returns (ExpandSecretResponse);
 }
 
+// Executor service for scheduler-driven discovery.
+// Exposed by executors so schedulers can query their registration information.
+service ExecutorService {
+    // Get the executor's registration information including task slots.
+    // Called by schedulers during executor discovery.
+    rpc DescribeExecutor(DescribeExecutorRequest) returns (DescribeExecutorResponse);
+}
+
+// Request message for DescribeExecutor RPC.
+message DescribeExecutorRequest {}
+
+// Response message for DescribeExecutor RPC.
+message DescribeExecutorResponse {
+    // Unique identifier for this executor.
+    string executor_id = 1;
+    // Hostname or IP address where the executor is reachable.
+    string host = 2;
+    // Port for the Arrow Flight service.
+    uint32 port = 3;
+    // Port for the gRPC service (used for push-based scheduling).
+    uint32 grpc_port = 4;
+    // Number of task slots available for concurrent task execution.
+    uint32 task_slots = 5;
+}
+
 // Request message for GetAppDefinition RPC.
 message GetAppDefinitionRequest {
     string executor_id = 1;

--- a/crates/runtime/src/cluster/discovery.rs
+++ b/crates/runtime/src/cluster/discovery.rs
@@ -1,0 +1,324 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Executor discovery for scheduler-driven cluster mode.
+//!
+//! This module implements DNS SRV-based executor discovery, allowing schedulers to
+//! automatically discover and register executors from Kubernetes headless services.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
+use ns_lookup::{SrvRecord, lookup_srv};
+use runtime_proto::DescribeExecutorRequest;
+use runtime_proto::executor_service_client::ExecutorServiceClient;
+use tokio_util::sync::CancellationToken;
+use tonic::transport::{ClientTlsConfig, Endpoint};
+use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
+
+use crate::Runtime;
+
+/// Maximum interval between executor discovery attempts (steady state).
+const MAX_DISCOVERY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Timeout for connecting to an executor during discovery.
+const EXECUTOR_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Starts the executor discovery loop for scheduler mode.
+///
+/// This function periodically queries the DNS SRV record specified by `--executor-discovery-dns`
+/// to discover executors. For each discovered executor, it calls the `DescribeExecutor` RPC
+/// to get registration information and registers the executor with the scheduler.
+///
+/// Discovery runs immediately on startup, then uses Fibonacci backoff starting at 1 second
+/// and gradually increasing to 30 seconds for steady-state polling.
+///
+/// # Arguments
+///
+/// * `rt` - The runtime instance containing cluster configuration
+/// * `shutdown` - Cancellation token to stop the discovery loop
+///
+/// # Errors
+///
+/// Returns an error if the discovery loop encounters an unrecoverable error.
+pub async fn start_executor_discovery_loop(
+    rt: Arc<Runtime>,
+    shutdown: CancellationToken,
+) -> crate::Result<()> {
+    let Some(executor_discovery_dns) = rt.df.cluster_config.executor_discovery_dns() else {
+        tracing::debug!("No --executor-discovery-dns configured, skipping executor discovery");
+        return Ok(());
+    };
+
+    tracing::info!(
+        "Starting executor discovery loop for SRV record: {}",
+        executor_discovery_dns
+    );
+
+    let executor_discovery_dns = executor_discovery_dns.to_string();
+    let client_tls_config = rt.df.cluster_config.client_tls_config().cloned();
+    let tls_enabled = rt.df.cluster_config.tls_enabled();
+
+    // Track known executors to avoid re-registering
+    let mut known_executors: HashSet<String> = HashSet::new();
+
+    // Use Fibonacci backoff: starts at 1s, increases to max 30s
+    let mut backoff = FibonacciBackoffBuilder::new()
+        .max_duration(Some(MAX_DISCOVERY_INTERVAL))
+        .build();
+
+    // Discover immediately on startup, then enter the backoff loop
+    loop {
+        // Run discovery and check if executor state changed (new registrations or removals)
+        let executor_changes = match discover_and_register_executors(
+            &rt,
+            &executor_discovery_dns,
+            client_tls_config.as_ref(),
+            tls_enabled,
+            &mut known_executors,
+        )
+        .await
+        {
+            Ok(count) => count,
+            Err(e) => {
+                tracing::warn!("Executor discovery error: {}", e);
+                0
+            }
+        };
+
+        // Reset backoff if executor state changed (more changes likely coming)
+        if executor_changes > 0 {
+            backoff.reset();
+        }
+
+        // Get next backoff interval (will always return Some since max_retries is None)
+        let interval = backoff.next_backoff().unwrap_or(MAX_DISCOVERY_INTERVAL);
+
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                tracing::info!("Executor discovery loop shutting down");
+                return Ok(());
+            }
+            () = tokio::time::sleep(interval) => {
+                // Continue to next discovery iteration
+            }
+        }
+    }
+}
+
+/// Discovers executors via DNS SRV and registers them with the scheduler.
+///
+/// Returns the number of executor changes (new registrations + removals).
+/// Also removes executors that are no longer present in DNS SRV records.
+async fn discover_and_register_executors(
+    rt: &Runtime,
+    srv_name: &str,
+    client_tls_config: Option<&ClientTlsConfig>,
+    tls_enabled: bool,
+    known_executors: &mut HashSet<String>,
+) -> crate::Result<usize> {
+    tracing::debug!("Performing SRV lookup for: {}", srv_name);
+
+    let srv_records = match lookup_srv(srv_name).await {
+        Ok(records) => records,
+        Err(e) => {
+            tracing::debug!("SRV lookup failed for {}: {}", srv_name, e);
+            return Ok(0);
+        }
+    };
+
+    // Get scheduler server to register/unregister executors
+    let scheduler_server = rt
+        .df
+        .scheduler_server
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone());
+
+    let Some(scheduler) = scheduler_server else {
+        tracing::warn!("Scheduler server not available for executor registration");
+        return Ok(0);
+    };
+
+    // Handle empty SRV records: remove all known executors
+    if srv_records.is_empty() {
+        tracing::debug!("No SRV records found for {}", srv_name);
+
+        let removed_count = known_executors.len();
+        for executor_id in known_executors.drain() {
+            tracing::info!("Removing stale executor (no SRV records): {}", executor_id);
+            if let Err(e) = scheduler
+                .state
+                .executor_manager
+                .remove_executor(
+                    &executor_id,
+                    Some("Removed from DNS SRV records".to_string()),
+                )
+                .await
+            {
+                tracing::warn!("Failed to remove executor {}: {}", executor_id, e);
+            }
+        }
+        return Ok(removed_count);
+    }
+
+    tracing::debug!("Found {} SRV records for {}", srv_records.len(), srv_name);
+
+    // Collect futures for all executor discovery attempts
+    let futures: Vec<_> = srv_records
+        .into_iter()
+        .map(|srv| discover_single_executor(srv, client_tls_config.cloned(), tls_enabled))
+        .collect();
+
+    // Execute all discovery attempts concurrently
+    let results = futures::future::join_all(futures).await;
+
+    // Track executors discovered in this round
+    let mut discovered_executors: HashSet<String> = HashSet::new();
+
+    // Register discovered executors
+    let mut change_count = 0;
+    for result in results {
+        match result {
+            Ok(Some((metadata, data))) => {
+                let executor_id = metadata.id.clone();
+                discovered_executors.insert(executor_id.clone());
+
+                // Skip if already known
+                if known_executors.contains(&executor_id) {
+                    tracing::trace!("Executor {} already registered, skipping", executor_id);
+                    continue;
+                }
+
+                tracing::info!(
+                    "Discovered new executor: {} at {}:{} with {} task slots",
+                    executor_id,
+                    metadata.host,
+                    metadata.port,
+                    data.total_task_slots
+                );
+
+                // Register with the scheduler's executor manager
+                if let Err(e) = scheduler
+                    .state
+                    .executor_manager
+                    .register_executor(metadata, data)
+                    .await
+                {
+                    tracing::warn!("Failed to register executor {}: {}", executor_id, e);
+                } else {
+                    known_executors.insert(executor_id);
+                    change_count += 1;
+                }
+            }
+            Ok(None) => {
+                // Executor not ready, skip
+            }
+            Err(e) => {
+                tracing::debug!("Failed to discover executor: {}", e);
+            }
+        }
+    }
+
+    // Remove executors that are no longer in DNS SRV records
+    let stale_executors: Vec<String> = known_executors
+        .difference(&discovered_executors)
+        .cloned()
+        .collect();
+
+    for executor_id in stale_executors {
+        tracing::info!(
+            "Removing stale executor (no longer in DNS SRV): {}",
+            executor_id
+        );
+        if let Err(e) = scheduler
+            .state
+            .executor_manager
+            .remove_executor(
+                &executor_id,
+                Some("Removed from DNS SRV records".to_string()),
+            )
+            .await
+        {
+            tracing::warn!("Failed to remove stale executor {}: {}", executor_id, e);
+        } else {
+            known_executors.remove(&executor_id);
+            change_count += 1;
+        }
+    }
+
+    Ok(change_count)
+}
+
+/// Discovers a single executor by connecting to it and calling `DescribeExecutor`.
+async fn discover_single_executor(
+    srv: SrvRecord,
+    client_tls_config: Option<ClientTlsConfig>,
+    tls_enabled: bool,
+) -> Result<Option<(ExecutorMetadata, ExecutorData)>, Box<dyn std::error::Error + Send + Sync>> {
+    let scheme = if tls_enabled { "https" } else { "http" };
+    let endpoint_url = format!("{}://{}:{}", scheme, srv.target, srv.port);
+
+    tracing::debug!("Attempting to connect to executor at {}", endpoint_url);
+
+    let mut endpoint =
+        Endpoint::from_shared(endpoint_url.clone())?.connect_timeout(EXECUTOR_CONNECT_TIMEOUT);
+
+    if let Some(tls_config) = client_tls_config {
+        endpoint = endpoint.tls_config(tls_config)?;
+    }
+
+    let channel = match endpoint.connect().await {
+        Ok(ch) => ch,
+        Err(e) => {
+            tracing::debug!("Failed to connect to {}: {}", endpoint_url, e);
+            return Ok(None);
+        }
+    };
+
+    let mut client = ExecutorServiceClient::new(channel);
+
+    let response = match client.describe_executor(DescribeExecutorRequest {}).await {
+        Ok(resp) => resp.into_inner(),
+        Err(e) => {
+            tracing::debug!("DescribeExecutor RPC failed for {}: {}", endpoint_url, e);
+            return Ok(None);
+        }
+    };
+
+    tracing::debug!("Successfully described executor {response:?} at {endpoint_url}");
+
+    #[expect(clippy::cast_possible_truncation)]
+    let metadata = ExecutorMetadata {
+        id: response.executor_id.clone(),
+        host: response.host.clone(),
+        port: response.port as u16,
+        grpc_port: response.grpc_port as u16,
+        specification: ballista_core::serde::scheduler::ExecutorSpecification {
+            task_slots: response.task_slots,
+        },
+    };
+
+    let data = ExecutorData {
+        executor_id: response.executor_id,
+        total_task_slots: response.task_slots,
+        available_task_slots: response.task_slots,
+    };
+
+    Ok(Some((metadata, data)))
+}

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -61,17 +61,18 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use url::Url;
-use uuid::Uuid;
 
 type SchedulerEndpointOverride =
     Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
 
 pub mod datafusion;
+mod discovery;
 mod servers;
 mod service;
 
+pub use discovery::start_executor_discovery_loop;
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
-pub use service::ClusterServiceImpl;
+pub use service::{ClusterServiceImpl, ExecutorServiceImpl};
 
 /// mTLS configuration for cluster communications.
 ///
@@ -329,6 +330,12 @@ impl ResolvedClusterConfig {
     pub fn client_tls_config(&self) -> Option<&ClientTlsConfig> {
         self.tls_config.as_ref().map(|t| &t.client_tls_config)
     }
+
+    /// Returns the DNS SRV record name for executor discovery (scheduler mode only).
+    #[must_use]
+    pub fn executor_discovery_dns(&self) -> Option<&str> {
+        self.config.executor_discovery_dns.as_deref()
+    }
 }
 
 /// Creates & binds a Ballista scheduler to the Runtime handle, then updates status
@@ -384,66 +391,6 @@ pub async fn initialize_cluster_executor(
 
         config
     });
-
-    // Generate executor_id early so we can use it for both the app definition request and executor registration
-    let executor_id = Uuid::new_v4().to_string();
-
-    // Fetch the app definition from the scheduler to get temp_directory for the work_dir.
-    // This ensures shuffle files are written to the configured directory.
-    let mut cluster_client =
-        create_cluster_service_client(scheduler_url, client_tls_config.clone()).await?;
-
-    let app_definition_request = GetAppDefinitionRequest {
-        executor_id: executor_id.clone(),
-    };
-
-    let response = cluster_client
-        .get_app_definition(app_definition_request)
-        .await
-        .map_err(|status| FailedToStartClusterExecutor {
-            source: format!("Failed to get app definition from scheduler: {status}").into(),
-        })?;
-
-    let app_json = response.into_inner().app_json;
-
-    let app_def: App = serde_json::from_str(&app_json)
-        .boxed()
-        .context(FailedToStartClusterExecutorSnafu)?;
-
-    // Extract temp_directory from the app definition for the executor's work_dir
-    let work_dir = app_def
-        .runtime
-        .query
-        .as_ref()
-        .and_then(|q| q.temp_directory.clone())
-        .unwrap_or_else(|| env::temp_dir().to_string_lossy().to_string());
-
-    let app_def = Arc::new(app_def);
-
-    let scheduler_endpoint = create_grpc_client_endpoint(scheduler_url.to_string())
-        .boxed()
-        .context(FailedToStartClusterExecutorSnafu)?;
-    let scheduler_endpoint = if let Some(tls_config) = client_tls_config.clone() {
-        scheduler_endpoint
-            .tls_config(tls_config)
-            .map_err(|e| FailedToStartClusterExecutor {
-                source: Box::new(e),
-            })?
-    } else {
-        scheduler_endpoint
-    };
-
-    let scheduler_connection =
-        scheduler_endpoint
-            .connect()
-            .await
-            .map_err(|e| FailedToStartClusterExecutor {
-                source: format!("Unable to connect to scheduler at {scheduler_url}: {e}").into(),
-            })?;
-
-    let scheduler = SchedulerGrpcClient::new(scheduler_connection)
-        .max_encoding_message_size(usize::MAX)
-        .max_decoding_message_size(usize::MAX);
 
     // Use the configured node_bind_address for the executor flight server.
     // Fall back to dynamic port assignment if binding fails (e.g., port already in use).
@@ -521,13 +468,73 @@ pub async fn initialize_cluster_executor(
         (hostname, bind_addr.port())
     };
 
+    // Use the advertise address as the executor_id for easier identification
+    let executor_id = format!("{advertise_host}:{advertise_port}");
+
+    // Fetch the app definition from the scheduler to get temp_directory for the work_dir.
+    // This ensures shuffle files are written to the configured directory.
+    let mut cluster_client =
+        create_cluster_service_client(scheduler_url, client_tls_config.clone()).await?;
+
+    let app_definition_request = GetAppDefinitionRequest {
+        executor_id: executor_id.clone(),
+    };
+
+    let response = cluster_client
+        .get_app_definition(app_definition_request)
+        .await
+        .map_err(|status| FailedToStartClusterExecutor {
+            source: format!("Failed to get app definition from scheduler: {status}").into(),
+        })?;
+
+    let app_json = response.into_inner().app_json;
+
+    let app_def: App = serde_json::from_str(&app_json)
+        .boxed()
+        .context(FailedToStartClusterExecutorSnafu)?;
+
+    // Extract temp_directory from the app definition for the executor's work_dir
+    let work_dir = app_def
+        .runtime
+        .query
+        .as_ref()
+        .and_then(|q| q.temp_directory.clone())
+        .unwrap_or_else(|| env::temp_dir().to_string_lossy().to_string());
+
+    let app_def = Arc::new(app_def);
+
+    let scheduler_endpoint = create_grpc_client_endpoint(scheduler_url.to_string())
+        .boxed()
+        .context(FailedToStartClusterExecutorSnafu)?;
+    let scheduler_endpoint = if let Some(tls_config) = client_tls_config.clone() {
+        scheduler_endpoint
+            .tls_config(tls_config)
+            .map_err(|e| FailedToStartClusterExecutor {
+                source: Box::new(e),
+            })?
+    } else {
+        scheduler_endpoint
+    };
+
+    let scheduler_connection =
+        scheduler_endpoint
+            .connect()
+            .await
+            .map_err(|e| FailedToStartClusterExecutor {
+                source: format!("Unable to connect to scheduler at {scheduler_url}: {e}").into(),
+            })?;
+
+    let scheduler = SchedulerGrpcClient::new(scheduler_connection)
+        .max_encoding_message_size(usize::MAX)
+        .max_decoding_message_size(usize::MAX);
+
     let executor_meta = ExecutorRegistration {
         id: executor_id.clone(),
         // flight service - use advertise address for scheduler to contact this executor
         host: Some(advertise_host),
         port: u32::from(advertise_port),
         // grpc_port is used only for push mode, and not initialized for pull mode (default)
-        grpc_port: 0,
+        grpc_port: u32::from(advertise_port),
         specification: Some(ExecutorSpecification {
             resources: vec![ExecutorResource {
                 resource: Some(Resource::TaskSlots(concurrent_tasks)),

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 use super::ClusterTlsConfig;
-use crate::cluster::ClusterServiceImpl;
+use crate::cluster::{ClusterServiceImpl, ExecutorServiceImpl};
 use crate::flight::{Error, is_address_in_use_error};
 use crate::{Runtime, metrics as runtime_metrics};
 use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer;
 use ballista_executor::flight_service::BallistaFlightService;
 use runtime_proto::cluster_service_server::ClusterServiceServer;
+use runtime_proto::executor_service_server::ExecutorServiceServer;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -144,13 +145,20 @@ pub async fn start_executor_flight_server(
         );
     }
 
-    // Executor: serve only BallistaFlightService for receiving query fragments.
-    // No OTel service needed on executors.
-    let server = server.add_service(
-        arrow_flight::flight_service_server::FlightServiceServer::new(BallistaFlightService::new())
+    // Executor: serve BallistaFlightService for receiving query fragments
+    // and ExecutorService for scheduler-driven discovery.
+    let executor_service = ExecutorServiceImpl::new(Arc::clone(&rt.df));
+    let executor_service_server = ExecutorServiceServer::new(executor_service);
+
+    let server = server
+        .add_service(
+            arrow_flight::flight_service_server::FlightServiceServer::new(
+                BallistaFlightService::new(),
+            )
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX),
-    );
+        )
+        .add_service(executor_service_server);
 
     // Use the executor's bound address if it was dynamically assigned during registration.
     #[expect(clippy::cast_possible_truncation)]

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -21,14 +21,18 @@ limitations under the License.
 
 use app::App;
 use runtime_proto::cluster_service_server::ClusterService;
+use runtime_proto::executor_service_server::ExecutorService;
 use runtime_proto::{
-    ExpandSecretRequest, ExpandSecretResponse, GetAppDefinitionRequest, GetAppDefinitionResponse,
+    DescribeExecutorRequest, DescribeExecutorResponse, ExpandSecretRequest, ExpandSecretResponse,
+    GetAppDefinitionRequest, GetAppDefinitionResponse,
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
+
+use crate::datafusion::DataFusion;
 
 /// Internal cluster service for scheduler-executor communication.
 pub struct ClusterServiceImpl {
@@ -114,6 +118,69 @@ impl ClusterService for ClusterServiceImpl {
         Ok(Response::new(ExpandSecretResponse {
             key: request.key,
             value: exposed.to_string(),
+        }))
+    }
+}
+
+/// Executor service for scheduler-driven discovery.
+///
+/// This service is exposed by executors so schedulers can query their
+/// registration information (executor ID, host, port, task slots).
+pub struct ExecutorServiceImpl {
+    df: Arc<DataFusion>,
+}
+
+impl ExecutorServiceImpl {
+    /// Creates a new executor service implementation.
+    #[must_use]
+    pub fn new(df: Arc<DataFusion>) -> Self {
+        Self { df }
+    }
+}
+
+#[tonic::async_trait]
+impl ExecutorService for ExecutorServiceImpl {
+    async fn describe_executor(
+        &self,
+        _request: Request<DescribeExecutorRequest>,
+    ) -> Result<Response<DescribeExecutorResponse>, Status> {
+        tracing::trace!("ExecutorService::describe_executor called");
+
+        let executor_guard = self
+            .df
+            .executor
+            .read()
+            .map_err(|_| Status::internal("Failed to acquire executor lock"))?;
+
+        let Some(ref executor) = *executor_guard else {
+            return Err(Status::unavailable(
+                "Executor registration not yet available",
+            ));
+        };
+
+        let registration = &executor.metadata;
+
+        let task_slots = registration
+            .specification
+            .as_ref()
+            .and_then(|spec| {
+                spec.resources.iter().find_map(|r| {
+                    r.resource.as_ref().map(|res| {
+                        let ballista_core::serde::protobuf::executor_resource::Resource::TaskSlots(
+                            slots,
+                        ) = res;
+                        *slots
+                    })
+                })
+            })
+            .unwrap_or(0);
+
+        Ok(Response::new(DescribeExecutorResponse {
+            executor_id: registration.id.clone(),
+            host: registration.host.clone().unwrap_or_default(),
+            port: registration.port,
+            grpc_port: registration.grpc_port,
+            task_slots,
         }))
     }
 }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -129,6 +129,18 @@ pub struct ClusterConfig {
     ///   https://<node-advertise-address>:<port from --node-bind-address> (http:// if --allow-insecure-connections is set)
     #[arg(long = "node-advertise-address", value_name = "NODE_ADVERTISE_ADDRESS")]
     pub node_advertise_address: Option<String>,
+
+    /// The DNS SRV record name for discovering executors (scheduler mode only).
+    /// When set, the scheduler will periodically query this DNS SRV record to discover
+    /// executor endpoints and automatically register them.
+    ///
+    /// This is typically a Kubernetes headless service name, e.g.:
+    ///   my-executor.default.svc.cluster.local
+    ///
+    /// The SRV query returns executor hostnames and ports, which are then used to
+    /// call the `DescribeExecutor` RPC on each discovered executor.
+    #[arg(long = "executor-discovery-dns", value_name = "EXECUTOR_DISCOVERY_DNS")]
+    pub executor_discovery_dns: Option<String>,
 }
 
 impl Default for ClusterConfig {
@@ -142,6 +154,7 @@ impl Default for ClusterConfig {
             allow_insecure_connections: false,
             scheduler_address: None,
             node_advertise_address: None,
+            executor_discovery_dns: None,
         }
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -659,6 +659,30 @@ impl Runtime {
             reason = "type alias scoped to cluster setup"
         )]
         type BoxedClusterFuture = std::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
+        // Discovery future (scheduler-only, optional based on --executor-discovery-dns)
+        let maybe_discovery_future: Option<BoxedClusterFuture> =
+            if self.df.cluster_config.effective_role() == Some(ClusterRole::Scheduler)
+                && self.df.cluster_config.executor_discovery_dns().is_some()
+            {
+                let discovery_shutdown = CancellationToken::new();
+                let discovery_rt = Arc::clone(&self);
+                let cloned_discovery_shutdown = discovery_shutdown.clone();
+                let discovery_fut = async move {
+                    cluster::start_executor_discovery_loop(discovery_rt, cloned_discovery_shutdown)
+                        .await
+                };
+                Some(Box::pin(
+                    self.start_runtime_task(
+                        "cluster_executor_discovery",
+                        Some(discovery_shutdown),
+                        discovery_fut,
+                    )
+                    .await,
+                ))
+            } else {
+                None
+            };
+
         let maybe_cluster_future: Option<BoxedClusterFuture> =
             match self.df.cluster_config.effective_role() {
                 Some(ClusterRole::Scheduler) => {
@@ -675,6 +699,7 @@ impl Runtime {
                         .await
                         .context(UnableToStartClusterServerSnafu)
                     };
+
                     let self_for_task = Arc::clone(&self);
                     Some(Box::pin(
                         self_for_task
@@ -829,29 +854,46 @@ impl Runtime {
             .await;
 
         // wait for all servers to shut down or if any of the servers fail to start
-        if let Some(cluster_future) = maybe_cluster_future {
-            return match tokio::try_join!(
-                http_future,
-                flight_future,
-                metrics_future,
-                pods_watcher_future,
-                cluster_future,
-                shutdown_signal_future
-            ) {
-                Err(err) => Err(err),
-                _ => Ok(()),
-            };
-        }
-
-        match tokio::try_join!(
-            http_future,
-            flight_future,
-            metrics_future,
-            pods_watcher_future,
-            shutdown_signal_future
-        ) {
-            Err(err) => Err(err),
-            _ => Ok(()),
+        match (maybe_cluster_future, maybe_discovery_future) {
+            (Some(cluster_future), Some(discovery_future)) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    cluster_future,
+                    discovery_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (Some(cluster_future), None) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    cluster_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            _ => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

Implement scheduler-driven executor discovery for HA stateless schedulers in cluster mode. Instead of executors registering themselves with schedulers, schedulers now discover executors by querying DNS SRV records (typically from Kubernetes headless services).

UX Change: New CLI flag for schedulers: `--executor-discovery-dns <dns>`

```rust
    /// The DNS SRV record name for discovering executors (scheduler mode only).
    /// When set, the scheduler will periodically query this DNS SRV record to discover
    /// executor endpoints and automatically register them.
    ///
    /// This is typically a Kubernetes headless service name, e.g.:
    ///   my-executor.default.svc.cluster.local
    ///
    /// The SRV query returns executor hostnames and ports, which are then used to
    /// call the `DescribeExecutor` RPC on each discovered executor.
    #[arg(long = "executor-discovery-dns", value_name = "EXECUTOR_DISCOVERY_DNS")]
    pub executor_discovery_dns: Option<String>,
```

Changes:
- Add ExecutorService gRPC with DescribeExecutor RPC (spice.proto) for schedulers to query executor registration info (id, host, port, task_slots)
- Add --executor-discovery-dns CLI parameter for schedulers to specify the DNS SRV record name to query for executor discovery
- Add DNS SRV lookup support to ns_lookup crate (lookup_srv function)
- Implement executor discovery loop with Fibonacci backoff (1s -> 30s) that:
  - Runs immediately on startup
  - Queries DNS SRV records periodically
  - Calls DescribeExecutor on discovered endpoints
  - Registers new executors with the scheduler
  - Resets backoff when new executors are found
- Use advertise address as executor_id (e.g., 'hostname:port') instead of UUID for easier identification
- Executors still connect to scheduler via --scheduler-address to pull Spicepod

This enables running multiple stateless scheduler replicas behind a load balancer, with each scheduler independently discovering the same set of executors.

## 🔗 Related

Part of #8559
