### PR TITLE
Use workspace version for cayenne crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "cayenne"
-version = "0.1.0"
+version = "1.11.0-unstable"
 dependencies = [
  "aegis",
  "arrow",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "cayenne"
 repository = "https://github.com/spiceai/spiceai"
-version = "0.1.0"
+version = "1.11.0-unstable"
 
 [dependencies]
 arrow = { workspace = true }

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "cayenne"
 repository = "https://github.com/spiceai/spiceai"
-version = "1.11.0-unstable"
+version.workspace = true
 
 [dependencies]
 arrow = { workspace = true }


### PR DESCRIPTION
Use the workspace version for the Cayenne crate to match our other internal crates