### PR TITLE
Add `BootstrapStatus` + Snapshot bootstrapping parallelization

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -18,7 +18,7 @@ use std::{any::Any, sync::Arc, time::Duration};
 
 use crate::component::dataset::acceleration::{RefreshMode, RefreshOnStartup, ZeroResultsAction};
 use crate::component::dataset::{ReadyState, TimeFormat};
-use crate::dataaccelerator::get_primary_keys_from_constraints;
+use crate::dataaccelerator::{BootstrapStatus, get_primary_keys_from_constraints};
 use crate::datafusion::error::SpiceExternalError;
 use crate::datafusion::is_spice_internal_dataset;
 use crate::federated_table::FederatedTable;
@@ -314,6 +314,7 @@ pub struct Builder {
     caching_stale_while_revalidate_ttl: Option<Duration>,
     caching_stale_if_error: bool,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
+    bootstrap_status: BootstrapStatus,
 }
 
 impl Builder {
@@ -354,6 +355,7 @@ impl Builder {
             caching_stale_while_revalidate_ttl: None,
             caching_stale_if_error: false,
             resource_monitor: None,
+            bootstrap_status: BootstrapStatus::none(),
         }
     }
 
@@ -515,6 +517,12 @@ impl Builder {
     /// Set whether to serve expired data on upstream error in cache mode
     pub fn caching_stale_if_error(&mut self, enabled: bool) -> &mut Self {
         self.caching_stale_if_error = enabled;
+        self
+    }
+
+    /// Set whether the dataset was bootstrapped from a snapshot.
+    pub fn bootstrap_status(&mut self, bootstrap_status: BootstrapStatus) -> &mut Self {
+        self.bootstrap_status = bootstrap_status;
         self
     }
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -653,6 +653,7 @@ impl Builder {
         }
 
         refresher.with_snapshot_creation_config(self.snapshot_creation_config);
+        refresher.set_bootstrap_status(self.bootstrap_status);
 
         if let Some(ref resource_monitor) = self.resource_monitor {
             refresher.with_resource_monitor(resource_monitor.clone());

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -49,6 +49,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{Mutex, Notify};
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
+use crate::dataaccelerator::BootstrapStatus;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -478,6 +479,8 @@ pub struct Refresher {
     /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations
     /// Shared with `CachingAccelerationScanExec`.
     accelerator_write_mutex: Arc<Mutex<()>>,
+    /// The bootstrap status from dataset initialization.
+    bootstrap_status: BootstrapStatus,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -528,6 +531,7 @@ impl Refresher {
             io_runtime,
             resource_monitor: None,
             accelerator_write_mutex,
+            bootstrap_status: BootstrapStatus::none(),
         }
     }
 
@@ -581,6 +585,12 @@ impl Refresher {
         snapshot_config: Option<SnapshotCreationConfig>,
     ) -> &mut Self {
         self.snapshot_config = snapshot_config;
+        self
+    }
+
+    /// Set the bootstrap status from dataset initialization.
+    pub fn set_bootstrap_status(&mut self, bootstrap_status: BootstrapStatus) -> &mut Self {
+        self.bootstrap_status = bootstrap_status;
         self
     }
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -29,6 +29,7 @@ use crate::accelerated_table::snapshots::{
 };
 use crate::component::dataset::TimeFormat;
 use crate::component::dataset::acceleration::{RefreshMode, RefreshOnStartup};
+use crate::dataaccelerator::BootstrapStatus;
 use crate::federated_table::FederatedTable;
 use crate::status;
 use arrow::datatypes::Schema;
@@ -49,7 +50,6 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{Mutex, Notify};
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
-use crate::dataaccelerator::BootstrapStatus;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -312,6 +312,8 @@ pub struct Acceleration {
     pub snapshots_trigger_threshold: Option<String>,
 
     pub snapshots_compaction: SnapshotsCompaction,
+
+    pub snapshots_reset_expiry_on_load: bool,
 }
 
 impl Acceleration {
@@ -412,6 +414,18 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             );
         }
 
+        if acceleration.snapshots_reset_expiry_on_load
+            && engine != Engine::DuckDB
+            && matches!(
+                acceleration.refresh_mode,
+                Some(spicepod_acceleration::RefreshMode::Caching)
+            )
+        {
+            tracing::warn!(
+                "Resetting expiry on load is only supported for DuckDB engine acceleration with caching refresh mode. Ignoring snapshots_reset_expiry_on_load."
+            );
+        }
+
         let disable_federation = parse_is_query_federation_disabled(&mut params)?;
 
         let caching_ttl = parse_caching_ttl(&mut params)?;
@@ -475,6 +489,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             snapshots_trigger: acceleration.snapshots_trigger,
             snapshots_trigger_threshold: acceleration.snapshots_trigger_threshold,
             snapshots_compaction: acceleration.snapshots_compaction,
+            snapshots_reset_expiry_on_load: acceleration.snapshots_reset_expiry_on_load,
         })
     }
 }
