### PR TITLE
fix: add missing feature-gate for AWS Secrets Manager error variant

### DIFF
--- a/crates/runtime-secrets/src/lib.rs
+++ b/crates/runtime-secrets/src/lib.rs
@@ -35,6 +35,7 @@ pub enum Error {
     #[snafu(display("Unable to load secrets: {source}"))]
     UnableToLoadSecrets { source: Box<dyn std::error::Error> },
 
+    #[cfg(feature = "aws-secrets-manager")]
     #[snafu(display("Unable to initialize AWS Secrets Manager: {source}"))]
     UnableToInitializeAwsSecretsManager {
         source: Box<stores::aws_secrets_manager::Error>,


### PR DESCRIPTION
## 📝 Summary

The `runtime-secrets` crate was unconditionally depending on `aws_secrets_manager`, even when the feature was disabled - which caused compile errors when compiling without default dependencies.
