### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -167,7 +167,7 @@ runs:
       shell: bash
       run: |
         mkdir -p /c/usr/local/bin
-        copy target/release/spicepod-validator.exe /c/usr/local/bin/spicepod-validator.exe
+        cp target/release/spicepod-validator.exe /c/usr/local/bin/spicepod-validator.exe
         chmod +x /c/usr/local/bin/spicepod-validator.exe
 
     - name: Set output path

--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -166,7 +166,7 @@ runs:
       shell: bash
       run: |
         mkdir -p /c/usr/local/bin
-        copy target/release/testoperator.exe /c/usr/local/bin/testoperator.exe
+        cp target/release/testoperator.exe /c/usr/local/bin/testoperator.exe
         chmod +x /c/usr/local/bin/testoperator.exe
 
     - name: Set output path
@@ -185,7 +185,7 @@ runs:
 
     - name: Upload testoperator artifact
       if: inputs.upload_artifact == 'true'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5
       with:
         name: testoperator-${{ steps.detect-os.outputs.os }}
         path: target/release/testoperator${{ steps.detect-os.outputs.ext }}

--- a/.github/actions/setup-make/action.yml
+++ b/.github/actions/setup-make/action.yml
@@ -27,7 +27,7 @@ runs:
         choco install make -y
 
     - name: Install make (macOS)
-      if: inputs.os == 'macos' && matrix.target.runner != 'spiceai-macos'
+      if: inputs.os == 'macos'
       shell: bash
       run: |
         # Check if make is already installed

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,16 +1,16 @@
 name: Setup sccache
-description: "composite action"
+description: 'composite action'
 
 inputs:
   minio_endpoint:
-    description: "MinIO endpoint"
+    description: 'MinIO endpoint'
     required: true
     type: string
   os:
-    description: "Operating system to set up the toolchain for"
-    default: "linux" # 'linux', 'darwin', 'windows'
+    description: 'Operating system to set up the toolchain for'
+    default: 'linux' # 'linux', 'darwin', 'windows'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set up sccache
       if: inputs.os == 'linux'

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -29,3 +29,4 @@ runs:
         server_side_encryption = false
         no_credentials = false
         region = "us-east-1"
+        EOF

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -93,15 +93,15 @@ runs:
       shell: ${{ env.SHELL }}
 
     - name: Upload artifact
-      if: matrix.target.target_os != 'windows'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: inputs.target_os != 'windows'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5
       with:
         name: spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}
         path: spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz
 
     - name: Upload artifact
-      if: matrix.target.target_os == 'windows'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: inputs.target_os == 'windows'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5
       with:
         name: spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}
         path: spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz

--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -57,12 +57,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build spiced
-        if: matrix.target.target_os != 'darwin'
         run: |
           make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
 
       - name: make spiced executable
-        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,14 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+      - name: Set up make
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-make
+
+      - name: Set up cc
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-cc
+
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild

--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -66,12 +66,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build spiced
-        if: matrix.target.target_os != 'darwin'
         run: |
           make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
 
       - name: make spiced executable
-        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -42,6 +42,14 @@ jobs:
         if: steps.check_pr.outputs.skip != 'true'
         run: rustup toolchain install stable --profile minimal
 
+      - name: Set up make
+        if: runner.os != 'macOS' && steps.check_pr.outputs.skip != 'true'
+        uses: ./.github/actions/setup-make
+
+      - name: Set up cc
+        if: runner.os != 'macOS' && steps.check_pr.outputs.skip != 'true'
+        uses: ./.github/actions/setup-cc
+
       - name: Build Cargo project
         if: steps.check_pr.outputs.skip != 'true'
         run: cargo build --manifest-path tools/spiceschema/Cargo.toml

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -37,6 +37,10 @@ jobs:
         if: runner.os != 'macOS' && (github.event_name != 'workflow_dispatch' || inputs.run_build)
         uses: ./.github/actions/setup-make
 
+      - name: Set up cc
+        if: runner.os != 'macOS' && (github.event_name != 'workflow_dispatch' || inputs.run_build)
+        uses: ./.github/actions/setup-cc
+
       - name: Build Cargo project
         if: github.event_name != 'workflow_dispatch' || inputs.run_build
         run: cargo build --manifest-path tools/spicepodschema/Cargo.toml

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   build:
-    name: Build Test Binary
+    name: Build Test Binary (macOS)
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -157,7 +157,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   test-ai-udf:
-    name: Test AI UDF
+    name: Test AI UDFs
     needs: build
     runs-on: 'spiceai-macos'
     steps:
@@ -246,7 +246,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   test-hf:
-    name: Test Huggingface Models
+    name: Test Hugging Face Models
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' || github.event_name == 'schedule' }}
     runs-on: 'spiceai-macos'
@@ -422,6 +422,9 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           os: 'linux'
+
+      - name: Set up cc
+        uses: ./.github/actions/setup-cc
 
       - name: Install Nextest
         run: |


### PR DESCRIPTION
This pull request updates several GitHub Actions and workflow files to improve cross-platform compatibility, update dependencies, and clean up conditional logic. The main changes include switching to the correct `cp` command in Windows build scripts, upgrading the `upload-artifact` action to v5, consistently setting up build tools, and simplifying workflow conditionals.

**Build script improvements:**

* Replaced the incorrect `copy` command with the correct `cp` command for copying executables in Windows build scripts in `.github/actions/build-spicepod-validator/action.yml` and `.github/actions/build-testoperator/action.yml`. [[1]](diffhunk://#diff-2d64b8f508dd7a154bba3e1e83714ce6de2085c9f87ed2c890063eb64d2a147eL170-R170) [[2]](diffhunk://#diff-98d5eec7bb1d4ecbdbf68b7ffb402f1a11512d1c4ceaf14c235cd2a0261050ddL169-R169)

**Dependency updates:**

* Upgraded the `actions/upload-artifact` action from v4 to v5 in `.github/actions/build-testoperator/action.yml` and `.github/actions/spiced-cuda-build/action.yaml` for improved reliability and features. [[1]](diffhunk://#diff-98d5eec7bb1d4ecbdbf68b7ffb402f1a11512d1c4ceaf14c235cd2a0261050ddL188-R188) [[2]](diffhunk://#diff-bebb4dfc6ed8f080a079ab3ca2446a54a47c4888f955f1c3d2b6d9616a6abd3bL96-R104)

**Build environment setup:**

* Added steps to set up `make` and `cc` (C compiler) tools in workflows that run on non-macOS runners, specifically in `codeql-analysis.yml`, `generate-openapi.yml`, and `generate_json_schema.yml`. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R44-R51) [[2]](diffhunk://#diff-ba3450a751f3a74e6af2e04486f74790e0a0536c34f0da45ba28b93056cc3fd0R45-R52) [[3]](diffhunk://#diff-39878ff52be1ad87d4bd525cf2f51b7f906da50ef249ce5798fd0556aa56bef9R40-R43)
* Simplified the condition for installing `make` on macOS in `.github/actions/setup-make/action.yml` so it always runs when `inputs.os == 'macos'`.

**Workflow conditional cleanup:**

* Removed redundant conditional checks for target OS in `ai_benchmark_nsql.yml` and `financebench.yml` to streamline the build and executable steps. [[1]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL60-L65) [[2]](diffhunk://#diff-6ef7811d2287503d25068de264b69873c52eb3569c78c52e1c46e27601c3f4a5L69-L74)

**Code style and action metadata:**

* Standardized the use of single quotes in `.github/actions/setup-sccache/action.yml` for consistency.
* Fixed a missing `EOF` in a heredoc in `.github/actions/setup-sccache/action.yml`.