### PR TITLE
Cayenne should warn if unable to parse configuration value

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -303,8 +303,14 @@ fn parse_usize(acceleration: &Acceleration, key: &str, default: usize) -> usize 
     acceleration
         .params
         .get(key)
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(default)
+        .map_or(default, |v| {
+            v.parse::<usize>().unwrap_or_else(|_| {
+                tracing::warn!(
+                    "An invalid '{key}' value was provided: '{v}'. Expected a positive integer, defaulting to {default}. For details, visit: https://spiceai.org/docs/components/data-accelerators/cayenne#configuration"
+                );
+                default
+            })
+        })
 }
 
 /// Returns true if the path is a local filesystem path (not a remote object store).


### PR DESCRIPTION
## 📝 Summary

Currently the following configuration will be ignored w/o any warning/message:


```yaml
params:
          cayenne_footer_cache_mb: 64MiB
          cayenne_segment_cache_mb: 2048MiB
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
