### PR TITLE
fix: Enable Cayenne acceleration snapshots

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -1093,12 +1093,6 @@ impl SnapshotManager {
             return Ok(None);
         };
 
-        tracing::info!(
-            "Downloading current snapshot. dataset={} snapshot={} sha={sha}",
-            self.dataset_name,
-            current_entry.snapshot,
-            sha = current_entry.snapshot_checksum.as_str(),
-        );
         self.download_snapshot_entry(&current_entry, &dataset_metadata, checkpointer_factory)
             .await
             .map(Some)

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -775,6 +775,7 @@ impl Refresher {
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
         let last_updated_at = Arc::clone(&self.last_updated_at);
+        let runtime_status = Arc::clone(&self.runtime_status);
 
         let synchronize_with = self.synchronize_with.clone();
 
@@ -868,6 +869,11 @@ impl Refresher {
                             }
 
                             if create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
+                                // Wait for the runtime to be fully ready before creating the first snapshot.
+                                // This ensures snapshots aren't uploaded until after "All components are loaded".
+                                if !runtime_status.is_ready() {
+                                    runtime_status.wait_for_ready().await;
+                                }
                                 create_checkpoint_and_snapshot(
                                     checkpointer,
                                     snapshot_manager.as_ref(),

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -54,7 +54,7 @@ use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_need
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
 use crate::spice_data_base_path;
-use runtime_acceleration::snapshot::AccelerationEngine;
+use runtime_acceleration::snapshot::{AccelerationEngine, SnapshotAdapter};
 
 /// Metadata key to identify the accelerator type in the schema metadata.
 const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
@@ -1653,6 +1653,16 @@ impl DataAccelerator for CayenneAccelerator {
                 engine: Engine::Cayenne,
                 source: err.into(),
             })
+    }
+
+    fn snapshot_adapter(&self, source: &dyn AccelerationSource) -> SnapshotAdapter {
+        let Ok(data_dir) = self.cayenne_data_dir(source) else {
+            return SnapshotAdapter::default();
+        };
+
+        let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
+
+        SnapshotAdapter::cayenne(PathBuf::from(metadata_dir), PathBuf::from(data_dir))
     }
 
     fn is_initialized(&self, source: &dyn AccelerationSource) -> bool {

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -377,8 +377,17 @@ pub trait DataAccelerator: Send + Sync {
     fn parameters(&self) -> &'static [ParameterSpec];
 
     /// Provides snapshot handling configuration for this accelerator.
-    fn snapshot_adapter(&self) -> SnapshotAdapter {
-        SnapshotAdapter::default()
+    ///
+    /// Returns the appropriate `SnapshotAdapter` for this engine type.
+    /// File-based accelerators (`DuckDB`, `SQLite`) return `SnapshotAdapter::file`,
+    /// while directory-based accelerators (Cayenne) return `SnapshotAdapter::cayenne`.
+    fn snapshot_adapter(&self, source: &dyn AccelerationSource) -> SnapshotAdapter {
+        // Default: use file-based adapter if file_path is available
+        if let Ok(path) = self.file_path(source) {
+            SnapshotAdapter::file(PathBuf::from(path))
+        } else {
+            SnapshotAdapter::default()
+        }
     }
 
     /// Initialize the accelerator for a component
@@ -636,6 +645,27 @@ pub async fn acceleration_file_path(
     let file = accelerator.file_path(source)?;
 
     Ok(PathBuf::from(file))
+}
+
+/// Gets the appropriate snapshot adapter for the given acceleration source.
+///
+/// This function retrieves the registered accelerator for the source's engine
+/// and returns the engine-specific snapshot adapter. Different engines use
+/// different adapter types:
+/// - File-based engines (`DuckDB`, `SQLite`): `SnapshotAdapter::file`
+/// - Directory-based engines (Cayenne): `SnapshotAdapter::cayenne`
+pub async fn acceleration_snapshot_adapter(
+    source: &dyn AccelerationSource,
+) -> Result<SnapshotAdapter, FilePathError> {
+    let acceleration_settings = source.acceleration().context(AccelerationNotEnabledSnafu)?;
+
+    let accelerator = get_registered_accelerator(source, acceleration_settings.engine)
+        .await
+        .context(AcceleratorEngineUnavailableSnafu {
+            engine: acceleration_settings.engine,
+        })?;
+
+    Ok(accelerator.snapshot_adapter(source))
 }
 
 pub(crate) fn get_primary_keys_from_constraints(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -78,10 +78,20 @@ use datafusion_federation::FederatedTableProviderAdaptor;
 use error::find_datafusion_root;
 use itertools::Itertools;
 use query::QueryBuilder;
-#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
+#[cfg(any(
+    feature = "duckdb",
+    feature = "sqlite",
+    feature = "postgres",
+    not(windows)
+))]
 use runtime_acceleration::snapshot::AccelerationEngine;
 use runtime_acceleration::snapshot::SnapshotAdapter;
-#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
+#[cfg(any(
+    feature = "duckdb",
+    feature = "sqlite",
+    feature = "postgres",
+    not(windows)
+))]
 use runtime_acceleration::snapshot::SnapshotManager;
 use runtime_async::ManagedTokioRuntime;
 use runtime_datafusion::schema_provider::SpiceSchemaProvider;
