### PR TITLE
Fix Docker build failing to copy shared libraries due to ldd output parsing

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -87,7 +87,8 @@ RUN cp -r /etc/ssl/certs /spice_sandbox/etc/ssl/certs
 RUN cp -r /usr/share/zoneinfo /spice_sandbox/usr/share/zoneinfo
 
 # Copy every dependent library reported by ldd
-RUN ldd /spice_sandbox/usr/local/bin/spiced | grep -o '/[^ ]*' | xargs -I '{}' sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"'
+# The sed removes trailing colons/parens that appear in ldd output, and grep -v filters memory addresses
+RUN ldd /spice_sandbox/usr/local/bin/spiced | grep -o '/[^ ]*' | sed 's/[:)]$//' | grep -v '^/spice_sandbox' | sort -u | xargs -I '{}' sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"'
 
 # Copy additional required libraries
 RUN find /lib /usr/lib -name 'libpthread.so.0' -exec sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"' \;


### PR DESCRIPTION
The ldd command outputs the binary path with a trailing colon on the first line (e.g., '/spice_sandbox/usr/local/bin/spiced:') and memory addresses with parens. The grep regex was capturing these artifacts, causing cp to fail with errors like:
  cp: cannot stat '/spice_sandbox/usr/local/bin/spiced:': No such file or directory

Fix by:
- Adding sed to strip trailing colons and closing parentheses
- Filtering out paths to the binary itself (we only want shared libraries)
- Deduplicating with sort -u to avoid redundant copies

This affected amd64 but not arm64 due to differences in ldd output format between glibc versions on different architectures.
