### PR TITLE
Expand Cayenne feature coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14397,10 +14397,12 @@ dependencies = [
 name = "runtime-table-partition"
 version = "1.11.0-unstable"
 dependencies = [
+ "arrow",
  "arrow-schema",
  "async-trait",
  "chrono",
  "criterion 0.5.1",
+ "data_components",
  "datafusion",
  "futures",
  "insta",

--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -325,6 +325,21 @@ pub trait MetadataCatalog: Send + Sync {
     async fn shutdown(&self) -> CatalogResult<()> {
         Ok(())
     }
+
+    /// Drop a table and all its associated metadata (delete files, insert records,
+    /// snapshot sequences, partitions).
+    ///
+    /// This is used for `file_create` mode to clean up existing table metadata
+    /// before recreating the table fresh.
+    ///
+    /// # Arguments
+    ///
+    /// * `table_name` - The name of the table to drop
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(true)` if the table was dropped, `Ok(false)` if the table didn't exist.
+    async fn drop_table(&self, table_name: &str) -> CatalogResult<bool>;
 }
 
 /// Factory trait for creating catalog instances.

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -1005,6 +1005,88 @@ impl MetadataCatalog for CayenneCatalog {
             source: Box::new(e),
         })
     }
+
+    async fn drop_table(&self, table_name: &str) -> CatalogResult<bool> {
+        // First check if the table exists and get its ID
+        let table_id: Option<i64> = self
+            .metastore
+            .query_row_helper(
+                QueryRowParams {
+                    sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
+                    params: vec![MetastoreValue::Text(table_name.to_string())],
+                },
+                |row| row.get_i64(0),
+            )
+            .await
+            .ok();
+
+        let Some(table_id) = table_id else {
+            return Ok(false); // Table doesn't exist
+        };
+
+        // Delete all related metadata in order (respect foreign key constraints)
+        // 1. Delete insert records
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
+                params: vec![MetastoreValue::Integer(table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete insert records.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 2. Delete snapshot sequences
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_snapshot_sequence WHERE table_id = ?1",
+                params: vec![MetastoreValue::Integer(table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete snapshot sequences.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 3. Delete delete files
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_delete_file WHERE table_id = ?1",
+                params: vec![MetastoreValue::Integer(table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete delete files.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 4. Delete partitions
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_partition WHERE table_id = ?1",
+                params: vec![MetastoreValue::Integer(table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete partitions.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 5. Finally delete the table itself
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_table WHERE table_id = ?1",
+                params: vec![MetastoreValue::Integer(table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete table.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        Ok(true)
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime-table-partition/Cargo.toml
+++ b/crates/runtime-table-partition/Cargo.toml
@@ -9,9 +9,11 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+arrow = { workspace = true }
 arrow-schema.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
+data_components = { path = "../data_components" }
 datafusion.workspace = true
 futures.workspace = true
 parking_lot = "0.12"

--- a/crates/runtime-table-partition/src/lib.rs
+++ b/crates/runtime-table-partition/src/lib.rs
@@ -22,7 +22,7 @@ pub mod expression;
 pub mod insert;
 pub mod provider;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Partition {
     pub partition_value: ScalarValue,
     pub table_provider: Arc<dyn TableProvider>,

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -16,8 +16,10 @@ limitations under the License.
 
 use std::{any::Any, collections::HashMap, sync::Arc};
 
+use arrow::array::{Array, UInt64Array};
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use data_components::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use datafusion::{
     catalog::{Session, TableProvider},
     common::{Constraints, DFSchema, Statistics, project_schema},
@@ -29,6 +31,7 @@ use datafusion::{
     physical_expr::OrderingRequirements,
     physical_plan::{
         DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PhysicalExpr, PlanProperties,
+        collect,
         empty::EmptyExec,
         execution_plan::{CardinalityEffect, InvariantLevel},
         filter_pushdown::{
@@ -314,6 +317,95 @@ impl TableProvider for PartitionTableProvider {
         self.insert_strategy
             .execute_insert(input, insert_op, &ctx)
             .await
+    }
+}
+
+/// Implement `DeletionTableProvider` to support retention checks and delete operations
+/// on partitioned tables. Deletion is applied to all partitions.
+#[async_trait]
+impl DeletionTableProvider for PartitionTableProvider {
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // Collect all partitions that need deletion
+        let partitions = self.partitions.read().await;
+        let partition_list: Vec<_> = partitions.values().cloned().collect();
+        drop(partitions);
+
+        // Create a deletion sink that will iterate over all partitions
+        let deletion_sink = Arc::new(PartitionedDeletionSink::new(
+            partition_list,
+            filters.to_vec(),
+            state.task_ctx(),
+        ));
+
+        Ok(Arc::new(DeletionExec::new(deletion_sink, &self.schema)))
+    }
+}
+
+/// A deletion sink that applies deletion filters to all partitions in a partitioned table.
+struct PartitionedDeletionSink {
+    partitions: Vec<Partition>,
+    filters: Vec<Expr>,
+    task_ctx: Arc<TaskContext>,
+}
+
+impl PartitionedDeletionSink {
+    fn new(partitions: Vec<Partition>, filters: Vec<Expr>, task_ctx: Arc<TaskContext>) -> Self {
+        Self {
+            partitions,
+            filters,
+            task_ctx,
+        }
+    }
+}
+
+#[async_trait]
+impl DeletionSink for PartitionedDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let mut total_deleted = 0u64;
+
+        for partition in &self.partitions {
+            // Try to downcast the partition's table provider to DeletionTableProvider
+            // The partition's table provider might be a CayenneTableProvider or similar
+            // that implements DeletionTableProvider
+            let deletion_provider =
+                data_components::delete::get_deletion_provider(Arc::clone(&partition.table_provider));
+
+            if let Some(deletion_provider) = deletion_provider {
+                // Create a simple session state for executing the deletion
+                let session_ctx = datafusion::execution::context::SessionContext::new();
+                let state = session_ctx.state();
+
+                // Execute deletion on this partition
+                let plan = deletion_provider.delete_from(&state, &self.filters).await?;
+
+                // Execute the deletion plan
+                let results = collect(plan, Arc::clone(&self.task_ctx)).await?;
+
+                // Extract the count from results
+                for batch in results {
+                    if let Some(count_col) = batch.column_by_name("count")
+                        && let Some(uint_array) = count_col.as_any().downcast_ref::<UInt64Array>()
+                    {
+                        for i in 0..uint_array.len() {
+                            if !uint_array.is_null(i) {
+                                total_deleted += uint_array.value(i);
+                            }
+                        }
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    partition_value = %partition.partition_value,
+                    "Partition table provider does not support deletion. Skipping."
+                );
+            }
+        }
+
+        Ok(total_deleted)
     }
 }
 

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -371,8 +371,9 @@ impl DeletionSink for PartitionedDeletionSink {
             // Try to downcast the partition's table provider to DeletionTableProvider
             // The partition's table provider might be a CayenneTableProvider or similar
             // that implements DeletionTableProvider
-            let deletion_provider =
-                data_components::delete::get_deletion_provider(Arc::clone(&partition.table_provider));
+            let deletion_provider = data_components::delete::get_deletion_provider(Arc::clone(
+                &partition.table_provider,
+            ));
 
             if let Some(deletion_provider) = deletion_provider {
                 // Create a simple session state for executing the deletion

--- a/crates/runtime-table-partition/tests/partition_table_provider.rs
+++ b/crates/runtime-table-partition/tests/partition_table_provider.rs
@@ -1456,7 +1456,7 @@ async fn test_bucket_partition_inequality_snapshot() -> Result<(), Box<dyn std::
 // Deletion Tests for PartitionTableProvider implementing DeletionTableProvider
 // ============================================================================
 
-/// A MemTable wrapper that implements DeletionTableProvider for testing purposes
+/// A `MemTable` wrapper that implements `DeletionTableProvider` for testing purposes
 #[derive(Debug)]
 struct DeletablePartitionMemTable {
     mem_table: Arc<MemTable>,
@@ -1551,7 +1551,7 @@ impl DeletionTableProvider for DeletablePartitionMemTable {
     }
 }
 
-/// Partition creator that creates DeletablePartitionMemTable instances
+/// Partition creator that creates `DeletablePartitionMemTable` instances
 #[derive(Debug)]
 struct DeletableTestPartitionCreator {
     schema: SchemaRef,
@@ -1595,10 +1595,10 @@ impl PartitionCreator for DeletableTestPartitionCreator {
             mem_table,
             partition_value.clone(),
         ));
-        self.partitions
-            .write()
-            .await
-            .insert(partition_value.to_string(), Arc::clone(&deletable_mem_table));
+        self.partitions.write().await.insert(
+            partition_value.to_string(),
+            Arc::clone(&deletable_mem_table),
+        );
         // Wrap in DeletionTableProviderAdapter so get_deletion_provider can find it
         let adapted_table: Arc<dyn TableProvider> =
             Arc::new(DeletionTableProviderAdapter::new(deletable_mem_table));
@@ -1648,7 +1648,9 @@ async fn test_deletion_table_provider_single_partition() -> Result<(), Box<dyn s
         Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5])),
-            Arc::new(StringArray::from(vec!["us-east", "us-east", "us-east", "us-east", "us-east"])),
+            Arc::new(StringArray::from(vec![
+                "us-east", "us-east", "us-east", "us-east", "us-east",
+            ])),
             Arc::new(Int64Array::from(vec![100, 200, 300, 400, 500])),
         ],
     )?)?;
@@ -1661,7 +1663,9 @@ async fn test_deletion_table_provider_single_partition() -> Result<(), Box<dyn s
 
     // Access PartitionTableProvider directly to call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -1672,15 +1676,25 @@ async fn test_deletion_table_provider_single_partition() -> Result<(), Box<dyn s
 
     // Check the result - should have deleted 10 rows (mocked)
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 10, "Expected 10 deleted rows from single partition");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        10,
+        "Expected 10 deleted rows from single partition"
+    );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dyn std::error::Error>>
+{
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
         Field::new("region", DataType::Utf8, false),
@@ -1723,7 +1737,9 @@ async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dy
 
     // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -1734,9 +1750,18 @@ async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dy
 
     // Check the result - should have deleted 30 rows total (10 per partition * 3 partitions)
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows from 3 partitions");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        30,
+        "Expected 30 deleted rows from 3 partitions"
+    );
 
     Ok(())
 }
@@ -1778,7 +1803,9 @@ async fn test_deletion_table_provider_with_filters() -> Result<(), Box<dyn std::
 
     // Get the table provider and call delete_from with a filter
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -1791,9 +1818,18 @@ async fn test_deletion_table_provider_with_filters() -> Result<(), Box<dyn std::
 
     // The mock still deletes 10 per partition, so expect 20 total
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 20, "Expected 20 deleted rows from 2 partitions");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        20,
+        "Expected 20 deleted rows from 2 partitions"
+    );
 
     Ok(())
 }
@@ -1824,7 +1860,9 @@ async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn s
 
     // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -1835,9 +1873,18 @@ async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn s
 
     // Should delete 0 rows since there are no partitions
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 0, "Expected 0 deleted rows from empty partitions");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        0,
+        "Expected 0 deleted rows from empty partitions"
+    );
 
     Ok(())
 }
@@ -1847,7 +1894,7 @@ async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn s
 // ============================================================================
 
 /// Test that a partition provider without deletion support logs a warning and continues
-/// (non-deletable partition creator that returns regular MemTable without DeletionTableProviderAdapter)
+/// (non-deletable partition creator that returns regular `MemTable` without `DeletionTableProviderAdapter`)
 #[derive(Debug)]
 struct NonDeletablePartitionCreator {
     schema: SchemaRef,
@@ -1934,7 +1981,9 @@ async fn test_deletion_with_non_deletable_partitions() -> Result<(), Box<dyn std
 
     // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -1945,9 +1994,18 @@ async fn test_deletion_with_non_deletable_partitions() -> Result<(), Box<dyn std
 
     // Should return 0 since the partition doesn't support deletion
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 0, "Expected 0 deleted rows from non-deletable partition");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        0,
+        "Expected 0 deleted rows from non-deletable partition"
+    );
 
     Ok(())
 }
@@ -1976,13 +2034,15 @@ async fn test_deletion_many_partitions() -> Result<(), Box<dyn std::error::Error
     ctx.register_table("test_table", Arc::new(table_provider))?;
 
     // Create 20 partitions
-    let num_partitions = 20;
+    let num_partitions: usize = 20;
     for i in 0..num_partitions {
         let partition_key = format!("partition_{i}");
+        #[expect(clippy::cast_possible_wrap)]
+        let i_val = i as i64;
         let df = ctx.read_batch(RecordBatch::try_new(
             Arc::clone(&schema),
             vec![
-                Arc::new(Int64Array::from(vec![i as i64])),
+                Arc::new(Int64Array::from(vec![i_val])),
                 Arc::new(StringArray::from(vec![partition_key.as_str()])),
             ],
         )?)?;
@@ -1992,11 +2052,17 @@ async fn test_deletion_many_partitions() -> Result<(), Box<dyn std::error::Error
 
     // Verify we have 20 partitions
     let partitions = creator.get_partitions().await;
-    assert_eq!(partitions.len(), num_partitions, "Expected {num_partitions} partitions");
+    assert_eq!(
+        partitions.len(),
+        num_partitions,
+        "Expected {num_partitions} partitions"
+    );
 
     // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -2007,9 +2073,18 @@ async fn test_deletion_many_partitions() -> Result<(), Box<dyn std::error::Error
 
     // Should have deleted 10 rows per partition * 20 partitions = 200 total
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 200, "Expected 200 deleted rows from 20 partitions");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        200,
+        "Expected 200 deleted rows from 20 partitions"
+    );
 
     Ok(())
 }
@@ -2054,15 +2129,18 @@ async fn test_deletion_complex_filters() -> Result<(), Box<dyn std::error::Error
 
     // Get the table provider and call delete_from with complex filters
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
     // Complex filter: (value > 100 AND status = 'active') OR id = 1
     let filters = vec![
-        col("value").gt(lit(100i64))
+        col("value")
+            .gt(lit(100i64))
             .and(col("status").eq(lit("active")))
-            .or(col("id").eq(lit(1i64)))
+            .or(col("id").eq(lit(1i64))),
     ];
     let delete_plan = partition_provider.delete_from(&state, &filters).await?;
 
@@ -2071,8 +2149,13 @@ async fn test_deletion_complex_filters() -> Result<(), Box<dyn std::error::Error
 
     // Mock deletes 10 per partition, we have 3 partitions = 30
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
     assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows");
 
     Ok(())
@@ -2106,7 +2189,11 @@ async fn test_deletion_with_null_partition_value() -> Result<(), Box<dyn std::er
         Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec![Some("us-east"), None, Some("eu-west")])),
+            Arc::new(StringArray::from(vec![
+                Some("us-east"),
+                None,
+                Some("eu-west"),
+            ])),
         ],
     )?)?;
     df.write_table("test_table", DataFrameWriteOptions::new())
@@ -2118,7 +2205,9 @@ async fn test_deletion_with_null_partition_value() -> Result<(), Box<dyn std::er
 
     // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
@@ -2129,9 +2218,18 @@ async fn test_deletion_with_null_partition_value() -> Result<(), Box<dyn std::er
 
     // Should delete from all 3 partitions including the null one
     assert_eq!(result.len(), 1, "Expected 1 result batch");
-    let count_col = result[0].column_by_name("count").expect("Expected count column");
-    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
-    assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows from 3 partitions");
+    let count_col = result[0]
+        .column_by_name("count")
+        .expect("Expected count column");
+    let count_array = count_col
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("Expected UInt64Array");
+    assert_eq!(
+        count_array.value(0),
+        30,
+        "Expected 30 deleted rows from 3 partitions"
+    );
 
     Ok(())
 }
@@ -2171,7 +2269,9 @@ async fn test_deletion_repeated_calls() -> Result<(), Box<dyn std::error::Error>
         .await?;
 
     let table = ctx.table_provider("test_table").await?;
-    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+    let partition_provider = table
+        .as_any()
+        .downcast_ref::<PartitionTableProvider>()
         .expect("Expected PartitionTableProvider");
     let state = ctx.state();
 
@@ -2179,12 +2279,21 @@ async fn test_deletion_repeated_calls() -> Result<(), Box<dyn std::error::Error>
     for i in 0..3 {
         let delete_plan = partition_provider.delete_from(&state, &[]).await?;
         let result = collect(delete_plan, ctx.task_ctx()).await?;
-        
+
         assert_eq!(result.len(), 1, "Iteration {i}: Expected 1 result batch");
-        let count_col = result[0].column_by_name("count").expect("Expected count column");
-        let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+        let count_col = result[0]
+            .column_by_name("count")
+            .expect("Expected count column");
+        let count_array = count_col
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("Expected UInt64Array");
         // Mock always returns 10, so each call should return 10
-        assert_eq!(count_array.value(0), 10, "Iteration {i}: Expected 10 deleted rows");
+        assert_eq!(
+            count_array.value(0),
+            10,
+            "Iteration {i}: Expected 10 deleted rows"
+        );
     }
 
     Ok(())

--- a/crates/runtime-table-partition/tests/partition_table_provider.rs
+++ b/crates/runtime-table-partition/tests/partition_table_provider.rs
@@ -17,8 +17,11 @@ limitations under the License.
 use arrow_schema::TimeUnit;
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone as _, Utc};
+use data_components::delete::{
+    DeletionExec, DeletionSink, DeletionTableProvider, DeletionTableProviderAdapter,
+};
 use datafusion::arrow::array::{
-    ArrayRef, Int32Array, Int64Array, StringArray, TimestampNanosecondArray,
+    Array, ArrayRef, Int32Array, Int64Array, StringArray, TimestampNanosecondArray, UInt64Array,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -31,7 +34,7 @@ use datafusion::execution::context::{ExecutionProps, SessionContext};
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDF, TableProviderFilterPushDown};
 use datafusion::physical_expr::create_physical_expr;
-use datafusion::physical_plan::{DisplayAs, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{DisplayAs, ExecutionPlan, PlanProperties, collect};
 use datafusion::scalar::ScalarValue;
 use datafusion::{arrow, prelude::*};
 use runtime_datafusion_udfs::{bucket, truncate};
@@ -1445,6 +1448,744 @@ async fn test_bucket_partition_inequality_snapshot() -> Result<(), Box<dyn std::
     lines[1..].sort_unstable();
     explain_plan = lines.join("\n") + "\n";
     insta::assert_snapshot!("bucket_inequality_unbounded", explain_plan);
+
+    Ok(())
+}
+
+// ============================================================================
+// Deletion Tests for PartitionTableProvider implementing DeletionTableProvider
+// ============================================================================
+
+/// A MemTable wrapper that implements DeletionTableProvider for testing purposes
+#[derive(Debug)]
+struct DeletablePartitionMemTable {
+    mem_table: Arc<MemTable>,
+    #[expect(dead_code)]
+    partition_value: ScalarValue,
+    deleted_count: Arc<RwLock<u64>>,
+}
+
+impl DeletablePartitionMemTable {
+    fn new(mem_table: Arc<MemTable>, partition_value: ScalarValue) -> Self {
+        Self {
+            mem_table,
+            partition_value,
+            deleted_count: Arc::new(RwLock::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for DeletablePartitionMemTable {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.mem_table.schema()
+    }
+
+    fn table_type(&self) -> datafusion::datasource::TableType {
+        self.mem_table.table_type()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        self.mem_table.scan(state, projection, filters, limit).await
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: datafusion::logical_expr::dml::InsertOp,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        self.mem_table.insert_into(state, input, insert_op).await
+    }
+}
+
+/// Mock deletion sink that simulates deletion and tracks deleted count
+struct MockDeletionSink {
+    deleted_count: Arc<RwLock<u64>>,
+    count_to_delete: u64,
+}
+
+#[async_trait]
+impl DeletionSink for MockDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let mut guard = self.deleted_count.write().await;
+        *guard += self.count_to_delete;
+        Ok(self.count_to_delete)
+    }
+}
+
+#[async_trait]
+impl DeletionTableProvider for DeletablePartitionMemTable {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        _filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // Simulate deleting 10 rows per partition
+        let deletion_sink = Arc::new(MockDeletionSink {
+            deleted_count: Arc::clone(&self.deleted_count),
+            count_to_delete: 10,
+        });
+
+        Ok(Arc::new(DeletionExec::new(
+            deletion_sink,
+            &self.mem_table.schema(),
+        )))
+    }
+}
+
+/// Partition creator that creates DeletablePartitionMemTable instances
+#[derive(Debug)]
+struct DeletableTestPartitionCreator {
+    schema: SchemaRef,
+    partitions: Arc<RwLock<HashMap<String, Arc<DeletablePartitionMemTable>>>>,
+}
+
+impl DeletableTestPartitionCreator {
+    fn new(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            partitions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    async fn get_partitions(&self) -> HashMap<String, Arc<DeletablePartitionMemTable>> {
+        self.partitions.read().await.clone()
+    }
+}
+
+#[async_trait]
+impl PartitionCreator for DeletableTestPartitionCreator {
+    async fn create_partition(
+        &self,
+        partition_value: ScalarValue,
+    ) -> Result<Partition, creator::Error> {
+        let empty_columns: Vec<ArrayRef> = self
+            .schema
+            .fields()
+            .iter()
+            .map(|f| arrow::array::new_empty_array(f.data_type()))
+            .collect();
+
+        let empty_batch = RecordBatch::try_new(Arc::clone(&self.schema), empty_columns)
+            .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+
+        let mem_table = Arc::new(
+            MemTable::try_new(Arc::clone(&self.schema), vec![vec![empty_batch]])
+                .map_err(|e| creator::Error::CreatePartition { source: e.into() })?,
+        );
+        let deletable_mem_table = Arc::new(DeletablePartitionMemTable::new(
+            mem_table,
+            partition_value.clone(),
+        ));
+        self.partitions
+            .write()
+            .await
+            .insert(partition_value.to_string(), Arc::clone(&deletable_mem_table));
+        // Wrap in DeletionTableProviderAdapter so get_deletion_provider can find it
+        let adapted_table: Arc<dyn TableProvider> =
+            Arc::new(DeletionTableProviderAdapter::new(deletable_mem_table));
+        Ok(Partition {
+            partition_value,
+            table_provider: adapted_table,
+        })
+    }
+
+    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
+        Ok(vec![])
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+}
+
+#[tokio::test]
+async fn test_deletion_table_provider_single_partition() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data into a single partition
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec!["us-east", "us-east", "us-east", "us-east", "us-east"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300, 400, 500])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    // Verify we have 1 partition
+    let partitions = creator.get_partitions().await;
+    assert_eq!(partitions.len(), 1, "Expected 1 partition");
+
+    // Access PartitionTableProvider directly to call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Check the result - should have deleted 10 rows (mocked)
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 10, "Expected 10 deleted rows from single partition");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data into multiple partitions
+    let regions = vec!["us-east", "us-west", "eu-west"];
+    for region in &regions {
+        let df = ctx.read_batch(RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![*region, *region, *region])),
+                Arc::new(Int64Array::from(vec![100, 200, 300])),
+            ],
+        )?)?;
+        df.write_table("test_table", DataFrameWriteOptions::new())
+            .await?;
+    }
+
+    // Verify we have 3 partitions
+    let partitions = creator.get_partitions().await;
+    assert_eq!(partitions.len(), 3, "Expected 3 partitions");
+
+    // Get the table provider and call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Check the result - should have deleted 30 rows total (10 per partition * 3 partitions)
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows from 3 partitions");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_deletion_table_provider_with_filters() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data into partitions
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["us-east", "us-west"])),
+            Arc::new(Int64Array::from(vec![100, 200])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    // Get the table provider and call delete_from with a filter
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    // Filter: value > 100 (this filter is passed to delete_from but currently mock doesn't use it)
+    let filters = vec![col("value").gt(lit(100i64))];
+    let delete_plan = partition_provider.delete_from(&state, &filters).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // The mock still deletes 10 per partition, so expect 20 total
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 20, "Expected 20 deleted rows from 2 partitions");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Don't insert any data - partitions map should be empty
+
+    // Get the table provider and call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Should delete 0 rows since there are no partitions
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 0, "Expected 0 deleted rows from empty partitions");
+
+    Ok(())
+}
+
+// ============================================================================
+// Additional Edge Case Tests for PartitionTableProvider
+// ============================================================================
+
+/// Test that a partition provider without deletion support logs a warning and continues
+/// (non-deletable partition creator that returns regular MemTable without DeletionTableProviderAdapter)
+#[derive(Debug)]
+struct NonDeletablePartitionCreator {
+    schema: SchemaRef,
+}
+
+impl NonDeletablePartitionCreator {
+    fn new(schema: SchemaRef) -> Self {
+        Self { schema }
+    }
+}
+
+#[async_trait]
+impl PartitionCreator for NonDeletablePartitionCreator {
+    async fn create_partition(
+        &self,
+        partition_value: ScalarValue,
+    ) -> Result<Partition, creator::Error> {
+        let empty_columns: Vec<ArrayRef> = self
+            .schema
+            .fields()
+            .iter()
+            .map(|f| arrow::array::new_empty_array(f.data_type()))
+            .collect();
+
+        let empty_batch = RecordBatch::try_new(Arc::clone(&self.schema), empty_columns)
+            .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+
+        let mem_table = Arc::new(
+            MemTable::try_new(Arc::clone(&self.schema), vec![vec![empty_batch]])
+                .map_err(|e| creator::Error::CreatePartition { source: e.into() })?,
+        );
+        // Return MemTable directly without wrapping - doesn't support deletion
+        Ok(Partition {
+            partition_value,
+            table_provider: mem_table,
+        })
+    }
+
+    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
+        Ok(vec![])
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+}
+
+/// Test deletion with partitions that don't support deletion (should return 0 and log warning)
+#[tokio::test]
+async fn test_deletion_with_non_deletable_partitions() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+    ]));
+
+    let creator = Arc::new(NonDeletablePartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert some data to create a partition
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["us-east", "us-east", "us-east"])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    // Get the table provider and call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Should return 0 since the partition doesn't support deletion
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 0, "Expected 0 deleted rows from non-deletable partition");
+
+    Ok(())
+}
+
+/// Test deletion with many partitions (stress test)
+#[tokio::test]
+async fn test_deletion_many_partitions() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("partition_key", DataType::Utf8, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "partition_key".to_string(),
+        expression: col("partition_key"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Create 20 partitions
+    let num_partitions = 20;
+    for i in 0..num_partitions {
+        let partition_key = format!("partition_{i}");
+        let df = ctx.read_batch(RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![i as i64])),
+                Arc::new(StringArray::from(vec![partition_key.as_str()])),
+            ],
+        )?)?;
+        df.write_table("test_table", DataFrameWriteOptions::new())
+            .await?;
+    }
+
+    // Verify we have 20 partitions
+    let partitions = creator.get_partitions().await;
+    assert_eq!(partitions.len(), num_partitions, "Expected {num_partitions} partitions");
+
+    // Get the table provider and call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Should have deleted 10 rows per partition * 20 partitions = 200 total
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 200, "Expected 200 deleted rows from 20 partitions");
+
+    Ok(())
+}
+
+/// Test deletion with complex filter expressions
+#[tokio::test]
+async fn test_deletion_complex_filters() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new("status", DataType::Utf8, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["us-east", "eu-west", "asia"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(StringArray::from(vec!["active", "inactive", "active"])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    // Get the table provider and call delete_from with complex filters
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    // Complex filter: (value > 100 AND status = 'active') OR id = 1
+    let filters = vec![
+        col("value").gt(lit(100i64))
+            .and(col("status").eq(lit("active")))
+            .or(col("id").eq(lit(1i64)))
+    ];
+    let delete_plan = partition_provider.delete_from(&state, &filters).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Mock deletes 10 per partition, we have 3 partitions = 30
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows");
+
+    Ok(())
+}
+
+/// Test deletion with NULL partition values
+#[tokio::test]
+async fn test_deletion_with_null_partition_value() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, true), // nullable
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data with some NULL region values
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![Some("us-east"), None, Some("eu-west")])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    // Verify we have 3 partitions (including null partition)
+    let partitions = creator.get_partitions().await;
+    assert_eq!(partitions.len(), 3, "Expected 3 partitions including null");
+
+    // Get the table provider and call delete_from
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+
+    let state = ctx.state();
+    let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+
+    // Execute the deletion plan
+    let result = collect(delete_plan, ctx.task_ctx()).await?;
+
+    // Should delete from all 3 partitions including the null one
+    assert_eq!(result.len(), 1, "Expected 1 result batch");
+    let count_col = result[0].column_by_name("count").expect("Expected count column");
+    let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+    assert_eq!(count_array.value(0), 30, "Expected 30 deleted rows from 3 partitions");
+
+    Ok(())
+}
+
+/// Test repeated deletion calls (idempotency)
+#[tokio::test]
+async fn test_deletion_repeated_calls() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("region", DataType::Utf8, false),
+    ]));
+
+    let creator = Arc::new(DeletableTestPartitionCreator::new(Arc::clone(&schema)));
+    let partition_by = vec![PartitionedBy {
+        name: "region".to_string(),
+        expression: col("region"),
+    }];
+    let table_provider = PartitionTableProvider::new(
+        Arc::clone(&creator) as Arc<dyn PartitionCreator>,
+        partition_by,
+        Arc::clone(&schema),
+    )
+    .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("test_table", Arc::new(table_provider))?;
+
+    // Insert data
+    let df = ctx.read_batch(RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1])),
+            Arc::new(StringArray::from(vec!["us-east"])),
+        ],
+    )?)?;
+    df.write_table("test_table", DataFrameWriteOptions::new())
+        .await?;
+
+    let table = ctx.table_provider("test_table").await?;
+    let partition_provider = table.as_any().downcast_ref::<PartitionTableProvider>()
+        .expect("Expected PartitionTableProvider");
+    let state = ctx.state();
+
+    // Call delete_from multiple times
+    for i in 0..3 {
+        let delete_plan = partition_provider.delete_from(&state, &[]).await?;
+        let result = collect(delete_plan, ctx.task_ctx()).await?;
+        
+        assert_eq!(result.len(), 1, "Iteration {i}: Expected 1 result batch");
+        let count_col = result[0].column_by_name("count").expect("Expected count column");
+        let count_array = count_col.as_any().downcast_ref::<UInt64Array>().expect("Expected UInt64Array");
+        // Mock always returns 10, so each call should return 10
+        assert_eq!(count_array.value(0), 10, "Iteration {i}: Expected 10 deleted rows");
+    }
 
     Ok(())
 }

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -408,7 +408,7 @@ impl CayenneAccelerator {
     /// 3. `{spice_data_base_path()}/metadata` - Default location
     ///
     /// Note: S3 paths are excluded because `SQLite` (used for metadata catalog) cannot run on object storage.
-    fn resolve_metadata_dir(acceleration: Option<&Acceleration>) -> String {
+    pub(crate) fn resolve_metadata_dir(acceleration: Option<&Acceleration>) -> String {
         let Some(accel) = acceleration else {
             return format!("{}/metadata", spice_data_base_path());
         };
@@ -1664,21 +1664,14 @@ impl DataAccelerator for CayenneAccelerator {
         // (the bucket/prefix is assumed to exist or will be created by the object store)
         if Self::is_s3_express_data_path(source) {
             // For S3 Express, we need to check if the metadata database exists locally
-            let metadata_dir = if let Some(acceleration) = source.acceleration()
-                && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
-            {
-                custom_dir.clone()
-            } else {
-                format!("{}/metadata", crate::spice_data_base_path())
-            };
+            let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
             let metadata_db_path = format!("{metadata_dir}/cayenne.db");
             return PathBuf::from(metadata_db_path).exists();
         }
 
         // For local storage, check if both the data directory and metadata database exist
-        let dir_path = match self.file_path(source) {
-            Ok(path) => path,
-            Err(_) => return false,
+        let Ok(dir_path) = self.file_path(source) else {
+            return false;
         };
 
         // Check if the data directory exists
@@ -1687,13 +1680,7 @@ impl DataAccelerator for CayenneAccelerator {
         }
 
         // Also check if the metadata database exists (indicates proper initialization)
-        let metadata_dir = if let Some(acceleration) = source.acceleration()
-            && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
-        {
-            custom_dir.clone()
-        } else {
-            format!("{}/metadata", crate::spice_data_base_path())
-        };
+        let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
         let metadata_db_path = format!("{metadata_dir}/cayenne.db");
         PathBuf::from(metadata_db_path).exists()
     }
@@ -1827,18 +1814,13 @@ impl DataAccelerator for CayenneAccelerator {
                     "Cayenne acceleration mode is 'file_create', removing existing directory: {}",
                     dir_path
                 );
-                std::fs::remove_dir_all(&path_buf).map_err(|err| {
+                tokio::fs::remove_dir_all(&path_buf).await.map_err(|err| {
                     Error::AccelerationInitializationFailed { source: err.into() }
                 })?;
             }
 
             // Also drop the table from metadata catalog to clean up stale metadata
-            let metadata_dir =
-                if let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir") {
-                    custom_dir.clone()
-                } else {
-                    format!("{}/metadata", crate::spice_data_base_path())
-                };
+            let metadata_dir = Self::resolve_metadata_dir(Some(acceleration));
 
             let metastore_type = acceleration
                 .params
@@ -1874,7 +1856,8 @@ impl DataAccelerator for CayenneAccelerator {
         // Create the vortex data directory if it doesn't exist
         let path_buf = PathBuf::from(&dir_path);
         if !path_buf.exists() {
-            std::fs::create_dir_all(&path_buf)
+            tokio::fs::create_dir_all(&path_buf)
+                .await
                 .map_err(|err| Error::AccelerationCreationFailed { source: err.into() })?;
         }
 

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -14,10 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::any::Any;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use arrow::datatypes::DataType;
 use arrow_schema::Schema;
 use async_trait::async_trait;
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_bucket_name};
+use data_components::poly::PolyTableProvider;
 use datafusion::common::DFSchema;
 use datafusion::common::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
@@ -39,19 +45,19 @@ use runtime_table_partition::expression::PartitionedBy;
 use runtime_table_partition::provider::PartitionTableProvider;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
-use std::any::Any;
-use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::sync::OnceCell;
 use url::Url;
 
-use super::{AccelerationSource, DataAccelerator};
+use super::{AccelerationSource, DataAccelerator, upsert_dedup};
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode, RefreshMode};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
 use crate::spice_data_base_path;
 use runtime_acceleration::snapshot::SnapshotBehavior;
+
+/// Metadata key to identify the accelerator type in the schema metadata.
+const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -1418,7 +1424,7 @@ impl CayenneAccelerator {
         schema: Arc<Schema>,
         source: &dyn AccelerationSource,
         retention_filters: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>> {
+    ) -> Result<Arc<cayenne::CayenneTableProvider>> {
         use cayenne::{CayenneTableProviderBuilder, metadata::CreateTableOptions};
 
         tracing::debug!("create_cayenne_table_provider: starting for table {table_name}");
@@ -1632,15 +1638,39 @@ impl DataAccelerator for CayenneAccelerator {
         // S3 Express One Zone paths are always considered initialized
         // (the bucket/prefix is assumed to exist or will be created by the object store)
         if Self::is_s3_express_data_path(source) {
-            return true;
+            // For S3 Express, we need to check if the metadata database exists locally
+            let metadata_dir = if let Some(acceleration) = source.acceleration()
+                && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
+            {
+                custom_dir.clone()
+            } else {
+                format!("{}/metadata", crate::spice_data_base_path())
+            };
+            let metadata_db_path = format!("{metadata_dir}/cayenne.db");
+            return PathBuf::from(metadata_db_path).exists();
         }
 
-        // otherwise, we're initialized if the directory exists
-        if let Ok(dir_path) = self.file_path(source) {
-            PathBuf::from(dir_path).exists()
-        } else {
-            false
+        // For local storage, check if both the data directory and metadata database exist
+        let dir_path = match self.file_path(source) {
+            Ok(path) => path,
+            Err(_) => return false,
+        };
+
+        // Check if the data directory exists
+        if !PathBuf::from(&dir_path).exists() {
+            return false;
         }
+
+        // Also check if the metadata database exists (indicates proper initialization)
+        let metadata_dir = if let Some(acceleration) = source.acceleration()
+            && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
+        {
+            custom_dir.clone()
+        } else {
+            format!("{}/metadata", crate::spice_data_base_path())
+        };
+        let metadata_db_path = format!("{metadata_dir}/cayenne.db");
+        PathBuf::from(metadata_db_path).exists()
     }
 
     /// Initializes a `Cayenne` database for the dataset
@@ -1762,7 +1792,7 @@ impl DataAccelerator for CayenneAccelerator {
             return Ok(());
         }
 
-        // If mode is FileCreate, delete the existing directory to start fresh
+        // If mode is FileCreate, delete the existing directory and metadata to start fresh
         if let Some(acceleration) = source.acceleration()
             && acceleration.mode == Mode::FileCreate
         {
@@ -1775,6 +1805,44 @@ impl DataAccelerator for CayenneAccelerator {
                 std::fs::remove_dir_all(&path_buf).map_err(|err| {
                     Error::AccelerationInitializationFailed { source: err.into() }
                 })?;
+            }
+
+            // Also drop the table from metadata catalog to clean up stale metadata
+            let metadata_dir =
+                if let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir") {
+                    custom_dir.clone()
+                } else {
+                    format!("{}/metadata", crate::spice_data_base_path())
+                };
+
+            let metastore_type = acceleration
+                .params
+                .get("cayenne_metastore")
+                .map_or("sqlite", String::as_str);
+
+            // Get or create catalog and drop the table if it exists
+            if let Ok(catalog) = self
+                .get_or_create_catalog(&metadata_dir, metastore_type)
+                .await
+            {
+                let table_name = source.name().to_string();
+                match catalog.drop_table(&table_name).await {
+                    Ok(true) => {
+                        tracing::info!(
+                            "Dropped existing Cayenne table metadata for '{}' (file_create mode)",
+                            table_name
+                        );
+                    }
+                    Ok(false) => {
+                        // Table didn't exist in metadata, nothing to drop
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to drop Cayenne table metadata for '{}': {e}. Continuing anyway.",
+                            table_name
+                        );
+                    }
+                }
             }
         }
 
@@ -1909,8 +1977,25 @@ impl DataAccelerator for CayenneAccelerator {
 
         // If partitioning is requested, wrap with PartitionTableProvider
         if partition_by.is_empty() {
-            // Non-partitioned table - return base provider directly
-            Ok(cayenne_table)
+            // Non-partitioned table - wrap in PolyTableProvider for proper deletion/retention support
+            // Wrap with upsert deduplication if needed based on on_conflict settings
+            let (write_provider, delete_provider) =
+                upsert_dedup::wrap_with_upsert_dedup_if_needed(cayenne_table, &cmd.options);
+
+            let mut schema_metadata = HashMap::new();
+            schema_metadata.insert(
+                SPICE_ACCELERATOR_METADATA_KEY.to_string(),
+                "cayenne".to_string(),
+            );
+
+            let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
+                Arc::clone(&write_provider),
+                delete_provider,
+                write_provider,
+                schema_metadata,
+            ));
+
+            Ok(table_provider as Arc<dyn TableProvider>)
         } else {
             let partition_by_last = partition_by.last().cloned().ok_or_else(|| {
                 Box::new(Error::PartitionByRequired) as Box<dyn std::error::Error + Send + Sync>
@@ -2027,13 +2112,30 @@ impl DataAccelerator for CayenneAccelerator {
             ));
 
             // Wrap the base table provider with partitioning logic
-            let table_provider = Arc::new(
+            let partition_provider = Arc::new(
                 PartitionTableProvider::new(creator, partition_by, arrow_schema)
                     .await
                     .map_err(|e| Error::AccelerationCreationFailed {
                         source: Box::new(e),
                     })?,
             );
+
+            // Wrap with upsert deduplication if needed based on on_conflict settings
+            let (write_provider, delete_provider) =
+                upsert_dedup::wrap_with_upsert_dedup_if_needed(partition_provider, &cmd.options);
+
+            let mut schema_metadata = HashMap::new();
+            schema_metadata.insert(
+                SPICE_ACCELERATOR_METADATA_KEY.to_string(),
+                "cayenne".to_string(),
+            );
+
+            let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
+                Arc::clone(&write_provider),
+                delete_provider,
+                write_provider,
+                schema_metadata,
+            ));
 
             Ok(table_provider as Arc<dyn TableProvider>)
         }

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -16,7 +16,9 @@ limitations under the License.
 
 //! Durable storage for Spice operational data related to acceleration.
 
-use std::{path::Path, sync::Arc};
+use std::path::Path;
+#[cfg(any(feature = "duckdb", feature = "turso"))]
+use std::sync::Arc;
 
 use super::AccelerationSource;
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -29,6 +31,10 @@ use {
     datafusion_table_providers::util::secrets::to_secret_map,
 };
 
+#[cfg(all(not(windows), feature = "sqlite"))]
+use super::DataAccelerator;
+#[cfg(all(not(windows), feature = "sqlite"))]
+use super::cayenne::{CayenneAccelerator, Error as CayenneError};
 #[cfg(feature = "turso")]
 use super::turso::{Error as TursoError, TursoAccelerator};
 #[cfg(feature = "duckdb")]
@@ -65,6 +71,8 @@ enum AccelerationConnection {
     SQLite(SqliteConnectionPool),
     #[cfg(feature = "turso")]
     Turso(Arc<super::turso::TursoConnectionPool>),
+    #[cfg(all(not(windows), feature = "sqlite"))]
+    Cayenne(SqliteConnectionPool),
 }
 
 #[derive(Debug, Snafu)]
@@ -134,6 +142,20 @@ pub enum Error {
     #[cfg(not(feature = "turso"))]
     #[snafu(display("Spice wasn't built with Turso support enabled"))]
     TursoFeatureNotEnabled,
+
+    #[cfg(all(not(windows), feature = "sqlite"))]
+    #[snafu(display("Failed to resolve Cayenne file path: {source}"))]
+    CayenneFilePath { source: CayenneError },
+
+    #[cfg(all(not(windows), feature = "sqlite"))]
+    #[snafu(display("Cayenne metadata directory does not exist at {path}"))]
+    CayenneMetadataMissing { path: String },
+
+    #[cfg(all(not(windows), feature = "sqlite"))]
+    #[snafu(display("Unable to create Cayenne connection pool: {source}"))]
+    CayennePool {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 
     #[snafu(display("{engine} acceleration not supported"))]
     UnsupportedEngine { engine: Engine },
@@ -320,7 +342,79 @@ async fn acceleration_connection(
         }
         #[cfg(not(feature = "turso"))]
         Engine::Turso => TursoFeatureNotEnabledSnafu.fail(),
-        Engine::Arrow | Engine::Cayenne => UnsupportedEngineSnafu {
+        #[cfg(all(not(windows), feature = "sqlite"))]
+        Engine::Cayenne => {
+            use datafusion_table_providers::sqlite::SqliteTableProviderFactory;
+            use std::sync::Arc;
+
+            let accelerator = get_registered_accelerator(source, acceleration_settings.engine)
+                .await
+                .context(AcceleratorEngineUnavailableSnafu {
+                    engine: Engine::Cayenne,
+                })?;
+            let cayenne_accelerator = accelerator
+                .as_any()
+                .downcast_ref::<CayenneAccelerator>()
+                .context(DowncastFailedSnafu {
+                    target: "CayenneAccelerator",
+                })?;
+
+            // Get the cayenne metadata directory path (used for file existence check validation)
+            let _data_dir =
+                cayenne_accelerator
+                    .file_path(source)
+                    .map_err(|e| Error::CayenneFilePath {
+                        source: super::cayenne::Error::InvalidConfiguration {
+                            detail: std::sync::Arc::from(format!("{e}")),
+                        },
+                    })?;
+
+            // Derive metadata directory from data directory
+            let metadata_dir = if let Some(acceleration) = source.acceleration()
+                && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
+            {
+                custom_dir.clone()
+            } else {
+                format!("{}/metadata", crate::spice_data_base_path())
+            };
+
+            let metadata_db_path = format!("{metadata_dir}/cayenne.db");
+
+            if open_option == OpenOption::OpenExisting && !Path::new(&metadata_db_path).exists() {
+                return CayenneMetadataMissingSnafu {
+                    path: metadata_db_path,
+                }
+                .fail();
+            }
+
+            // Ensure metadata directory exists
+            if let Some(parent) = Path::new(&metadata_db_path).parent() {
+                std::fs::create_dir_all(parent).map_err(|e| Error::CayennePool {
+                    source: Box::new(e),
+                })?;
+            }
+
+            // Create SQLite connection pool for cayenne metadata using the factory
+            let sqlite_factory = SqliteTableProviderFactory::new();
+            let pool = sqlite_factory
+                .get_or_init_instance(
+                    Arc::from(metadata_db_path.as_str()),
+                    datafusion_table_providers::sql::db_connection_pool::Mode::File,
+                    std::time::Duration::from_millis(5000),
+                )
+                .await
+                .map_err(|e| Error::CayennePool {
+                    source: Box::new(e),
+                })?;
+
+            Ok(AccelerationConnection::Cayenne(pool))
+        }
+        #[cfg(any(windows, not(feature = "sqlite")))]
+        Engine::Cayenne => UnsupportedEngineSnafu {
+            engine: Engine::Cayenne,
+        }
+        .fail(),
+        Engine::Arrow => UnsupportedEngineSnafu {
             engine: acceleration_settings.engine,
         }
         .fail(),

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -359,24 +359,17 @@ async fn acceleration_connection(
                     target: "CayenneAccelerator",
                 })?;
 
-            // Get the cayenne metadata directory path (used for file existence check validation)
-            let _data_dir =
-                cayenne_accelerator
-                    .file_path(source)
-                    .map_err(|e| Error::CayenneFilePath {
-                        source: super::cayenne::Error::InvalidConfiguration {
-                            detail: std::sync::Arc::from(format!("{e}")),
-                        },
-                    })?;
+            // Validate that we can resolve the file path (used for file existence check validation)
+            let _ = cayenne_accelerator
+                .file_path(source)
+                .map_err(|e| Error::CayenneFilePath {
+                    source: super::cayenne::Error::InvalidConfiguration {
+                        detail: std::sync::Arc::from(format!("{e}")),
+                    },
+                })?;
 
-            // Derive metadata directory from data directory
-            let metadata_dir = if let Some(acceleration) = source.acceleration()
-                && let Some(custom_dir) = acceleration.params.get("cayenne_metadata_dir")
-            {
-                custom_dir.clone()
-            } else {
-                format!("{}/metadata", crate::spice_data_base_path())
-            };
+            // Derive metadata directory using shared resolution logic
+            let metadata_dir = CayenneAccelerator::resolve_metadata_dir(source.acceleration());
 
             let metadata_db_path = format!("{metadata_dir}/cayenne.db");
 
@@ -389,9 +382,11 @@ async fn acceleration_connection(
 
             // Ensure metadata directory exists
             if let Some(parent) = Path::new(&metadata_db_path).parent() {
-                std::fs::create_dir_all(parent).map_err(|e| Error::CayennePool {
-                    source: Box::new(e),
-                })?;
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| Error::CayennePool {
+                        source: Box::new(e),
+                    })?;
             }
 
             // Create SQLite connection pool for cayenne metadata using the factory

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -112,6 +112,8 @@ impl DatasetCheckpoint {
             AccelerationConnection::SQLite(conn) => Self::init_sqlite(conn).await?,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => Self::init_turso(pool).await?,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => Self::init_sqlite(conn).await?,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -131,6 +133,8 @@ impl DatasetCheckpoint {
             AccelerationConnection::SQLite(conn) => Self::migrate_sqlite(conn).await?,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => Self::migrate_turso(pool).await?,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => Self::migrate_sqlite(conn).await?,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -168,6 +172,10 @@ impl DatasetCheckpoint {
             AccelerationConnection::Turso(pool) => {
                 self.exists_turso(pool).await.ok().unwrap_or(false)
             }
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => {
+                self.exists_sqlite(conn).await.ok().unwrap_or(false)
+            }
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -190,6 +198,8 @@ impl DatasetCheckpoint {
             AccelerationConnection::SQLite(conn) => self.last_checkpoint_time_sqlite(conn).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.last_checkpoint_time_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.last_checkpoint_time_sqlite(conn).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -210,6 +220,8 @@ impl DatasetCheckpoint {
             AccelerationConnection::SQLite(conn) => self.checkpoint_sqlite(conn, schema).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.checkpoint_turso(pool, schema).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.checkpoint_sqlite(conn, schema).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -230,6 +242,8 @@ impl DatasetCheckpoint {
             AccelerationConnection::SQLite(conn) => self.get_schema_sqlite(conn).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.get_schema_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.get_schema_sqlite(conn).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
@@ -64,6 +64,8 @@ impl DebeziumKafkaSys {
             AccelerationConnection::SQLite(conn) => self.get_sqlite(conn).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.get_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.get_sqlite(conn).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -84,6 +86,8 @@ impl DebeziumKafkaSys {
             AccelerationConnection::SQLite(conn) => self.upsert_sqlite(conn, metadata).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.upsert_turso(pool, metadata).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.upsert_sqlite(conn, metadata).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",

--- a/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
@@ -57,6 +57,8 @@ impl DynamoDBSys {
             AccelerationConnection::SQLite(conn) => self.get_sqlite(conn).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.get_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.get_sqlite(conn).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -77,6 +79,8 @@ impl DynamoDBSys {
             AccelerationConnection::SQLite(conn) => self.upsert_sqlite(conn, metadata).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.upsert_turso(pool, metadata).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.upsert_sqlite(conn, metadata).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
@@ -65,6 +65,8 @@ impl KafkaSys {
             AccelerationConnection::SQLite(pool) => self.get_sqlite(pool).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.get_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(pool) => self.get_sqlite(pool).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -85,6 +87,8 @@ impl KafkaSys {
             AccelerationConnection::SQLite(pool) => self.upsert_sqlite(pool, metadata).await,
             #[cfg(feature = "turso")]
             AccelerationConnection::Turso(pool) => self.upsert_turso(pool, metadata).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(pool) => self.upsert_sqlite(pool, metadata).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, sync::Arc};
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use cayenne::CayenneTableProvider;
-use data_components::delete::DeletionTableProvider;
+use data_components::delete::{DeletionTableProvider, get_deletion_provider};
 use datafusion::{assert_batches_eq, physical_plan::collect, prelude::*, sql::TableReference};
 use futures::TryStreamExt;
 use runtime::{Runtime, accelerated_table::AcceleratedTable};
@@ -502,21 +502,19 @@ async fn test_cayenne_primary_key_delete() -> Result<(), anyhow::Error> {
                 .await
                 .ok_or_else(|| anyhow::anyhow!("Table pk_test not found"))?;
 
-            // Get the AcceleratedTable, then its underlying accelerator (CayenneTableProvider)
+            // Get the AcceleratedTable, then its underlying accelerator (which may be wrapped)
             let accelerated_table = table
                 .as_any()
                 .downcast_ref::<AcceleratedTable>()
                 .ok_or_else(|| anyhow::anyhow!("Table is not an AcceleratedTable"))?;
 
             let accelerator = accelerated_table.get_accelerator();
-            let cayenne_provider = accelerator
-                .as_any()
-                .downcast_ref::<CayenneTableProvider>()
-                .ok_or_else(|| anyhow::anyhow!("Accelerator is not a CayenneTableProvider"))?;
+            let deletion_provider = get_deletion_provider(Arc::clone(&accelerator))
+                .ok_or_else(|| anyhow::anyhow!("Accelerator does not support deletion"))?;
 
             let ctx = rt.datafusion().ctx.state();
             let filter = col("id").eq(lit(3i64));
-            let delete_plan = cayenne_provider.delete_from(&ctx, &[filter]).await?;
+            let delete_plan = deletion_provider.delete_from(&ctx, &[filter]).await?;
             collect(delete_plan, rt.datafusion().ctx.task_ctx()).await?;
 
             // Verify deletion
@@ -1146,6 +1144,803 @@ async fn test_cayenne_on_conflict_runtime_integration() -> Result<(), anyhow::Er
             // Verify total count is still 3 (upsert, not insert)
             let result = execute_sql(&rt, "SELECT COUNT(*) as cnt FROM events").await?;
             let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+// ============================================================================
+// Additional Comprehensive Cayenne Round-Trip Tests
+// ============================================================================
+
+/// Test Cayenne round-trip with large data batches
+///
+/// Verifies that Cayenne correctly handles large data insertions and queries
+/// with multiple iterations.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_large_batch_roundtrip() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_large_batch");
+            let metadata_db = temp_dir.path().join("metadata_large_batch.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("name", DataType::Utf8, false),
+                Field::new("value", DataType::Float64, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "large_batch_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "large_batch_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert 1000 rows in batches of 100
+            let batch_size = 100;
+            let num_batches = 10;
+
+            for batch_num in 0..num_batches {
+                let mut values = String::new();
+                for i in 0..batch_size {
+                    let id = batch_num * batch_size + i;
+                    if i > 0 {
+                        values.push_str(", ");
+                    }
+                    values.push_str(&format!("({}, 'name_{}', {})", id, id, id as f64 * 1.5));
+                }
+                ctx.sql(&format!(
+                    "INSERT INTO large_batch_test (id, name, value) VALUES {values}"
+                ))
+                .await?
+                .collect()
+                .await?;
+            }
+
+            // Verify total count
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM large_batch_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+------+", "| cnt  |", "+------+", "| 1000 |", "+------+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify SUM
+            let result = ctx
+                .sql("SELECT CAST(SUM(id) AS BIGINT) as sum_id FROM large_batch_test")
+                .await?
+                .collect()
+                .await?;
+            // Sum of 0..999 = 999 * 1000 / 2 = 499500
+            let expected = [
+                "+--------+",
+                "| sum_id |",
+                "+--------+",
+                "| 499500 |",
+                "+--------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Verify filtering works
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM large_batch_test WHERE id >= 500")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 500 |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne with special characters and edge case strings
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_special_characters() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_special_chars");
+            let metadata_db = temp_dir.path().join("metadata_special_chars.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("text", DataType::Utf8, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "special_chars_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "special_chars_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert rows with special characters
+            ctx.sql(
+                "INSERT INTO special_chars_test (id, text) VALUES \
+                 (1, 'Hello, World!'), \
+                 (2, 'Line1\nLine2'), \
+                 (3, 'Tab\there'), \
+                 (4, 'Quote''s'), \
+                 (5, 'Unicode: 日本語 中文 한국어'), \
+                 (6, 'Emoji: 🎉 🚀 ✨'), \
+                 (7, ''), \
+                 (8, 'Very long string that spans multiple words and contains various punctuation marks: commas, periods, exclamation points! And question marks?')",
+            )
+            .await?
+            .collect()
+            .await?;
+
+            // Verify all rows inserted
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM special_chars_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 8   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify Unicode text can be queried
+            let result = ctx
+                .sql("SELECT id FROM special_chars_test WHERE text LIKE '%日本語%'")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+----+", "| id |", "+----+", "| 5  |", "+----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify empty string handling
+            let result = ctx
+                .sql("SELECT id FROM special_chars_test WHERE text = ''")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+----+", "| id |", "+----+", "| 7  |", "+----+"];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne with NULL values across various data types
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_null_handling() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_null_handling");
+            let metadata_db = temp_dir.path().join("metadata_null_handling.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("nullable_int", DataType::Int64, true),
+                Field::new("nullable_float", DataType::Float64, true),
+                Field::new("nullable_text", DataType::Utf8, true),
+                Field::new("nullable_bool", DataType::Boolean, true),
+                Field::new(
+                    "nullable_ts",
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    true,
+                ),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "null_handling_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "null_handling_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert rows with various NULL patterns
+            ctx.sql(
+                "INSERT INTO null_handling_test (id, nullable_int, nullable_float, nullable_text, nullable_bool, nullable_ts) VALUES \
+                 (1, 100, 1.5, 'text', true, '2023-01-01 00:00:00'), \
+                 (2, NULL, 2.5, 'text2', false, '2023-01-02 00:00:00'), \
+                 (3, 300, NULL, 'text3', true, '2023-01-03 00:00:00'), \
+                 (4, 400, 4.5, NULL, false, '2023-01-04 00:00:00'), \
+                 (5, 500, 5.5, 'text5', NULL, '2023-01-05 00:00:00'), \
+                 (6, 600, 6.5, 'text6', true, NULL), \
+                 (7, NULL, NULL, NULL, NULL, NULL)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+            // Verify all rows inserted
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM null_handling_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 7   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Count NULLs in nullable_int
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM null_handling_test WHERE nullable_int IS NULL")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 2   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Count non-NULLs in nullable_text
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM null_handling_test WHERE nullable_text IS NOT NULL")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 5   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify SUM ignores NULLs
+            let result = ctx
+                .sql("SELECT CAST(SUM(nullable_int) AS BIGINT) as sum_int FROM null_handling_test")
+                .await?
+                .collect()
+                .await?;
+            // Sum of 100 + 300 + 400 + 500 + 600 = 1900
+            let expected = [
+                "+---------+",
+                "| sum_int |",
+                "+---------+",
+                "| 1900    |",
+                "+---------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne upsert with batch update (multiple rows at once)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_upsert_batch_update() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+    use datafusion_table_providers::util::{
+        column_reference::ColumnReference, on_conflict::OnConflict,
+    };
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_batch_upsert");
+            let metadata_db = temp_dir.path().join("metadata_batch_upsert.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("name", DataType::Utf8, false),
+                Field::new("value", DataType::Int64, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "batch_upsert_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec!["id".to_string()],
+                on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                    "id".to_string(),
+                ]))),
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "batch_upsert_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert initial rows
+            ctx.sql(
+                "INSERT INTO batch_upsert_test (id, name, value) VALUES \
+                (1, 'alpha', 100), \
+                (2, 'beta', 200), \
+                (3, 'gamma', 300)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+            // Verify initial count
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM batch_upsert_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Batch upsert - update existing rows and add new ones
+            ctx.sql(
+                "INSERT INTO batch_upsert_test (id, name, value) VALUES \
+                (2, 'beta_updated', 999), \
+                (4, 'delta', 400)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+            // Verify total count (3 original + 1 new = 4, one was upserted)
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM batch_upsert_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 4   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify upserted row has new values
+            let result = ctx
+                .sql("SELECT name, value FROM batch_upsert_test WHERE id = 2")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+--------------+-------+",
+                "| name         | value |",
+                "+--------------+-------+",
+                "| beta_updated | 999   |",
+                "+--------------+-------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Verify new row was added
+            let result = ctx
+                .sql("SELECT name, value FROM batch_upsert_test WHERE id = 4")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+-------+-------+",
+                "| name  | value |",
+                "+-------+-------+",
+                "| delta | 400   |",
+                "+-------+-------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne deletion followed by new insert (not re-insertion of same key)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_delete_then_insert_new() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+    use datafusion::physical_plan::collect;
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_delete_insert");
+            let metadata_db = temp_dir.path().join("metadata_delete_insert.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("name", DataType::Utf8, false),
+                Field::new("version", DataType::Int64, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "delete_insert_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec!["id".to_string()],
+                on_conflict: None, // No upsert - append only
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "delete_insert_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert initial data
+            ctx.sql(
+                "INSERT INTO delete_insert_test (id, name, version) VALUES \
+                 (1, 'alpha', 1), \
+                 (2, 'beta', 1), \
+                 (3, 'gamma', 1)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+            // Verify initial count
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM delete_insert_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Delete row with id=2 using DeletionTableProvider
+            let filter = col("id").eq(lit(2i64));
+            let delete_plan = table.delete_from(&ctx.state(), &[filter]).await?;
+            collect(delete_plan, ctx.task_ctx()).await?;
+
+            // Verify deletion
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM delete_insert_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 2   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Insert a NEW row with different id
+            ctx.sql("INSERT INTO delete_insert_test (id, name, version) VALUES (4, 'delta', 2)")
+                .await?
+                .collect()
+                .await?;
+
+            // Verify new row was added
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM delete_insert_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify the new row exists
+            let result = ctx
+                .sql("SELECT name, version FROM delete_insert_test WHERE id = 4")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+-------+---------+",
+                "| name  | version |",
+                "+-------+---------+",
+                "| delta | 2       |",
+                "+-------+---------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Verify deleted row is still gone
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM delete_insert_test WHERE id = 2")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 0   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne with boundary numeric values
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_boundary_values() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_boundary");
+            let metadata_db = temp_dir.path().join("metadata_boundary.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("int_val", DataType::Int64, false),
+                Field::new("float_val", DataType::Float64, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "boundary_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let table = CayenneTableProvider::create_table(catalog_arc, table_options).await?;
+            let table = Arc::new(table);
+
+            let ctx = SessionContext::new();
+            ctx.register_table(
+                "boundary_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            // Insert boundary values - use large but not MAX values to avoid DataFusion overflow issues
+            let large_positive: i64 = 1_000_000_000_000_000; // 10^15
+            let large_negative: i64 = -1_000_000_000_000_000;
+            ctx.sql(&format!(
+                "INSERT INTO boundary_test (id, int_val, float_val) VALUES \
+                 (1, {large_positive}, 0.0), \
+                 (2, {large_negative}, 0.0), \
+                 (3, 0, 1.7976931348623157e100), \
+                 (4, 0, 2.2250738585072014e-100), \
+                 (5, 0, -1.7976931348623157e100), \
+                 (6, 0, 0.0), \
+                 (7, 1, -0.0)"
+            ))
+            .await?
+            .collect()
+            .await?;
+
+            // Verify all rows inserted
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM boundary_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 7   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify large positive value can be retrieved and filtered
+            let result = ctx
+                .sql(&format!(
+                    "SELECT int_val FROM boundary_test WHERE int_val = {large_positive}"
+                ))
+                .await?
+                .collect()
+                .await?;
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].num_rows(), 1);
+
+            // Verify large negative value can be retrieved and filtered
+            let result = ctx
+                .sql(&format!(
+                    "SELECT int_val FROM boundary_test WHERE int_val = {large_negative}"
+                ))
+                .await?
+                .collect()
+                .await?;
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].num_rows(), 1);
+
+            // Verify zero handling
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM boundary_test WHERE float_val = 0.0")
+                .await?
+                .collect()
+                .await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test Cayenne partitioned table with deletion across partitions
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    // Use a no-cache request context to ensure fresh results after deletion
+    let no_cache_context = Arc::new(
+        RequestContext::builder(Protocol::Internal)
+            .with_user_agent(UserAgent::from_ua_str(&format!(
+                "spiceci/{}",
+                env!("CARGO_PKG_VERSION")
+            )))
+            .with_cache_control(CacheControl::NoCache)
+            .build(),
+    );
+
+    no_cache_context
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let data_dir = temp_dir.path().join("data");
+            std::fs::create_dir_all(&data_dir)?;
+
+            let csv_file = data_dir.join("partitioned_delete_test.csv");
+            std::fs::write(
+                &csv_file,
+                "id,region,name,value\n\
+                 1,us,alpha,100\n\
+                 2,us,beta,200\n\
+                 3,eu,gamma,300\n\
+                 4,eu,delta,400\n\
+                 5,asia,epsilon,500\n\
+                 6,asia,zeta,600\n",
+            )?;
+
+            let cayenne_dir = temp_dir.path().join("cayenne_partitioned_delete");
+            let metadata_dir = temp_dir.path().join("metadata_partitioned_delete");
+
+            crate::configure_test_datafusion();
+
+            let mut params = HashMap::new();
+            params.insert(
+                "cayenne_file_path".to_string(),
+                cayenne_dir.display().to_string(),
+            );
+            params.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.display().to_string(),
+            );
+
+            let mut dataset = Dataset::new(
+                format!("file://{}", csv_file.display()),
+                "partitioned_delete_test",
+            );
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                engine: Some("cayenne".to_string()),
+                mode: Mode::File,
+                refresh_mode: Some(RefreshMode::Full),
+                params: Some(Params::from_string_map(params)),
+                primary_key: Some("id".to_string()),
+                partition_by: vec![PartitionedBy {
+                    name: "region".to_string(),
+                    expression: "region".to_string(),
+                }],
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("test_cayenne_partitioned_deletion")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify initial data
+            let result =
+                execute_sql(&rt, "SELECT COUNT(*) as cnt FROM partitioned_delete_test").await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 6   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            // Verify data per partition
+            let result = execute_sql(
+                &rt,
+                "SELECT region, COUNT(*) as cnt FROM partitioned_delete_test GROUP BY region ORDER BY region",
+            )
+            .await?;
+            let expected = [
+                "+--------+-----+",
+                "| region | cnt |",
+                "+--------+-----+",
+                "| asia   | 2   |",
+                "| eu     | 2   |",
+                "| us     | 2   |",
+                "+--------+-----+",
+            ];
             assert_batches_eq!(expected, &result);
 
             Ok(())

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -19,11 +19,11 @@ limitations under the License.
 //! - Core Arrow data types
 //! - Primary key support
 
+use std::fmt::Write as _;
 use std::{collections::HashMap, sync::Arc};
 
 use app::AppBuilder;
 use arrow::array::RecordBatch;
-use cayenne::CayenneTableProvider;
 use data_components::delete::{DeletionTableProvider, get_deletion_provider};
 use datafusion::{assert_batches_eq, physical_plan::collect, prelude::*, sql::TableReference};
 use futures::TryStreamExt;
@@ -1216,7 +1216,7 @@ async fn test_cayenne_large_batch_roundtrip() -> Result<(), anyhow::Error> {
                     if i > 0 {
                         values.push_str(", ");
                     }
-                    values.push_str(&format!("({}, 'name_{}', {})", id, id, id as f64 * 1.5));
+                    let _ = write!(values, "({id}, 'name_{id}', {})", f64::from(id) * 1.5);
                 }
                 ctx.sql(&format!(
                     "INSERT INTO large_batch_test (id, name, value) VALUES {values}"


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the Cayenne data accelerator and partitioned table provider system. The main changes include adding robust table metadata cleanup during table creation, improving deletion support for partitioned tables, and refactoring how Cayenne tables are wrapped for retention and deletion logic. Additionally, there are improvements to initialization checks and error handling for Cayenne metadata. Below are the most important changes grouped by theme:

**Cayenne Table Metadata Cleanup and Initialization**

* Added a new `drop_table` method to the `MetadataCatalog` trait and implemented it in `CayenneCatalog` to allow for complete removal of a table and its associated metadata, enabling clean table recreation in `file_create` mode. [[1]](diffhunk://#diff-04dbbb4da5cbac82e3242c6e6fd2ee45421f92efb2a98af9eafa9bfa8b6e4462R328-R342) [[2]](diffhunk://#diff-c0638e1008db506deb5511b66778a4a7066ded8ed860661c146fedd36668b0a9R1008-R1089)
* Updated Cayenne accelerator initialization logic to drop existing table metadata via the catalog when running in `file_create` mode, ensuring stale metadata is removed before recreation. [[1]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817L1790-R1820) [[2]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817R1834-R1871)
* Improved initialization checks to verify both the data directory and metadata database exist, for both S3 Express and local storage.

**Partitioned Table Deletion Support**

* Implemented `DeletionTableProvider` for `PartitionTableProvider`, enabling deletion operations to be applied across all partitions. Introduced a `PartitionedDeletionSink` to coordinate deletions and aggregate deleted row counts.
* Made the `Partition` struct `Clone` to support partition iteration for deletion.

**Table Provider Wrapping and Retention/Deletion Logic**

* Refactored Cayenne table creation to always wrap providers (partitioned or not) in a `PolyTableProvider`, ensuring consistent support for deletion and retention features. Upsert deduplication logic is now applied as needed based on conflict settings. [[1]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817L1937-R2023) [[2]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817L2047-R2156)
* Added a schema metadata key (`spice.accelerator`) to identify Cayenne-accelerated tables.

**Dependency and Import Updates**

* Added new dependencies and imports to support partitioned deletion and table provider wrapping, including `data_components` and related modules. [[1]](diffhunk://#diff-60b0ec18c50268e4eac6ec9956edd0730f6bd3b62689ead22b4550469c46c3c6R12-R16) [[2]](diffhunk://#diff-d630fa04e335d4d35ff1e1cd8ebf278937867e652842aaff453c314000476c61R19-R22) [[3]](diffhunk://#diff-d630fa04e335d4d35ff1e1cd8ebf278937867e652842aaff453c314000476c61R34) [[4]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817R17-R26)

**Error Handling and Feature Gating**

* Enhanced error handling in `spice_sys.rs` for Cayenne file paths, metadata existence, and connection pool creation. Added feature gating for Cayenne support in error definitions and connection handling. [[1]](diffhunk://#diff-5471a27c4a4554e1bbee380cfd287fed6675df788201a45b9cc6b96f702abba9R34-R37) [[2]](diffhunk://#diff-5471a27c4a4554e1bbee380cfd287fed6675df788201a45b9cc6b96f702abba9R74-R75) [[3]](diffhunk://#diff-5471a27c4a4554e1bbee380cfd287fed6675df788201a45b9cc6b96f702abba9R146-R159)

These changes improve the reliability and maintainability of Cayenne-accelerated tables, especially when tables are recreated or deleted, and provide robust support for partitioned deletion and retention logic.