### PR TITLE
Remove waiting for runtime to be ready before creating snapshot

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -775,7 +775,6 @@ impl Refresher {
 
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
         let last_updated_at = Arc::clone(&self.last_updated_at);
-        let runtime_status = Arc::clone(&self.runtime_status);
 
         let synchronize_with = self.synchronize_with.clone();
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -869,11 +869,6 @@ impl Refresher {
                             }
 
                             if create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
-                                // Wait for the runtime to be fully ready before creating the first snapshot.
-                                // This ensures snapshots aren't uploaded until after "All components are loaded".
-                                if !runtime_status.is_ready() {
-                                    runtime_status.wait_for_ready().await;
-                                }
                                 create_checkpoint_and_snapshot(
                                     checkpointer,
                                     snapshot_manager.as_ref(),


### PR DESCRIPTION
## 📝 Summary

Do not wait for runtime to be ready after refresh and before creating snapshots as it will block dataset refresh.

Follow up task to only start creating snapshots once runtime is ready https://github.com/spiceai/spiceai/issues/9031