### PR TITLE
fix: Normalize request_query filter values in HTTP cache lookups

### DIFF
--- a/crates/data_components/src/http/mod.rs
+++ b/crates/data_components/src/http/mod.rs
@@ -15,3 +15,5 @@ limitations under the License.
 */
 
 pub mod provider;
+
+pub use provider::sort_query_params;

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -118,6 +118,27 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024; // 16 KiB
 const MAX_REQUEST_PATH_LENGTH: usize = 1024;
 type PartitionSpec = (Option<String>, Option<String>, Option<String>);
 
+/// Sort query parameters alphabetically for consistent cache key handling.
+///
+/// This ensures that `param1=a&param2=b` and `param2=b&param1=a` are treated as equivalent
+/// when used as cache keys or for matching against stored data.
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(sort_query_params("b=2&a=1"), "a=1&b=2");
+/// assert_eq!(sort_query_params(""), "");
+/// ```
+#[must_use]
+pub fn sort_query_params(query: &str) -> String {
+    if query.is_empty() {
+        return String::new();
+    }
+
+    let mut params: Vec<&str> = query.split('&').collect();
+    params.sort_unstable();
+    params.join("&")
+}
+
 #[derive(Clone)]
 struct CachedResponse {
     content: Arc<String>,
@@ -1465,18 +1486,7 @@ impl HttpTableProvider {
         }
 
         let query = raw.strip_prefix('?').unwrap_or(raw);
-        Ok(Self::sort_query_params(query))
-    }
-
-    /// Sort query parameters alphabetically by key for consistent primary key handling
-    fn sort_query_params(query: &str) -> String {
-        if query.is_empty() {
-            return String::new();
-        }
-
-        let mut params: Vec<&str> = query.split('&').collect();
-        params.sort_unstable();
-        params.join("&")
+        Ok(sort_query_params(query))
     }
 
     fn ensure_allowed_body(&self, raw: &str) -> Result<String> {
@@ -2100,35 +2110,26 @@ mod tests {
     #[test]
     fn test_sort_query_params() {
         // Test empty query
-        assert_eq!(HttpTableProvider::sort_query_params(""), "");
+        assert_eq!(sort_query_params(""), "");
 
         // Test single parameter
-        assert_eq!(
-            HttpTableProvider::sort_query_params("key=value"),
-            "key=value"
-        );
+        assert_eq!(sort_query_params("key=value"), "key=value");
 
         // Test already sorted parameters
-        assert_eq!(
-            HttpTableProvider::sort_query_params("a=1&b=2&c=3"),
-            "a=1&b=2&c=3"
-        );
+        assert_eq!(sort_query_params("a=1&b=2&c=3"), "a=1&b=2&c=3");
 
         // Test unsorted parameters - should be sorted alphabetically
-        assert_eq!(
-            HttpTableProvider::sort_query_params("c=3&a=1&b=2"),
-            "a=1&b=2&c=3"
-        );
+        assert_eq!(sort_query_params("c=3&a=1&b=2"), "a=1&b=2&c=3");
 
         // Test with URL encoding
         assert_eq!(
-            HttpTableProvider::sort_query_params("z=last&a=first&m=middle"),
+            sort_query_params("z=last&a=first&m=middle"),
             "a=first&m=middle&z=last"
         );
 
         // Test complex query string
         assert_eq!(
-            HttpTableProvider::sort_query_params("userId=1&title=foo&body=bar"),
+            sort_query_params("userId=1&title=foo&body=bar"),
             "body=bar&title=foo&userId=1"
         );
     }

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -24,9 +24,12 @@ use arrow::array::StringArray;
 use arrow::array::{Array, RecordBatch, TimestampNanosecondArray};
 use arrow::datatypes::SchemaRef;
 use arrow_tools::format::SchemaDisplay;
+use data_components::http::sort_query_params;
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
 use datafusion::datasource::TableProvider;
 use datafusion::execution::TaskContext;
+use datafusion::logical_expr::Operator;
+use datafusion::logical_expr::expr::{BinaryExpr, InList};
 use datafusion::logical_expr::{Expr, dml::InsertOp, not};
 use datafusion::logical_expr::{col, lit};
 use datafusion::physical_plan::execution_plan::EmissionType;
@@ -1695,6 +1698,120 @@ impl ExecutionPlan for CachingAccelerationScanExec {
     }
 }
 
+/// Check if an expression is a `request_query` filter that we normalize.
+/// Used to determine if we should return Exact filter support.
+///
+/// Returns true for:
+/// - Simple equality: `request_query = 'value'`
+/// - IN lists: `request_query IN ('value1', 'value2')`
+/// - OR of `request_query` filters: `request_query = 'a' OR request_query = 'b'`
+#[must_use]
+pub fn is_request_query_filter(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) if *op == Operator::Eq => {
+            if let Expr::Column(col) = left.as_ref() {
+                col.name == "request_query"
+            } else if let Expr::Column(col) = right.as_ref() {
+                col.name == "request_query"
+            } else {
+                false
+            }
+        }
+        Expr::InList(in_list) => {
+            if let Expr::Column(col) = in_list.expr.as_ref() {
+                col.name == "request_query"
+            } else {
+                false
+            }
+        }
+        // OR of request_query filters: both sides must be request_query filters.
+        // Example: request_query = 'a' OR request_query = 'b'
+        // Note: AND expressions are passed as separate filters by DataFusion.
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) if *op == Operator::Or => {
+            is_request_query_filter(left) && is_request_query_filter(right)
+        }
+        _ => false,
+    }
+}
+
+/// Normalize `request_query` filter values by sorting query parameters alphabetically.
+///
+/// This ensures that queries with parameters in different orders match correctly against
+/// cached data. For example, `request_query='param2=b&param1=a'` will be normalized to
+/// `request_query='param1=a&param2=b'` to match how data is stored in the cache.
+///
+/// Handles:
+/// - Simple equality: `request_query = 'param2=b&param1=a'`
+/// - IN lists: `request_query IN ('param2=b&param1=a', 'param3=c&param1=a')`
+/// - AND/OR expressions (recursive)
+pub fn normalize_request_query_filters(filters: &[Expr]) -> Vec<Expr> {
+    filters.iter().map(normalize_expr).collect()
+}
+
+fn normalize_expr(expr: &Expr) -> Expr {
+    match expr {
+        // Handle: request_query = 'value'
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) if *op == Operator::Eq => {
+            if let Expr::Column(col) = left.as_ref()
+                && col.name == "request_query"
+                && let Expr::Literal(ScalarValue::Utf8(Some(value)), sort) = right.as_ref()
+            {
+                let normalized = sort_query_params(value);
+                Expr::BinaryExpr(BinaryExpr {
+                    left: left.clone(),
+                    op: *op,
+                    right: Box::new(Expr::Literal(
+                        ScalarValue::Utf8(Some(normalized)),
+                        sort.clone(),
+                    )),
+                })
+            } else {
+                expr.clone()
+            }
+        }
+        // Handle: request_query IN ('value1', 'value2', ...)
+        Expr::InList(in_list) => {
+            if let Expr::Column(col) = in_list.expr.as_ref()
+                && col.name == "request_query"
+            {
+                let normalized_list: Vec<Expr> = in_list
+                    .list
+                    .iter()
+                    .map(|item| {
+                        if let Expr::Literal(ScalarValue::Utf8(Some(value)), sort) = item {
+                            Expr::Literal(
+                                ScalarValue::Utf8(Some(sort_query_params(value))),
+                                sort.clone(),
+                            )
+                        } else {
+                            item.clone()
+                        }
+                    })
+                    .collect();
+                Expr::InList(InList {
+                    expr: in_list.expr.clone(),
+                    list: normalized_list,
+                    negated: in_list.negated,
+                })
+            } else {
+                expr.clone()
+            }
+        }
+        // Handle: expr1 AND expr2, expr1 OR expr2 (recursive)
+        Expr::BinaryExpr(BinaryExpr { left, op, right })
+            if *op == Operator::And || *op == Operator::Or =>
+        {
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(normalize_expr(left)),
+                op: *op,
+                right: Box::new(normalize_expr(right)),
+            })
+        }
+        // All other expressions: return as-is
+        _ => expr.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2766,5 +2883,110 @@ mod tests {
 
         let total_rows: usize = data.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "Should have 3 rows from 3 requests");
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_equality() {
+        // Test simple equality filter: request_query = 'param2=b&param1=a'
+        let filters = vec![col("request_query").eq(lit("param2=b&param1=a"))];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        // Should be normalized to param1=a&param2=b (sorted)
+        let expected = col("request_query").eq(lit("param1=a&param2=b"));
+        assert_eq!(
+            format!("{}", normalized[0].human_display()),
+            format!("{}", expected.human_display())
+        );
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_already_sorted() {
+        // Test already sorted: request_query = 'a=1&b=2'
+        let filters = vec![col("request_query").eq(lit("a=1&b=2"))];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        let expected = col("request_query").eq(lit("a=1&b=2"));
+        assert_eq!(
+            format!("{}", normalized[0].human_display()),
+            format!("{}", expected.human_display())
+        );
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_in_list() {
+        // Test IN list: request_query IN ('z=3&a=1', 'b=2&a=1')
+        let filters = vec![Expr::InList(InList {
+            expr: Box::new(col("request_query")),
+            list: vec![lit("z=3&a=1"), lit("b=2&a=1")],
+            negated: false,
+        })];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        // Should normalize each value in the list
+        if let Expr::InList(in_list) = &normalized[0] {
+            assert_eq!(in_list.list.len(), 2);
+            // Values should be sorted: a=1&z=3 and a=1&b=2
+            assert_eq!(
+                format!("{}", in_list.list[0].human_display()),
+                format!("{}", lit("a=1&z=3").human_display())
+            );
+            assert_eq!(
+                format!("{}", in_list.list[1].human_display()),
+                format!("{}", lit("a=1&b=2").human_display())
+            );
+        } else {
+            panic!("Expected InList expression");
+        }
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_and_expression() {
+        // Test AND: request_path = '/api' AND request_query = 'b=2&a=1'
+        let filters = vec![
+            col("request_path")
+                .eq(lit("/api"))
+                .and(col("request_query").eq(lit("b=2&a=1"))),
+        ];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        // The request_query part should be normalized, request_path unchanged
+        let expected = col("request_path")
+            .eq(lit("/api"))
+            .and(col("request_query").eq(lit("a=1&b=2")));
+        assert_eq!(
+            format!("{}", normalized[0].human_display()),
+            format!("{}", expected.human_display())
+        );
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_non_query_unchanged() {
+        // Test that non-request_query columns are unchanged
+        let filters = vec![col("request_path").eq(lit("/api/users"))];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        assert_eq!(
+            format!("{}", normalized[0].human_display()),
+            format!("{}", filters[0].human_display())
+        );
+    }
+
+    #[test]
+    fn test_normalize_request_query_filters_empty() {
+        // Test empty query string
+        let filters = vec![col("request_query").eq(lit(""))];
+        let normalized = normalize_request_query_filters(&filters);
+
+        assert_eq!(normalized.len(), 1);
+        let expected = col("request_query").eq(lit(""));
+        assert_eq!(
+            format!("{}", normalized[0].human_display()),
+            format!("{}", expected.human_display())
+        );
     }
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1054,10 +1054,34 @@ impl TableProvider for AcceleratedTable {
         &self,
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
-        // In caching mode, we handle filters ourselves (not pushed to accelerator)
-        // Return Inexact to indicate we'll use the filters but they shouldn't be optimized away
+        // The HTTP connector returns data with normalized `request_query` values
+        // (e.g., `param2=b&param1=a` → `param1=a&param2=b`), which is then stored in the
+        // caching accelerator.
+        //
+        // Returning Inexact would cause DataFusion to add FilterExec with the original
+        // (non-normalized) filter value, which would reject correct results since stored
+        // data has normalized values.
+        //
+        // It is safe to return Exact for `request_query` filters because:
+        // 1. This mirrors how the HTTP connector returns Exact for the same reason
+        // 2. Both write path (HttpTableProvider::ensure_allowed_query) and read path
+        //    (normalize_request_query_filters) use the same sort_query_params normalization
+        // 3. `request_query` has special meaning and supports predefined format / expressions
+        //
+        // Other filters (request_path, request_body, etc.) remain Inexact as a conservative
+        // default. While the accelerator can fully handle equality correctly, Inexact ensures
+        // DataFusion verifies results for complex expressions (LIKE, functions, etc.).
         if self.refresh_mode == RefreshMode::Caching {
-            return Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]);
+            return Ok(filters
+                .iter()
+                .map(|f| {
+                    if caching::is_request_query_filter(f) {
+                        TableProviderFilterPushDown::Exact
+                    } else {
+                        TableProviderFilterPushDown::Inexact
+                    }
+                })
+                .collect());
         }
 
         match self.zero_results_action {
@@ -1101,10 +1125,20 @@ impl TableProvider for AcceleratedTable {
             }
         }
 
+        // For caching mode, normalize request_query filter values by sorting query parameters.
+        // This ensures that `param2=b&param1=a` matches stored data with `param1=a&param2=b`.
+        let normalized_filters: Vec<Expr>;
+        let effective_filters = if is_caching_mode {
+            normalized_filters = caching::normalize_request_query_filters(filters);
+            &normalized_filters[..]
+        } else {
+            filters
+        };
+
         // For caching mode with filters, extend projection to include fetched_at for freshness checking if needed.
         // Added columns will be automatically stripped by `SchemaCastScanExec`, similar to
         // fallback-to-source on cache miss where results return all columns.
-        let extended_projection = if is_caching_mode && !filters.is_empty() {
+        let extended_projection = if is_caching_mode && !effective_filters.is_empty() {
             extend_projection_for_caching(projection, &self.accelerator.schema())
         } else {
             None
@@ -1112,7 +1146,7 @@ impl TableProvider for AcceleratedTable {
         let scan_projection = extended_projection.as_ref().or(projection);
         let input = self
             .accelerator
-            .scan(state, scan_projection, filters, limit)
+            .scan(state, scan_projection, effective_filters, limit)
             .await?;
         let federated = Arc::clone(&self.federated);
         let fallback_fn: FallbackAsyncTableProvider = Arc::new(move || {
@@ -1126,7 +1160,7 @@ impl TableProvider for AcceleratedTable {
 
                 // Check which filters the accelerator doesn't fully support and need to be re-applied.
                 // This ensures correct results when the accelerator returns Inexact or Unsupported for some filters.
-                let filters_to_reapply = self.get_filters_to_reapply(filters)?;
+                let filters_to_reapply = self.get_filters_to_reapply(effective_filters)?;
                 let input = if filters_to_reapply.is_empty() {
                     input
                 } else {
@@ -1147,7 +1181,7 @@ impl TableProvider for AcceleratedTable {
                     Arc::clone(&self.accelerator),
                     self.dataset_name.to_string(),
                     self.io_runtime.clone(),
-                    filters.to_vec(),
+                    effective_filters.to_vec(),
                     projection.cloned(),
                     limit,
                     Arc::clone(&self.accelerator_write_mutex),

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -2345,6 +2345,157 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
         .await
 }
 
+/// Test that query parameters in different orders are correctly supported.
+///
+/// Workflow:
+/// 1. Query with `q=michael&page=1` → cache miss → fetch → stored as `page=1&q=michael`
+/// 2. Query with `page=1&q=michael` → cache hit (normalized order matches)
+/// 3. Query with `q=michael&page=1` → cache hit (original order also matches after normalization)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_caching_mode_query_param_order_normalization() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=trace,runtime::accelerated_table::cache=trace",
+    ));
+
+    test_request_context()
+        .scope(async {
+            // Create HTTP dataset with caching mode using DuckDB for proper upsert support
+            let mut dataset = Dataset::new("https://api.tvmaze.com", "tvmaze");
+            dataset.params = Some(Params::from_string_map(
+                vec![
+                    (
+                        "allowed_request_paths".to_string(),
+                        "/search/people".to_string(),
+                    ),
+                    ("request_query_filters".to_string(), "enabled".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                engine: Some("duckdb".to_string()),
+                mode: Mode::File,
+                refresh_mode: Some(RefreshMode::Caching),
+                refresh_check_interval: Some("30s".to_string()),
+                ..Acceleration::default()
+            });
+
+            let mut app = AppBuilder::new("test_caching_param_order")
+                .with_dataset(dataset)
+                .build();
+
+            // Disable SQL results caching
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let status = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&status).load_components() => {}
+            }
+
+            runtime_ready_check(&status).await;
+
+            // STEP 1: Cache miss - query with params in one order (q first, page second)
+            eprintln!("TEST: Step 1 - querying with q=michael&page=1...");
+            let df1 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("q=michael&page=1")))?
+                .select(vec![col("request_path"), col("request_query")])?
+                .limit(0, Some(1))?;
+
+            let batches1 = df1.collect().await?;
+            assert!(
+                !batches1.is_empty() && batches1[0].num_rows() > 0,
+                "Should have results from HTTP API"
+            );
+
+            let batch1 = &batches1[0];
+            let request_query_array1 = batch1
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("request_query should be StringArray");
+
+            // Data is stored with normalized (sorted) params
+            assert_eq!(
+                request_query_array1.value(0),
+                "page=1&q=michael",
+                "Stored data should have normalized (alphabetically sorted) params"
+            );
+            eprintln!("TEST: Step 1 complete - data fetched and cached with normalized params");
+
+            // STEP 2: Cache hit with reversed param order (page first, q second)
+            // This tests that the fix normalizes the query filter before lookup
+            eprintln!("TEST: Step 2 - querying with page=1&q=michael (reversed order)...");
+            let df2 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("page=1&q=michael")))?
+                .select(vec![col("request_path"), col("request_query")])?
+                .limit(0, Some(1))?;
+
+            let batches2 = df2.collect().await?;
+            assert!(
+                !batches2.is_empty() && batches2[0].num_rows() > 0,
+                "Should have cached results with reversed param order (issue #9056 fix)"
+            );
+
+            let batch2 = &batches2[0];
+            let request_query_array2 = batch2
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("request_query should be StringArray");
+            assert_eq!(
+                request_query_array2.value(0),
+                "page=1&q=michael",
+                "Should return cached data"
+            );
+            eprintln!("TEST: Step 2 complete - reversed param order matched cached data");
+
+            // STEP 3: Cache hit with original param order (q first, page second)
+            // Verify the original order still works after normalization
+            eprintln!("TEST: Step 3 - querying with q=michael&page=1 (original order)...");
+            let df3 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("q=michael&page=1")))?
+                .select(vec![col("request_path"), col("request_query")])?
+                .limit(0, Some(1))?;
+
+            let batches3 = df3.collect().await?;
+            assert!(
+                !batches3.is_empty() && batches3[0].num_rows() > 0,
+                "Should have cached results with original param order"
+            );
+            eprintln!("TEST: Step 3 complete - original param order still works");
+
+            Ok(())
+        })
+        .await
+}
+
 /// Asserts that the specified column in the given record batches contains non-empty string data.
 fn assert_column_has_data(batches: &[arrow::array::RecordBatch], column_name: &str) {
     assert!(!batches.is_empty(), "expected at least one batch");


### PR DESCRIPTION
## 📝 Summary

HTTP cache returns no results when `request_query` filter parameters are in a different order than stored. The HTTP provider normalizes query parameters (sorts alphabetically) when returning data, but the accelerated table's caching mode passes user filters directly to the accelerator without normalization, the same issue with DataFusion post-filters (comparison is based on original query)


Federated (Non-Caching) Mode

```
User Query: WHERE request_query = 'param2=demo&param1=demo'
                    ↓
         HTTP Connector extracts filter
                    ↓
         ensure_allowed_query() normalizes → 'param1=demo&param2=demo'
                    ↓
         HTTP request made with normalized params
                    ↓
         Response returned with request_query = 'param1=demo&param2=demo'
                    ↓
         TableProvider returns ✅Exact for filter support
                    ↓
         DataFusion trusts the filter is handled, no post-filtering
                    ↓
         ✅ Data returned to user
```

Caching Mode

```
User Query: WHERE request_query = 'param2=demo&param1=demo'
                    ↓
         Filter pushed to DuckDB/SQLite (no normalization!)
                    ↓
         Cache miss → fetch from HTTP (which normalizes)
                    ↓
         Data stored with request_query = 'param1=demo&param2=demo'
                    ↓
         ❌  DataFusion post-filters with original: 'param2=demo&param1=demo' 
                    ↓
         ❌ String mismatch → 0 rows
```

PR applies two changes:

1. **Normalize \`request_query\` filter values** in \`AcceleratedTable::scan()\` before passing to the accelerator in caching mode. This transforms \`param2=demo&param1=demo\` to \`param1=demo&param2=demo\` to match stored data.

2. **Return \`Exact\` for \`request_query\` filters** in \`supports_filters_pushdown()\` for caching mode. This mirrors how the HTTP connector returns Exact for the same reason preventing DataFusion from adding a post-filter \`FilterExec\` that would compare against the original non-normalized value.

## 🔗 Related

Fixes
- https://github.com/spiceai/spiceai/issues/9056

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

We might want to revise sorting functionality to simplify overall logic (not sure this adds much value) plus this can confuse, for example

```
SELECT request_query FROM registry 
WHERE request_path = '/v1/devices' 
  AND request_query = 'param2=demo1234&param1=demo';
+-----------------------------+
| request_query               |
+-----------------------------+
| param1=demo&param2=demo1234 |
+-----------------------------+
```
