### PR TITLE
Fix `duckdb_file_path` in search integration test

### DIFF
--- a/crates/runtime/tests/search/mod.rs
+++ b/crates/runtime/tests/search/mod.rs
@@ -150,7 +150,7 @@ impl AccelerationOptions {
                 engine: Some("duckdb".to_string()),
                 mode: Mode::File,
                 params: Some(spicepod::param::Params::from_string_map(HashMap::from([(
-                    "duckdb_file_path".to_string(),
+                    "duckdb_file".to_string(),
                     format!(".spice/data/duckdb_acceleration_{unique_id}.db"),
                 )]))),
                 ..Default::default()


### PR DESCRIPTION
## 📝 Summary
 - `duckdb_file_path` -> `duckdb_file`
 - Running CI: https://github.com/spiceai/spiceai/actions/runs/21124854809