### PR TITLE
Remove setup for cc from integration_models.yml

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -438,9 +438,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Set up cc
-        uses: ./.github/actions/setup-cc
-
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
         with:


### PR DESCRIPTION
Regression in #8909 caused integration_model builds to fail since `setup-cc` does not seem to have `runner.os` set correctly.

`setup-cc` doesn't seem to be needed. Randomly added in #8845
