### PR TITLE
fix: flaky test test_concurrent_partition_creation

### DIFF
--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -39,6 +39,20 @@ pub struct SqliteMetastore {
     conn: OnceCell<tokio_rusqlite::Connection>,
 }
 
+/// Convert a `tokio_rusqlite::Error` to a `CatalogError`, preserving the underlying
+/// `rusqlite::Error` when possible for better error matching.
+fn convert_tokio_rusqlite_error(
+    e: tokio_rusqlite::Error<rusqlite::Error>,
+    context: &str,
+) -> CatalogError {
+    match e {
+        tokio_rusqlite::Error::Error(sqlite_err) => CatalogError::Sqlite { source: sqlite_err },
+        other => CatalogError::Database {
+            message: format!("{context}: {other}"),
+        },
+    }
+}
+
 impl std::fmt::Debug for SqliteMetastore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SqliteMetastore")
@@ -362,11 +376,7 @@ impl MetastoreBackend for SqliteMetastore {
             Ok::<_, rusqlite::Error>(())
         })
         .await
-        .map_err(
-            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
-                message: format!("Failed to execute statement: {e}"),
-            },
-        )?;
+        .map_err(|e| convert_tokio_rusqlite_error(e, "Failed to execute statement"))?;
 
         Ok(())
     }


### PR DESCRIPTION
## 📝 Summary

Fixes a flaky Cayenne test: `test_concurrent_partition_creation`.

The original code converted all `tokio_rusqlite::Error` to `CatalogError::Database` with a string message, losing the ability to match on specific SQLite error types.

The code below was never invoked and thus did not work to prevent confliclts:

```rust
Err(CatalogError::Sqlite {
    source: rusqlite::Error::SqliteFailure(err, _),
}) if err.code == rusqlite::ErrorCode::ConstraintViolation
```