### PR TITLE
Fix testoperator dispatch

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-compound_hash_index.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-compound_hash_index.yaml
@@ -1,7 +1,7 @@
 tests:
   bench:
     spicepod_path: accelerated/indexes/file[parquet]-arrow-compound_hash_index.yaml
-    query_set: scenario
+    query_set: tpch
     scenario_query_file: scenario/hash_index/compound_index_lookup.yaml
     runner_type: spiceai-dev-runners
     ready_wait: 300

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-pk_hash_index.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-pk_hash_index.yaml
@@ -1,7 +1,7 @@
 tests:
   bench:
     spicepod_path: accelerated/indexes/file[parquet]-arrow-pk_hash_index.yaml
-    query_set: scenario
+    query_set: tpch
     scenario_query_file: scenario/hash_index/primary_key_lookup.yaml
     runner_type: spiceai-dev-runners
     ready_wait: 300

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-secondary_hash_index.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-secondary_hash_index.yaml
@@ -1,7 +1,7 @@
 tests:
   bench:
     spicepod_path: accelerated/indexes/file[parquet]-arrow-secondary_hash_index.yaml
-    query_set: scenario
+    query_set: tpch
     scenario_query_file: scenario/hash_index/secondary_index_lookup.yaml
     runner_type: spiceai-dev-runners
     ready_wait: 300


### PR DESCRIPTION
## 📝 Summary

Replace `query_set: scenario` to `tpch` in recently added dispatch configurations

>38/67 - Dispatching benchmark test from ./tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-arrow-secondary_hash_index.yaml
Error: GitHub
Caused by:
    Provided value 'scenario' for input 'query_set' not in the list of allowed values
    Documentation URL: https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
