### PR TITLE
perf(caching): Non-blocking cache writes on cache miss

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -780,6 +780,7 @@ impl CacheRefreshHelper {
     ///   when the upstream source returns an error instead of propagating the error.
     /// * `expired_batches` - The expired cached data to serve if `stale_if_error` is enabled and
     ///   the source returns an error.
+    /// * `io_runtime` - Tokio runtime handle for spawning background write tasks.
     /// * `accelerator_write_mutex` - Mutex to protect concurrent access to the accelerator.
     /// * `synchronized_children` - Child accelerators that should also receive the cached data.
     #[expect(clippy::too_many_arguments)]
@@ -793,6 +794,7 @@ impl CacheRefreshHelper {
         is_expired: bool,
         stale_if_error: bool,
         expired_batches: Option<Vec<RecordBatch>>,
+        io_runtime: &Handle,
         accelerator_write_mutex: Arc<Mutex<()>>,
         synchronized_children: SynchronizedChildren,
     ) -> SendableRecordBatchStream {
@@ -806,49 +808,67 @@ impl CacheRefreshHelper {
                     dataset_name
                 );
 
-                // Acquire the mutex to protect accelerator operations
-                let lock_guard = accelerator_write_mutex.lock().await;
-
-                // Store in accelerator for future queries
-                let store_result = if is_expired {
-                    // Data exists but is expired - upsert (remove matching rows, add new)
-                    tracing::debug!("Upserting expired cache entry for dataset={dataset_name}");
-                    Self::upsert_into_accelerator(
-                        &accelerator,
-                        dataset_name,
-                        filters,
-                        batches.clone(),
-                    )
-                    .await
-                } else {
-                    // No data exists - insert (append)
-                    tracing::debug!("Inserting new cache entry for dataset={dataset_name}");
-                    Self::insert_into_accelerator(&accelerator, dataset_name, batches.clone()).await
-                };
-
-                drop(lock_guard); // Release the mutex
-
-                if let Err(e) = store_result {
-                    tracing::warn!(
-                        "Failed to store fetched data in accelerator for dataset {}: {}",
-                        dataset_name,
-                        e
-                    );
-                }
-
-                // Propagate to synchronized children (localpod caching)
-                Self::propagate_to_synchronized_children(
-                    &synchronized_children,
-                    dataset_name,
-                    filters,
-                    &batches,
-                    is_expired,
-                )
-                .await;
-
-                // Use the schema from the fetched batches, not from the accelerator scan
+                // Use the schema from the fetched batches
                 let batch_schema = batches[0].schema();
-                tracing::debug!("Fetched batch schema:\n{}", SchemaDisplay(&batch_schema));
+                tracing::trace!("Fetched batch schema:\n{}", SchemaDisplay(&batch_schema));
+
+                // Clone batches for background write task.
+                // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
+                let batches_for_write = batches.clone();
+                let accelerator_clone = Arc::clone(&accelerator);
+                let dataset_name_clone = dataset_name.to_string();
+                let filters_clone: Vec<Expr> = filters.to_vec();
+                let synchronized_children_clone = Arc::clone(&synchronized_children);
+
+                // Spawn background task to write to accelerator (don't block user response)
+                io_runtime.spawn(async move {
+                    // Acquire the mutex to protect accelerator operations
+                    let lock_guard = accelerator_write_mutex.lock().await;
+
+                    // Store in accelerator for future queries
+                    let store_result = if is_expired {
+                        // Data exists but is expired - upsert (remove matching rows, add new)
+                        tracing::debug!("Upserting expired cache entry for dataset={dataset_name_clone}");
+                        Self::upsert_into_accelerator(
+                            &accelerator_clone,
+                            &dataset_name_clone,
+                            &filters_clone,
+                            batches_for_write.clone(),
+                        )
+                        .await
+                    } else {
+                        // No data exists - insert (append)
+                        tracing::debug!("Inserting new cache entry for dataset={dataset_name_clone}");
+                        Self::insert_into_accelerator(&accelerator_clone, &dataset_name_clone, batches_for_write.clone()).await
+                    };
+
+                    drop(lock_guard); // Release the mutex
+
+                    if let Err(e) = store_result {
+                        tracing::warn!(
+                            "Failed to store fetched data in accelerator for dataset {}: {}",
+                            dataset_name_clone,
+                            e
+                        );
+                    }
+
+                    // Propagate to synchronized children (localpod caching)
+                    Self::propagate_to_synchronized_children(
+                        &synchronized_children_clone,
+                        &dataset_name_clone,
+                        &filters_clone,
+                        &batches_for_write,
+                        is_expired,
+                    )
+                    .await;
+
+                    tracing::debug!(
+                        "Background cache write completed for dataset={dataset_name_clone}, {} rows",
+                        total_rows
+                    );
+                });
+
+                // Return data to user immediately (don't wait for background write)
                 let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
                 let adapter = RecordBatchStreamAdapter::new(batch_schema, batch_stream);
                 Box::pin(adapter)
@@ -1266,6 +1286,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             true, // is_expired = true, will upsert
                             stale_if_error,
                             expired_batches,
+                            &io_runtime,
                             Arc::clone(&accelerator_write_mutex),
                             Arc::clone(&synchronized_children),
                         )
@@ -1303,6 +1324,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     false, // is_expired = false, will insert (append)
                     false, // stale_if_error = false, no expired data to fall back to
                     None,  // no expired batches
+                    &io_runtime,
                     accelerator_write_mutex,
                     synchronized_children,
                 )

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -1994,6 +1994,9 @@ async fn test_localpod_caching_initialization_from_existing_parent_data()
             let parent_row_count = parent_results[0].num_rows();
             eprintln!("TEST: Parent cache populated with {parent_row_count} rows");
 
