### PR TITLE
Update ballista to add exponential backoff for scheduler disconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=b9b273d45111438116a0496480c425e94f2e9ed8#b9b273d45111438116a0496480c425e94f2e9ed8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2120,11 +2120,12 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=b9b273d45111438116a0496480c425e94f2e9ed8#b9b273d45111438116a0496480c425e94f2e9ed8"
 dependencies = [
  "arrow",
  "arrow-flight",
  "async-trait",
+ "backoff",
  "ballista-core",
  "clap 4.5.54",
  "dashmap",
@@ -2149,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "50.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista?rev=9c17685db62a1511ecf2e90aa72b19feabdea1cb#9c17685db62a1511ecf2e90aa72b19feabdea1cb"
+source = "git+https://github.com/spiceai/datafusion-ballista?rev=b9b273d45111438116a0496480c425e94f2e9ed8#b9b273d45111438116a0496480c425e94f2e9ed8"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,9 +349,9 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "afcbd1ce99703f1322d176fc1b99745f647234d0" } # spiceai:spiceai-50
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" }           # spiceai:spiceai-50
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" }   # spiceai:spiceai-50
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista", rev = "9c17685db62a1511ecf2e90aa72b19feabdea1cb" } # spiceai:spiceai-50
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista", rev = "b9b273d45111438116a0496480c425e94f2e9ed8" }           # spiceai:spiceai-50
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista", rev = "b9b273d45111438116a0496480c425e94f2e9ed8" }   # spiceai:spiceai-50
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista", rev = "b9b273d45111438116a0496480c425e94f2e9ed8" } # spiceai:spiceai-50
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "8477c0ba72bc14e31bf829e0ea9b7b217b6e3e5d" } # spiceai-0.16.0
 


### PR DESCRIPTION
## Summary

- Closes #8589

Updates datafusion-ballista fork to include fix for executor log spam when scheduler disconnects before executor in distributed query cluster mode.

**Problem:**
When the scheduler shuts down before the executor, the executor poll loop logs WARN messages every ~100ms:
```
2025-12-15T23:02:44.486012Z  WARN ballista_executor::execution_loop: Executor poll work loop failed. If this continues to happen the Scheduler might be marked as dead. Error: status: Unavailable, message: "tcp connect error"...
```

**Solution:**
- Exponential backoff (100ms to 30s) using the `backoff` crate
- Log level reduces from WARN to DEBUG after 5 consecutive failures
- Info log when connection is restored

## Related

- Ballista PR: https://github.com/spiceai/datafusion-ballista/pull/6