### PR TITLE
Add timezone database to Docker image to fix Cayenne acceleration panic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG ORACLE_INSTANTCLIENT_SHA256_ARM64=1d27641f16df1b1384f5d61cdcbd95a5ca57ba5d25
 
 # Install required packages
 RUN apt update \
-    && apt install --yes ca-certificates libssl3 findutils --no-install-recommends \
+    && apt install --yes ca-certificates libssl3 findutils tzdata --no-install-recommends \
     && if echo "$CARGO_FEATURES" | grep -q "odbc"; then \
     apt install --yes unixodbc --no-install-recommends; \
     fi \
@@ -55,6 +55,7 @@ RUN mkdir -p /spice_sandbox/bin && \
     mkdir -p /spice_sandbox/lib && \
     mkdir -p /spice_sandbox/usr/lib && \
     mkdir -p /spice_sandbox/usr/local/bin && \
+    mkdir -p /spice_sandbox/usr/share && \
     mkdir -p /spice_sandbox/etc && \
     mkdir -p /spice_sandbox/etc/ssl && \
     mkdir -p /spice_sandbox/dev && \
@@ -66,6 +67,9 @@ COPY --from=build /root/spiced /spice_sandbox/usr/local/bin/
 
 # Copy CA certificates
 RUN cp -r /etc/ssl/certs /spice_sandbox/etc/ssl/certs
+
+# Copy timezone database (IANA tzdb) - used by jiff, chrono, libc, and other timezone-aware libraries
+RUN cp -r /usr/share/zoneinfo /spice_sandbox/usr/share/zoneinfo
 
 # Copy every dependent library reported by ldd
 RUN ldd /spice_sandbox/usr/local/bin/spiced | grep -o '/[^ ]*' | xargs -I '{}' sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"'


### PR DESCRIPTION
## 📝 Summary

PR fixes panic in Cayenne acceleration when using timestamp with time zone predicate. It also prevented stats based pruning to work

>alloc::fmt::format::format_inner
itertools::Itertools::join
vortex_scan::filter::FilterExpr::report_selectivity

The  Docker image lacked the IANA timezone database when filtering with timestamp predicates, vortex's `ExtScalar::Display` called jiff to format timestamps for selectivity logging, which failed with: `failed to find time zone UTC` since there is no time zone database configured returning `std::fmt::Error` from `Display::fmt` caused a panic in `FilterExpr::report_selectivity`.

Alternative (or companion) fix could be in Vortex to include `tzdb-bundle-always`, but adding IANA timezone database seems a better fix as database is updated every Docker build and will also cover potential similar issues for other libraries.

```
# In vortex Cargo.toml
jiff = { version = "0.2.0", features = ["tzdb-bundle-always"] }
```

## 🔗 Related

Fixes
- https://github.com/spiceai/spiceai/issues/8792
