### PR TITLE
Rename Ingestion Lag chart in example dashboards

### DIFF
--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -727,7 +727,7 @@
           {
             "id": 303,
             "definition": {
-              "title": "Dataset Ingestion Lag (ms)",
+              "title": "Refresh Staleness",
               "title_size": "16",
               "title_align": "left",
               "time": {},
@@ -795,7 +795,7 @@
           {
             "id": 358266188692798,
             "definition": {
-              "title": "Refresh Timestamp Lag",
+              "title": "Refresh Timestamp Advancement",
               "title_size": "16",
               "title_align": "left",
               "time": {},

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_PROMETHEUS",
-      "label": "Prometheus_Customer_Scenarios",
+      "label": "Prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -1576,7 +1576,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Ingestion lag for accelerated datasets: how far behind real time the ingested data is.\nMeasured as dataset_acceleration_ingestion_lag_ms (milliseconds between data availability and ingestion into acceleration).\n\n",
+      "description": "How far behind the data was at the time of the last refresh. Calculated as: (wall clock time when refresh completed) − (max timestamp in the refreshed data)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1649,7 +1649,7 @@
           "refId": "A"
         }
       ],
-      "title": "Ingestion Lag",
+      "title": "Refresh Staleness",
       "type": "bargauge"
     },
     {
@@ -1657,7 +1657,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The difference between max timestamp after and before refresh",
+      "description": "The difference between max timestamp after and before last refresh",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
## 📝 Summary

Rename `Ingestion Lag` to `Refresh Staleness` chart in example Grafana/Datadog dashboards