### PR TITLE
Cherry-pick 1.11.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6651,7 +6651,9 @@ dependencies = [
  "rustls-native-certs 0.8.3",
  "secrecy",
  "snafu",
+ "tokio",
  "tonic",
+ "url",
 ]
 
 [[package]]

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -558,7 +558,7 @@ pub async fn get_client_for_flight_endpoint(
     if ep.location.is_empty() {
         Ok(client.clone())
     } else {
-        let channel = new_tls_flight_channel(&ep.location[0].uri).await?;
+        let channel = new_tls_flight_channel(&ep.location[0].uri, None).await?;
         Ok(FlightSqlServiceClient::new(channel))
     }
 }

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -19,8 +19,13 @@ futures.workspace = true
 rustls-native-certs = "0.8.2"
 secrecy.workspace = true
 snafu.workspace = true
+tokio = { workspace = true, features = ["fs"] }
 tonic = { workspace = true, features = [
     "transport",
     "tls-ring",
     "tls-native-roots",
 ] }
+url.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -258,8 +258,11 @@ impl FlightClient {
     ///
     /// # Arguments
     ///
-    /// * `username` - The username to use.
-    /// * `password` - The password to use.
+    /// * `url` - The URL to connect to.
+    /// * `credentials` - The credentials to use for authentication.
+    /// * `metadata` - Optional metadata to include with requests.
+    /// * `ca_certificate_path` - Optional path to a CA certificate file (PEM format)
+    ///   for TLS verification. If not provided, system certificates will be used.
     ///
     /// # Errors
     ///
@@ -268,8 +271,9 @@ impl FlightClient {
         url: Arc<str>,
         credentials: Credentials,
         metadata: Option<tonic::metadata::MetadataMap>,
+        ca_certificate_path: Option<&std::path::Path>,
     ) -> Result<Self> {
-        let flight_channel = tls::new_tls_flight_channel(&url)
+        let flight_channel = tls::new_tls_flight_channel(&url, ca_certificate_path)
             .await
             .context(UnableToConnectToServerSnafu)?;
 

--- a/crates/flight_client/src/tls.rs
+++ b/crates/flight_client/src/tls.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ limitations under the License.
 use base64::{Engine as _, engine::general_purpose};
 use snafu::prelude::*;
 use std::io::Write;
+use std::path::Path;
 use std::str::FromStr;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use url::Url;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -35,6 +37,15 @@ pub enum Error {
 
     #[snafu(display("IO error: {source}"))]
     Io { source: std::io::Error },
+
+    #[snafu(display("CA certificate file not found: {path}"))]
+    CaCertificateFileNotFound { path: String },
+
+    #[snafu(display("Failed to read CA certificate file '{path}': {source}"))]
+    FailedToReadCaCertificate {
+        path: String,
+        source: std::io::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -66,35 +77,209 @@ pub fn system_tls_certificate() -> Result<tonic::transport::Certificate> {
     Ok(tonic::transport::Certificate::from_pem(pem))
 }
 
+/// Loads a CA certificate from a file path.
+///
+/// The certificate file should be in PEM format.
+///
+/// # Errors
+///
+/// Will return `Err` if:
+///     - The file does not exist.
+///     - The file could not be read.
+pub async fn load_ca_certificate_from_file(path: &Path) -> Result<tonic::transport::Certificate> {
+    if !path.exists() {
+        return Err(Error::CaCertificateFileNotFound {
+            path: path.display().to_string(),
+        });
+    }
+
+    let pem = tokio::fs::read(path)
+        .await
+        .context(FailedToReadCaCertificateSnafu {
+            path: path.display().to_string(),
+        })?;
+
+    Ok(tonic::transport::Certificate::from_pem(pem))
+}
+
+/// TLS endpoint information extracted from a URL.
+struct TlsEndpointInfo {
+    /// The endpoint URL normalized for tonic (using https:// scheme).
+    normalized_url: String,
+    /// The hostname for TLS certificate verification.
+    domain_name: String,
+}
+
+/// Extracts TLS endpoint information from a URL.
+///
+/// Handles `https://` and `grpc+tls://` schemes. For `grpc+tls://`, the scheme
+/// is normalized to `https://` since tonic's `Endpoint` only recognizes standard
+/// HTTP schemes.
+///
+/// Returns `None` if the URL doesn't use a TLS scheme or if parsing fails.
+fn extract_tls_endpoint_info(endpoint_str: &str) -> Option<TlsEndpointInfo> {
+    let tls_prefixes = ["https://", "grpc+tls://"];
+
+    for prefix in &tls_prefixes {
+        if endpoint_str.starts_with(prefix) {
+            // Normalize grpc+tls:// to https:// for tonic compatibility
+            let normalized_url = if *prefix == "grpc+tls://" {
+                endpoint_str.replacen("grpc+tls://", "https://", 1)
+            } else {
+                endpoint_str.to_string()
+            };
+
+            if let Ok(url) = Url::parse(&normalized_url)
+                && let Some(host) = url.host_str()
+            {
+                return Some(TlsEndpointInfo {
+                    normalized_url,
+                    domain_name: host.to_string(),
+                });
+            }
+        }
+    }
+
+    None
+}
+
+/// Creates a new TLS-enabled Flight channel.
+///
+/// If `ca_certificate_path` is provided, the certificate from that file will be used
+/// for server verification. Otherwise, system certificates will be loaded.
+///
 /// # Errors
 ///
 /// Will return `Err` if:
 ///    - It couldn't connect to the endpoint.
-///    - It couldn't load the system TLS certificate.
-pub async fn new_tls_flight_channel(endpoint_str: &str) -> Result<Channel> {
-    let mut endpoint = Endpoint::from_str(endpoint_str).context(UnableToConnectToEndpointSnafu)?;
+///    - It couldn't load the TLS certificate (either from file or system).
+pub async fn new_tls_flight_channel(
+    endpoint_str: &str,
+    ca_certificate_path: Option<&Path>,
+) -> Result<Channel> {
+    if let Some(tls_info) = extract_tls_endpoint_info(endpoint_str) {
+        // Use the normalized URL (https://) for tonic compatibility
+        let mut endpoint =
+            Endpoint::from_str(&tls_info.normalized_url).context(UnableToConnectToEndpointSnafu)?;
 
-    let mut tls_domain_name = None;
-    let tls_prefixes = ["https://", "grpc+tls://"];
-    for prefix in &tls_prefixes {
-        if endpoint_str.starts_with(prefix) {
-            tls_domain_name = Some(endpoint_str.trim_start_matches(prefix));
-            break;
-        }
-    }
+        let cert = if let Some(ca_path) = ca_certificate_path {
+            load_ca_certificate_from_file(ca_path).await?
+        } else {
+            system_tls_certificate()?
+        };
 
-    if let Some(tls_domain_name) = tls_domain_name {
-        let cert = system_tls_certificate()?;
         let tls_config = ClientTlsConfig::new()
             .ca_certificate(cert)
-            .domain_name(tls_domain_name);
+            .domain_name(tls_info.domain_name);
         endpoint = endpoint
             .tls_config(tls_config)
             .context(UnableToConnectToEndpointSnafu)?;
+
+        endpoint
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    } else {
+        // Non-TLS endpoint, connect without TLS config
+        Endpoint::from_str(endpoint_str)
+            .context(UnableToConnectToEndpointSnafu)?
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_tls_endpoint_info_grpc_tls_with_port() {
+        let info = extract_tls_endpoint_info("grpc+tls://localhost:31337")
+            .expect("should parse grpc+tls URL with port");
+        assert_eq!(info.normalized_url, "https://localhost:31337");
+        assert_eq!(info.domain_name, "localhost");
     }
 
-    endpoint
-        .connect()
-        .await
-        .context(UnableToConnectToEndpointSnafu)
+    #[test]
+    fn test_extract_tls_endpoint_info_grpc_tls_without_port() {
+        let info = extract_tls_endpoint_info("grpc+tls://example.com")
+            .expect("should parse grpc+tls URL without port");
+        assert_eq!(info.normalized_url, "https://example.com");
+        assert_eq!(info.domain_name, "example.com");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_https_with_port() {
+        let info = extract_tls_endpoint_info("https://myhost.example.com:443")
+            .expect("should parse https URL with port");
+        assert_eq!(info.normalized_url, "https://myhost.example.com:443");
+        assert_eq!(info.domain_name, "myhost.example.com");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_https_without_port() {
+        let info = extract_tls_endpoint_info("https://secure.example.org")
+            .expect("should parse https URL without port");
+        assert_eq!(info.normalized_url, "https://secure.example.org");
+        assert_eq!(info.domain_name, "secure.example.org");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_https_with_path() {
+        let info = extract_tls_endpoint_info("https://api.example.com:8443/v1/flight")
+            .expect("should parse https URL with path");
+        assert_eq!(
+            info.normalized_url,
+            "https://api.example.com:8443/v1/flight"
+        );
+        assert_eq!(info.domain_name, "api.example.com");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_http_returns_none() {
+        assert!(extract_tls_endpoint_info("http://localhost:8080").is_none());
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_grpc_plaintext_returns_none() {
+        assert!(extract_tls_endpoint_info("grpc://localhost:50051").is_none());
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_ipv4_address() {
+        let info = extract_tls_endpoint_info("grpc+tls://192.168.1.100:31337")
+            .expect("should parse grpc+tls URL with IPv4 address");
+        assert_eq!(info.normalized_url, "https://192.168.1.100:31337");
+        assert_eq!(info.domain_name, "192.168.1.100");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_ipv6_address() {
+        let info = extract_tls_endpoint_info("https://[::1]:8443")
+            .expect("should parse https URL with IPv6 address");
+        assert_eq!(info.normalized_url, "https://[::1]:8443");
+        assert_eq!(info.domain_name, "[::1]");
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_empty_string() {
+        assert!(extract_tls_endpoint_info("").is_none());
+    }
+
+    #[test]
+    fn test_extract_tls_endpoint_info_invalid_url() {
+        assert!(extract_tls_endpoint_info("grpc+tls://").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_load_ca_certificate_from_file_not_found() {
+        let result = load_ca_certificate_from_file(Path::new("/nonexistent/path/ca.pem")).await;
+        assert!(result.is_err());
+        let err = result.expect_err("should return error for non-existent file");
+        assert!(
+            matches!(err, Error::CaCertificateFileNotFound { .. }),
+            "expected CaCertificateFileNotFound error, got: {err:?}"
+        );
+    }
 }

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -167,7 +167,7 @@ impl DataConnectorFactory for DremioFactory {
                     .cloned()
                     .unwrap_or("".into()),
             );
-            let flight_client = FlightClient::try_new(endpoint, credentials, None)
+            let flight_client = FlightClient::try_new(endpoint, credentials, None, None)
                 .await
                 .context(UnableToCreateFlightClientSnafu)?;
             let flight_factory =

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ use flight_client::tls::new_tls_flight_channel;
 use flight_client::{MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE};
 use snafu::prelude::*;
 use std::any::Any;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::{future::Future, sync::Arc};
 
@@ -79,6 +80,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("username").secret(),
     ParameterSpec::component("password").secret(),
     ParameterSpec::component("endpoint"),
+    ParameterSpec::component("tls_ca_certificate_file")
+        .description("Path to a CA certificate file (PEM format) to use for TLS verification instead of system certificates."),
 ];
 
 impl DataConnectorFactory for FlightSQLFactory {
@@ -99,7 +102,15 @@ impl DataConnectorFactory for FlightSQLFactory {
                     parameter: p.to_string(),
                 })?
                 .to_string();
-            let flight_channel = new_tls_flight_channel(&endpoint)
+
+            let ca_certificate_path: Option<PathBuf> = params
+                .parameters
+                .get("tls_ca_certificate_file")
+                .expose()
+                .ok()
+                .map(PathBuf::from);
+
+            let flight_channel = new_tls_flight_channel(&endpoint, ca_certificate_path.as_deref())
                 .await
                 .context(UnableToConstructTlsChannelSnafu)?;
 

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -193,7 +193,7 @@ impl DataConnectorFactory for SpiceAIFactory {
                 .ok_or_else(|p| MissingRequiredParameterSnafu { parameter: p.0 }.build())?;
             let credentials = Credentials::new("", api_key.clone());
 
-            let mut flight_client = FlightClient::try_new(url, credentials, None)
+            let mut flight_client = FlightClient::try_new(url, credentials, None, None)
                 .await
                 .context(UnableToCreateFlightClientSnafu)?;
 

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -166,6 +166,7 @@ async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
         format!("http://{flight_addr}").into(),
         Credentials::anonymous(),
         None,
+        None,
     )
     .await
     {

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -74,7 +74,7 @@ impl TelemetryExporterBuilder {
         let credentials = self.credentials.unwrap_or(Credentials::anonymous());
 
         let endpoint = self.endpoint.ok_or(Error::MissingEndpoint)?;
-        let flight_client = match FlightClient::try_new(endpoint, credentials, None).await {
+        let flight_client = match FlightClient::try_new(endpoint, credentials, None, None).await {
             Ok(client) => Some(client),
             Err(e) => {
                 tracing::trace!("Unable to initialize telemetry: {e}");

--- a/docs/release_notes/v1.11.0-rc.3.md
+++ b/docs/release_notes/v1.11.0-rc.3.md
@@ -1,6 +1,6 @@
 # Spice v1.11.0-rc.3 (Jan 22, 2026)
 
-v1.11.0-rc.3 is a patch release that includes improvements to Hash Indexing for Arrow Acceleration, adding support for primary key, secondary, and composite hash indexes with O(1) average-case lookup performance.  
+v1.11.0-rc.3 is a patch release that includes improvements to Hash Indexing for Arrow Acceleration and fixes for TLS connections with Flight SQL endpoints.
 
 ## What's New in v1.11.0-rc.3
 
@@ -30,9 +30,14 @@ datasets:
 
 For more details, refer to the [Hash Index Documentation](https://spiceai.org/docs/next/features/data-acceleration/hash-index).
 
+### Flight SQL TLS Connection Fixes
+
+**TLS Connection Support**: Fixed TLS connection issues when using `grpc+tls://` scheme with Flight SQL endpoints. Added support for custom CA certificate files via the new `flightsql_tls_ca_certificate_file` parameter.
+
 ## Contributors
 
 - [@lukekim](https://github.com/lukekim)
+- [@phillipleblanc](https://github.com/phillipleblanc)
 
 ## Breaking Changes
 
@@ -87,3 +92,4 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 
 - Hash indexing for Arrow Acceleration by [@lukekim](https://github.com/lukekim) in [#8924](https://github.com/spiceai/spiceai/pull/8924)
 - Improve validation and logging for hash indexes [@lukekim](https://github.com/lukekim) in [#9047](https://github.com/spiceai/spiceai/pull/9047)
+- Fix TLS connection for grpc+tls:// Flight SQL endpoints and add custom CA certificate support [@phillipleblanc](https://github.com/phillipleblanc) in [#9073](https://github.com/spiceai/spiceai/pull/9073)


### PR DESCRIPTION
## 📝 Summary

Cherry-pick to 1.11.0-rc.3:
* [Fix TLS connection for grpc+tls:// Flight SQL endpoints and add custom CA certificate support](https://github.com/spiceai/spiceai/pull/9073) 
* Release notes