### PR TITLE
Change base image from bookworm-slim to trixie-slim

### DIFF
--- a/tools/testoperator/Dockerfile
+++ b/tools/testoperator/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.7
 
-ARG BASE_IMAGE=debian:bookworm-slim
+ARG BASE_IMAGE=debian:trixie-slim
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
## 📝 Summary
Issue with testoperator being built. Needs to upgrade docker. 
```
>>> kubectl logs nutmeg-accelerated-manual-wrxlw -n spiceai-testing
/usr/local/bin/testoperator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/testoperator)
/usr/local/bin/testoperator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/testoperator)
```
