### PR TITLE
HTTP cache snapshots: default to `time_interval` and fix `snapshots_creation_policy: on_change`

### DIFF
--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::AtomicI64;
 use std::time::{Duration, SystemTime};
 
 use arrow::array::StringArray;
@@ -99,12 +100,14 @@ pub fn create_cache_write_channel() -> (CacheWriteSender, CacheWriteReceiver) {
 /// Spawns a background task that batches cache writes on interval basis.
 ///
 /// Removes cache keys from `in_flight_revalidations` after writes complete.
+/// Updates `last_updated_at` after successful writes to support `snapshots_creation_policy: on_change`.
 pub fn spawn_batched_cache_write_task(
     mut rx: CacheWriteReceiver,
     accelerator: Arc<dyn TableProvider>,
     dataset_name: String,
     accelerator_write_mutex: Arc<Mutex<()>>,
     in_flight_revalidations: InFlightRevalidations,
+    last_updated_at: Arc<AtomicI64>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut batch_buffer: Vec<CacheWriteRequest> = Vec::new();
@@ -137,6 +140,7 @@ pub fn spawn_batched_cache_write_task(
                                 &dataset_name,
                                 &accelerator_write_mutex,
                                 &in_flight_revalidations,
+                                &last_updated_at,
                             ).await;
                         }
                         break;
@@ -152,6 +156,7 @@ pub fn spawn_batched_cache_write_task(
                             &dataset_name,
                             &accelerator_write_mutex,
                             &in_flight_revalidations,
+                            &last_updated_at,
                         ).await;
                     }
                 }
@@ -169,6 +174,7 @@ async fn flush_cache_writes(
     dataset_name: &str,
     accelerator_write_mutex: &Arc<Mutex<()>>,
     in_flight_revalidations: &InFlightRevalidations,
+    last_updated_at: &Arc<AtomicI64>,
 ) {
     if buffer.is_empty() {
         return;
@@ -249,6 +255,9 @@ async fn flush_cache_writes(
     if let Err(e) = result {
         tracing::warn!("Failed to flush cache updates for dataset {dataset_name}: {e}");
     } else if insert_rows > 0 || upsert_rows > 0 {
+        // Update last_updated_at for snapshots_creation_policy: on_change support
+        super::AcceleratedTable::set_timestamp_to_now(last_updated_at);
+
         tracing::trace!(
             "Cache write completed for dataset={dataset_name}: inserts={insert_rows} rows, upserts={upsert_count}, {upsert_rows} rows in {write_ms}ms"
         );
@@ -1797,12 +1806,14 @@ mod tests {
     ) -> (CacheWriteSender, tokio::task::JoinHandle<()>) {
         let (tx, rx) = create_cache_write_channel();
         let accelerator_write_mutex = Arc::new(Mutex::new(()));
+        let last_updated_at = Arc::new(AtomicI64::new(0));
         let handle = spawn_batched_cache_write_task(
             rx,
             Arc::clone(accelerator) as Arc<dyn TableProvider>,
             "test_dataset".to_string(),
             accelerator_write_mutex,
             Arc::clone(in_flight_revalidations),
+            last_updated_at,
         );
         (tx, handle)
     }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -692,6 +692,7 @@ impl Builder {
                 self.dataset_name.to_string(),
                 Arc::clone(&accelerator_write_mutex),
                 Arc::clone(&in_flight_revalidations),
+                Arc::clone(&last_updated_at),
             );
             // The consumer task will be automatically stopped (aborted) when AcceleratedTable is dropped
             handlers.push(consumer_handle);
@@ -923,13 +924,19 @@ impl AcceleratedTable {
         Ok(filters_to_reapply)
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     fn update_last_updated_at(&self) {
+        Self::set_timestamp_to_now(&self.last_updated_at);
+    }
+
+    /// Sets an `AtomicI64` timestamp to the current time in milliseconds.
+    /// Used by both `AcceleratedTable` instance methods and the caching background task.
+    #[expect(clippy::cast_possible_truncation)]
+    pub(crate) fn set_timestamp_to_now(last_updated_at: &AtomicI64) {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as i64;
-        self.last_updated_at.store(now_ms, Ordering::Release);
+        last_updated_at.store(now_ms, Ordering::Release);
     }
 }
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -1366,14 +1366,8 @@ impl RefreshTask {
             .await;
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     fn update_last_updated_at(&self) {
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        self.last_updated_at
-            .store(now_ms, std::sync::atomic::Ordering::Release);
+        super::AcceleratedTable::set_timestamp_to_now(&self.last_updated_at);
     }
 }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -350,9 +350,7 @@ pub enum Error {
     ))]
     UnsupportedRefreshCompleteForStream,
 
-    #[snafu(display(
-        "Caching refresh mode only supports 'time_interval' for snapshots_trigger"
-    ))]
+    #[snafu(display("Caching refresh mode only supports 'time_interval' for snapshots_trigger"))]
     UnsupportedSnapshotTriggerForCaching,
 
     #[snafu(display(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -351,6 +351,11 @@ pub enum Error {
     UnsupportedRefreshCompleteForStream,
 
     #[snafu(display(
+        "Caching refresh mode only supports 'time_interval' for snapshots_trigger"
+    ))]
+    UnsupportedSnapshotTriggerForCaching,
+
+    #[snafu(display(
         "Invalid snapshot configuration: Only DuckDB, Turso and SQlite support snapshots"
     ))]
     UnsupportedAccelerationEngineForSnapshots,
@@ -2181,7 +2186,20 @@ async fn build_snapshot_creation_config(
         }
     };
 
-    let snapshot_creation_trigger = if is_streaming_refresh {
+    // Caching mode only supports time_interval - no "refresh complete" or "stream_batches" events.
+    let is_caching = matches!(refresh_mode, RefreshMode::Caching);
+
+    let snapshot_creation_trigger = if is_caching {
+        match snapshot_trigger {
+            None | Some(SnapshotsTrigger::TimeInterval) => {
+                let interval = parse_interval(&snapshot_threshold)?;
+                SnapshotCreateTrigger::Interval(interval)
+            }
+            Some(SnapshotsTrigger::RefreshComplete | SnapshotsTrigger::StreamBatches) => {
+                return Err(Error::UnsupportedSnapshotTriggerForCaching);
+            }
+        }
+    } else if is_streaming_refresh {
         match snapshot_trigger {
             None | Some(SnapshotsTrigger::TimeInterval) => {
                 let interval = parse_interval(&snapshot_threshold)?;


### PR DESCRIPTION
## 📝 Summary


**1. Default `snapshots_trigger` to `time_interval` for caching mode**

Caching mode has no "refresh complete" event, the previous default (`refresh_complete`) never triggered snapshots.

Now caching mode defaults to `time_interval` (10 min default). Explicitly setting `refresh_complete` or `stream_batches` with caching mode returns an error.

**2. Fix `snapshots_creation_policy: on_change` for caching mode**

The `on_change` policy skips snapshots when no data has changed. Previously, caching mode's batched writer didn't update `last_updated_at`, so this check always failed.

Now `flush_cache_writes` updates `last_updated_at` after successful writes, enabling correct `on_change` behavior.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
