### PR TITLE
Switch executor scheduling to push-staged with scheduler polling and shared executor gRPC service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=f13a56adea886e60c438585883b1fe404e5666e3#f13a56adea886e60c438585883b1fe404e5666e3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=f13a56adea886e60c438585883b1fe404e5666e3#f13a56adea886e60c438585883b1fe404e5666e3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=f13a56adea886e60c438585883b1fe404e5666e3#f13a56adea886e60c438585883b1fe404e5666e3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5651,7 +5651,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6129,7 +6129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8049,7 +8049,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8605,7 +8605,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8668,7 +8668,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10679,7 +10679,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12770,7 +12770,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14590,7 +14590,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15764,7 +15764,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -19720,7 +19720,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,9 +337,9 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "afcbd1ce99703f1322d176fc1b99745f647234d0" } # spiceai:spiceai-50
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" }           # spiceai:spiceai-50
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" }   # spiceai:spiceai-50
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" } # spiceai:spiceai-50
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista", rev = "f13a56adea886e60c438585883b1fe404e5666e3" }           # spiceai:spiceai-50
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista", rev = "f13a56adea886e60c438585883b1fe404e5666e3" }       # spiceai:spiceai-50
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista", rev = "f13a56adea886e60c438585883b1fe404e5666e3" }      # spiceai:spiceai-50
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "8477c0ba72bc14e31bf829e0ea9b7b217b6e3e5d" } # spiceai-0.16.0
 

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -23,6 +23,8 @@ service ExecutorService {
     // Get the executor's registration information including task slots.
     // Called by schedulers during executor discovery.
     rpc DescribeExecutor(DescribeExecutorRequest) returns (DescribeExecutorResponse);
+    // Poll the executor for task status updates and basic health.
+    rpc PollExecutor(PollExecutorRequest) returns (PollExecutorResponse);
 }
 
 // Request message for DescribeExecutor RPC.
@@ -40,6 +42,26 @@ message DescribeExecutorResponse {
     uint32 grpc_port = 4;
     // Number of task slots available for concurrent task execution.
     uint32 task_slots = 5;
+}
+
+// Request message for PollExecutor RPC.
+message PollExecutorRequest {
+    // Scheduler ID requesting status updates.
+    string scheduler_id = 1;
+    // Maximum number of task statuses to return. Zero means no limit.
+    uint32 max_statuses = 2;
+}
+
+// Response message for PollExecutor RPC.
+message PollExecutorResponse {
+    // Executor ID that produced the response.
+    string executor_id = 1;
+    // True if the executor is terminating.
+    bool terminating = 2;
+    // Milliseconds since UNIX epoch for this snapshot.
+    uint64 timestamp_millis = 3;
+    // Serialized TaskStatus protobufs (ballista_core::serde::protobuf::TaskStatus).
+    repeated bytes task_statuses = 4;
 }
 
 // Request message for GetAppDefinition RPC.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 use ::datafusion::execution::SessionStateBuilder;
 use ::datafusion::prelude::SessionConfig;
 use app::App;
+use ballista_core::config::TaskSchedulingPolicy;
 use ballista_core::extension::SessionConfigExt;
 use ballista_core::registry::BallistaFunctionRegistry;
 use ballista_core::serde::BallistaCodec;
@@ -36,9 +37,11 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::utils::create_grpc_client_endpoint;
 use ballista_core::{ConfigProducer, RuntimeProducer};
-use ballista_executor::execution_loop;
 use ballista_executor::executor::Executor;
+use ballista_executor::executor_process::ExecutorProcessConfig;
+use ballista_executor::executor_server::create_executor_server_without_registration;
 use ballista_executor::metrics::LoggingMetricsCollector;
+use ballista_executor::shutdown::ShutdownNotifier;
 use ballista_scheduler::cluster::BallistaCluster;
 use ballista_scheduler::config::SchedulerConfig;
 use ballista_scheduler::scheduler_process;
@@ -47,7 +50,6 @@ use datafusion::codec::spice_logical_codec::SpiceLogicalCodec;
 use datafusion::codec::spice_physical_codec::SpicePhysicalCodec;
 use datafusion_datasource::ListingTableUrl;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
