### PR TITLE
fix: Disable TPC-DS result validation (not yet supported)

### DIFF
--- a/tools/testoperator/dispatch/tpcds/sf1/accelerated/file[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/tpcds/sf1/accelerated/file[parquet]-cayenne[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/file[parquet]-cayenne[file].yaml
     query_set: tpcds
     runner_type: spiceai-dev-runners
-    validate_results: true
+    validate_results: false
   throughput:
     spicepod_path: accelerated/file[parquet]-cayenne[file].yaml
     query_set: tpcds

--- a/tools/testoperator/dispatch/tpcds/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results.yaml
+++ b/tools/testoperator/dispatch/tpcds/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results.yaml
@@ -3,4 +3,4 @@ tests:
     spicepod_path: accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results.yaml
     query_set: tpcds
     runner_type: spiceai-dev-runners
-    validate_results: true
+    validate_results: false

--- a/tools/testoperator/dispatch/tpcds/sf1/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/tpcds/sf1/accelerated/s3[parquet]-cayenne[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/s3[parquet]-cayenne[file].yaml
     query_set: tpcds
     runner_type: spiceai-dev-runners
-    validate_results: true
+    validate_results: false
   throughput:
     spicepod_path: accelerated/s3[parquet]-cayenne[file].yaml
     query_set: tpcds

--- a/tools/testoperator/dispatch/tpcds/sf10/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/tpcds/sf10/accelerated/s3[parquet]-cayenne[file].yaml
@@ -5,7 +5,7 @@ tests:
     runner_type: spiceai-dev-large-runners
     ready_wait: 1200
     scale_factor: 10
-    validate_results: true
+    validate_results: false
   throughput:
     spicepod_path: accelerated/s3[parquet]-cayenne[file].yaml
     query_set: tpcds

--- a/tools/testoperator/dispatch/tpcds/sf100/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/tpcds/sf100/accelerated/s3[parquet]-cayenne[file].yaml
@@ -5,4 +5,4 @@ tests:
     runner_type: spiceai-dev-large-runners
     ready_wait: 6000
     scale_factor: 100
-    validate_results: true
+    validate_results: false


### PR DESCRIPTION
## 📝 Summary

TPC-DS benchmarks were failing with `NoExpectedAnswer` validation errors because the test framework only has expected answer files for TPC-H queries, not TPC-DS.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