@@ -2200,7 +2210,12 @@ async fn build_snapshot_creation_config(
         }
     };
 
-    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
+    #[cfg(any(
+        feature = "duckdb",
+        feature = "sqlite",
+        feature = "postgres",
+        not(windows)
+    ))]
     let acceleration_engine = match acceleration_settings.engine {
         #[cfg(feature = "duckdb")]
         Engine::DuckDB => AccelerationEngine::DuckDB,
@@ -2219,14 +2234,24 @@ async fn build_snapshot_creation_config(
         }
     };
 
-    #[cfg(not(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows))))]
+    #[cfg(not(any(
+        feature = "duckdb",
+        feature = "sqlite",
+        feature = "postgres",
+        not(windows)
+    )))]
     {
         let _ = snapshot_adapter;
         let _ = snapshot_creation_trigger;
         return Err(Error::UnsupportedAccelerationEngineForSnapshots);
     }
 
-    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
+    #[cfg(any(
+        feature = "duckdb",
+        feature = "sqlite",
+        feature = "postgres",
+        not(windows)
+    ))]
     Ok(SnapshotManager::try_new(
         dataset.name.to_string(),
         acceleration_settings.snapshot_behavior.clone(),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -78,8 +78,10 @@ use datafusion_federation::FederatedTableProviderAdaptor;
 use error::find_datafusion_root;
 use itertools::Itertools;
 use query::QueryBuilder;
+#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
 use runtime_acceleration::snapshot::AccelerationEngine;
 use runtime_acceleration::snapshot::SnapshotAdapter;
+#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
 use runtime_acceleration::snapshot::SnapshotManager;
 use runtime_async::ManagedTokioRuntime;
 use runtime_datafusion::schema_provider::SpiceSchemaProvider;
@@ -2198,6 +2200,7 @@ async fn build_snapshot_creation_config(
         }
     };
 
+    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
     let acceleration_engine = match acceleration_settings.engine {
         #[cfg(feature = "duckdb")]
         Engine::DuckDB => AccelerationEngine::DuckDB,
@@ -2216,6 +2219,14 @@ async fn build_snapshot_creation_config(
         }
     };
 
+    #[cfg(not(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows))))]
+    {
+        let _ = snapshot_adapter;
+        let _ = snapshot_creation_trigger;
+        return Err(Error::UnsupportedAccelerationEngineForSnapshots);
+    }
+
+    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres", not(windows)))]
     Ok(SnapshotManager::try_new(
         dataset.name.to_string(),
         acceleration_settings.snapshot_behavior.clone(),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -31,7 +31,7 @@ use crate::component::view::View;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
 use crate::dataaccelerator::{self, BootstrapStatus};
-use crate::dataaccelerator::{AcceleratorEngineRegistry, acceleration_file_path};
+use crate::dataaccelerator::{AcceleratorEngineRegistry, acceleration_snapshot_adapter};
 use crate::dataconnector::deferred::DeferredConnector;
 use crate::dataconnector::localpod::LOCALPOD_DATACONNECTOR;
 use crate::dataconnector::sink::SinkConnector;
@@ -78,10 +78,8 @@ use datafusion_federation::FederatedTableProviderAdaptor;
 use error::find_datafusion_root;
 use itertools::Itertools;
 use query::QueryBuilder;
-#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres"))]
 use runtime_acceleration::snapshot::AccelerationEngine;
 use runtime_acceleration::snapshot::SnapshotAdapter;
-#[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres"))]
 use runtime_acceleration::snapshot::SnapshotManager;
 use runtime_async::ManagedTokioRuntime;
 use runtime_datafusion::schema_provider::SpiceSchemaProvider;
@@ -1259,16 +1257,23 @@ impl DataFusion {
         }
 
         if acceleration_settings.snapshot_behavior.create_enabled() {
-            if let Ok(snapshot_path) = acceleration_file_path(dataset).await {
-                if let Some(snapshot_config) = build_snapshot_creation_config(
-                    dataset,
-                    &acceleration_settings,
-                    refresh_mode,
-                    SnapshotAdapter::file(snapshot_path),
-                )
-                .await?
-                {
-                    accelerated_table_builder.snapshot_creation_config(Some(snapshot_config));
+            if let Ok(snapshot_adapter) = acceleration_snapshot_adapter(dataset).await {
+                if snapshot_adapter.is_enabled() {
+                    if let Some(snapshot_config) = build_snapshot_creation_config(
+                        dataset,
+                        &acceleration_settings,
+                        refresh_mode,
+                        snapshot_adapter,
+                    )
+                    .await?
+                    {
+                        accelerated_table_builder.snapshot_creation_config(Some(snapshot_config));
+                    }
+                } else {
+                    tracing::warn!(
+                        "Dataset {} accelerator does not support snapshots.",
+                        dataset.name
+                    );
                 }
             } else {
                 tracing::warn!(
@@ -2193,7 +2198,6 @@ async fn build_snapshot_creation_config(
         }
     };
 
-    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres"))]
     let acceleration_engine = match acceleration_settings.engine {
         #[cfg(feature = "duckdb")]
         Engine::DuckDB => AccelerationEngine::DuckDB,
@@ -2203,6 +2207,8 @@ async fn build_snapshot_creation_config(
         Engine::Sqlite => AccelerationEngine::Sqlite,
         #[cfg(feature = "turso")]
         Engine::Turso => AccelerationEngine::Turso,
+        #[cfg(not(windows))]
+        Engine::Cayenne => AccelerationEngine::Cayenne,
         _ => {
             // This code is unreachable since build_snapshot_creation_config is
             // only called iff acceleration_file_path returned Some(<file_path>)
@@ -2210,14 +2216,6 @@ async fn build_snapshot_creation_config(
         }
     };
 
-    #[cfg(not(any(feature = "duckdb", feature = "sqlite", feature = "postgres")))]
-    {
-        let _ = snapshot_adapter;
-        let _ = snapshot_creation_trigger;
-        Err(Error::UnsupportedAccelerationEngineForSnapshots)
-    }
-
-    #[cfg(any(feature = "duckdb", feature = "sqlite", feature = "postgres"))]
     Ok(SnapshotManager::try_new(
         dataset.name.to_string(),
         acceleration_settings.snapshot_behavior.clone(),

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -21,6 +21,7 @@ use std::{
         Arc, RwLock,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 
 use tokio::sync::watch;

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -395,6 +395,20 @@ impl RuntimeStatus {
         let component_name = format!("cluster:{node_name}");
         self.wait_for_component_ready(&component_name).await;
     }
+
+    /// Waits for the entire runtime to be ready (all registered components have been ready at least once).
+    ///
+    /// This polls the `is_ready()` status at a regular interval until the runtime is ready.
+    /// If the runtime is already ready, this returns immediately.
+    pub async fn wait_for_ready(&self) {
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+        loop {
+            if self.is_ready() {
+                return;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request refactors how snapshot adapters are selected and used for different acceleration engines, making snapshot support more flexible and engine-aware. The changes introduce a new `snapshot_adapter` method that allows each accelerator to specify the appropriate snapshot handling logic (file-based or directory-based), and updates the codebase to use this method throughout. This enables support for directory-based engines like Cayenne and improves maintainability by centralizing snapshot adapter selection.

**Snapshot Adapter Refactoring and Engine Awareness:**

* Added a `snapshot_adapter(&self, source: &dyn AccelerationSource)` method to the `DataAccelerator` trait, allowing each accelerator to specify its own snapshot adapter logic (file-based for DuckDB/SQLite, directory-based for Cayenne) (`crates/runtime/src/dataaccelerator/mod.rs`, `crates/runtime/src/dataaccelerator/cayenne.rs`). [[1]](diffhunk://#diff-02d1414a02e216d3fba378843908b3334e3d5729d060b8619f2b4ef8db82d002L380-R391) [[2]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817R1658-R1667)
* Implemented Cayenne-specific logic in its accelerator to return a directory-based `SnapshotAdapter` (`crates/runtime/src/dataaccelerator/cayenne.rs`).
* Introduced the async function `acceleration_snapshot_adapter` to retrieve the correct snapshot adapter for a given source, replacing direct file path usage (`crates/runtime/src/dataaccelerator/mod.rs`).

**Integration and Usage Updates:**

* Updated DataFusion logic to use `acceleration_snapshot_adapter` instead of `acceleration_file_path`, ensuring the correct adapter is used for each engine and adding warnings if snapshots are not supported (`crates/runtime/src/datafusion/mod.rs`). [[1]](diffhunk://#diff-3b4876394302bd3ebcd9e03115b22aeb573efe710f1570f39d341988beee12ffL34-R34) [[2]](diffhunk://#diff-3b4876394302bd3ebcd9e03115b22aeb573efe710f1570f39d341988beee12ffL1262-R1277)
* Adjusted snapshot creation configuration logic to support Cayenne and removed unnecessary feature gating, making the snapshot logic more consistent across engines (`crates/runtime/src/datafusion/mod.rs`). [[1]](diffhunk://#diff-3b4876394302bd3ebcd9e03115b22aeb573efe710f1570f39d341988beee12ffL2196) [[2]](diffhunk://#diff-3b4876394302bd3ebcd9e03115b22aeb573efe710f1570f39d341988beee12ffR2210-L2220)

**Dependency and Import Cleanups:**

* Updated imports to include `SnapshotAdapter` and remove unused feature-gated imports (`crates/runtime/src/dataaccelerator/cayenne.rs`, `crates/runtime/src/datafusion/mod.rs`). [[1]](diffhunk://#diff-36e8c90575884e9459dface95f34039b1bb1772a089bd521d1e8d5a214b70817L57-R57) [[2]](diffhunk://#diff-3b4876394302bd3ebcd9e03115b22aeb573efe710f1570f39d341988beee12ffL81-L84)