### PR TITLE
fix(ci): restore cached spicepod-validator binary instead of lookup-only

### DIFF
--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -91,7 +91,6 @@ runs:
         path: |
           target/release/spicepod-validator${{ steps.detect-os.outputs.ext }}
         key: spicepod-validator-${{ steps.detect-os.outputs.os }}-${{ steps.commit-sha.outputs.sha }}
-        lookup-only: true
 
     - name: Setup Rust
       if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-validator.outputs.cache-hit != 'true')


### PR DESCRIPTION
## Summary

- Remove `lookup-only: true` from the cache action so the spicepod-validator binary is actually restored when a cache hit occurs
- Fixes the install step that expects the binary at `target/release/spicepod-validator`

## Problem

When the cache was found with `lookup-only: true`, the action would:
1. Set `cache-hit` to `true`
2. Skip the build step (since cache hit)
3. Fail on install because the binary was never actually downloaded

## Solution

Remove `lookup-only: true` so the cache is restored when found.