### PR TITLE
fix(caching): Fix HTTP caching always MISS when projection excludes fetched_at

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -103,7 +103,10 @@ fn check_cache_freshness(
     let schema = batches[0].schema();
     if schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_none() {
         // No metadata column means data was never refreshed in cache mode - treat as expired
-        tracing::debug!("check_cache_freshness: no {} column, returning Expired", CACHE_REFRESHED_AT_COLUMN);
+        tracing::debug!(
+            "check_cache_freshness: no {} column, returning Expired",
+            CACHE_REFRESHED_AT_COLUMN
+        );
         return Ok(CacheFreshness::Expired);
     }
 
@@ -149,7 +152,9 @@ fn check_cache_freshness(
         for i in 0..ts_array.len() {
             if !ts_array.is_valid(i) {
                 // Null value = expired, return immediately (can't get worse)
-                tracing::debug!("check_cache_freshness: NULL timestamp at index {i}, returning Expired");
+                tracing::debug!(
+                    "check_cache_freshness: NULL timestamp at index {i}, returning Expired"
+                );
                 return Ok(CacheFreshness::Expired);
             }
             let ts = ts_array.value(i);
@@ -1867,7 +1872,7 @@ mod tests {
         );
     }
 
-        #[test]
+    #[test]
     fn test_check_cache_freshness_without_fetched_at_column() {
         // Test that batches without fetched_at column are treated as expired
         let schema = create_test_schema_without_refresh_timestamp();
@@ -1881,9 +1886,9 @@ mod tests {
         .expect("Failed to create batch");
 
         let max_age = Duration::from_secs(60);
-        let freshness = check_cache_freshness(&[batch], max_age, None)
-            .expect("Should check freshness");
-        
+        let freshness =
+            check_cache_freshness(&[batch], max_age, None).expect("Should check freshness");
+
         assert_eq!(
             freshness,
             CacheFreshness::Expired,
@@ -1910,9 +1915,9 @@ mod tests {
         .expect("Failed to create batch");
 
         let max_age = Duration::from_secs(60);
-        let freshness = check_cache_freshness(&[batch], max_age, None)
-            .expect("Should check freshness");
-        
+        let freshness =
+            check_cache_freshness(&[batch], max_age, None).expect("Should check freshness");
+
         assert_eq!(
             freshness,
             CacheFreshness::Expired,

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -89,6 +89,12 @@ fn check_cache_freshness(
     max_age: Duration,
     stale_while_revalidate: Option<Duration>,
 ) -> DataFusionResult<CacheFreshness> {
+    tracing::trace!(
+        "check_cache_freshness CALLED: num_batches={}, max_age={:?}, swr={:?}",
+        batches.len(),
+        max_age,
+        stale_while_revalidate
+    );
     if batches.is_empty() {
         return Ok(CacheFreshness::Fresh); // No data means nothing to check
     }
@@ -97,6 +103,7 @@ fn check_cache_freshness(
     let schema = batches[0].schema();
     if schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_none() {
         // No metadata column means data was never refreshed in cache mode - treat as expired
+        tracing::debug!("check_cache_freshness: no {} column, returning Expired", CACHE_REFRESHED_AT_COLUMN);
         return Ok(CacheFreshness::Expired);
     }
 
@@ -142,6 +149,7 @@ fn check_cache_freshness(
         for i in 0..ts_array.len() {
             if !ts_array.is_valid(i) {
                 // Null value = expired, return immediately (can't get worse)
+                tracing::debug!("check_cache_freshness: NULL timestamp at index {i}, returning Expired");
                 return Ok(CacheFreshness::Expired);
             }
             let ts = ts_array.value(i);
@@ -1189,9 +1197,10 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                 // Check if data is expired (past max_age + stale_while_revalidate)
                 // If expired, treat as cache miss with is_expired=true (will upsert)
                 if let Some(max_age) = max_age {
-                    let freshness =
-                        check_cache_freshness(&cached_batches, max_age, stale_while_revalidate)
-                            .unwrap_or(CacheFreshness::Expired);
+                    let freshness = check_cache_freshness(&cached_batches, max_age, stale_while_revalidate).unwrap_or_else(|e| {
+                        tracing::warn!("Failed to check cache data freshness for dataset={dataset_name}: {e}, treating as Expired");
+                        CacheFreshness::Expired
+                    });
 
                     if freshness == CacheFreshness::Expired {
                         tracing::debug!(
@@ -1855,6 +1864,59 @@ mod tests {
             filter_sets.len(),
             2,
             "Should deduplicate 5 identical rows + 1 different row into 2 filter sets"
+        );
+    }
+
+        #[test]
+    fn test_check_cache_freshness_without_fetched_at_column() {
+        // Test that batches without fetched_at column are treated as expired
+        let schema = create_test_schema_without_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1, 2]);
+        let name_array = StringArray::from(vec![Some("Alice"), Some("Bob")]);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(id_array), Arc::new(name_array)],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let freshness = check_cache_freshness(&[batch], max_age, None)
+            .expect("Should check freshness");
+        
+        assert_eq!(
+            freshness,
+            CacheFreshness::Expired,
+            "Batches without fetched_at column should be expired"
+        );
+    }
+
+    #[test]
+    fn test_check_cache_freshness_with_null_timestamp() {
+        // Test that batches with NULL fetched_at are treated as expired
+        let schema = create_test_schema_with_refresh_timestamp();
+        let id_array = Int32Array::from(vec![1]);
+        let name_array = StringArray::from(vec![Some("Alice")]);
+        let refresh_timestamps = TimestampNanosecondArray::from(vec![None]); // NULL timestamp
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(id_array),
+                Arc::new(name_array),
+                Arc::new(refresh_timestamps),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let max_age = Duration::from_secs(60);
+        let freshness = check_cache_freshness(&[batch], max_age, None)
+            .expect("Should check freshness");
+        
+        assert_eq!(
+            freshness,
+            CacheFreshness::Expired,
+            "Batches with NULL fetched_at should be expired"
         );
     }
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -33,9 +33,7 @@ use datafusion::common::Constraints;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::logical_expr::dml::InsertOp;
-use datafusion::physical_expr::{PhysicalExpr, expressions::Column};
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::sql::TableReference;
 use datafusion::{
@@ -969,7 +967,8 @@ impl TableProvider for AcceleratedTable {
         }
 
         // For caching mode, extend projection to include fetched_at for freshness checking if needed.
-        // If added internally, we'll strip it from results before returning to the user.
+        // Added columns will be automatically stripped by `SchemaCastScanExec`, similar to
+        // fallback-to-source on cache miss where results return all columns.
         let extended_projection = if is_caching_mode {
             extend_projection_for_caching(projection, &self.accelerator.schema())
         } else {
@@ -1000,31 +999,22 @@ impl TableProvider for AcceleratedTable {
                 };
 
                 let federated_provider = self.federated.table_provider().await;
-                let caching_exec: Arc<dyn ExecutionPlan> =
-                    Arc::new(caching::CachingAccelerationScanExec::new(
-                        input,
-                        self.cache_ttl,
-                        self.cache_stale_while_revalidate_ttl,
-                        self.cache_stale_if_error,
-                        federated_provider,
-                        Arc::clone(&self.accelerator),
-                        self.dataset_name.to_string(),
-                        self.io_runtime.clone(),
-                        filters.to_vec(),
-                        projection.cloned(),
-                        limit,
-                        Arc::clone(&self.accelerator_write_mutex),
-                        Arc::clone(&self.in_flight_revalidations),
-                        Arc::clone(&self.synchronized_children),
-                    ));
-
-                // If we extended projection to add fetched_at, strip it from results
-                if let (true, Some(proj)) = (extended_projection.is_some(), projection) {
-                    // extended_projection is Some only when projection is Some and didn't already include fetched_at (was modified)
-                    apply_projection(caching_exec, proj)?
-                } else {
-                    caching_exec
-                }
+                Arc::new(caching::CachingAccelerationScanExec::new(
+                    input,
+                    self.cache_ttl,
+                    self.cache_stale_while_revalidate_ttl,
+                    self.cache_stale_if_error,
+                    federated_provider,
+                    Arc::clone(&self.accelerator),
+                    self.dataset_name.to_string(),
+                    self.io_runtime.clone(),
+                    filters.to_vec(),
+                    projection.cloned(),
+                    limit,
+                    Arc::clone(&self.accelerator_write_mutex),
+                    Arc::clone(&self.in_flight_revalidations),
+                    Arc::clone(&self.synchronized_children),
+                ))
             }
             (false, ZeroResultsAction::ReturnEmpty) => input,
             (false, ZeroResultsAction::UseSource) => Arc::new(FallbackOnZeroResultsScanExec::new(
@@ -1099,25 +1089,6 @@ fn extend_projection_for_caching(
     let mut extended = proj.clone();
     extended.push(idx);
     Some(extended)
-}
-
-/// Wraps plan with `ProjectionExec` to return only the user's originally requested columns.
-/// Used to strip internally-added columns (e.g., `fetched_at`) from user-facing results.
-fn apply_projection(
-    plan: Arc<dyn ExecutionPlan>,
-    projection: &[usize],
-) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-    let schema = plan.schema();
-    let projection_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = (0..projection.len())
-        .map(|i| {
-            let field = schema.field(i);
-            (
-                Arc::new(Column::new(field.name(), i)) as Arc<dyn PhysicalExpr>,
-                field.name().clone(),
-            )
-        })
-        .collect();
-    Ok(Arc::new(ProjectionExec::try_new(projection_expr, plan)?))
 }
 
 #[derive(Debug)]
@@ -1281,7 +1252,6 @@ impl Retention {
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-    use datafusion::physical_plan::empty::EmptyExec;
 
     fn schema_with_fetched_at() -> SchemaRef {
         Arc::new(Schema::new(vec![
@@ -1340,30 +1310,5 @@ mod tests {
             vec![2, 3],
             "Should add fetched_at to single column"
         );
-    }
-
-    #[test]
-    fn test_apply_projection_reduces_columns() {
-        // Create a schema with 4 columns
-        let schema = schema_with_fetched_at();
-
-        // Create a dummy EmptyExec with the schema
-        let empty_exec = EmptyExec::new(Arc::clone(&schema));
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(empty_exec);
-
-        // Apply projection for 2 columns (simulating user requested 2 columns)
-        let user_projection = vec![0, 2]; // id, content
-        let projected_plan =
-            apply_projection(plan, &user_projection).expect("apply_projection should succeed");
-
-        // Verify output schema has only the first 2 columns
-        let output_schema = projected_plan.schema();
-        assert_eq!(
-            output_schema.fields().len(),
-            2,
-            "Should have 2 columns after projection"
-        );
-        assert_eq!(output_schema.field(0).name(), "id");
-        assert_eq!(output_schema.field(1).name(), "name");
     }
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -33,7 +33,9 @@ use datafusion::common::Constraints;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::logical_expr::dml::InsertOp;
+use datafusion::physical_expr::{PhysicalExpr, expressions::Column};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::sql::TableReference;
 use datafusion::{
@@ -966,11 +968,17 @@ impl TableProvider for AcceleratedTable {
             }
         }
 
-        // In caching mode, pass filters to accelerator so it can check for cached data.
-        // If accelerator returns 0 rows → cache miss → fetch from source.
+        // For caching mode, extend projection to include fetched_at for freshness checking if needed.
+        // If added internally, we'll strip it from results before returning to the user.
+        let extended_projection = if is_caching_mode {
+            extend_projection_for_caching(projection, &self.accelerator.schema())
+        } else {
+            None
+        };
+        let scan_projection = extended_projection.as_ref().or(projection);
         let input = self
             .accelerator
-            .scan(state, projection, filters, limit)
+            .scan(state, scan_projection, filters, limit)
             .await?;
         let federated = Arc::clone(&self.federated);
         let fallback_fn: FallbackAsyncTableProvider = Arc::new(move || {
@@ -992,22 +1000,31 @@ impl TableProvider for AcceleratedTable {
                 };
 
                 let federated_provider = self.federated.table_provider().await;
-                Arc::new(caching::CachingAccelerationScanExec::new(
-                    input,
-                    self.cache_ttl,
-                    self.cache_stale_while_revalidate_ttl,
-                    self.cache_stale_if_error,
-                    federated_provider,
-                    Arc::clone(&self.accelerator),
-                    self.dataset_name.to_string(),
-                    self.io_runtime.clone(),
-                    filters.to_vec(),
-                    projection.cloned(),
-                    limit,
-                    Arc::clone(&self.accelerator_write_mutex),
-                    Arc::clone(&self.in_flight_revalidations),
-                    Arc::clone(&self.synchronized_children),
-                ))
+                let caching_exec: Arc<dyn ExecutionPlan> =
+                    Arc::new(caching::CachingAccelerationScanExec::new(
+                        input,
+                        self.cache_ttl,
+                        self.cache_stale_while_revalidate_ttl,
+                        self.cache_stale_if_error,
+                        federated_provider,
+                        Arc::clone(&self.accelerator),
+                        self.dataset_name.to_string(),
+                        self.io_runtime.clone(),
+                        filters.to_vec(),
+                        projection.cloned(),
+                        limit,
+                        Arc::clone(&self.accelerator_write_mutex),
+                        Arc::clone(&self.in_flight_revalidations),
+                        Arc::clone(&self.synchronized_children),
+                    ));
+
+                // If we extended projection to add fetched_at, strip it from results
+                if let (true, Some(proj)) = (extended_projection.is_some(), projection) {
+                    // extended_projection is Some only when projection is Some and didn't already include fetched_at (was modified)
+                    apply_projection(caching_exec, proj)?
+                } else {
+                    caching_exec
+                }
             }
             (false, ZeroResultsAction::ReturnEmpty) => input,
             (false, ZeroResultsAction::UseSource) => Arc::new(FallbackOnZeroResultsScanExec::new(
@@ -1064,6 +1081,43 @@ impl TableProvider for AcceleratedTable {
 
         Ok(union_plan)
     }
+}
+
+/// Extends projection to include `fetched_at` column for cache freshness checking.
+/// Returns `Some(extended_projection)` if extension was needed,
+/// or `None` if no extension needed (projection already includes it or is None).
+fn extend_projection_for_caching(
+    projection: Option<&Vec<usize>>,
+    schema: &SchemaRef,
+) -> Option<Vec<usize>> {
+    let proj = projection?;
+    let idx = schema.index_of(caching::CACHE_REFRESHED_AT_COLUMN).ok()?;
+    if proj.contains(&idx) {
+        return None;
+    }
+    // User projection doesn't include fetched_at - add it as last column
+    let mut extended = proj.clone();
+    extended.push(idx);
+    Some(extended)
+}
+
+/// Wraps plan with `ProjectionExec` to return only the user's originally requested columns.
+/// Used to strip internally-added columns (e.g., `fetched_at`) from user-facing results.
+fn apply_projection(
+    plan: Arc<dyn ExecutionPlan>,
+    projection: &[usize],
+) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+    let schema = plan.schema();
+    let projection_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = (0..projection.len())
+        .map(|i| {
+            let field = schema.field(i);
+            (
+                Arc::new(Column::new(field.name(), i)) as Arc<dyn PhysicalExpr>,
+                field.name().clone(),
+            )
+        })
+        .collect();
+    Ok(Arc::new(ProjectionExec::try_new(projection_expr, plan)?))
 }
 
 #[derive(Debug)]

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1276,3 +1276,94 @@ impl Retention {
         RetentionBuilder::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    fn schema_with_fetched_at() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("content", DataType::Utf8, true),
+            Field::new(
+                caching::CACHE_REFRESHED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        ]))
+    }
+
+    #[test]
+    fn test_extend_projection_none_returns_none() {
+        let schema = schema_with_fetched_at();
+        let result = extend_projection_for_caching(None, &schema);
+        assert!(result.is_none(), "None projection should return None");
+    }
+
+    #[test]
+    fn test_extend_projection_already_includes_fetched_at() {
+        let schema = schema_with_fetched_at();
+        // Projection includes fetched_at (index 3)
+        let projection = vec![0, 1, 3];
+        let result = extend_projection_for_caching(Some(&projection), &schema);
+        assert!(
+            result.is_none(),
+            "Projection already including fetched_at should return None"
+        );
+    }
+
+    #[test]
+    fn test_extend_projection_adds_fetched_at() {
+        let schema = schema_with_fetched_at();
+        // Projection does NOT include fetched_at
+        let projection = vec![0, 2]; // id, content
+        let extended = extend_projection_for_caching(Some(&projection), &schema)
+            .expect("Should extend projection");
+        assert_eq!(
+            extended,
+            vec![0, 2, 3],
+            "Should add fetched_at index at end"
+        );
+    }
+
+    #[test]
+    fn test_extend_projection_single_column() {
+        let schema = schema_with_fetched_at();
+        let projection = vec![2]; // just content
+        let extended = extend_projection_for_caching(Some(&projection), &schema)
+            .expect("Should extend projection");
+        assert_eq!(
+            extended,
+            vec![2, 3],
+            "Should add fetched_at to single column"
+        );
+    }
+
+    #[test]
+    fn test_apply_projection_reduces_columns() {
+        // Create a schema with 4 columns
+        let schema = schema_with_fetched_at();
+
+        // Create a dummy EmptyExec with the schema
+        let empty_exec = EmptyExec::new(Arc::clone(&schema));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(empty_exec);
+
+        // Apply projection for 2 columns (simulating user requested 2 columns)
+        let user_projection = vec![0, 2]; // id, content
+        let projected_plan =
+            apply_projection(plan, &user_projection).expect("apply_projection should succeed");
+
+        // Verify output schema has only the first 2 columns
+        let output_schema = projected_plan.schema();
+        assert_eq!(
+            output_schema.fields().len(),
+            2,
+            "Should have 2 columns after projection"
+        );
+        assert_eq!(output_schema.field(0).name(), "id");
+        assert_eq!(output_schema.field(1).name(), "name");
+    }
+}

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -2123,3 +2123,135 @@ async fn test_localpod_caching_initialization_from_existing_parent_data()
         })
         .await
 }
+
+/// Test that queries with explicit column selection work correctly in caching mode.
+///
+/// This verifies that:
+/// 1. Queries selecting specific columns return only those columns
+/// 2. Internal columns used for cache management are not exposed
+/// 3. Data integrity is maintained for the columns users did request
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            // Create HTTP dataset with caching mode
+            let mut dataset = Dataset::new("https://api.tvmaze.com", "tvmaze");
+            dataset.params = Some(Params::from_string_map(
+                vec![
+                    (
+                        "allowed_request_paths".to_string(),
+                        "/search/people".to_string(),
+                    ),
+                    ("request_query_filters".to_string(), "enabled".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                mode: Mode::Memory,
+                refresh_mode: Some(RefreshMode::Caching),
+                refresh_check_interval: Some("300s".to_string()), // Long TTL to ensure no expiry during test
+                ..Acceleration::default()
+            });
+
+            let mut app = AppBuilder::new("test_projection")
+                .with_dataset(dataset)
+                .build();
+
+            // Disable SQL results caching
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let status = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&status).load_components() => {}
+            }
+
+            runtime_ready_check(&status).await;
+
+            // STEP 1: First query to populate the cache (SELECT content - cache miss)
+            eprintln!("TEST: Step 1 - Populating cache with SELECT content...");
+            let df_populate = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("q=lauren")))?
+                .select(vec![col("content")])?;
+
+            let populate_results = df_populate.collect().await?;
+            assert!(
+                !populate_results.is_empty() && populate_results[0].num_rows() > 0,
+                "Should have fetched data from HTTP source"
+            );
+            let row_count = populate_results[0].num_rows();
+            
+            // Verify Step 1 returns only the requested column
+            let schema_step1 = populate_results[0].schema();
+            assert!(
+                schema_step1.column_with_name("content").is_some(),
+                "content should be in results"
+            );
+            assert_eq!(
+                schema_step1.fields().len(),
+                1,
+                "Should only have 1 column (content)"
+            );
+
+            // STEP 2: Query with same projection (cache hit)
+            eprintln!("TEST: Step 2 - Querying with SELECT content (should hit cache)...");
+            let df = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("q=lauren")))?
+                .select(vec![col("content")])?;
+
+            let results = df.collect().await?;
+
+            assert!(
+                !results.is_empty() && results[0].num_rows() > 0,
+                "Should have data from cache"
+            );
+
+            let schema = results[0].schema();
+            
+            // Verify only the requested column is present
+            assert!(
+                schema.column_with_name("content").is_some(),
+                "content should be in results"
+            );
+
+            // Verify we only have the 1 column we requested
+            assert_eq!(
+                schema.fields().len(),
+                1,
+                "Should only have 1 column (content)"
+            );
+
+            eprintln!("\nTEST SUMMARY:");
+            eprintln!("✅ Step 1: SELECT content (cache miss) - populated cache, only content column returned");
+            eprintln!("✅ Step 2: SELECT content (cache hit) - only content column returned");
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -2200,6 +2200,7 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
                 !populate_results.is_empty() && populate_results[0].num_rows() > 0,
                 "Should have fetched data from HTTP source"
             );
+            assert_column_has_data(&populate_results, "content");
 
             // Verify Step 1 returns only the requested column
             let schema_step1 = populate_results[0].schema();
@@ -2230,6 +2231,7 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
                 !results.is_empty() && results[0].num_rows() > 0,
                 "Should have data from cache"
             );
+            assert_column_has_data(&results, "content");
 
             let schema = results[0].schema();
 
@@ -2247,10 +2249,31 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
             );
 
             eprintln!("\nTEST SUMMARY:");
-            eprintln!("✅ Step 1: SELECT content (cache miss) - populated cache, only content column returned");
-            eprintln!("✅ Step 2: SELECT content (cache hit) - only content column returned");
+            eprintln!("✅ Step 1: SELECT content (cache miss) - populated cache, content has data");
+            eprintln!("✅ Step 2: SELECT content (cache hit) - content has data");
 
             Ok(())
         })
         .await
+}
+
+/// Asserts that the specified column in the given record batches contains non-empty string data.
+fn assert_column_has_data(batches: &[arrow::array::RecordBatch], column_name: &str) {
+    assert!(!batches.is_empty(), "expected at least one batch");
+
+    let total_len: usize = batches
+        .iter()
+        .filter_map(|b| b.schema().index_of(column_name).ok().map(|i| b.column(i)))
+        .map(|col| {
+            col.as_any()
+                .downcast_ref::<StringArray>()
+                .expect("column should be StringArray")
+                .iter()
+                .flatten()
+                .map(str::len)
+                .sum::<usize>()
+        })
+        .sum();
+
+    assert!(total_len > 0, "'{column_name}' column has no data");
 }

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -2200,8 +2200,7 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
                 !populate_results.is_empty() && populate_results[0].num_rows() > 0,
                 "Should have fetched data from HTTP source"
             );
-            let row_count = populate_results[0].num_rows();
-            
+
             // Verify Step 1 returns only the requested column
             let schema_step1 = populate_results[0].schema();
             assert!(
@@ -2233,7 +2232,7 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
             );
 
             let schema = results[0].schema();
-            
+
             // Verify only the requested column is present
             assert!(
                 schema.column_with_name("content").is_some(),


### PR DESCRIPTION
## 📝 Summary

Problem:

HTTP caching acceleration always returned cache MISS when queries used column projections that didn't include the internal `fetched_at` timestamp column (e.g., `SELECT content FROM ...`).

The `fetched_at` column is required for cache freshness checking, but the internally used accelerator only fetches columns in the user's projection so `fetched_at` was missing resulting in `check_cache_freshness` always returned `Expired`.


Solution:

- Add `extend_projection_for_caching()` to internally extend user projections to include `fetched_at` for accelerator scan
- Users still get only their requested columns via `SchemaCastScanExec` wrapper (similar to source fallback on cache miss where we don't pass projection)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
