### PR TITLE
Correct MinIO path syntax for spiced download

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -153,9 +153,9 @@ runs:
         else
           features="models"
         fi
-        PLATFORM="${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}"
+        PLATFORM="${{ steps.platform.outputs.os }}_${{ steps.platform.outputs.arch }}"
         EXT="${{ steps.platform.outputs.ext }}"
-        mc cp "spice-minio/artifacts/spiced/${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}}/$SPICED_COMMIT/spiced_${features}_${PLATFORM}.${EXT}" spiced_${features}_${PLATFORM}.${EXT}
+        mc cp "spice-minio/artifacts/spiced/${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}/$SPICED_COMMIT/spiced_${features}_${PLATFORM}.${EXT}" spiced_${features}_${PLATFORM}.${EXT}
         tar -xzf spiced_${features}_${PLATFORM}.${EXT}
         sudo cp ./spiced /usr/local/bin/spiced
 

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -155,7 +155,7 @@ runs:
         fi
         PLATFORM="${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}"
         EXT="${{ steps.platform.outputs.ext }}"
-        mc cp spice-minio/artifacts/spiced/${PLATFORM}/$SPICED_COMMIT/spiced_${features}_${PLATFORM}.${EXT} spiced_${features}_${PLATFORM}.${EXT}
+        mc cp "spice-minio/artifacts/spiced/${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}}/$SPICED_COMMIT/spiced_${features}_${PLATFORM}.${EXT}" spiced_${features}_${PLATFORM}.${EXT}
         tar -xzf spiced_${features}_${PLATFORM}.${EXT}
         sudo cp ./spiced /usr/local/bin/spiced
 


### PR DESCRIPTION
Fix bug introduced in #8909 that causes syntax error in MinIO path for artifact download.

## 📝 Summary
- [build_and_release](https://github.com/spiceai/spiceai/actions/runs/20975348676/job/60288685839#step:27:61) builds with `spice-minio/artifacts/spiced/linux-x86_64`
```
spice-minio/artifacts/spiced/linux-x86_64/f805dff9c0d691f2ad01651ae5492507417730e0/spiced_models_linux_x86_64.tar.gz
```

- [setup_spiced](https://github.com/spiceai/spiceai/actions/runs/20981897553/job/60308562879#step:7:41) has been changed to download from `spice-minio/artifacts/spiced/linux_x86_64`: 
```
PLATFORM="${{ steps.platform.outputs.os }}_${{ steps.platform.outputs.arch }}"
spice-minio/artifacts/spiced/${PLATFORM}/$SPICED_COMMIT/spiced_${features}_${PLATFORM}.${EXT} spiced_${features}_${PLATFORM}.${EXT}
```

