### PR TITLE
fix(caching): Return cached data directly for unfiltered queries (SELECT *)

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1103,6 +1103,17 @@ impl ExecutionPlan for CachingAccelerationScanExec {
 
         // Execute the accelerator scan
         let accelerator_stream = self.input.execute(partition, Arc::clone(&context))?;
+
+        // When no filters are provided (e.g., SELECT *), return cached data directly
+        // without triggering HTTP requests to the federated source or staleness checks.
+        if self.filters.is_empty() {
+            tracing::debug!(
+                "CachingAccelerationScanExec::execute: No filters for dataset={}, returning accelerator stream directly",
+                self.dataset_name
+            );
+            return Ok(accelerator_stream);
+        }
+
         let schema = accelerator_stream.schema();
         let schema_clone = Arc::clone(&schema);
 

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -912,7 +912,7 @@ async fn test_caching_mode_no_filters() -> Result<(), anyhow::Error> {
                 .await?
                 .limit(0, Some(1))?;
             let empty_batches = df.collect().await?;
-            let empty_row_count: usize = empty_batches.iter().map(|b| b.num_rows()).sum();
+            let empty_row_count: usize = empty_batches.iter().map(arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(empty_row_count, 0, "Empty cache should return no rows");
 
             // Populate the cache with a filtered query

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -868,7 +868,8 @@ async fn test_caching_mode_no_filters() -> Result<(), anyhow::Error> {
                 vec![(
                     "allowed_request_paths".to_string(),
                     "/search/people".to_string(),
-                )]
+                ),
+                 ("request_query_filters".to_string(), "enabled".to_string()),]
                 .into_iter()
                 .collect(),
             ));
@@ -903,7 +904,27 @@ async fn test_caching_mode_no_filters() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&status).await;
 
-            // Query without filters - should still cache based on request metadata
+            // Query empty cache - should return no rows
+            let df = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .limit(0, Some(1))?;
+            let empty_batches = df.collect().await?;
+            let empty_row_count: usize = empty_batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(empty_row_count, 0, "Empty cache should return no rows");
+
+            // Populate the cache with a filtered query
+            let sql = "SELECT * FROM tvmaze WHERE request_path = '/search/people' AND request_query = 'q=test'";
+            let df = status.datafusion().ctx.sql(sql).await?;
+            let initial_batches = df.collect().await?;
+            assert!(
+                !initial_batches.is_empty(),
+                "Should have results from HTTP request"
+            );
+
+            // Query cache again - should now return cached data
             let df = status
                 .datafusion()
                 .ctx


### PR DESCRIPTION
## 📝 Summary

Skip cache freshness validation and HTTP requests when querying accelerated HTTP datasets without filters (e.g., `SELECT *`).

Previously, `SELECT *` on a caching-mode HTTP dataset would:
1. Evaluate freshness across **ALL** cached rows
2. Trigger HTTP request to **base URL** if any row expired
3. If any stale record return only base URL data


Fix: when `filters.is_empty()`, return accelerator stream directly without freshness checks or upstream fetches. This allows browsing all cached records without side effects.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
