### PR TITLE
Pin reqwest to 0.12.24 to fix HuggingFace embedding model download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8006,7 +8006,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8050,7 +8050,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12773,7 +12773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -12819,7 +12819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -12832,7 +12832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -13096,7 +13096,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -13133,7 +13133,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -13614,10 +13614,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.26"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -17820,18 +17821,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "async-compression",
  "bitflags 2.10.0",
  "bytes",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -19726,7 +19723,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,9 @@ r2d2 = "0.8.10"
 rand = "0.9.2"
 rdkafka = { version = "0.38.0" }
 regex = "1.12.2"
-reqwest = { version = "0.12.26", features = ["json", "rustls-tls"] }
+# Pinned to 0.12.24 due to hf-hub content-range header issue with 0.12.25+ (tower-http decompression change)
+# See: https://github.com/seanmonstar/reqwest/pull/2840
+reqwest = { version = "=0.12.24", features = ["json", "rustls-tls"] }
 rmcp = { git = "https://github.com/spiceai/modelcontextprotocol-rust-sdk.git", rev = "a66f66ae345a0fafde1e2ee496ec137d77aef82a" }
 roaring = "0.11"
 rusqlite = { version = "0.37.0", features = ["bundled-decimal", "chrono"] }


### PR DESCRIPTION
## 📝 Summary

closes #8834 

Loading HuggingFace embedding models fails with "Header content-range is missing" after reqwest 0.12.25+.

**Short-term fix for Spice:**

Pin reqwest to version 0.12.24, which works as expected.

**Long-term fix:**

Report upstream to either reqwest (to restore skipping `Accept-Encoding` for range requests) or hf-hub (to handle this edge case gracefully).

---

**Hypothesis:**

reqwest 0.12.25 (PR #2840) refactored compression to use `tower-http::Decompression`, which now adds `Accept-Encoding: gzip` to all requests, including range requests. The `hf-hub` crate uses `Range: bytes=0-0` requests for metadata and expects `Content-Range` in the response. The combination breaks HuggingFace CDN responses.

reqwest 0.12.24 skipped adding `Accept-Encoding` header when a `Range` header was present:

https://github.com/seanmonstar/reqwest/blob/b126ca49da7897e5d676639cdbf67a0f6838b586/src/async_impl/client.rs#L2489-L2493
```rust
        if let Some(accept_encoding) = accept_encoding {
            if !headers.contains_key(ACCEPT_ENCODING) && !headers.contains_key(RANGE) {
                headers.insert(ACCEPT_ENCODING, HeaderValue::from_static(accept_encoding));
            }
        }
``` 

This was removed in https://github.com/seanmonstar/reqwest/pull/2840

hf-hub sends range header
https://github.com/huggingface/hf-hub/blob/86f85179527d52d71c9999ee3527432091db248c/src/api/tokio.rs#L500-L505
```rust
        let response = self
            .relative_redirect_client
            .get(url)
            .header(RANGE, "bytes=0-0")
            .send()
            .await?;
```

and expects it response:
https://github.com/huggingface/hf-hub/blob/86f85179527d52d71c9999ee3527432091db248c/src/api/tokio.rs#L537-L541
```rust
        let headers = response.headers();
        let content_range = headers
            .get(CONTENT_RANGE)
            .ok_or(ApiError::MissingHeader(CONTENT_RANGE))?
            .to_str()?;
```

### To Reproduce:

spicepod:

```yaml
name: scp-synthetics-test-app
kind: Spicepod
version: v1

embeddings:
  - name: local_embedding_model
    from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
```

Note: make sure to delete `~/.cache/huggingface` before testing, to have clean state

Before (on trunk and spiced v1.110-rc.1):

```console
2026-01-09T14:39:03.205583Z  WARN runtime::init::embedding: Failed to load Embedding Model local_embedding_model. When preparing an embedding model, an issue occurred with the Huggingface API. Header content-range is missing. Verify the model configuration, and try again. Verify configuration and try again.
For details, visit https://spiceai.org/docs/components/embeddings
```

After:

```console
2026-01-09T14:39:52.105962Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
2026-01-09T14:39:52.107402Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
2026-01-09T14:39:52.307039Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2026-01-09T14:39:56.741793Z  INFO runtime::init::embedding: Embedding Model local_embedding_model ready
```
