### PR TITLE
Cayenne: Allow append mode with both primary_key and time_column

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -589,14 +589,51 @@ impl Builder {
                 }
 
                 let schema = self.accelerator.schema();
-                let has_primary_key = self.accelerator.constraints().is_some_and(|constraints| {
-                    !get_primary_keys_from_constraints(constraints, &schema).is_empty()
-                });
+                let primary_keys = self
+                    .accelerator
+                    .constraints()
+                    .map_or_else(Vec::new, |constraints| {
+                        get_primary_keys_from_constraints(constraints, &schema)
+                    });
+                let has_primary_key = !primary_keys.is_empty();
                 let has_time_column = self.refresh.time_column.is_some();
                 let has_append_stream = self.append_stream.is_some();
 
                 let append_mode =
                     AppendMode::try_new(has_time_column, has_primary_key, has_append_stream)?;
+
+                // Log append mode configuration for debugging
+                match (has_primary_key, has_time_column, has_append_stream) {
+                    (_, _, true) => {
+                        tracing::debug!(
+                            dataset = %self.dataset_name,
+                            "Append mode: using changes stream"
+                        );
+                    }
+                    (true, true, false) => {
+                        tracing::debug!(
+                            dataset = %self.dataset_name,
+                            ?primary_keys,
+                            "Append mode: using time_column for incremental queries and primary_key for deduplication"
+                        );
+                    }
+                    (true, false, false) => {
+                        tracing::debug!(
+                            dataset = %self.dataset_name,
+                            ?primary_keys,
+                            "Append mode: using primary_key for deduplication (full fetch each refresh)"
+                        );
+                    }
+                    (false, true, false) => {
+                        tracing::debug!(
+                            dataset = %self.dataset_name,
+                            "Append mode: using time_column for incremental queries"
+                        );
+                    }
+                    (false, false, false) => {
+                        // This case is handled by AppendMode::try_new returning an error
+                    }
+                }
 
                 match append_mode {
                     AppendMode::ChangesStream => {

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -49,7 +49,7 @@ use tokio::sync::OnceCell;
 use url::Url;
 
 use super::{AccelerationSource, BootstrapStatus, DataAccelerator, upsert_dedup};
-use crate::component::dataset::acceleration::{Acceleration, Engine, Mode, RefreshMode};
+use crate::component::dataset::acceleration::{Acceleration, Engine, Mode};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
@@ -1927,59 +1927,6 @@ impl DataAccelerator for CayenneAccelerator {
         let dir_path = self.resolve_storage_config(source).boxed()?;
         let arrow_schema = Self::transformed_arrow_schema(&cmd, source).boxed()?;
         let _ = Self::ensure_directory(&dir_path).boxed()?;
-
-        // Validate append mode configuration: requires either none, primary_key or time_column, but not both
-        if let Some(acceleration) = source.acceleration()
-            && let Some(refresh_mode) = acceleration.refresh_mode
-            && refresh_mode == RefreshMode::Append
-        {
-            // Get primary keys from constraints
-            let arrow_schema_for_pk = Arc::new(cmd.schema.as_arrow().clone());
-            let primary_keys = if cmd.constraints.is_empty() {
-                Vec::new()
-            } else {
-                super::get_primary_keys_from_constraints(&cmd.constraints, &arrow_schema_for_pk)
-            };
-            let has_primary_key = !primary_keys.is_empty();
-
-            // Get time_column from the source via the trait method
-            let has_time_column = source.time_column().is_some();
-
-            // Validate: must have exactly one (not both, not neither)
-            match (has_primary_key, has_time_column) {
-                (false, false) => {
-                    return Err(Box::new(Error::InvalidConfiguration {
-                        detail: Arc::from(
-                            "Append mode requires either primary_key or time_column to be specified. \
-                            Please add one of these to your dataset configuration.",
-                        ),
-                    })
-                        as Box<dyn std::error::Error + Send + Sync>);
-                }
-                (true, true) => {
-                    return Err(Box::new(Error::InvalidConfiguration {
-                        detail: Arc::from(
-                            "Append mode currently cannot have both primary_key and time_column specified. \
-                            Please specify only one of these in your dataset configuration.",
-                        ),
-                    })
-                        as Box<dyn std::error::Error + Send + Sync>);
-                }
-                (true, false) => {
-                    tracing::info!(
-                        "Append mode for dataset '{}': using primary_key {:?} for deduplication",
-                        source.name(),
-                        primary_keys
-                    );
-                }
-                (false, true) => {
-                    tracing::info!(
-                        "Append mode for dataset '{}': using time_column for append operations",
-                        source.name()
-                    );
-                }
-            }
-        }
 
         // Get the table name from the source
         let table_name = source.name().to_string();

--- a/crates/runtime/tests/acceleration/refresh/common.rs
+++ b/crates/runtime/tests/acceleration/refresh/common.rs
@@ -146,6 +146,40 @@ pub(crate) async fn initialize_postgres(port: usize) -> Result<PostgresConnectio
     Ok(db_conn)
 }
 
+/// Initialize postgres with a test table that includes a `value` column for testing upsert behavior.
+/// The table has: id (PK), created_at (timestamp), value (text)
+pub(crate) async fn initialize_postgres_with_value_column(
+    port: usize,
+) -> Result<PostgresConnection, anyhow::Error> {
+    let pool = common::get_postgres_connection_pool(port, None).await?;
+
+    let db_conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("Error connecting: {e}"))?;
+
+    execute_ps_sql(
+        &db_conn,
+        "
+                CREATE TABLE test_table (
+                    id SERIAL PRIMARY KEY,
+                    created_at TIMESTAMP(3) WITH TIME ZONE,
+                    value TEXT
+                )",
+    )
+    .await?;
+
+    execute_ps_sql(
+        &db_conn,
+        "INSERT INTO test_table (created_at, value) VALUES (date_trunc('milliseconds', now()), 'initial_value')",
+    )
+    .await?;
+
+    execute_ps_sql(&db_conn, "CREATE DATABASE acceleration").await?;
+
+    Ok(db_conn)
+}
+
 pub(crate) async fn start_test_runtime(
     port: usize,
     acceleration: Acceleration,

--- a/crates/runtime/tests/acceleration/refresh/common.rs
+++ b/crates/runtime/tests/acceleration/refresh/common.rs
@@ -147,7 +147,7 @@ pub(crate) async fn initialize_postgres(port: usize) -> Result<PostgresConnectio
 }
 
 /// Initialize postgres with a test table that includes a `value` column for testing upsert behavior.
-/// The table has: id (PK), created_at (timestamp), value (text)
+/// The table has: id (PK), `created_at` (timestamp), value (text)
 pub(crate) async fn initialize_postgres_with_value_column(
     port: usize,
 ) -> Result<PostgresConnection, anyhow::Error> {

--- a/crates/runtime/tests/acceleration/refresh/refresh_cayenne.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_cayenne.rs
@@ -151,10 +151,10 @@ async fn test_acceleration_refresh_cayenne_full() -> Result<(), anyhow::Error> {
         .await
 }
 
-/// Test that Cayenne append mode works with both primary_key and time_column specified.
+/// Test that Cayenne append mode works with both `primary_key` and `time_column` specified.
 /// This validates that:
-/// 1. time_column is used for incremental queries (fetch only new data)
-/// 2. primary_key is used for deduplication at insert time (upsert behavior)
+/// 1. `time_column` is used for incremental queries (fetch only new data)
+/// 2. `primary_key` is used for deduplication at insert time (upsert behavior)
 #[tokio::test]
 async fn test_cayenne_append_mode_with_pk_and_time_column() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -207,7 +207,7 @@ async fn test_cayenne_append_mode_with_pk_and_time_column() -> Result<(), anyhow
                         .as_any()
                         .downcast_ref::<arrow::array::StringArray>()
                 })
