### PR TITLE
Improvements for `snapshots_creation_policy`

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -89,12 +89,6 @@ struct DatasetMetadata {
     snapshots: Vec<SnapshotEntry>,
     #[serde(rename = "current-snapshot-id")]
     current_snapshot_id: Option<u64>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        rename = "last-updated-at-ms"
-    )]
-    last_updated_at_ms: Option<i64>,
     #[serde(default)]
     properties: HashMap<String, String>,
 }
@@ -119,6 +113,12 @@ struct SnapshotEntry {
     snapshot_checksum_algorithm: String,
     #[serde(rename = "snapshot-size")]
     snapshot_size: u64,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "snapshot-last-updated-at-ms"
+    )]
+    snapshot_last_updated_at_ms: Option<i64>,
 }
 
 impl SnapshotMetadata {
@@ -695,7 +695,8 @@ impl SnapshotManager {
         ) && let Some(last_updated_at) = last_updated_at
             && let Ok(Some(handle)) = self.load_metadata().await
             && let Some(dataset_meta) = handle.metadata.datasets.get(&self.dataset_name)
-            && dataset_meta.last_updated_at_ms == Some(last_updated_at)
+            && let Some(snapshot_entry) = dataset_meta.snapshots.last()
+            && snapshot_entry.snapshot_last_updated_at_ms == Some(last_updated_at)
         {
             tracing::info!(
                 "Skipping snapshot creation - no updates since last snapshot. dataset={} last_updated_at_ms={}",
@@ -1316,7 +1317,7 @@ impl SnapshotManager {
                 schema,
                 bytes_downloaded: actual_size,
                 checksum: actual_checksum,
-                last_updated_at: dataset_metadata.last_updated_at_ms,
+                last_updated_at: entry.snapshot_last_updated_at_ms,
             })
         } else {
             tracing::warn!(
@@ -1649,13 +1650,13 @@ impl SnapshotManager {
                 snapshot_checksum: checksum_for_metadata,
                 snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
                 snapshot_size: size,
+                snapshot_last_updated_at_ms: last_updated_at,
             };
+
+            println!("Snapshot entry: {snapshot_entry:#?}");
 
             dataset_entry.snapshots.push(snapshot_entry);
             dataset_entry.current_snapshot_id = Some(next_snapshot_id);
-
-            // Store timestamp metadata on the dataset entry
-            dataset_entry.last_updated_at_ms = last_updated_at;
 
             let serialized = serde_json::to_vec_pretty(&metadata).map_err(|source| {
                 SnapshotUploadError::UploadSerializeMetadata {
@@ -1924,7 +1925,6 @@ mod tests {
             current_schema_id: 0,
             snapshots,
             current_snapshot_id,
-            last_updated_at_ms: None,
             properties: HashMap::new(),
         }
     }
@@ -1978,6 +1978,7 @@ mod tests {
             snapshot_checksum: checksum.clone(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
 
         let schema = sample_schema();
@@ -2055,6 +2056,7 @@ mod tests {
             snapshot_checksum: "0000".to_string(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: first_contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
 
         let valid_checksum = compute_sha256_hex(second_contents.as_ref());
@@ -2065,6 +2067,7 @@ mod tests {
             snapshot_checksum: valid_checksum.clone(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: second_contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
 
         let schema = sample_schema();
@@ -2170,6 +2173,7 @@ mod tests {
             SNAPSHOT_CHECKSUM_ALGORITHM
         );
         assert_eq!(entry.snapshot, snapshot_uri(&uploaded_path));
+        assert_eq!(entry.snapshot_last_updated_at_ms, None);
 
         let metadata_schema = dataset
             .current_schema()
@@ -2177,9 +2181,6 @@ mod tests {
             .to_schema_ref()
             .expect("deserialize schema");
         assert_eq!(metadata_schema.as_ref(), schema.as_ref());
-
-        // Verify no timestamp fields when None passed
-        assert_eq!(dataset.last_updated_at_ms, None);
     }
 
     #[tokio::test]
@@ -2231,7 +2232,11 @@ mod tests {
             .expect("dataset metadata present");
 
         // Verify timestamp field is stored
-        assert_eq!(dataset.last_updated_at_ms, Some(1_704_153_600_000));
+        let snapshot_entry = dataset.snapshots.last().expect("snapshot");
+        assert_eq!(
+            snapshot_entry.snapshot_last_updated_at_ms,
+            Some(1_704_153_600_000)
+        );
     }
 
     #[tokio::test]
@@ -2280,8 +2285,8 @@ mod tests {
             .get(DATASET_NAME)
             .expect("dataset metadata present");
 
-        // Verify updated_at is None
-        assert_eq!(dataset.last_updated_at_ms, None);
+        let snapshot_entry = dataset.snapshots.last().expect("snapshot");
+        assert_eq!(snapshot_entry.snapshot_last_updated_at_ms, None);
     }
 
     #[tokio::test]
@@ -2310,6 +2315,7 @@ mod tests {
             snapshot_checksum: checksum,
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
         let metadata = DatasetMetadata {
             name: DATASET_NAME.to_string(),
@@ -2374,6 +2380,7 @@ mod tests {
             snapshot_checksum: checksum,
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64 + 1,
+            snapshot_last_updated_at_ms: None,
         };
         let metadata = DatasetMetadata {
             name: DATASET_NAME.to_string(),
@@ -2438,6 +2445,7 @@ mod tests {
             snapshot_checksum: checksum,
             snapshot_checksum_algorithm: "MD5".to_string(),
             snapshot_size: contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
         let metadata = DatasetMetadata {
             name: DATASET_NAME.to_string(),
@@ -2507,6 +2515,7 @@ mod tests {
             snapshot_checksum: checksum,
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
         let metadata = DatasetMetadata {
             name: DATASET_NAME.to_string(),
@@ -2816,6 +2825,7 @@ mod tests {
             snapshot_checksum: checksum.clone(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64,
+            snapshot_last_updated_at_ms: None,
         };
 
         let schema = sample_schema();

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -1653,8 +1653,6 @@ impl SnapshotManager {
                 snapshot_last_updated_at_ms: last_updated_at,
             };
 
-            println!("Snapshot entry: {snapshot_entry:#?}");
-
             dataset_entry.snapshots.push(snapshot_entry);
             dataset_entry.current_snapshot_id = Some(next_snapshot_id);
 

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -691,7 +691,7 @@ impl SnapshotManager {
         // Check if we should skip due to no updates
         if matches!(
             self.snapshots_creation_policy,
-            SnapshotsCreationPolicy::Changed
+            SnapshotsCreationPolicy::OnChange
         ) && let Some(last_updated_at) = last_updated_at
             && let Ok(Some(handle)) = self.load_metadata().await
             && let Some(dataset_meta) = handle.metadata.datasets.get(&self.dataset_name)

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -636,11 +636,15 @@ impl Builder {
         let in_flight_revalidations: caching::InFlightRevalidations =
             Arc::new(Mutex::new(std::collections::HashSet::new()));
         // Create last_updated_at atomic to track insert_into timestamps, shared with Refresher for snapshots.
-        // Initialize from bootstrap metadata if available, otherwise None.
+        // Initialize from bootstrap metadata if available.
         let last_updated_at = Arc::new(
             self.bootstrap_status
                 .last_updated_at()
                 .map_or(AtomicI64::new(0), AtomicI64::new),
+        );
+        println!(
+            "!!!!! Bootstrap status: {} - {:#?}",
+            self.dataset_name, self.bootstrap_status
         );
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -637,11 +637,11 @@ impl Builder {
             Arc::new(Mutex::new(std::collections::HashSet::new()));
         // Create last_updated_at atomic to track insert_into timestamps, shared with Refresher for snapshots.
         // Initialize from bootstrap metadata if available, otherwise None.
-        let last_updated_at: Arc<AtomicI64> = self
-            .bootstrap_status
-            .last_updated_at()
-            .map(|ts| Arc::new(AtomicI64::new(ts)))
-            .unwrap_or(Arc::new(AtomicI64::new(0)));
+        let last_updated_at = Arc::new(
+            self.bootstrap_status
+                .last_updated_at()
+                .map_or(AtomicI64::new(0), |ts| AtomicI64::new(ts)),
+        );
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
@@ -923,6 +923,7 @@ impl AcceleratedTable {
         Ok(filters_to_reapply)
     }
 
+    #[expect(clippy::cast_possible_truncation)]
     fn update_last_updated_at(&self) {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1076,7 +1077,6 @@ impl TableProvider for AcceleratedTable {
         Ok(Arc::new(SchemaCastScanExec::new(plan, self.schema())))
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     async fn insert_into(
         &self,
         state: &dyn Session,

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -245,7 +245,8 @@ pub struct AcceleratedTable {
     in_flight_revalidations: caching::InFlightRevalidations,
     /// Timestamp (milliseconds since epoch) of the last `insert_into` operation.
     /// `None` if no insert has occurred yet (and no bootstrap timestamp was provided).
-    last_updated_at: Option<Arc<AtomicI64>>,
+    /// Shared with `RefreshTask`
+    last_updated_at: Arc<AtomicI64>,
     /// Sender for batched cache writes. Only used in caching refresh mode.
     batch_write_tx: Option<caching::CacheWriteSender>,
 }
@@ -636,10 +637,11 @@ impl Builder {
             Arc::new(Mutex::new(std::collections::HashSet::new()));
         // Create last_updated_at atomic to track insert_into timestamps, shared with Refresher for snapshots.
         // Initialize from bootstrap metadata if available, otherwise None.
-        let last_updated_at: Option<Arc<AtomicI64>> = self
+        let last_updated_at: Arc<AtomicI64> = self
             .bootstrap_status
             .last_updated_at()
-            .map(|ts| Arc::new(AtomicI64::new(ts)));
+            .map(|ts| Arc::new(AtomicI64::new(ts)))
+            .unwrap_or(Arc::new(AtomicI64::new(0)));
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
@@ -657,7 +659,7 @@ impl Builder {
         refresher.refresh_on_startup(self.refresh_on_startup);
         refresher.set_initial_load_completed(self.initial_load_complete);
         refresher.disable_federation(self.disable_federation);
-        refresher.with_last_updated_at(last_updated_at.clone());
+        refresher.with_last_updated_at(Arc::clone(&last_updated_at));
         refresher.with_metrics(self.metrics);
         if let Some(synchronize_with) = &self.synchronize_with {
             refresher.synchronize_with(synchronize_with.clone());
@@ -920,6 +922,14 @@ impl AcceleratedTable {
 
         Ok(filters_to_reapply)
     }
+
+    fn update_last_updated_at(&self) {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        self.last_updated_at.store(now_ms, Ordering::Release);
+    }
 }
 
 impl Drop for AcceleratedTable {
@@ -1073,14 +1083,7 @@ impl TableProvider for AcceleratedTable {
         input: Arc<dyn ExecutionPlan>,
         overwrite: InsertOp,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        // Update last_updated_at timestamp
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        if let Some(ref last_updated_at) = self.last_updated_at {
-            last_updated_at.store(now_ms, Ordering::Release);
-        }
+        self.update_last_updated_at();
 
         // When on_conflict is configured, writes go only to the accelerator
         // (the federated source may not support writes, e.g., file connector).

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -642,10 +642,6 @@ impl Builder {
                 .last_updated_at()
                 .map_or(AtomicI64::new(0), AtomicI64::new),
         );
-        println!(
-            "!!!!! Bootstrap status: {} - {:#?}",
-            self.dataset_name, self.bootstrap_status
-        );
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -640,7 +640,7 @@ impl Builder {
         let last_updated_at = Arc::new(
             self.bootstrap_status
                 .last_updated_at()
-                .map_or(AtomicI64::new(0), |ts| AtomicI64::new(ts)),
+                .map_or(AtomicI64::new(0), AtomicI64::new),
         );
         let mut refresher = refresh::Refresher::new(
             Arc::clone(&self.runtime_status),

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -745,7 +745,7 @@ impl Refresher {
             Arc::clone(&self.accelerator_write_mutex),
         )
         .with_disable_federation(self.disable_federation)
-        .with_last_updated_at(self.last_updated_at.clone());
+        .with_last_updated_at(Arc::clone(&self.last_updated_at));
 
         if let Some(semaphore) = &self.semaphore {
             refresh_task_runner = refresh_task_runner.with_semaphore(Arc::clone(semaphore));
@@ -774,7 +774,7 @@ impl Refresher {
         let snapshot_mutex = Arc::clone(&self.accelerator_write_mutex);
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
-        let last_updated_at = self.last_updated_at.clone();
+        let last_updated_at = Arc::clone(&self.last_updated_at);
 
         let synchronize_with = self.synchronize_with.clone();
 
@@ -795,7 +795,7 @@ impl Refresher {
                         Arc::clone(&federated_schema),
                         Arc::clone(&self.runtime_status),
                         self.bootstrap_status.clone(),
-                        self.last_updated_at.clone(),
+                        Arc::clone(&self.last_updated_at),
                     ),
                     false,
                 ),
@@ -944,7 +944,7 @@ impl Refresher {
             .with_cpu_runtime(self.cpu_runtime.clone())
             .with_metrics(self.metrics.clone())
             .with_on_stream_batch_process_callback(on_batch_process_callback)
-            .with_last_updated_at(self.last_updated_at.clone())
+            .with_last_updated_at(Arc::clone(&self.last_updated_at.clone))
             .build(),
         );
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -484,7 +484,7 @@ pub struct Refresher {
     bootstrap_status: BootstrapStatus,
     /// Timestamp (milliseconds since epoch) of the last `insert_into` operation.
     /// Shared with `AcceleratedTable`.
-    last_updated_at: Option<Arc<AtomicI64>>,
+    last_updated_at: Arc<AtomicI64>,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -536,7 +536,7 @@ impl Refresher {
             resource_monitor: None,
             accelerator_write_mutex,
             bootstrap_status: BootstrapStatus::none(),
-            last_updated_at: None,
+            last_updated_at: Arc::new(AtomicI64::from(0)),
         }
     }
 
@@ -575,7 +575,7 @@ impl Refresher {
         self
     }
 
-    pub fn with_last_updated_at(&mut self, last_updated_at: Option<Arc<AtomicI64>>) -> &mut Self {
+    pub fn with_last_updated_at(&mut self, last_updated_at: Arc<AtomicI64>) -> &mut Self {
         self.last_updated_at = last_updated_at;
         self
     }
@@ -708,7 +708,7 @@ impl Refresher {
                             Arc::clone(&federated_schema),
                             Arc::clone(&self.runtime_status),
                             self.bootstrap_status.clone(),
-                            self.last_updated_at.clone(),
+                            Arc::clone(&self.last_updated_at),
                         ),
                         None,
                     ),
@@ -722,7 +722,7 @@ impl Refresher {
                             &self.dataset_name,
                             self.federated.schema(),
                             Arc::clone(&self.runtime_status),
-                            self.last_updated_at.clone(),
+                            Arc::clone(&self.last_updated_at),
                         ),
                     ),
                 };
@@ -744,7 +744,8 @@ impl Refresher {
             self.io_runtime.clone(),
             Arc::clone(&self.accelerator_write_mutex),
         )
-        .with_disable_federation(self.disable_federation);
+        .with_disable_federation(self.disable_federation)
+        .with_last_updated_at(self.last_updated_at.clone());
 
         if let Some(semaphore) = &self.semaphore {
             refresh_task_runner = refresh_task_runner.with_semaphore(Arc::clone(semaphore));
@@ -873,7 +874,7 @@ impl Refresher {
                                     &federated_schema,
                                     &snapshot_mutex,
                                     &dataset_name,
-                                    last_updated_at.as_ref(),
+                                    &last_updated_at,
                                 ).await;
                             }
                         }
@@ -943,6 +944,7 @@ impl Refresher {
             .with_cpu_runtime(self.cpu_runtime.clone())
             .with_metrics(self.metrics.clone())
             .with_on_stream_batch_process_callback(on_batch_process_callback)
+            .with_last_updated_at(self.last_updated_at.clone())
             .build(),
         );
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -944,7 +944,7 @@ impl Refresher {
             .with_cpu_runtime(self.cpu_runtime.clone())
             .with_metrics(self.metrics.clone())
             .with_on_stream_batch_process_callback(on_batch_process_callback)
-            .with_last_updated_at(Arc::clone(&self.last_updated_at.clone))
+            .with_last_updated_at(Arc::clone(&self.last_updated_at))
             .build(),
         );
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -78,6 +78,7 @@ use snafu::{OptionExt, ResultExt};
 use spicepod::metric::Metrics;
 use std::collections::HashSet;
 use std::pin::Pin;
+use std::sync::atomic::AtomicI64;
 use std::time::{Duration, UNIX_EPOCH};
 use std::{cmp::Ordering, sync::Arc, time::SystemTime};
 use tokio::{
@@ -119,6 +120,7 @@ pub struct RefreshTaskBuilder {
     /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
+    last_updated_at: Arc<AtomicI64>,
 }
 
 impl RefreshTaskBuilder {
@@ -146,6 +148,7 @@ impl RefreshTaskBuilder {
             resource_monitor: None,
             accelerator_write_mutex,
             on_stream_batch_process_callback: None,
+            last_updated_at: Arc::new(AtomicI64::new(0)),
         }
     }
 
@@ -189,6 +192,12 @@ impl RefreshTaskBuilder {
         callback: Option<StreamBatchProcessCallback>,
     ) -> RefreshTaskBuilder {
         self.on_stream_batch_process_callback = callback;
+        self
+    }
+
+    #[must_use]
+    pub fn with_last_updated_at(mut self, last_updated_at: Arc<AtomicI64>) -> RefreshTaskBuilder {
+        self.last_updated_at = last_updated_at;
         self
     }
 
@@ -240,6 +249,7 @@ impl RefreshTaskBuilder {
             resource_monitor: self.resource_monitor,
             accelerator_write_mutex: self.accelerator_write_mutex,
             on_stream_batch_process_callback: self.on_stream_batch_process_callback,
+            last_updated_at: self.last_updated_at,
         }
     }
 }
@@ -261,6 +271,7 @@ pub struct RefreshTask {
     /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     accelerator_write_mutex: Arc<Mutex<()>>,
     on_stream_batch_process_callback: Option<StreamBatchProcessCallback>,
+    last_updated_at: Arc<AtomicI64>,
 }
 
 impl std::fmt::Debug for RefreshTask {
@@ -1353,6 +1364,15 @@ impl RefreshTask {
         );
         self.set_refresh_status(refresh_sql, status::ComponentStatus::Error)
             .await;
+    }
+
+    fn update_last_updated_at(&self) {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        self.last_updated_at
+            .store(now_ms, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -1366,6 +1366,7 @@ impl RefreshTask {
             .await;
     }
 
+    #[expect(clippy::cast_possible_truncation)]
     fn update_last_updated_at(&self) {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -257,6 +257,8 @@ impl RefreshTask {
             .map_err(find_datafusion_root)
             .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
 
+        self.update_last_updated_at();
+
         Ok(())
     }
 
@@ -294,6 +296,8 @@ impl RefreshTask {
                 .map_err(find_datafusion_root)
                 .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
         }
+
+        self.update_last_updated_at();
 
         Ok(())
     }

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -31,11 +31,14 @@ use tokio::{
     task::JoinHandle,
 };
 
+use std::sync::atomic::AtomicI64;
 use std::{any::Any, panic::AssertUnwindSafe, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
 
 use super::refresh::Refresh;
+use crate::accelerated_table::refresh_task::RefreshTaskBuilder;
 use datafusion::{datasource::TableProvider, sql::TableReference};
+use imap::types::QuotaResourceName::Atom;
 use opentelemetry::KeyValue;
 use spicepod::metric::Metrics;
 
@@ -55,6 +58,7 @@ pub struct RefreshTaskRunnerBuilder {
     /// Mutex to protect concurrent access to the accelerator during cache/snapshot operations.
     /// Shared with `CachingAccelerationScanExec`.
     accelerator_write_mutex: Arc<Mutex<()>>,
+    last_updated_at: Arc<AtomicI64>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -84,6 +88,7 @@ impl RefreshTaskRunnerBuilder {
             io_runtime,
             resource_monitor: None,
             accelerator_write_mutex,
+            last_updated_at: Arc::new(AtomicI64::new(0)),
         }
     }
 
@@ -122,6 +127,12 @@ impl RefreshTaskRunnerBuilder {
     }
 
     #[must_use]
+    pub fn with_last_updated_at(mut self, last_updated_at: Arc<AtomicI64>) -> Self {
+        self.last_updated_at = last_updated_at;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> RefreshTaskRunner {
         let mut refresh_task_builder = RefreshTask::builder(
             self.runtime_status,
@@ -133,6 +144,7 @@ impl RefreshTaskRunnerBuilder {
             self.accelerator_write_mutex,
         )
         .with_disable_federation(self.disable_federation)
+        .with_last_updated_at(Arc::clone(&self.last_updated_at))
         .with_metrics(self.metrics);
 
         if let Some(semaphore) = self.semaphore {

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -38,7 +38,6 @@ use tokio::sync::{Mutex, RwLock};
 use super::refresh::Refresh;
 use crate::accelerated_table::refresh_task::RefreshTaskBuilder;
 use datafusion::{datasource::TableProvider, sql::TableReference};
-use imap::types::QuotaResourceName::Atom;
 use opentelemetry::KeyValue;
 use spicepod::metric::Metrics;
 

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -36,7 +36,6 @@ use std::{any::Any, panic::AssertUnwindSafe, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
 
 use super::refresh::Refresh;
-use crate::accelerated_table::refresh_task::RefreshTaskBuilder;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use opentelemetry::KeyValue;
 use spicepod::metric::Metrics;

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -173,7 +173,7 @@ pub fn create_periodic_snapshot_callback(
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
                 let dataset_ready = Arc::clone(&dataset_ready);
-                let last_updated_at = last_updated_at.clone();
+                let last_updated_at = Arc::clone(&last_updated_at);
 
                 Box::pin(async move {
                     // Only count batches after the dataset is ready

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -60,7 +60,7 @@ pub fn spawn_snapshot_interval_task(
     federated_schema: Arc<Schema>,
     runtime_status: Arc<RuntimeStatus>,
     bootstrap_status: crate::dataaccelerator::BootstrapStatus,
-    last_updated_at: Option<Arc<AtomicI64>>,
+    last_updated_at: Arc<AtomicI64>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     let interval_duration = snapshots_create_interval?;
     let checkpointer = checkpointer?;
@@ -113,7 +113,7 @@ pub fn spawn_snapshot_interval_task(
                 &federated_schema,
                 &accelerator_write_mutex,
                 &dataset_name,
-                last_updated_at.as_ref(),
+                &last_updated_at,
             )
             .await;
 
@@ -136,7 +136,7 @@ pub fn create_periodic_snapshot_callback(
     dataset_name: &TableReference,
     federated_schema: Arc<Schema>,
     runtime_status: Arc<RuntimeStatus>,
-    last_updated_at: Option<Arc<AtomicI64>>,
+    last_updated_at: Arc<AtomicI64>,
 ) -> Option<SnapshotCallback> {
     match (checkpointer, snapshot_manager) {
         (Some(checkpointer), Some(snapshot_manager)) => {
@@ -193,7 +193,7 @@ pub fn create_periodic_snapshot_callback(
                             &federated_schema,
                             &accelerator_write_mutex,
                             &dataset_name,
-                            last_updated_at.as_ref(),
+                            &last_updated_at,
                         )
                         .await;
                     }
@@ -213,7 +213,7 @@ pub async fn create_checkpoint_and_snapshot(
     federated_schema: &Arc<Schema>,
     accelerator_write_mutex: &Arc<Mutex<()>>,
     dataset_name: &TableReference,
-    last_updated_at: Option<&Arc<AtomicI64>>,
+    last_updated_at: &Arc<AtomicI64>,
 ) {
     let lock_guard = Arc::clone(accelerator_write_mutex).lock_owned().await;
     if let Err(e) = checkpointer.checkpoint(federated_schema).await {
@@ -222,7 +222,10 @@ pub async fn create_checkpoint_and_snapshot(
     }
 
     if let Some(snapshot_manager) = snapshot_manager {
-        let updated_at = last_updated_at.map(|a| a.load(Ordering::Acquire));
+        let updated_at = match last_updated_at.load(Ordering::Acquire) {
+            0 => None,
+            i => Some(i),
+        };
 
         match snapshot_manager
             .create_snapshot(federated_schema, lock_guard, updated_at)

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -159,27 +159,27 @@ pub enum SnapshotsResetExpiryOnLoad {
 pub enum SnapshotsCreationPolicy {
     Always,
     #[default]
-    Changed,
+    OnChange,
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
 fn is_default_snapshot_behavior(b: &SnapshotBehavior) -> bool {
-    *b == SnapshotBehavior::Disabled
+    *b == SnapshotBehavior::default()
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
 fn is_default_snapshot_compaction(c: &SnapshotsCompaction) -> bool {
-    *c == SnapshotsCompaction::Disabled
+    *c == SnapshotsCompaction::default()
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
 fn is_default_snapshots_reset_expiry_on_load(c: &SnapshotsResetExpiryOnLoad) -> bool {
-    *c == SnapshotsResetExpiryOnLoad::Disabled
+    *c == SnapshotsResetExpiryOnLoad::default()
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
 fn is_default_snapshots_creation_policy(c: &SnapshotsCreationPolicy) -> bool {
-    *c == SnapshotsCreationPolicy::Changed
+    *c == SnapshotsCreationPolicy::default()
 }
 
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]


### PR DESCRIPTION
## 📝 Summary

1. Properly propagate `last_updated_at` to make sure it is properly seen in `SnapshotManager`.

2. Rename `snapshots_creation_policy: changed -> on_change`

3. Move `last_updated_at` from dataset to snapshot entry