@@ -514,6 +529,7 @@ impl Default for Acceleration {
             snapshots_trigger: None,
             snapshots_trigger_threshold: None,
             snapshots_compaction: SnapshotsCompaction::Disabled,
+            snapshots_reset_expiry_on_load: false,
         }
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -48,7 +48,7 @@ use snafu::prelude::*;
 use tokio::sync::OnceCell;
 use url::Url;
 
-use super::{AccelerationSource, DataAccelerator, upsert_dedup};
+use super::{AccelerationSource, BootstrapStatus, DataAccelerator, upsert_dedup};
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode, RefreshMode};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
@@ -1701,7 +1701,7 @@ impl DataAccelerator for CayenneAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         tracing::warn!(
             "Cayenne data accelerator (Alpha) is in preview and should not be used in production."
         );
@@ -1806,7 +1806,7 @@ impl DataAccelerator for CayenneAccelerator {
                 }
             }
 
-            return Ok(());
+            return Ok(BootstrapStatus::none());
         }
 
         // If mode is FileCreate, delete the existing directory and metadata to start fresh
@@ -1867,16 +1867,16 @@ impl DataAccelerator for CayenneAccelerator {
         }
 
         if let Some(acceleration) = source.acceleration() {
-            download_snapshot_if_needed(
+            Ok(download_snapshot_if_needed(
                 acceleration,
                 source,
                 path_buf,
                 AccelerationEngine::Cayenne,
             )
-            .await;
+            .await)
+        } else {
+            Ok(BootstrapStatus::none())
         }
-
-        Ok(())
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{AccelerationSource, DataAccelerator};
+use super::{AccelerationSource, BootstrapStatus, DataAccelerator};
 use crate::{
     App, Runtime,
     component::{
@@ -341,9 +341,9 @@ impl DataAccelerator for DuckDBAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         if !source.is_file_accelerated() {
-            return Ok(());
+            return Ok(BootstrapStatus::none());
         }
 
         let path = self.file_path(source)?;
@@ -384,7 +384,7 @@ impl DataAccelerator for DuckDBAccelerator {
                 }
             }
 
-            download_snapshot_if_needed(
+            let was_bootstrapped = download_snapshot_if_needed(
                 acceleration,
                 source,
                 PathBuf::from(path),
@@ -393,9 +393,11 @@ impl DataAccelerator for DuckDBAccelerator {
             .await;
 
             self.get_shared_pool(source).await?;
+
+            return Ok(was_bootstrapped);
         }
 
-        Ok(())
+        Ok(BootstrapStatus::none())
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -371,11 +371,13 @@ pub trait DataAccelerator: Send + Sync {
     fn parameters(&self) -> &'static [ParameterSpec];
 
     /// Initialize the accelerator for a component
+    /// Returns `WasBootstrapped::yes()` if the accelerator was initialized from existing data,
+    /// `WasBootstrapped::no()` otherwise.
     async fn init(
         &self,
         _source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        Ok(())
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(BootstrapStatus::none())
     }
 
     /// Check if the accelerator is initialized for a component
@@ -654,6 +656,31 @@ async fn get_registered_accelerator(
         .accelerator_engine_registry()
         .get_accelerator_engine(engine)
         .await
+}
+
+/// Indicates whether a data accelerator was bootstrapped (initialized from existing data)
+/// during initialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapStatus {
+    Bootstrapped,
+    None,
+}
+
+impl BootstrapStatus {
+    #[must_use]
+    pub const fn bootstrapped() -> Self {
+        Self::Bootstrapped
+    }
+
+    #[must_use]
+    pub const fn none() -> Self {
+        Self::None
+    }
+
+    #[must_use]
+    pub fn is_bootstrapped(&self) -> bool {
+        matches!(self, BootstrapStatus::Bootstrapped)
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -52,7 +52,7 @@ use snafu::{OptionExt, prelude::*};
 use tokio::{fs::create_dir_all, sync::Mutex};
 
 use super::{
-    AccelerationSource, DataAccelerator,
+    AccelerationSource, BootstrapStatus, DataAccelerator,
     duckdb::{DuckDBAccelerator, create_table_provider, settings::OrderByNonIntegerLiteral},
 };
 use crate::{
@@ -269,14 +269,14 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(acceleration_settings) = source.acceleration() {
             ensure!(
                 matches!(acceleration_settings.mode, Mode::File),
                 FileModeOnlySnafu
             );
         }
-        Ok(())
+        Ok(BootstrapStatus::none())
     }
 
     async fn create_external_table(

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -51,6 +51,7 @@ use runtime_table_partition::{
 };
 use snafu::{OptionExt, prelude::*};
 
+use crate::dataaccelerator::BootstrapStatus;
 use crate::{
     component::dataset::acceleration::{Engine, Mode},
     dataaccelerator::{
@@ -143,7 +144,7 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(acceleration_settings) = source.acceleration() {
             ensure!(
                 matches!(acceleration_settings.mode, Mode::File),
@@ -176,7 +177,7 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
             }
             self.get_shared_pool(source).await?;
         }
-        Ok(())
+        Ok(BootstrapStatus::none())
     }
 
     async fn create_external_table(

--- a/crates/runtime/src/dataaccelerator/snapshots.rs
+++ b/crates/runtime/src/dataaccelerator/snapshots.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Instant};
 
+use crate::dataaccelerator::BootstrapStatus;
 use crate::{
     component::dataset::acceleration::Acceleration,
     dataaccelerator::{
@@ -35,9 +36,9 @@ pub(super) async fn download_snapshot_if_needed(
     source: &dyn AccelerationSource,
     path: PathBuf,
     engine: AccelerationEngine,
-) {
+) -> BootstrapStatus {
     if !acceleration.snapshot_behavior.bootstrap_enabled() {
-        return;
+        return BootstrapStatus::none();
     }
 
     if path.exists() {
@@ -45,7 +46,7 @@ pub(super) async fn download_snapshot_if_needed(
             "Acceleration already exists at {}, skipping snapshot download",
             path.display()
         );
-        return;
+        return BootstrapStatus::none();
     }
 
     let dataset_name = source.name().to_string();
@@ -88,12 +89,16 @@ pub(super) async fn download_snapshot_if_needed(
                     bytes_downloaded,
                     &checksum,
                 );
+                BootstrapStatus::bootstrapped()
             }
-            Ok(None) => {}
+            Ok(None) => BootstrapStatus::none(),
             Err(e) => {
                 tracing::error!("Failed to download snapshot: {}", e);
+                BootstrapStatus::none()
             }
         }
+    } else {
+        BootstrapStatus::none()
     }
 }
 

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -40,7 +40,7 @@ use rusqlite::ffi::{sqlite3_auto_extension, sqlite3_decimal_init};
 use snafu::prelude::*;
 use std::{any::Any, ffi::OsStr, os::raw::c_char, path::PathBuf, time::Duration};
 
-use super::{AccelerationSource, DataAccelerator, upsert_dedup};
+use super::{AccelerationSource, BootstrapStatus, DataAccelerator, upsert_dedup};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -230,9 +230,9 @@ impl DataAccelerator for SqliteAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         if !source.is_file_accelerated() {
-            return Ok(());
+            return Ok(BootstrapStatus::none());
         }
 
         let path = self.file_path(source)?;
@@ -272,7 +272,7 @@ impl DataAccelerator for SqliteAccelerator {
                 }
             }
 
-            download_snapshot_if_needed(
+            let was_bootstrapped = download_snapshot_if_needed(
                 acceleration,
                 source,
                 PathBuf::from(path),
@@ -281,9 +281,11 @@ impl DataAccelerator for SqliteAccelerator {
             .await;
 
             self.get_shared_pool(source).await?;
+
+            return Ok(was_bootstrapped);
         }
 
-        Ok(())
+        Ok(BootstrapStatus::none())
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -62,7 +62,7 @@ use crate::{
     register_data_accelerator, spice_data_base_path,
 };
 
-use super::{AccelerationSource, DataAccelerator, upsert_dedup};
+use super::{AccelerationSource, BootstrapStatus, DataAccelerator, upsert_dedup};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -441,7 +441,7 @@ impl DataAccelerator for TursoAccelerator {
     async fn init(
         &self,
         source: &dyn AccelerationSource,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<BootstrapStatus, Box<dyn std::error::Error + Send + Sync>> {
         // Reject remote database configurations (not supported as accelerators)
         // Note: This is an accelerator-specific limitation. Remote databases will be
         // supported when Turso is used as a data connector.
@@ -459,7 +459,7 @@ impl DataAccelerator for TursoAccelerator {
             // Initialize the shared pool to verify connectivity
             let pool = self.get_shared_pool(source).await?;
             pool.connect().await?;
-            return Ok(());
+            return Ok(BootstrapStatus::none());
         }
 
         // Handle file mode: validate path and setup file-based database
@@ -498,7 +498,7 @@ impl DataAccelerator for TursoAccelerator {
                 }
             }
 
-            download_snapshot_if_needed(
+            let was_bootstrapped = download_snapshot_if_needed(
                 acceleration,
                 source,
                 PathBuf::from(path),
@@ -509,9 +509,11 @@ impl DataAccelerator for TursoAccelerator {
             // Initialize the database file using the shared pool
             let pool = self.get_shared_pool(source).await?;
             pool.connect().await?;
+
+            return Ok(was_bootstrapped);
         }
 
-        Ok(())
+        Ok(BootstrapStatus::none())
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -31,7 +31,7 @@ use crate::component::dataset::{Dataset, ReadyState};
 use crate::component::view::View;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
-use crate::dataaccelerator::{self};
+use crate::dataaccelerator::{self, BootstrapStatus};
 use crate::dataaccelerator::{AcceleratorEngineRegistry, acceleration_file_path};
 use crate::dataconnector::deferred::DeferredConnector;
 use crate::dataconnector::localpod::LOCALPOD_DATACONNECTOR;
@@ -350,6 +350,7 @@ pub enum Table {
         federated_read_table: FederatedTable,
         accelerated_table: Option<Arc<AcceleratedTable>>,
         secrets: Arc<TokioRwLock<Secrets>>,
+        bootstrap_status: BootstrapStatus,
     },
     Federated {
         data_connector: Arc<dyn DataConnector>,
@@ -542,6 +543,7 @@ impl DataFusion {
                 federated_read_table,
                 accelerated_table,
                 secrets,
+                bootstrap_status,
             } => {
                 if let Some(accelerated_table) = accelerated_table {
                     tracing::debug!(
@@ -569,8 +571,14 @@ impl DataFusion {
                         });
                     None
                 } else {
-                    self.register_accelerated_table(dataset, source, federated_read_table, secrets)
-                        .await?
+                    self.register_accelerated_table(
+                        dataset,
+                        source,
+                        federated_read_table,
+                        secrets,
+                        bootstrap_status,
+                    )
+                    .await?
                 }
             }
             Table::Federated {
@@ -806,6 +814,7 @@ impl DataFusion {
             sink_connector,
             federated_table,
             Arc::clone(&pending_registration.secrets),
+            BootstrapStatus::None, // Sink datasets don't bootstrap from snapshots
         )
         .await?;
 
@@ -1007,6 +1016,7 @@ impl DataFusion {
         source: Arc<dyn DataConnector>,
         federated_read_table: FederatedTable,
         secrets: Arc<TokioRwLock<Secrets>>,
+        bootstrap_status: BootstrapStatus,
     ) -> Result<AcceleratedTable> {
         tracing::trace!("Creating accelerated table {dataset:?}");
 
@@ -1330,6 +1340,8 @@ impl DataFusion {
             accelerated_table_builder.write_to_accelerator_only();
         }
 
+        accelerated_table_builder.bootstrap_status(bootstrap_status);
+
         accelerated_table_builder
             .build()
             .await
@@ -1422,9 +1434,16 @@ impl DataFusion {
         source: Arc<dyn DataConnector>,
         federated_read_table: FederatedTable,
         secrets: Arc<TokioRwLock<Secrets>>,
+        bootstrap_status: BootstrapStatus,
     ) -> Result<Option<Arc<Notify>>> {
         let mut accelerated_table = self
-            .create_accelerated_table(&dataset, Arc::clone(&source), federated_read_table, secrets)
+            .create_accelerated_table(
+                &dataset,
+                Arc::clone(&source),
+                federated_read_table,
+                secrets,
+                bootstrap_status,
+            )
             .await?;
         let notifier = accelerated_table.refresher().on_complete_notification();
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
+use crate::dataaccelerator::BootstrapStatus;
 use crate::{
     AcceleratedReadWriteTableWithoutReplicationSnafu, AcceleratedTableInvalidChangesSnafu,
     AcceleratorEngineNotAvailableSnafu, AcceleratorInitializationFailedSnafu, Error,
@@ -77,30 +78,42 @@ impl Runtime {
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
 
-        let initialized_datasets = self.initialize_datasets_accelerators(&valid_datasets).await;
+        let init_results = self.initialize_datasets_accelerators(&valid_datasets).await;
         // Create a map of dataset names to their futures
         let mut dataset_futures = HashMap::new();
         let mut localpod_datasets = Vec::new();
 
         // First create futures for non-localpod datasets
-        for ds in initialized_datasets {
+        for ds in &valid_datasets {
+            let bootstrap_status = match init_results.get(&ds.name) {
+                Some(Ok(status)) => *status,
+                Some(Err(_)) => {
+                    // Error already logged in initialize_datasets_accelerators
+                    continue;
+                }
+                None => {
+                    tracing::error!("Dataset {} missing from initialization results", ds.name);
+                    continue;
+                }
+            };
+
             if ds.source() == LOCALPOD_DATACONNECTOR {
-                localpod_datasets.push(ds);
+                localpod_datasets.push((Arc::clone(ds), bootstrap_status));
                 continue;
             }
 
             self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-            let ds_clone = Arc::clone(&ds);
+            let ds_clone = Arc::clone(ds);
             let cloned_self = Arc::clone(&self);
             let future: Pin<Box<dyn Future<Output = ()> + Send>> =
-                Box::pin(async move { cloned_self.load_dataset(ds_clone).await })
+                Box::pin(async move { cloned_self.load_dataset(ds_clone, bootstrap_status).await })
                     as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);
         }
 
         // For each localpod dataset, chain it after its parent's future
-        for ds in localpod_datasets {
+        for (ds, bootstrap_status) in localpod_datasets {
             self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
 
@@ -111,12 +124,11 @@ impl Runtime {
             // Find and remove the parent dataset's future
             if let Some(parent_future) = dataset_futures.remove(&path_table_ref) {
                 let ds_clone = Arc::clone(&ds);
-
                 let cloned_self = Arc::clone(&self);
                 // Chain the localpod dataset load after its parent
                 let chained_future = Box::pin(async move {
                     parent_future.await;
-                    cloned_self.load_dataset(ds_clone).await;
+                    cloned_self.load_dataset(ds_clone, bootstrap_status).await;
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>;
 
                 // Replace parent future with the chained future
@@ -250,7 +262,7 @@ impl Runtime {
     }
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
-    async fn load_dataset(self: Arc<Self>, ds: Arc<Dataset>) {
+    async fn load_dataset(self: Arc<Self>, ds: Arc<Dataset>, bootstrap_status: BootstrapStatus) {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
         if let Err(err) = validate_dataset(&ds) {
@@ -288,7 +300,7 @@ impl Runtime {
             };
 
             if let Err(err) = Arc::clone(&runtime)
-                .register_loaded_dataset(Arc::clone(&ds), connector, None)
+                .register_loaded_dataset(Arc::clone(&ds), connector, None, bootstrap_status)
                 .await
             {
                 if runtime.status.is_shutdown() {
@@ -308,6 +320,7 @@ impl Runtime {
         ds: Arc<Dataset>,
         data_connector: Arc<dyn DataConnector>,
         accelerated_table: Option<Arc<AcceleratedTable>>,
+        bootstrap_status: BootstrapStatus,
     ) -> Result<()> {
         let source = ds.source();
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
@@ -366,6 +379,7 @@ impl Runtime {
                     federated_read_table: federated_table,
                     source: source.to_string(),
                     accelerated_table,
+                    bootstrap_status,
                 },
             )
             .await
@@ -502,7 +516,12 @@ impl Runtime {
                     .await;
 
                 if Arc::clone(&self)
-                    .register_loaded_dataset(Arc::clone(&ds), Arc::clone(&connector), None)
+                    .register_loaded_dataset(
+                        Arc::clone(&ds),
+                        Arc::clone(&connector),
+                        None,
+                        BootstrapStatus::None,
+                    )
                     .await
                     .is_err()
                 {
@@ -574,6 +593,7 @@ impl Runtime {
                     Arc::clone(&connector),
                     federated_table,
                     self.secrets(),
+                    BootstrapStatus::None,
                 )
                 .await
                 .context(UnableToCreateAcceleratedTableSnafu {
@@ -595,8 +615,14 @@ impl Runtime {
 
         tracing::debug!("Accelerated table for dataset {} is ready", ds.name);
 
-        self.register_loaded_dataset(ds, Arc::clone(&connector), Some(accelerated_table))
-            .await?;
+        // Hot reload doesn't bootstrap from snapshot
+        self.register_loaded_dataset(
+            ds,
+            Arc::clone(&connector),
+            Some(accelerated_table),
+            BootstrapStatus::None,
+        )
+        .await?;
 
         Ok(())
     }
@@ -660,6 +686,7 @@ impl Runtime {
             federated_read_table,
             source,
             accelerated_table,
+            bootstrap_status,
         } = register_dataset_ctx;
 
         let replicate = ds.replication.as_ref().is_some_and(|r| r.enabled);
@@ -729,6 +756,7 @@ impl Runtime {
                     federated_read_table,
                     accelerated_table,
                     secrets: self.secrets(),
+                    bootstrap_status,
                 },
             )
             .await
@@ -759,18 +787,32 @@ impl Runtime {
         new_app: &Arc<App>,
     ) {
         let valid_datasets = Arc::clone(&self).get_valid_datasets(new_app, LogErrors(true));
-        let initialized_datasets = self.initialize_datasets_accelerators(&valid_datasets).await;
+        let init_results = self.initialize_datasets_accelerators(&valid_datasets).await;
         let existing_datasets = Arc::clone(&self).get_valid_datasets(current_app, LogErrors(false));
 
-        for ds in initialized_datasets {
+        for ds in &valid_datasets {
+            let bootstrap_status = match init_results.get(&ds.name) {
+                Some(Ok(status)) => *status,
+                Some(Err(_)) => {
+                    // Error already logged in initialize_datasets_accelerators
+                    continue;
+                }
+                None => {
+                    tracing::error!("Dataset {} missing from initialization results", ds.name);
+                    continue;
+                }
+            };
+
             if let Some(current_ds) = existing_datasets.iter().find(|d| d.name == ds.name) {
-                if ds != *current_ds {
-                    Arc::clone(&self).update_dataset(ds).await;
+                if ds != current_ds {
+                    Arc::clone(&self).update_dataset(Arc::clone(ds)).await;
                 }
             } else {
                 self.status
                     .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                Arc::clone(&self).load_dataset(ds).await;
+                Arc::clone(&self)
+                    .load_dataset(Arc::clone(ds), bootstrap_status)
+                    .await;
             }
         }
 
@@ -814,67 +856,75 @@ impl Runtime {
     /// Initialize datasets configured with accelerators before registering the datasets.
     /// This ensures that the required resources for acceleration are available before registration,
     /// which is important for acceleration federation for some acceleration engines (e.g. `SQLite`).
+    /// Returns a `HashMap` mapping each dataset name to its initialization result, which contains
+    /// the `BootstrapStatus` on success or an error on failure.
     async fn initialize_datasets_accelerators(
         &self,
         datasets: &[Arc<Dataset>],
-    ) -> Vec<Arc<Dataset>> {
+    ) -> HashMap<TableReference, Result<BootstrapStatus>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
-        let mut initialized_datasets = vec![];
-        for ds in datasets {
-            // Non-accelerated datasets or disabled acceleration are always successfully initialized
-            if ds.acceleration.as_ref().is_none_or(|acc| !acc.enabled) {
-                initialized_datasets.push(Arc::clone(ds));
-                continue;
+        let init_futures = datasets.iter().map(|ds| {
+            let ds = Arc::clone(ds);
+            let spaced_tracer = Arc::clone(&spaced_tracer);
+            let status = Arc::clone(&self.status);
+            let accelerator_engine_registry = Arc::clone(&self.accelerator_engine_registry);
+
+            async move {
+                // Non-accelerated datasets or disabled acceleration are always successfully initialized
+                if ds.acceleration.as_ref().is_none_or(|acc| !acc.enabled) {
+                    return (ds.name.clone(), Ok(BootstrapStatus::None));
+                }
+
+                let Some(acceleration_settings) = &ds.acceleration else {
+                    unreachable!("acceleration is Some and enabled");
+                };
+
+                let accelerator = match accelerator_engine_registry
+                    .get_accelerator_engine(acceleration_settings.engine)
+                    .await
+                    .context(AcceleratorEngineNotAvailableSnafu {
+                        name: acceleration_settings.engine.to_string(),
+                    }) {
+                    Ok(accelerator) => accelerator,
+                    Err(err) => {
+                        let ds_name = &ds.name;
+                        status.update_dataset(ds_name, status::ComponentStatus::Error);
+                        metrics::datasets::LOAD_ERROR.add(1, &[]);
+                        warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
+                        return (ds.name.clone(), Err(err));
+                    }
+                };
+
+                match accelerator.init(ds.as_ref()).await.context(
+                    AcceleratorInitializationFailedSnafu {
+                        name: acceleration_settings.engine.to_string(),
+                    },
+                ) {
+                    Ok(bootstrap_status) => (ds.name.clone(), Ok(bootstrap_status)),
+                    Err(err) => {
+                        let ds_name = &ds.name;
+                        status.update_dataset(ds_name, status::ComponentStatus::Error);
+                        metrics::datasets::LOAD_ERROR.add(1, &[]);
+                        warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
+                        (ds.name.clone(), Err(err))
+                    }
+                }
             }
+        });
 
-            let Some(acceleration_settings) = &ds.acceleration else {
-                unreachable!("acceleration is Some and enabled");
-            };
+        let results = join_all(init_futures).await;
+        let init_results: HashMap<TableReference, Result<BootstrapStatus>> =
+            results.into_iter().collect();
 
-            let accelerator = match self
-                .accelerator_engine_registry
-                .get_accelerator_engine(acceleration_settings.engine)
-                .await
-                .context(AcceleratorEngineNotAvailableSnafu {
-                    name: acceleration_settings.engine.to_string(),
-                }) {
-                Ok(accelerator) => accelerator,
-                Err(err) => {
-                    let ds_name = &ds.name;
-                    self.status
-                        .update_dataset(ds_name, status::ComponentStatus::Error);
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
-                    continue;
-                }
-            };
-
-            match accelerator.init(ds.as_ref()).await.context(
-                AcceleratorInitializationFailedSnafu {
-                    name: acceleration_settings.engine.to_string(),
-                },
-            ) {
-                Ok(()) => {
-                    initialized_datasets.push(Arc::clone(ds));
-                }
-                Err(err) => {
-                    let ds_name = &ds.name;
-                    self.status
-                        .update_dataset(ds_name, status::ComponentStatus::Error);
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
-                }
-            }
-        }
-
-        let snapshot_sources: Vec<Arc<dyn AccelerationSource>> = initialized_datasets
+        let initialized_datasets: Vec<Arc<dyn AccelerationSource>> = datasets
             .iter()
+            .filter(|ds| init_results.get(&ds.name).is_some_and(Result::is_ok))
             .map(|ds| ds.clone_arc())
             .collect();
-        validate_snapshot_paths(snapshot_sources).await;
+        validate_snapshot_paths(initialized_datasets).await;
 
-        initialized_datasets
+        init_results
     }
 
     /// Returns a list of valid datasets from the given App, skipping any that fail to parse and logging an error for them.
@@ -910,6 +960,7 @@ pub struct RegisterDatasetContext {
     federated_read_table: FederatedTable,
     source: String,
     accelerated_table: Option<Arc<AcceleratedTable>>,
+    bootstrap_status: BootstrapStatus,
 }
 
 #[expect(clippy::result_large_err)]

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -273,7 +273,7 @@ impl Runtime {
                     name: acceleration_settings.engine.to_string(),
                 },
             ) {
-                Ok(()) => {
+                Ok(_) => {
                     // Initialization successful, continue to next view
                 }
                 Err(err) => {

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -304,6 +304,9 @@ pub struct Acceleration {
 
     #[serde(default, skip_serializing_if = "is_default_snapshot_compaction")]
     pub snapshots_compaction: SnapshotsCompaction,
+
+    #[serde(default = "default_false")]
+    pub snapshots_reset_expiry_on_load: bool,
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
@@ -313,6 +316,9 @@ fn is_false(b: &bool) -> bool {
 
 const fn default_true() -> bool {
     true
+}
+const fn default_false() -> bool {
+    false
 }
 
 impl Default for Acceleration {
@@ -349,6 +355,7 @@ impl Default for Acceleration {
             snapshots_trigger: None,
             snapshots_trigger_threshold: None,
             snapshots_compaction: SnapshotsCompaction::Disabled,
+            snapshots_reset_expiry_on_load: false,
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

1. Adds `BootstrapStatus` propagated from `download_snapshot_if_needed` to `Refresher`
2. Initialize snapshots in parallel instead of sequentially for improved performance