### PR TITLE
Cayenne: share upload semaphore across partitions to bound memory growth and optimize I/O

### DIFF
--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -19,6 +19,7 @@ limitations under the License.
 use std::sync::Arc;
 
 use datafusion_execution::config::SessionConfig;
+use tokio::sync::Semaphore;
 use vortex::VortexSessionDefault;
 use vortex_datafusion::{VortexFormat, VortexOptions};
 use vortex_session::VortexSession;
@@ -44,6 +45,8 @@ pub struct CayenneContext {
     config: VortexConfig,
     /// Session configuration for `DataFusion` listing options.
     session_config: SessionConfig,
+    /// Shared semaphore for limiting concurrent file writes / uploads across all partitions.
+    upload_semaphore: Arc<Semaphore>,
 }
 
 impl CayenneContext {
@@ -59,6 +62,7 @@ impl CayenneContext {
             vortex_format,
             config: config.clone(),
             session_config: SessionConfig::default(),
+            upload_semaphore: Arc::new(Semaphore::new(config.upload_concurrency)),
         })
     }
 
@@ -104,6 +108,12 @@ impl CayenneContext {
     #[must_use]
     pub fn upload_concurrency(&self) -> usize {
         self.config.upload_concurrency.max(1)
+    }
+
+    /// Get the shared semaphore for limiting concurrent file writes / uploads.
+    #[must_use]
+    pub fn upload_semaphore(&self) -> &Arc<Semaphore> {
+        &self.upload_semaphore
     }
 
     /// Create a `VortexFormat` from configuration.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1322,11 +1322,9 @@ impl CayenneTableProvider {
     ) -> CatalogResult<(u64, usize)> {
         use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
         use std::time::Instant;
-        use tokio::sync::Semaphore;
 
         // Bounded parallelism: configurable concurrent writes to optimize I/O
-        let upload_concurrency = self.context.upload_concurrency();
-        let semaphore = Arc::new(Semaphore::new(upload_concurrency));
+        let semaphore = Arc::clone(self.context.upload_semaphore());
 
         // Progress tracking for S3 Express uploads
         let is_s3_storage = self.table_metadata.path.starts_with("s3://");
@@ -1539,7 +1537,6 @@ impl CayenneTableProvider {
     ) -> CatalogResult<(u64, usize)> {
         use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
         use std::time::Instant;
-        use tokio::sync::Semaphore;
 
         // Construct snapshot directory URL
         let snapshot_dir_url = Self::snapshot_dir_url(
@@ -1556,8 +1553,7 @@ impl CayenneTableProvider {
         )?;
 
         // Bounded parallelism: configurable concurrent writes to optimize I/O
-        let upload_concurrency = self.context.upload_concurrency();
-        let semaphore = Arc::new(Semaphore::new(upload_concurrency));
+        let semaphore = Arc::clone(self.context.upload_semaphore());
 
         // Progress tracking for S3 Express uploads
         let is_s3_storage = self.table_metadata.path.starts_with("s3://");


### PR DESCRIPTION
## 📝 Summary

When writing to partitioned Cayenne tables, each partition creates its own `CayenneTableProvider` with an independent `Semaphore` for limiting concurrent writes / uploads. With N partitions × M (default to 4) concurrent writes per partition, memory usage becomes unbounded:

100 partitions × 4 concurrent writes × 128MB buffer = 50GB+ potential memory usage for 100 partitions.

PR updates `chunk_and_write_parallel` to use shared semaphore from context that is shared across partitions.

Note: there is built-in HIVE-style partitioning functionality supported by DF and Vortex we might re-use instead of own implementation. 

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
