### PR TITLE
fix: infer executor role from --scheduler-address when --role is omitted

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -248,16 +248,20 @@ pub async fn run(args: Args) -> Result<()> {
         .with_runtime_config(args.runtime.clone())
         .with_io_runtime(Handle::current());
 
+    // Check for explicit cluster role OR implicit executor role (scheduler_address set without explicit role)
+    let is_cluster_mode =
+        args.runtime.cluster.role.is_some() || args.runtime.cluster.scheduler_address.is_some();
+
     match resolved_cluster_config {
         Ok(resolved_cluster_config) => {
             builder = builder.with_resolved_cluster_config(resolved_cluster_config);
         }
-        Err(e) if args.runtime.cluster.role.is_some() => {
-            // If --role was explicitly specified, surface the configuration error
+        Err(e) if is_cluster_mode => {
+            // If cluster mode is intended (explicit --role or implicit via --scheduler-address), surface the error
             return Err(Error::InvalidClusterConfig { source: e });
         }
         Err(_) => {
-            // No explicit role specified, silently continue in standalone mode
+            // No cluster mode specified, silently continue in standalone mode
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where omitting `--role executor` when `--scheduler-address` is provided would start spiced in standalone mode instead of executor mode
- The error handling now checks for both explicit `--role` and implicit executor role (via `--scheduler-address`) to properly surface cluster configuration errors

## Problem

When `--scheduler-address` is provided without `--role`, the intent is to start in executor mode. The `ResolvedClusterConfig::try_new()` correctly identifies this as cluster mode and returns an error if required flags are missing. However, the error handling in `bin/spiced/src/lib.rs` only checked `args.runtime.cluster.role.is_some()`, which would be `false` when only `--scheduler-address` was provided, causing the error to be silently ignored.

## Solution

Added an `is_cluster_mode` check that mirrors the logic in `ResolvedClusterConfig::try_new()`:

\`\`\`rust
let is_cluster_mode = args.runtime.cluster.role.is_some()
    || args.runtime.cluster.scheduler_address.is_some();
\`\`\`

This ensures configuration errors are surfaced when cluster mode is intended via either explicit `--role` or implicit executor role via `--scheduler-address`.