### PR TITLE
refactor: make ConnectorParams fields public for external connectors

### DIFF
--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -44,7 +44,7 @@ use datafusion::prelude::ident;
 use datafusion::sql::TableReference;
 use datafusion::sql::unparser::Unparser;
 use linkme::distributed_slice;
-use parameters::ConnectorParams;
+pub use parameters::ConnectorParams;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;

--- a/crates/runtime/src/dataconnector/parameters.rs
+++ b/crates/runtime/src/dataconnector/parameters.rs
@@ -43,12 +43,12 @@ pub(crate) trait Validator {
 
 #[derive(Clone)]
 pub struct ConnectorParams {
-    pub(crate) parameters: Parameters,
-    pub(crate) unsupported_type_action: Option<UnsupportedTypeAction>,
-    pub(crate) component: ConnectorComponent,
-    pub(crate) app: Option<Arc<App>>,
-    pub(crate) runtime: Option<Arc<Runtime>>,
-    pub(crate) io_runtime: Handle,
+    pub parameters: Parameters,
+    pub unsupported_type_action: Option<UnsupportedTypeAction>,
+    pub component: ConnectorComponent,
+    pub app: Option<Arc<App>>,
+    pub runtime: Option<Arc<Runtime>>,
+    pub io_runtime: Handle,
 }
 
 pub struct ConnectorParamsBuilder {


### PR DESCRIPTION
## 📝 Summary

Makes the ConnectorParams public so that data connectors can be moved outside of the core runtime crate.
