### PR TITLE
fix: Preserve query parameter order in HTTP connector to match filter values

### DIFF
--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1465,18 +1465,13 @@ impl HttpTableProvider {
         }
 
         let query = raw.strip_prefix('?').unwrap_or(raw);
-        Ok(Self::sort_query_params(query))
-    }
 
-    /// Sort query parameters alphabetically by key for consistent primary key handling
-    fn sort_query_params(query: &str) -> String {
-        if query.is_empty() {
-            return String::new();
-        }
-
-        let mut params: Vec<&str> = query.split('&').collect();
-        params.sort_unstable();
-        params.join("&")
+        // We preserve the original query parameter order without sorting.
+        // DataFusion's FilterExec uses the original filter value for matching:
+        //   FilterExec: request_query@1 = q=test&page=1
+        // If we sorted params to `page=1&q=test`, the stored data wouldn't match
+        // the filter and queries would return no results.
+        Ok(query.to_string())
     }
 
     fn ensure_allowed_body(&self, raw: &str) -> Result<String> {
@@ -2097,39 +2092,50 @@ mod tests {
         assert_eq!(result, vec![TableProviderFilterPushDown::Inexact]);
     }
 
-    #[test]
-    fn test_sort_query_params() {
-        // Test empty query
-        assert_eq!(HttpTableProvider::sort_query_params(""), "");
+    #[tokio::test]
+    async fn test_query_params_any_order_works() {
+        use datafusion::prelude::SessionContext;
 
-        // Test single parameter
-        assert_eq!(
-            HttpTableProvider::sort_query_params("key=value"),
-            "key=value"
+        let url = Url::parse("https://api.tvmaze.com").expect("valid URL");
+        let provider = HttpTableProvider::new(url, Client::new(), "json".to_string(), false)
+            .with_allowed_paths(vec!["/search/people".to_string()])
+            .expect("allowed paths")
+            .enable_query_filters(128);
+
+        let ctx = SessionContext::new();
+        ctx.register_table("tvmaze", Arc::new(provider))
+            .expect("register table");
+
+        // Query with unordered params (q first, page second)
+        let df1 = ctx
+            .sql("SELECT content FROM tvmaze WHERE request_path = '/search/people' AND request_query = 'q=lauren&page=1'")
+            .await
+            .expect("unordered query should succeed");
+
+        let results1 = df1.collect().await.expect("collect should succeed");
+        assert!(
+            !results1.is_empty(),
+            "Should have results for unordered params"
+        );
+        assert!(
+            results1[0].num_rows() > 0,
+            "Should have rows for unordered params"
         );
 
-        // Test already sorted parameters
-        assert_eq!(
-            HttpTableProvider::sort_query_params("a=1&b=2&c=3"),
-            "a=1&b=2&c=3"
-        );
+        // Query with alphabetically ordered params (page first, q second)
+        let df2 = ctx
+            .sql("SELECT content FROM tvmaze WHERE request_path = '/search/people' AND request_query = 'page=1&q=michael'")
+            .await
+            .expect("alphabetical query should succeed");
 
-        // Test unsorted parameters - should be sorted alphabetically
-        assert_eq!(
-            HttpTableProvider::sort_query_params("c=3&a=1&b=2"),
-            "a=1&b=2&c=3"
+        let results2 = df2.collect().await.expect("collect should succeed");
+        assert!(
+            !results2.is_empty(),
+            "Should have results for alphabetical params"
         );
-
-        // Test with URL encoding
-        assert_eq!(
-            HttpTableProvider::sort_query_params("z=last&a=first&m=middle"),
-            "a=first&m=middle&z=last"
-        );
-
-        // Test complex query string
-        assert_eq!(
-            HttpTableProvider::sort_query_params("userId=1&title=foo&body=bar"),
-            "body=bar&title=foo&userId=1"
+        assert!(
+            results2[0].num_rows() > 0,
+            "Should have rows for alphabetical params"
         );
     }
 

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -2345,6 +2345,94 @@ async fn test_caching_mode_query_specific_columns() -> Result<(), anyhow::Error>
         .await
 }
 
+/// Test that query parameters in different orders both work correctly.
+///
+/// This test verifies that both `q=michael&page=1` and `page=1&q=michael` return data.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_caching_mode_query_param_order() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=trace,runtime::accelerated_table::cache=trace",
+    ));
+
+    test_request_context()
+        .scope(async {
+            // Create HTTP dataset with caching mode
+            let mut dataset = Dataset::new("https://api.tvmaze.com", "tvmaze");
+            dataset.params = Some(Params::from_string_map(
+                vec![
+                    (
+                        "allowed_request_paths".to_string(),
+                        "/search/people".to_string(),
+                    ),
+                    ("request_query_filters".to_string(), "enabled".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                mode: Mode::Memory,
+                refresh_mode: Some(RefreshMode::Caching),
+                refresh_check_interval: Some("30s".to_string()),
+                ..Acceleration::default()
+            });
+
+            let mut app = AppBuilder::new("test_caching_param_order")
+                .with_dataset(dataset)
+                .build();
+
+            // Disable SQL results caching
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let status = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&status).load_components() => {}
+            }
+
+            runtime_ready_check(&status).await;
+
+            // Query with params in one order
+            let df1 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("q=michael&page=1")))?
+                .select(vec![col("content")])?;
+
+            let batches1 = df1.collect().await?;
+            assert_column_has_data(&batches1, "content");
+
+            // Query with params in different order
+            let df2 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/people")))?
+                .filter(col("request_query").eq(lit("page=1&q=michael")))?
+                .select(vec![col("content")])?;
+
+            let batches2 = df2.collect().await?;
+            assert_column_has_data(&batches2, "content");
+
+            Ok(())
+        })
+        .await
+}
+
 /// Asserts that the specified column in the given record batches contains non-empty string data.
 fn assert_column_has_data(batches: &[arrow::array::RecordBatch], column_name: &str) {
     assert!(!batches.is_empty(), "expected at least one batch");


### PR DESCRIPTION
## 📝 Summary

Fixes #9056

The HTTP connector was sorting query parameters alphabetically before storing them (e.g., `q=test&page=1` → `page=1&q=test`). This caused a mismatch with DataFusion's `FilterExec` which uses the original unsorted filter value, resulting in no results being returned.

**Changes:**
- Remove query parameter sorting in `ensure_allowed_query`
- Add integration test verifying both ordered and unordered params work
- Update caching mode test to verify correctness without normalization

## 🔗 Related

Fixes
- https://github.com/spiceai/spiceai/issues/9056

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I initially started from approach to normalize query params so both `p1=X&p2=Y` and `p2=Y&p1=X` end up to the same cache lookup, but encountered with few edge cases where it is hard to do due to FilterExec and other logic which is changed when we switch to Exact filter pushdown so some projections are automatically removed by DF optimizations and this requires more work + plus HTTP connector needs similar improvements, this adds unnecessary complexity. Switched to simple approach to disable params order.
 - https://github.com/spiceai/spiceai/pull/9101
