### PR TITLE
Helm: Allow command override via values.yaml

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: Always
           workingDir: /app
+          {{- if .Values.command }}
+          command: {{ toYaml .Values.command | nindent 12 }}
+          {{- else }}
           command:
             [
               "/usr/local/bin/spiced",
@@ -67,6 +70,7 @@ spec:
               "--flight",
               "0.0.0.0:50051"
             ]
+          {{- end }}
           env:
             {{- if .Values.additionalEnv }}
             {{- .Values.additionalEnv | toYaml | nindent 12 }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -34,6 +34,16 @@ serviceAccount:
 #     cpu: 500m
 #     memory: 1Gi
 
+# Override the default command for spiced
+# command:
+#   - /usr/local/bin/spiced
+#   - --http
+#   - 0.0.0.0:8090
+#   - --metrics
+#   - 0.0.0.0:9090
+#   - --flight
+#   - 0.0.0.0:50051
+
 # Additional environment variables
 # additionalEnv:
 #   - name: ENV_VAR_NAME


### PR DESCRIPTION
## 📝 Summary

Add optional `command` field to values.yaml to override the default spiced startup command. Useful for debugging scenarios

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
