### PR TITLE
ci: use arduino/setup-protoc for official protobuf compiler

### DIFF
--- a/.github/actions/setup-cc/action.yml
+++ b/.github/actions/setup-cc/action.yml
@@ -10,13 +10,13 @@ runs:
       run: |
         sudo apt-get update
         # Install mold linker for faster linking (20-30% faster link times)
-        sudo apt-get install -y build-essential cmake pkg-config libssl-dev unixodbc unixodbc-dev protobuf-compiler libclang-dev libnfs-dev mold lld clang
+        sudo apt-get install -y build-essential cmake pkg-config libssl-dev unixodbc unixodbc-dev libclang-dev libnfs-dev mold lld clang
 
     - name: Install cc (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install cmake pkg-config openssl unixodbc protobuf llvm libnfs
+        brew install cmake pkg-config openssl unixodbc llvm libnfs
 
     - name: Install cc (Windows)
       if: runner.os == 'Windows'
@@ -30,6 +30,6 @@ runs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
         }
-        choco install cmake pkgconfiglite protoc llvm -y
+        choco install cmake pkgconfiglite llvm -y
         echo "C:\Program Files\CMake\bin" >> $env:GITHUB_PATH
         echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -189,7 +189,7 @@ jobs:
         if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'aarch64'
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential libssl-dev pkg-config cmake protobuf-compiler unixodbc unixodbc-dev -y
+          sudo apt-get install build-essential libssl-dev pkg-config cmake unixodbc unixodbc-dev -y
 
       # The x86_64 runner does not unixodbc pre-installed
       - name: Install missing tools (Linux x86_64)
@@ -201,10 +201,14 @@ jobs:
         if: matrix.target.target_os == 'darwin'
         run: |
           brew update
-          brew install protobuf
           brew list cmake || brew install cmake
           brew install unixodbc
           echo "RUSTFLAGS=-L /opt/homebrew/lib" >> $GITHUB_ENV
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       ## Default flavor
       - name: Build spiced


### PR DESCRIPTION
## Summary
- Replace package manager protobuf installations (`apt install protobuf-compiler`, `brew install protobuf`, `choco install protoc`) with `arduino/setup-protoc` action
- This ensures a consistent and recent version of protoc across all platforms by downloading official pre-compiled binaries from GitHub releases

## Changes
- Updated `setup-cc` action to remove protobuf from package manager installs
- Added explicit `arduino/setup-protoc` steps to all workflows that need protoc