### PR TITLE
fix: Ubuntu 24.04+ renamed libaio1 to libaio1t64

### DIFF
--- a/.github/actions/setup-oracle-odpi/action.yml
+++ b/.github/actions/setup-oracle-odpi/action.yml
@@ -7,7 +7,8 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libaio1
+        # Ubuntu 24.04+ renamed libaio1 to libaio1t64 for 64-bit time_t transition
+        sudo apt-get install -y libaio1t64 || sudo apt-get install -y libaio1
 
         # Download and extract Oracle Instant Client
         curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip


### PR DESCRIPTION
This pull request updates the Oracle ODPI setup action to improve compatibility with newer Ubuntu versions. The main change ensures that the correct version of the `libaio` library is installed, regardless of the Ubuntu release.

Dependency installation compatibility:

* Updated the installation command in `.github/actions/setup-oracle-odpi/action.yml` to try installing `libaio1t64` first (required for Ubuntu 24.04+), and fall back to `libaio1` for older versions. This ensures the action works across different Ubuntu versions.