### PR TITLE
Add TPC-DS integration tests with S3 source and PostgreSQL acceleration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -255,6 +255,10 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
           GITHUB_ORG_TOKEN: ${{ steps.github-app-token.outputs.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MinIO/S3-compatible storage for TPC-DS and other S3 tests
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          MINIO_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
           # old dbc instance
           TEST_DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           TEST_DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -103,6 +103,8 @@ mod spiceai;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 mod tls;
+#[cfg(feature = "postgres")]
+mod tpcds_postgres;
 mod utils;
 mod view;
 

--- a/crates/runtime/tests/tpcds_postgres/mod.rs
+++ b/crates/runtime/tests/tpcds_postgres/mod.rs
@@ -1,0 +1,465 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-DS integration tests with S3 source and PostgreSQL acceleration.
+//!
+//! These tests verify that TPC-DS queries execute correctly when data is loaded from
+//! an S3-compatible storage (rustfs locally, MinIO in CI) and accelerated into a
+//! PostgreSQL database.
+//!
+//! # CI Environment
+//!
+//! In CI, the TPC-DS data is pre-loaded in MinIO and the following environment
+//! variables are automatically set:
+//! - `MINIO_ENDPOINT`: The MinIO/S3 endpoint URL
+//! - `MINIO_ACCESS_KEY_ID`: The MinIO/S3 access key
+//! - `MINIO_SECRET_ACCESS_KEY`: The MinIO/S3 secret key
+//!
+//! # Running Tests Locally
+//!
+//! To run these tests locally, you need to:
+//!
+//! 1. **Install dependencies:**
+//!    - Docker (for rustfs and PostgreSQL containers)
+//!    - DuckDB CLI (`brew install duckdb` on macOS)
+//!
+//! 2. **Run the setup script:**
+//!    ```bash
+//!    cd crates/runtime/tests/tpcds_postgres
+//!    chmod +x setup_local_test_data.sh
+//!    ./setup_local_test_data.sh
+//!    ```
+//!
+//!    This script will:
+//!    - Start a rustfs container (S3-compatible storage) on port 9000
+//!    - Use DuckDB to generate TPC-DS SF1 data (~1GB)
+//!    - Export all 24 TPC-DS tables to Parquet format
+//!    - Upload the Parquet files to rustfs
+//!
+//! 3. **Set environment variables:**
+//!    ```bash
+//!    export MINIO_ENDPOINT="http://localhost:9000"
+//!    export MINIO_ACCESS_KEY_ID="rustfsadmin"
+//!    export MINIO_SECRET_ACCESS_KEY="rustfsadmin"
+//!    ```
+//!
+//! 4. **Run the tests:**
+//!    ```bash
+//!    cargo test -p runtime --test integration --features postgres tpcds_postgres
+//!    ```
+//!
+//! 5. **Clean up when done:**
+//!    ```bash
+//!    ./setup_local_test_data.sh cleanup
+//!    ```
+//!
+//! # Test Structure
+//!
+//! The tests share a single runtime instance to avoid the overhead of starting
+//! a new PostgreSQL container and loading all 24 TPC-DS tables for each query.
+//! The shared environment is initialized lazily on the first test and reused
+//! by all subsequent tests.
+//!
+//! Test flow:
+//! 1. First test triggers initialization: starts PostgreSQL, loads all datasets
+//! 2. All tests (q36, q70, q86) execute queries against the shared runtime
+//! 3. Container cleanup happens when the test process exits
+//!
+//! # Queries Tested
+//!
+//! - **Q36**: Gross margin calculation with ROLLUP grouping by item category/class
+//! - **Q70**: Store sales net profit by state/county with ROLLUP and correlated subquery
+//! - **Q86**: Web sales net paid by item category/class with ROLLUP
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+use futures::TryStreamExt;
+use runtime::Runtime;
+use tokio::sync::OnceCell;
+
+use crate::docker::RunningContainer;
+use crate::utils::runtime_ready_check_with_timeout;
+use crate::{
+    configure_test_datafusion, init_tracing,
+    postgres::common::{
+        PG_PASSWORD, get_pg_params, get_random_port, start_postgres_docker_container,
+    },
+    utils::test_request_context,
+};
+
+mod q36;
+mod q70;
+mod q86;
+
+/// Shared test environment containing the runtime and PostgreSQL container.
+/// Initialized once and reused across all TPC-DS query tests.
+struct SharedTestEnv {
+    rt: Arc<Runtime>,
+    #[expect(dead_code)]
+    running_container: RunningContainer<'static>,
+}
+
+/// Global shared test environment, initialized lazily on first use.
+static SHARED_ENV: OnceCell<SharedTestEnv> = OnceCell::const_new();
+
+/// Initializes the shared test environment (PostgreSQL container + Runtime with all datasets).
+/// This is called once and the result is cached for all subsequent tests.
+async fn init_shared_env() -> Result<SharedTestEnv, anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let port = get_random_port()?;
+    let running_container = start_postgres_docker_container(port).await?;
+
+    let pg_db = "tpcds_test";
+
+    // Create the database before loading the spicepod
+    create_database(port, pg_db).await?;
+
+    let spicepod_yaml = get_tpcds_spicepod_yaml(port, pg_db);
+
+    let app = test_framework::app_utils::load_app_from_spicepod_str(&spicepod_yaml)
+        .await
+        .expect("Should load app from spicepod string");
+
+    configure_test_datafusion();
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+    // Wait for datasets to load with a longer timeout since we're loading many tables
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(600)) => {
+            return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+        }
+        () = Arc::clone(&rt).load_components() => {}
+    }
+
+    // Wait for runtime to be ready with extended timeout for acceleration
+    runtime_ready_check_with_timeout(&rt, std::time::Duration::from_secs(300)).await;
+
+    tracing::info!("TPC-DS shared test environment initialized successfully");
+
+    Ok(SharedTestEnv {
+        rt,
+        running_container,
+    })
+}
+
+/// Gets the shared test environment, initializing it if necessary.
+/// All TPC-DS query tests use this to share the same runtime instance.
+async fn get_shared_env() -> Result<&'static SharedTestEnv, anyhow::Error> {
+    SHARED_ENV
+        .get_or_try_init(init_shared_env)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to initialize shared test environment: {e}"))
+}
+
+/// Creates a spicepod YAML string for TPC-DS with MinIO S3 source and PostgreSQL acceleration.
+///
+/// This function generates a spicepod configuration that:
+/// 1. Reads TPC-DS SF1 parquet files from an S3-compatible endpoint (MinIO in CI)
+/// 2. Accelerates the data into a PostgreSQL database
+#[expect(clippy::expect_used)]
+fn get_tpcds_spicepod_yaml(pg_port: usize, pg_db: &str) -> String {
+    let minio_endpoint =
+        std::env::var("MINIO_ENDPOINT").expect("MINIO_ENDPOINT environment variable must be set");
+    let minio_access_key = std::env::var("MINIO_ACCESS_KEY_ID")
+        .expect("MINIO_ACCESS_KEY_ID environment variable must be set");
+    let minio_secret_key = std::env::var("MINIO_SECRET_ACCESS_KEY")
+        .expect("MINIO_SECRET_ACCESS_KEY environment variable must be set");
+
+    format!(
+        r#"version: v1
+kind: Spicepod
+name: tpcds-s3-postgres-test
+datasets:
+  - from: s3://benchmarks/tpcds_sf1/catalog_sales.parquet
+    name: catalog_sales
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: {minio_endpoint}
+      s3_key: {minio_access_key}
+      s3_secret: {minio_secret_key}
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: &pg_params
+        pg_host: localhost
+        pg_user: postgres
+        pg_pass: {pg_password}
+        pg_db: {pg_db}
+        pg_port: {pg_port}
+        pg_sslmode: disable
+      primary_key: (cs_item_sk, cs_order_number)
+  - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
+    name: catalog_returns
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (cr_item_sk, cr_order_number)
+  - from: s3://benchmarks/tpcds_sf1/inventory.parquet
+    name: inventory
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (inv_date_sk, inv_item_sk, inv_warehouse_sk)
+  - from: s3://benchmarks/tpcds_sf1/store_sales.parquet
+    name: store_sales
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (ss_item_sk, ss_ticket_number)
+  - from: s3://benchmarks/tpcds_sf1/store_returns.parquet
+    name: store_returns
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (sr_item_sk, sr_ticket_number)
+  - from: s3://benchmarks/tpcds_sf1/web_sales.parquet
+    name: web_sales
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (ws_item_sk, ws_order_number)
+  - from: s3://benchmarks/tpcds_sf1/web_returns.parquet
+    name: web_returns
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (wr_item_sk, wr_order_number)
+  - from: s3://benchmarks/tpcds_sf1/customer.parquet
+    name: customer
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (c_customer_sk)
+  - from: s3://benchmarks/tpcds_sf1/customer_address.parquet
+    name: customer_address
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (ca_address_sk)
+  - from: s3://benchmarks/tpcds_sf1/customer_demographics.parquet
+    name: customer_demographics
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (cd_demo_sk)
+  - from: s3://benchmarks/tpcds_sf1/date_dim.parquet
+    name: date_dim
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (d_date_sk)
+  - from: s3://benchmarks/tpcds_sf1/household_demographics.parquet
+    name: household_demographics
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (hd_demo_sk)
+  - from: s3://benchmarks/tpcds_sf1/item.parquet
+    name: item
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (i_item_sk)
+  - from: s3://benchmarks/tpcds_sf1/promotion.parquet
+    name: promotion
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (p_promo_sk)
+  - from: s3://benchmarks/tpcds_sf1/ship_mode.parquet
+    name: ship_mode
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (sm_ship_mode_sk)
+  - from: s3://benchmarks/tpcds_sf1/store.parquet
+    name: store
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (s_store_sk)
+  - from: s3://benchmarks/tpcds_sf1/time_dim.parquet
+    name: time_dim
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (t_time_sk)
+  - from: s3://benchmarks/tpcds_sf1/warehouse.parquet
+    name: warehouse
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (w_warehouse_sk)
+  - from: s3://benchmarks/tpcds_sf1/web_page.parquet
+    name: web_page
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (wp_web_page_sk)
+  - from: s3://benchmarks/tpcds_sf1/web_site.parquet
+    name: web_site
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (web_site_sk)
+  - from: s3://benchmarks/tpcds_sf1/reason.parquet
+    name: reason
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (r_reason_sk)
+  - from: s3://benchmarks/tpcds_sf1/call_center.parquet
+    name: call_center
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (cc_call_center_sk)
+  - from: s3://benchmarks/tpcds_sf1/income_band.parquet
+    name: income_band
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (ib_income_band_sk)
+  - from: s3://benchmarks/tpcds_sf1/catalog_page.parquet
+    name: catalog_page
+    params: *s3_params
+    acceleration:
+      enabled: true
+      engine: postgres
+      params: *pg_params
+      primary_key: (cp_catalog_page_sk)
+"#,
+        minio_endpoint = minio_endpoint,
+        minio_access_key = minio_access_key,
+        minio_secret_key = minio_secret_key,
+        pg_password = PG_PASSWORD,
+        pg_db = pg_db,
+        pg_port = pg_port,
+    )
+}
+
+/// Creates the test database in PostgreSQL.
+async fn create_database(port: usize, db_name: &str) -> Result<(), anyhow::Error> {
+    let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
+    let conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("Error connecting to PostgreSQL: {e}"))?;
+
+    // Create the database (ignore error if it already exists)
+    let create_db_sql = format!("CREATE DATABASE {db_name}");
+    if let Err(e) = conn.conn.execute(&create_db_sql, &[]).await {
+        // Ignore "database already exists" error
+        if !e.to_string().contains("already exists") {
+            return Err(anyhow::anyhow!("Error creating database: {e}"));
+        }
+    }
+
+    Ok(())
+}
+
+/// Runs a TPC-DS query against the shared accelerated PostgreSQL runtime.
+///
+/// This function:
+/// 1. Gets or initializes the shared test environment (PostgreSQL + Runtime)
+/// 2. Executes the query and validates that results are returned
+///
+/// The shared environment is initialized once on the first test and reused
+/// by all subsequent tests, making the test suite much faster.
+async fn test_tpcds_query(query: &str) -> Result<(), anyhow::Error> {
+    test_request_context()
+        .scope(async {
+            let env = get_shared_env().await?;
+
+            // Run EXPLAIN to verify query planning
+            let query_result = env
+                .rt
+                .datafusion()
+                .query_builder(&format!("EXPLAIN VERBOSE {query}"))
+                .build()
+                .run()
+                .await?;
+            let explain_plan = query_result.data.try_collect::<Vec<RecordBatch>>().await?;
+            let explain_plan_display = arrow::util::pretty::pretty_format_batches(&explain_plan)?;
+            tracing::info!("Query plan:\n{explain_plan_display}");
+
+            // Execute the actual query
+            let query_result = env
+                .rt
+                .datafusion()
+                .query_builder(query)
+                .build()
+                .run()
+                .await?;
+            let results = query_result.data.try_collect::<Vec<RecordBatch>>().await?;
+
+            // Validate that we got some results
+            let total_rows: usize = results.iter().map(RecordBatch::num_rows).sum();
+            tracing::info!("Query returned {total_rows} rows");
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/tpcds_postgres/mod.rs
+++ b/crates/runtime/tests/tpcds_postgres/mod.rs
@@ -69,12 +69,15 @@ limitations under the License.
 //! # Test Structure
 //!
 //! The tests share a single runtime instance to avoid the overhead of starting
-//! a new PostgreSQL container and loading all 24 TPC-DS tables for each query.
+//! a new PostgreSQL container and loading tables for each query. Only the 5
+//! tables required by the tested queries are loaded (not all 24 TPC-DS tables).
 //! The shared environment is initialized lazily on the first test and reused
 //! by all subsequent tests.
 //!
+//! Tables loaded: `store_sales`, `web_sales`, `date_dim`, `item`, `store`
+//!
 //! Test flow:
-//! 1. First test triggers initialization: starts PostgreSQL, loads all datasets
+//! 1. First test triggers initialization: starts PostgreSQL, loads required datasets
 //! 2. All tests (q36, q70, q86) execute queries against the shared runtime
 //! 3. Container cleanup happens when the test process exits
 //!
@@ -172,6 +175,13 @@ async fn get_shared_env() -> Result<&'static SharedTestEnv, anyhow::Error> {
 /// This function generates a spicepod configuration that:
 /// 1. Reads TPC-DS SF1 parquet files from an S3-compatible endpoint (MinIO in CI)
 /// 2. Accelerates the data into a PostgreSQL database
+///
+/// Only loads the tables required by queries Q36, Q70, and Q86:
+/// - store_sales (Q36, Q70)
+/// - web_sales (Q86)
+/// - date_dim (Q36, Q70, Q86)
+/// - item (Q36, Q86)
+/// - store (Q36, Q70)
 #[expect(clippy::expect_used)]
 fn get_tpcds_spicepod_yaml(pg_port: usize, pg_db: &str) -> String {
     let minio_endpoint =
@@ -186,8 +196,9 @@ fn get_tpcds_spicepod_yaml(pg_port: usize, pg_db: &str) -> String {
 kind: Spicepod
 name: tpcds-s3-postgres-test
 datasets:
-  - from: s3://benchmarks/tpcds_sf1/catalog_sales.parquet
-    name: catalog_sales
+  # store_sales - used by Q36, Q70 (largest table, ~2M rows at SF1)
+  - from: s3://benchmarks/tpcds_sf1/store_sales.parquet
+    name: store_sales
     params: &s3_params
       file_format: parquet
       allow_http: true
@@ -205,39 +216,8 @@ datasets:
         pg_db: {pg_db}
         pg_port: {pg_port}
         pg_sslmode: disable
-      primary_key: (cs_item_sk, cs_order_number)
-  - from: s3://benchmarks/tpcds_sf1/catalog_returns.parquet
-    name: catalog_returns
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (cr_item_sk, cr_order_number)
-  - from: s3://benchmarks/tpcds_sf1/inventory.parquet
-    name: inventory
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (inv_date_sk, inv_item_sk, inv_warehouse_sk)
-  - from: s3://benchmarks/tpcds_sf1/store_sales.parquet
-    name: store_sales
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
       primary_key: (ss_item_sk, ss_ticket_number)
-  - from: s3://benchmarks/tpcds_sf1/store_returns.parquet
-    name: store_returns
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (sr_item_sk, sr_ticket_number)
+  # web_sales - used by Q86
   - from: s3://benchmarks/tpcds_sf1/web_sales.parquet
     name: web_sales
     params: *s3_params
@@ -246,38 +226,7 @@ datasets:
       engine: postgres
       params: *pg_params
       primary_key: (ws_item_sk, ws_order_number)
-  - from: s3://benchmarks/tpcds_sf1/web_returns.parquet
-    name: web_returns
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (wr_item_sk, wr_order_number)
-  - from: s3://benchmarks/tpcds_sf1/customer.parquet
-    name: customer
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (c_customer_sk)
-  - from: s3://benchmarks/tpcds_sf1/customer_address.parquet
-    name: customer_address
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (ca_address_sk)
-  - from: s3://benchmarks/tpcds_sf1/customer_demographics.parquet
-    name: customer_demographics
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (cd_demo_sk)
+  # date_dim - used by Q36, Q70, Q86
   - from: s3://benchmarks/tpcds_sf1/date_dim.parquet
     name: date_dim
     params: *s3_params
@@ -286,14 +235,7 @@ datasets:
       engine: postgres
       params: *pg_params
       primary_key: (d_date_sk)
-  - from: s3://benchmarks/tpcds_sf1/household_demographics.parquet
-    name: household_demographics
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (hd_demo_sk)
+  # item - used by Q36, Q86
   - from: s3://benchmarks/tpcds_sf1/item.parquet
     name: item
     params: *s3_params
@@ -302,22 +244,7 @@ datasets:
       engine: postgres
       params: *pg_params
       primary_key: (i_item_sk)
-  - from: s3://benchmarks/tpcds_sf1/promotion.parquet
-    name: promotion
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (p_promo_sk)
-  - from: s3://benchmarks/tpcds_sf1/ship_mode.parquet
-    name: ship_mode
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (sm_ship_mode_sk)
+  # store - used by Q36, Q70
   - from: s3://benchmarks/tpcds_sf1/store.parquet
     name: store
     params: *s3_params
@@ -326,70 +253,6 @@ datasets:
       engine: postgres
       params: *pg_params
       primary_key: (s_store_sk)
-  - from: s3://benchmarks/tpcds_sf1/time_dim.parquet
-    name: time_dim
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (t_time_sk)
-  - from: s3://benchmarks/tpcds_sf1/warehouse.parquet
-    name: warehouse
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (w_warehouse_sk)
-  - from: s3://benchmarks/tpcds_sf1/web_page.parquet
-    name: web_page
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (wp_web_page_sk)
-  - from: s3://benchmarks/tpcds_sf1/web_site.parquet
-    name: web_site
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (web_site_sk)
-  - from: s3://benchmarks/tpcds_sf1/reason.parquet
-    name: reason
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (r_reason_sk)
-  - from: s3://benchmarks/tpcds_sf1/call_center.parquet
-    name: call_center
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (cc_call_center_sk)
-  - from: s3://benchmarks/tpcds_sf1/income_band.parquet
-    name: income_band
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (ib_income_band_sk)
-  - from: s3://benchmarks/tpcds_sf1/catalog_page.parquet
-    name: catalog_page
-    params: *s3_params
-    acceleration:
-      enabled: true
-      engine: postgres
-      params: *pg_params
-      primary_key: (cp_catalog_page_sk)
 "#,
         minio_endpoint = minio_endpoint,
         minio_access_key = minio_access_key,

--- a/crates/runtime/tests/tpcds_postgres/mod.rs
+++ b/crates/runtime/tests/tpcds_postgres/mod.rs
@@ -14,27 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! TPC-DS integration tests with S3 source and PostgreSQL acceleration.
+//! TPC-DS integration tests with S3 source and `PostgreSQL` acceleration.
 //!
 //! These tests verify that TPC-DS queries execute correctly when data is loaded from
-//! an S3-compatible storage (rustfs locally, MinIO in CI) and accelerated into a
-//! PostgreSQL database.
+//! an S3-compatible storage (rustfs locally, `MinIO` in CI) and accelerated into a
+//! `PostgreSQL` database.
 //!
 //! # CI Environment
 //!
-//! In CI, the TPC-DS data is pre-loaded in MinIO and the following environment
+//! In CI, the TPC-DS data is pre-loaded in `MinIO` and the following environment
 //! variables are automatically set:
-//! - `MINIO_ENDPOINT`: The MinIO/S3 endpoint URL
-//! - `MINIO_ACCESS_KEY_ID`: The MinIO/S3 access key
-//! - `MINIO_SECRET_ACCESS_KEY`: The MinIO/S3 secret key
+//! - `MINIO_ENDPOINT`: The `MinIO`/S3 endpoint URL
+//! - `MINIO_ACCESS_KEY_ID`: The `MinIO`/S3 access key
+//! - `MINIO_SECRET_ACCESS_KEY`: The `MinIO`/S3 secret key
 //!
 //! # Running Tests Locally
 //!
 //! To run these tests locally, you need to:
 //!
 //! 1. **Install dependencies:**
-//!    - Docker (for rustfs and PostgreSQL containers)
-//!    - DuckDB CLI (`brew install duckdb` on macOS)
+//!    - Docker (for rustfs and `PostgreSQL` containers)
+//!    - `DuckDB` CLI (`brew install duckdb` on macOS)
 //!
 //! 2. **Run the setup script:**
 //!    ```bash
@@ -45,7 +45,7 @@ limitations under the License.
 //!
 //!    This script will:
 //!    - Start a rustfs container (S3-compatible storage) on port 9000
-//!    - Use DuckDB to generate TPC-DS SF1 data (~1GB)
+//!    - Use `DuckDB` to generate TPC-DS SF1 data (~1GB)
 //!    - Export all 24 TPC-DS tables to Parquet format
 //!    - Upload the Parquet files to rustfs
 //!
@@ -69,7 +69,7 @@ limitations under the License.
 //! # Test Structure
 //!
 //! The tests share a single runtime instance to avoid the overhead of starting
-//! a new PostgreSQL container and loading tables for each query. Only the 5
+//! a new `PostgreSQL` container and loading tables for each query. Only the 5
 //! tables required by the tested queries are loaded (not all 24 TPC-DS tables).
 //! The shared environment is initialized lazily on the first test and reused
 //! by all subsequent tests.
@@ -77,7 +77,7 @@ limitations under the License.
 //! Tables loaded: `store_sales`, `web_sales`, `date_dim`, `item`, `store`
 //!
 //! Test flow:
-//! 1. First test triggers initialization: starts PostgreSQL, loads required datasets
+//! 1. First test triggers initialization: starts `PostgreSQL`, loads required datasets
 //! 2. All tests (q36, q70, q86) execute queries against the shared runtime
 //! 3. Container cleanup happens when the test process exits
 //!
@@ -109,7 +109,7 @@ mod q36;
 mod q70;
 mod q86;
 
-/// Shared test environment containing the runtime and PostgreSQL container.
+/// Shared test environment containing the runtime and `PostgreSQL` container.
 /// Initialized once and reused across all TPC-DS query tests.
 struct SharedTestEnv {
     rt: Arc<Runtime>,
@@ -120,7 +120,7 @@ struct SharedTestEnv {
 /// Global shared test environment, initialized lazily on first use.
 static SHARED_ENV: OnceCell<SharedTestEnv> = OnceCell::const_new();
 
-/// Initializes the shared test environment (PostgreSQL container + Runtime with all datasets).
+/// Initializes the shared test environment (`PostgreSQL` container + Runtime with all datasets).
 /// This is called once and the result is cached for all subsequent tests.
 async fn init_shared_env() -> Result<SharedTestEnv, anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -170,16 +170,16 @@ async fn get_shared_env() -> Result<&'static SharedTestEnv, anyhow::Error> {
         .map_err(|e| anyhow::anyhow!("Failed to initialize shared test environment: {e}"))
 }
 
-/// Creates a spicepod YAML string for TPC-DS with MinIO S3 source and PostgreSQL acceleration.
+/// Creates a spicepod YAML string for TPC-DS with `MinIO` S3 source and `PostgreSQL` acceleration.
 ///
 /// This function generates a spicepod configuration that:
-/// 1. Reads TPC-DS SF1 parquet files from an S3-compatible endpoint (MinIO in CI)
-/// 2. Accelerates the data into a PostgreSQL database
+/// 1. Reads TPC-DS SF1 parquet files from an S3-compatible endpoint (`MinIO` in CI)
+/// 2. Accelerates the data into a `PostgreSQL` database
 ///
 /// Only loads the tables required by queries Q36, Q70, and Q86:
-/// - store_sales (Q36, Q70)
-/// - web_sales (Q86)
-/// - date_dim (Q36, Q70, Q86)
+/// - `store_sales` (Q36, Q70)
+/// - `web_sales` (Q86)
+/// - `date_dim` (Q36, Q70, Q86)
 /// - item (Q36, Q86)
 /// - store (Q36, Q70)
 #[expect(clippy::expect_used)]
@@ -191,8 +191,10 @@ fn get_tpcds_spicepod_yaml(pg_port: usize, pg_db: &str) -> String {
     let minio_secret_key = std::env::var("MINIO_SECRET_ACCESS_KEY")
         .expect("MINIO_SECRET_ACCESS_KEY environment variable must be set");
 
+    let pg_password = PG_PASSWORD;
+
     format!(
-        r#"version: v1
+        r"version: v1
 kind: Spicepod
 name: tpcds-s3-postgres-test
 datasets:
@@ -253,17 +255,11 @@ datasets:
       engine: postgres
       params: *pg_params
       primary_key: (s_store_sk)
-"#,
-        minio_endpoint = minio_endpoint,
-        minio_access_key = minio_access_key,
-        minio_secret_key = minio_secret_key,
-        pg_password = PG_PASSWORD,
-        pg_db = pg_db,
-        pg_port = pg_port,
+",
     )
 }
 
-/// Creates the test database in PostgreSQL.
+/// Creates the test database in `PostgreSQL`.
 async fn create_database(port: usize, db_name: &str) -> Result<(), anyhow::Error> {
     let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
     let conn = pool
@@ -283,10 +279,10 @@ async fn create_database(port: usize, db_name: &str) -> Result<(), anyhow::Error
     Ok(())
 }
 
-/// Runs a TPC-DS query against the shared accelerated PostgreSQL runtime.
+/// Runs a TPC-DS query against the shared accelerated `PostgreSQL` runtime.
 ///
 /// This function:
-/// 1. Gets or initializes the shared test environment (PostgreSQL + Runtime)
+/// 1. Gets or initializes the shared test environment (`PostgreSQL` + Runtime)
 /// 2. Executes the query and validates that results are returned
 ///
 /// The shared environment is initialized once on the first test and reused

--- a/crates/runtime/tests/tpcds_postgres/q36.rs
+++ b/crates/runtime/tests/tpcds_postgres/q36.rs
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-DS Query 36: Gross margin calculation with ROLLUP grouping
+//!
+//! This query calculates gross margin (net profit / extended sales price) by item category
+//! and class using ROLLUP for hierarchical aggregation.
+
+const Q36_QUERY: &str = r#"
+select
+    sum(ss_net_profit)/sum(ss_ext_sales_price) as gross_margin
+   ,i_category
+   ,i_class
+   ,grouping(i_category)+grouping(i_class) as lochierarchy
+   ,rank() over (
+ 	partition by grouping(i_category)+grouping(i_class),
+ 	case when grouping(i_class) = 0 then i_category end
+ 	order by sum(ss_net_profit)/sum(ss_ext_sales_price) asc) as rank_within_parent
+ from
+    store_sales
+   ,date_dim       d1
+   ,item
+   ,store
+ where
+    d1.d_year = 2001
+ and d1.d_date_sk = ss_sold_date_sk
+ and i_item_sk  = ss_item_sk
+ and s_store_sk  = ss_store_sk
+ and s_state in ('TN','TN','TN','TN',
+                 'TN','TN','TN','TN')
+ group by rollup(i_category,i_class)
+ order by
+   grouping(i_category)+grouping(i_class) desc
+  ,case when grouping(i_category)+grouping(i_class) = 0 then i_category end
+  ,rank_within_parent
+   LIMIT 100
+"#;
+
+#[tokio::test]
+async fn test_tpcds_q36() -> Result<(), anyhow::Error> {
+    super::test_tpcds_query(Q36_QUERY).await
+}

--- a/crates/runtime/tests/tpcds_postgres/q36.rs
+++ b/crates/runtime/tests/tpcds_postgres/q36.rs
@@ -19,7 +19,7 @@ limitations under the License.
 //! This query calculates gross margin (net profit / extended sales price) by item category
 //! and class using ROLLUP for hierarchical aggregation.
 
-const Q36_QUERY: &str = r#"
+const Q36_QUERY: &str = r"
 select
     sum(ss_net_profit)/sum(ss_ext_sales_price) as gross_margin
    ,i_category
@@ -47,7 +47,7 @@ select
   ,case when grouping(i_category)+grouping(i_class) = 0 then i_category end
   ,rank_within_parent
    LIMIT 100
-"#;
+";
 
 #[tokio::test]
 async fn test_tpcds_q36() -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/tpcds_postgres/q70.rs
+++ b/crates/runtime/tests/tpcds_postgres/q70.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-DS Query 70: Store sales net profit by state and county with ROLLUP
+//!
+//! This query calculates net profit from store sales, grouped by state and county
+//! using ROLLUP for hierarchical totals. It includes a correlated subquery to
+//! filter states by their ranking based on total net profit.
+
+const Q70_QUERY: &str = r#"
+select
+    sum(ss_net_profit) as total_sum
+   ,s_state
+   ,s_county
+   ,grouping(s_state)+grouping(s_county) as lochierarchy
+   ,rank() over (
+ 	partition by grouping(s_state)+grouping(s_county),
+ 	case when grouping(s_county) = 0 then s_state end
+ 	order by sum(ss_net_profit) desc) as rank_within_parent
+ from
+    store_sales
+   ,date_dim       d1
+   ,store
+ where
+    d1.d_month_seq between 1180 and 1180+11
+ and d1.d_date_sk = ss_sold_date_sk
+ and s_store_sk  = ss_store_sk
+ and s_state in
+             ( select s_state
+               from  (select s_state as s_state,
+ 			    rank() over ( partition by s_state order by sum(ss_net_profit) desc) as ranking
+                      from   store_sales, store, date_dim
+                      where  d_month_seq between 1180 and 1180+11
+ 			    and d_date_sk = ss_sold_date_sk
+ 			    and s_store_sk  = ss_store_sk
+                      group by s_state
+                     ) tmp1
+               where ranking <= 5
+             )
+ group by rollup(s_state,s_county)
+ order by
+   lochierarchy desc
+  ,case when grouping(s_state)+grouping(s_county) = 0 then s_state end
+  ,rank_within_parent
+  LIMIT 100
+"#;
+
+#[tokio::test]
+async fn test_tpcds_q70() -> Result<(), anyhow::Error> {
+    super::test_tpcds_query(Q70_QUERY).await
+}

--- a/crates/runtime/tests/tpcds_postgres/q70.rs
+++ b/crates/runtime/tests/tpcds_postgres/q70.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! using ROLLUP for hierarchical totals. It includes a correlated subquery to
 //! filter states by their ranking based on total net profit.
 
-const Q70_QUERY: &str = r#"
+const Q70_QUERY: &str = r"
 select
     sum(ss_net_profit) as total_sum
    ,s_state
@@ -56,7 +56,7 @@ select
   ,case when grouping(s_state)+grouping(s_county) = 0 then s_state end
   ,rank_within_parent
   LIMIT 100
-"#;
+";
 
 #[tokio::test]
 async fn test_tpcds_q70() -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/tpcds_postgres/q86.rs
+++ b/crates/runtime/tests/tpcds_postgres/q86.rs
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-DS Query 86: Web sales net paid by item category and class with ROLLUP
+//!
+//! This query calculates net paid amounts from web sales, grouped by item category
+//! and class using ROLLUP for hierarchical totals.
+
+const Q86_QUERY: &str = r#"
+select
+    sum(ws_net_paid) as total_sum
+   ,i_category
+   ,i_class
+   ,grouping(i_category)+grouping(i_class) as lochierarchy
+   ,rank() over (
+ 	partition by grouping(i_category)+grouping(i_class),
+ 	case when grouping(i_class) = 0 then i_category end
+ 	order by sum(ws_net_paid) desc) as rank_within_parent
+ from
+    web_sales
+   ,date_dim       d1
+   ,item
+ where
+    d1.d_month_seq between 1205 and 1205+11
+ and d1.d_date_sk = ws_sold_date_sk
+ and i_item_sk  = ws_item_sk
+ group by rollup(i_category,i_class)
+ order by
+   lochierarchy desc,
+   case when grouping(i_category)+grouping(i_class) = 0 then i_category end,
+   rank_within_parent
+  LIMIT 100
+"#;
+
+#[tokio::test]
+async fn test_tpcds_q86() -> Result<(), anyhow::Error> {
+    super::test_tpcds_query(Q86_QUERY).await
+}

--- a/crates/runtime/tests/tpcds_postgres/q86.rs
+++ b/crates/runtime/tests/tpcds_postgres/q86.rs
@@ -19,7 +19,7 @@ limitations under the License.
 //! This query calculates net paid amounts from web sales, grouped by item category
 //! and class using ROLLUP for hierarchical totals.
 
-const Q86_QUERY: &str = r#"
+const Q86_QUERY: &str = r"
 select
     sum(ws_net_paid) as total_sum
    ,i_category
@@ -43,7 +43,7 @@ select
    case when grouping(i_category)+grouping(i_class) = 0 then i_category end,
    rank_within_parent
   LIMIT 100
-"#;
+";
 
 #[tokio::test]
 async fn test_tpcds_q86() -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/tpcds_postgres/setup_local_test_data.sh
+++ b/crates/runtime/tests/tpcds_postgres/setup_local_test_data.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# Copyright 2026 The Spice.ai OSS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# TPC-DS Test Data Setup Script
+# =============================================================================
+#
+# This script sets up the local test environment for TPC-DS PostgreSQL 
+# acceleration integration tests. It:
+#
+# 1. Starts a rustfs container (S3-compatible storage)
+# 2. Uses DuckDB to generate TPC-DS SF1 data and export to Parquet
+# 3. Uploads the Parquet files to rustfs
+#
+# Usage:
+#   ./setup_local_test_data.sh
+#
+# After running, set these environment variables to run the tests:
+#   export MINIO_ENDPOINT="http://localhost:9000"
+#   export MINIO_ACCESS_KEY_ID="rustfsadmin"
+#   export MINIO_SECRET_ACCESS_KEY="rustfsadmin"
+#
+# Then run the tests:
+#   cargo test -p runtime --test integration --features postgres tpcds_postgres
+#
+# To clean up:
+#   ./setup_local_test_data.sh cleanup
+# =============================================================================
+
+set -euo pipefail
+
+# Configuration
+RUSTFS_CONTAINER_NAME="spice_tpcds_test_rustfs"
+RUSTFS_PORT="${RUSTFS_PORT:-9000}"
+RUSTFS_IMAGE="rustfs/rustfs:latest"
+RUSTFS_ACCESS_KEY="rustfsadmin"
+RUSTFS_SECRET_KEY="rustfsadmin"
+S3_BUCKET="benchmarks"
+TPCDS_SCALE_FACTOR="${TPCDS_SCALE_FACTOR:-1}"
+DATA_DIR="${DATA_DIR:-/tmp/tpcds_test_data}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+cleanup() {
+    log_info "Cleaning up..."
+    
+    # Stop and remove rustfs container
+    if docker ps -a --format '{{.Names}}' | grep -q "^${RUSTFS_CONTAINER_NAME}$"; then
+        log_info "Stopping and removing rustfs container..."
+        docker stop "${RUSTFS_CONTAINER_NAME}" 2>/dev/null || true
+        docker rm "${RUSTFS_CONTAINER_NAME}" 2>/dev/null || true
+    fi
+    
+    # Clean up data directory
+    if [ -d "${DATA_DIR}" ]; then
+        log_info "Removing data directory: ${DATA_DIR}"
+        rm -rf "${DATA_DIR}"
+    fi
+    
+    log_info "Cleanup complete."
+}
+
+check_dependencies() {
+    log_info "Checking dependencies..."
+    
+    if ! command -v docker &> /dev/null; then
+        log_error "Docker is not installed. Please install Docker first."
+        exit 1
+    fi
+    
+    if ! command -v duckdb &> /dev/null; then
+        log_error "DuckDB CLI is not installed."
+        log_info "Install via: brew install duckdb (macOS) or see https://duckdb.org/docs/installation/"
+        exit 1
+    fi
+    
+    if ! command -v aws &> /dev/null; then
+        log_error "AWS CLI is not installed."
+        log_info "Install via: brew install awscli (macOS) or see https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        exit 1
+    fi
+    
+    log_info "Dependencies check passed."
+}
+
+start_rustfs() {
+    log_info "Starting rustfs container..."
+    
+    # Check if container already exists
+    if docker ps --format '{{.Names}}' | grep -q "^${RUSTFS_CONTAINER_NAME}$"; then
+        log_info "rustfs container is already running."
+        return 0
+    fi
+    
+    # Remove stopped container if exists
+    if docker ps -a --format '{{.Names}}' | grep -q "^${RUSTFS_CONTAINER_NAME}$"; then
+        log_info "Removing stopped rustfs container..."
+        docker rm "${RUSTFS_CONTAINER_NAME}"
+    fi
+    
+    # Create data directory for rustfs
+    mkdir -p "${DATA_DIR}/rustfs"
+    
+    # Start rustfs container
+    docker run -d \
+        --name "${RUSTFS_CONTAINER_NAME}" \
+        -p "${RUSTFS_PORT}:9000" \
+        -v "${DATA_DIR}/rustfs:/data" \
+        "${RUSTFS_IMAGE}" \
+        /data
+    
+    # Wait for rustfs to be ready
+    log_info "Waiting for rustfs to be ready..."
+    local retries=30
+    while [ $retries -gt 0 ]; do
+        if curl -s "http://localhost:${RUSTFS_PORT}" > /dev/null 2>&1; then
+            log_info "rustfs is ready."
+            return 0
+        fi
+        sleep 1
+        retries=$((retries - 1))
+    done
+    
+    log_error "rustfs failed to start within timeout."
+    exit 1
+}
+
+generate_tpcds_data() {
+    log_info "Generating TPC-DS SF${TPCDS_SCALE_FACTOR} data using DuckDB..."
+    
+    mkdir -p "${DATA_DIR}/parquet"
+    
+    # TPC-DS tables to generate
+    local tables=(
+        "call_center"
+        "catalog_page"
+        "catalog_returns"
+        "catalog_sales"
+        "customer"
+        "customer_address"
+        "customer_demographics"
+        "date_dim"
+        "household_demographics"
+        "income_band"
+        "inventory"
+        "item"
+        "promotion"
+        "reason"
+        "ship_mode"
+        "store"
+        "store_returns"
+        "store_sales"
+        "time_dim"
+        "warehouse"
+        "web_page"
+        "web_returns"
+        "web_sales"
+        "web_site"
+    )
+    
+    # Generate TPC-DS data and export each table to Parquet
+    log_info "Installing TPC-DS extension and generating data..."
+    
+    duckdb -c "
+        INSTALL tpcds;
+        LOAD tpcds;
+        CALL dsdgen(sf=${TPCDS_SCALE_FACTOR});
+    " "${DATA_DIR}/tpcds.duckdb"
+    
+    log_info "Exporting tables to Parquet format..."
+    
+    for table in "${tables[@]}"; do
+        log_info "  Exporting ${table}..."
+        duckdb "${DATA_DIR}/tpcds.duckdb" -c "
+            COPY ${table} TO '${DATA_DIR}/parquet/${table}.parquet' (FORMAT PARQUET, COMPRESSION SNAPPY);
+        "
+    done
+    
+    log_info "TPC-DS data generation complete."
+}
+
+create_bucket() {
+    log_info "Creating S3 bucket: ${S3_BUCKET} via S3 API..."
+    
+    # Use AWS CLI to create the bucket via the S3 API
+    # rustfs requires buckets to be created via S3 API, not filesystem
+    export AWS_ACCESS_KEY_ID="${RUSTFS_ACCESS_KEY}"
+    export AWS_SECRET_ACCESS_KEY="${RUSTFS_SECRET_KEY}"
+    export AWS_DEFAULT_REGION="us-east-1"
+    
+    local endpoint="http://localhost:${RUSTFS_PORT}"
+    
+    # Create the bucket (ignore error if it already exists)
+    aws --endpoint-url "${endpoint}" s3 mb "s3://${S3_BUCKET}" 2>/dev/null || true
+    
+    log_info "Bucket created."
+}
+
+upload_data() {
+    log_info "Uploading Parquet files to rustfs via S3 API..."
+    
+    export AWS_ACCESS_KEY_ID="${RUSTFS_ACCESS_KEY}"
+    export AWS_SECRET_ACCESS_KEY="${RUSTFS_SECRET_KEY}"
+    export AWS_DEFAULT_REGION="us-east-1"
+    
+    local endpoint="http://localhost:${RUSTFS_PORT}"
+    
+    # Upload all parquet files to the S3 bucket
+    for parquet_file in "${DATA_DIR}/parquet"/*.parquet; do
+        local filename=$(basename "${parquet_file}")
+        log_info "  Uploading ${filename}..."
+        aws --endpoint-url "${endpoint}" s3 cp "${parquet_file}" "s3://${S3_BUCKET}/tpcds_sf1/${filename}"
+    done
+    
+    log_info "Upload complete."
+    
+    # Verify the upload (use subshell to avoid broken pipe error from head)
+    log_info "Verifying uploaded files..."
+    local file_count
+    file_count=$(aws --endpoint-url "${endpoint}" s3 ls "s3://${S3_BUCKET}/tpcds_sf1/" | wc -l)
+    log_info "Uploaded ${file_count} files to s3://${S3_BUCKET}/tpcds_sf1/"
+}
+
+print_env_vars() {
+    echo ""
+    echo "=============================================="
+    echo "Setup complete! Set these environment variables:"
+    echo "=============================================="
+    echo ""
+    echo "export MINIO_ENDPOINT=\"http://localhost:${RUSTFS_PORT}\""
+    echo "export MINIO_ACCESS_KEY_ID=\"${RUSTFS_ACCESS_KEY}\""
+    echo "export MINIO_SECRET_ACCESS_KEY=\"${RUSTFS_SECRET_KEY}\""
+    echo ""
+    echo "Then run the tests:"
+    echo ""
+    echo "cargo test -p runtime --test integration --features postgres tpcds_postgres"
+    echo ""
+    echo "To clean up when done:"
+    echo ""
+    echo "$0 cleanup"
+    echo ""
+}
+
+main() {
+    if [ "${1:-}" = "cleanup" ]; then
+        cleanup
+        exit 0
+    fi
+    
+    log_info "Starting TPC-DS test data setup..."
+    
+    check_dependencies
+    start_rustfs
+    generate_tpcds_data
+    create_bucket
+    upload_data
+    print_env_vars
+    
+    log_info "Setup complete!"
+}
+
+main "$@"


### PR DESCRIPTION
Add integration tests for TPC-DS queries Q36, Q70, and Q86 that verify data correctness when loading from S3-compatible storage (MinIO/rustfs) and accelerating into PostgreSQL.

Features:
- Shared runtime across all tests via tokio::sync::OnceCell for efficiency
- Only loads 5 required tables (store_sales, web_sales, date_dim, item, store)
  instead of all 24 TPC-DS tables for faster test execution
- Local test setup script using DuckDB to generate TPC-DS SF1 data
- AWS CLI-based S3 uploads to rustfs container
- Tests ROLLUP grouping, correlated subqueries, and aggregations
- Added MINIO env vars to CI integration test job