### PR TITLE
Fix duplicate snapshot creation on startup

### DIFF
--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -105,6 +105,8 @@ pub fn spawn_snapshot_interval_task(
         }
 
         let mut ticker = interval(interval_duration);
+        // Consume the first tick which returns immediately per tokio::time::interval behavior
+        ticker.tick().await;
 
         loop {
             create_checkpoint_and_snapshot(


### PR DESCRIPTION
## 📝 Summary

When using snapshots_trigger: time_interval, duplicate "Skipping snapshot creation" messages appeared on startup:

```
2026-01-21T15:06:07.907859Z  INFO runtime_acceleration::snapshot: Skipping snapshot creation - no data writes have occurred yet. dataset=taxi_trips_2024
2026-01-21T15:06:07.913597Z  INFO runtime_acceleration::snapshot: Skipping snapshot creation - no data writes have occurred yet. dataset=taxi_trips_2024
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
