### PR TITLE
Fix distributed query gRPC message size limit (16MB -> 100MB)

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -708,7 +708,11 @@ pub async fn initialize_cluster_executor(
     let config_producer: ConfigProducer = Arc::new(move || {
         let mut config = SessionConfig::new_with_ballista()
             .with_option_extension(SpiceClusterConfig::default())
-            .with_ballista_use_tls(tls_enabled);
+            .with_ballista_use_tls(tls_enabled)
+            // Use 100MB max message size to match other gRPC configurations in the codebase.
+            // The default Ballista config is 16MB which is too small for shuffle operations
+            // with large batches.
+            .with_ballista_grpc_client_max_message_size(100 * 1024 * 1024);
 
         if let Some(tls_config) = config_producer_tls.clone() {
             config = config.with_ballista_override_create_grpc_client_endpoint({

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -189,7 +189,11 @@ impl Query {
             .ctx
             .copied_config()
             .with_ballista_logical_extension_codec(SpiceLogicalCodec::new_codec())
-            .with_ballista_use_tls(tls_enabled);
+            .with_ballista_use_tls(tls_enabled)
+            // Use 100MB max message size to match other gRPC configurations in the codebase
+            // (see flight_client::MAX_DECODING_MESSAGE_SIZE). The default Ballista config
+            // is 16MB which is too small for queries returning large batches.
+            .with_ballista_grpc_client_max_message_size(100 * 1024 * 1024);
 
         if let Some(tls_config) = client_tls_config {
             cfg = cfg.with_ballista_override_create_grpc_client_endpoint(Arc::new(move |ep| {


### PR DESCRIPTION
## Summary

- Increases the Ballista gRPC client max message size from 16MB (default) to 100MB for distributed queries
- Aligns with other gRPC configurations in the codebase (`flight_client::MAX_DECODING_MESSAGE_SIZE`)
- Closes #8670

## Problem

When running Spice in clustered mode (scheduler + executors), queries that produce batches larger than 16MB fail with:

```
Arrow error: External error: status: OutOfRange, message: "Error, decoded message length too large: found 20000537 bytes, the limit is: 16777216 bytes"
```

The same query works in non-distributed mode because the local execution path doesn't have this limit.

## Root Cause

The `BallistaClient` used to fetch partition results from executors uses a configurable `max_message_size` that defaults to 16MB in `BallistaConfig`. While other gRPC configurations in the codebase (cluster server endpoints, Flight services) are configured with large limits (100MB or `usize::MAX`), the distributed query client configuration was missing this override.

## Solution

Configure `with_ballista_grpc_client_max_message_size(100MB)` when setting up the session config for distributed queries, matching the existing `flight_client::MAX_DECODING_MESSAGE_SIZE` constant.