### PR TITLE
Trace metrics export errors

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -304,11 +304,15 @@ impl SpanExporter for OtelExportMultiplexer {
         let zipkin_future = self.zipkin.as_ref().map(|exporter| exporter.export(batch));
 
         async move {
-            if let Some(zipkin_future) = zipkin_future {
-                let _ = zipkin_future.await;
+            if let Some(zipkin_future) = zipkin_future
+                && let Err(e) = zipkin_future.await
+            {
+                tracing::warn!("Failed to send traces to Zipkin: {e}");
             }
 
-            let _ = history_future.await;
+            if let Err(e) = history_future.await {
+                tracing::warn!("Failed to write to task history: {e}");
+            }
 
             Ok(())
         }

--- a/crates/runtime/src/otel_push_exporter.rs
+++ b/crates/runtime/src/otel_push_exporter.rs
@@ -33,6 +33,7 @@ limitations under the License.
 
 use std::{collections::HashSet, sync::Arc};
 
+use futures::TryFutureExt;
 use opentelemetry_otlp::{MetricExporter, Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::{
     metrics::{
@@ -102,7 +103,17 @@ impl PushMetricExporter for FilteringExporter {
         metrics: &mut ResourceMetrics,
     ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
         self.filter_metrics(metrics);
-        self.inner.export(metrics)
+        self.inner.export(metrics).inspect_err(|err| {
+            match err {
+                opentelemetry_sdk::error::OTelSdkError::InternalFailure(msg) => {
+                    tracing::warn!("Failed to export metrics: {msg}");
+                }
+                opentelemetry_sdk::error::OTelSdkError::Timeout(duration) => {
+                    tracing::warn!("Failed to export metrics: timed out after {duration:?}");
+                }
+                opentelemetry_sdk::error::OTelSdkError::AlreadyShutdown => (), // No logging needed
+            }
+        })
     }
 
     fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {


### PR DESCRIPTION
## 📝 Summary

Trace warning when we are unable to export metrics (OTEL export, Zipkin) or write into task history.

## 🔗 Related

Closes
 - https://github.com/spiceai/spiceai/issues/8772

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Alternative approach might be to update tracing `OFF_FILTERS` to specify `WARN` instead of complete `OFF`

```
const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,delta_kernel::listed_log_files=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
```

->

```
const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=WARN, ..."
```
