### PR TITLE
Cayenne: fix memory growth due to vortex metrics allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18856,7 +18856,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "fastlanes",
  "rand 0.9.2",
@@ -18894,7 +18894,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -18913,7 +18913,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arcref",
  "arrow-arith",
@@ -18966,7 +18966,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "getrandom 0.3.4",
  "itertools 0.14.0",
@@ -18995,7 +18995,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -19010,7 +19010,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -19024,7 +19024,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -19040,7 +19040,7 @@ dependencies = [
 [[package]]
 name = "vortex-datafusion"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19073,7 +19073,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19088,7 +19088,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19103,7 +19103,7 @@ dependencies = [
 [[package]]
 name = "vortex-dtype"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -19127,7 +19127,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -19141,7 +19141,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -19166,7 +19166,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "async-trait",
  "bytes",
@@ -19209,7 +19209,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -19218,7 +19218,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "async-trait",
  "fsst-rs",
@@ -19235,7 +19235,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "async-compat",
  "async-fs",
@@ -19265,7 +19265,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -19282,7 +19282,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arcref",
  "arrow-buffer",
@@ -19326,7 +19326,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -19336,7 +19336,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "getrandom 0.3.4",
  "parking_lot 0.12.5",
@@ -19347,7 +19347,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "pco",
@@ -19365,7 +19365,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -19374,7 +19374,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -19392,7 +19392,7 @@ dependencies = [
 [[package]]
 name = "vortex-scalar"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-array",
  "bytes",
@@ -19412,7 +19412,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -19437,7 +19437,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19455,7 +19455,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "dashmap",
  "vortex-error",
@@ -19465,7 +19465,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -19482,7 +19482,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.1",
@@ -19491,7 +19491,7 @@ dependencies = [
 [[package]]
 name = "vortex-vector"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "paste",
  "static_assertions",
@@ -19504,7 +19504,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "vortex-array",
@@ -19519,7 +19519,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=96950b8c250e7409bca5cd7cb723e10d9db37785#96950b8c250e7409bca5cd7cb723e10d9db37785"
+source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18856,7 +18856,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "fastlanes",
  "rand 0.9.2",
@@ -18894,7 +18894,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -18913,7 +18913,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arcref",
  "arrow-arith",
@@ -18966,7 +18966,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "getrandom 0.3.4",
  "itertools 0.14.0",
@@ -18995,7 +18995,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -19010,7 +19010,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -19024,7 +19024,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -19040,7 +19040,7 @@ dependencies = [
 [[package]]
 name = "vortex-datafusion"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19073,7 +19073,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19088,7 +19088,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19103,7 +19103,7 @@ dependencies = [
 [[package]]
 name = "vortex-dtype"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -19127,7 +19127,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -19141,7 +19141,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -19166,7 +19166,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -19209,7 +19209,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -19218,7 +19218,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "async-trait",
  "fsst-rs",
@@ -19235,7 +19235,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "async-compat",
  "async-fs",
@@ -19265,7 +19265,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -19282,7 +19282,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arcref",
  "arrow-buffer",
@@ -19326,7 +19326,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -19336,7 +19336,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "getrandom 0.3.4",
  "parking_lot 0.12.5",
@@ -19347,7 +19347,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "pco",
@@ -19365,7 +19365,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -19374,7 +19374,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -19392,7 +19392,7 @@ dependencies = [
 [[package]]
 name = "vortex-scalar"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-array",
  "bytes",
@@ -19412,7 +19412,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -19437,7 +19437,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -19455,7 +19455,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "dashmap",
  "vortex-error",
@@ -19465,7 +19465,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -19482,7 +19482,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.1",
@@ -19491,7 +19491,7 @@ dependencies = [
 [[package]]
 name = "vortex-vector"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "paste",
  "static_assertions",
@@ -19504,7 +19504,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "vortex-array",
@@ -19519,7 +19519,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?rev=02840f35ae85986367a406696a037eb053e47532#02840f35ae85986367a406696a037eb053e47532"
+source = "git+https://github.com/spiceai/vortex?rev=f258e7b427377084f9f1f6c4d5f271be04522c5d#f258e7b427377084f9f1f6c4d5f271be04522c5d"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,11 +296,11 @@ url = "2.5"
 util = { path = "crates/util" }
 uuid = "1"
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
-vortex = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
-vortex-array = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
-vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
-vortex-session = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
-vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
+vortex = { git = "https://github.com/spiceai/vortex", rev = "f258e7b427377084f9f1f6c4d5f271be04522c5d" }
+vortex-array = { git = "https://github.com/spiceai/vortex", rev = "f258e7b427377084f9f1f6c4d5f271be04522c5d" }
+vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "f258e7b427377084f9f1f6c4d5f271be04522c5d" }
+vortex-session = { git = "https://github.com/spiceai/vortex", rev = "f258e7b427377084f9f1f6c4d5f271be04522c5d" }
+vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "f258e7b427377084f9f1f6c4d5f271be04522c5d" }
 x509-certificate = "0.25.0"
 # TODO: Switch to official crate once spice-rs is released
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "0ca5a48dae189bc4297350cba7265e9c6036188b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,11 +296,11 @@ url = "2.5"
 util = { path = "crates/util" }
 uuid = "1"
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
-vortex = { git = "https://github.com/spiceai/vortex", rev = "96950b8c250e7409bca5cd7cb723e10d9db37785" }
-vortex-array = { git = "https://github.com/spiceai/vortex", rev = "96950b8c250e7409bca5cd7cb723e10d9db37785" }
-vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "96950b8c250e7409bca5cd7cb723e10d9db37785" }
-vortex-session = { git = "https://github.com/spiceai/vortex", rev = "96950b8c250e7409bca5cd7cb723e10d9db37785" }
-vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "96950b8c250e7409bca5cd7cb723e10d9db37785" }
+vortex = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
+vortex-array = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
+vortex-datafusion = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
+vortex-session = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
+vortex-utils = { git = "https://github.com/spiceai/vortex", rev = "02840f35ae85986367a406696a037eb053e47532" }
 x509-certificate = "0.25.0"
 # TODO: Switch to official crate once spice-rs is released
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "0ca5a48dae189bc4297350cba7265e9c6036188b" }


### PR DESCRIPTION
## 📝 Summary

Update Vortex version to disable child metric registration in VortexMetrics to prevent unbounded memory growth in long-lived VortexSession instances:
 - https://github.com/spiceai/vortex/pull/10

DataFusion/Spice don't use VortexMetrics.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
