### PR TITLE
feat: Add HTTP health endpoint for cluster executors

### DIFF
--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -54,6 +54,64 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Starts a minimal HTTP server that only serves the `/health` endpoint.
+///
+/// This is used by cluster executors which need a health endpoint for Kubernetes
+/// probes but don't require the full HTTP API.
+pub(crate) async fn start_health_only<A>(
+    bind_address: A,
+    shutdown_signal: Option<CancellationToken>,
+) -> Result<()>
+where
+    A: ToSocketAddrs + Debug,
+{
+    use axum::routing::get;
+
+    let routes = Router::new().route("/health", get(|| async { "ok\n" }));
+
+    let listener = TcpListener::bind(&bind_address)
+        .await
+        .context(UnableToBindServerToPortSnafu)?;
+    tracing::info!("Spice Runtime HTTP health endpoint listening on {bind_address:?}");
+
+    let shutdown_signal = shutdown_signal.unwrap_or_default();
+
+    let (shutdown_notify, _) = watch::channel(());
+
+    loop {
+        tokio::select! {
+            conn = listener.accept() => {
+                let stream = match conn {
+                    Ok((stream, _)) => stream,
+                    Err(e) => {
+                        tracing::debug!("Error accepting connection to serve HTTP request: {e}");
+                        continue;
+                    }
+                };
+
+                process_tcp_stream(stream, routes.clone(), shutdown_notify.subscribe());
+            },
+            () = shutdown_signal.cancelled() => {
+                tracing::debug!("Health HTTP server received shutdown signal");
+                drop(listener);
+                let num_active = shutdown_notify.receiver_count();
+                if num_active > 0 {
+                    tracing::info!(
+                        "Detected {num_active} active health check requests. Waiting for completion before shutting down..."
+                    );
+                }
+                shutdown_notify.send(()).ok();
+                shutdown_notify.closed().await;
+                break;
+            }
+        }
+    }
+
+    tracing::debug!("Health HTTP server stopped");
+
+    Ok(())
+}
+
 pub(crate) async fn start<A>(
     bind_address: A,
     rt: Arc<Runtime>,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -753,7 +753,7 @@ impl Runtime {
                 )
             };
 
-        // If this is an executor, we only need the shutdown signal and flight server
+        // If this is an executor, we only need the shutdown signal, flight server, and health endpoint
         if matches!(
             self.df.cluster_config.effective_role(),
             Some(ClusterRole::Executor)
@@ -766,8 +766,25 @@ impl Runtime {
                 });
             };
 
-            return tokio::try_join!(shutdown_signal_future, executor_future, flight_future,)
-                .map(|_| ());
+            // Start health-only HTTP server for executor
+            let http_shutdown = CancellationToken::new();
+            let http_bind_address = config.http_bind_address;
+            let health_http_future = self
+                .start_runtime_task(
+                    HTTP_SERVER,
+                    Some(http_shutdown.clone()),
+                    http::start_health_only(http_bind_address, Some(http_shutdown))
+                        .map_err(Error::from),
+                )
+                .await;
+
+            return tokio::try_join!(
+                shutdown_signal_future,
+                executor_future,
+                flight_future,
+                health_http_future,
+            )
+            .map(|_| ());
         }
 
         // Start Http server


### PR DESCRIPTION
## Summary

- Adds a `/health` HTTP endpoint (unauthenticated, no TLS) to cluster mode executors
- Returns `ok\n` - the same response as the non-cluster mode health endpoint
- Enables Kubernetes health probes and similar monitoring tools to verify executor availability

- Closes #7674

## Changes

- Added `start_health_only()` function in `crates/runtime/src/http/mod.rs` that starts a minimal HTTP server exposing only `/health`
- Modified executor startup path in `crates/runtime/src/lib.rs` to include the health HTTP server alongside the flight server

## Testing

- The health endpoint reuses existing TCP stream handling infrastructure
- Manual testing: start an executor with `--scheduler-address` and verify `curl http://127.0.0.1:8090/health` returns `ok`