### PR TITLE
fix: Remove --no-default-features from cargo-hack command in features workflow

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -74,9 +74,11 @@ jobs:
       # Use cargo-hack to efficiently check all feature combinations
       # This reuses build artifacts between checks, making it much faster than
       # running individual cargo check commands
+      # Note: --each-feature already includes a run with --no-default-features,
+      # so we don't need to specify it separately
       - name: Check all feature combinations
         run: |
-          cargo hack check --no-default-features --each-feature --profile lint \
+          cargo hack check --each-feature --profile lint \
             --exclude-features default,extended_tests,models,cuda,metal,mcp,odbc,release,kafka,iceberg-write,snapshots,tpc-extension,spark,s3_vectors,bedrock
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}


### PR DESCRIPTION
## Summary
- Remove redundant `--no-default-features` flag from `cargo hack check` command in features workflow
- Fixes CI failure: `cargo-hack` 0.6.31 disallows combining `--no-default-features` with `--each-feature` since `--each-feature` already includes a run with `--no-default-features` by default

Fixes https://github.com/spiceai/spiceai/actions/runs/21126042207/job/60747423290