### PR TITLE
feat(cli): add `spice query` command for async queries REPL

### DIFF
--- a/bin/spice/cmd/query.go
+++ b/bin/spice/cmd/query.go
@@ -1,0 +1,962 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/peterh/liner"
+	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/api"
+	rtcontext "github.com/spiceai/spiceai/bin/spice/pkg/context"
+	"github.com/spiceai/spiceai/bin/spice/pkg/display"
+	"github.com/spiceai/spiceai/bin/spice/pkg/history"
+)
+
+const (
+	// MaxDisplayRows is the maximum number of rows to display in results
+	MaxDisplayRows = 500
+	// QueryHistoryType is the history type for query REPL
+	QueryHistoryType history.HistoryType = "query_history.txt"
+)
+
+// spinnerFrames contains the braille spinner characters for the progress indicator
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// TrackedQuery represents a query being tracked in the REPL session
+type TrackedQuery struct {
+	QueryID     string
+	SQL         string
+	Status      string
+	SubmittedAt time.Time
+	CompletedAt *time.Time
+}
+
+// QueryREPL handles the interactive query REPL state
+type QueryREPL struct {
+	client         *api.QueriesClient
+	liner          *liner.State
+	trackedQueries map[string]*TrackedQuery
+	historyMgr     *history.Manager
+}
+
+var queryCmd = &cobra.Command{
+	Use:   "query [sql]",
+	Short: "Submit an async query or start an interactive async query REPL",
+	Long: `Submit an async SQL query or start an interactive REPL for managing async queries via the /v1/queries API.
+
+Queries are submitted asynchronously and the CLI auto-polls for completion. Press Ctrl+C to stop
+waiting for a query (the query continues running in the background).
+
+Async queries require cluster mode with scheduler.state_location configured.`,
+	Example: `
+# Submit a single query and wait for results
+$ spice query "SELECT * FROM my_table"
+
+# Submit a query without waiting
+$ spice query --no-wait "SELECT * FROM my_table"
+
+# Start interactive REPL
+$ spice query
+
+# List all queries
+$ spice query list
+
+# Check status of a specific query
+$ spice query status qry_01ABC123
+
+# Get results of a completed query
+$ spice query results qry_01ABC123
+
+# Cancel a running query
+$ spice query cancel qry_01ABC123
+`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, err := rtcontext.FromFlags(cmd.Flags())
+		if err != nil {
+			slog.Error("failed to initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
+		// If SQL argument provided, submit directly
+		if len(args) == 1 {
+			noWait, _ := cmd.Flags().GetBool("no-wait")
+			timeout, _ := cmd.Flags().GetDuration("timeout")
+
+			client := api.NewQueriesClient(ctx)
+			sql := args[0]
+
+			if err := submitAndWait(client, sql, !noWait, timeout); err != nil {
+				slog.Error("submitting query", "error", err)
+				os.Exit(1)
+			}
+			return
+		}
+
+		// No argument, start REPL
+		if err := runQueryREPL(ctx); err != nil {
+			slog.Error("running query REPL", "error", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var queryListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all queries",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, err := rtcontext.FromFlags(cmd.Flags())
+		if err != nil {
+			slog.Error("failed to initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
+		status, _ := cmd.Flags().GetString("status")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		client := api.NewQueriesClient(ctx)
+
+		resp, err := client.List(context.Background(), status, limit)
+		if err != nil {
+			slog.Error("listing queries", "error", err)
+			os.Exit(1)
+		}
+
+		displayQueryList(resp.Queries)
+	},
+}
+
+var queryStatusCmd = &cobra.Command{
+	Use:   "status <query_id>",
+	Short: "Check the status of a query",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, err := rtcontext.FromFlags(cmd.Flags())
+		if err != nil {
+			slog.Error("failed to initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
+		client := api.NewQueriesClient(ctx)
+		queryID := args[0]
+
+		info, err := client.GetQuery(context.Background(), queryID)
+		if err != nil {
+			slog.Error("getting query status", "error", err)
+			os.Exit(1)
+		}
+
+		displayQueryInfo(info)
+	},
+}
+
+var queryResultsCmd = &cobra.Command{
+	Use:   "results <query_id>",
+	Short: "Fetch and display results of a completed query",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, err := rtcontext.FromFlags(cmd.Flags())
+		if err != nil {
+			slog.Error("failed to initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
+		client := api.NewQueriesClient(ctx)
+		queryID := args[0]
+
+		if err := displayResults(client, queryID); err != nil {
+			slog.Error("getting query results", "error", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var queryCancelCmd = &cobra.Command{
+	Use:   "cancel <query_id>",
+	Short: "Cancel a running query",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, err := rtcontext.FromFlags(cmd.Flags())
+		if err != nil {
+			slog.Error("failed to initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
+		client := api.NewQueriesClient(ctx)
+		queryID := args[0]
+
+		info, err := client.Cancel(context.Background(), queryID)
+		if err != nil {
+			slog.Error("cancelling query", "error", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Query %s cancelled (status: %s)\n", info.QueryID, info.Status.State)
+	},
+}
+
+func runQueryREPL(ctx *rtcontext.RuntimeContext) error {
+	fmt.Println("Welcome to the Spice.ai async query REPL.")
+	fmt.Println("Type SQL to submit a query, or .help for commands.")
+	fmt.Println()
+
+	// Initialize history manager
+	historyMgr, err := history.NewManager(QueryHistoryType)
+	if err != nil {
+		slog.Warn("failed to initialize query history", "error", err)
+		historyMgr = nil
+	}
+
+	// Setup liner for REPL
+	line := liner.NewLiner()
+	line.SetCtrlCAborts(true)
+	defer func() {
+		if historyMgr != nil {
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save query history", "error", err)
+			}
+		}
+		if err := line.Close(); err != nil {
+			slog.Error("closing liner", "error", err)
+		}
+	}()
+
+	// Load history into liner
+	if historyMgr != nil {
+		historyMgr.LoadIntoLiner(line)
+		line.SetCompleter(historyMgr.GetCompleter())
+	}
+
+	client := api.NewQueriesClient(ctx)
+
+	repl := &QueryREPL{
+		client:         client,
+		liner:          line,
+		trackedQueries: make(map[string]*TrackedQuery),
+		historyMgr:     historyMgr,
+	}
+
+	// Set up signal handling
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+
+	var queryMutex sync.Mutex
+	var cancelPoll context.CancelFunc
+	var isPolling bool
+	var exitRequested bool
+
+	// Helper to safely cancel any active poll context
+	cleanupPoll := func() {
+		queryMutex.Lock()
+		if cancelPoll != nil {
+			cancelPoll()
+			cancelPoll = nil
+		}
+		queryMutex.Unlock()
+	}
+	defer cleanupPoll()
+
+	// Handle signals in a goroutine
+	go func() {
+		for range sigChan {
+			queryMutex.Lock()
+			if isPolling && cancelPoll != nil {
+				// Cancel the polling
+				cancelPoll()
+				exitRequested = false
+			} else {
+				if exitRequested {
+					fmt.Println("\nExiting...")
+					if historyMgr != nil {
+						_ = historyMgr.Save()
+					}
+					os.Exit(0)
+				}
+				exitRequested = true
+				fmt.Println("\nPress Ctrl+C again to exit, or continue entering commands.")
+			}
+			queryMutex.Unlock()
+		}
+	}()
+
+	for {
+		queryMutex.Lock()
+		shouldExit := exitRequested
+		queryMutex.Unlock()
+
+		if shouldExit {
+			fmt.Println()
+			return nil
+		}
+
+		// Read input
+		inputStr, err := readQueryInput(line, "query> ")
+		if err == io.EOF {
+			fmt.Println()
+			return nil
+		} else if err != nil {
+			slog.Error("reading line", "error", err)
+			continue
+		}
+
+		if inputStr == "" {
+			continue
+		}
+
+		// Reset exit request on valid input
+		queryMutex.Lock()
+		exitRequested = false
+		queryMutex.Unlock()
+
+		// Handle special commands
+		if strings.HasPrefix(inputStr, ".") {
+			if repl.handleSpecialCommand(inputStr) {
+				continue
+			}
+			// Exit requested
+			return nil
+		}
+
+		// Handle regular commands
+		lowerInput := strings.ToLower(inputStr)
+		if lowerInput == "exit" || lowerInput == "quit" || lowerInput == "q" {
+			return nil
+		}
+
+		if lowerInput == "help" {
+			printQueryHelp()
+			continue
+		}
+
+		// Add to history
+		line.AppendHistory(inputStr)
+		if historyMgr != nil {
+			historyMgr.Add(inputStr)
+			if err := historyMgr.Save(); err != nil {
+				slog.Warn("failed to save history", "error", err)
+			}
+		}
+
+		// Submit query
+		req := &api.SubmitRequest{SQL: inputStr}
+		resp, err := client.Submit(context.Background(), req)
+		if err != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", err)
+			continue
+		}
+
+		// Track the query
+		repl.trackedQueries[resp.QueryID] = &TrackedQuery{
+			QueryID:     resp.QueryID,
+			SQL:         inputStr,
+			Status:      resp.Status.State,
+			SubmittedAt: time.Now(),
+		}
+
+		fmt.Printf("Submitted query: %s (%s)\n", resp.QueryID, resp.Status.State)
+		fmt.Println("Press Ctrl+C to stop waiting (query continues in background)")
+
+		// Create cancellable context for polling
+		var pollCtx context.Context
+		queryMutex.Lock()
+		pollCtx, cancelPoll = context.WithCancel(context.Background())
+		isPolling = true
+		queryMutex.Unlock()
+
+		// Poll for completion
+		finalStatus, wasCancelled, elapsed := pollForCompletion(pollCtx, client, resp.QueryID)
+
+		queryMutex.Lock()
+		isPolling = false
+		cancelPoll = nil // Clear to avoid double-cancel in cleanup
+		queryMutex.Unlock()
+
+		if wasCancelled {
+			fmt.Printf("\nStopped waiting. Check status with: .status %s\n", resp.QueryID)
+			fmt.Printf("Wait for completion with: .wait %s\n", resp.QueryID)
+			continue
+		}
+
+		// Update tracked query
+		if tracked, ok := repl.trackedQueries[resp.QueryID]; ok {
+			tracked.Status = finalStatus.State
+			now := time.Now()
+			tracked.CompletedAt = &now
+		}
+
+		// Handle final status
+		if finalStatus.IsSuccess() {
+			if err := displayResultsWithTiming(client, resp.QueryID, elapsed); err != nil {
+				fmt.Printf("\033[31mError displaying results:\033[0m %v\n", err)
+			}
+		} else if finalStatus.IsFailed() {
+			fmt.Printf("\033[31m✗ FAILED\033[0m\n")
+			if finalStatus.Error != nil {
+				fmt.Printf("Error: %s\n", finalStatus.Error.Message)
+			}
+		} else if finalStatus.IsCancelled() {
+			fmt.Printf("\033[33m⊘ CANCELLED\033[0m\n")
+		} else {
+			fmt.Printf("Query ended with status: %s\n", finalStatus.State)
+		}
+	}
+}
+
+// handleSpecialCommand processes dot commands and returns true to continue REPL, false to exit
+func (r *QueryREPL) handleSpecialCommand(cmd string) bool {
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return true
+	}
+
+	command := strings.ToLower(parts[0])
+	args := parts[1:]
+
+	switch command {
+	case ".exit", ".quit", ".q":
+		return false
+
+	case ".help":
+		printQueryHelp()
+
+	case ".list":
+		// List all tracked queries
+		r.listTrackedQueries()
+
+	case ".status":
+		if len(args) == 0 {
+			fmt.Println("Usage: .status <query_id>")
+			return true
+		}
+		// Show status of specific query
+		queryID := r.resolveQueryID(args[0])
+		if queryID == "" {
+			return true
+		}
+		info, err := r.client.GetQuery(context.Background(), queryID)
+		if err != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", err)
+			return true
+		}
+		displayQueryInfo(info)
+
+	case ".results":
+		if len(args) == 0 {
+			fmt.Println("Usage: .results <query_id>")
+			return true
+		}
+		queryID := r.resolveQueryID(args[0])
+		if queryID == "" {
+			return true
+		}
+		if err := displayResults(r.client, queryID); err != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", err)
+		}
+
+	case ".wait":
+		if len(args) == 0 {
+			fmt.Println("Usage: .wait <query_id>")
+			return true
+		}
+		queryID := r.resolveQueryID(args[0])
+		if queryID == "" {
+			return true
+		}
+		r.waitForQuery(queryID)
+
+	case ".cancel":
+		if len(args) == 0 {
+			fmt.Println("Usage: .cancel <query_id>")
+			return true
+		}
+		queryID := r.resolveQueryID(args[0])
+		if queryID == "" {
+			return true
+		}
+		info, err := r.client.Cancel(context.Background(), queryID)
+		if err != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", err)
+			return true
+		}
+		fmt.Printf("Query %s cancelled (status: %s)\n", info.QueryID, info.Status.State)
+		if tracked, ok := r.trackedQueries[queryID]; ok {
+			tracked.Status = info.Status.State
+		}
+
+	case ".clear":
+		if len(args) > 0 && strings.ToLower(args[0]) == "history" {
+			r.liner.ClearHistory()
+			if r.historyMgr != nil {
+				r.historyMgr.Clear()
+				if err := r.historyMgr.Save(); err != nil {
+					fmt.Printf("\033[31mError:\033[0m Failed to clear history: %v\n", err)
+				} else {
+					fmt.Println("Query history cleared.")
+				}
+			}
+		} else {
+			// Clear tracked queries
+			r.trackedQueries = make(map[string]*TrackedQuery)
+			fmt.Println("Tracked queries cleared.")
+		}
+
+	default:
+		fmt.Printf("Unknown command: %s. Type .help for available commands.\n", command)
+	}
+
+	return true
+}
+
+// resolveQueryID resolves a partial query ID to a full query ID
+func (r *QueryREPL) resolveQueryID(partial string) string {
+	// First, try exact match in tracked queries
+	if _, ok := r.trackedQueries[partial]; ok {
+		return partial
+	}
+
+	// Try partial match
+	var matches []string
+	for id := range r.trackedQueries {
+		if strings.HasPrefix(id, partial) || strings.Contains(id, partial) {
+			matches = append(matches, id)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0]
+	} else if len(matches) > 1 {
+		fmt.Printf("Multiple queries match '%s': %s. Please be more specific.\n", partial, strings.Join(matches, ", "))
+		return ""
+	}
+
+	// No match in tracked queries, use the ID as-is (let the API handle it)
+	return partial
+}
+
+// listTrackedQueries displays all tracked queries
+func (r *QueryREPL) listTrackedQueries() {
+	if len(r.trackedQueries) == 0 {
+		fmt.Println("No tracked queries. Submit a query to start tracking.")
+		return
+	}
+
+	// Prepare table data
+	colNames := []string{"QUERY ID", "STATUS", "SUBMITTED", "SQL"}
+	colWidths := []int{20, 12, 15, 40}
+	var rows [][]string
+
+	for _, q := range r.trackedQueries {
+		ago := humanize.Time(q.SubmittedAt)
+		sql := q.SQL
+		if len(sql) > 37 {
+			sql = sql[:37] + "..."
+		}
+		rows = append(rows, []string{q.QueryID, q.Status, ago, sql})
+	}
+
+	display.Table(colNames, nil, rows, colWidths)
+}
+
+// waitForQuery waits for a query to complete
+func (r *QueryREPL) waitForQuery(queryID string) {
+	fmt.Println("Press Ctrl+C to stop waiting (query continues in background)")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Handle Ctrl+C
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+	defer signal.Stop(sigChan)
+
+	finalStatus, wasCancelled, elapsed := pollForCompletion(ctx, r.client, queryID)
+	cancel()
+
+	if wasCancelled {
+		fmt.Printf("\nStopped waiting. Check status with: .status %s\n", queryID)
+		return
+	}
+
+	// Update tracked query if exists
+	if tracked, ok := r.trackedQueries[queryID]; ok {
+		tracked.Status = finalStatus.State
+		now := time.Now()
+		tracked.CompletedAt = &now
+	}
+
+	if finalStatus.IsSuccess() {
+		if err := displayResultsWithTiming(r.client, queryID, elapsed); err != nil {
+			fmt.Printf("\033[31mError displaying results:\033[0m %v\n", err)
+		}
+	} else if finalStatus.IsFailed() {
+		fmt.Printf("\033[31m✗ FAILED\033[0m\n")
+		if finalStatus.Error != nil {
+			fmt.Printf("Error: %s\n", finalStatus.Error.Message)
+		}
+	} else if finalStatus.IsCancelled() {
+		fmt.Printf("\033[33m⊘ CANCELLED\033[0m\n")
+	}
+}
+
+// pollForCompletion polls for query completion with a spinner
+// Returns the final status, whether polling was cancelled, and the elapsed time
+func pollForCompletion(ctx context.Context, client *api.QueriesClient, queryID string) (*api.QueryStatus, bool, time.Duration) {
+	ticker := time.NewTicker(api.PollInterval)
+	defer ticker.Stop()
+
+	spinnerIdx := 0
+	startTime := time.Now()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Clear spinner line
+			fmt.Print("\r\033[K")
+			return nil, true, time.Since(startTime)
+
+		case <-ticker.C:
+			status, err := client.GetStatus(ctx, queryID)
+			if err != nil {
+				// If context was cancelled, treat as cancelled
+				if ctx.Err() != nil {
+					fmt.Print("\r\033[K")
+					return nil, true, time.Since(startTime)
+				}
+				// Otherwise, continue polling (might be transient error)
+				continue
+			}
+
+			elapsed := time.Since(startTime)
+
+			if status.IsTerminal() {
+				// Clear spinner and show final status
+				fmt.Print("\r\033[K")
+				if status.IsSuccess() {
+					fmt.Printf("\033[32m✓ SUCCEEDED\033[0m (%.1fs)\n", elapsed.Seconds())
+				}
+				return status, false, elapsed
+			}
+
+			// Update spinner
+			frame := spinnerFrames[spinnerIdx%len(spinnerFrames)]
+			spinnerIdx++
+			fmt.Printf("\r%s %s (%.1fs)...", frame, status.State, elapsed.Seconds())
+		}
+	}
+}
+
+// submitAndWait submits a query and optionally waits for completion
+func submitAndWait(client *api.QueriesClient, sql string, wait bool, timeout time.Duration) error {
+	req := &api.SubmitRequest{SQL: sql}
+	resp, err := client.Submit(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Submitted query: %s (%s)\n", resp.QueryID, resp.Status.State)
+
+	if !wait {
+		fmt.Printf("Status URL: %s\n", resp.StatusURL)
+		fmt.Printf("Results URL: %s\n", resp.ResultsURL)
+		return nil
+	}
+
+	fmt.Println("Waiting for completion... (Ctrl+C to stop waiting)")
+
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	// Handle Ctrl+C
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+	defer signal.Stop(sigChan)
+
+	finalStatus, wasCancelled, elapsed := pollForCompletion(ctx, client, resp.QueryID)
+
+	if wasCancelled {
+		fmt.Printf("\nStopped waiting. Query ID: %s\n", resp.QueryID)
+		return nil
+	}
+
+	if finalStatus.IsSuccess() {
+		return displayResultsWithTiming(client, resp.QueryID, elapsed)
+	} else if finalStatus.IsFailed() {
+		if finalStatus.Error != nil {
+			return fmt.Errorf("query failed: %s", finalStatus.Error.Message)
+		}
+		return fmt.Errorf("query failed")
+	} else if finalStatus.IsCancelled() {
+		fmt.Println("Query was cancelled.")
+	}
+
+	return nil
+}
+
+// displayResults fetches and displays query results
+func displayResults(client *api.QueriesClient, queryID string) error {
+	return displayResultsWithTiming(client, queryID, 0)
+}
+
+// displayResultsWithTiming fetches and displays query results with optional timing info
+func displayResultsWithTiming(client *api.QueriesClient, queryID string, elapsed time.Duration) error {
+	// First get query info to check status and get manifest
+	info, err := client.GetQuery(context.Background(), queryID)
+	if err != nil {
+		return err
+	}
+
+	if !info.Status.IsSuccess() {
+		return fmt.Errorf("query '%s' is still %s. Use .wait %s to wait for completion", queryID, info.Status.State, queryID)
+	}
+
+	if info.Manifest == nil {
+		return fmt.Errorf("no result manifest available")
+	}
+
+	// Collect all rows up to MaxDisplayRows
+	var allRows []map[string]interface{}
+	totalRows := info.Manifest.TotalRowCount
+	chunkIndex := 0
+
+	for len(allRows) < MaxDisplayRows && chunkIndex < info.Manifest.TotalChunkCount {
+		chunk, err := client.GetResults(context.Background(), queryID, chunkIndex)
+		if err != nil {
+			return fmt.Errorf("getting chunk %d: %w", chunkIndex, err)
+		}
+
+		for _, row := range chunk.DataArray {
+			if len(allRows) >= MaxDisplayRows {
+				break
+			}
+			allRows = append(allRows, row)
+		}
+
+		if chunk.NextChunkIndex == nil {
+			break
+		}
+		chunkIndex = *chunk.NextChunkIndex
+	}
+
+	if len(allRows) == 0 {
+		if elapsed > 0 {
+			fmt.Printf("Time: %.8f seconds. 0 rows.\n", elapsed.Seconds())
+		} else {
+			fmt.Println("No results.")
+		}
+		return nil
+	}
+
+	// Extract column info from manifest
+	colNames := make([]string, len(info.Manifest.Schema.Columns))
+	colTypes := make([]string, len(info.Manifest.Schema.Columns))
+	colWidths := make([]int, len(info.Manifest.Schema.Columns))
+
+	for _, col := range info.Manifest.Schema.Columns {
+		colNames[col.Position] = col.Name
+		colTypes[col.Position] = col.TypeName
+		colWidths[col.Position] = max(len(col.Name), len(col.TypeName))
+	}
+
+	// Convert rows to string arrays and calculate widths
+	var rows [][]string
+	for _, row := range allRows {
+		rowValues := make([]string, len(colNames))
+		for i, colName := range colNames {
+			if val, ok := row[colName]; ok && val != nil {
+				rowValues[i] = fmt.Sprintf("%v", val)
+			}
+			if len(rowValues[i]) > colWidths[i] {
+				colWidths[i] = len(rowValues[i])
+			}
+		}
+		rows = append(rows, rowValues)
+	}
+
+	// Display table
+	display.Table(colNames, colTypes, rows, colWidths)
+
+	// Show timing and row count (matching spice sql format)
+	if elapsed > 0 {
+		fmt.Printf("\nTime: %.8f seconds. %d rows.\n", elapsed.Seconds(), totalRows)
+	} else if len(allRows) < totalRows {
+		fmt.Printf("\nShowing %d/%d rows\n", len(allRows), totalRows)
+	} else {
+		fmt.Printf("\n%d row(s)\n", len(allRows))
+	}
+
+	return nil
+}
+
+// displayQueryList displays a list of queries
+func displayQueryList(queries []api.QuerySummary) {
+	if len(queries) == 0 {
+		fmt.Println("No queries found.")
+		return
+	}
+
+	colNames := []string{"QUERY ID", "STATE", "CREATED", "SQL PREVIEW"}
+	colWidths := []int{20, 12, 25, 50}
+	var rows [][]string
+
+	for _, q := range queries {
+		sql := q.SQLPreview
+		if len(sql) > 47 {
+			sql = sql[:47] + "..."
+		}
+		rows = append(rows, []string{q.QueryID, q.State, q.CreatedAt, sql})
+	}
+
+	display.Table(colNames, nil, rows, colWidths)
+	fmt.Printf("\nTotal: %d queries\n", len(queries))
+}
+
+// displayQueryInfo displays detailed query information
+func displayQueryInfo(info *api.QueryInfo) {
+	fmt.Printf("Query ID:    %s\n", info.QueryID)
+	fmt.Printf("Status:      %s\n", info.Status.State)
+	fmt.Printf("Created:     %s\n", info.CreatedAt)
+	if info.StartedAt != "" {
+		fmt.Printf("Started:     %s\n", info.StartedAt)
+	}
+	if info.CompletedAt != "" {
+		fmt.Printf("Completed:   %s\n", info.CompletedAt)
+	}
+	if info.ExpiresAt != "" {
+		fmt.Printf("Expires:     %s\n", info.ExpiresAt)
+	}
+	if info.Status.Error != nil {
+		fmt.Printf("Error:       %s\n", info.Status.Error.Message)
+	}
+	if info.Manifest != nil {
+		fmt.Printf("Rows:        %d\n", info.Manifest.TotalRowCount)
+		fmt.Printf("Chunks:      %d\n", info.Manifest.TotalChunkCount)
+	}
+}
+
+// readQueryInput reads multi-line SQL input until semicolon or special command
+func readQueryInput(line *liner.State, prompt string) (string, error) {
+	var query strings.Builder
+	firstLine := true
+	currentPrompt := prompt
+
+	for {
+		inputLine, err := line.Prompt(currentPrompt)
+
+		if err == liner.ErrPromptAborted {
+			if query.Len() == 0 && firstLine {
+				return "", io.EOF
+			}
+			return "", nil
+		} else if err == io.EOF {
+			if query.Len() == 0 {
+				return "", io.EOF
+			}
+			return "", nil
+		} else if err != nil {
+			return "", fmt.Errorf("reading line: %w", err)
+		}
+
+		if query.Len() > 0 {
+			query.WriteString("\n")
+		}
+		query.WriteString(inputLine)
+
+		trimmedQuery := strings.TrimSpace(query.String())
+		lowerQuery := strings.ToLower(trimmedQuery)
+
+		// Check for special commands on first line
+		if firstLine && (lowerQuery == "help" || lowerQuery == "exit" || lowerQuery == "quit" || lowerQuery == "q" || strings.HasPrefix(lowerQuery, ".")) {
+			break
+		}
+
+		// Check if query ends with semicolon
+		if strings.HasSuffix(trimmedQuery, ";") {
+			break
+		}
+
+		firstLine = false
+		currentPrompt = "     > "
+	}
+
+	return strings.TrimSpace(query.String()), nil
+}
+
+func printQueryHelp() {
+	fmt.Println("Available commands:")
+	fmt.Println()
+	fmt.Println("  SQL statements    - Submit a query (end with semicolon)")
+	fmt.Println()
+	fmt.Println("Special commands:")
+	fmt.Println("  .list             - List all tracked queries")
+	fmt.Println("  .status <id>      - Show detailed status of a specific query")
+	fmt.Println("  .results <id>     - Fetch and display results of a completed query")
+	fmt.Println("  .wait <id>        - Resume waiting for a query to complete")
+	fmt.Println("  .cancel <id>      - Cancel a running query")
+	fmt.Println("  .clear            - Clear tracked queries from local list")
+	fmt.Println("  .clear history    - Clear command history")
+	fmt.Println("  .help             - Show this help message")
+	fmt.Println("  .exit, .quit, .q  - Exit the REPL")
+	fmt.Println()
+	fmt.Println("Tips:")
+	fmt.Println("  - Partial query IDs work if they uniquely identify a query")
+	fmt.Println("  - Press Ctrl+C while waiting to stop (query continues in background)")
+	fmt.Println("  - Press Ctrl+D or type .exit to quit")
+	fmt.Println()
+}
+
+func init() {
+	// Query command flags (for direct submission)
+	queryCmd.Flags().Bool("no-wait", false, "Submit and return immediately without waiting for results")
+	queryCmd.Flags().Duration("timeout", 0, "Maximum time to wait for query completion (0 = no timeout)")
+
+	// Query list subcommand
+	queryListCmd.Flags().String("status", "", "Filter by status (pending, running, succeeded, failed, cancelled)")
+	queryListCmd.Flags().Int("limit", 100, "Maximum number of queries to return")
+
+	// Add subcommands
+	queryCmd.AddCommand(queryListCmd)
+	queryCmd.AddCommand(queryStatusCmd)
+	queryCmd.AddCommand(queryResultsCmd)
+	queryCmd.AddCommand(queryCancelCmd)
+
+	// Add to root
+	RootCmd.AddCommand(queryCmd)
+}

--- a/bin/spice/pkg/api/queries.go
+++ b/bin/spice/pkg/api/queries.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	runtimecontext "github.com/spiceai/spiceai/bin/spice/pkg/context"
+)
+
+// QueriesClient provides methods to interact with the /v1/queries API.
+type QueriesClient struct {
+	rtcontext *runtimecontext.RuntimeContext
+}
+
+// NewQueriesClient creates a new client for the async queries API.
+func NewQueriesClient(rtcontext *runtimecontext.RuntimeContext) *QueriesClient {
+	return &QueriesClient{
+		rtcontext: rtcontext,
+	}
+}
+
+// SubmitRequest is the request body for submitting a new query.
+type SubmitRequest struct {
+	SQL            string      `json:"sql"`
+	Parameters     interface{} `json:"parameters,omitempty"`
+	TimeoutSeconds int         `json:"timeout_seconds,omitempty"`
+}
+
+// SubmitResponse is the response from submitting a query.
+type SubmitResponse struct {
+	QueryID    string      `json:"query_id"`
+	Status     QueryStatus `json:"status"`
+	StatusURL  string      `json:"status_url"`
+	ResultsURL string      `json:"results_url"`
+}
+
+// QueryStatus represents the current status of a query.
+type QueryStatus struct {
+	State string      `json:"state"` // PENDING, RUNNING, SUCCEEDED, FAILED, CANCELLED, CLOSED
+	Error *QueryError `json:"error,omitempty"`
+}
+
+// QueryError contains error details for a failed query.
+type QueryError struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+	SQLState  string `json:"sql_state,omitempty"`
+}
+
+// QueryInfo contains full information about a query.
+type QueryInfo struct {
+	QueryID     string          `json:"query_id"`
+	Status      QueryStatus     `json:"status"`
+	Manifest    *ResultManifest `json:"manifest,omitempty"`
+	Result      *ResultChunk    `json:"result,omitempty"`
+	CreatedAt   string          `json:"created_at"`
+	StartedAt   string          `json:"started_at,omitempty"`
+	CompletedAt string          `json:"completed_at,omitempty"`
+	ExpiresAt   string          `json:"expires_at,omitempty"`
+}
+
+// ResultManifest describes the result set metadata.
+type ResultManifest struct {
+	Format          string       `json:"format"`
+	Schema          ResultSchema `json:"schema"`
+	TotalRowCount   int          `json:"total_row_count"`
+	TotalChunkCount int          `json:"total_chunk_count"`
+	Truncated       bool         `json:"truncated"`
+}
+
+// ResultSchema describes the schema of the result set.
+type ResultSchema struct {
+	ColumnCount int            `json:"column_count"`
+	Columns     []ColumnSchema `json:"columns"`
+}
+
+// ColumnSchema describes a single column in the result set.
+type ColumnSchema struct {
+	Name     string `json:"name"`
+	TypeName string `json:"type_name"`
+	Nullable bool   `json:"nullable"`
+	Position int    `json:"position"`
+}
+
+// ResultChunk contains a chunk of result data.
+type ResultChunk struct {
+	ChunkIndex     int                      `json:"chunk_index"`
+	RowOffset      int                      `json:"row_offset"`
+	RowCount       int                      `json:"row_count"`
+	NextChunkIndex *int                     `json:"next_chunk_index,omitempty"`
+	NextChunkURL   string                   `json:"next_chunk_url,omitempty"`
+	DataArray      []map[string]interface{} `json:"data_array,omitempty"`
+}
+
+// QueryListResponse is the response from listing queries.
+type QueryListResponse struct {
+	Queries    []QuerySummary `json:"queries"`
+	TotalCount int            `json:"total_count"`
+}
+
+// QuerySummary is a summary of a query for listing.
+type QuerySummary struct {
+	QueryID    string `json:"query_id"`
+	State      string `json:"state"`
+	SQLPreview string `json:"sql_preview"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// Submit submits a new SQL query for async execution.
+func (c *QueriesClient) Submit(ctx context.Context, req *SubmitRequest) (*SubmitResponse, error) {
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/queries", strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("async queries require cluster mode with scheduler.state_location configured")
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, c.parseError(resp)
+	}
+
+	var result SubmitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetStatus gets only the status of a query.
+func (c *QueriesClient) GetStatus(ctx context.Context, queryID string) (*QueryStatus, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/queries/%s/status", queryID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("query '%s' not found", queryID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result QueryStatus
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetQuery gets full query information including first result chunk if completed.
+func (c *QueriesClient) GetQuery(ctx context.Context, queryID string) (*QueryInfo, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/queries/%s", queryID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("query '%s' not found", queryID)
+	}
+
+	if resp.StatusCode == http.StatusGone {
+		return nil, fmt.Errorf("query '%s' results have expired", queryID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result QueryInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetResults gets results for a completed query.
+func (c *QueriesClient) GetResults(ctx context.Context, queryID string, chunkIndex int) (*ResultChunk, error) {
+	path := fmt.Sprintf("/v1/queries/%s/results", queryID)
+	if chunkIndex > 0 {
+		path = fmt.Sprintf("/v1/queries/%s/results/chunks/%d", queryID, chunkIndex)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("query '%s' not found", queryID)
+	}
+
+	if resp.StatusCode == http.StatusGone {
+		return nil, fmt.Errorf("query '%s' results have expired or were cancelled", queryID)
+	}
+
+	// 425 Too Early or 409 Conflict - query not complete
+	if resp.StatusCode == 425 || resp.StatusCode == http.StatusConflict {
+		return nil, fmt.Errorf("query '%s' is not yet complete", queryID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result ResultChunk
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// Cancel cancels a running query.
+func (c *QueriesClient) Cancel(ctx context.Context, queryID string) (*QueryInfo, error) {
+	resp, err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/v1/queries/%s/cancel", queryID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("query '%s' not found", queryID)
+	}
+
+	if resp.StatusCode == http.StatusConflict {
+		return nil, fmt.Errorf("query '%s' has already completed", queryID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result QueryInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// List lists queries with optional status filter.
+func (c *QueriesClient) List(ctx context.Context, status string, limit int) (*QueryListResponse, error) {
+	path := "/v1/queries"
+	params := []string{}
+	if status != "" {
+		params = append(params, fmt.Sprintf("status=%s", status))
+	}
+	if limit > 0 {
+		params = append(params, fmt.Sprintf("limit=%d", limit))
+	}
+	if len(params) > 0 {
+		path = path + "?" + strings.Join(params, "&")
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("async queries require cluster mode with scheduler.state_location configured")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result QueryListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// doRequest performs an HTTP request with context support.
+func (c *QueriesClient) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	// Create request with context
+	url := fmt.Sprintf("%s%s", c.rtcontext.HttpEndpoint(), path)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add headers
+	headers := c.rtcontext.GetHeaders()
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Use long-running client since queries can take time
+	client := c.rtcontext.LongRunningClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "connection refused") {
+			return nil, c.rtcontext.RuntimeUnavailableError()
+		}
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+// parseError extracts an error message from an HTTP response.
+func (c *QueriesClient) parseError(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return fmt.Errorf("%s", errResp.Error)
+	}
+
+	return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+}
+
+// closeBody safely closes an HTTP response body.
+func closeBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("closing response body", "error", err)
+		}
+	}
+}
+
+// IsTerminal returns true if the query state is terminal (no longer running).
+func (s *QueryStatus) IsTerminal() bool {
+	switch strings.ToUpper(s.State) {
+	case "SUCCEEDED", "FAILED", "CANCELLED", "CLOSED":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSuccess returns true if the query completed successfully.
+func (s *QueryStatus) IsSuccess() bool {
+	return strings.ToUpper(s.State) == "SUCCEEDED"
+}
+
+// IsFailed returns true if the query failed.
+func (s *QueryStatus) IsFailed() bool {
+	return strings.ToUpper(s.State) == "FAILED"
+}
+
+// IsCancelled returns true if the query was cancelled.
+func (s *QueryStatus) IsCancelled() bool {
+	return strings.ToUpper(s.State) == "CANCELLED"
+}
+
+// PollInterval is the default interval between status polls.
+const PollInterval = 500 * time.Millisecond


### PR DESCRIPTION
Add a new `spice query` CLI command that provides an interactive REPL for submitting and managing async queries via the /v1/queries API.

Features:
- Interactive REPL with multi-line SQL input and command history
- Auto-poll for query completion with spinner progress indicator
- Ctrl+C support to stop waiting (query continues in background)
- Special commands: .list, .status, .results, .wait, .cancel, .clear, .help, .exit
- Partial query ID matching for convenience
- Results display with 500 row limit in ASCII table format
- Timing output matching `spice sql` format
- Subcommands for non-interactive use: list, status, results, cancel

# `spice query` - Async Query REPL

The `spice query` command provides an interactive REPL for submitting and managing asynchronous SQL queries via the `/v1/queries` API.

## Prerequisites

Async queries require a **distributed query** cluster.

## Quick Start

```bash
# Start the interactive REPL
spice query

# Or submit a single query directly
spice query "SELECT * FROM my_table"

# Submit without waiting for results
spice query --no-wait "SELECT * FROM my_table"
```

## Interactive REPL

The REPL provides a familiar SQL interface with async query management:

```
$ spice query
Welcome to the Spice.ai async query REPL.
Type SQL to submit a query, or .help for commands.

query> SELECT count(*) FROM orders;
Submitted query: 019BE-686-29F-4007EC (PENDING)
Press Ctrl+C to stop waiting (query continues in background)
⠹ RUNNING (1.2s)...
✓ SUCCEEDED (3.4s)

+----------+
| count(*) |
|  Int64   |
+----------+
| 1234567  |
+----------+

Time: 3.42156789 seconds. 1 rows.
```

### Submitting Queries

Type SQL statements ending with a semicolon. Multi-line queries are supported:

```
query> SELECT 
     >   customer_id,
     >   SUM(total) as revenue
     > FROM orders
     > GROUP BY customer_id;
```

### Interrupting Long Queries

Press **Ctrl+C** while waiting to stop polling. The query continues running in the background:

```
query> SELECT * FROM very_large_table;
Submitted query: 019BE-686-29F-4007EC (PENDING)
⠙ RUNNING (15.2s)...
^C
Stopped waiting. Check status with: .status 019BE-686-29F-4007EC
Wait for completion with: .wait 019BE-686-29F-4007EC
```

### Special Commands

| Command | Description |
|---------|-------------|
| `.list` | List all tracked queries in current session |
| `.status <id>` | Show detailed status for a specific query |
| `.results <id>` | Fetch and display results of a completed query |
| `.wait <id>` | Resume waiting for a query to complete |
| `.cancel <id>` | Cancel a running query |
| `.clear` | Clear tracked queries from local session |
| `.clear history` | Clear command history |
| `.help` | Show help message |
| `.exit` | Exit the REPL (also: `.quit`, `.q`, `exit`, `quit`) |

### Partial Query ID Matching

You don't need to type the full query ID - partial IDs work if they uniquely identify a query:

```
query> .status 019BE-686
Query ID:    019BE-686-29F-4007EC
Status:      SUCCEEDED
Created:     2024-01-15T10:30:00Z
...

query> .results 019BE-686
+----+----------+
| id | name     |
...
```

If multiple queries match, you'll be prompted to be more specific:

```
query> .status 019
Multiple queries match '019': 019BE-686-29F-4007EC, 019BE-686-30F-4007EC. Please be more specific.
```

### Tracked Queries

The REPL tracks all queries submitted in the current session. Use `.list` to see them:

```
query> .list
+--------------------+------------+-----------+------------------------------------------+
| QUERY ID           | STATUS     | SUBMITTED | SQL                                      |
+--------------------+------------+-----------+------------------------------------------+
| 019BE-686-29F-4007EC       | SUCCEEDED  | 5m ago    | SELECT count(*) FROM orders              |
| 019BE-686-30F-4007EC       | RUNNING    | 30s ago   | SELECT * FROM very_large_table           |
+--------------------+------------+-----------+------------------------------------------+
```

## Non-Interactive Commands

For scripting or one-off queries:

### Direct Query Submission

Submit a query directly from the command line:

```bash
# Submit and wait for results (default)
spice query "SELECT * FROM my_table"

# Submit without waiting
spice query --no-wait "SELECT * FROM my_table"

# Submit with timeout
spice query --timeout 30s "SELECT * FROM my_table"
```

**Flags:**

- `--no-wait` - Return immediately after submission
- `--timeout <duration>` - Maximum time to wait (e.g., `30s`, `5m`)

### `spice query list`

List queries on the server:

```bash
# List all queries
spice query list

# Filter by status
spice query list --status running
spice query list --status succeeded

# Limit results
spice query list --limit 10
```

**Flags:**

- `--status <state>` - Filter by status: `pending`, `running`, `succeeded`, `failed`, `cancelled`
- `--limit <n>` - Maximum number of queries to return (default: 100)

### `spice query status`

Check the status of a specific query:

```bash
spice query status qry_01ABC123
```

Output:

```
Query ID:    qry_01ABC123
Status:      SUCCEEDED
Created:     2024-01-15T10:30:00Z
Started:     2024-01-15T10:30:01Z
Completed:   2024-01-15T10:30:05Z
Expires:     2024-01-15T11:30:05Z
Rows:        1234
Chunks:      2
```

### `spice query results`

Fetch and display results of a completed query:

```bash
spice query results qry_01ABC123
```

Results are displayed in an ASCII table format, limited to 500 rows:

```
+----+----------+-------------+
| id | name     | category    |
+----+----------+-------------+
| 1  | Laptop   | electronics |
| 2  | Phone    | electronics |
...
+----+----------+-------------+
Showing 500/15234 rows
```

### `spice query cancel`

Cancel a running query:

```bash
spice query cancel qry_02DEF456
```

Output:

```
Query qry_02DEF456 cancelled (status: CANCELLED)
```

## Query States

| State | Description |
|-------|-------------|
| `PENDING` | Query is queued, waiting for execution |
| `RUNNING` | Query is currently executing |
| `SUCCEEDED` | Query completed successfully, results available |
| `FAILED` | Query execution failed |
| `CANCELLED` | Query was cancelled by user |
| `CLOSED` | Query results have expired |

## Command History

The REPL maintains persistent command history across sessions, stored in `~/.spice/query_history.txt`. Use the up/down arrow keys to navigate history, and Tab for completion based on previous commands.

## Examples

### Long-running analytics query

```bash
$ spice query
query> SELECT 
     >   date_trunc('month', order_date) as month,
     >   SUM(total) as revenue
     > FROM orders
     > WHERE order_date >= '2023-01-01'
     > GROUP BY 1
     > ORDER BY 1;
Submitted query: qry_03GHI789 (PENDING)
Press Ctrl+C to stop waiting (query continues in background)
⠸ RUNNING (45.2s)...
✓ SUCCEEDED (67.3s)

+------------+------------+
| month      | revenue    |
| Timestamp  | Decimal128 |
+------------+------------+
| 2023-01-01 | 1234567.89 |
| 2023-02-01 | 2345678.90 |
...
+------------+------------+

Time: 67.31234567 seconds. 12 rows.
```

### Managing multiple concurrent queries

```bash
$ spice query
query> SELECT * FROM large_table_1;
Submitted query: qry_A (PENDING)
⠙ RUNNING...
^C
Stopped waiting. Check status with: .status qry_A

query> SELECT * FROM large_table_2;
Submitted query: qry_B (PENDING)
⠙ RUNNING...
^C
Stopped waiting. Check status with: .status qry_B

query> .list
+----------+-----------+---------+---------------------------+
| QUERY ID | STATUS    | SUBMITTED | SQL                     |
+----------+-----------+---------+---------------------------+
| qry_A    | RUNNING   | 2m ago    | SELECT * FROM large_... |
| qry_B    | RUNNING   | 30s ago   | SELECT * FROM large_... |
+----------+-----------+---------+---------------------------+

query> .wait qry_A
⠸ RUNNING (125.3s)...
✓ SUCCEEDED (142.1s)
...results displayed...

query> .results qry_B
...results displayed...
```