### PR TITLE
Upgrade to Rust 1.91

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,12 +36,12 @@ runs:
       if: inputs.os != 'windows'
       shell: bash
       run: |
-        rustup toolchain install 1.90
-        rustup default 1.90
+        rustup toolchain install 1.91
+        rustup default 1.91
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
-        rustup toolchain install 1.90
-        rustup default 1.90
+        rustup toolchain install 1.91
+        rustup default 1.91

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ exclude = [".github/"]
 homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.90"
+rust-version = "1.91"
 version = "1.11.0-unstable"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.90
+ARG RUST_VERSION=1.91
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.90
+ARG RUST_VERSION=1.91
 
 FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS build
 

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -563,7 +563,7 @@ fn apply_overrides(
 
     for (path, value) in overrides {
         let yaml_value =
-            serde_yaml::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()));
+            serde_yaml::from_str(value).unwrap_or_else(|_| Value::String(value.clone()));
         match apply_override(&mut yaml, path, yaml_value) {
             Ok(()) => (),
             Err(e) => {

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -258,7 +258,7 @@ async fn zipkin_task_history_otel_exporter(
         return Ok(None);
     }
 
-    let collector_endpoint: String = zipkin_endpoint.to_string();
+    let collector_endpoint: String = zipkin_endpoint.clone();
 
     Ok(Some(
         ZipkinExporter::builder()

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -264,7 +264,7 @@ pub fn record_to_param_values(batch: &RecordBatch) -> Result<ParamValues, DataFu
 
         // Not a numbered parameter - switch to named mode
         is_list = false;
-        named_params.push((name.to_string(), scalar));
+        named_params.push((name.clone(), scalar));
     }
 
     if is_list && !list_params.is_empty() {

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -966,7 +966,7 @@ impl DataSink for MemSink {
                 // Just collect unique keys and check for nulls, don't enforce uniqueness
                 for id in &new_primary_key_ids {
                     if let Some(key) = id {
-                        new_key_set.insert(key.to_string());
+                        new_key_set.insert(key.clone());
                     } else {
                         return Err(DataFusionError::Execution(
                             "Primary key values cannot be null".to_string(),

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -75,7 +75,7 @@ impl DatabricksDelta {
                     storage_options.insert("timeout".into(), value.clone());
                 }
                 _ => {
-                    storage_options.insert(key.to_string(), value.clone());
+                    storage_options.insert(key.clone(), value.clone());
                 }
             }
         }

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -314,7 +314,7 @@ impl SqlWarehouseApi {
             )));
         }
 
-        let token = token.to_string();
+        let token = token.clone();
         let stream = stream::unfold(initial_external_link, move |current_link| {
             let api = Arc::clone(&self);
             let token = token.clone();

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -165,7 +165,7 @@ pub fn append_value_to_struct_builder(
     for (idx, field) in builder.fields().iter().enumerate() {
         let Some(field_value) = value.get(field.name()) else {
             return MissingFieldInValueSnafu {
-                field_name: field.name().to_string(),
+                field_name: field.name().clone(),
                 value,
             }
             .fail();

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -153,7 +153,7 @@ impl DeltaTable {
                     storage_options.insert("timeout".into(), value.expose_secret().to_string());
                 }
                 _ => {
-                    storage_options.insert(key.to_string(), value.expose_secret().to_string());
+                    storage_options.insert(key.clone(), value.expose_secret().to_string());
                 }
             }
         }

--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -41,7 +41,7 @@ pub fn json_nest_except_fields(
                 let json_string =
                     serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
                 result.insert(
-                    json_nesting.json_field_name.to_string(),
+                    json_nesting.json_field_name.clone(),
                     AttributeValue::S(json_string),
                 );
             }

--- a/crates/data_components/src/dynamodb/request_builder.rs
+++ b/crates/data_components/src/dynamodb/request_builder.rs
@@ -345,7 +345,7 @@ impl DynamoDBRequestPlanBuilder {
                 }
             } else {
                 // For non-flattened fields, add the full name
-                attribute_names.insert(format!("#{field_name}"), field_name.to_string());
+                attribute_names.insert(format!("#{field_name}"), field_name.clone());
             }
         }
     }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -223,7 +223,7 @@ impl TableProvider for GraphQLTableProvider {
                 let col_name = self.table_schema.field(*idx).name();
                 projection_expr.push((
                     Arc::new(Column::new(col_name, *idx)) as Arc<dyn PhysicalExpr>,
-                    col_name.to_string(),
+                    col_name.clone(),
                 ));
             }
 

--- a/crates/data_components/src/object/mod.rs
+++ b/crates/data_components/src/object/mod.rs
@@ -115,7 +115,7 @@ pub(crate) fn parse_prefix_and_regex(
                 .strip_suffix(filename.as_str())
                 .unwrap_or_default()
                 .to_string(),
-            Some(filename.to_string()),
+            Some(filename.clone()),
         ))
     } else if let Some(ext) = extension {
         Ok((

--- a/crates/data_components/src/oracle/convert.rs
+++ b/crates/data_components/src/oracle/convert.rs
@@ -186,11 +186,9 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         row,
                         idx,
                         |v: String| {
-                            let decimal =
-                                v.parse::<BigDecimal>()
-                                    .context(FailedToParseBigDecimalSnafu {
-                                        value: v.to_string(),
-                                    })?;
+                            let decimal = v
+                                .parse::<BigDecimal>()
+                                .context(FailedToParseBigDecimalSnafu { value: v.clone() })?;
 
                             big_decimal_to_i128(&decimal, *scale).context(
                                 FailedToConvertBigDecimalToI128Snafu {

--- a/crates/data_components/src/s3_vectors/metadata_column.rs
+++ b/crates/data_components/src/s3_vectors/metadata_column.rs
@@ -95,24 +95,21 @@ impl MetadataColumns {
     pub fn non_filterable_names(&self) -> Vec<String> {
         self.non_filterable()
             .iter()
-            .map(|f| f.name().to_string())
+            .map(|f| f.name().clone())
             .collect()
     }
 
     #[must_use]
     pub fn filterable_names(&self) -> Vec<String> {
-        self.filterable()
-            .iter()
-            .map(|f| f.name().to_string())
-            .collect()
+        self.filterable().iter().map(|f| f.name().clone()).collect()
     }
 
     #[must_use]
     pub fn all_names(&self) -> Vec<String> {
         self.non_filterable()
             .iter()
-            .map(|f| f.name().to_string())
-            .chain(self.filterable().iter().map(|f| f.name().to_string()))
+            .map(|f| f.name().clone())
+            .chain(self.filterable().iter().map(|f| f.name().clone()))
             .collect()
     }
 }

--- a/crates/data_components/src/s3_vectors/put_vectors_sink.rs
+++ b/crates/data_components/src/s3_vectors/put_vectors_sink.rs
@@ -253,14 +253,14 @@ fn create_put_input_vectors(record_batch: &RecordBatch) -> Result<Vec<PutInputVe
             // Validate metadata key
             if name.is_empty() {
                 return Err(Error::InvalidMetadataKey {
-                    key: (*name).to_string(),
+                    key: (*name).clone(),
                     row,
                     reason: "Metadata key cannot be empty".to_string(),
                 });
             }
             if name.len() > 256 {
                 return Err(Error::InvalidMetadataKey {
-                    key: (*name).to_string(),
+                    key: (*name).clone(),
                     row,
                     reason: format!(
                         "Metadata key exceeds maximum length of 256 characters (got {})",
@@ -271,7 +271,7 @@ fn create_put_input_vectors(record_batch: &RecordBatch) -> Result<Vec<PutInputVe
             // Metadata keys should not contain control characters or special chars
             if name.chars().any(|c| c.is_control() || c == '\0') {
                 return Err(Error::InvalidMetadataKey {
-                    key: (*name).to_string(),
+                    key: (*name).clone(),
                     row,
                     reason: "Metadata key contains invalid characters".to_string(),
                 });
@@ -279,7 +279,7 @@ fn create_put_input_vectors(record_batch: &RecordBatch) -> Result<Vec<PutInputVe
 
             let col = record_batch.column(*index);
             let value = metadata_from_row(row, data_type, col)?;
-            metadata.insert((*name).to_string(), value);
+            metadata.insert((*name).clone(), value);
         }
 
         let metadata = if metadata.is_empty() {

--- a/crates/data_components/src/s3_vectors/spill/mod.rs
+++ b/crates/data_components/src/s3_vectors/spill/mod.rs
@@ -233,7 +233,7 @@ pub(super) async fn all_spill_tables(
             .iter()
             .map(|spill_index_name| {
                 table.clone().with_new_id(S3VectorIdentifier::Index {
-                    bucket_name: bucket_name.to_string(),
+                    bucket_name: bucket_name.clone(),
                     index_name: spill_index_name.clone(),
                 })
             })

--- a/crates/data_components/src/sharepoint/client.rs
+++ b/crates/data_components/src/sharepoint/client.rs
@@ -156,10 +156,10 @@ async fn resolve_drive_ptr(
     drive: &PublicDrivePtr,
 ) -> Result<DrivePtr, Error> {
     match drive {
-        PublicDrivePtr::DriveId(id) => Ok(DrivePtr::DriveId(id.to_string())),
-        PublicDrivePtr::UserId(id) => Ok(DrivePtr::UserId(id.to_string())),
-        PublicDrivePtr::GroupId(id) => Ok(DrivePtr::GroupId(id.to_string())),
-        PublicDrivePtr::SiteId(id) => Ok(DrivePtr::SiteId(id.to_string())),
+        PublicDrivePtr::DriveId(id) => Ok(DrivePtr::DriveId(id.clone())),
+        PublicDrivePtr::UserId(id) => Ok(DrivePtr::UserId(id.clone())),
+        PublicDrivePtr::GroupId(id) => Ok(DrivePtr::GroupId(id.clone())),
+        PublicDrivePtr::SiteId(id) => Ok(DrivePtr::SiteId(id.clone())),
         PublicDrivePtr::Me => Ok(DrivePtr::Me),
         PublicDrivePtr::DriveName(name) => {
             let drives = get_drive_items(Arc::clone(&client)).await.map_err(|e| {
@@ -178,10 +178,10 @@ async fn resolve_drive_ptr(
                         .join(", ")
                 );
                 return Err(Error::DriveNotFound {
-                    drive: name.to_string(),
+                    drive: name.clone(),
                 });
             };
-            Ok(DrivePtr::DriveId(drive_id.to_string()))
+            Ok(DrivePtr::DriveId(drive_id.clone()))
         }
         PublicDrivePtr::GroupName(name) => {
             let groups = get_group_items(Arc::clone(&client)).await.map_err(|e| {
@@ -200,7 +200,7 @@ async fn resolve_drive_ptr(
                         .join(", ")
                 );
                 return Err(Error::GroupNotFound {
-                    group: name.to_string(),
+                    group: name.clone(),
                 });
             };
 
@@ -214,12 +214,12 @@ async fn resolve_drive_ptr(
             {
                 Err(_) => {
                     return Err(Error::GroupHasNoDrive {
-                        group: name.to_string(),
+                        group: name.clone(),
                     });
                 }
                 Ok(r) if !r.status().is_success() => {
                     return Err(Error::GroupHasNoDrive {
-                        group: name.to_string(),
+                        group: name.clone(),
                     });
                 }
                 Ok(_) => {
@@ -227,7 +227,7 @@ async fn resolve_drive_ptr(
                 }
             }
 
-            Ok(DrivePtr::GroupId(group_id.to_string()))
+            Ok(DrivePtr::GroupId(group_id.clone()))
         }
         PublicDrivePtr::SiteName(name) => {
             let sites = get_site_items(Arc::clone(&client)).await.map_err(|e| {
@@ -245,9 +245,7 @@ async fn resolve_drive_ptr(
                         .collect::<Vec<String>>()
                         .join(", ")
                 );
-                return Err(Error::SiteNotFound {
-                    site: name.to_string(),
-                });
+                return Err(Error::SiteNotFound { site: name.clone() });
             };
             // Check if the site has a drive. This can't be done in the above `get_site_items` call (with an $expand).
             match Arc::clone(&client)
@@ -258,20 +256,16 @@ async fn resolve_drive_ptr(
                 .await
             {
                 Err(_) => {
-                    return Err(Error::SiteHasNoDrive {
-                        site: name.to_string(),
-                    });
+                    return Err(Error::SiteHasNoDrive { site: name.clone() });
                 }
                 Ok(r) if !r.status().is_success() => {
-                    return Err(Error::SiteHasNoDrive {
-                        site: name.to_string(),
-                    });
+                    return Err(Error::SiteHasNoDrive { site: name.clone() });
                 }
                 Ok(_) => {
                     tracing::debug!("Found a drive for sharepoint site '{name}'");
                 }
             }
-            Ok(DrivePtr::SiteId(site_id.to_string()))
+            Ok(DrivePtr::SiteId(site_id.clone()))
         }
     }
 }

--- a/crates/data_components/src/spice_cloud/provider.rs
+++ b/crates/data_components/src/spice_cloud/provider.rs
@@ -109,7 +109,7 @@ impl SpiceCloudPlatformCatalogProvider {
             let Some(last_name) = name_inner.last() else {
                 unreachable!("The namespace should have at least one element");
             };
-            child_namespace_vec.push(last_name.to_string());
+            child_namespace_vec.push(last_name.clone());
             let Ok(child_namespace) = NamespaceIdent::from_vec(child_namespace_vec) else {
                 unreachable!("This only panics if the vec is empty");
             };
@@ -135,7 +135,7 @@ impl SpiceCloudPlatformCatalogProvider {
                 let Some(last_name) = name_inner.last() else {
                     unreachable!("The namespace should have at least one element");
                 };
-                (last_name.to_string(), provider)
+                (last_name.clone(), provider)
             })
             .collect();
 

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -155,13 +155,13 @@ impl UnityCatalogSchemaProvider {
             .list_tables(&schema.catalog_name, &schema.name)
             .await?
             .context(super::SchemaDoesntExistSnafu {
-                schema: schema.name.to_string(),
-                catalog_id: schema.catalog_name.to_string(),
+                schema: schema.name.clone(),
+                catalog_id: schema.catalog_name.clone(),
             })?;
 
         let mut tables_map = HashMap::new();
         for table in tables {
-            let table_name = table.name.to_string();
+            let table_name = table.name.clone();
             let table_reference = table_reference_creator(&table);
 
             let Some(table_reference) = table_reference else {
@@ -204,8 +204,8 @@ impl UnityCatalogSchemaProvider {
             .list_tables(&self.schema.catalog_name, &self.schema.name)
             .await?
             .context(super::SchemaDoesntExistSnafu {
-                schema: self.schema.name.to_string(),
-                catalog_id: self.schema.catalog_name.to_string(),
+                schema: self.schema.name.clone(),
+                catalog_id: self.schema.catalog_name.clone(),
             })?;
 
         let mut new_tables = Vec::new();
@@ -236,7 +236,7 @@ impl UnityCatalogSchemaProvider {
             else {
                 continue;
             };
-            new_table_providers.insert(table.name.to_string(), provider);
+            new_table_providers.insert(table.name.clone(), provider);
         }
 
         let mut guard = match self.tables.write() {
@@ -285,7 +285,7 @@ impl UnityCatalogSchemaProvider {
         table_reference_creator: fn(&UCTable) -> Option<TableReference>,
         include: Option<Arc<GlobSet>>,
     ) -> Option<Arc<dyn TableProvider>> {
-        let table_name = table.name.to_string();
+        let table_name = table.name.clone();
         let table_reference = table_reference_creator(table)?;
 
         let schema_with_table = format!("{}.{}", schema.name, table_name);

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -420,14 +420,14 @@ pub async fn initialize_state_from_checkpoint(
         );
 
         let shard = ActiveShard {
-            shard_id: shard_id.to_string(),
+            shard_id: shard_id.clone(),
             parent_shard_id: shard_checkpoint.parent_id.clone(),
             iterator,
             last_checkpoint: shard_checkpoint.clone(),
             current_watermark: None,
         };
 
-        state.active.insert(shard_id.to_string(), shard);
+        state.active.insert(shard_id.clone(), shard);
 
         // Recursively add all descendants to blocked
         add_all_descendants_to_blocked(&mut state, shard_id, &parent_map, &all_shards)?;

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -330,7 +330,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
     rl.set_helper(Some(EditorHelper::new(
         Some(client.clone()),
         repl_config.api_key.clone(),
-        user_agent.to_string(),
+        user_agent.clone(),
     )));
     if let Some(helper) = rl.helper_mut() {
         // Perform initial refresh to populate autocomplete immediately with a 2-second timeout

--- a/crates/llms/src/anthropic/chat.rs
+++ b/crates/llms/src/anthropic/chat.rs
@@ -95,7 +95,7 @@ impl TryFrom<MessageCreateResponse> for CreateChatCompletionResponse {
     fn try_from(value: MessageCreateResponse) -> Result<Self, Self::Error> {
         Ok(CreateChatCompletionResponse {
             id: value.id,
-            model: value.model.to_string(),
+            model: value.model.clone(),
             usage: Some(CompletionUsage {
                 prompt_tokens: value.usage.input_tokens,
                 completion_tokens: value.usage.output_tokens,

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -524,7 +524,7 @@ pub fn message_to_mistral(
                         };
 
                         let mut map = IndexMap::new();
-                        map.insert("id".to_string(), Value::String(func_call.id.to_string()));
+                        map.insert("id".to_string(), Value::String(func_call.id.clone()));
                         map.insert("function".to_string(), function);
                         map.insert("type".to_string(), Value::String("function".to_string()));
 

--- a/crates/llms/src/embeddings/candle/util.rs
+++ b/crates/llms/src/embeddings/candle/util.rs
@@ -85,7 +85,7 @@ pub(crate) fn position_offset(config: &ModelConfig) -> usize {
 /// Converts the `OpenAI` format to the TEI format
 pub(crate) fn inputs_from_openai(input: &EmbeddingInput) -> Vec<EncodingInput> {
     match input {
-        EmbeddingInput::String(s) => vec![EncodingInput::Single(s.to_string())],
+        EmbeddingInput::String(s) => vec![EncodingInput::Single(s.clone())],
         EmbeddingInput::StringArray(arr) => arr
             .iter()
             .map(|s| EncodingInput::Single(s.clone()))

--- a/crates/llms/src/perplexity/mod.rs
+++ b/crates/llms/src/perplexity/mod.rs
@@ -65,7 +65,7 @@ impl PerplexitySonar {
             .iter()
             .filter_map(|(k, v)| {
                 if *k != auth_token_key {
-                    return Some((k.to_string(), v.expose_secret().to_string()));
+                    return Some((k.clone(), v.expose_secret().to_string()));
                 }
                 None
             })

--- a/crates/model_components/src/model.rs
+++ b/crates/model_components/src/model.rs
@@ -61,10 +61,7 @@ impl Model {
             });
         };
 
-        params.insert(
-            "name".to_string(),
-            SecretString::from(model.name.to_string()),
-        );
+        params.insert("name".to_string(), SecretString::from(model.name.clone()));
         params.insert("path".to_string(), SecretString::from(path(&model.from)));
         params.insert("from".to_string(), SecretString::from(path(&model.from)));
         params.insert(

--- a/crates/runtime-object-store/src/registry/mod.rs
+++ b/crates/runtime-object-store/src/registry/mod.rs
@@ -417,7 +417,7 @@ impl SpiceObjectStoreRegistry {
             builder = builder.with_tenant_id(tenant_id);
         }
         if let Some(endpoint) = params.get("endpoint") {
-            builder = builder.with_endpoint(endpoint.to_string());
+            builder = builder.with_endpoint(endpoint.clone());
         }
 
         if let Some(use_fabric_endpoint) = params.get("use_fabric_endpoint") {

--- a/crates/runtime-object-store/src/store/github.rs
+++ b/crates/runtime-object-store/src/store/github.rs
@@ -189,7 +189,7 @@ impl ObjectStore for GitHubRawObjectStore {
             let files: Vec<GitTreeNode> = git_tree
                 .tree
                 .into_iter()
-                .filter(|node| node.node_type == "blob" && prefix.as_ref().is_none_or(|p| node.path.starts_with(&p.to_string())))
+                .filter(|node| node.node_type == "blob" && prefix.as_ref().is_none_or(|p| node.path.starts_with(&p.clone())))
                 .collect();
 
             for file in files {

--- a/crates/runtime-secrets/src/lib.rs
+++ b/crates/runtime-secrets/src/lib.rs
@@ -280,7 +280,7 @@ fn spicepod_secret_store_type(store: &SpicepodSecret) -> Result<SecretStoreType>
             if let Some(params) = store.params.as_ref() {
                 let params = params.as_string_map();
                 if let Some(path) = params.get("file_path") {
-                    return Ok(SecretStoreType::EnvCustomPath(path.to_string()));
+                    return Ok(SecretStoreType::EnvCustomPath(path.clone()));
                 }
             }
             Ok(SecretStoreType::Env)

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1100,7 +1100,7 @@ async fn notify_refresh_done(
     let mut labels = vec![KeyValue::new("dataset", dataset_name.to_string())];
     let refresh_guard = refresh.read().await;
     if let Some(sql) = &refresh_guard.sql {
-        labels.push(KeyValue::new("sql", sql.to_string()));
+        labels.push(KeyValue::new("sql", sql.clone()));
     }
 
     metrics::LAST_REFRESH_TIME_MS.record(now.as_secs_f64() * 1000.0, &labels);

--- a/crates/runtime/src/catalogconnector/glue/provider.rs
+++ b/crates/runtime/src/catalogconnector/glue/provider.rs
@@ -175,7 +175,7 @@ impl GlueCatalogProvider {
             for table in some_tables {
                 let mut parameters = self.parameters.parameters.clone();
                 if let Some(catalog_id) = &self.catalog_id {
-                    parameters.insert("catalog_id".to_string(), catalog_id.to_string().into());
+                    parameters.insert("catalog_id".to_string(), catalog_id.clone().into());
                 }
 
                 let connector =

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -247,11 +247,11 @@ impl CatalogBuilder {
 
     pub fn build(self) -> Result<Catalog> {
         let app = self.app.ok_or(Error::UnableToBuildCatalog {
-            catalog: self.name.to_string(),
+            catalog: self.name.clone(),
             missing_component: "app".to_string(),
         })?;
         let runtime = self.runtime.ok_or(Error::UnableToBuildCatalog {
-            catalog: self.name.to_string(),
+            catalog: self.name.clone(),
             missing_component: "runtime".to_string(),
         })?;
 

--- a/crates/runtime/src/component/dataset/acceleration/constraints.rs
+++ b/crates/runtime/src/component/dataset/acceleration/constraints.rs
@@ -37,7 +37,7 @@ impl Acceleration {
         schema
             .flattened_fields()
             .into_iter()
-            .map(|f| f.name().to_string())
+            .map(|f| f.name().clone())
             .collect::<Vec<_>>()
             .join(", ")
     }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -177,7 +177,7 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
         let table_reference = Dataset::parse_table_reference(&view.name)?;
 
         let sql = if let Some(view_sql) = &view.sql {
-            view_sql.to_string()
+            view_sql.clone()
         } else if let Some(sql_ref) = &view.sql_ref {
             View::load_sql_ref(sql_ref)?
         } else {

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -2187,7 +2187,7 @@ mod accelerator_compat_tests {
                 if _mode == "file" {
                     options.insert("file".to_string(), location.clone());
                 }
-                options.insert("mode".to_string(), _mode.to_string());
+                options.insert("mode".to_string(), _mode.clone());
 
                 let external_table = CreateExternalTable {
                     schema: df_schema,

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -635,7 +635,7 @@ pub(crate) fn get_primary_keys_from_constraints(
                 Some(
                     col_indexes
                         .iter()
-                        .map(|&col_index| schema.field(col_index).name().to_string()),
+                        .map(|&col_index| schema.field(col_index).name().clone()),
                 )
             } else {
                 None

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/partition_buffer/config.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/partition_buffer/config.rs
@@ -25,9 +25,10 @@ use crate::spice_data_base_path;
 const ROWS_PER_PARTITION_BUFFER: usize = 122_880;
 
 /// Configuration for partition buffer type selection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum PartitionBufferType {
     /// Use in-memory buffers (default behavior)
+    #[default]
     Memory,
     /// Use Parquet file-based buffers
     Parquet,
@@ -56,12 +57,6 @@ impl PartitionBufferType {
             Self::Memory => "memory",
             Self::Parquet => "parquet",
         }
-    }
-}
-
-impl Default for PartitionBufferType {
-    fn default() -> Self {
-        Self::Memory
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/workflow_runs.rs
+++ b/crates/runtime/src/dataconnector/github/workflow_runs.rs
@@ -356,7 +356,7 @@ impl TableProvider for WorkflowRunsTableProvider {
                 projection_expr.push((
                     Arc::new(physical_expr::expressions::Column::new(col_name, *idx))
                         as Arc<dyn PhysicalExpr>,
-                    col_name.to_string(),
+                    col_name.clone(),
                 ));
             }
 

--- a/crates/runtime/src/dataconnector/github/workflows.rs
+++ b/crates/runtime/src/dataconnector/github/workflows.rs
@@ -153,7 +153,7 @@ impl TableProvider for WorkflowsTableProvider {
                 let col_name = self.schema.field(*idx).name();
                 projection_expr.push((
                     Arc::new(Column::new(col_name, *idx)) as Arc<dyn PhysicalExpr>,
-                    col_name.to_string(),
+                    col_name.clone(),
                 ));
             }
 

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -434,7 +434,7 @@ async fn create_iceberg_provider(
 
     props.insert(
         GLUE_CATALOG_PROP_WAREHOUSE.to_string(),
-        metadata_location.to_string(),
+        metadata_location.clone(),
     );
 
     if let Some(catalog_id) = table.catalog_id.clone() {
@@ -557,7 +557,7 @@ fn get_metadata_location(table: &Table) -> Result<String, Error> {
     const METADATA_LOCATION: &str = "metadata_location";
     match &table.parameters {
         Some(properties) => match properties.get(METADATA_LOCATION) {
-            Some(location) => Ok(location.to_string()),
+            Some(location) => Ok(location.clone()),
             None => Err(Error::MissingMetadataLocation {
                 table: table.name().to_string(),
                 message: format!("No property '{METADATA_LOCATION}' found"),

--- a/crates/runtime/src/dataconnector/imap.rs
+++ b/crates/runtime/src/dataconnector/imap.rs
@@ -164,7 +164,7 @@ impl ImapFactory {
                         dataconnector: "imap".to_string(),
                         connector_component: params.component.clone(),
                         source: Error::InvalidFrom {
-                            from: dataset.from.to_string(),
+                            from: dataset.from.clone(),
                         }
                         .into(),
                     }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -131,7 +131,7 @@ impl LocationPruningListingTable {
 
         let mut values = Vec::with_capacity(self.partition_column_types().len());
         for (value, (_, dtype)) in parts.into_iter().zip(self.partition_column_types()) {
-            let scalar = ScalarValue::try_from_string(value.to_string(), dtype).ok()?;
+            let scalar = ScalarValue::try_from_string(value.clone(), dtype).ok()?;
             values.push(scalar);
         }
         Some(values)
@@ -1058,7 +1058,7 @@ pub trait ListingTableConnector: DataConnector {
         let mut idents = schema
             .fields
             .iter()
-            .map(|f| (f.name().to_string(), f.as_ref().clone()))
+            .map(|f| (f.name().clone(), f.as_ref().clone()))
             .collect::<HashMap<_, _>>();
 
         for (name, partition_type) in partition_cols {

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -706,7 +706,7 @@ fn include_computed_columns(
                                 {
                                     proj.expr.push(Expr::Column(Column::new(
                                         proj.schema.qualified_field(idx).0.cloned(),
-                                        computed_column.name().to_string(),
+                                        computed_column.name().clone(),
                                     )));
                                 }
                             }

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -147,9 +147,9 @@ impl DatasetsHealthMonitor {
 
         let mut monitored_datasets = self.monitored_datasets.lock().await;
         monitored_datasets.insert(
-            dataset_name.to_string(),
+            dataset_name.clone(),
             Arc::new(DatasetAvailabilityInfo::new(
-                dataset_name.to_string(),
+                dataset_name.clone(),
                 table_provider,
             )),
         );
@@ -290,7 +290,7 @@ AND labels.error_code IS NULL"
                                     Ok(()) => AvailabilityVerificationResult::Available,
                                     Err(err) => {
                                         let err_message = match err.find_root() {
-                                            DataFusionError::Execution(e) => e.to_string(),
+                                            DataFusionError::Execution(e) => e.clone(),
                                             _ => err.to_string(),
                                         };
 
@@ -345,8 +345,8 @@ async fn update_dataset_availability_info(
     }
 }
 
-fn report_dataset_unavailable_time(dataset_name: &String, last_available_time: Option<SystemTime>) {
-    let labels = vec![KeyValue::new("dataset", dataset_name.to_string())];
+fn report_dataset_unavailable_time(dataset_name: &str, last_available_time: Option<SystemTime>) {
+    let labels = vec![KeyValue::new("dataset", dataset_name.to_owned())];
 
     match last_available_time {
         Some(last_available_time) => metrics::datasets::UNAVAILABLE_TIME_MS.record(

--- a/crates/runtime/src/embeddings/metrics.rs
+++ b/crates/runtime/src/embeddings/metrics.rs
@@ -59,16 +59,13 @@ pub(crate) fn request_labels(req: &CreateEmbeddingRequest) -> Vec<KeyValue> {
         Some(EncodingFormat::Base64) => "base64",
     };
     let mut labels = vec![
-        KeyValue::new(
-            Key::new("model"),
-            Value::String(req.model.to_string().into()),
-        ),
+        KeyValue::new(Key::new("model"), Value::String(req.model.clone().into())),
         KeyValue::new(Key::new("encoding_format"), Value::String(encoding.into())),
     ];
     if let Some(ref user) = req.user {
         labels.push(KeyValue::new(
             Key::new("user"),
-            Value::String(user.to_string().into()),
+            Value::String(user.clone().into()),
         ));
     }
 

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -548,10 +548,7 @@ impl TableProvider for EmbeddingTable {
                         let embedding_fields = self.embedding_fields(field);
                         computed_columns_meta.insert(
                             base_column_name.clone(),
-                            embedding_fields
-                                .iter()
-                                .map(|f| f.name().to_string())
-                                .collect(),
+                            embedding_fields.iter().map(|f| f.name().clone()).collect(),
                         );
                         embedding_fields
                     })
@@ -662,7 +659,7 @@ impl TableProvider for EmbeddingTable {
             .schema()
             .fields
             .iter()
-            .map(|f| f.name().to_string())
+            .map(|f| f.name().clone())
             .collect();
 
         let push_downs = filters

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -314,7 +314,7 @@ impl VectorSearchTableFunc {
             tbl: tbl_ref
                 .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
                 .into(),
-            query: q.to_string(),
+            query: q.clone(),
             column,
             limit: limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX)),
             include_score,

--- a/crates/runtime/src/flight/flightsql/get_schemas.rs
+++ b/crates/runtime/src/flight/flightsql/get_schemas.rs
@@ -66,7 +66,7 @@ pub(crate) async fn do_get(
     let catalog = &query.catalog;
     tracing::trace!("do_get: {query:?}");
     let filtered_catalogs = match catalog {
-        Some(catalog) => vec![catalog.to_string()],
+        Some(catalog) => vec![catalog.clone()],
         None => datafusion.ctx.catalog_names(),
     };
     let mut builder = query.into_builder();

--- a/crates/runtime/src/flight/flightsql/get_tables.rs
+++ b/crates/runtime/src/flight/flightsql/get_tables.rs
@@ -63,7 +63,7 @@ pub(crate) async fn do_get(
     let catalog = &query.catalog;
     tracing::trace!("do_get_tables: {query:?}");
     let filtered_catalogs = match catalog {
-        Some(catalog) => vec![catalog.to_string()],
+        Some(catalog) => vec![catalog.clone()],
         None => datafusion.ctx.catalog_names(),
     };
     let mut builder = query.into_builder();

--- a/crates/runtime/src/http/v1/embeddings.rs
+++ b/crates/runtime/src/http/v1/embeddings.rs
@@ -89,7 +89,7 @@ pub(crate) async fn post(
     Extension(embeddings): Extension<Arc<RwLock<EmbeddingModelStore>>>,
     Json(req): Json<CreateEmbeddingRequest>,
 ) -> Response {
-    let model_id = req.model.clone().clone();
+    let model_id = req.model.clone();
     match embeddings.read().await.get(&model_id) {
         Some(model) => {
             let resp: Response = match model.embed_request(req).await {

--- a/crates/runtime/src/http/v1/embeddings.rs
+++ b/crates/runtime/src/http/v1/embeddings.rs
@@ -89,7 +89,7 @@ pub(crate) async fn post(
     Extension(embeddings): Extension<Arc<RwLock<EmbeddingModelStore>>>,
     Json(req): Json<CreateEmbeddingRequest>,
 ) -> Response {
-    let model_id = req.model.clone().to_string();
+    let model_id = req.model.clone().clone();
     match embeddings.read().await.get(&model_id) {
         Some(model) => {
             let resp: Response = match model.embed_request(req).await {

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -115,7 +115,7 @@ impl Runtime {
             .map(CatalogBuilder::try_from)
             .map(move |catalog_builder_result| {
                 catalog_builder_result.and_then(|catalog_builder| {
-                    let catalog_name = catalog_builder.name.to_string();
+                    let catalog_name = catalog_builder.name.clone();
                     catalog_builder
                         .with_app(Arc::clone(app))
                         .with_runtime(Arc::clone(&self))

--- a/crates/runtime/src/model/eval/dataset.rs
+++ b/crates/runtime/src/model/eval/dataset.rs
@@ -66,7 +66,7 @@ pub async fn get_eval_data(
     validate_identifier(&eval.dataset)
         .boxed()
         .context(FailedToQueryDatasetSnafu {
-            dataset_name: eval.dataset.to_string(),
+            dataset_name: eval.dataset.clone(),
         })?;
 
     let dataset = TableReference::parse_str(&eval.dataset)

--- a/crates/runtime/src/model/eval/result.rs
+++ b/crates/runtime/src/model/eval/result.rs
@@ -64,7 +64,7 @@ pub(super) async fn write_result_to_table(
         .finish()
         .boxed()
         .context(FailedToWriteEvalResultsSnafu {
-            eval_run_id: id.to_string(),
+            eval_run_id: id.clone(),
         })?;
 
     df.write_data(
@@ -78,7 +78,7 @@ pub(super) async fn write_result_to_table(
     .await
     .boxed()
     .context(FailedToWriteEvalResultsSnafu {
-        eval_run_id: id.to_string(),
+        eval_run_id: id.clone(),
     })
 }
 

--- a/crates/runtime/src/model/eval/runs.rs
+++ b/crates/runtime/src/model/eval/runs.rs
@@ -211,7 +211,7 @@ pub async fn start_tracing_eval_run(
     let rb = eval_runs_record(id.as_str(), model_name, eval)
         .boxed()
         .context(FailedToUpdateEvalRunTableSnafu {
-            eval_run_id: id.to_string(),
+            eval_run_id: id.clone(),
         })?;
 
     df.write_data(
@@ -225,7 +225,7 @@ pub async fn start_tracing_eval_run(
     .await
     .boxed()
     .context(FailedToUpdateEvalRunTableSnafu {
-        eval_run_id: id.to_string(),
+        eval_run_id: id.clone(),
     })?;
 
     Ok(id)

--- a/crates/runtime/src/model/eval/scorer/mod.rs
+++ b/crates/runtime/src/model/eval/scorer/mod.rs
@@ -108,7 +108,7 @@ pub(crate) async fn score_results(
             if let Some(scorer_results) = aggregate.get_mut(name) {
                 scorer_results.push(s);
             } else {
-                aggregate.insert((*name).to_string(), vec![s]);
+                aggregate.insert((*name).clone(), vec![s]);
             }
         }
     }

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -118,7 +118,7 @@ impl MetricsService for Service {
                             Ok(record_batch) => {
                                 if !self
                                     .datafusion
-                                    .is_writable(&TableReference::bare(metric.name.to_string()))
+                                    .is_writable(&TableReference::bare(metric.name.clone()))
                                 {
                                     warn_once!(
                                         self.once_tracer,

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -251,7 +251,7 @@ impl TextSearchTableFunc {
             tbl: tbl_ref
                 .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
                 .into(),
-            query: q.to_string(),
+            query: q.clone(),
             column,
             limit: limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX)),
             include_score,

--- a/crates/runtime/src/tools/builtin/table_schema.rs
+++ b/crates/runtime/src/tools/builtin/table_schema.rs
@@ -175,7 +175,7 @@ impl TableSchemaTool {
                         }
                     };
 
-                    table_schemas.push((t.to_string(), schema));
+                    table_schemas.push((t.clone(), schema));
                 }
 
                 Ok(table_schemas)

--- a/crates/runtime/src/tools/memory/store.rs
+++ b/crates/runtime/src/tools/memory/store.rs
@@ -43,7 +43,7 @@ impl From<StoreMemoryParams> for Vec<MemoryTableElement> {
             .iter()
             .map(|thought| MemoryTableElement {
                 id: uuid::Uuid::now_v7(),
-                value: thought.to_string(),
+                value: thought.clone(),
                 created_by: None,
                 created_at: chrono::Utc::now().timestamp(),
             })

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -61,7 +61,7 @@ pub async fn create_tool_use_messages(
                     id: id.to_string(),
                     function: FunctionCall {
                         name: tool.name().to_string(),
-                        arguments: arg.to_string(),
+                        arguments: arg.clone(),
                     },
                 },
             )])

--- a/crates/runtime/tests/acceleration/checkpoint_turso.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_turso.rs
@@ -206,11 +206,11 @@ async fn query_to_record_batches(
 
     let columns = stmt.columns();
 
-    for i in 0..column_count {
+    for (i, value) in all_rows[0].iter().enumerate().take(column_count) {
         let field_name = columns
             .get(i)
             .map_or_else(|| format!("column_{i}"), |col| col.name().to_string());
-        let data_type = match &all_rows[0][i] {
+        let data_type = match value {
             turso::Value::Integer(_) => DataType::Int64,
             turso::Value::Real(_) => DataType::Float64,
             turso::Value::Null | turso::Value::Text(_) => DataType::Utf8,

--- a/crates/runtime/tests/search/s3_vectors.rs
+++ b/crates/runtime/tests/search/s3_vectors.rs
@@ -67,8 +67,8 @@ pub(super) async fn prepare_for_aws_tests(
         let s3_vector_client = Client::new(&config);
 
         let input = DeleteIndexInput::builder()
-            .set_index_name(Some(index_name.to_string()))
-            .set_vector_bucket_name(Some(bucket_name.to_string()))
+            .set_index_name(Some(index_name.clone()))
+            .set_vector_bucket_name(Some(bucket_name.clone()))
             .build()?;
 
         // Don't return error if delete fails, as index may not exist

--- a/crates/search/src/aggregation.rs
+++ b/crates/search/src/aggregation.rs
@@ -147,7 +147,7 @@ fn from_single_input(
             {
                 None
             } else {
-                Some(f.name().to_string())
+                Some(f.name().clone())
             }
         })
         .collect();

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -73,7 +73,7 @@ impl VectorScanTableProvider {
         if !projection.is_subset(
             &schema
                 .iter()
-                .map(|f| f.name().to_string())
+                .map(|f| f.name().clone())
                 .collect::<HashSet<String>>(),
         ) {
             // schema does not have all columns.

--- a/crates/search/src/metadata.rs
+++ b/crates/search/src/metadata.rs
@@ -103,24 +103,21 @@ impl MetadataColumns {
     pub fn non_filterable_names(&self) -> Vec<String> {
         self.non_filterable()
             .iter()
-            .map(|f| f.name().to_string())
+            .map(|f| f.name().clone())
             .collect()
     }
 
     #[must_use]
     pub fn filterable_names(&self) -> Vec<String> {
-        self.filterable()
-            .iter()
-            .map(|f| f.name().to_string())
-            .collect()
+        self.filterable().iter().map(|f| f.name().clone()).collect()
     }
 
     #[must_use]
     pub fn all_names(&self) -> Vec<String> {
         self.non_filterable()
             .iter()
-            .map(|f| f.name().to_string())
-            .chain(self.filterable().iter().map(|f| f.name().to_string()))
+            .map(|f| f.name().clone())
+            .chain(self.filterable().iter().map(|f| f.name().clone()))
             .collect()
     }
 }

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -360,7 +360,7 @@ impl SearchQueryProvider {
         let search_index_columns: HashSet<String> = search_index_schema
             .fields()
             .iter()
-            .map(|f| f.name().to_string())
+            .map(|f| f.name().clone())
             .collect();
 
         // Check if projection can be satisfied

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -120,8 +120,8 @@ impl SpiceExtension {
         self.manifest
             .params
             .get("endpoint")
-            .unwrap_or(&"https://data.spiceai.io".to_string())
-            .to_string()
+            .cloned()
+            .unwrap_or_else(|| "https://data.spiceai.io".to_string())
     }
 
     async fn get_spice_api_key(&self, runtime: &Runtime) -> Result<String, Error> {
@@ -229,7 +229,7 @@ impl SpiceExtension {
             connection.org_name, connection.app_name, connection.metrics_dataset_name
         );
 
-        let from = spiceai_metrics_dataset_path.to_string();
+        let from = spiceai_metrics_dataset_path;
         self.register_runtime_metrics_table(runtime, from.clone())
             .await?;
         tracing::info!("Enabled metrics sync from runtime.metrics to {from}");

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -241,10 +241,10 @@ impl Dataset {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.to_string());
+            metadata.insert("description".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.to_string(), v.to_string());
+            metadata.insert(k.clone(), v.to_string());
         }
         metadata
     }

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -99,10 +99,10 @@ impl View {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.to_string());
+            metadata.insert("description".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.to_string(), v.to_string());
+            metadata.insert(k.clone(), v.to_string());
         }
         metadata
     }

--- a/crates/spicepod/src/semantic.rs
+++ b/crates/spicepod/src/semantic.rs
@@ -84,10 +84,10 @@ impl Column {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.to_string());
+            metadata.insert("description".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.to_string(), v.to_string());
+            metadata.insert(k.clone(), v.to_string());
         }
         metadata
     }

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -642,7 +642,7 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
     /// The record batch is a single row, representing the run as a whole - which can pass or fail separately from individual queries
     pub fn build_run(&self, status: &QueryStatus) -> Result<Vec<RecordBatch>> {
         let run_id = vec![self.run_id.to_string()];
-        let spiced_version = vec![self.spiced_version.to_string()];
+        let spiced_version = vec![self.spiced_version.clone()];
         let run_name = vec![self.run_name.clone()];
         let commit_sha = vec![self.commit_sha.clone()];
         let branch_name = vec![self.branch_name.clone()];

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.0"
 components = ["rustc", "cargo", "rustfmt", "clippy"]

--- a/tools/evalconverter/src/eval.rs
+++ b/tools/evalconverter/src/eval.rs
@@ -151,7 +151,7 @@ impl EvalSpecification {
 
                 Ok(Eval {
                     id: id.clone(),
-                    name: name.to_string(),
+                    name: name.clone(),
                     class: def.class.clone(),
                     args: def.args.clone(),
                 })

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -194,8 +194,8 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     telemetry.set_resource(benchmark_resource);
 
     let attributes = vec![
-        KeyValue::new("model_name", model.to_string()),
-        KeyValue::new("benchmark_name", eval.to_string()),
+        KeyValue::new("model_name", model.clone()),
+        KeyValue::new("benchmark_name", eval.clone()),
     ];
     crate::metrics::STATUS.record(metrics.status.to_u64(), &attributes);
     crate::metrics::SCORE.record(metrics.score, &attributes);


### PR DESCRIPTION
## 📝 Summary

- Update rust-toolchain.toml from 1.90.0 to 1.91.0
- Fix clippy::implicit_clone lint errors across codebase
  - Replace `.to_string()` with `.clone()` for String references
- Fix clippy::ptr_arg lint (use &str instead of &String)
- Various other clippy fixes for Rust 1.91 compatibility
