### PR TITLE
Add dynamic dataset support to runtime model (Phase 1)

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -62,6 +62,7 @@ pub struct DatasetBuilder {
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    pub dynamic: bool,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -107,6 +108,17 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             }
         }
 
+        // Parse params.dynamic flag
+        let dynamic = dataset
+            .params
+            .as_ref()
+            .and_then(|p| p.data.get("dynamic"))
+            .is_some_and(|v| match v {
+                spicepod::param::ParamValue::Bool(b) => *b,
+                spicepod::param::ParamValue::String(s) => s.eq_ignore_ascii_case("true"),
+                _ => false,
+            });
+
         Ok(DatasetBuilder {
             from: dataset.from,
             name: table_reference,
@@ -142,6 +154,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             runtime: None,
             vectors: dataset.vectors,
             check_availability: CheckAvailability::from(dataset.check_availability),
+            dynamic,
         })
     }
 }
@@ -172,6 +185,7 @@ impl DatasetBuilder {
             runtime: None,
             vectors: None,
             check_availability: CheckAvailability::default(),
+            dynamic: false,
         })
     }
 
@@ -268,7 +282,40 @@ impl DatasetBuilder {
             runtime,
             vectors: self.vectors,
             check_availability: self.check_availability,
+            dynamic: self.dynamic,
         };
+
+        // Validate dynamic dataset configuration
+        if dataset.dynamic {
+            // Dynamic datasets must be read-only
+            if dataset.access != AccessMode::Read {
+                return Err(Error::DynamicDatasetMustBeReadOnly {
+                    dataset: dataset.name.to_string(),
+                });
+            }
+
+            // Dynamic datasets cannot have acceleration
+            if dataset.is_accelerated() {
+                return Err(Error::DynamicDatasetCannotHaveAcceleration {
+                    dataset: dataset.name.to_string(),
+                });
+            }
+
+            // Dynamic datasets cannot have embeddings
+            if dataset.has_embeddings() {
+                return Err(Error::DynamicDatasetCannotHaveEmbeddings {
+                    dataset: dataset.name.to_string(),
+                });
+            }
+
+            // Dynamic datasets must use object-store listing connectors
+            if !dataset.source_supports_dynamic() {
+                return Err(Error::DynamicDatasetUnsupportedConnector {
+                    dataset: dataset.name.to_string(),
+                    connector: dataset.source().to_string(),
+                });
+            }
+        }
 
         Ok(dataset)
     }

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -116,6 +116,26 @@ pub enum Error {
         "'snapshots_batches' is required when setting 'snapshots_trigger: batches'. For details, visit: https://spiceai.org/docs/features/data-acceleration/snapshots"
     ))]
     SnapshotTriggerIntervalRequiresInterval,
+
+    #[snafu(display(
+        "Dynamic dataset '{dataset}' must be read-only. Set 'access: readonly' or remove the 'params.dynamic' flag."
+    ))]
+    DynamicDatasetMustBeReadOnly { dataset: String },
+
+    #[snafu(display(
+        "Dynamic dataset '{dataset}' cannot have acceleration enabled. Remove the 'acceleration' configuration or set 'params.dynamic: false'."
+    ))]
+    DynamicDatasetCannotHaveAcceleration { dataset: String },
+
+    #[snafu(display(
+        "Dynamic dataset '{dataset}' cannot have embeddings configured. Remove the 'embeddings' configuration or set 'params.dynamic: false'."
+    ))]
+    DynamicDatasetCannotHaveEmbeddings { dataset: String },
+
+    #[snafu(display(
+        "Dynamic dataset '{dataset}' uses an unsupported connector '{connector}'. Dynamic datasets only support object-store listing connectors: s3, abfs, file, http, https, ftp, nfs, smb."
+    ))]
+    DynamicDatasetUnsupportedConnector { dataset: String, connector: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -265,6 +285,10 @@ pub struct Dataset {
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    /// Dynamic datasets use UDTF-based queries to list objects in object stores.
+    /// When enabled, the dataset must be read-only, cannot have acceleration or embeddings,
+    /// and can only use object-store listing connectors (s3, abfs, file, http, https, ftp, nfs, smb).
+    pub dynamic: bool,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -290,6 +314,7 @@ impl std::fmt::Debug for Dataset {
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
             .field("check_availability", &self.check_availability)
+            .field("dynamic", &self.dynamic)
             .finish_non_exhaustive()
     }
 }
@@ -315,6 +340,7 @@ impl PartialEq for Dataset {
             && self.metrics == other.metrics
             && self.vectors == other.vectors
             && self.check_availability == other.check_availability
+            && self.dynamic == other.dynamic
     }
 }
 
@@ -551,6 +577,20 @@ impl Dataset {
         }
 
         false
+    }
+
+    #[must_use]
+    pub fn is_dynamic(&self) -> bool {
+        self.dynamic
+    }
+
+    /// Returns true if the dataset's source connector supports dynamic datasets.
+    /// Dynamic datasets only work with object-store listing connectors.
+    #[must_use]
+    pub fn source_supports_dynamic(&self) -> bool {
+        const DYNAMIC_SUPPORTED_SOURCES: &[&str] =
+            &["s3", "abfs", "file", "http", "https", "ftp", "nfs", "smb"];
+        DYNAMIC_SUPPORTED_SOURCES.contains(&self.source())
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary
- Add support for dynamic datasets that use UDTF-based queries to list objects in object stores
- Parse `params.dynamic = true` flag from spicepod configuration  
- Add validation ensuring dynamic datasets are read-only, have no acceleration/embeddings, and only use object-store listing connectors (s3, abfs, file, http, https, ftp, nfs, smb)
- Add `is_dynamic()` and `source_supports_dynamic()` helper methods to Dataset

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Manual test: Configure a dataset with `params.dynamic: true` and verify it loads correctly with a supported connector (s3, file)
- [ ] Manual test: Verify error messages when dynamic dataset has invalid config (acceleration enabled, wrong access mode, unsupported connector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)