### PR TITLE
Implements executor-owned leasing of task slots

### DIFF
--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -27,6 +27,19 @@ service ExecutorService {
     rpc PollExecutor(PollExecutorRequest) returns (PollExecutorResponse);
 }
 
+// Executor lease service for task slot reservation.
+// Exposed by executors so schedulers can reserve capacity before dispatching tasks.
+service ExecutorLeaseService {
+    // Reserve task slots on this executor. Idempotent via request_id.
+    rpc ReserveSlots(ReserveSlotsRequest) returns (ReserveSlotsResponse);
+    // Renew an existing lease to extend its TTL.
+    rpc RenewLease(RenewLeaseRequest) returns (RenewLeaseResponse);
+    // Release a lease, returning slots to the available pool.
+    rpc ReleaseLease(ReleaseLeaseRequest) returns (ReleaseLeaseResponse);
+    // Get the executor's current capacity (total and available slots).
+    rpc GetCapacity(GetCapacityRequest) returns (GetCapacityResponse);
+}
+
 // Request message for DescribeExecutor RPC.
 message DescribeExecutorRequest {}
 
@@ -85,6 +98,83 @@ message ExpandSecretRequest {
 message ExpandSecretResponse {
     string key = 1;
     string value = 2;
+}
+
+// Request message for ReserveSlots RPC.
+message ReserveSlotsRequest {
+    // Unique identifier for this request (for idempotency).
+    string request_id = 1;
+    // Scheduler ID requesting the slots.
+    string scheduler_id = 2;
+    // Number of slots to reserve.
+    uint32 slots = 3;
+    // Requested TTL in milliseconds. Server may grant a different TTL.
+    uint64 ttl_ms = 4;
+}
+
+// Response message for ReserveSlots RPC.
+message ReserveSlotsResponse {
+    // Whether the reservation was successful.
+    bool granted = 1;
+    // Lease ID if granted (empty if not granted).
+    string lease_id = 2;
+    // Actual TTL granted in milliseconds.
+    uint64 ttl_ms = 3;
+    // Number of slots granted (may be less than requested).
+    uint32 slots_granted = 4;
+    // Reason for rejection if not granted.
+    string rejection_reason = 5;
+}
+
+// Request message for RenewLease RPC.
+message RenewLeaseRequest {
+    // Lease ID to renew.
+    string lease_id = 1;
+    // Scheduler ID (must match original lease holder).
+    string scheduler_id = 2;
+    // Requested TTL extension in milliseconds.
+    uint64 ttl_ms = 3;
+}
+
+// Response message for RenewLease RPC.
+message RenewLeaseResponse {
+    // Whether the renewal was successful.
+    bool renewed = 1;
+    // New TTL in milliseconds (from now).
+    uint64 ttl_ms = 2;
+    // Reason for rejection if not renewed.
+    string rejection_reason = 3;
+}
+
+// Request message for ReleaseLease RPC.
+message ReleaseLeaseRequest {
+    // Lease ID to release.
+    string lease_id = 1;
+    // Scheduler ID (must match original lease holder).
+    string scheduler_id = 2;
+}
+
+// Response message for ReleaseLease RPC.
+message ReleaseLeaseResponse {
+    // Whether the release was successful.
+    bool released = 1;
+    // Number of slots returned to the pool.
+    uint32 slots_released = 2;
+}
+
+// Request message for GetCapacity RPC.
+message GetCapacityRequest {}
+
+// Response message for GetCapacity RPC.
+message GetCapacityResponse {
+    // Total task slots on this executor.
+    uint32 total_slots = 1;
+    // Currently available (unreserved) slots.
+    uint32 available_slots = 2;
+    // Number of slots currently reserved via leases.
+    uint32 reserved_slots = 3;
+    // Number of slots currently in use (executing tasks).
+    uint32 in_use_slots = 4;
 }
 
 // Physical plan

--- a/crates/runtime/src/cluster/lease.rs
+++ b/crates/runtime/src/cluster/lease.rs
@@ -1,0 +1,823 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Lease-based task slot management for executors.
+//!
+//! This module implements executor-owned lease management, allowing schedulers
+//! to reserve task slots before dispatching tasks. Key properties:
+//!
+//! - **Executor-owned state**: The executor is the source of truth for capacity
+//! - **Lease TTL with automatic expiration**: Leases expire if not renewed
+//! - **Idempotent reservation**: Same `request_id` returns same lease
+//! - **Enforcement at task execution**: Tasks check lease validity before running
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// TTL for `request_id` idempotency cache entries (60 seconds).
+const REQUEST_ID_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Default lease TTL if not specified (30 seconds).
+const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
+
+/// Maximum allowed lease TTL (5 minutes).
+const MAX_LEASE_TTL: Duration = Duration::from_secs(300);
+
+/// Minimum allowed lease TTL (5 seconds).
+const MIN_LEASE_TTL: Duration = Duration::from_secs(5);
+
+/// Interval for the background expiration cleanup loop.
+const EXPIRATION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Unique identifier for a lease.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LeaseId(String);
+
+impl LeaseId {
+    /// Creates a new random lease ID.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    /// Returns the lease ID as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for LeaseId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<String> for LeaseId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl std::fmt::Display for LeaseId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A lease representing reserved task slots on an executor.
+#[derive(Debug, Clone)]
+pub struct Lease {
+    /// Unique identifier for this lease.
+    pub id: LeaseId,
+    /// Scheduler that owns this lease.
+    pub scheduler_id: String,
+    /// Number of slots reserved by this lease.
+    pub slots: u32,
+    /// When this lease expires.
+    pub expires_at: Instant,
+    /// Number of slots currently in use from this lease.
+    pub slots_in_use: u32,
+}
+
+impl Lease {
+    /// Creates a new lease.
+    fn new(scheduler_id: String, slots: u32, ttl: Duration) -> Self {
+        Self {
+            id: LeaseId::new(),
+            scheduler_id,
+            slots,
+            expires_at: Instant::now() + ttl,
+            slots_in_use: 0,
+        }
+    }
+
+    /// Returns true if this lease has expired.
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+
+    /// Returns the remaining TTL for this lease.
+    #[must_use]
+    pub fn remaining_ttl(&self) -> Duration {
+        self.expires_at.saturating_duration_since(Instant::now())
+    }
+
+    /// Returns the number of unused slots in this lease.
+    #[must_use]
+    pub fn available_slots(&self) -> u32 {
+        self.slots.saturating_sub(self.slots_in_use)
+    }
+}
+
+/// Cached result from a previous reservation request (for idempotency).
+#[derive(Debug, Clone)]
+struct IdempotencyEntry {
+    /// The lease ID that was created for this request.
+    lease_id: LeaseId,
+    /// When this cache entry expires.
+    expires_at: Instant,
+}
+
+/// Result of a slot reservation attempt.
+#[derive(Debug)]
+pub enum ReservationResult {
+    /// Reservation was granted with the given lease.
+    Granted {
+        lease_id: LeaseId,
+        slots_granted: u32,
+        ttl: Duration,
+    },
+    /// Reservation was denied.
+    Denied { reason: String },
+    /// Request was a duplicate (idempotent replay).
+    Duplicate {
+        lease_id: LeaseId,
+        slots_granted: u32,
+        ttl: Duration,
+    },
+}
+
+/// Result of a lease renewal attempt.
+#[derive(Debug)]
+pub enum RenewalResult {
+    /// Renewal was successful.
+    Renewed { new_ttl: Duration },
+    /// Renewal failed.
+    Failed { reason: String },
+}
+
+/// Result of a lease release attempt.
+#[derive(Debug)]
+pub enum ReleaseResult {
+    /// Release was successful.
+    Released { slots_released: u32 },
+    /// Release failed.
+    Failed { reason: String },
+}
+
+/// Result of trying to use a slot from a lease.
+#[derive(Debug)]
+pub enum UseSlotResult {
+    /// Slot was successfully acquired.
+    Acquired,
+    /// Could not acquire slot.
+    Failed { reason: String },
+}
+
+/// Callback for handling lease expiration events.
+pub trait LeaseExpirationHandler: Send + Sync {
+    /// Called when a lease expires. This can be used to cancel tasks
+    /// associated with the lease.
+    fn on_lease_expired(&self, lease: &Lease);
+}
+
+/// A no-op expiration handler for testing or when cancellation isn't needed.
+pub struct NoOpExpirationHandler;
+
+impl LeaseExpirationHandler for NoOpExpirationHandler {
+    fn on_lease_expired(&self, _lease: &Lease) {
+        // No-op
+    }
+}
+
+/// Internal state for the lease manager.
+struct LeaseManagerState {
+    /// Total number of task slots on this executor.
+    total_slots: u32,
+    /// Active leases indexed by lease ID.
+    leases: HashMap<LeaseId, Lease>,
+    /// Idempotency cache: `request_id` -> lease info.
+    idempotency_cache: HashMap<String, IdempotencyEntry>,
+    /// Number of slots currently in use (executing tasks).
+    slots_in_use: u32,
+}
+
+impl LeaseManagerState {
+    fn new(total_slots: u32) -> Self {
+        Self {
+            total_slots,
+            leases: HashMap::new(),
+            idempotency_cache: HashMap::new(),
+            slots_in_use: 0,
+        }
+    }
+
+    /// Returns the number of slots reserved by active (non-expired) leases.
+    fn reserved_slots(&self) -> u32 {
+        self.leases
+            .values()
+            .filter(|l| !l.is_expired())
+            .map(|l| l.slots)
+            .sum()
+    }
+
+    /// Returns the number of available (unreserved and not in use) slots.
+    fn available_slots(&self) -> u32 {
+        self.total_slots
+            .saturating_sub(self.reserved_slots())
+            .saturating_sub(self.slots_in_use)
+    }
+
+    /// Cleans up expired leases and idempotency cache entries.
+    /// Returns the expired leases for notification.
+    fn cleanup_expired(&mut self) -> Vec<Lease> {
+        let now = Instant::now();
+
+        // Collect expired leases
+        let expired_lease_ids: Vec<LeaseId> = self
+            .leases
+            .iter()
+            .filter(|(_, l)| l.is_expired())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        let mut expired_leases = Vec::with_capacity(expired_lease_ids.len());
+        for id in expired_lease_ids {
+            if let Some(lease) = self.leases.remove(&id) {
+                expired_leases.push(lease);
+            }
+        }
+
+        // Clean up expired idempotency cache entries
+        self.idempotency_cache
+            .retain(|_, entry| entry.expires_at > now);
+
+        expired_leases
+    }
+}
+
+/// Manages task slot leases for an executor.
+///
+/// The `LeaseManager` is the executor's source of truth for capacity management.
+/// Schedulers request leases to reserve slots before dispatching tasks.
+pub struct LeaseManager {
+    state: Arc<Mutex<LeaseManagerState>>,
+    expiration_handler: Arc<dyn LeaseExpirationHandler>,
+    shutdown_token: CancellationToken,
+}
+
+impl LeaseManager {
+    /// Creates a new `LeaseManager` with the given total slots and expiration handler.
+    ///
+    /// This also spawns a background task for cleaning up expired leases.
+    #[must_use]
+    pub fn new(total_slots: u32, expiration_handler: Arc<dyn LeaseExpirationHandler>) -> Arc<Self> {
+        let state = Arc::new(Mutex::new(LeaseManagerState::new(total_slots)));
+        let shutdown_token = CancellationToken::new();
+
+        let manager = Arc::new(Self {
+            state,
+            expiration_handler,
+            shutdown_token,
+        });
+
+        // Spawn background expiration loop
+        let manager_clone = Arc::clone(&manager);
+        tokio::spawn(async move {
+            manager_clone.expiration_loop().await;
+        });
+
+        manager
+    }
+
+    /// Creates a new `LeaseManager` without an expiration handler.
+    #[must_use]
+    pub fn new_without_handler(total_slots: u32) -> Arc<Self> {
+        Self::new(total_slots, Arc::new(NoOpExpirationHandler))
+    }
+
+    /// Shuts down the lease manager, stopping the background expiration loop.
+    pub fn shutdown(&self) {
+        self.shutdown_token.cancel();
+    }
+
+    /// Background loop that periodically cleans up expired leases.
+    async fn expiration_loop(&self) {
+        let mut interval = tokio::time::interval(EXPIRATION_CHECK_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                () = self.shutdown_token.cancelled() => {
+                    tracing::debug!("LeaseManager expiration loop shutting down");
+                    break;
+                }
+                _ = interval.tick() => {
+                    let expired_leases = {
+                        let mut state = self.state.lock().await;
+                        state.cleanup_expired()
+                    };
+
+                    // Notify handler of expired leases (outside the lock)
+                    for lease in expired_leases {
+                        tracing::info!(
+                            lease_id = %lease.id,
+                            scheduler_id = %lease.scheduler_id,
+                            slots = lease.slots,
+                            "Lease expired"
+                        );
+                        self.expiration_handler.on_lease_expired(&lease);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reserves task slots for a scheduler.
+    ///
+    /// This operation is idempotent: if the same `request_id` is seen within
+    /// the cache TTL, the same lease is returned.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "TTL is clamped to max 5 minutes, fits in u64"
+    )]
+    pub async fn reserve_slots(
+        &self,
+        request_id: &str,
+        scheduler_id: &str,
+        slots: u32,
+        ttl_ms: u64,
+    ) -> ReservationResult {
+        let mut state = self.state.lock().await;
+
+        // Check idempotency cache first
+        if let Some(entry) = state.idempotency_cache.get(request_id)
+            && entry.expires_at > Instant::now()
+        {
+            // Return cached result
+            if let Some(lease) = state.leases.get(&entry.lease_id) {
+                return ReservationResult::Duplicate {
+                    lease_id: lease.id.clone(),
+                    slots_granted: lease.slots,
+                    ttl: lease.remaining_ttl(),
+                };
+            }
+        }
+
+        // Validate and clamp TTL
+        let ttl = if ttl_ms == 0 {
+            DEFAULT_LEASE_TTL
+        } else {
+            Duration::from_millis(ttl_ms).clamp(MIN_LEASE_TTL, MAX_LEASE_TTL)
+        };
+
+        // Check available capacity
+        let available = state.available_slots();
+        if slots == 0 {
+            return ReservationResult::Denied {
+                reason: "Cannot reserve zero slots".to_string(),
+            };
+        }
+
+        if available == 0 {
+            return ReservationResult::Denied {
+                reason: format!(
+                    "No slots available (total: {}, reserved: {}, in_use: {})",
+                    state.total_slots,
+                    state.reserved_slots(),
+                    state.slots_in_use
+                ),
+            };
+        }
+
+        // Grant as many slots as possible up to the request
+        let slots_granted = slots.min(available);
+        let lease = Lease::new(scheduler_id.to_string(), slots_granted, ttl);
+        let lease_id = lease.id.clone();
+
+        tracing::info!(
+            lease_id = %lease_id,
+            scheduler_id = %scheduler_id,
+            request_id = %request_id,
+            slots_requested = slots,
+            slots_granted = slots_granted,
+            ttl_ms = ttl.as_millis() as u64,
+            "Lease granted"
+        );
+
+        // Store lease
+        state.leases.insert(lease_id.clone(), lease);
+
+        // Store in idempotency cache
+        state.idempotency_cache.insert(
+            request_id.to_string(),
+            IdempotencyEntry {
+                lease_id: lease_id.clone(),
+                expires_at: Instant::now() + REQUEST_ID_CACHE_TTL,
+            },
+        );
+
+        ReservationResult::Granted {
+            lease_id,
+            slots_granted,
+            ttl,
+        }
+    }
+
+    /// Renews an existing lease to extend its TTL.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "TTL is clamped to max 5 minutes, fits in u64"
+    )]
+    pub async fn renew_lease(
+        &self,
+        lease_id: &str,
+        scheduler_id: &str,
+        ttl_ms: u64,
+    ) -> RenewalResult {
+        let mut state = self.state.lock().await;
+
+        let lease_id = LeaseId::from(lease_id.to_string());
+        let Some(lease) = state.leases.get_mut(&lease_id) else {
+            return RenewalResult::Failed {
+                reason: "Lease not found".to_string(),
+            };
+        };
+
+        // Verify ownership
+        if lease.scheduler_id != scheduler_id {
+            return RenewalResult::Failed {
+                reason: "Scheduler ID mismatch".to_string(),
+            };
+        }
+
+        // Check if already expired
+        if lease.is_expired() {
+            return RenewalResult::Failed {
+                reason: "Lease has expired".to_string(),
+            };
+        }
+
+        // Validate and clamp TTL
+        let ttl = if ttl_ms == 0 {
+            DEFAULT_LEASE_TTL
+        } else {
+            Duration::from_millis(ttl_ms).clamp(MIN_LEASE_TTL, MAX_LEASE_TTL)
+        };
+
+        // Extend the lease
+        lease.expires_at = Instant::now() + ttl;
+
+        tracing::debug!(
+            lease_id = %lease.id,
+            scheduler_id = %scheduler_id,
+            new_ttl_ms = ttl.as_millis() as u64,
+            "Lease renewed"
+        );
+
+        RenewalResult::Renewed { new_ttl: ttl }
+    }
+
+    /// Releases a lease, returning reserved slots to the pool.
+    pub async fn release_lease(&self, lease_id: &str, scheduler_id: &str) -> ReleaseResult {
+        let mut state = self.state.lock().await;
+
+        let lease_id = LeaseId::from(lease_id.to_string());
+        let Some(lease) = state.leases.get(&lease_id) else {
+            return ReleaseResult::Failed {
+                reason: "Lease not found".to_string(),
+            };
+        };
+
+        // Verify ownership
+        if lease.scheduler_id != scheduler_id {
+            return ReleaseResult::Failed {
+                reason: "Scheduler ID mismatch".to_string(),
+            };
+        }
+
+        let slots_released = lease.slots;
+
+        // Check for slots still in use
+        if lease.slots_in_use > 0 {
+            tracing::warn!(
+                lease_id = %lease.id,
+                slots_in_use = lease.slots_in_use,
+                "Releasing lease with slots still in use"
+            );
+        }
+
+        state.leases.remove(&lease_id);
+
+        tracing::info!(
+            lease_id = %lease_id,
+            scheduler_id = %scheduler_id,
+            slots_released = slots_released,
+            "Lease released"
+        );
+
+        ReleaseResult::Released { slots_released }
+    }
+
+    /// Attempts to use a slot from a lease for task execution.
+    ///
+    /// This is called when a task is about to start execution. It verifies
+    /// the lease is valid and marks a slot as in use.
+    pub async fn try_use_slot(&self, lease_id: &str) -> UseSlotResult {
+        let mut state = self.state.lock().await;
+
+        let lease_id_key = LeaseId::from(lease_id.to_string());
+
+        // Get the lease mutably and check in one step
+        let Some(lease) = state.leases.get_mut(&lease_id_key) else {
+            return UseSlotResult::Failed {
+                reason: "Lease not found".to_string(),
+            };
+        };
+
+        if lease.is_expired() {
+            return UseSlotResult::Failed {
+                reason: "Lease has expired".to_string(),
+            };
+        }
+
+        if lease.available_slots() == 0 {
+            return UseSlotResult::Failed {
+                reason: "No available slots in lease".to_string(),
+            };
+        }
+
+        // Update the lease
+        lease.slots_in_use += 1;
+        let slots_after = lease.slots_in_use;
+        state.slots_in_use += 1;
+
+        tracing::trace!(
+            lease_id = %lease_id,
+            slots_in_use = slots_after,
+            "Slot acquired from lease"
+        );
+
+        UseSlotResult::Acquired
+    }
+
+    /// Returns a slot to a lease after task completion.
+    ///
+    /// This is called when a task finishes (successfully or not).
+    pub async fn return_slot(&self, lease_id: &str) {
+        let mut state = self.state.lock().await;
+
+        let lease_id_key = LeaseId::from(lease_id.to_string());
+
+        // Try to get the lease and return the slot
+        if let Some(lease) = state.leases.get_mut(&lease_id_key) {
+            if lease.slots_in_use > 0 {
+                lease.slots_in_use -= 1;
+                let slots_after = lease.slots_in_use;
+                state.slots_in_use = state.slots_in_use.saturating_sub(1);
+
+                tracing::trace!(
+                    lease_id = %lease_id,
+                    slots_in_use = slots_after,
+                    "Slot returned to lease"
+                );
+            }
+            // else: Lease exists but no slots in use - nothing to do
+        } else {
+            // Lease was already removed (expired or released), just decrement global count
+            state.slots_in_use = state.slots_in_use.saturating_sub(1);
+            tracing::trace!(
+                lease_id = %lease_id,
+                "Slot returned (lease already removed)"
+            );
+        }
+    }
+
+    /// Returns the current capacity information.
+    pub async fn get_capacity(&self) -> CapacityInfo {
+        let state = self.state.lock().await;
+        CapacityInfo {
+            total_slots: state.total_slots,
+            available_slots: state.available_slots(),
+            reserved_slots: state.reserved_slots(),
+            in_use_slots: state.slots_in_use,
+        }
+    }
+
+    /// Updates the total number of slots (e.g., after configuration change).
+    pub async fn set_total_slots(&self, total_slots: u32) {
+        let mut state = self.state.lock().await;
+        state.total_slots = total_slots;
+        tracing::info!(
+            total_slots = total_slots,
+            "LeaseManager total slots updated"
+        );
+    }
+}
+
+/// Capacity information returned by `get_capacity`.
+#[derive(Debug, Clone)]
+pub struct CapacityInfo {
+    /// Total task slots on this executor.
+    pub total_slots: u32,
+    /// Currently available (unreserved and not in use) slots.
+    pub available_slots: u32,
+    /// Slots reserved by active leases.
+    pub reserved_slots: u32,
+    /// Slots currently in use (executing tasks).
+    pub in_use_slots: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_reserve_and_release() {
+        let manager = LeaseManager::new_without_handler(4);
+
+        // Reserve 2 slots
+        let result = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 30_000)
+            .await;
+        let lease_id = match result {
+            ReservationResult::Granted {
+                lease_id,
+                slots_granted,
+                ..
+            } => {
+                assert_eq!(slots_granted, 2);
+                lease_id
+            }
+            _ => panic!("Expected Granted"),
+        };
+
+        // Check capacity
+        let capacity = manager.get_capacity().await;
+        assert_eq!(capacity.total_slots, 4);
+        assert_eq!(capacity.reserved_slots, 2);
+        assert_eq!(capacity.available_slots, 2);
+
+        // Release the lease
+        let result = manager
+            .release_lease(lease_id.as_str(), "scheduler-1")
+            .await;
+        match result {
+            ReleaseResult::Released { slots_released } => {
+                assert_eq!(slots_released, 2);
+            }
+            _ => panic!("Expected Released"),
+        }
+
+        // Check capacity after release
+        let capacity = manager.get_capacity().await;
+        assert_eq!(capacity.reserved_slots, 0);
+        assert_eq!(capacity.available_slots, 4);
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_idempotency() {
+        let manager = LeaseManager::new_without_handler(4);
+
+        // First request
+        let result1 = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 30_000)
+            .await;
+        let lease_id1 = match result1 {
+            ReservationResult::Granted { lease_id, .. } => lease_id,
+            _ => panic!("Expected Granted"),
+        };
+
+        // Same request ID should return duplicate
+        let result2 = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 30_000)
+            .await;
+        let lease_id2 = match result2 {
+            ReservationResult::Duplicate { lease_id, .. } => lease_id,
+            _ => panic!("Expected Duplicate"),
+        };
+
+        assert_eq!(lease_id1, lease_id2);
+
+        // Only 2 slots should be reserved (not 4)
+        let capacity = manager.get_capacity().await;
+        assert_eq!(capacity.reserved_slots, 2);
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_partial_grant() {
+        let manager = LeaseManager::new_without_handler(2);
+
+        // Request more slots than available
+        let result = manager
+            .reserve_slots("req-1", "scheduler-1", 5, 30_000)
+            .await;
+        match result {
+            ReservationResult::Granted { slots_granted, .. } => {
+                assert_eq!(slots_granted, 2); // Only 2 available
+            }
+            _ => panic!("Expected Granted with partial allocation"),
+        }
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_use_and_return_slots() {
+        let manager = LeaseManager::new_without_handler(4);
+
+        // Reserve 2 slots
+        let result = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 30_000)
+            .await;
+        let lease_id = match result {
+            ReservationResult::Granted { lease_id, .. } => lease_id,
+            _ => panic!("Expected Granted"),
+        };
+
+        // Use a slot
+        let use_result = manager.try_use_slot(lease_id.as_str()).await;
+        assert!(matches!(use_result, UseSlotResult::Acquired));
+
+        // Check capacity
+        let capacity = manager.get_capacity().await;
+        assert_eq!(capacity.in_use_slots, 1);
+
+        // Return the slot
+        manager.return_slot(lease_id.as_str()).await;
+
+        // Check capacity after return
+        let capacity = manager.get_capacity().await;
+        assert_eq!(capacity.in_use_slots, 0);
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_renew_lease() {
+        let manager = LeaseManager::new_without_handler(4);
+
+        // Reserve slots
+        let result = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 5_000) // 5 second TTL
+            .await;
+        let lease_id = match result {
+            ReservationResult::Granted { lease_id, .. } => lease_id,
+            _ => panic!("Expected Granted"),
+        };
+
+        // Renew with longer TTL
+        let renew_result = manager
+            .renew_lease(lease_id.as_str(), "scheduler-1", 30_000)
+            .await;
+        match renew_result {
+            RenewalResult::Renewed { new_ttl } => {
+                assert!(new_ttl >= Duration::from_secs(29)); // Should be close to 30s
+            }
+            _ => panic!("Expected Renewed"),
+        }
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_ownership_verification() {
+        let manager = LeaseManager::new_without_handler(4);
+
+        // Reserve slots as scheduler-1
+        let result = manager
+            .reserve_slots("req-1", "scheduler-1", 2, 30_000)
+            .await;
+        let lease_id = match result {
+            ReservationResult::Granted { lease_id, .. } => lease_id,
+            _ => panic!("Expected Granted"),
+        };
+
+        // Try to release as different scheduler
+        let release_result = manager
+            .release_lease(lease_id.as_str(), "scheduler-2")
+            .await;
+        assert!(matches!(release_result, ReleaseResult::Failed { .. }));
+
+        // Try to renew as different scheduler
+        let renew_result = manager
+            .renew_lease(lease_id.as_str(), "scheduler-2", 30_000)
+            .await;
+        assert!(matches!(renew_result, RenewalResult::Failed { .. }));
+
+        manager.shutdown();
+    }
+}

--- a/crates/runtime/src/cluster/lease_executor.rs
+++ b/crates/runtime/src/cluster/lease_executor.rs
@@ -1,0 +1,320 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Lease-validating wrapper for Ballista `ExecutorGrpc` service.
+//!
+//! This module wraps the Ballista executor to add lease validation for task slots.
+//! When tasks are launched, the wrapper extracts the `lease_id` from task properties,
+//! validates the lease via `LeaseManager`, and tracks slot usage.
+
+use crate::cluster::lease::{LeaseManager, UseSlotResult};
+use ballista_core::serde::protobuf::executor_grpc_server::ExecutorGrpc;
+use ballista_core::serde::protobuf::{
+    CancelTasksParams, CancelTasksResult, KeyValuePair, LaunchMultiTaskParams,
+    LaunchMultiTaskResult, LaunchTaskParams, LaunchTaskResult, RemoveJobDataParams,
+    RemoveJobDataResult, StopExecutorParams, StopExecutorResult,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tonic::{Request, Response, Status};
+
+/// Key used to store lease ID in task properties.
+pub const LEASE_ID_PROP_KEY: &str = "spice.cluster.lease_id";
+
+/// Tracks task-to-lease mappings for returning slots on completion.
+#[derive(Debug, Default)]
+struct TaskLeaseTracker {
+    /// Maps task_id to lease_id for slot tracking.
+    task_to_lease: HashMap<String, String>,
+}
+
+impl TaskLeaseTracker {
+    fn track(&mut self, task_id: String, lease_id: String) {
+        self.task_to_lease.insert(task_id, lease_id);
+    }
+
+    fn remove(&mut self, task_id: &str) -> Option<String> {
+        self.task_to_lease.remove(task_id)
+    }
+}
+
+/// Wrapper around `ExecutorGrpc` that validates leases before task execution.
+///
+/// This wrapper intercepts `launch_task` and `launch_multi_task` calls to:
+/// 1. Extract `lease_id` from task properties
+/// 2. Validate the lease via `LeaseManager::try_use_slot()`
+/// 3. Reject tasks with invalid/expired leases
+/// 4. Track task-to-lease mappings for slot returns
+pub struct LeaseValidatingExecutorGrpc<T: ExecutorGrpc> {
+    inner: T,
+    lease_manager: Arc<LeaseManager>,
+    tracker: RwLock<TaskLeaseTracker>,
+}
+
+impl<T: ExecutorGrpc> LeaseValidatingExecutorGrpc<T> {
+    /// Creates a new lease-validating executor wrapper.
+    pub fn new(inner: T, lease_manager: Arc<LeaseManager>) -> Self {
+        Self {
+            inner,
+            lease_manager,
+            tracker: RwLock::new(TaskLeaseTracker::default()),
+        }
+    }
+
+    /// Extracts lease ID from task properties (Vec of KeyValuePair).
+    fn extract_lease_id(props: &[KeyValuePair]) -> Option<&str> {
+        props
+            .iter()
+            .find(|kv| kv.key == LEASE_ID_PROP_KEY)
+            .and_then(|kv| kv.value.as_deref())
+    }
+
+    /// Validates and acquires a slot for a lease.
+    async fn validate_lease(&self, lease_id: &str) -> Result<(), Status> {
+        match self.lease_manager.try_use_slot(lease_id).await {
+            UseSlotResult::Acquired => Ok(()),
+            UseSlotResult::Failed { reason } => Err(Status::failed_precondition(format!(
+                "Lease validation failed: {reason}"
+            ))),
+        }
+    }
+
+    /// Returns a slot to a lease.
+    async fn return_slot(&self, lease_id: &str) {
+        self.lease_manager.return_slot(lease_id).await;
+    }
+
+    /// Returns slots for completed/failed tasks.
+    pub async fn return_slots_for_tasks(&self, task_ids: &[String]) {
+        let mut tracker = self.tracker.write().await;
+        for task_id in task_ids {
+            if let Some(lease_id) = tracker.remove(task_id) {
+                self.lease_manager.return_slot(&lease_id).await;
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl<T: ExecutorGrpc> ExecutorGrpc for LeaseValidatingExecutorGrpc<T> {
+    async fn launch_task(
+        &self,
+        request: Request<LaunchTaskParams>,
+    ) -> Result<Response<LaunchTaskResult>, Status> {
+        let params = request.get_ref();
+        let mut acquired_slots: Vec<(String, String)> = Vec::new();
+
+        // LaunchTaskParams contains repeated TaskDefinition tasks
+        for task in &params.tasks {
+            let task_id = format!("{}/{}/{}", task.job_id, task.stage_id, task.partition_id);
+
+            // Check for lease_id in task properties
+            if let Some(lease_id) = Self::extract_lease_id(&task.props) {
+                // Validate and acquire slot
+                if let Err(e) = self.validate_lease(lease_id).await {
+                    // Release any slots we've acquired
+                    for (_, acquired_lease_id) in &acquired_slots {
+                        self.return_slot(acquired_lease_id).await;
+                    }
+                    return Err(e);
+                }
+
+                acquired_slots.push((task_id.clone(), lease_id.to_string()));
+
+                tracing::debug!(
+                    task_id = %task_id,
+                    lease_id = %lease_id,
+                    "Task launched with lease validation"
+                );
+            } else {
+                // No lease_id - allow task (backwards compatibility)
+                tracing::trace!(
+                    task_id = %task_id,
+                    "Task launched without lease (no lease_id in props)"
+                );
+            }
+        }
+
+        // Track all task-to-lease mappings
+        if !acquired_slots.is_empty() {
+            let mut tracker = self.tracker.write().await;
+            for (task_id, lease_id) in &acquired_slots {
+                tracker.track(task_id.clone(), lease_id.clone());
+            }
+        }
+
+        // Forward to inner executor
+        match self.inner.launch_task(request).await {
+            Ok(response) => Ok(response),
+            Err(e) => {
+                // Task launch failed - release acquired slots
+                for (_, lease_id) in &acquired_slots {
+                    self.return_slot(lease_id).await;
+                }
+                // Also remove from tracker
+                {
+                    let mut tracker = self.tracker.write().await;
+                    for (task_id, _) in &acquired_slots {
+                        tracker.remove(task_id);
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn launch_multi_task(
+        &self,
+        request: Request<LaunchMultiTaskParams>,
+    ) -> Result<Response<LaunchMultiTaskResult>, Status> {
+        let params = request.get_ref();
+        let mut acquired_slots: Vec<(String, String)> = Vec::new();
+
+        // LaunchMultiTaskParams contains repeated MultiTaskDefinition multi_tasks
+        for multi_task in &params.multi_tasks {
+            // Check for lease_id in multi_task properties
+            if let Some(lease_id) = Self::extract_lease_id(&multi_task.props) {
+                // Each task in the multi_task batch shares the same lease
+                // Validate and acquire slots for each partition
+                for task_id in &multi_task.task_ids {
+                    let full_task_id = format!(
+                        "{}/{}/{}",
+                        multi_task.job_id, multi_task.stage_id, task_id.partition_id
+                    );
+
+                    // Validate and acquire slot for each task
+                    if let Err(e) = self.validate_lease(lease_id).await {
+                        // Release any slots we've acquired
+                        for (_, acquired_lease_id) in &acquired_slots {
+                            self.return_slot(acquired_lease_id).await;
+                        }
+                        return Err(e);
+                    }
+
+                    acquired_slots.push((full_task_id.clone(), lease_id.to_string()));
+                }
+
+                tracing::debug!(
+                    job_id = %multi_task.job_id,
+                    stage_id = %multi_task.stage_id,
+                    lease_id = %lease_id,
+                    task_count = multi_task.task_ids.len(),
+                    "Multi-task batch launched with lease validation"
+                );
+            } else {
+                // No lease_id - allow tasks (backwards compatibility)
+                tracing::trace!(
+                    job_id = %multi_task.job_id,
+                    stage_id = %multi_task.stage_id,
+                    "Multi-task batch launched without lease (no lease_id in props)"
+                );
+            }
+        }
+
+        // Track all task-to-lease mappings
+        if !acquired_slots.is_empty() {
+            let mut tracker = self.tracker.write().await;
+            for (task_id, lease_id) in &acquired_slots {
+                tracker.track(task_id.clone(), lease_id.clone());
+            }
+        }
+
+        // Forward to inner executor
+        match self.inner.launch_multi_task(request).await {
+            Ok(response) => Ok(response),
+            Err(e) => {
+                // Task launch failed - release acquired slots
+                for (_, lease_id) in &acquired_slots {
+                    self.return_slot(lease_id).await;
+                }
+                // Also remove from tracker
+                {
+                    let mut tracker = self.tracker.write().await;
+                    for (task_id, _) in &acquired_slots {
+                        tracker.remove(task_id);
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn stop_executor(
+        &self,
+        request: Request<StopExecutorParams>,
+    ) -> Result<Response<StopExecutorResult>, Status> {
+        self.inner.stop_executor(request).await
+    }
+
+    async fn cancel_tasks(
+        &self,
+        request: Request<CancelTasksParams>,
+    ) -> Result<Response<CancelTasksResult>, Status> {
+        // Return slots for cancelled tasks
+        let task_ids: Vec<String> = request
+            .get_ref()
+            .task_infos
+            .iter()
+            .map(|ti| format!("{}/{}/{}", ti.job_id, ti.stage_id, ti.partition_id))
+            .collect();
+
+        self.return_slots_for_tasks(&task_ids).await;
+
+        self.inner.cancel_tasks(request).await
+    }
+
+    async fn remove_job_data(
+        &self,
+        request: Request<RemoveJobDataParams>,
+    ) -> Result<Response<RemoveJobDataResult>, Status> {
+        self.inner.remove_job_data(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_lease_id() {
+        let props = vec![KeyValuePair {
+            key: LEASE_ID_PROP_KEY.to_string(),
+            value: Some("lease-123".to_string()),
+        }];
+
+        let lease_id = LeaseValidatingExecutorGrpc::<()>::extract_lease_id(&props);
+        assert_eq!(lease_id, Some("lease-123"));
+    }
+
+    #[test]
+    fn test_extract_lease_id_missing() {
+        let props: Vec<KeyValuePair> = vec![];
+        let lease_id = LeaseValidatingExecutorGrpc::<()>::extract_lease_id(&props);
+        assert_eq!(lease_id, None);
+    }
+
+    #[test]
+    fn test_extract_lease_id_none_value() {
+        let props = vec![KeyValuePair {
+            key: LEASE_ID_PROP_KEY.to_string(),
+            value: None,
+        }];
+
+        let lease_id = LeaseValidatingExecutorGrpc::<()>::extract_lease_id(&props);
+        assert_eq!(lease_id, None);
+    }
+}

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -70,12 +70,14 @@ type SchedulerEndpointOverride =
 pub mod datafusion;
 mod discovery;
 pub mod lease;
+pub mod lease_executor;
 mod polling;
 mod servers;
 mod service;
 
 pub use discovery::start_executor_discovery_loop;
 pub use lease::LeaseManager;
+pub use lease_executor::{LEASE_ID_PROP_KEY, LeaseValidatingExecutorGrpc};
 pub use polling::start_executor_poll_loop;
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
 pub use service::{ClusterServiceImpl, ExecutorLeaseServiceImpl, ExecutorServiceImpl};

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -69,14 +69,16 @@ type SchedulerEndpointOverride =
 
 pub mod datafusion;
 mod discovery;
+pub mod lease;
 mod polling;
 mod servers;
 mod service;
 
 pub use discovery::start_executor_discovery_loop;
+pub use lease::LeaseManager;
 pub use polling::start_executor_poll_loop;
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
-pub use service::{ClusterServiceImpl, ExecutorServiceImpl};
+pub use service::{ClusterServiceImpl, ExecutorLeaseServiceImpl, ExecutorServiceImpl};
 
 /// mTLS configuration for cluster communications.
 ///
@@ -617,6 +619,13 @@ pub async fn initialize_cluster_executor(
 
     rt.df
         .bind_executor_grpc(Arc::clone(&executor_server))
+        .boxed()
+        .context(FailedToStartClusterExecutorSnafu)?;
+
+    // Create and bind the lease manager for task slot reservation
+    let lease_manager = lease::LeaseManager::new_without_handler(concurrent_tasks);
+    rt.df
+        .bind_lease_manager(Arc::clone(&lease_manager))
         .boxed()
         .context(FailedToStartClusterExecutorSnafu)?;
 

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use super::ClusterTlsConfig;
-use crate::cluster::{ClusterServiceImpl, ExecutorServiceImpl};
+use super::lease::LeaseManager;
+use crate::cluster::{ClusterServiceImpl, ExecutorLeaseServiceImpl, ExecutorServiceImpl};
 use crate::flight::{Error, is_address_in_use_error};
 use crate::{Runtime, metrics as runtime_metrics};
 use ballista_core::serde::protobuf::executor_grpc_server::ExecutorGrpcServer;
@@ -25,6 +26,7 @@ use ballista_core::utils::create_grpc_client_endpoint;
 use ballista_executor::executor_server::register_executor_with_scheduler;
 use ballista_executor::flight_service::BallistaFlightService;
 use runtime_proto::cluster_service_server::ClusterServiceServer;
+use runtime_proto::executor_lease_service_server::ExecutorLeaseServiceServer;
 use runtime_proto::executor_service_server::ExecutorServiceServer;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -128,6 +130,7 @@ pub async fn start_internal_cluster_server(
 pub async fn start_executor_flight_server(
     bind_address: std::net::SocketAddr,
     rt: Arc<Runtime>,
+    lease_manager: Arc<LeaseManager>,
     shutdown_signal: Option<CancellationToken>,
 ) -> ClusterServerResult<()> {
     let tls_config = rt.df.cluster_config.tls_config();
@@ -148,10 +151,13 @@ pub async fn start_executor_flight_server(
         );
     }
 
-    // Executor: serve BallistaFlightService for receiving query fragments
-    // and ExecutorService for scheduler-driven discovery.
+    // Executor: serve BallistaFlightService for receiving query fragments,
+    // ExecutorService for scheduler-driven discovery, and ExecutorLeaseService
+    // for task slot reservation.
     let executor_service = ExecutorServiceImpl::new(Arc::clone(&rt.df));
     let executor_service_server = ExecutorServiceServer::new(executor_service);
+    let executor_lease_service = ExecutorLeaseServiceImpl::new(Arc::clone(&lease_manager));
+    let executor_lease_service_server = ExecutorLeaseServiceServer::new(executor_lease_service);
     let executor_grpc = rt
         .df
         .executor_grpc
@@ -172,6 +178,7 @@ pub async fn start_executor_flight_server(
             .max_encoding_message_size(usize::MAX),
         )
         .add_service(executor_service_server)
+        .add_service(executor_lease_service_server)
         .add_service(executor_grpc_server);
 
     // Use the executor's bound address if it was dynamically assigned during registration.

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use super::ClusterTlsConfig;
 use super::lease::LeaseManager;
+use super::lease_executor::LeaseValidatingExecutorGrpc;
 use crate::cluster::{ClusterServiceImpl, ExecutorLeaseServiceImpl, ExecutorServiceImpl};
 use crate::flight::{Error, is_address_in_use_error};
 use crate::{Runtime, metrics as runtime_metrics};
@@ -165,7 +166,12 @@ pub async fn start_executor_flight_server(
         .ok()
         .and_then(|maybe_executor| maybe_executor.clone())
         .ok_or(Error::ClusterExecutorNotInitialized {})?;
-    let executor_grpc_server = ExecutorGrpcServer::new(executor_grpc.as_ref().clone())
+    // Wrap executor with lease validation to enforce slot reservations
+    let lease_validating_executor = LeaseValidatingExecutorGrpc::new(
+        executor_grpc.as_ref().clone(),
+        Arc::clone(&lease_manager),
+    );
+    let executor_grpc_server = ExecutorGrpcServer::new(lease_validating_executor)
         .max_decoding_message_size(usize::MAX)
         .max_encoding_message_size(usize::MAX);
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -21,10 +21,13 @@ limitations under the License.
 
 use app::App;
 use runtime_proto::cluster_service_server::ClusterService;
+use runtime_proto::executor_lease_service_server::ExecutorLeaseService;
 use runtime_proto::executor_service_server::ExecutorService;
 use runtime_proto::{
     DescribeExecutorRequest, DescribeExecutorResponse, ExpandSecretRequest, ExpandSecretResponse,
-    GetAppDefinitionRequest, GetAppDefinitionResponse, PollExecutorRequest, PollExecutorResponse,
+    GetAppDefinitionRequest, GetAppDefinitionResponse, GetCapacityRequest, GetCapacityResponse,
+    PollExecutorRequest, PollExecutorResponse, ReleaseLeaseRequest, ReleaseLeaseResponse,
+    RenewLeaseRequest, RenewLeaseResponse, ReserveSlotsRequest, ReserveSlotsResponse,
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
@@ -34,6 +37,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
+use super::lease::{LeaseManager, ReleaseResult, RenewalResult, ReservationResult};
 use crate::datafusion::DataFusion;
 use ballista_executor::executor_server::TERMINATING;
 use prost::Message;
@@ -237,6 +241,188 @@ impl ExecutorService for ExecutorServiceImpl {
             terminating: TERMINATING.load(Ordering::Acquire),
             timestamp_millis,
             task_statuses: encoded,
+        }))
+    }
+}
+
+/// Executor lease service for task slot reservation.
+///
+/// This service allows schedulers to reserve task slots on the executor
+/// before dispatching tasks, enabling better capacity management.
+pub struct ExecutorLeaseServiceImpl {
+    lease_manager: Arc<LeaseManager>,
+}
+
+impl ExecutorLeaseServiceImpl {
+    /// Creates a new executor lease service implementation.
+    #[must_use]
+    pub fn new(lease_manager: Arc<LeaseManager>) -> Self {
+        Self { lease_manager }
+    }
+}
+
+#[tonic::async_trait]
+impl ExecutorLeaseService for ExecutorLeaseServiceImpl {
+    async fn reserve_slots(
+        &self,
+        request: Request<ReserveSlotsRequest>,
+    ) -> Result<Response<ReserveSlotsResponse>, Status> {
+        let request = request.into_inner();
+
+        if request.request_id.is_empty() {
+            return Err(Status::invalid_argument("request_id is required"));
+        }
+        if request.scheduler_id.is_empty() {
+            return Err(Status::invalid_argument("scheduler_id is required"));
+        }
+
+        tracing::trace!(
+            request_id = %request.request_id,
+            scheduler_id = %request.scheduler_id,
+            slots = request.slots,
+            ttl_ms = request.ttl_ms,
+            "ExecutorLeaseService::reserve_slots"
+        );
+
+        let result = self
+            .lease_manager
+            .reserve_slots(
+                &request.request_id,
+                &request.scheduler_id,
+                request.slots,
+                request.ttl_ms,
+            )
+            .await;
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "TTL is clamped to max 5 minutes, fits in u64"
+        )]
+        let response = match result {
+            ReservationResult::Granted {
+                lease_id,
+                slots_granted,
+                ttl,
+            }
+            | ReservationResult::Duplicate {
+                lease_id,
+                slots_granted,
+                ttl,
+            } => ReserveSlotsResponse {
+                granted: true,
+                lease_id: lease_id.to_string(),
+                slots_granted,
+                ttl_ms: ttl.as_millis() as u64,
+                rejection_reason: String::new(),
+            },
+            ReservationResult::Denied { reason } => ReserveSlotsResponse {
+                granted: false,
+                lease_id: String::new(),
+                slots_granted: 0,
+                ttl_ms: 0,
+                rejection_reason: reason,
+            },
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn renew_lease(
+        &self,
+        request: Request<RenewLeaseRequest>,
+    ) -> Result<Response<RenewLeaseResponse>, Status> {
+        let request = request.into_inner();
+
+        if request.lease_id.is_empty() {
+            return Err(Status::invalid_argument("lease_id is required"));
+        }
+        if request.scheduler_id.is_empty() {
+            return Err(Status::invalid_argument("scheduler_id is required"));
+        }
+
+        tracing::trace!(
+            lease_id = %request.lease_id,
+            scheduler_id = %request.scheduler_id,
+            ttl_ms = request.ttl_ms,
+            "ExecutorLeaseService::renew_lease"
+        );
+
+        let result = self
+            .lease_manager
+            .renew_lease(&request.lease_id, &request.scheduler_id, request.ttl_ms)
+            .await;
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "TTL is clamped to max 5 minutes, fits in u64"
+        )]
+        let response = match result {
+            RenewalResult::Renewed { new_ttl } => RenewLeaseResponse {
+                renewed: true,
+                ttl_ms: new_ttl.as_millis() as u64,
+                rejection_reason: String::new(),
+            },
+            RenewalResult::Failed { reason } => RenewLeaseResponse {
+                renewed: false,
+                ttl_ms: 0,
+                rejection_reason: reason,
+            },
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn release_lease(
+        &self,
+        request: Request<ReleaseLeaseRequest>,
+    ) -> Result<Response<ReleaseLeaseResponse>, Status> {
+        let request = request.into_inner();
+
+        if request.lease_id.is_empty() {
+            return Err(Status::invalid_argument("lease_id is required"));
+        }
+        if request.scheduler_id.is_empty() {
+            return Err(Status::invalid_argument("scheduler_id is required"));
+        }
+
+        tracing::trace!(
+            lease_id = %request.lease_id,
+            scheduler_id = %request.scheduler_id,
+            "ExecutorLeaseService::release_lease"
+        );
+
+        let result = self
+            .lease_manager
+            .release_lease(&request.lease_id, &request.scheduler_id)
+            .await;
+
+        let response = match result {
+            ReleaseResult::Released { slots_released } => ReleaseLeaseResponse {
+                released: true,
+                slots_released,
+            },
+            ReleaseResult::Failed { reason: _ } => ReleaseLeaseResponse {
+                released: false,
+                slots_released: 0,
+            },
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn get_capacity(
+        &self,
+        _request: Request<GetCapacityRequest>,
+    ) -> Result<Response<GetCapacityResponse>, Status> {
+        tracing::trace!("ExecutorLeaseService::get_capacity");
+
+        let capacity = self.lease_manager.get_capacity().await;
+
+        Ok(Response::new(GetCapacityResponse {
+            total_slots: capacity.total_slots,
+            available_slots: capacity.available_slots,
+            reserved_slots: capacity.reserved_slots,
+            in_use_slots: capacity.in_use_slots,
         }))
     }
 }

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -378,6 +378,7 @@ impl DataFusionBuilder {
             scheduler_server: RwLock::new(None),
             executor: RwLock::new(None),
             executor_grpc: RwLock::new(None),
+            lease_manager: RwLock::new(None),
         }
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -368,6 +368,7 @@ pub struct DataFusion {
     pub executor: RwLock<Option<Arc<Executor>>>,
     pub executor_grpc:
         RwLock<Option<Arc<BallistaExecutorServer<LogicalPlanNode, PhysicalPlanNode>>>>,
+    pub lease_manager: RwLock<Option<Arc<crate::cluster::lease::LeaseManager>>>,
 }
 
 impl std::fmt::Debug for DataFusion {
@@ -1974,6 +1975,18 @@ impl DataFusion {
             .try_write()
             .map_err(|_| Error::UnableToLockWritableExecutorGrpcHandle {})?;
         *executor_grpc_handle = Some(executor_grpc);
+        Ok(())
+    }
+
+    pub fn bind_lease_manager(
+        &self,
+        lease_manager: Arc<crate::cluster::lease::LeaseManager>,
+    ) -> Result<()> {
+        let mut lease_manager_handle = self
+            .lease_manager
+            .try_write()
+            .map_err(|_| Error::UnableToLockWritableExecutorHandle {})?;
+        *lease_manager_handle = Some(lease_manager);
         Ok(())
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -753,6 +753,17 @@ impl Runtime {
         let cloned_tls_config = tls_config.clone();
         let flight_future: std::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>> =
             if self.df.cluster_config.effective_role() == Some(ClusterRole::Executor) {
+                let lease_manager = self
+                    .df
+                    .lease_manager
+                    .read()
+                    .map_err(|_| Error::FailedToStartClusterExecutor {
+                        source: "Unable to acquire lease_manager lock".to_string().into(),
+                    })?
+                    .clone()
+                    .ok_or_else(|| Error::FailedToStartClusterExecutor {
+                        source: "LeaseManager not initialized".to_string().into(),
+                    })?;
                 Box::pin(
                     self.start_runtime_task(
                         FLIGHT_SERVER,
@@ -761,6 +772,7 @@ impl Runtime {
                             cluster::start_executor_flight_server(
                                 config.flight_bind_address,
                                 Arc::clone(&self_ref),
+                                lease_manager,
                                 Some(flight_shutdown),
                             )
                             .await


### PR DESCRIPTION
## 📝 Summary

In the upstream Ballista model, the scheduler is responsible for owning the state of how busy the executors are. In an HA model, a given scheduler doesn't have the complete picture of how busy an executor is. Add RPCs to allow them to lease task slots and enforce them on the executor side.

Implements executor-side lease management for task slot reservation in cluster mode. This enables schedulers to reserve capacity on executors before dispatching tasks, preventing over-subscription and improving load balancing.

Key components:
- LeaseManager: Executor-owned state for tracking reserved slots with TTL-based expiration, idempotent reservations via request_id, and automatic cleanup of expired leases
- ExecutorService gRPC service: Exposes DescribeExecutor and PollExecutor RPCs for scheduler-driven discovery and status polling
- ExecutorLeaseService gRPC service: Exposes ReserveSlots, RenewLease, ReleaseLease, and GetCapacity RPCs for slot reservation
- LeaseValidatingExecutorGrpc: Wrapper that validates lease ownership before task execution

Design properties:

- Executor is the source of truth for capacity
- Leases expire automatically if not renewed
- Partial grants allowed (request 10 slots, get 5)
- Slots tracked at two levels: reserved (leased) vs in-use (executing)