+            // Wait for background cache write to complete
+            tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
             // Get the parent's accelerator reference for later verification
             let parent_accelerator = runtime_phase1
                 .datafusion()


### PR DESCRIPTION
## 📝 Summary

On cache miss, write to accelerator in background task instead of blocking the user response.

Previously, `handle_cache_miss` blocked until cache write completed:
1. Fetch from source
2. Acquire mutex + write to accelerator (slow)
3. Return data to user

Now, data is returned immediately after fetch:
1. Fetch from source
2. Clone batches for background task (cheap - RecordBatch uses Arc internally)
3. Spawn background write via `io_runtime.spawn()`
4. Return data to user immediately

This significantly improves query latency on cache miss which is no longer depends on synchronized write to accelerator.

Global results cache gets also populated much faster when data returns, not after slower accelerator write completes.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

1. Main concern was DuckDB file acceleration that could become a bottleneck resulting in increased num of pending tasks, but it worked well in my test (fast SSD storage). Note: Write can be optimized further (if needed): 1- replace existing `Read-Combine-Overwrite` pattern with Append+upsert; 2 - add batching / write queue

1. Example perf results for the case where most of queries hit MISS due to large query randomization factor (each request param is randomly selected from 1M records), 50 parallel virtual users / queries (VU).

**Before: p(95)=13.88s**
**After: p(95)=289.23ms**

```
k6 run \
  -e SPICE_HTTP_ENDPOINT=http://localhost:8090 \
  -e TEST_PARAM_COUNT=1000000 \
  -e TEST_VUS=50 \
  -e TEST_DURATION=10m \
  test.js
```

```

runtime:
  caching:
    sql_results:
      enabled: true
      item_ttl: 10s

 - from: http://localhost:8091
    ...
    acceleration:
          enabled: true
          engine: duckdb
          mode: file
          refresh_mode: caching
          params:
            caching_ttl: 1s # in-memory cache is used for this purpose
            caching_stale_while_revalidate_ttl: 30s
            caching_stale_if_error: enabled
            duckdb_preserve_insertion_order: false
            duckdb_memory_limit: '1GB'
```

**Before: p(95)=13.88s**

```
█ TOTAL RESULTS 

    checks_total.......: 4500    7.329446/s
    checks_succeeded...: 100.00% 4500 out of 4500
    checks_failed......: 0.00%   0 out of 4500

    ✓ status is 200
    ✓ response has data

    CUSTOM
    cache_misses...................: 2250   3.664723/s
    query_errors...................: 0      0/s
    query_latency..................: avg=13.49s min=413ms    med=13.63s max=14.06s p(90)=13.84s p(95)=13.88s
    query_success..................: 2250   3.664723/s

    HTTP
    http_req_duration..............: avg=13.48s min=5.92ms   med=13.63s max=14.06s p(90)=13.84s p(95)=13.88s
      { expected_response:true }...: avg=13.48s min=5.92ms   med=13.63s max=14.06s p(90)=13.84s p(95)=13.88s
    http_req_failed................: 0.00%  0 out of 2251
    http_reqs......................: 2251   3.666352/s

    EXECUTION
    iteration_duration.............: avg=13.49s min=413.14ms med=13.63s max=14.06s p(90)=13.84s p(95)=13.88s
    iterations.....................: 2250   3.664723/s
    vus............................: 4      min=4         max=50
    vus_max........................: 50     min=50        max=50
```

**After: p(95)=289.23ms**

```
 █ TOTAL RESULTS 

    checks_total.......: 399404  661.888187/s
    checks_succeeded...: 100.00% 399404 out of 399404
    checks_failed......: 0.00%   0 out of 399404

    ✓ status is 200
    ✓ response has data

    CUSTOM
    cache_hits.....................: 650    1.077173/s
    cache_misses...................: 199052 329.86692/s
    query_errors...................: 0      0/s
    query_latency..................: avg=150.35ms min=0s       med=168ms    max=9.3s p(90)=244ms    p(95)=289ms   
    query_success..................: 199702 330.944093/s

    HTTP
    http_req_duration..............: avg=150.32ms min=125µs    med=168.3ms  max=9.3s p(90)=243.88ms p(95)=289.23ms
      { expected_response:true }...: avg=150.32ms min=125µs    med=168.3ms  max=9.3s p(90)=243.88ms p(95)=289.23ms
    http_req_failed................: 0.00%  0 out of 199703
    http_reqs......................: 199703 330.945751/s

    EXECUTION
    iteration_duration.............: avg=150.39ms min=171.66µs med=168.37ms max=9.3s p(90)=243.94ms p(95)=289.32ms
    iterations.....................: 199702 330.944093/s
    vus............................: 1      min=1           max=50
    vus_max........................: 50     min=50          max=50

    NETWORK
    data_received..................: 406 MB 673 kB/s
    data_sent......................: 67 MB  112 kB/s
```