-                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0).to_string()) } else { None })
+                .and_then(|arr| if arr.is_empty() { None } else { Some(arr.value(0).to_string()) })
                 .expect("Should have initial value");
             assert_eq!(initial_value, "initial_value", "Initial value should be 'initial_value'");
 
@@ -220,7 +220,7 @@ async fn test_cayenne_append_mode_with_pk_and_time_column() -> Result<(), anyhow
                         .as_any()
                         .downcast_ref::<arrow::array::Int32Array>()
                 })
-                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0)) } else { None })
+                .and_then(|arr| if arr.is_empty() { None } else { Some(arr.value(0)) })
                 .expect("Should have at least one row");
 
             // Insert a new row with a new timestamp and different value
@@ -278,7 +278,7 @@ async fn test_cayenne_append_mode_with_pk_and_time_column() -> Result<(), anyhow
                         .as_any()
                         .downcast_ref::<arrow::array::StringArray>()
                 })
-                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0).to_string()) } else { None })
+                .and_then(|arr| if arr.is_empty() { None } else { Some(arr.value(0).to_string()) })
                 .expect("Should have updated value");
             assert_eq!(
                 updated_value, "updated_value",

--- a/crates/runtime/tests/acceleration/refresh/refresh_cayenne.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_cayenne.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 use crate::acceleration::refresh::common::{
     execute_ps_sql, execute_rt_sql, get_acceleration_config_append, get_acceleration_config_full,
-    get_dataset_no_time_column, initialize_postgres, refresh_table, start_test_runtime,
+    get_dataset_no_time_column, initialize_postgres, initialize_postgres_with_value_column,
+    refresh_table, start_test_runtime,
 };
 use crate::postgres::common;
 use crate::postgres::common::get_random_port;
@@ -23,6 +24,7 @@ use crate::{
     configure_test_datafusion, configure_test_datafusion_request_context, init_tracing,
     utils::test_request_context,
 };
+use arrow::array::Array;
 use spicepod::acceleration::Mode;
 use spicepod::param::Params;
 use std::collections::HashMap;
@@ -142,6 +144,159 @@ async fn test_acceleration_refresh_cayenne_full() -> Result<(), anyhow::Error> {
                     .sum::<usize>(),
                 2
             );
+
+            running_container.remove().await?;
+            Ok(())
+        })
+        .await
+}
+
+/// Test that Cayenne append mode works with both primary_key and time_column specified.
+/// This validates that:
+/// 1. time_column is used for incremental queries (fetch only new data)
+/// 2. primary_key is used for deduplication at insert time (upsert behavior)
+#[tokio::test]
+async fn test_cayenne_append_mode_with_pk_and_time_column() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port: usize = get_random_port()?;
+            let running_container = common::start_postgres_docker_container(port).await?;
+
+            // Use table with value column for testing upserts
+            let db_conn = initialize_postgres_with_value_column(port).await?;
+
+            // Create unique temp directory for this test
+            let temp_dir = tempfile::tempdir()?;
+            let metadata_dir = temp_dir.path().join("cayenne_metadata");
+            std::fs::create_dir_all(&metadata_dir)?;
+
+            let mut params = HashMap::new();
+            params.insert(
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.to_str().expect("valid UTF-8 path").to_string(),
+            );
+
+            // Configure with BOTH primary_key and time_column
+            let mut acceleration_config =
+                get_acceleration_config_append("cayenne", Some(Params::from_string_map(params)));
+            acceleration_config.mode = Mode::File;
+            // Keep both primary_key (from get_acceleration_config_append) and time_column (from get_dataset)
+
+            let rt = start_test_runtime(port, acceleration_config).await?;
+
+            // Verify initial data loaded with correct value
+            let results =
+                execute_rt_sql(Arc::clone(&rt), "SELECT id, value from test_table").await?;
+            assert_eq!(
+                results
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1,
+                "Expected 1 row after initial load"
+            );
+
+            // Check initial value
+            let initial_value = results
+                .first()
+                .and_then(|batch| {
+                    batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                })
+                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0).to_string()) } else { None })
+                .expect("Should have initial value");
+            assert_eq!(initial_value, "initial_value", "Initial value should be 'initial_value'");
+
+            // Get the ID of the first row for later upsert test
+            let first_id = results
+                .first()
+                .and_then(|batch| {
+                    batch
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int32Array>()
+                })
+                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0)) } else { None })
+                .expect("Should have at least one row");
+
+            // Insert a new row with a new timestamp and different value
+            execute_ps_sql(
+                &db_conn,
+                "INSERT INTO test_table (created_at, value) VALUES (date_trunc('milliseconds', now()), 'second_value');",
+            )
+            .await?;
+
+            refresh_table(Arc::clone(&rt), "test_table").await?;
+
+            // Verify new row was appended
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * from test_table").await?;
+            assert_eq!(
+                results
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum::<usize>(),
+                2,
+                "Expected 2 rows after refresh with new data"
+            );
+
+            // Test upsert: update existing row (same PK, new timestamp, new value)
+            execute_ps_sql(
+                &db_conn,
+                &format!(
+                    "UPDATE test_table SET created_at = date_trunc('milliseconds', now() + interval '1 second'), value = 'updated_value' WHERE id = {first_id};"
+                ),
+            )
+            .await?;
+
+            refresh_table(Arc::clone(&rt), "test_table").await?;
+
+            // Should still have 2 rows (upsert updated the existing row, not inserted a new one)
+            let results = execute_rt_sql(
+                Arc::clone(&rt),
+                &format!("SELECT id, value from test_table WHERE id = {first_id}"),
+            )
+            .await?;
+            assert_eq!(
+                results
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1,
+                "Expected exactly 1 row with the upserted id"
+            );
+
+            // Verify the value was actually updated
+            let updated_value = results
+                .first()
+                .and_then(|batch| {
+                    batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                })
+                .and_then(|arr| if !arr.is_empty() { Some(arr.value(0).to_string()) } else { None })
+                .expect("Should have updated value");
+            assert_eq!(
+                updated_value, "updated_value",
+                "Value should be updated to 'updated_value' after upsert"
+            );
+
+            // Verify total row count is still 2
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * from test_table").await?;
+            assert_eq!(
+                results
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum::<usize>(),
+                2,
+                "Expected 2 rows total after upsert (not 3) - PK deduplication should work"
+            );
+
+            tracing::info!("✓ Cayenne append mode with both primary_key and time_column works correctly");
 
             running_container.remove().await?;
             Ok(())


### PR DESCRIPTION
## 📝 Summary

Removes Cayenne-specific append mode validation that incorrectly rejected configurations with both `primary_key` and `time_column`. These are complementary, not conflicting:
- `time_column`: controls incremental data fetching from source
- `primary_key`: controls deduplication at insert time

### Changes
- Remove duplicate validation in Cayenne accelerator (generic layer already handles this)
- Add debug logging for append mode configuration in generic `AcceleratedTable` builder
- Add helper `initialize_postgres_with_value_column()` for integration tests
- Add integration test `test_cayenne_append_mode_with_pk_and_time_column`

## 🔗 Related

Fixes
- https://github.com/spiceai/spiceai/issues/8427

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