-use futures::TryFutureExt;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 use runtime_object_store::registry::default_runtime_env;
 use runtime_proto::GetAppDefinitionRequest;
@@ -58,7 +60,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use url::Url;
 
@@ -67,10 +69,12 @@ type SchedulerEndpointOverride =
 
 pub mod datafusion;
 mod discovery;
+mod polling;
 mod servers;
 mod service;
 
 pub use discovery::start_executor_discovery_loop;
+pub use polling::start_executor_poll_loop;
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
 pub use service::{ClusterServiceImpl, ExecutorServiceImpl};
 
@@ -531,9 +535,9 @@ pub async fn initialize_cluster_executor(
     let executor_meta = ExecutorRegistration {
         id: executor_id.clone(),
         // flight service - use advertise address for scheduler to contact this executor
-        host: Some(advertise_host),
+        host: Some(advertise_host.clone()),
         port: u32::from(advertise_port),
-        // grpc_port is used only for push mode, and not initialized for pull mode (default)
+        // executor gRPC service shares the executor cluster service port
         grpc_port: u32::from(advertise_port),
         specification: Some(ExecutorSpecification {
             resources: vec![ExecutorResource {
@@ -565,22 +569,58 @@ pub async fn initialize_cluster_executor(
         .boxed()
         .context(FailedToStartClusterExecutorSnafu)?;
 
-    let (tx_ready, rx_ready) = oneshot::channel::<String>();
+    let (stop_send, mut stop_recv) = mpsc::channel::<bool>(10);
+    let shutdown_noti = ShutdownNotifier::new();
 
-    let executor_poll_loop = tokio::spawn(
-        execution_loop::poll_loop(scheduler, Arc::clone(&executor), codec, Some(tx_ready)).map_err(
-            |e| FailedToStartClusterExecutor {
-                source: Box::new(e),
-            },
-        ),
-    );
+    let scheduler_host = scheduler_url
+        .host_str()
+        .ok_or_else(|| FailedToStartClusterExecutor {
+            source: "Unable to determine scheduler host".to_string().into(),
+        })?
+        .to_string();
+    let scheduler_port =
+        scheduler_url
+            .port_or_known_default()
+            .ok_or_else(|| FailedToStartClusterExecutor {
+                source: "Unable to determine scheduler port".to_string().into(),
+            })?;
+
+    let executor_config = ExecutorProcessConfig {
+        task_scheduling_policy: TaskSchedulingPolicy::PushStaged,
+        bind_host: "0.0.0.0".to_string(),
+        external_host: Some(advertise_host.clone()),
+        port: advertise_port,
+        grpc_port: advertise_port,
+        scheduler_host,
+        scheduler_port,
+        grpc_max_decoding_message_size: u32::MAX,
+        grpc_max_encoding_message_size: u32::MAX,
+        disable_scheduler_heartbeats: true,
+        disable_task_status_push: true,
+        override_create_grpc_client_endpoint: client_tls_config
+            .clone()
+            .map(|tls_config| Arc::new(move |ep: Endpoint| ep.tls_config(tls_config.clone())) as _),
+        ..Default::default()
+    };
+
+    let executor_server = create_executor_server_without_registration(
+        scheduler,
+        Arc::new(executor_config),
+        Arc::clone(&executor),
+        codec,
+        stop_send,
+        &shutdown_noti,
+    )
+    .await
+    .boxed()
+    .context(FailedToStartClusterExecutorSnafu)?;
+
+    rt.df
+        .bind_executor_grpc(Arc::clone(&executor_server))
+        .boxed()
+        .context(FailedToStartClusterExecutorSnafu)?;
 
     Ok(async move {
-        let _ = rx_ready
-            .await
-            .boxed()
-            .context(FailedToStartClusterExecutorSnafu)?;
-
         // Bind the already-fetched app and initialize secrets for object store configuration
         executor_bind_app(&rt, executor_id, app_def, client_tls_config).await?;
 
@@ -588,10 +628,11 @@ pub async fn initialize_cluster_executor(
 
         rt.status.update_cluster("executor", ComponentStatus::Ready);
 
-        executor_poll_loop
-            .await
-            .boxed()
-            .context(FailedToStartClusterExecutorSnafu)?
+        if stop_recv.recv().await.is_some() {
+            let _ = shutdown_noti.notify_shutdown.send(());
+        }
+
+        Ok(())
     })
 }
 
@@ -612,6 +653,7 @@ async fn create_scheduler_server(
     let scheduler_config = SchedulerConfig {
         bind_host: bind_addr.ip().to_string(),
         bind_port: bind_addr.port(),
+        scheduling_policy: TaskSchedulingPolicy::PushStaged,
 
         override_logical_codec: Some(SpiceLogicalCodec::new_with_runtime(Arc::clone(rt))),
         override_physical_codec: Some(
@@ -622,6 +664,7 @@ async fn create_scheduler_server(
 
         grpc_server_max_decoding_message_size: u32::MAX,
         grpc_server_max_encoding_message_size: u32::MAX,
+        executor_grpc_use_tls: client_tls_config.is_some(),
 
         override_session_builder: Some(Arc::new(move |_cfg| {
             let cfg = current_context

--- a/crates/runtime/src/cluster/polling.rs
+++ b/crates/runtime/src/cluster/polling.rs
@@ -1,0 +1,178 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::Runtime;
+use ballista_core::serde::protobuf::{
+    ExecutorHeartbeat, ExecutorStatus, TaskStatus, executor_status,
+};
+use prost::Message;
+use runtime_proto::PollExecutorRequest;
+use runtime_proto::executor_service_client::ExecutorServiceClient;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tonic::transport::{Channel, Endpoint};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const MAX_STATUS_BATCH: u32 = 1024;
+
+pub async fn start_executor_poll_loop(
+    rt: Arc<Runtime>,
+    shutdown: CancellationToken,
+) -> crate::Result<()> {
+    let scheduler = rt
+        .df
+        .scheduler_server
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+        .ok_or_else(|| crate::Error::FailedToStartClusterScheduler {
+            source: "Scheduler server not available for executor polling"
+                .to_string()
+                .into(),
+        })?;
+
+    let scheduler_id = scheduler.scheduler_name.clone();
+    let client_tls_config = rt.df.cluster_config.client_tls_config().cloned();
+    let mut clients: HashMap<String, ExecutorServiceClient<Channel>> = HashMap::new();
+
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                tracing::info!("Executor polling loop shutting down");
+                return Ok(());
+            }
+            () = tokio::time::sleep(POLL_INTERVAL) => {}
+        }
+
+        let executors = match scheduler.state.executor_manager.get_executor_state().await {
+            Ok(executors) => executors,
+            Err(e) => {
+                tracing::warn!("Executor polling: failed to list executors: {e}");
+                continue;
+            }
+        };
+
+        for (metadata, _last_seen) in executors {
+            let host = metadata.host.clone();
+            let scheme = if client_tls_config.is_some() {
+                "https"
+            } else {
+                "http"
+            };
+            let endpoint_url = format!("{scheme}://{host}:{}", metadata.port);
+
+            let client = if let Some(client) = clients.get(&metadata.id).cloned() {
+                client
+            } else {
+                let mut endpoint = Endpoint::from_shared(endpoint_url.clone()).map_err(|e| {
+                    crate::Error::FailedToStartClusterScheduler {
+                        source: Box::new(e),
+                    }
+                })?;
+                if let Some(tls_config) = client_tls_config.clone() {
+                    endpoint = endpoint.tls_config(tls_config).map_err(|e| {
+                        crate::Error::FailedToStartClusterScheduler {
+                            source: Box::new(e),
+                        }
+                    })?;
+                }
+                let channel = match endpoint.connect().await {
+                    Ok(channel) => channel,
+                    Err(e) => {
+                        tracing::debug!(
+                            "Executor polling: failed to connect to {}: {e}",
+                            metadata.id
+                        );
+                        continue;
+                    }
+                };
+                let client = ExecutorServiceClient::new(channel);
+                clients.insert(metadata.id.clone(), client.clone());
+                client
+            };
+
+            let response = match client
+                .clone()
+                .poll_executor(PollExecutorRequest {
+                    scheduler_id: scheduler_id.clone(),
+                    max_statuses: MAX_STATUS_BATCH,
+                })
+                .await
+            {
+                Ok(response) => response.into_inner(),
+                Err(e) => {
+                    tracing::debug!("Executor polling: poll failed for {}: {e}", metadata.id);
+                    clients.remove(&metadata.id);
+                    continue;
+                }
+            };
+
+            if !response.task_statuses.is_empty() {
+                let mut decoded: Vec<TaskStatus> = Vec::with_capacity(response.task_statuses.len());
+                for bytes in response.task_statuses {
+                    match TaskStatus::decode(bytes.as_slice()) {
+                        Ok(status) => decoded.push(status),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Executor polling: failed to decode task status from {}: {e}",
+                                metadata.id
+                            );
+                        }
+                    }
+                }
+                if !decoded.is_empty()
+                    && let Err(e) = scheduler
+                        .update_task_status(&response.executor_id, decoded)
+                        .await
+                {
+                    tracing::warn!(
+                        "Executor polling: failed to update task status for {}: {e}",
+                        response.executor_id
+                    );
+                }
+            }
+
+            let status = if response.terminating {
+                executor_status::Status::Terminating(String::new())
+            } else {
+                executor_status::Status::Active(String::new())
+            };
+
+            let heartbeat = ExecutorHeartbeat {
+                executor_id: response.executor_id,
+                timestamp: response.timestamp_millis / 1000,
+                metrics: Vec::new(),
+                status: Some(ExecutorStatus {
+                    status: Some(status),
+                }),
+            };
+
+            if let Err(e) = scheduler
+                .state
+                .executor_manager
+                .save_executor_heartbeat(heartbeat)
+                .await
+            {
+                tracing::warn!(
+                    "Executor polling: failed to save heartbeat for {}: {e}",
+                    metadata.id
+                );
+            }
+        }
+    }
+}

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -18,11 +18,14 @@ use super::ClusterTlsConfig;
 use crate::cluster::{ClusterServiceImpl, ExecutorServiceImpl};
 use crate::flight::{Error, is_address_in_use_error};
 use crate::{Runtime, metrics as runtime_metrics};
+use ballista_core::serde::protobuf::executor_grpc_server::ExecutorGrpcServer;
+use ballista_core::serde::protobuf::scheduler_grpc_client::SchedulerGrpcClient;
 use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer;
+use ballista_core::utils::create_grpc_client_endpoint;
+use ballista_executor::executor_server::register_executor_with_scheduler;
 use ballista_executor::flight_service::BallistaFlightService;
 use runtime_proto::cluster_service_server::ClusterServiceServer;
 use runtime_proto::executor_service_server::ExecutorServiceServer;
-use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tonic::transport::{Server, ServerTlsConfig};
@@ -149,6 +152,16 @@ pub async fn start_executor_flight_server(
     // and ExecutorService for scheduler-driven discovery.
     let executor_service = ExecutorServiceImpl::new(Arc::clone(&rt.df));
     let executor_service_server = ExecutorServiceServer::new(executor_service);
+    let executor_grpc = rt
+        .df
+        .executor_grpc
+        .read()
+        .ok()
+        .and_then(|maybe_executor| maybe_executor.clone())
+        .ok_or(Error::ClusterExecutorNotInitialized {})?;
+    let executor_grpc_server = ExecutorGrpcServer::new(executor_grpc.as_ref().clone())
+        .max_decoding_message_size(usize::MAX)
+        .max_encoding_message_size(usize::MAX);
 
     let server = server
         .add_service(
@@ -158,10 +171,11 @@ pub async fn start_executor_flight_server(
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX),
         )
-        .add_service(executor_service_server);
+        .add_service(executor_service_server)
+        .add_service(executor_grpc_server);
 
     // Use the executor's bound address if it was dynamically assigned during registration.
-    #[expect(clippy::cast_possible_truncation)]
+    let cluster_bind_ip = rt.df.cluster_config.node_bind_address().ip();
     let bind_address = rt
         .df
         .executor
@@ -170,39 +184,78 @@ pub async fn start_executor_flight_server(
         .and_then(|maybe_executor| {
             maybe_executor
                 .as_ref()
-                .and_then(|e| e.metadata.host.clone().map(|h| (h, e.metadata.port as u16)))
+                .map(|e| e.metadata.port)
+                .and_then(|port| u16::try_from(port).ok())
         })
-        .and_then(|spec| {
-            let (host, port) = &spec;
-            tokio::task::block_in_place(|| match spec.to_socket_addrs() {
-                Ok(sa) => Some(sa),
-                Err(e) => {
-                    tracing::error!("Unable to resolve bound executor host {host}:{port}: {e}");
-                    None
-                }
-            })
-        })
-        .and_then(|mut addrs| addrs.next())
-        .unwrap_or(bind_address);
+        .map_or(bind_address, |port| {
+            std::net::SocketAddr::new(cluster_bind_ip, port)
+        });
 
     tracing::info!("Spice Runtime executor Flight listening on {bind_address}");
     runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);
 
-    if let Some(token) = shutdown_signal {
+    let server_shutdown = shutdown_signal.unwrap_or_default();
+    let server_shutdown_token = server_shutdown.clone();
+    let server_handle = tokio::spawn(async move {
         server
-            .serve_with_shutdown(bind_address, token.cancelled())
+            .serve_with_shutdown(bind_address, server_shutdown_token.cancelled())
             .await
-    } else {
-        server.serve(bind_address).await
-    }
-    .map_err(|e| {
-        if is_address_in_use_error(&e) {
-            return Error::AddressAlreadyInUse {
-                addr: bind_address.to_string(),
-            };
+    });
+
+    if let Some(scheduler_url) = rt.df.cluster_config.scheduler_address() {
+        let mut endpoint = create_grpc_client_endpoint(scheduler_url.to_string()).map_err(|e| {
+            Error::FailedToRegisterExecutor {
+                source: Box::new(e),
+            }
+        })?;
+        if let Some(tls_config) = rt.df.cluster_config.client_tls_config().cloned() {
+            endpoint =
+                endpoint
+                    .tls_config(tls_config)
+                    .map_err(|e| Error::FailedToRegisterExecutor {
+                        source: Box::new(e),
+                    })?;
         }
-        Error::UnableToStartFlightServer { source: e }
-    })?;
+        let channel = endpoint
+            .connect()
+            .await
+            .map_err(|e| Error::FailedToRegisterExecutor {
+                source: Box::new(e),
+            })?;
+        let mut scheduler = SchedulerGrpcClient::new(channel)
+            .max_encoding_message_size(usize::MAX)
+            .max_decoding_message_size(usize::MAX);
+
+        let executor = rt
+            .df
+            .executor
+            .read()
+            .ok()
+            .and_then(|maybe_executor| maybe_executor.clone())
+            .ok_or(Error::ClusterExecutorNotInitialized {})?;
+
+        if let Err(e) = register_executor_with_scheduler(&mut scheduler, executor).await {
+            server_shutdown.cancel();
+            let _ = server_handle.await;
+            return Err(Error::FailedToRegisterExecutor {
+                source: Box::new(e),
+            });
+        }
+    }
+
+    server_handle
+        .await
+        .map_err(|e| Error::FlightServerTaskFailed {
+            source: Box::new(e),
+        })?
+        .map_err(|e| {
+            if is_address_in_use_error(&e) {
+                return Error::AddressAlreadyInUse {
+                    addr: bind_address.to_string(),
+                };
+            }
+            Error::UnableToStartFlightServer { source: e }
+        })?;
 
     tracing::debug!("Spice Runtime executor Flight stopped");
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -24,15 +24,19 @@ use runtime_proto::cluster_service_server::ClusterService;
 use runtime_proto::executor_service_server::ExecutorService;
 use runtime_proto::{
     DescribeExecutorRequest, DescribeExecutorResponse, ExpandSecretRequest, ExpandSecretResponse,
-    GetAppDefinitionRequest, GetAppDefinitionResponse,
+    GetAppDefinitionRequest, GetAppDefinitionResponse, PollExecutorRequest, PollExecutorResponse,
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
 use crate::datafusion::DataFusion;
+use ballista_executor::executor_server::TERMINATING;
+use prost::Message;
 
 /// Internal cluster service for scheduler-executor communication.
 pub struct ClusterServiceImpl {
@@ -181,6 +185,58 @@ impl ExecutorService for ExecutorServiceImpl {
             port: registration.port,
             grpc_port: registration.grpc_port,
             task_slots,
+        }))
+    }
+
+    async fn poll_executor(
+        &self,
+        request: Request<PollExecutorRequest>,
+    ) -> Result<Response<PollExecutorResponse>, Status> {
+        let request = request.into_inner();
+        tracing::trace!(
+            "ExecutorService::poll_executor called for scheduler {}",
+            request.scheduler_id
+        );
+
+        let executor_guard = self
+            .df
+            .executor
+            .read()
+            .map_err(|_| Status::internal("Failed to acquire executor lock"))?;
+
+        let Some(ref executor) = *executor_guard else {
+            return Err(Status::unavailable(
+                "Executor registration not yet available",
+            ));
+        };
+
+        let max_statuses = usize::try_from(request.max_statuses).unwrap_or(0);
+        let task_statuses = executor
+            .status_store()
+            .drain_task_statuses(&request.scheduler_id, max_statuses);
+
+        let mut encoded = Vec::with_capacity(task_statuses.len());
+        for status in task_statuses {
+            let mut buf = Vec::new();
+            status
+                .encode(&mut buf)
+                .map_err(|e| Status::internal(format!("Failed to encode task status: {e}")))?;
+            encoded.push(buf);
+        }
+
+        let timestamp_millis = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| Status::internal(format!("Failed to read system time: {e}")))?
+                .as_millis(),
+        )
+        .map_err(|e| Status::internal(format!("Failed to read system time: {e}")))?;
+
+        Ok(Response::new(PollExecutorResponse {
+            executor_id: executor.metadata.id.clone(),
+            terminating: TERMINATING.load(Ordering::Acquire),
+            timestamp_millis,
+            task_statuses: encoded,
         }))
     }
 }

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -377,6 +377,7 @@ impl DataFusionBuilder {
             cluster_config: self.cluster_config.unwrap_or_default(),
             scheduler_server: RwLock::new(None),
             executor: RwLock::new(None),
+            executor_grpc: RwLock::new(None),
         }
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -48,6 +48,7 @@ use crate::{status, view};
 use {
     crate::cluster::ResolvedClusterConfig,
     ballista_executor::executor::Executor,
+    ballista_executor::executor_server::ExecutorServer as BallistaExecutorServer,
     ballista_scheduler::scheduler_server::SchedulerServer,
     datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode},
 };
@@ -249,6 +250,9 @@ pub enum Error {
     #[snafu(display("Unable to acquire lock for cluster scheduler state"))]
     UnableToLockWritableExecutorHandle {},
 
+    #[snafu(display("Unable to acquire lock for cluster scheduler state"))]
+    UnableToLockWritableExecutorGrpcHandle {},
+
     #[snafu(display(
         "The schema returned by the data connector for 'refresh_mode: changes' does not contain a data field"
     ))]
@@ -362,6 +366,8 @@ pub struct DataFusion {
     pub cluster_config: Arc<ResolvedClusterConfig>,
     pub scheduler_server: RwLock<Option<Arc<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>>>>,
     pub executor: RwLock<Option<Arc<Executor>>>,
+    pub executor_grpc:
+        RwLock<Option<Arc<BallistaExecutorServer<LogicalPlanNode, PhysicalPlanNode>>>>,
 }
 
 impl std::fmt::Debug for DataFusion {
@@ -1956,6 +1962,18 @@ impl DataFusion {
             .try_write()
             .map_err(|_| Error::UnableToLockWritableExecutorHandle {})?;
         *executor_handle = Some(executor);
+        Ok(())
+    }
+
+    pub fn bind_executor_grpc(
+        &self,
+        executor_grpc: Arc<BallistaExecutorServer<LogicalPlanNode, PhysicalPlanNode>>,
+    ) -> Result<()> {
+        let mut executor_grpc_handle = self
+            .executor_grpc
+            .try_write()
+            .map_err(|_| Error::UnableToLockWritableExecutorGrpcHandle {})?;
+        *executor_grpc_handle = Some(executor_grpc);
         Ok(())
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -428,11 +428,26 @@ pub enum Error {
     ))]
     ClusterSchedulerNotInitialized {},
 
+    #[snafu(display(
+        "The cluster executor is not initialized, preventing the flight service from starting."
+    ))]
+    ClusterExecutorNotInitialized {},
+
     #[snafu(display("Unable to start internal cluster server: {source}"))]
     UnableToStartClusterServer { source: tonic::transport::Error },
 
     #[snafu(display("The flight service has an insecure configuration: {message}"))]
     InsecureConfiguration { message: String },
+
+    #[snafu(display("Failed to register executor with scheduler: {source}"))]
+    FailedToRegisterExecutor {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Executor flight server task failed: {source}"))]
+    FlightServerTaskFailed {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -683,6 +683,23 @@ impl Runtime {
                 None
             };
 
+        // Executor polling future (scheduler-only)
+        let maybe_poll_future: Option<BoxedClusterFuture> =
+            if self.df.cluster_config.effective_role() == Some(ClusterRole::Scheduler) {
+                let poll_shutdown = CancellationToken::new();
+                let poll_rt = Arc::clone(&self);
+                let cloned_poll_shutdown = poll_shutdown.clone();
+                let poll_fut = async move {
+                    cluster::start_executor_poll_loop(poll_rt, cloned_poll_shutdown).await
+                };
+                Some(Box::pin(
+                    self.start_runtime_task("cluster_executor_poll", Some(poll_shutdown), poll_fut)
+                        .await,
+                ))
+            } else {
+                None
+            };
+
         let maybe_cluster_future: Option<BoxedClusterFuture> =
             match self.df.cluster_config.effective_role() {
                 Some(ClusterRole::Scheduler) => {
@@ -854,8 +871,27 @@ impl Runtime {
             .await;
 
         // wait for all servers to shut down or if any of the servers fail to start
-        match (maybe_cluster_future, maybe_discovery_future) {
-            (Some(cluster_future), Some(discovery_future)) => {
+        match (
+            maybe_cluster_future,
+            maybe_discovery_future,
+            maybe_poll_future,
+        ) {
+            (Some(cluster_future), Some(discovery_future), Some(poll_future)) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    cluster_future,
+                    discovery_future,
+                    poll_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (Some(cluster_future), Some(discovery_future), None) => {
                 match tokio::try_join!(
                     http_future,
                     flight_future,
@@ -869,13 +905,67 @@ impl Runtime {
                     _ => Ok(()),
                 }
             }
-            (Some(cluster_future), None) => {
+            (Some(cluster_future), None, Some(poll_future)) => {
                 match tokio::try_join!(
                     http_future,
                     flight_future,
                     metrics_future,
                     pods_watcher_future,
                     cluster_future,
+                    poll_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (Some(cluster_future), None, None) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    cluster_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (None, Some(discovery_future), Some(poll_future)) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    discovery_future,
+                    poll_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (None, Some(discovery_future), None) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    discovery_future,
+                    shutdown_signal_future
+                ) {
+                    Err(err) => Err(err),
+                    _ => Ok(()),
+                }
+            }
+            (None, None, Some(poll_future)) => {
+                match tokio::try_join!(
+                    http_future,
+                    flight_future,
+                    metrics_future,
+                    pods_watcher_future,
+                    poll_future,
                     shutdown_signal_future
                 ) {
                     Err(err) => Err(err),


### PR DESCRIPTION
## 📝 Summary

- Depends on: https://github.com/spiceai/spiceai/pull/8746

Switches the Ballista scheduling mode from pull based to push based, which is more compatible with an HA scheduler configuration.

- Brings in the following Ballista change: https://github.com/spiceai/datafusion-ballista/pull/5

With this change multiple schedulers can now push work to executors independently.
