### PR TITLE
feat: Add spicepod generation tracking for cluster coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14140,6 +14140,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "snafu",
  "snowflake-api",
  "spice-cloud",

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -10,15 +10,16 @@ option java_outer_classname = "SpiceProto";
 service ClusterService {
     // Get the app definition (Spicepod) from the scheduler.
     // Called by executors during initialization.
+    // Returns UNAVAILABLE if the scheduler has an outdated spicepod generation.
     rpc GetAppDefinition(GetAppDefinitionRequest) returns (GetAppDefinitionResponse);
 
     // Expand a secret value from the scheduler's secret store.
     // Called by executors when they need to resolve secrets.
     rpc ExpandSecret(ExpandSecretRequest) returns (ExpandSecretResponse);
 
-    // Get the scheduler membership list.
-    // Called by executors during initialization.
-    rpc GetSchedulers(GetSchedulersRequest) returns (GetSchedulersResponse);
+    // Get the cluster state including scheduler membership and spicepod generation.
+    // Called by executors during initialization and periodically to detect config changes.
+    rpc GetClusterState(GetClusterStateRequest) returns (GetClusterStateResponse);
 }
 
 // Request message for GetAppDefinition RPC.
@@ -30,6 +31,10 @@ message GetAppDefinitionRequest {
 message GetAppDefinitionResponse {
     // JSON-serialized app definition.
     string app_json = 1;
+    // Spicepod generation number. Executors should monitor for changes.
+    uint64 spicepod_generation = 2;
+    // SHA256 hash of the serialized spicepod for verification.
+    string spicepod_content_hash = 3;
 }
 
 // Request message for ExpandSecret RPC.
@@ -44,8 +49,8 @@ message ExpandSecretResponse {
     string value = 2;
 }
 
-// Request message for GetSchedulers RPC.
-message GetSchedulersRequest {}
+// Request message for GetClusterState RPC.
+message GetClusterStateRequest {}
 
 // Scheduler instance information.
 message SchedulerInstance {
@@ -53,9 +58,14 @@ message SchedulerInstance {
     map<string, string> labels = 2;
 }
 
-// Response message for GetSchedulers RPC.
-message GetSchedulersResponse {
+// Response message for GetClusterState RPC.
+message GetClusterStateResponse {
+    // List of known scheduler instances in the cluster.
     repeated SchedulerInstance schedulers = 1;
+    // Current spicepod generation number. Executors should exit when this changes.
+    uint64 spicepod_generation = 2;
+    // SHA256 hash of the current spicepod content.
+    string spicepod_content_hash = 3;
 }
 
 // Physical plan

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -153,6 +153,7 @@ secrecy.workspace = true
 scylla = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sha2.workspace = true
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 spicepod = { path = "../spicepod" }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use crate::cluster::ResolvedClusterConfig;
+use crate::cluster::SpicepodGeneration;
 use crate::config::Config;
 use crate::datafusion::udf::register_udfs;
 use crate::{
@@ -33,6 +34,7 @@ use crate::{
 };
 use app::App;
 use spicepod::component::caching::Caching;
+use std::sync::atomic::AtomicBool;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
 use tokio::runtime::Handle;
@@ -294,6 +296,8 @@ impl RuntimeBuilder {
             token_provider_registry: self.token_provider_registry,
             schedulers: Arc::new(RwLock::new(HashMap::new())),
             scheduler_peers: Arc::new(RwLock::new(HashMap::new())),
+            scheduler_outdated: Arc::new(AtomicBool::new(false)),
+            scheduler_generation: Arc::new(RwLock::new(SpicepodGeneration::default())),
             resource_monitor,
             config: Arc::clone(&self.runtime_config),
         };

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -50,7 +50,7 @@ use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 use runtime_object_store::registry::default_runtime_env;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
-use runtime_proto::{GetAppDefinitionRequest, GetSchedulersRequest};
+use runtime_proto::{GetAppDefinitionRequest, GetClusterStateRequest};
 use runtime_secrets::Secrets;
 use snafu::ResultExt;
 use std::collections::{HashMap, HashSet};
@@ -70,9 +70,19 @@ use x509_certificate::CapturedX509Certificate;
 
 const SCHEDULER_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SCHEDULER_BACKOFF_MAX: Duration = Duration::from_secs(5);
+const EXECUTOR_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
+/// Exit code used when executor exits due to spicepod generation change.
+const GENERATION_CHANGE_EXIT_CODE: i32 = 42;
 
 type SchedulerEndpointOverride =
     Arc<dyn Fn(Endpoint) -> Result<Endpoint, tonic::transport::Error> + Send + Sync>;
+
+/// Result from fetching cluster state, including scheduler membership and generation info.
+struct ClusterStateResult {
+    scheduler_addresses: Vec<String>,
+    spicepod_generation: u64,
+    spicepod_content_hash: String,
+}
 
 struct SchedulerPollHandle {
     cancel: CancellationToken,
@@ -256,10 +266,10 @@ fn spawn_scheduler_poll_loop(
     SchedulerPollHandle { cancel, task }
 }
 
-async fn fetch_scheduler_membership(
+async fn fetch_cluster_state(
     scheduler_url: &Url,
     client_tls_config: Option<ClientTlsConfig>,
-) -> Option<Vec<String>> {
+) -> Option<ClusterStateResult> {
     let mut cluster_client =
         match create_cluster_service_client(scheduler_url, client_tls_config.clone()).await {
             Ok(client) => client,
@@ -269,17 +279,25 @@ async fn fetch_scheduler_membership(
             }
         };
 
-    match cluster_client.get_schedulers(GetSchedulersRequest {}).await {
+    match cluster_client
+        .get_cluster_state(GetClusterStateRequest {})
+        .await
+    {
         Ok(response) => {
-            let schedulers = response.into_inner().schedulers;
-            let scheduler_addresses = schedulers
+            let inner = response.into_inner();
+            let scheduler_addresses = inner
+                .schedulers
                 .iter()
                 .map(|scheduler| scheduler.advertise_address.clone())
                 .collect::<Vec<_>>();
-            Some(scheduler_addresses)
+            Some(ClusterStateResult {
+                scheduler_addresses,
+                spicepod_generation: inner.spicepod_generation,
+                spicepod_content_hash: inner.spicepod_content_hash,
+            })
         }
         Err(status) => {
-            tracing::warn!("Failed to get scheduler membership from scheduler: {status}");
+            tracing::warn!("Failed to get cluster state from scheduler: {status}");
             None
         }
     }
@@ -342,7 +360,9 @@ mod servers;
 mod service;
 
 pub use scheduler_registry::start_scheduler_registry;
-pub use scheduler_registry::{SchedulerPeers, SchedulerRecord};
+pub use scheduler_registry::{
+    SchedulerPeers, SchedulerRecord, SpicepodGeneration, compute_spicepod_hash,
+};
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
 pub use service::ClusterServiceImpl;
 
@@ -731,22 +751,24 @@ pub async fn initialize_cluster_executor(
     let mut cluster_client =
         create_cluster_service_client(scheduler_url, client_tls_config.clone()).await?;
 
-    let initial_scheduler_addresses =
-        match cluster_client.get_schedulers(GetSchedulersRequest {}).await {
-            Ok(response) => {
-                let schedulers = response.into_inner().schedulers;
-                let scheduler_addresses = schedulers
-                    .iter()
-                    .map(|scheduler| scheduler.advertise_address.clone())
-                    .collect::<Vec<_>>();
-                tracing::info!("Scheduler membership: {:?}", scheduler_addresses);
-                scheduler_addresses
-            }
-            Err(status) => {
-                tracing::warn!("Failed to get scheduler membership from scheduler: {status}");
-                Vec::new()
-            }
-        };
+    let initial_scheduler_addresses = match cluster_client
+        .get_cluster_state(GetClusterStateRequest {})
+        .await
+    {
+        Ok(response) => {
+            let schedulers = response.into_inner().schedulers;
+            let scheduler_addresses = schedulers
+                .iter()
+                .map(|scheduler| scheduler.advertise_address.clone())
+                .collect::<Vec<_>>();
+            tracing::info!("Scheduler membership: {:?}", scheduler_addresses);
+            scheduler_addresses
+        }
+        Err(status) => {
+            tracing::warn!("Failed to get scheduler membership from scheduler: {status}");
+            Vec::new()
+        }
+    };
 
     let app_definition_request = GetAppDefinitionRequest {
         executor_id: executor_id.clone(),
@@ -759,7 +781,16 @@ pub async fn initialize_cluster_executor(
             source: format!("Failed to get app definition from scheduler: {status}").into(),
         })?;
 
-    let app_json = response.into_inner().app_json;
+    let response_inner = response.into_inner();
+    let app_json = response_inner.app_json;
+    let expected_generation = response_inner.spicepod_generation;
+    let expected_content_hash = response_inner.spicepod_content_hash;
+
+    tracing::info!(
+        "Executor received spicepod generation {} (hash {})",
+        expected_generation,
+        expected_content_hash
+    );
 
     let app_def: App = serde_json::from_str(&app_json)
         .boxed()
@@ -871,6 +902,8 @@ pub async fn initialize_cluster_executor(
     let executor_for_manager = Arc::clone(&executor);
     let codec_for_manager = codec;
     let initial_scheduler_addresses_for_manager = initial_scheduler_addresses.clone();
+    let expected_generation_for_manager = expected_generation;
+    let expected_content_hash_for_manager = expected_content_hash.clone();
 
     let poll_manager = tokio::spawn(async move {
         let mut pollers: HashMap<String, SchedulerPollHandle> = HashMap::new();
@@ -894,12 +927,45 @@ pub async fn initialize_cluster_executor(
         let mut refresh = tokio::time::interval(SCHEDULER_REFRESH_INTERVAL);
         loop {
             refresh.tick().await;
-            if let Some(addresses) = fetch_scheduler_membership(
+            if let Some(cluster_state) = fetch_cluster_state(
                 &scheduler_url_for_manager,
                 client_tls_config_for_manager.clone(),
             )
             .await
             {
+                // Check if generation has changed
+                if cluster_state.spicepod_generation > expected_generation_for_manager
+                    || (cluster_state.spicepod_generation == expected_generation_for_manager
+                        && cluster_state.spicepod_content_hash != expected_content_hash_for_manager)
+                {
+                    tracing::warn!(
+                        "Spicepod configuration changed: cluster generation {} (hash {}) vs expected {} (hash {}). Initiating graceful drain and restart.",
+                        cluster_state.spicepod_generation,
+                        cluster_state.spicepod_content_hash,
+                        expected_generation_for_manager,
+                        expected_content_hash_for_manager,
+                    );
+
+                    // Cancel all scheduler poll loops to stop accepting new work
+                    for (_address, handle) in pollers.drain() {
+                        handle.cancel.cancel();
+                    }
+
+                    // Wait for in-flight tasks to complete (drain timeout)
+                    tracing::info!(
+                        "Draining in-flight tasks (timeout: {:?})...",
+                        EXECUTOR_DRAIN_TIMEOUT
+                    );
+                    tokio::time::sleep(EXECUTOR_DRAIN_TIMEOUT).await;
+
+                    tracing::info!(
+                        "Drain complete. Exiting with code {} for orchestrator restart.",
+                        GENERATION_CHANGE_EXIT_CODE
+                    );
+                    std::process::exit(GENERATION_CHANGE_EXIT_CODE);
+                }
+
+                let addresses = cluster_state.scheduler_addresses;
                 if addresses.is_empty() {
                     tracing::warn!(
                         "Scheduler membership refresh returned empty list; keeping existing schedulers"

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -15,9 +15,11 @@ limitations under the License.
 */
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use app::App;
 use app::spicepod::component::runtime::Scheduler as SchedulerConfig;
 use aws_sdk_credential_bridge::object_store_builder::S3ObjectStoreBuilder;
 use datafusion::execution::object_store::ObjectStoreRegistry;
@@ -28,6 +30,7 @@ use runtime_object_store::registry::SpiceObjectStoreRegistry;
 use runtime_parameters::{ParameterSpec, Parameters};
 use runtime_secrets::{Secrets, get_params_with_secrets};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -107,6 +110,22 @@ pub struct SchedulerRecord {
 struct ClusterMetadata {
     schema_version: u32,
     created_at_ms: u64,
+    /// Spicepod generation number. Increments when spicepod content changes.
+    #[serde(default)]
+    spicepod_generation: u64,
+    /// SHA256 hash of the serialized spicepod JSON.
+    #[serde(default)]
+    spicepod_content_hash: String,
+    /// Timestamp when the spicepod generation was last updated.
+    #[serde(default)]
+    spicepod_updated_at_ms: u64,
+}
+
+/// Current spicepod generation state, shared with the cluster service.
+#[derive(Debug, Clone, Default)]
+pub struct SpicepodGeneration {
+    pub generation: u64,
+    pub content_hash: String,
 }
 
 pub type SchedulerPeers = HashMap<String, SchedulerRecord>;
@@ -120,6 +139,14 @@ struct SchedulerRegistryRunner {
     record: SchedulerRecord,
     update_version: Option<UpdateVersion>,
     peers: Arc<RwLock<SchedulerPeers>>,
+    /// Content hash of this scheduler's spicepod.
+    local_content_hash: String,
+    /// Generation number when this scheduler started.
+    startup_generation: u64,
+    /// Shared flag indicating this scheduler is outdated (newer generation exists).
+    outdated: Arc<AtomicBool>,
+    /// Shared current generation state for the cluster service.
+    current_generation: Arc<RwLock<SpicepodGeneration>>,
 }
 
 pub async fn start_scheduler_registry(
@@ -127,6 +154,8 @@ pub async fn start_scheduler_registry(
     config: &SchedulerConfig,
     cancel: CancellationToken,
     peers: Arc<RwLock<SchedulerPeers>>,
+    outdated: Arc<AtomicBool>,
+    current_generation: Arc<RwLock<SpicepodGeneration>>,
 ) -> Result<()> {
     let state_url = Url::parse(&config.state_location).context(InvalidStateLocationSnafu {
         location: config.state_location.clone(),
@@ -160,24 +189,39 @@ pub async fn start_scheduler_registry(
         labels: HashMap::new(),
     };
 
+    // Compute content hash from the current app definition
+    let app_guard = rt.app.read().await;
+    let local_content_hash = match &*app_guard {
+        Some(app) => compute_spicepod_hash(app),
+        None => String::new(),
+    };
+    drop(app_guard);
+
     let runner = SchedulerRegistryRunner::new(
         store,
         &base_prefix,
         scheduler_id,
         record,
         Arc::clone(&peers),
+        local_content_hash,
+        outdated,
+        current_generation,
     );
 
     runner.run(cancel).await
 }
 
 impl SchedulerRegistryRunner {
+    #[expect(clippy::too_many_arguments)]
     fn new(
         store: Arc<dyn ObjectStore>,
         base_prefix: &str,
         scheduler_id: String,
         record: SchedulerRecord,
         peers: Arc<RwLock<SchedulerPeers>>,
+        local_content_hash: String,
+        outdated: Arc<AtomicBool>,
+        current_generation: Arc<RwLock<SpicepodGeneration>>,
     ) -> Self {
         let metadata_path = join_path(base_prefix, "metadata/cluster.json");
         let record_path = join_path(base_prefix, &format!("schedulers/{scheduler_id}.json"));
@@ -192,6 +236,10 @@ impl SchedulerRegistryRunner {
             record,
             update_version: None,
             peers,
+            local_content_hash,
+            startup_generation: 0, // Will be set in ensure_cluster_metadata
+            outdated,
+            current_generation,
         }
     }
 
@@ -219,6 +267,10 @@ impl SchedulerRegistryRunner {
                     if let Err(err) = self.refresh_peers().await {
                         tracing::warn!("Scheduler discovery failed: {err}");
                     }
+                    // Also check if generation has advanced
+                    if let Err(err) = self.check_generation().await {
+                        tracing::warn!("Generation check failed: {err}");
+                    }
                 }
             }
         }
@@ -226,26 +278,190 @@ impl SchedulerRegistryRunner {
         Ok(())
     }
 
-    async fn ensure_cluster_metadata(&self) -> Result<()> {
-        let metadata = ClusterMetadata {
-            schema_version: CLUSTER_SCHEMA_VERSION,
-            created_at_ms: now_ms()?,
-        };
-        let payload = serde_json::to_vec(&metadata).context(SerializeStateSnafu)?;
+    async fn ensure_cluster_metadata(&mut self) -> Result<()> {
+        let now = now_ms()?;
 
+        // First, try to read existing metadata
+        match self.read_cluster_metadata().await {
+            Ok(existing) => {
+                // Metadata exists - check if our content hash matches
+                if existing.spicepod_content_hash == self.local_content_hash {
+                    // Same spicepod, use existing generation
+                    self.startup_generation = existing.spicepod_generation;
+                    self.update_current_generation(
+                        existing.spicepod_generation,
+                        existing.spicepod_content_hash,
+                    )
+                    .await;
+                    tracing::info!(
+                        "Joined cluster with existing spicepod generation {}",
+                        self.startup_generation
+                    );
+                    return Ok(());
+                }
+
+                // Different content hash - need to update generation
+                let new_generation = existing.spicepod_generation.saturating_add(1);
+                let updated_metadata = ClusterMetadata {
+                    schema_version: CLUSTER_SCHEMA_VERSION,
+                    created_at_ms: existing.created_at_ms,
+                    spicepod_generation: new_generation,
+                    spicepod_content_hash: self.local_content_hash.clone(),
+                    spicepod_updated_at_ms: now,
+                };
+
+                if self.try_update_cluster_metadata(&updated_metadata).await? {
+                    self.startup_generation = new_generation;
+                    self.update_current_generation(new_generation, self.local_content_hash.clone())
+                        .await;
+                    tracing::info!(
+                        "Updated cluster to spicepod generation {} (content hash changed)",
+                        new_generation
+                    );
+                } else {
+                    // Another scheduler won the race - re-read and accept their generation
+                    let refreshed = self.read_cluster_metadata().await?;
+                    self.startup_generation = refreshed.spicepod_generation;
+                    self.update_current_generation(
+                        refreshed.spicepod_generation,
+                        refreshed.spicepod_content_hash,
+                    )
+                    .await;
+                    tracing::info!(
+                        "Accepted cluster spicepod generation {} from peer",
+                        self.startup_generation
+                    );
+                }
+                Ok(())
+            }
+            Err(Error::ObjectStoreRead {
+                source: ObjectStoreError::NotFound { .. },
+            }) => {
+                // No metadata exists - try to create it
+                let metadata = ClusterMetadata {
+                    schema_version: CLUSTER_SCHEMA_VERSION,
+                    created_at_ms: now,
+                    spicepod_generation: 1,
+                    spicepod_content_hash: self.local_content_hash.clone(),
+                    spicepod_updated_at_ms: now,
+                };
+                let payload = serde_json::to_vec(&metadata).context(SerializeStateSnafu)?;
+
+                let put_result = self
+                    .store
+                    .put_opts(
+                        &self.metadata_path,
+                        payload.into(),
+                        PutOptions::from(PutMode::Create),
+                    )
+                    .await;
+
+                match put_result {
+                    Ok(_) => {
+                        self.startup_generation = 1;
+                        self.update_current_generation(1, self.local_content_hash.clone())
+                            .await;
+                        tracing::info!("Created cluster with spicepod generation 1");
+                        Ok(())
+                    }
+                    Err(ObjectStoreError::AlreadyExists { .. }) => {
+                        // Lost the race - re-read and use existing
+                        let existing = self.read_cluster_metadata().await?;
+                        self.startup_generation = existing.spicepod_generation;
+                        self.update_current_generation(
+                            existing.spicepod_generation,
+                            existing.spicepod_content_hash,
+                        )
+                        .await;
+                        tracing::info!(
+                            "Lost race to create cluster metadata, using generation {}",
+                            self.startup_generation
+                        );
+                        Ok(())
+                    }
+                    Err(err) => Err(Error::ObjectStoreWrite { source: err }),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn read_cluster_metadata(&self) -> Result<ClusterMetadata> {
+        let result = self
+            .store
+            .get(&self.metadata_path)
+            .await
+            .map_err(|source| Error::ObjectStoreRead { source })?;
+        let bytes = result
+            .bytes()
+            .await
+            .map_err(|source| Error::ObjectStoreRead { source })?;
+        serde_json::from_slice(&bytes).context(DeserializeStateSnafu)
+    }
+
+    async fn try_update_cluster_metadata(&self, metadata: &ClusterMetadata) -> Result<bool> {
+        // Read current metadata to get version for conditional update
+        let get_result = self
+            .store
+            .get(&self.metadata_path)
+            .await
+            .map_err(|source| Error::ObjectStoreRead { source })?;
+        let version = UpdateVersion {
+            e_tag: get_result.meta.e_tag,
+            version: get_result.meta.version,
+        };
+
+        let payload = serde_json::to_vec(metadata).context(SerializeStateSnafu)?;
         let put_result = self
             .store
             .put_opts(
                 &self.metadata_path,
                 payload.into(),
-                PutOptions::from(PutMode::Create),
+                PutOptions::from(PutMode::Update(version)),
             )
             .await;
 
         match put_result {
-            Ok(_) | Err(ObjectStoreError::AlreadyExists { .. }) => Ok(()),
+            Ok(_) => Ok(true),
+            Err(ObjectStoreError::Precondition { .. }) => Ok(false),
             Err(err) => Err(Error::ObjectStoreWrite { source: err }),
         }
+    }
+
+    async fn check_generation(&mut self) -> Result<()> {
+        let metadata = match self.read_cluster_metadata().await {
+            Ok(m) => m,
+            Err(Error::ObjectStoreRead {
+                source: ObjectStoreError::NotFound { .. },
+            }) => return Ok(()), // Metadata disappeared, ignore
+            Err(err) => return Err(err),
+        };
+
+        // Update shared current generation state
+        self.update_current_generation(
+            metadata.spicepod_generation,
+            metadata.spicepod_content_hash.clone(),
+        )
+        .await;
+
+        if metadata.spicepod_generation > self.startup_generation
+            && !self.outdated.load(Ordering::Relaxed)
+        {
+            tracing::warn!(
+                "Scheduler is outdated: cluster generation {} > startup generation {}. This scheduler will refuse GetAppDefinition requests.",
+                metadata.spicepod_generation,
+                self.startup_generation
+            );
+            self.outdated.store(true, Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    async fn update_current_generation(&self, generation: u64, content_hash: String) {
+        let mut gen_state = self.current_generation.write().await;
+        gen_state.generation = generation;
+        gen_state.content_hash = content_hash;
     }
 
     async fn bootstrap_record(&mut self) -> Result<()> {
@@ -523,4 +739,13 @@ fn now_ms() -> Result<u64> {
             source: Box::new(source),
         },
     })
+}
+
+/// Computes a SHA256 hash of the serialized spicepod for generation tracking.
+#[must_use]
+pub fn compute_spicepod_hash(app: &App) -> String {
+    let json = serde_json::to_string(app).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(json.as_bytes());
+    format!("{:x}", hasher.finalize())
 }

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -105,6 +105,8 @@ pub async fn start_internal_cluster_server(
         Arc::clone(&rt.secrets),
         advertise_address,
         rt.scheduler_peers(),
+        rt.scheduler_outdated(),
+        rt.scheduler_generation(),
     );
     let cluster_service_server = ClusterServiceServer::new(cluster_service);
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -23,15 +23,17 @@ use app::App;
 use runtime_proto::cluster_service_server::ClusterService;
 use runtime_proto::{
     ExpandSecretRequest, ExpandSecretResponse, GetAppDefinitionRequest, GetAppDefinitionResponse,
-    GetSchedulersRequest, GetSchedulersResponse, SchedulerInstance,
+    GetClusterStateRequest, GetClusterStateResponse, SchedulerInstance,
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
 use crate::cluster::SchedulerPeers;
+use crate::cluster::scheduler_registry::SpicepodGeneration;
 
 /// Internal cluster service for scheduler-executor communication.
 pub struct ClusterServiceImpl {
@@ -39,6 +41,10 @@ pub struct ClusterServiceImpl {
     secrets: Arc<RwLock<Secrets>>,
     advertise_address: String,
     scheduler_peers: Arc<RwLock<SchedulerPeers>>,
+    /// Whether this scheduler is outdated (newer generation exists in cluster).
+    outdated: Arc<AtomicBool>,
+    /// Current spicepod generation state.
+    current_generation: Arc<RwLock<SpicepodGeneration>>,
 }
 
 impl ClusterServiceImpl {
@@ -49,12 +55,16 @@ impl ClusterServiceImpl {
         secrets: Arc<RwLock<Secrets>>,
         advertise_address: String,
         scheduler_peers: Arc<RwLock<SchedulerPeers>>,
+        outdated: Arc<AtomicBool>,
+        current_generation: Arc<RwLock<SpicepodGeneration>>,
     ) -> Self {
         Self {
             app,
             secrets,
             advertise_address,
             scheduler_peers,
+            outdated,
+            current_generation,
         }
     }
 }
@@ -71,6 +81,17 @@ impl ClusterService for ClusterServiceImpl {
             request.executor_id
         );
 
+        // If this scheduler is outdated, refuse to serve app definitions
+        if self.outdated.load(Ordering::Relaxed) {
+            tracing::warn!(
+                "Refusing GetAppDefinition for executor {} - scheduler is outdated",
+                request.executor_id
+            );
+            return Err(Status::unavailable(
+                "Scheduler has outdated spicepod configuration. Please retry with another scheduler.",
+            ));
+        }
+
         let app_guard = self.app.read().await;
         let Some(ref app) = *app_guard else {
             return Err(Status::internal("App context not available"));
@@ -79,7 +100,17 @@ impl ClusterService for ClusterServiceImpl {
         let app_json = serde_json::to_string(app.as_ref())
             .map_err(|e| Status::internal(format!("Failed to serialize app: {e}")))?;
 
-        Ok(Response::new(GetAppDefinitionResponse { app_json }))
+        // Get current generation info
+        let gen_state = self.current_generation.read().await;
+        let spicepod_generation = gen_state.generation;
+        let spicepod_content_hash = gen_state.content_hash.clone();
+        drop(gen_state);
+
+        Ok(Response::new(GetAppDefinitionResponse {
+            app_json,
+            spicepod_generation,
+            spicepod_content_hash,
+        }))
     }
 
     async fn expand_secret(
@@ -132,11 +163,11 @@ impl ClusterService for ClusterServiceImpl {
         }))
     }
 
-    async fn get_schedulers(
+    async fn get_cluster_state(
         &self,
-        _request: Request<GetSchedulersRequest>,
-    ) -> Result<Response<GetSchedulersResponse>, Status> {
-        tracing::debug!("ClusterService::get_schedulers request");
+        _request: Request<GetClusterStateRequest>,
+    ) -> Result<Response<GetClusterStateResponse>, Status> {
+        tracing::debug!("ClusterService::get_cluster_state request");
 
         let peers = self.scheduler_peers.read().await;
         let mut schedulers = peers
@@ -159,10 +190,21 @@ impl ClusterService for ClusterServiceImpl {
             .map(|scheduler| scheduler.advertise_address.as_str())
             .collect::<Vec<_>>()
             .join(",");
+
+        // Get current generation info
+        let gen_state = self.current_generation.read().await;
+        let spicepod_generation = gen_state.generation;
+        let spicepod_content_hash = gen_state.content_hash.clone();
+        drop(gen_state);
+
         tracing::debug!(
-            "ClusterService::get_schedulers response schedulers=[{scheduler_addresses}]"
+            "ClusterService::get_cluster_state response schedulers=[{scheduler_addresses}], generation={spicepod_generation}"
         );
 
-        Ok(Response::new(GetSchedulersResponse { schedulers }))
+        Ok(Response::new(GetClusterStateResponse {
+            schedulers,
+            spicepod_generation,
+            spicepod_content_hash,
+        }))
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,6 +25,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Weak;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use token_provider::registry::TokenProviderRegistry;
@@ -75,7 +76,7 @@ use tokio::sync::{RwLock, oneshot::error::RecvError};
 use tokio_util::sync::CancellationToken;
 pub use util::shutdown_signal;
 
-use crate::cluster::SchedulerPeers;
+use crate::cluster::{SchedulerPeers, SpicepodGeneration};
 use crate::extension::Extension;
 use crate::udtfs::ListUDFTableFunc;
 pub mod accelerated_table;
@@ -483,6 +484,11 @@ pub struct Runtime {
 
     schedulers: Arc<ScheduleRegistry>,
     scheduler_peers: Arc<RwLock<SchedulerPeers>>,
+    /// Shared flag indicating this scheduler is outdated (newer generation exists).
+    /// Used to refuse `GetAppDefinition` requests when the scheduler has stale config.
+    scheduler_outdated: Arc<AtomicBool>,
+    /// Shared current spicepod generation state for cluster coordination.
+    scheduler_generation: Arc<RwLock<SpicepodGeneration>>,
 
     resource_monitor: resource_monitor::ResourceMonitor,
 
@@ -575,6 +581,16 @@ impl Runtime {
     #[must_use]
     pub fn scheduler_peers(&self) -> Arc<RwLock<SchedulerPeers>> {
         Arc::clone(&self.scheduler_peers)
+    }
+
+    #[must_use]
+    pub fn scheduler_outdated(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.scheduler_outdated)
+    }
+
+    #[must_use]
+    pub fn scheduler_generation(&self) -> Arc<RwLock<SpicepodGeneration>> {
+        Arc::clone(&self.scheduler_generation)
     }
 
     #[must_use]
@@ -704,6 +720,8 @@ impl Runtime {
                             let registry_shutdown = CancellationToken::new();
                             let registry_shutdown_for_task = registry_shutdown.clone();
                             let peers = self.scheduler_peers();
+                            let outdated = self.scheduler_outdated();
+                            let generation = self.scheduler_generation();
                             let self_ref = Arc::clone(&self);
                             let registry_task = async move {
                                 cluster::start_scheduler_registry(
@@ -711,6 +729,8 @@ impl Runtime {
                                     &config,
                                     registry_shutdown.clone(),
                                     peers,
+                                    outdated,
+                                    generation,
                                 )
                                 .await
                                 .map_err(|err| {


### PR DESCRIPTION
## Summary

Implement generation-based coordination for distributed query mode to handle scheduler re-deployments with updated spicepod configurations.

### Problem
In distributed query cluster mode, when schedulers are re-deployed with an updated `spicepod.yaml`:
1. Executors don't re-fetch the config and are stuck with their local copy until restarted
2. In HA mode with multiple schedulers, during deployment some schedulers have old config, some have new

### Solution
Add generation-based coordination using the existing object store coordination mechanism:

**Scheduler side:**
- Track `(generation_number, content_hash, timestamp)` in `cluster.json`
- Content hash (SHA256) determines if config changed; generation number orders changes
- Outdated schedulers refuse to serve `GetAppDefinition` (return `UNAVAILABLE`)

**Executor side:**
- Store expected generation from initial `GetAppDefinition` response
- Poll `GetClusterState` every 10s (reuses existing scheduler refresh loop)
- On generation mismatch: gracefully drain (60s timeout), then `exit(42)`
- Exit code 42 signals orchestrator to restart executor with new config

### Key Changes
- Add `spicepod_generation` and `spicepod_content_hash` to `cluster.json`
- Rename `GetSchedulers` RPC → `GetClusterState` (includes generation info)
- Add `scheduler_outdated` and `scheduler_generation` fields to `Runtime` struct
- Implement drain and exit logic in executor poll manager

### Testing
- [ ] Manual testing with HA scheduler deployment
- [ ] Verify executor exits with code 42 on config change
- [ ] Verify outdated schedulers return UNAVAILABLE