### PR TITLE
Snowflake data connector - add `snowflake_private_key` parameter

### DIFF
--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -82,6 +82,11 @@ pub enum Error {
         "Failed to save decrypted private key content as PEM. Verify filesystem permissions, and try again. {source}"
     ))]
     FailedToCreatePem { source: pkcs8::der::Error },
+
+    #[snafu(display(
+        "Both 'snowflake_private_key' and 'snowflake_private_key_path' are specified. Only one of these options can be specified for a given dataset. For details, visit: https://spiceai.org/docs/components/data-connectors/snowflake#auth"
+    ))]
+    MutuallyExclusivePrivateKeyParams,
 }
 
 pub struct SnowflakeConnectionPool {
@@ -214,17 +219,24 @@ fn init_snowflake_api_with_keypair_auth(
     role: Option<&String>,
     params: &HashMap<String, SecretString>,
 ) -> Result<SnowflakeApi, Error> {
-    let private_key_path = params
-        .get("private_key_path")
-        .map(SecretBox::expose_secret)
-        .context(MissingRequiredSecretSnafu {
-            name: "snowflake_private_key_path",
-        })?;
+    let private_key_content = params.get("private_key").map(SecretBox::expose_secret);
+    let private_key_path = params.get("private_key_path").map(SecretBox::expose_secret);
 
-    let mut private_key_pem: String =
-        fs::read_to_string(private_key_path).context(ErrorReadingPrivateKeyFileSnafu {
-            file_path: private_key_path,
-        })?;
+    let mut private_key_pem: String = match (private_key_content, private_key_path) {
+        (Some(_), Some(_)) => {
+            return MutuallyExclusivePrivateKeyParamsSnafu.fail();
+        }
+        (Some(content), None) => content.to_string(),
+        (None, Some(path)) => {
+            fs::read_to_string(path).context(ErrorReadingPrivateKeyFileSnafu { file_path: path })?
+        }
+        (None, None) => {
+            return MissingRequiredSecretSnafu {
+                name: "snowflake_private_key or snowflake_private_key_path",
+            }
+            .fail();
+        }
+    };
 
     let (label, data) =
         SecretDocument::from_pem(&private_key_pem).context(UnableToParsePrivateKeySnafu)?;

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -69,6 +69,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("username").secret(),
     ParameterSpec::component("password").secret(),
     ParameterSpec::component("private_key_path").secret(),
+    ParameterSpec::component("private_key").secret(),
     ParameterSpec::component("private_key_passphrase").secret(),
     ParameterSpec::component("account").secret(),
     ParameterSpec::component("warehouse").secret(),


### PR DESCRIPTION
## 📝 Summary

Added support for specifying the Snowflake private key directly via the `private_key` parameter, in addition to the existing `private_key_path` option in the connector's configuration (`crates/runtime/src/dataconnector/snowflake.rs`).
* Updated the initialization logic in `init_snowflake_api_with_keypair_auth` to accept either `private_key` content or `private_key_path`, and to return a clear error if both are provided or if neither is specified (`crates/db_connection_pool/src/snowflakepool.rs`).

Example spicepod:

```yaml
version: v1
kind: Spicepod
name: test
datasets:
  - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM
    name: lineitem
    params:
      snowflake_role: accountadmin
      snowflake_warehouse: COMPUTE_WH
      snowflake_account: ${ secrets:SN_ACCOUNT }
      snowflake_auth_type: keypair
      snowflake_username: ${ secrets:SN_USERNAME }
      snowflake_private_key: ${ secrets:SN_PRIVATE_KEY } # contents of rsa_key.p8
      snowflake_private_key_passphrase: ${ secrets:SN_PRIVATE_KEY_PASSPHRASE }
```
