### PR TITLE
Cayenne: include `cayenne_metadata_dir` to known params

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -1590,6 +1590,8 @@ impl CayenneAccelerator {
 const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("file_path")
         .description("Path for storing Cayenne data files (Vortex files). Can be a local path or an S3 Express One Zone path. For S3 Express One Zone, use format: 's3://{bucket-name}--{zone-id}--x-s3/{prefix}/'. When S3 Express One Zone is specified, data files are stored exclusively in S3 while metadata (SQLite) remains on local disk."),
+    ParameterSpec::component("metadata_dir")
+        .description("Path for storing Cayenne metadata (SQLite catalog). If not specified, defaults to '{cayenne_file_path}/metadata'."),
     ParameterSpec::component("metastore")
         .description("Metastore backend for Cayenne catalog. Options: 'sqlite' (default), 'turso' (requires 'turso' feature enabled at build time)")
         .default("sqlite"),


### PR DESCRIPTION
## 📝 Summary

Found the following warning when using the latest nightly version.

>2026-01-15T16:57:59.249055Z  WARN runtime_parameters: Ignoring parameter cayenne_metadata_dir: not supported for accelerator cayenne.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I tested this last week and it worked, also checked that there were no changes in `PARAMETERS` list so not 100% sure what happened and how it worked before
