### PR TITLE
DynamoDB fixes: JSON nesting for Streams, proper batch deletions

### DIFF
--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -11,7 +11,6 @@ pub struct JsonNesting {
     pub static_fields: HashSet<String>,
     pub json_field_name: String,
 }
-
 /// With the following configuration: `JsonNesting` {`static_fields`: {"PK", "SK", "Baz"}, `json_field_name`: "Data"}
 ///
 /// This schema:
@@ -24,31 +23,36 @@ pub fn json_nest_except_fields(
     json_nesting: &JsonNesting,
 ) -> Result<Vec<DynamoDBRow>> {
     rows.into_iter()
-        .map(|row| {
-            let mut result = HashMap::new();
-            // To make fields sorted alphabetically
-            let mut data_map = BTreeMap::new();
-
-            for (key, value) in row {
-                if json_nesting.static_fields.contains(&key) {
-                    result.insert(key, value);
-                } else {
-                    data_map.insert(key, attribute_value_to_json(&value));
-                }
-            }
-
-            if !data_map.is_empty() {
-                let json_string =
-                    serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
-                result.insert(
-                    json_nesting.json_field_name.clone(),
-                    AttributeValue::S(json_string),
-                );
-            }
-
-            Ok(result)
-        })
+        .map(|row| json_nest_row_except_fields(row, json_nesting))
         .collect()
+}
+
+pub fn json_nest_row_except_fields(
+    row: DynamoDBRow,
+    json_nesting: &JsonNesting,
+) -> Result<DynamoDBRow> {
+    let mut result = HashMap::new();
+    // To make fields sorted alphabetically
+    let mut data_map = BTreeMap::new();
+
+    for (key, value) in row {
+        if json_nesting.static_fields.contains(&key) {
+            result.insert(key, value);
+        } else {
+            data_map.insert(key, attribute_value_to_json(&value));
+        }
+    }
+
+    if !data_map.is_empty() {
+        let json_string =
+            serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
+        result.insert(
+            json_nesting.json_field_name.clone(),
+            AttributeValue::S(json_string),
+        );
+    }
+
+    Ok(result)
 }
 
 fn attribute_value_to_json(attr: &AttributeValue) -> Value {

--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -44,8 +44,7 @@ pub fn json_nest_row_except_fields(
     }
 
     if !data_map.is_empty() {
-        let json_string =
-            serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
+        let json_string = serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
         result.insert(
             json_nesting.json_field_name.clone(),
             AttributeValue::S(json_string),

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -324,6 +324,7 @@ impl DynamoDBTableProvider {
         let primary_keys = self.table_schema.primary_keys().clone();
         let unnest_depth = self.unnest_depth;
         let time_format = Arc::clone(&self.table_schema.time_format());
+        let json_nesting = self.json_nesting.clone();
 
         let stream = self
             .streams_client
@@ -337,6 +338,7 @@ impl DynamoDBTableProvider {
                     &primary_keys,
                     unnest_depth,
                     &time_format,
+                    json_nesting.as_ref(),
                 )
                 .map_err(crate::cdc::StreamError::DynamoDB)
             });

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -842,14 +842,20 @@ mod tests {
             let id_col = data_batch
                 .column_by_name("id")
                 .expect("id column should exist");
-            let id_array = id_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let id_array = id_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             assert_eq!(id_array.value(0), "123");
 
             // Verify "Data" contains nested JSON with "name" and "count"
             let data_col = data_batch
                 .column_by_name("Data")
                 .expect("Data column should exist");
-            let data_array = data_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let data_array = data_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             let json_str = data_array.value(0);
 
             let parsed: serde_json::Value =
@@ -875,10 +881,7 @@ mod tests {
                 "SK".to_string(),
                 StreamsAttributeValue::S("sk456".to_string()),
             );
-            new_image.insert(
-                "MapField".to_string(),
-                StreamsAttributeValue::M(nested_map),
-            );
+            new_image.insert("MapField".to_string(), StreamsAttributeValue::M(nested_map));
             new_image.insert(
                 "ListField".to_string(),
                 StreamsAttributeValue::L(vec![
@@ -886,10 +889,7 @@ mod tests {
                     StreamsAttributeValue::S("item2".to_string()),
                 ]),
             );
-            new_image.insert(
-                "BoolField".to_string(),
-                StreamsAttributeValue::Bool(true),
-            );
+            new_image.insert("BoolField".to_string(), StreamsAttributeValue::Bool(true));
 
             let record = create_test_record(OperationType::Modify, Some(new_image), None);
             let batch = vec![record];
@@ -922,16 +922,27 @@ mod tests {
 
             // Verify static fields
             let pk_col = data_batch.column_by_name("PK").expect("PK should exist");
-            let pk_array = pk_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let pk_array = pk_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             assert_eq!(pk_array.value(0), "pk123");
 
             let sk_col = data_batch.column_by_name("SK").expect("SK should exist");
-            let sk_array = sk_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let sk_array = sk_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             assert_eq!(sk_array.value(0), "sk456");
 
             // Verify nested JSON contains complex types
-            let data_col = data_batch.column_by_name("Data").expect("Data should exist");
-            let data_array = data_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let data_col = data_batch
+                .column_by_name("Data")
+                .expect("Data should exist");
+            let data_array = data_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             let json_str = data_array.value(0);
 
             let parsed: serde_json::Value =
@@ -990,11 +1001,19 @@ mod tests {
 
             // Verify both fields are at top level
             let id_col = data_batch.column_by_name("id").expect("id should exist");
-            let id_array = id_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let id_array = id_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             assert_eq!(id_array.value(0), "123");
 
-            let name_col = data_batch.column_by_name("name").expect("name should exist");
-            let name_array = name_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let name_col = data_batch
+                .column_by_name("name")
+                .expect("name should exist");
+            let name_array = name_col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result");
             assert_eq!(name_array.value(0), "Test");
 
             // Data field should not exist (or be null/empty)

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use super::{Error, Result};
+use super::{Error, JsonNesting, Result};
 use crate::arrow::struct_builder::StructBuilder;
 use crate::cdc::{ChangeBatch, ChangeBatchError, changes_schema};
 use crate::dynamodb::arrow::append_item_to_struct_builder;
@@ -33,6 +33,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::SystemTime;
+use crate::dynamodb::json_nest::{json_nest_except_fields, json_nest_row_except_fields};
+use crate::dynamodb::provider::to_execution_error;
 
 #[derive(Debug, Snafu)]
 pub enum StreamError {
@@ -122,6 +124,7 @@ pub fn process_batch(
     primary_keys: &[String],
     unnest_depth: Option<usize>,
     time_format: &str,
+    json_nesting: Option<&JsonNesting>,
 ) -> Result<(ChangeBatch, Checkpoint, Option<SystemTime>), StreamError> {
     let batch = batch.context(FailedToReceiveMessageSnafu)?;
     let records = batch.records;
@@ -149,13 +152,19 @@ pub fn process_batch(
                             .context(FailedToUnnestSnafu)?,
                     };
 
+                    let final_streams_item = match json_nesting.clone() {
+                        None => unnested_streams_item,
+                        Some(ref json_nesting) => json_nest_row_except_fields(unnested_streams_item, json_nesting)
+                            .context(FailedToUnnestSnafu)?,
+                    };
+
                     let op = if matches!(event_name, OperationType::Insert) {
                         "c"
                     } else {
                         "u"
                     };
 
-                    (op, unnested_streams_item)
+                    (op, final_streams_item)
                 }
                 OperationType::Remove => {
                     let Some(keys_item) = &dynamodb.keys else {
@@ -331,6 +340,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -368,6 +378,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -401,6 +412,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -427,6 +439,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -470,6 +483,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -508,6 +522,7 @@ mod tests {
                 &primary_keys,
                 Some(2),
                 TIME_FORMAT,
+                None,
             );
 
             result.expect("Should create change envelope with unnesting");
@@ -537,6 +552,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -561,6 +577,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -588,6 +605,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -615,6 +633,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -648,6 +667,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -686,6 +706,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -719,6 +740,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -753,6 +775,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
+                None,
             );
 
             let (change_batch, _checkpoint, _watermark) =

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -17,6 +17,7 @@ use super::{Error, JsonNesting, Result};
 use crate::arrow::struct_builder::StructBuilder;
 use crate::cdc::{ChangeBatch, ChangeBatchError, changes_schema};
 use crate::dynamodb::arrow::append_item_to_struct_builder;
+use crate::dynamodb::json_nest::json_nest_row_except_fields;
 use crate::dynamodb::unnest::unnest_dynamodb_row;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -33,8 +34,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::SystemTime;
-use crate::dynamodb::json_nest::{json_nest_except_fields, json_nest_row_except_fields};
-use crate::dynamodb::provider::to_execution_error;
 
 #[derive(Debug, Snafu)]
 pub enum StreamError {
@@ -152,10 +151,12 @@ pub fn process_batch(
                             .context(FailedToUnnestSnafu)?,
                     };
 
-                    let final_streams_item = match json_nesting.clone() {
+                    let final_streams_item = match json_nesting {
                         None => unnested_streams_item,
-                        Some(ref json_nesting) => json_nest_row_except_fields(unnested_streams_item, json_nesting)
-                            .context(FailedToUnnestSnafu)?,
+                        Some(json_nesting) => {
+                            json_nest_row_except_fields(unnested_streams_item, json_nesting)
+                                .context(FailedToUnnestSnafu)?
+                        }
                     };
 
                     let op = if matches!(event_name, OperationType::Insert) {

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -787,6 +787,219 @@ mod tests {
             assert_eq!(data_batch.num_rows(), 1);
             assert_eq!(data_batch.num_columns(), 2); // id and name
         }
+
+        use arrow::array::StringArray;
+
+        #[test]
+        fn test_process_batch_with_json_nesting_verifies_data() {
+            let mut new_image = HashMap::new();
+            new_image.insert(
+                "id".to_string(),
+                StreamsAttributeValue::S("123".to_string()),
+            );
+            new_image.insert(
+                "name".to_string(),
+                StreamsAttributeValue::S("Test Item".to_string()),
+            );
+            new_image.insert(
+                "count".to_string(),
+                StreamsAttributeValue::N("42".to_string()),
+            );
+
+            let record = create_test_record(OperationType::Insert, Some(new_image), None);
+            let batch = vec![record];
+
+            let table_schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Utf8, true),
+                Field::new("Data", DataType::Utf8, true),
+            ]));
+            let primary_keys = vec!["id".to_string()];
+
+            let json_nesting = JsonNesting {
+                static_fields: HashSet::from(["id".to_string()]),
+                json_field_name: "Data".to_string(),
+            };
+
+            let result = process_batch(
+                create_stream_result(batch),
+                &table_schema,
+                &primary_keys,
+                None,
+                TIME_FORMAT,
+                Some(&json_nesting),
+            );
+
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
+
+            assert_eq!(change_batch.record.num_rows(), 1);
+
+            // Extract and verify the data
+            let data_batch = change_batch.data(0);
+            assert_eq!(data_batch.num_rows(), 1);
+
+            // Verify "id" is a top-level field
+            let id_col = data_batch
+                .column_by_name("id")
+                .expect("id column should exist");
+            let id_array = id_col.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(id_array.value(0), "123");
+
+            // Verify "Data" contains nested JSON with "name" and "count"
+            let data_col = data_batch
+                .column_by_name("Data")
+                .expect("Data column should exist");
+            let data_array = data_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let json_str = data_array.value(0);
+
+            let parsed: serde_json::Value =
+                serde_json::from_str(json_str).expect("Data should be valid JSON");
+            assert_eq!(parsed["name"], "Test Item");
+            assert_eq!(parsed["count"], 42.0); // Numbers are parsed as f64
+        }
+
+        #[test]
+        fn test_process_batch_with_json_nesting_complex_types_verifies_data() {
+            let mut nested_map = HashMap::new();
+            nested_map.insert(
+                "nested_key".to_string(),
+                StreamsAttributeValue::S("nested_value".to_string()),
+            );
+
+            let mut new_image = HashMap::new();
+            new_image.insert(
+                "PK".to_string(),
+                StreamsAttributeValue::S("pk123".to_string()),
+            );
+            new_image.insert(
+                "SK".to_string(),
+                StreamsAttributeValue::S("sk456".to_string()),
+            );
+            new_image.insert(
+                "MapField".to_string(),
+                StreamsAttributeValue::M(nested_map),
+            );
+            new_image.insert(
+                "ListField".to_string(),
+                StreamsAttributeValue::L(vec![
+                    StreamsAttributeValue::S("item1".to_string()),
+                    StreamsAttributeValue::S("item2".to_string()),
+                ]),
+            );
+            new_image.insert(
+                "BoolField".to_string(),
+                StreamsAttributeValue::Bool(true),
+            );
+
+            let record = create_test_record(OperationType::Modify, Some(new_image), None);
+            let batch = vec![record];
+
+            let table_schema = Arc::new(Schema::new(vec![
+                Field::new("PK", DataType::Utf8, true),
+                Field::new("SK", DataType::Utf8, true),
+                Field::new("Data", DataType::Utf8, true),
+            ]));
+            let primary_keys = vec!["PK".to_string(), "SK".to_string()];
+
+            let json_nesting = JsonNesting {
+                static_fields: HashSet::from(["PK".to_string(), "SK".to_string()]),
+                json_field_name: "Data".to_string(),
+            };
+
+            let result = process_batch(
+                create_stream_result(batch),
+                &table_schema,
+                &primary_keys,
+                None,
+                TIME_FORMAT,
+                Some(&json_nesting),
+            );
+
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
+
+            let data_batch = change_batch.data(0);
+
+            // Verify static fields
+            let pk_col = data_batch.column_by_name("PK").expect("PK should exist");
+            let pk_array = pk_col.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(pk_array.value(0), "pk123");
+
+            let sk_col = data_batch.column_by_name("SK").expect("SK should exist");
+            let sk_array = sk_col.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(sk_array.value(0), "sk456");
+
+            // Verify nested JSON contains complex types
+            let data_col = data_batch.column_by_name("Data").expect("Data should exist");
+            let data_array = data_col.as_any().downcast_ref::<StringArray>().unwrap();
+            let json_str = data_array.value(0);
+
+            let parsed: serde_json::Value =
+                serde_json::from_str(json_str).expect("Data should be valid JSON");
+
+            // Verify nested map
+            assert_eq!(parsed["MapField"]["nested_key"], "nested_value");
+
+            // Verify list
+            assert_eq!(parsed["ListField"], serde_json::json!(["item1", "item2"]));
+
+            // Verify bool
+            assert_eq!(parsed["BoolField"], true);
+        }
+
+        #[test]
+        fn test_process_batch_with_json_nesting_all_fields_static() {
+            // When all fields are static, no "Data" field should be created
+            let mut new_image = HashMap::new();
+            new_image.insert(
+                "id".to_string(),
+                StreamsAttributeValue::S("123".to_string()),
+            );
+            new_image.insert(
+                "name".to_string(),
+                StreamsAttributeValue::S("Test".to_string()),
+            );
+
+            let record = create_test_record(OperationType::Insert, Some(new_image), None);
+            let batch = vec![record];
+
+            let table_schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Utf8, true),
+                Field::new("name", DataType::Utf8, true),
+            ]));
+            let primary_keys = vec!["id".to_string()];
+
+            let json_nesting = JsonNesting {
+                static_fields: HashSet::from(["id".to_string(), "name".to_string()]),
+                json_field_name: "Data".to_string(),
+            };
+
+            let result = process_batch(
+                create_stream_result(batch),
+                &table_schema,
+                &primary_keys,
+                None,
+                TIME_FORMAT,
+                Some(&json_nesting),
+            );
+
+            let (change_batch, _checkpoint, _watermark) =
+                result.expect("Should create change envelope");
+
+            let data_batch = change_batch.data(0);
+
+            // Verify both fields are at top level
+            let id_col = data_batch.column_by_name("id").expect("id should exist");
+            let id_array = id_col.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(id_array.value(0), "123");
+
+            let name_col = data_batch.column_by_name("name").expect("name should exist");
+            let name_array = name_col.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(name_array.value(0), "Test");
+
+            // Data field should not exist (or be null/empty)
+            assert!(data_batch.column_by_name("Data").is_none());
+        }
     }
 
     #[cfg(test)]
@@ -1363,53 +1576,6 @@ mod tests {
             let item = HashMap::new();
             let result = streams_to_dynamodb_item(item);
             assert!(result.is_empty());
-        }
-    }
-
-    /// Tests that demonstrate bugs in the stream conversion module.
-    /// These tests document incorrect behavior and will FAIL when the bugs are fixed.
-    mod bug_tests {
-        /// BUG: `streams_to_dynamodb_attribute` silently converts unknown variants to `Null(true)`.
-        ///
-        /// When AWS adds a new `AttributeValue` variant (which has happened in the past,
-        /// e.g., when they added Document types), this function will silently convert
-        /// it to Null, causing DATA LOSS.
-        ///
-        /// Current behavior: `_ => DynamoDbAttributeValue::Null(true)` - silent data loss
-        /// Correct behavior: Should return `Result` and error on unknown variants,
-        ///                   or at minimum log a warning.
-        ///
-        /// This test will FAIL when the bug is fixed (i.e., when the function
-        /// properly handles unknown variants instead of silently discarding data).
-        ///
-        /// NOTE: We cannot directly test this since we can't construct an "unknown"
-        /// variant without modifying the AWS SDK. Instead, we document this as a
-        /// code review finding. The `_ => ...` pattern should be replaced with
-        /// explicit handling of all known variants.
-        #[test]
-        fn test_bug_unknown_variant_becomes_null_documented() {
-            // This test documents the bug but cannot directly trigger it.
-            // The bug is in this code pattern:
-            //
-            // ```rust
-            // fn streams_to_dynamodb_attribute(value: &StreamsAttributeValue) -> DynamoDbAttributeValue {
-            //     match value {
-            //         ... // all known variants
-            //         _ => DynamoDbAttributeValue::Null(true),  // BUG: silent data loss
-            //     }
-            // }
-            // ```
-            //
-            // When AWS adds new variants (which they have done historically),
-            // this will silently convert them to Null, causing data corruption.
-            //
-            // The fix is to either:
-            // 1. Return Result<DynamoDbAttributeValue, Error> and error on unknown
-            // 2. Use #[non_exhaustive] handling with explicit error
-            // 3. At minimum, log a warning when encountering unknown variants
-            //
-            // This test passes to document the finding - the actual fix requires
-            // a code change to the function signature.
         }
     }
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -164,6 +164,9 @@ pub enum Error {
 
     #[snafu(display("Failed to create RecordBatch: {source}"))]
     FailedToBuildRecordBatch { source: ArrowError },
+
+    #[snafu(display("No primary keys defined for dataset {dataset_name}"))]
+    NoPrimaryKeysDefined { dataset_name: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -209,12 +209,11 @@ impl RefreshTask {
 
         let data_batch = change_batch.data_batch();
 
-        if row_indices.len() > 0 {
+        if !row_indices.is_empty() {
             tracing::trace!(
                 "Processing upsert batch for {dataset_name} with {} rows",
                 row_indices.len()
             );
-            println!("data_batch: {:#?}", data_batch);
         }
 
         let indices_array = UInt32Array::from(
@@ -261,50 +260,6 @@ impl RefreshTask {
         Ok(())
     }
 
-    // async fn process_delete_batch(
-    //     &self,
-    //     change_batch: &ChangeBatch,
-    //     row_indices: &[usize],
-    //     deletion_provider: &Arc<dyn DeletionTableProvider>,
-    // ) -> crate::accelerated_table::Result<()> {
-    //     let dataset_name = &self.dataset_name;
-    //
-    //     tracing::trace!(
-    //         "Processing delete batch for {dataset_name} with {} rows",
-    //         row_indices.len()
-    //     );
-    //
-    //     let ctx = SessionContext::new();
-    //     let session_state = ctx.state();
-    //
-    //     let row_conditions: Vec<Expr> = row_indices.iter()
-    //         .map(|&row| {
-    //             let primary_keys = change_batch.primary_keys(row);
-    //             let exprs = get_delete_where_expr(&change_batch.data(row), primary_keys)?;
-    //             // AND together exprs for this row: (PK=x AND SK=y)
-    //             Ok(exprs.into_iter().reduce(|a, b| a.and(b)).unwrap())
-    //         })
-    //         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
-    //
-    //     // OR together all row conditions: (PK=1 AND SK='300') OR (PK=1 AND SK='400')
-    //     let combined = row_conditions.into_iter().reduce(|a, b| a.or(b));
-    //
-    //     if let Some(combined) = combined {
-    //         let _lock_guard = self.accelerator_write_mutex.lock().await;
-    //         let delete_plan = deletion_provider
-    //             .delete_from(&session_state, &[combined])
-    //             .await
-    //             .map_err(find_datafusion_root)
-    //             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
-    //         collect(delete_plan, ctx.task_ctx())
-    //             .await
-    //             .map_err(find_datafusion_root)
-    //             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
-    //     }
-    //
-    //     Ok(())
-    // }
-
     async fn process_delete_batch(
         &self,
         change_batch: &ChangeBatch,
@@ -318,7 +273,7 @@ impl RefreshTask {
             row_indices.len()
         );
 
-        let combined = build_batch_delete_expr_from_change_batch(change_batch, row_indices)?;
+        let combined = build_batch_delete_expr_from_change_batch(change_batch, row_indices, dataset_name.to_string().as_str())?;
 
         if let Some(combined) = combined {
             let ctx = SessionContext::new();
@@ -344,6 +299,7 @@ pub fn build_batch_delete_expr<F, G>(
     row_indices: &[usize],
     get_primary_keys: F,
     get_row_data: G,
+    dataset_name: &str,
 ) -> crate::accelerated_table::Result<Option<Expr>>
 where
     F: Fn(usize) -> Vec<String>,
@@ -359,27 +315,31 @@ where
             let primary_keys = get_primary_keys(row);
             let row_data = get_row_data(row);
             let exprs = get_delete_where_expr(&row_data, primary_keys)?;
-            // AND together exprs for this row: (PK=x AND SK=y)
-            Ok(exprs
+            exprs
                 .into_iter()
-                .reduce(|a, b| a.and(b))
-                .expect("primary_keys should not be empty"))
+                .reduce(datafusion_expr::Expr::and)
+                .ok_or_else(|| {
+                    crate::accelerated_table::Error::NoPrimaryKeysDefined {
+                        dataset_name: dataset_name.to_string(),
+                    }
+                })
         })
         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
 
-    // OR together all row conditions
-    Ok(row_conditions.into_iter().reduce(|a, b| a.or(b)))
+    Ok(row_conditions.into_iter().reduce(datafusion_expr::Expr::or))
 }
 
-/// Simplified version that works directly with ChangeBatch
+/// Simplified version that works directly with `ChangeBatch`
 pub fn build_batch_delete_expr_from_change_batch(
     change_batch: &ChangeBatch,
     row_indices: &[usize],
+    dataset_name: &str,
 ) -> crate::accelerated_table::Result<Option<Expr>> {
     build_batch_delete_expr(
         row_indices,
         |row| change_batch.primary_keys(row),
         |row| change_batch.data(row),
+        dataset_name,
     )
 }
 
@@ -603,9 +563,9 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use data_components::cdc::changes_schema;
-    use std::sync::Arc;
-    use datafusion::logical_expr::Operator;
     use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::Operator;
+    use std::sync::Arc;
 
     fn create_test_data_schema() -> Schema {
         Schema::new(vec![
@@ -934,8 +894,9 @@ mod tests {
             &[],
             |_| vec!["id".to_string()],
             |_| make_single_key_batch("test"),
+            "test_dataset",
         )
-            .expect("result");
+        .expect("result");
 
         assert!(result.is_none());
     }
@@ -948,9 +909,10 @@ mod tests {
             &row_indices,
             |_| vec!["id".to_string()],
             |_| make_single_key_batch("id-5"),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Should be: id = 'id-5' (a single equality expression)
         if let Expr::BinaryExpr(binary) = &result {
@@ -967,7 +929,10 @@ mod tests {
             if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = binary.right.as_ref() {
                 assert_eq!(val, "id-5");
             } else {
-                panic!("Expected Utf8 literal on right side, got: {:?}", binary.right);
+                panic!(
+                    "Expected Utf8 literal on right side, got: {:?}",
+                    binary.right
+                );
             }
         } else {
             panic!("Expected BinaryExpr, got: {result:?}");
@@ -984,9 +949,10 @@ mod tests {
             &row_indices,
             |_| vec!["id".to_string()],
             |row| make_single_key_batch(ids[row]),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Collect all equality conditions from the OR tree
         let conditions = collect_or_conditions(&result);
@@ -1012,9 +978,10 @@ mod tests {
             &row_indices,
             |_| vec!["PK".to_string(), "SK".to_string()],
             |_| make_single_row_batch(1, "300"),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Should be AND at top level
         if let Expr::BinaryExpr(binary) = &result {
@@ -1044,9 +1011,10 @@ mod tests {
             &row_indices,
             |_| vec!["PK".to_string(), "SK".to_string()],
             |row| make_single_row_batch(rows[row].0, rows[row].1),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Collect top-level OR conditions
         let or_conditions = collect_or_conditions(&result);
@@ -1082,9 +1050,10 @@ mod tests {
             &row_indices,
             |_| vec!["id".to_string()],
             |row| make_single_key_batch(ids[row]),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Collect OR conditions
         let conditions = collect_or_conditions(&result);
@@ -1119,9 +1088,10 @@ mod tests {
             &row_indices,
             |_| vec!["PK".to_string(), "SK".to_string()],
             |row| make_single_row_batch(rows[row].0, rows[row].1),
+            "test_dataset",
         )
-            .unwrap()
-            .unwrap();
+        .expect("result")
+        .expect("result");
 
         // Collect top-level OR conditions
         let or_conditions = collect_or_conditions(&result);
@@ -1192,7 +1162,9 @@ mod tests {
             if binary.op == Operator::Eq {
                 if let Expr::Column(col) = binary.left.as_ref() {
                     if col.name == column_name {
-                        if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = binary.right.as_ref() {
+                        if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) =
+                            binary.right.as_ref()
+                        {
                             return val.clone();
                         }
                     }
@@ -1215,12 +1187,16 @@ mod tests {
                     if let Expr::Column(col) = binary.left.as_ref() {
                         match col.name.as_str() {
                             "pk" => {
-                                if let Expr::Literal(ScalarValue::Int64(Some(v)), _) = binary.right.as_ref() {
+                                if let Expr::Literal(ScalarValue::Int64(Some(v)), _) =
+                                    binary.right.as_ref()
+                                {
                                     pk_value = Some(*v);
                                 }
                             }
                             "sk" => {
-                                if let Expr::Literal(ScalarValue::Utf8(Some(v)), _) = binary.right.as_ref() {
+                                if let Expr::Literal(ScalarValue::Utf8(Some(v)), _) =
+                                    binary.right.as_ref()
+                                {
                                     sk_value = Some(v.clone());
                                 }
                             }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -207,12 +207,15 @@ impl RefreshTask {
     ) -> crate::accelerated_table::Result<()> {
         let dataset_name = &self.dataset_name;
 
-        tracing::trace!(
-            "Processing upsert batch for {dataset_name} with {} rows",
-            row_indices.len()
-        );
-
         let data_batch = change_batch.data_batch();
+
+        if row_indices.len() > 0 {
+            tracing::trace!(
+                "Processing upsert batch for {dataset_name} with {} rows",
+                row_indices.len()
+            );
+            println!("data_batch: {:#?}", data_batch);
+        }
 
         let indices_array = UInt32Array::from(
             row_indices
@@ -258,6 +261,50 @@ impl RefreshTask {
         Ok(())
     }
 
+    // async fn process_delete_batch(
+    //     &self,
+    //     change_batch: &ChangeBatch,
+    //     row_indices: &[usize],
+    //     deletion_provider: &Arc<dyn DeletionTableProvider>,
+    // ) -> crate::accelerated_table::Result<()> {
+    //     let dataset_name = &self.dataset_name;
+    //
+    //     tracing::trace!(
+    //         "Processing delete batch for {dataset_name} with {} rows",
+    //         row_indices.len()
+    //     );
+    //
+    //     let ctx = SessionContext::new();
+    //     let session_state = ctx.state();
+    //
+    //     let row_conditions: Vec<Expr> = row_indices.iter()
+    //         .map(|&row| {
+    //             let primary_keys = change_batch.primary_keys(row);
+    //             let exprs = get_delete_where_expr(&change_batch.data(row), primary_keys)?;
+    //             // AND together exprs for this row: (PK=x AND SK=y)
+    //             Ok(exprs.into_iter().reduce(|a, b| a.and(b)).unwrap())
+    //         })
+    //         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
+    //
+    //     // OR together all row conditions: (PK=1 AND SK='300') OR (PK=1 AND SK='400')
+    //     let combined = row_conditions.into_iter().reduce(|a, b| a.or(b));
+    //
+    //     if let Some(combined) = combined {
+    //         let _lock_guard = self.accelerator_write_mutex.lock().await;
+    //         let delete_plan = deletion_provider
+    //             .delete_from(&session_state, &[combined])
+    //             .await
+    //             .map_err(find_datafusion_root)
+    //             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+    //         collect(delete_plan, ctx.task_ctx())
+    //             .await
+    //             .map_err(find_datafusion_root)
+    //             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+    //     }
+    //
+    //     Ok(())
+    // }
+
     async fn process_delete_batch(
         &self,
         change_batch: &ChangeBatch,
@@ -271,34 +318,69 @@ impl RefreshTask {
             row_indices.len()
         );
 
-        let ctx = SessionContext::new();
-        let session_state = ctx.state();
+        let combined = build_batch_delete_expr_from_change_batch(change_batch, row_indices)?;
 
-        let mut all_where_exprs = Vec::new();
+        if let Some(combined) = combined {
+            let ctx = SessionContext::new();
+            let session_state = ctx.state();
 
-        for &row in row_indices {
-            let inner_data = change_batch.data(row);
-            let primary_keys = change_batch.primary_keys(row);
-            let primary_key_log_fmt = get_primary_key_log_fmt(&inner_data, &primary_keys)?;
-            let delete_where_exprs = get_delete_where_expr(&inner_data, primary_keys)?;
-
-            tracing::trace!("Deleting data for {dataset_name} where {primary_key_log_fmt}");
-            all_where_exprs.extend(delete_where_exprs);
+            let _lock_guard = self.accelerator_write_mutex.lock().await;
+            let delete_plan = deletion_provider
+                .delete_from(&session_state, &[combined])
+                .await
+                .map_err(find_datafusion_root)
+                .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+            collect(delete_plan, ctx.task_ctx())
+                .await
+                .map_err(find_datafusion_root)
+                .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
         }
-
-        let _lock_guard = self.accelerator_write_mutex.lock().await;
-        let delete_plan = deletion_provider
-            .delete_from(&session_state, &all_where_exprs)
-            .await
-            .map_err(find_datafusion_root)
-            .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
-        collect(delete_plan, ctx.task_ctx())
-            .await
-            .map_err(find_datafusion_root)
-            .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
 
         Ok(())
     }
+}
+
+pub fn build_batch_delete_expr<F, G>(
+    row_indices: &[usize],
+    get_primary_keys: F,
+    get_row_data: G,
+) -> crate::accelerated_table::Result<Option<Expr>>
+where
+    F: Fn(usize) -> Vec<String>,
+    G: Fn(usize) -> RecordBatch,
+{
+    if row_indices.is_empty() {
+        return Ok(None);
+    }
+
+    let row_conditions: Vec<Expr> = row_indices
+        .iter()
+        .map(|&row| {
+            let primary_keys = get_primary_keys(row);
+            let row_data = get_row_data(row);
+            let exprs = get_delete_where_expr(&row_data, primary_keys)?;
+            // AND together exprs for this row: (PK=x AND SK=y)
+            Ok(exprs
+                .into_iter()
+                .reduce(|a, b| a.and(b))
+                .expect("primary_keys should not be empty"))
+        })
+        .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
+
+    // OR together all row conditions
+    Ok(row_conditions.into_iter().reduce(|a, b| a.or(b)))
+}
+
+/// Simplified version that works directly with ChangeBatch
+pub fn build_batch_delete_expr_from_change_batch(
+    change_batch: &ChangeBatch,
+    row_indices: &[usize],
+) -> crate::accelerated_table::Result<Option<Expr>> {
+    build_batch_delete_expr(
+        row_indices,
+        |row| change_batch.primary_keys(row),
+        |row| change_batch.data(row),
+    )
 }
 
 fn get_primary_key_log_fmt(
@@ -522,6 +604,8 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use data_components::cdc::changes_schema;
     use std::sync::Arc;
+    use datafusion::logical_expr::Operator;
+    use datafusion::common::ScalarValue;
 
     fn create_test_data_schema() -> Schema {
         Schema::new(vec![
@@ -817,5 +901,339 @@ mod tests {
 
         assert_eq!(result[3].0, ChangeOperationType::Delete);
         assert_eq!(result[3].1, vec![3]);
+    }
+
+    // Helper to create a RecordBatch with a single row for testing
+    fn make_single_row_batch(pk: i64, sk: &str) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("PK", DataType::Int64, false),
+            Field::new("SK", DataType::Utf8, false),
+        ]));
+
+        let pk_array: ArrayRef = Arc::new(Int64Array::from(vec![pk]));
+        let sk_array: ArrayRef = Arc::new(StringArray::from(vec![sk]));
+
+        RecordBatch::try_new(schema, vec![pk_array, sk_array]).expect("record batch")
+    }
+
+    /// Helper to create a RecordBatch with a single string key
+    fn make_single_key_batch(id: &str) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+        let id_array: ArrayRef = Arc::new(StringArray::from(vec![id]));
+        RecordBatch::try_new(schema, vec![id_array]).expect("record batch")
+    }
+
+    /// Extracts string representation of an Expr for easier assertion
+    fn expr_to_string(expr: &Expr) -> String {
+        format!("{expr}")
+    }
+
+    #[test]
+    fn test_empty_row_indices_returns_none() {
+        let result = build_batch_delete_expr(
+            &[],
+            |_| vec!["id".to_string()],
+            |_| make_single_key_batch("test"),
+        )
+            .expect("result");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_single_row_single_key() {
+        // Single row with single primary key: WHERE id='id-5'
+        let row_indices = vec![0];
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["id".to_string()],
+            |_| make_single_key_batch("id-5"),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Should be: id = 'id-5' (a single equality expression)
+        if let Expr::BinaryExpr(binary) = &result {
+            assert_eq!(binary.op, Operator::Eq, "Expected Eq operator");
+
+            // Left side should be column "id"
+            if let Expr::Column(col) = binary.left.as_ref() {
+                assert_eq!(col.name, "id");
+            } else {
+                panic!("Expected Column on left side, got: {:?}", binary.left);
+            }
+
+            // Right side should be literal "id-5"
+            if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = binary.right.as_ref() {
+                assert_eq!(val, "id-5");
+            } else {
+                panic!("Expected Utf8 literal on right side, got: {:?}", binary.right);
+            }
+        } else {
+            panic!("Expected BinaryExpr, got: {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_multiple_rows_single_key_produces_or() {
+        // Should produce: id='id-5' OR id='id-6' OR id='id-7'
+        let row_indices = vec![0, 1, 2];
+        let ids = vec!["id-5", "id-6", "id-7"];
+
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["id".to_string()],
+            |row| make_single_key_batch(ids[row]),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Collect all equality conditions from the OR tree
+        let conditions = collect_or_conditions(&result);
+        assert_eq!(conditions.len(), 3, "Expected 3 OR conditions");
+
+        // Verify each condition is id = 'id-X'
+        let values: Vec<String> = conditions
+            .iter()
+            .map(|expr| extract_eq_value(expr, "id"))
+            .collect();
+
+        assert!(values.contains(&"id-5".to_string()));
+        assert!(values.contains(&"id-6".to_string()));
+        assert!(values.contains(&"id-7".to_string()));
+    }
+
+    #[test]
+    fn test_single_row_composite_key_produces_and() {
+        // Single row with composite key: WHERE pk=1 AND sk='300'
+        let row_indices = vec![0];
+
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["PK".to_string(), "SK".to_string()],
+            |_| make_single_row_batch(1, "300"),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Should be AND at top level
+        if let Expr::BinaryExpr(binary) = &result {
+            assert_eq!(binary.op, Operator::And, "Expected AND for composite key");
+
+            // Collect the two equality conditions
+            let conditions = collect_and_conditions(&result);
+            assert_eq!(conditions.len(), 2, "Expected 2 AND conditions");
+
+            // Verify we have conditions for both pk and sk
+            let has_pk = conditions.iter().any(|e| is_column_eq(e, "pk"));
+            let has_sk = conditions.iter().any(|e| is_column_eq(e, "sk"));
+            assert!(has_pk, "Expected condition for pk");
+            assert!(has_sk, "Expected condition for sk");
+        } else {
+            panic!("Expected BinaryExpr with AND, got: {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_multiple_rows_composite_key_produces_or_of_ands() {
+        // Should produce: (pk=1 AND sk='300') OR (pk=1 AND sk='400') OR (pk=2 AND sk='100')
+        let row_indices = vec![0, 1, 2];
+        let rows = vec![(1i64, "300"), (1i64, "400"), (2i64, "100")];
+
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["PK".to_string(), "SK".to_string()],
+            |row| make_single_row_batch(rows[row].0, rows[row].1),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Collect top-level OR conditions
+        let or_conditions = collect_or_conditions(&result);
+        assert_eq!(or_conditions.len(), 3, "Expected 3 OR conditions");
+
+        // Each OR condition should be an AND of two equality expressions
+        for condition in &or_conditions {
+            if let Expr::BinaryExpr(binary) = condition {
+                assert_eq!(binary.op, Operator::And, "Each OR branch should be AND");
+            } else {
+                panic!("Expected AND expression in OR branch, got: {condition:?}");
+            }
+        }
+
+        // Verify we have the expected (pk, sk) pairs
+        let pairs: Vec<(i64, String)> = or_conditions
+            .iter()
+            .map(|expr| extract_pk_sk_values(expr))
+            .collect();
+
+        assert!(pairs.contains(&(1, "300".to_string())));
+        assert!(pairs.contains(&(1, "400".to_string())));
+        assert!(pairs.contains(&(2, "100".to_string())));
+    }
+
+    #[test]
+    fn test_two_rows_single_key_structure() {
+        // Test the exact structure: id='a' OR id='b'
+        let row_indices = vec![0, 1];
+        let ids = vec!["a", "b"];
+
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["id".to_string()],
+            |row| make_single_key_batch(ids[row]),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Collect OR conditions
+        let conditions = collect_or_conditions(&result);
+        assert_eq!(conditions.len(), 2, "Expected 2 OR conditions");
+
+        // Each condition should be a simple equality
+        for cond in &conditions {
+            if let Expr::BinaryExpr(binary) = cond {
+                assert_eq!(binary.op, Operator::Eq, "Each condition should be Eq");
+            } else {
+                panic!("Expected BinaryExpr with Eq, got: {cond:?}");
+            }
+        }
+
+        // Verify the values
+        let values: Vec<String> = conditions
+            .iter()
+            .map(|expr| extract_eq_value(expr, "id"))
+            .collect();
+
+        assert!(values.contains(&"a".to_string()));
+        assert!(values.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_two_rows_composite_key_structure() {
+        // Test: (pk=1 AND sk='a') OR (pk=2 AND sk='b')
+        let row_indices = vec![0, 1];
+        let rows = vec![(1i64, "a"), (2i64, "b")];
+
+        let result = build_batch_delete_expr(
+            &row_indices,
+            |_| vec!["PK".to_string(), "SK".to_string()],
+            |row| make_single_row_batch(rows[row].0, rows[row].1),
+        )
+            .unwrap()
+            .unwrap();
+
+        // Collect top-level OR conditions
+        let or_conditions = collect_or_conditions(&result);
+        assert_eq!(or_conditions.len(), 2, "Expected 2 OR conditions");
+
+        // Each OR condition should be an AND
+        for cond in &or_conditions {
+            if let Expr::BinaryExpr(binary) = cond {
+                assert_eq!(binary.op, Operator::And, "Each OR branch should be AND");
+            } else {
+                panic!("Expected AND in OR branch, got: {cond:?}");
+            }
+
+            // Each AND should have 2 equality conditions
+            let and_conditions = collect_and_conditions(cond);
+            assert_eq!(and_conditions.len(), 2, "Expected 2 AND conditions per row");
+        }
+
+        // Verify the (pk, sk) pairs
+        let pairs: Vec<(i64, String)> = or_conditions
+            .iter()
+            .map(|expr| extract_pk_sk_values(expr))
+            .collect();
+
+        assert!(pairs.contains(&(1, "a".to_string())));
+        assert!(pairs.contains(&(2, "b".to_string())));
+    }
+
+    /// Recursively collects all leaf conditions from an OR tree
+    fn collect_or_conditions(expr: &Expr) -> Vec<&Expr> {
+        match expr {
+            Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
+                let mut conditions = collect_or_conditions(&binary.left);
+                conditions.extend(collect_or_conditions(&binary.right));
+                conditions
+            }
+            _ => vec![expr],
+        }
+    }
+
+    /// Recursively collects all leaf conditions from an AND tree
+    fn collect_and_conditions(expr: &Expr) -> Vec<&Expr> {
+        match expr {
+            Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+                let mut conditions = collect_and_conditions(&binary.left);
+                conditions.extend(collect_and_conditions(&binary.right));
+                conditions
+            }
+            _ => vec![expr],
+        }
+    }
+
+    /// Checks if expression is `column_name = <something>`
+    fn is_column_eq(expr: &Expr, column_name: &str) -> bool {
+        if let Expr::BinaryExpr(binary) = expr {
+            if binary.op == Operator::Eq {
+                if let Expr::Column(col) = binary.left.as_ref() {
+                    return col.name == column_name;
+                }
+            }
+        }
+        false
+    }
+
+    /// Extracts the string value from `column_name = 'value'`
+    fn extract_eq_value(expr: &Expr, column_name: &str) -> String {
+        if let Expr::BinaryExpr(binary) = expr {
+            if binary.op == Operator::Eq {
+                if let Expr::Column(col) = binary.left.as_ref() {
+                    if col.name == column_name {
+                        if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = binary.right.as_ref() {
+                            return val.clone();
+                        }
+                    }
+                }
+            }
+        }
+        panic!("Expected {column_name} = 'value', got: {expr:?}");
+    }
+
+    /// Extracts (pk, sk) values from `pk = N AND sk = 'S'`
+    fn extract_pk_sk_values(expr: &Expr) -> (i64, String) {
+        let conditions = collect_and_conditions(expr);
+
+        let mut pk_value: Option<i64> = None;
+        let mut sk_value: Option<String> = None;
+
+        for cond in conditions {
+            if let Expr::BinaryExpr(binary) = cond {
+                if binary.op == Operator::Eq {
+                    if let Expr::Column(col) = binary.left.as_ref() {
+                        match col.name.as_str() {
+                            "pk" => {
+                                if let Expr::Literal(ScalarValue::Int64(Some(v)), _) = binary.right.as_ref() {
+                                    pk_value = Some(*v);
+                                }
+                            }
+                            "sk" => {
+                                if let Expr::Literal(ScalarValue::Utf8(Some(v)), _) = binary.right.as_ref() {
+                                    sk_value = Some(v.clone());
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        (
+            pk_value.expect("Expected pk value"),
+            sk_value.expect("Expected sk value"),
+        )
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -273,7 +273,11 @@ impl RefreshTask {
             row_indices.len()
         );
 
-        let combined = build_batch_delete_expr_from_change_batch(change_batch, row_indices, dataset_name.to_string().as_str())?;
+        let combined = build_batch_delete_expr_from_change_batch(
+            change_batch,
+            row_indices,
+            dataset_name.to_string().as_str(),
+        )?;
 
         if let Some(combined) = combined {
             let ctx = SessionContext::new();
@@ -318,10 +322,8 @@ where
             exprs
                 .into_iter()
                 .reduce(datafusion_expr::Expr::and)
-                .ok_or_else(|| {
-                    crate::accelerated_table::Error::NoPrimaryKeysDefined {
-                        dataset_name: dataset_name.to_string(),
-                    }
+                .ok_or_else(|| crate::accelerated_table::Error::NoPrimaryKeysDefined {
+                    dataset_name: dataset_name.to_string(),
                 })
         })
         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -865,7 +865,6 @@ mod tests {
         assert_eq!(result[3].1, vec![3]);
     }
 
-    // Helper to create a RecordBatch with a single row for testing
     fn make_single_row_batch(pk: i64, sk: &str) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("PK", DataType::Int64, false),
@@ -878,16 +877,10 @@ mod tests {
         RecordBatch::try_new(schema, vec![pk_array, sk_array]).expect("record batch")
     }
 
-    /// Helper to create a RecordBatch with a single string key
     fn make_single_key_batch(id: &str) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
         let id_array: ArrayRef = Arc::new(StringArray::from(vec![id]));
         RecordBatch::try_new(schema, vec![id_array]).expect("record batch")
-    }
-
-    /// Extracts string representation of an Expr for easier assertion
-    fn expr_to_string(expr: &Expr) -> String {
-        format!("{expr}")
     }
 
     #[test]
@@ -945,7 +938,7 @@ mod tests {
     fn test_multiple_rows_single_key_produces_or() {
         // Should produce: id='id-5' OR id='id-6' OR id='id-7'
         let row_indices = vec![0, 1, 2];
-        let ids = vec!["id-5", "id-6", "id-7"];
+        let ids = ["id-5", "id-6", "id-7"];
 
         let result = build_batch_delete_expr(
             &row_indices,
@@ -995,6 +988,7 @@ mod tests {
 
             // Verify we have conditions for both pk and sk
             let has_pk = conditions.iter().any(|e| is_column_eq(e, "pk"));
+            #[allow(clippy::similar_names)]
             let has_sk = conditions.iter().any(|e| is_column_eq(e, "sk"));
             assert!(has_pk, "Expected condition for pk");
             assert!(has_sk, "Expected condition for sk");
@@ -1007,7 +1001,7 @@ mod tests {
     fn test_multiple_rows_composite_key_produces_or_of_ands() {
         // Should produce: (pk=1 AND sk='300') OR (pk=1 AND sk='400') OR (pk=2 AND sk='100')
         let row_indices = vec![0, 1, 2];
-        let rows = vec![(1i64, "300"), (1i64, "400"), (2i64, "100")];
+        let rows = [(1i64, "300"), (1i64, "400"), (2i64, "100")];
 
         let result = build_batch_delete_expr(
             &row_indices,
@@ -1046,7 +1040,7 @@ mod tests {
     fn test_two_rows_single_key_structure() {
         // Test the exact structure: id='a' OR id='b'
         let row_indices = vec![0, 1];
-        let ids = vec!["a", "b"];
+        let ids = ["a", "b"];
 
         let result = build_batch_delete_expr(
             &row_indices,
@@ -1084,7 +1078,7 @@ mod tests {
     fn test_two_rows_composite_key_structure() {
         // Test: (pk=1 AND sk='a') OR (pk=2 AND sk='b')
         let row_indices = vec![0, 1];
-        let rows = vec![(1i64, "a"), (2i64, "b")];
+        let rows = [(1i64, "a"), (2i64, "b")];
 
         let result = build_batch_delete_expr(
             &row_indices,
@@ -1148,11 +1142,11 @@ mod tests {
 
     /// Checks if expression is `column_name = <something>`
     fn is_column_eq(expr: &Expr, column_name: &str) -> bool {
-        if let Expr::BinaryExpr(binary) = expr {
-            if binary.op == Operator::Eq {
-                if let Expr::Column(col) = binary.left.as_ref() {
-                    return col.name == column_name;
-                }
+        if let Expr::BinaryExpr(binary) = expr
+            && binary.op == Operator::Eq
+        {
+            if let Expr::Column(col) = binary.left.as_ref() {
+                return col.name == column_name;
             }
         }
         false
@@ -1160,18 +1154,13 @@ mod tests {
 
     /// Extracts the string value from `column_name = 'value'`
     fn extract_eq_value(expr: &Expr, column_name: &str) -> String {
-        if let Expr::BinaryExpr(binary) = expr {
-            if binary.op == Operator::Eq {
-                if let Expr::Column(col) = binary.left.as_ref() {
-                    if col.name == column_name {
-                        if let Expr::Literal(ScalarValue::Utf8(Some(val)), _) =
-                            binary.right.as_ref()
-                        {
-                            return val.clone();
-                        }
-                    }
-                }
-            }
+        if let Expr::BinaryExpr(binary) = expr
+            && binary.op == Operator::Eq
+            && let Expr::Column(col) = binary.left.as_ref()
+            && col.name == column_name
+            && let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = binary.right.as_ref()
+        {
+            return val.clone();
         }
         panic!("Expected {column_name} = 'value', got: {expr:?}");
     }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -965,6 +965,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::similar_names)]
     fn test_single_row_composite_key_produces_and() {
         // Single row with composite key: WHERE pk=1 AND sk='300'
         let row_indices = vec![0];
@@ -988,7 +989,6 @@ mod tests {
 
             // Verify we have conditions for both pk and sk
             let has_pk = conditions.iter().any(|e| is_column_eq(e, "pk"));
-            #[allow(clippy::similar_names)]
             let has_sk = conditions.iter().any(|e| is_column_eq(e, "sk"));
             assert!(has_pk, "Expected condition for pk");
             assert!(has_sk, "Expected condition for sk");
@@ -1144,10 +1144,9 @@ mod tests {
     fn is_column_eq(expr: &Expr, column_name: &str) -> bool {
         if let Expr::BinaryExpr(binary) = expr
             && binary.op == Operator::Eq
+            && let Expr::Column(col) = binary.left.as_ref()
         {
-            if let Expr::Column(col) = binary.left.as_ref() {
-                return col.name == column_name;
-            }
+            return col.name == column_name;
         }
         false
     }
@@ -1173,27 +1172,24 @@ mod tests {
         let mut sk_value: Option<String> = None;
 
         for cond in conditions {
-            if let Expr::BinaryExpr(binary) = cond {
-                if binary.op == Operator::Eq {
-                    if let Expr::Column(col) = binary.left.as_ref() {
-                        match col.name.as_str() {
-                            "pk" => {
-                                if let Expr::Literal(ScalarValue::Int64(Some(v)), _) =
-                                    binary.right.as_ref()
-                                {
-                                    pk_value = Some(*v);
-                                }
-                            }
-                            "sk" => {
-                                if let Expr::Literal(ScalarValue::Utf8(Some(v)), _) =
-                                    binary.right.as_ref()
-                                {
-                                    sk_value = Some(v.clone());
-                                }
-                            }
-                            _ => {}
+            if let Expr::BinaryExpr(binary) = cond
+                && binary.op == Operator::Eq
+                && let Expr::Column(col) = binary.left.as_ref()
+            {
+                match col.name.as_str() {
+                    "pk" => {
+                        if let Expr::Literal(ScalarValue::Int64(Some(v)), _) = binary.right.as_ref()
+                        {
+                            pk_value = Some(*v);
                         }
                     }
+                    "sk" => {
+                        if let Expr::Literal(ScalarValue::Utf8(Some(v)), _) = binary.right.as_ref()
+                        {
+                            sk_value = Some(v.clone());
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__batch_delete_final_state.snap
+++ b/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__batch_delete_final_state.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/dynamodb/streams.rs
+expression: formatted
+---
++------+--------+---------+
+| id   | name   | version |
++------+--------+---------+
+| id-0 | Item 0 | 0       |
+| id-1 | Item 1 | 1       |
+| id-2 | Item 2 | 2       |
+| id-3 | Item 3 | 3       |
+| id-4 | Item 4 | 4       |
++------+--------+---------+

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -289,7 +289,7 @@ async fn dynamodb_streams_delete() -> anyhow::Result<()> {
                     table_name,
                     &format!("id-{i}"),
                     &format!("Item {i}"),
-                    i as i32,
+                    i,
                 )
                 .await;
             }
@@ -299,7 +299,7 @@ async fn dynamodb_streams_delete() -> anyhow::Result<()> {
                     table_name,
                     &format!("id-{i}"),
                     &format!("Item {i}"),
-                    i as i32,
+                    i,
                 )
                 .await;
             }

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -284,10 +284,24 @@ async fn dynamodb_streams_delete() -> anyhow::Result<()> {
 
             create_table(&client, table_name).await;
             for i in 0..5 {
-                insert_item(&client, table_name, &format!("id-{i}"), &format!("Item {i}"), i as i32).await;
+                insert_item(
+                    &client,
+                    table_name,
+                    &format!("id-{i}"),
+                    &format!("Item {i}"),
+                    i as i32,
+                )
+                .await;
             }
             for i in 5..8 {
-                insert_item(&client, table_name, &format!("id-{i}"), &format!("Item {i}"), i as i32).await;
+                insert_item(
+                    &client,
+                    table_name,
+                    &format!("id-{i}"),
+                    &format!("Item {i}"),
+                    i as i32,
+                )
+                .await;
             }
 
             delete_item(&client, table_name, "id-5").await;
@@ -297,7 +311,9 @@ async fn dynamodb_streams_delete() -> anyhow::Result<()> {
             sleep(Duration::from_secs(1)).await;
 
             let app = AppBuilder::new("dynamodb_batch_delete_test")
-                .with_dataset(make_dynamodb_dataset(table_name, PORT1, access_key, secret_key, true))
+                .with_dataset(make_dynamodb_dataset(
+                    table_name, PORT1, access_key, secret_key, true,
+                ))
                 .with_results_cache(ResultsCache {
                     enabled: false,
                     ..Default::default()
@@ -323,7 +339,7 @@ async fn dynamodb_streams_delete() -> anyhow::Result<()> {
                 &format!("SELECT * FROM {table_name} ORDER BY id"),
                 "batch_delete_final_state",
             )
-                .await?;
+            .await?;
 
             running_container.remove().await.map_err(|e| {
                 tracing::error!("running_container.remove: {e}");

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -42,7 +42,8 @@ use tokio::time::sleep;
 use tracing::instrument;
 
 const DYNAMODB_DOCKER_CONTAINER: &str = "runtime-integration-test-dynamodb";
-const PORT: u16 = 8001;
+const PORT1: u16 = 8001;
+const PORT2: u16 = 8002;
 
 #[instrument]
 pub async fn start_dynamodb_docker_container(
@@ -165,6 +166,28 @@ async fn insert_rows(client: &Client, table_name: &str, range: Range<usize>) {
     }
 }
 
+async fn insert_item(client: &Client, table_name: &str, id: &str, name: &str, version: i32) {
+    client
+        .put_item()
+        .table_name(table_name)
+        .item("id", AttributeValue::S(id.to_string()))
+        .item("name", AttributeValue::S(name.to_string()))
+        .item("version", AttributeValue::N(version.to_string()))
+        .send()
+        .await
+        .expect("Failed to insert item");
+}
+
+async fn delete_item(client: &Client, table_name: &str, id: &str) {
+    client
+        .delete_item()
+        .table_name(table_name)
+        .key("id", AttributeValue::S(id.to_string()))
+        .send()
+        .await
+        .expect("Failed to delete item");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn dynamodb_streams() -> anyhow::Result<()> {
     let _tracing = init_tracing(Some(
@@ -177,9 +200,9 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
 
     test_request_context()
         .scope(async {
-            let running_container = start_dynamodb_docker_container(PORT).await?;
+            let running_container = start_dynamodb_docker_container(PORT2).await?;
 
-            let client = get_client(PORT, access_key, secret_key);
+            let client = get_client(PORT2, access_key, secret_key);
 
             create_table(&client, table_name).await;
             insert_rows(&client, "test_table", 0..5).await;
@@ -187,7 +210,7 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
 
             let app = AppBuilder::new("dynamodb_integration_test")
                 .with_dataset(make_dynamodb_dataset(
-                    table_name, PORT, access_key, secret_key, true,
+                    table_name, PORT2, access_key, secret_key, true,
                 ))
                 .with_results_cache(ResultsCache {
                     enabled: false,
@@ -233,6 +256,74 @@ async fn dynamodb_streams() -> anyhow::Result<()> {
                 "test3",
             )
             .await?;
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_streams_delete() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,dynamodb_streams=debug,info",
+    ));
+
+    let table_name = "batch_delete_test";
+    let access_key = "foo";
+    let secret_key = "bar";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT1).await?;
+            let client = get_client(PORT1, access_key, secret_key);
+
+            create_table(&client, table_name).await;
+            for i in 0..5 {
+                insert_item(&client, table_name, &format!("id-{i}"), &format!("Item {i}"), i as i32).await;
+            }
+            for i in 5..8 {
+                insert_item(&client, table_name, &format!("id-{i}"), &format!("Item {i}"), i as i32).await;
+            }
+
+            delete_item(&client, table_name, "id-5").await;
+            delete_item(&client, table_name, "id-6").await;
+            delete_item(&client, table_name, "id-7").await;
+
+            sleep(Duration::from_secs(1)).await;
+
+            let app = AppBuilder::new("dynamodb_batch_delete_test")
+                .with_dataset(make_dynamodb_dataset(table_name, PORT1, access_key, secret_key, true))
+                .with_results_cache(ResultsCache {
+                    enabled: false,
+                    ..Default::default()
+                })
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+            sleep(Duration::from_secs(3)).await;
+
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "batch_delete_final_state",
+            )
+                .await?;
 
             running_container.remove().await.map_err(|e| {
                 tracing::error!("running_container.remove: {e}");


### PR DESCRIPTION
## 📝 Summary

Two fixes:
1. Make JSON unnesting work for DynamoDB Streams (there was a missing logic for it to work properly)
2. Properly handle build expression building during batch deletions (previously if multiple records were deleted we would create expression `id=1 AND id=2` which would not match any records. 
3. Tests for both


