### PR TITLE
fix: Support primary key constraints in partitioned DuckDB tables mode

### DIFF
--- a/crates/runtime-table-partition/src/creator.rs
+++ b/crates/runtime-table-partition/src/creator.rs
@@ -18,8 +18,8 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use datafusion::{
-    error::DataFusionError, logical_expr::TableProviderFilterPushDown, prelude::Expr,
-    scalar::ScalarValue,
+    common::Constraints, error::DataFusionError, logical_expr::TableProviderFilterPushDown,
+    prelude::Expr, scalar::ScalarValue,
 };
 use snafu::prelude::*;
 
@@ -64,4 +64,9 @@ pub trait PartitionCreator: Debug + Send + Sync {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError>;
+
+    /// Returns the constraints (primary key, unique, etc.) for partitions.
+    fn constraints(&self) -> Option<&Constraints> {
+        None
+    }
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -182,7 +182,7 @@ impl TableProvider for PartitionTableProvider {
     }
 
     fn constraints(&self) -> Option<&Constraints> {
-        None
+        self.creator.constraints()
     }
 
     fn table_type(&self) -> TableType {

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -51,7 +51,7 @@ use runtime_table_partition::{
 };
 use snafu::{OptionExt, prelude::*};
 
-use crate::dataaccelerator::BootstrapStatus;
+use crate::dataaccelerator::{BootstrapStatus, upsert_dedup::UpsertDedupTableProvider};
 use crate::{
     component::dataset::acceleration::{Engine, Mode},
     dataaccelerator::{
@@ -274,11 +274,7 @@ impl DuckDBPartitionCreator {
             .ok_or("Expected PolyTableProvider but got different table provider type")?;
 
         let writer = poly_table.writer();
-
-        let writer = writer
-            .as_any()
-            .downcast_ref::<DuckDBTableWriter>()
-            .ok_or("Expected DuckDBTableWriter but got different writer type")?;
+        let writer = extract_duckdb_writer(&writer)?;
 
         // Extract UpsertOptions from cmd options
         let upsert_options = Self::extract_upsert_options(&cmd);
@@ -440,6 +436,14 @@ impl PartitionCreator for DuckDBPartitionCreator {
             })
             .collect())
     }
+
+    fn constraints(&self) -> Option<&datafusion::common::Constraints> {
+        if self.cmd.constraints.is_empty() {
+            None
+        } else {
+            Some(&self.cmd.constraints)
+        }
+    }
 }
 
 fn create_factory() -> DuckDBTableProviderFactory {
@@ -466,6 +470,28 @@ async fn get_pool(
             .get_or_init_instance_with_builder(pool_builder)
             .await?,
     ))
+}
+
+/// Extracts the `DuckDBTableWriter` from a table provider, handling the case where
+/// it may be wrapped in an `UpsertDedupTableProvider` when upsert options are enabled.
+fn extract_duckdb_writer(
+    writer: &Arc<dyn TableProvider>,
+) -> std::result::Result<&DuckDBTableWriter, Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(w) = writer.as_any().downcast_ref::<DuckDBTableWriter>() {
+        Ok(w)
+    } else if let Some(upsert_provider) = writer.as_any().downcast_ref::<UpsertDedupTableProvider>()
+    {
+        upsert_provider
+            .inner()
+            .as_any()
+            .downcast_ref::<DuckDBTableWriter>()
+            .ok_or_else(|| "UpsertDedupTableProvider inner is not DuckDBTableWriter".into())
+    } else {
+        Err(
+            "Expected DuckDBTableWriter or UpsertDedupTableProvider but got different writer type"
+                .into(),
+        )
+    }
 }
 
 register_data_accelerator!(

--- a/crates/runtime/src/dataaccelerator/upsert_dedup.rs
+++ b/crates/runtime/src/dataaccelerator/upsert_dedup.rs
@@ -75,6 +75,12 @@ impl UpsertDedupTableProvider {
     fn needs_dedup(&self) -> bool {
         self.upsert_options.remove_duplicates || self.upsert_options.last_write_wins
     }
+
+    /// Returns a reference to the inner table provider.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn TableProvider> {
+        &self.inner
+    }
 }
 
 impl std::fmt::Debug for UpsertDedupTableProvider {


### PR DESCRIPTION
## 📝 Summary

Fixes partitioned DuckDB tables mode failing when `primary_key` is defined with `upsert_dedup` options.

Also adds logic for `PartitionTableProvider` to propagate constraints configuration

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
