### PR TITLE
Add parameter to force using iam_role for DynamoDB

### DIFF
--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -420,8 +420,7 @@ pub async fn initiate_config_with_credentials(
 /// # Returns
 /// A `ConfigLoader` that can be further customized before loading.
 pub async fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
-    let provider_config = ProviderConfig::default()
-        .with_region(Some(Region::new(region.clone())));
+    let provider_config = ProviderConfig::default().with_region(Some(Region::new(region.clone())));
 
     let web_identity_provider = WebIdentityTokenCredentialsProvider::builder()
         .configure(&provider_config)

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -419,6 +419,7 @@ pub async fn initiate_config_with_credentials(
 ///
 /// # Returns
 /// A `ConfigLoader` that can be further customized before loading.
+#[must_use]
 pub fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
     let provider_config = ProviderConfig::default().with_region(Some(Region::new(region.clone())));
 

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -420,11 +420,8 @@ pub async fn initiate_config_with_credentials(
 /// # Returns
 /// A `ConfigLoader` that can be further customized before loading.
 pub async fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
-    if let Err(err) = get_or_init_sdk_config().await {
-        tracing::warn!("Unable to initialize AWS SDK config: {err}");
-    }
-
-    let provider_config = ProviderConfig::with_default_region().await;
+    let provider_config = ProviderConfig::default()
+        .with_region(Some(Region::new(region.clone())));
 
     let web_identity_provider = WebIdentityTokenCredentialsProvider::builder()
         .configure(&provider_config)

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -408,7 +408,7 @@ pub async fn initiate_config_with_credentials(
 
 /// Initiates an AWS SDK configuration that only uses IAM role authentication.
 ///
-/// This bypasses environment variables (AWS_ACCESS_KEY_ID, etc.) and profile credentials,
+/// This bypasses environment variables (`AWS_ACCESS_KEY_ID`, etc.) and profile credentials,
 /// only using:
 /// - Web Identity Token (EKS/IRSA)
 /// - ECS Container Credentials
@@ -419,7 +419,7 @@ pub async fn initiate_config_with_credentials(
 ///
 /// # Returns
 /// A `ConfigLoader` that can be further customized before loading.
-pub async fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
+pub fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
     let provider_config = ProviderConfig::default().with_region(Some(Region::new(region.clone())));
 
     let web_identity_provider = WebIdentityTokenCredentialsProvider::builder()

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -17,6 +17,12 @@ limitations under the License.
 mod credential_provider;
 use std::{sync::Arc, time::Duration};
 
+use aws_config::Region;
+use aws_config::ecs::EcsCredentialsProvider;
+use aws_config::imds::credentials::ImdsCredentialsProvider;
+use aws_config::meta::credentials::CredentialsProviderChain;
+use aws_config::provider_config::ProviderConfig;
+use aws_config::web_identity_token::WebIdentityTokenCredentialsProvider;
 use aws_config::{BehaviorVersion, SdkConfig};
 use aws_credential_types::provider::error::CredentialsError;
 use aws_sdk_s3::{config::ProvideCredentials, error::ConnectorError};
@@ -398,6 +404,46 @@ pub async fn initiate_config_with_credentials(
         }
         default_aws_config().region(Region::new(region))
     }
+}
+
+/// Initiates an AWS SDK configuration that only uses IAM role authentication.
+///
+/// This bypasses environment variables (AWS_ACCESS_KEY_ID, etc.) and profile credentials,
+/// only using:
+/// - Web Identity Token (EKS/IRSA)
+/// - ECS Container Credentials
+/// - EC2 Instance Metadata (IMDS)
+///
+/// # Parameters
+/// - `region`: AWS region
+///
+/// # Returns
+/// A `ConfigLoader` that can be further customized before loading.
+pub async fn initiate_config_with_iam_role_only(region: String) -> aws_config::ConfigLoader {
+    if let Err(err) = get_or_init_sdk_config().await {
+        tracing::warn!("Unable to initialize AWS SDK config: {err}");
+    }
+
+    let provider_config = ProviderConfig::with_default_region().await;
+
+    let web_identity_provider = WebIdentityTokenCredentialsProvider::builder()
+        .configure(&provider_config)
+        .build();
+    let ecs_provider = EcsCredentialsProvider::builder()
+        .configure(&provider_config)
+        .build();
+    let imds_provider = ImdsCredentialsProvider::builder()
+        .configure(&provider_config)
+        .build();
+
+    let iam_only_chain =
+        CredentialsProviderChain::first_try("WebIdentityToken", web_identity_provider)
+            .or_else("EcsContainer", ecs_provider)
+            .or_else("Ec2InstanceMetadata", imds_provider);
+
+    default_aws_config()
+        .region(Region::new(region))
+        .credentials_provider(iam_only_chain)
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -237,7 +237,7 @@ impl DataConnector for DynamoDB {
             .unwrap_or(false);
 
         let mut config_loader = if aws_force_iam_only {
-            initiate_config_with_iam_role_only("aws_region", &self.params)
+            initiate_config_with_iam_role_only("aws_region", &self.params).await
         } else {
             initiate_config_with_credentials(
                 "DynamoDBTableProvider",
@@ -247,8 +247,8 @@ impl DataConnector for DynamoDB {
                 "aws_session_token",
                 &self.params,
             )
+            .await
         }
-        .await
         .map_err(|message| DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: "dynamodb".to_string(),
             connector_component: ConnectorComponent::from(dataset),

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -237,7 +237,7 @@ impl DataConnector for DynamoDB {
             .unwrap_or(false);
 
         let mut config_loader = if aws_force_iam_only {
-            initiate_config_with_iam_role_only("aws_region", &self.params).await
+            initiate_config_with_iam_role_only("aws_region", &self.params)
         } else {
             initiate_config_with_credentials(
                 "DynamoDBTableProvider",

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     ParameterSpec, Parameters, parameters::aws::initiate_config_with_credentials,
+    parameters::aws::initiate_config_with_iam_role_only,
 };
 use crate::component::ComponentType;
 use crate::component::dataset::Dataset;
@@ -27,6 +28,7 @@ use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, Dy
 use crate::federated_table::FederatedTable;
 use crate::register_data_connector;
 use async_trait::async_trait;
+use aws_config::ConfigLoader;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError};
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use data_components::dynamodb::{Error, JsonNesting};
@@ -85,6 +87,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_session_token")
         .description("The AWS session token to use for DynamoDB.")
         .secret(),
+    ParameterSpec::component("aws_force_iam_only")
+        .description("Force IAM role authentication only, ignoring environment variables and profile credentials")
+        .default("false"),
     ParameterSpec::runtime("unnest_depth")
         .description("Maximum nesting depth for unnesting embedded documents into a flattened structure. Higher values expand deeper nested fields."),
     ParameterSpec::runtime("schema_infer_max_records")
@@ -223,14 +228,26 @@ impl DataConnector for DynamoDB {
 
         let table_name = dataset.path();
 
-        let mut config_loader = initiate_config_with_credentials(
-            "DynamoDBTableProvider",
-            "aws_region",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
-            &self.params,
-        )
+        let aws_force_iam_only = self
+            .params
+            .get("aws_force_iam_only")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
+
+        let mut config_loader = if aws_force_iam_only {
+            initiate_config_with_iam_role_only("aws_region", &self.params)
+        } else {
+            initiate_config_with_credentials(
+                "DynamoDBTableProvider",
+                "aws_region",
+                "aws_access_key_id",
+                "aws_secret_access_key",
+                "aws_session_token",
+                &self.params,
+            )
+        }
         .await
         .map_err(|message| DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: "dynamodb".to_string(),

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -28,7 +28,6 @@ use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, Dy
 use crate::federated_table::FederatedTable;
 use crate::register_data_connector;
 use async_trait::async_trait;
-use aws_config::ConfigLoader;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError};
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use data_components::dynamodb::{Error, JsonNesting};

--- a/crates/runtime/src/dataconnector/parameters/aws.rs
+++ b/crates/runtime/src/dataconnector/parameters/aws.rs
@@ -235,7 +235,7 @@ pub async fn initiate_config_with_credentials(
 /// Initiate a [`ConfigLoader`] with only IAM role authentication (ignoring environment variables).
 ///
 /// Return [`ConfigLoader`] to allow further customization.
-pub async fn initiate_config_with_iam_role_only(
+pub fn initiate_config_with_iam_role_only(
     region_name: &'static str,
     params: &Parameters,
 ) -> Result<ConfigLoader, Error> {
@@ -248,5 +248,5 @@ pub async fn initiate_config_with_iam_role_only(
         .to_string();
 
     // Delegate to the common implementation in aws-sdk-credential-bridge
-    Ok(aws_sdk_credential_bridge::initiate_config_with_iam_role_only(region).await)
+    Ok(aws_sdk_credential_bridge::initiate_config_with_iam_role_only(region))
 }

--- a/crates/runtime/src/dataconnector/parameters/aws.rs
+++ b/crates/runtime/src/dataconnector/parameters/aws.rs
@@ -231,3 +231,22 @@ pub async fn initiate_config_with_credentials(
     )
     .await)
 }
+
+/// Initiate a [`ConfigLoader`] with only IAM role authentication (ignoring environment variables).
+///
+/// Return [`ConfigLoader`] to allow further customization.
+pub async fn initiate_config_with_iam_role_only(
+    region_name: &'static str,
+    params: &Parameters,
+) -> Result<ConfigLoader, Error> {
+    let region = params
+        .get(region_name)
+        .expose()
+        .ok_or_else(|_| Error::NoRegionSpecified {
+            region: region_name.to_string(),
+        })?
+        .to_string();
+
+    // Delegate to the common implementation in aws-sdk-credential-bridge
+    Ok(aws_sdk_credential_bridge::initiate_config_with_iam_role_only(region).await)
+}


### PR DESCRIPTION
## 📝 Summary

Per @phillipleblanc's [comment](https://github.com/spiceai/spiceai/issues/8585#issuecomment-3695352951):
> Force using IAM instance tokens (i.e. not environment variable keys)

Add `aws_force_iam_only` parameter to force using IAM instance tokens (ignore environment variables and `~/.aws/credentials` files).

Example:
```yaml
datasets:
  - from: dynamodb:my_table
    name: my_table
    params:
      dynamodb_aws_region: us-west-2
      dynamodb_aws_force_iam_only: true
```

## 🔗 Related

Closes #8585

## 📚 Docs

TODO