### PR TITLE
fix: Schema mismatch when using projection with no filters with HTTP caching

### DIFF
--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -43,7 +43,6 @@ use futures::StreamExt;
 use std::any::Any;
 use std::clone::Clone;
 use std::fmt;
-use std::ops::Deref;
 use std::sync::Arc;
 
 pub struct SchemaCastScanExec {
@@ -118,11 +117,11 @@ impl ExecutionPlan for SchemaCastScanExec {
                     .schema()
                     .fields()
                     .into_iter()
-                    .map(|field| {
+                    .filter_map(|field| {
                         self.schema
                             .field_with_name(field.name())
                             .ok()
-                            .map_or(field.deref().clone(), Clone::clone)
+                            .map(Clone::clone)
                     })
                     .collect::<Vec<Field>>(),
             )

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1010,10 +1010,11 @@ impl TableProvider for AcceleratedTable {
             }
         }
 
-        // For caching mode, extend projection to include fetched_at for freshness checking if needed.
+        // For caching mode with filters, extend projection to include fetched_at for freshness checking if needed.
         // Added columns will be automatically stripped by `SchemaCastScanExec`, similar to
         // fallback-to-source on cache miss where results return all columns.
-        let extended_projection = if is_caching_mode {
+        // When filters are present, we need the fetched_at column to check cache freshness.
+        let extended_projection = if is_caching_mode && !filters.is_empty() {
             extend_projection_for_caching(projection, &self.accelerator.schema())
         } else {
             None

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -943,6 +943,32 @@ async fn test_caching_mode_no_filters() -> Result<(), anyhow::Error> {
                 "Should have results from cache with no filters"
             );
 
+            // Query with specific projection (only 'content' column) and no filters
+            let df = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .select(vec![col("content")])?
+                .limit(0, Some(1))?;
+
+            let batches = df.collect().await?;
+            assert!(
+                !batches.is_empty(),
+                "Should have results from cache with projection and no filters"
+            );
+            // Verify only the 'content' column is returned
+            assert_eq!(
+                batches[0].num_columns(),
+                1,
+                "Should only return the projected column"
+            );
+            assert_eq!(
+                batches[0].schema().field(0).name(),
+                "content",
+                "Should return the 'content' column"
+            );
+
             Ok(())
         })
         .await


### PR DESCRIPTION
## 📝 Summary

Fix for GitHub issue #9019: HTTP caching mode returns extra `fetched_at` column on cache HIT when using column projection.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
