### PR TITLE
Update testoperator scheduler to use `release/1.11` branch

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         branch:
           - 'trunk'
-          - 'release/1.10'
+          - 'release/1.11'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

Use `release/1.11` in testoperator scheduler workflow