### PR TITLE
Update NSQL models

### DIFF
--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -10,12 +10,11 @@ on:
         type: choice
         options:
           - 'all'
-          - 'gpt-5.1'
-          - 'gpt-5-mini'
+          - 'gpt-5.2'
           - 'o3-mini'
           - 'llama3-3B-Instruct'
-          - 'claude-sonnet-4-5'
-          - 'grok4'
+          - 'claude-haiku'
+          - 'grok-4-fast'
         default: 'all'
   schedule:
     - cron: '0 5 * * 2,5' # Every Monday and Thursday at 10pm PST (5am UTC next day)
@@ -82,12 +81,11 @@ jobs:
         with:
           script: |
             const matrix = [
-              { name: "gpt-5.1" },
-              { name: "gpt-5-mini" },
+              { name: "gpt-5.2" },
               { name: "o3-mini" },
               { name: "llama3-3B-Instruct" },
-              { name: "claude-sonnet-4-5" },
-              { name: "grok4" },
+              { name: "claude-haiku" },
+              { name: "grok-4-fast" },
             ];
 
             const model_option = context.payload.inputs?.model_option || 'all';

--- a/test/spicepods/models/nsql_bench.yaml
+++ b/test/spicepods/models/nsql_bench.yaml
@@ -33,27 +33,14 @@ system_prompt: &system_prompt |
     3. Ensure responses are concise and to the point.
 
 models:
-  - name: gpt-5
-    from: openai:gpt-5
+  - name: gpt-5.2
+    from: openai:gpt-5.2
     params:
       spice_tools: auto
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
-      system_prompt: *system_prompt
-  - name: gpt-5-mini
-    from: openai:gpt-5-mini
-    params:
-      spice_tools: auto
-      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
-      system_prompt: *system_prompt
-  - name: o1
-    from: openai:o1-2024-12-17
-    params:
-      spice_tools: auto
-      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
-      openai_reasoning_effort: high
       system_prompt: *system_prompt
   - name: o3-mini
-    from: openai:o3-mini-2025-01-31
+    from: openai:o3-mini
     params:
       spice_tools: auto
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
@@ -65,20 +52,14 @@ models:
       hf_token: ${ secrets:SPICE_HF_TOKEN }
       spice_tools: auto
       system_prompt: *system_prompt
-  - name: claude-sonnet-4-5
-    from: anthropic:claude-sonnet-4-5
+  - name: claude-haiku
+    from: anthropic:claude-haiku-4-5-20251001
     params:
       spice_tools: auto
       anthropic_api_key: ${ secrets:SPICE_ANTHROPIC_API_KEY }
       system_prompt: *system_prompt
-  - name: grok3
-    from: xai:grok-3
-    params:
-      spice_tools: auto
-      xai_api_key: ${secrets:SPICE_XAI_API_KEY}
-      system_prompt: *system_prompt
-  - name: grok4
-    from: xai:grok-4
+  - name: grok-4-fast
+    from: xai:grok-4-1-fast-non-reasoning
     params:
       spice_tools: auto
       xai_api_key: ${secrets:SPICE_XAI_API_KEY}


### PR DESCRIPTION
This pull request updates the benchmark configuration and model matrix for the NSQL AI benchmarking workflow and test suite. The main focus is on updating the list of evaluated models to newer versions and removing deprecated or unused models to keep the benchmarks current and relevant.

**Model updates and replacements:**

* Replaced `gpt-5.1` and `gpt-5-mini` with `gpt-5.2` in both the workflow matrix (`.github/workflows/ai_benchmark_nsql.yml`) and the test model definitions (`test/spicepods/models/nsql_bench.yaml`). [[1]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL13-R17) [[2]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL85-R88) [[3]](diffhunk://#diff-b5222e1cdf19929fadea1afb5bbd90b9bd6d17efe810840335292c588932435aL36-R43)
* Replaced `claude-sonnet-4-5` with `claude-haiku` and updated the Anthropic model reference accordingly. [[1]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL13-R17) [[2]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL85-R88) [[3]](diffhunk://#diff-b5222e1cdf19929fadea1afb5bbd90b9bd6d17efe810840335292c588932435aL68-R62)
* Replaced `grok4` (and removed `grok3`) with `grok-4-fast`, updating the XAI model reference. [[1]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL13-R17) [[2]](diffhunk://#diff-fdb827b7d3c2ef0bb6040f87c07f84268cf47fefae88a87f0d3461e899c216ceL85-R88) [[3]](diffhunk://#diff-b5222e1cdf19929fadea1afb5bbd90b9bd6d17efe810840335292c588932435aL68-R62)

**Model removals:**

* Removed the `o1` model from the test suite, leaving only `o3-mini` as the OpenAI "o" series model.
* Removed the `grok3` model from the test suite as part of cleaning up unused models.

**Other minor updates:**

* Updated model references for `o3-mini` to use the latest model identifier.