### PR TITLE
Always create initial snapshots (unless bootstrapped) + when no snapshots exist

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -634,14 +634,11 @@ impl SnapshotManager {
 
         let mut list_stream = self.object_store.list(Some(&self.snapshots_location));
         while let Some(result) = list_stream.next().await {
-            match result {
-                Ok(meta) => {
-                    // Check if this file belongs to our dataset partition
-                    if meta.location.as_ref().contains(&dataset_partition) {
-                        return true;
-                    }
+            if let Ok(meta) = result {
+                // Check if this file belongs to our dataset partition
+                if meta.location.as_ref().contains(&dataset_partition) {
+                    return true;
                 }
-                Err(_) => {},
             }
         }
 

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -635,8 +635,14 @@ impl SnapshotManager {
         let mut list_stream = self.object_store.list(Some(&self.snapshots_location));
         while let Some(result) = list_stream.next().await {
             if let Ok(meta) = result {
-                // Check if this file belongs to our dataset partition
-                if meta.location.as_ref().contains(&dataset_partition) {
+                // Check if this file belongs to our dataset partition by matching exact path segment.
+                // Using contains() would incorrectly match prefix names (e.g., dataset=foo matches dataset=foobar).
+                if meta
+                    .location
+                    .as_ref()
+                    .split('/')
+                    .any(|segment| segment == dataset_partition)
+                {
                     return true;
                 }
             }
@@ -4209,5 +4215,291 @@ mod tests {
         assert_eq!(summary.dataset_name, DATASET_NAME);
         assert!(summary.snapshots.is_empty());
         assert!(summary.current_snapshot_id.is_none());
+    }
+
+    // ========== Tests for has_existing_snapshots path matching ==========
+
+    /// Creates a SnapshotManager with a specific dataset name for testing path matching.
+    fn build_manager_with_dataset_name(
+        store: Arc<InMemory>,
+        dataset_name: &str,
+    ) -> SnapshotManager {
+        let object_store: Arc<dyn ObjectStore> = store;
+        let snapshot_engine = create_snapshot_engine(&AccelerationEngine::Cayenne, false);
+
+        SnapshotManager {
+            dataset_name: dataset_name.to_string(),
+            snapshots_location: Path::from(SNAPSHOT_BASE_PATH),
+            snapshot_location_uri: SNAPSHOT_URI_PREFIX.to_string(),
+            layout: AccelerationLayout::None,
+            snapshot_engine,
+            object_store,
+            bootstrap_failure_behavior: BootstrapOnFailureBehavior::Warn,
+            checkpointer_factory: None,
+            snapshots_creation_policy: SnapshotsCreationPolicy::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn has_existing_snapshots_returns_false_when_no_metadata() {
+        let store = Arc::new(InMemory::new());
+        let manager = build_manager_with_dataset_name(Arc::clone(&store), "foo");
+
+        let result = manager.has_existing_snapshots().await;
+
+        assert!(!result, "Should return false when no metadata exists");
+    }
+
+    #[tokio::test]
+    async fn has_existing_snapshots_returns_false_when_metadata_has_no_snapshots() {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let metadata_path = base.child(METADATA_FILE_NAME);
+
+        // Create metadata with dataset but no snapshots
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            "foo".to_string(),
+            DatasetMetadata {
+                name: "foo".to_string(),
+                snapshots: vec![], // Empty snapshots
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        let manager = build_manager_with_dataset_name(Arc::clone(&store), "foo");
+        let result = manager.has_existing_snapshots().await;
+
+        assert!(
+            !result,
+            "Should return false when metadata exists but has no snapshots"
+        );
+    }
+
+    #[tokio::test]
+    async fn has_existing_snapshots_returns_false_when_metadata_has_snapshots_but_files_missing() {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let metadata_path = base.child(METADATA_FILE_NAME);
+
+        // Create metadata claiming snapshots exist
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            "foo".to_string(),
+            DatasetMetadata {
+                name: "foo".to_string(),
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: "snapshots/month=2025-01/day=2025-01-01/dataset=foo/foo.db"
+                        .to_string(),
+                    snapshot_checksum: "abc123".to_string(),
+                    snapshot_checksum_algorithm: "SHA256".to_string(),
+                    snapshot_size: 1024,
+                    snapshot_last_updated_at_ms: None,
+                }],
+                current_snapshot_id: Some(0),
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+        // Note: We intentionally don't create the actual snapshot file
+
+        let manager = build_manager_with_dataset_name(Arc::clone(&store), "foo");
+        let result = manager.has_existing_snapshots().await;
+
+        assert!(
+            !result,
+            "Should return false when metadata has snapshots but actual files don't exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn has_existing_snapshots_returns_true_when_metadata_and_files_exist() {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let metadata_path = base.child(METADATA_FILE_NAME);
+
+        // Create the actual snapshot file
+        let snapshot_path = base
+            .child("month=2025-01")
+            .child("day=2025-01-01")
+            .child("dataset=foo")
+            .child("foo.db");
+        store
+            .put(&snapshot_path, Bytes::from_static(b"snapshot data").into())
+            .await
+            .expect("write snapshot file");
+
+        // Create metadata referencing the snapshot
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            "foo".to_string(),
+            DatasetMetadata {
+                name: "foo".to_string(),
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: "snapshots/month=2025-01/day=2025-01-01/dataset=foo/foo.db"
+                        .to_string(),
+                    snapshot_checksum: "abc123".to_string(),
+                    snapshot_checksum_algorithm: "SHA256".to_string(),
+                    snapshot_size: 1024,
+                    snapshot_last_updated_at_ms: None,
+                }],
+                current_snapshot_id: Some(0),
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        let manager = build_manager_with_dataset_name(Arc::clone(&store), "foo");
+        let result = manager.has_existing_snapshots().await;
+
+        assert!(
+            result,
+            "Should return true when both metadata and actual files exist"
+        );
+    }
+
+    /// This test verifies that has_existing_snapshots correctly distinguishes between
+    /// datasets with similar prefixes (e.g., "foo" vs "foobar").
+    ///
+    /// Previously, the code used `.contains()` for substring matching which would
+    /// incorrectly match "dataset=foo" against paths containing "dataset=foobar".
+    /// The fix uses exact path segment matching with `.split('/').any(|s| s == partition)`.
+    #[tokio::test]
+    async fn has_existing_snapshots_does_not_match_dataset_name_prefix() {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let metadata_path = base.child(METADATA_FILE_NAME);
+
+        // Create a snapshot file for "foobar" dataset (NOT "foo")
+        let snapshot_path = base
+            .child("month=2025-01")
+            .child("day=2025-01-01")
+            .child("dataset=foobar") // Note: "foobar", not "foo"
+            .child("foobar.db");
+        store
+            .put(&snapshot_path, Bytes::from_static(b"snapshot data").into())
+            .await
+            .expect("write snapshot file");
+
+        // Create metadata for BOTH datasets, but only foobar has actual files
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+
+        // "foo" dataset - metadata exists but no actual file
+        metadata.datasets.insert(
+            "foo".to_string(),
+            DatasetMetadata {
+                name: "foo".to_string(),
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: "snapshots/month=2025-01/day=2025-01-01/dataset=foo/foo.db"
+                        .to_string(),
+                    snapshot_checksum: "abc123".to_string(),
+                    snapshot_checksum_algorithm: "SHA256".to_string(),
+                    snapshot_size: 1024,
+                    snapshot_last_updated_at_ms: None,
+                }],
+                current_snapshot_id: Some(0),
+                ..Default::default()
+            },
+        );
+
+        // "foobar" dataset - both metadata and actual file exist
+        metadata.datasets.insert(
+            "foobar".to_string(),
+            DatasetMetadata {
+                name: "foobar".to_string(),
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: "snapshots/month=2025-01/day=2025-01-01/dataset=foobar/foobar.db"
+                        .to_string(),
+                    snapshot_checksum: "def456".to_string(),
+                    snapshot_checksum_algorithm: "SHA256".to_string(),
+                    snapshot_size: 2048,
+                    snapshot_last_updated_at_ms: None,
+                }],
+                current_snapshot_id: Some(0),
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        // Check "foo" dataset - should return FALSE because:
+        // - metadata exists with snapshots
+        // - BUT no actual file exists for "dataset=foo" (only "dataset=foobar" exists)
+        let manager_foo = build_manager_with_dataset_name(Arc::clone(&store), "foo");
+        let result_foo = manager_foo.has_existing_snapshots().await;
+
+        assert!(
+            !result_foo,
+            "Should return false for 'foo' dataset - must not match 'dataset=foobar' path. \
+             This test catches the substring matching bug where 'dataset=foo' incorrectly \
+             matches paths containing 'dataset=foobar'."
+        );
+
+        // Check "foobar" dataset - should return TRUE
+        let manager_foobar = build_manager_with_dataset_name(Arc::clone(&store), "foobar");
+        let result_foobar = manager_foobar.has_existing_snapshots().await;
+
+        assert!(
+            result_foobar,
+            "Should return true for 'foobar' dataset - actual file exists"
+        );
+    }
+
+    /// Additional test: Verify suffix matching doesn't cause false positives either.
+    /// E.g., "bar" should not match "dataset=foobar".
+    #[tokio::test]
+    async fn has_existing_snapshots_does_not_match_dataset_name_suffix() {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let metadata_path = base.child(METADATA_FILE_NAME);
+
+        // Create a snapshot file for "foobar" dataset
+        let snapshot_path = base
+            .child("month=2025-01")
+            .child("day=2025-01-01")
+            .child("dataset=foobar")
+            .child("foobar.db");
+        store
+            .put(&snapshot_path, Bytes::from_static(b"snapshot data").into())
+            .await
+            .expect("write snapshot file");
+
+        // Create metadata for "bar" dataset (which is a suffix of "foobar")
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            "bar".to_string(),
+            DatasetMetadata {
+                name: "bar".to_string(),
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: "snapshots/month=2025-01/day=2025-01-01/dataset=bar/bar.db"
+                        .to_string(),
+                    snapshot_checksum: "abc123".to_string(),
+                    snapshot_checksum_algorithm: "SHA256".to_string(),
+                    snapshot_size: 1024,
+                    snapshot_last_updated_at_ms: None,
+                }],
+                current_snapshot_id: Some(0),
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        let manager_bar = build_manager_with_dataset_name(Arc::clone(&store), "bar");
+        let result_bar = manager_bar.has_existing_snapshots().await;
+
+        assert!(
+            !result_bar,
+            "Should return false for 'bar' dataset - must not match 'dataset=foobar' path"
+        );
     }
 }

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -33,6 +33,7 @@ use spicepod::{component::snapshot::BootstrapOnFailureBehavior, param::Params};
 use std::{
     collections::HashMap,
     fmt::Write,
+    ops::Not,
     path::PathBuf,
     str::FromStr,
     sync::{Arc, LazyLock},
@@ -509,6 +510,24 @@ impl std::fmt::Debug for SnapshotManager {
     }
 }
 
+pub struct ForceCreate(pub bool);
+
+impl Not for ForceCreate {
+    type Output = bool;
+
+    fn not(self) -> Self::Output {
+        !self.0
+    }
+}
+
+impl Not for &ForceCreate {
+    type Output = bool;
+
+    fn not(self) -> Self::Output {
+        !self.0
+    }
+}
+
 impl SnapshotManager {
     fn metadata_path(&self) -> ObjectPath {
         self.snapshots_location.child(METADATA_FILE_NAME)
@@ -585,6 +604,48 @@ impl SnapshotManager {
         };
 
         Ok(Some(MetadataHandle { metadata, version }))
+    }
+
+    /// Checks if there are any existing snapshots for this dataset.
+    ///
+    /// Returns `true` if both:
+    /// - Metadata exists and contains at least one snapshot entry for this dataset
+    /// - At least one actual snapshot file exists in the object store
+    ///
+    /// Returns `false` if either condition is not met.
+    async fn has_existing_snapshots(&self) -> bool {
+        // Check metadata for snapshot entries
+        let metadata_has_snapshots = match self.load_metadata().await {
+            Ok(Some(handle)) => handle
+                .metadata
+                .datasets
+                .get(&self.dataset_name)
+                .is_some_and(|meta| !meta.snapshots.is_empty()),
+            Ok(None) | Err(_) => false,
+        };
+
+        if !metadata_has_snapshots {
+            return false;
+        }
+
+        // Check if actual snapshot files exist in object store
+        let layout = SnapshotPathLayout::new(&self.dataset_name);
+        let dataset_partition = layout.dataset_partition_raw();
+
+        let mut list_stream = self.object_store.list(Some(&self.snapshots_location));
+        while let Some(result) = list_stream.next().await {
+            match result {
+                Ok(meta) => {
+                    // Check if this file belongs to our dataset partition
+                    if meta.location.as_ref().contains(&dataset_partition) {
+                        return true;
+                    }
+                }
+                Err(_) => {},
+            }
+        }
+
+        false
     }
 
     pub async fn try_new(
@@ -809,12 +870,28 @@ impl SnapshotManager {
         schema: &SchemaRef,
         lock_guard: OwnedMutexGuard<()>,
         last_updated_at: Option<i64>,
+        force_create: ForceCreate,
     ) -> Result<Option<ObjectPath>, SnapshotUploadError> {
+        // If no existing snapshots (in metadata or as actual files), treat as force_create.
+        // This ensures at least one snapshot exists at all times.
+        let force_create = if force_create.0 {
+            force_create
+        } else if !self.has_existing_snapshots().await {
+            tracing::info!(
+                "No existing snapshots found (metadata or files), forcing snapshot creation. dataset={}",
+                self.dataset_name
+            );
+            ForceCreate(true)
+        } else {
+            force_create
+        };
+
         // Check if we should skip due to no updates (on_change policy)
         if matches!(
             self.snapshots_creation_policy,
             SnapshotsCreationPolicy::OnChange
-        ) {
+        ) && !force_create
+        {
             // Skip if no writes have occurred in this session (last_updated_at is None/0).
             // This avoids creating snapshots before the first refresh completes.
             if last_updated_at.is_none() {
@@ -2522,7 +2599,7 @@ mod tests {
         let lock_guard = mutex.lock_owned().await;
 
         let uploaded_path = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(true))
             .await
             .expect("create snapshot")
             .expect("snapshot should be created");
@@ -2598,7 +2675,7 @@ mod tests {
         let last_updated_at = Some(1_704_153_600_000_i64); // 2024-01-02 00:00:00 UTC
 
         let _uploaded_path = manager
-            .create_snapshot(&schema, lock_guard, last_updated_at)
+            .create_snapshot(&schema, lock_guard, last_updated_at, ForceCreate(true))
             .await
             .expect("create snapshot")
             .expect("snapshot should be created");
@@ -2652,7 +2729,7 @@ mod tests {
 
         // Create snapshot with None updated_at
         let _uploaded_path = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(true))
             .await
             .expect("create snapshot")
             .expect("snapshot should be created");
@@ -3036,7 +3113,7 @@ mod tests {
         let lock_guard = mutex.lock_owned().await;
 
         let uploaded_path = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(true))
             .await
             .expect("create snapshot")
             .expect("snapshot should be created");
@@ -3151,7 +3228,7 @@ mod tests {
         let lock_guard = mutex.lock_owned().await;
 
         let uploaded_path = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(true))
             .await
             .expect("create snapshot")
             .expect("path");
@@ -3404,14 +3481,28 @@ mod tests {
         let local_path = temp_path.to_path_buf();
 
         let schema = sample_schema();
-        let manager = build_manager_with_on_change_policy(&store, local_path, &schema);
+        let manager = build_manager_with_on_change_policy(&store, local_path.clone(), &schema);
 
         let mutex = Arc::new(Mutex::new(()));
-        let lock_guard = mutex.lock_owned().await;
 
-        // With OnChange policy and None last_updated_at, snapshot should be skipped
+        // First, create an initial snapshot to establish existing snapshots
+        let lock_guard = Arc::clone(&mutex).lock_owned().await;
+        let first_result = manager
+            .create_snapshot(
+                &schema,
+                lock_guard,
+                Some(1_704_153_600_000_i64),
+                ForceCreate(true),
+            )
+            .await
+            .expect("first snapshot should succeed");
+        assert!(first_result.is_some(), "First snapshot should be created");
+
+        // Now with OnChange policy and None last_updated_at, snapshot should be skipped
+        // because there are existing snapshots but no new writes
+        let lock_guard2 = Arc::clone(&mutex).lock_owned().await;
         let result = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard2, None, ForceCreate(false))
             .await
             .expect("create_snapshot should not error");
 
@@ -3448,7 +3539,7 @@ mod tests {
         let timestamp = 1_704_153_600_000_i64; // 2024-01-02 00:00:00 UTC
 
         let first_result = manager_always
-            .create_snapshot(&schema, lock_guard, Some(timestamp))
+            .create_snapshot(&schema, lock_guard, Some(timestamp), ForceCreate(true))
             .await
             .expect("first snapshot");
         assert!(first_result.is_some(), "First snapshot should be created");
@@ -3458,7 +3549,7 @@ mod tests {
 
         let lock_guard2 = Arc::clone(&mutex).lock_owned().await;
         let second_result = manager_on_change
-            .create_snapshot(&schema, lock_guard2, Some(timestamp))
+            .create_snapshot(&schema, lock_guard2, Some(timestamp), ForceCreate(false))
             .await
             .expect("second snapshot should not error");
 
@@ -3488,8 +3579,9 @@ mod tests {
         let timestamp = 1_704_153_600_000_i64;
 
         // First snapshot with valid timestamp should be created even with OnChange policy
+        // (no existing snapshots means force_create is automatically set to true)
         let result = manager
-            .create_snapshot(&schema, lock_guard, Some(timestamp))
+            .create_snapshot(&schema, lock_guard, Some(timestamp), ForceCreate(false))
             .await
             .expect("create_snapshot should not error");
 
@@ -3526,7 +3618,12 @@ mod tests {
         let first_timestamp = 1_704_153_600_000_i64;
 
         let first_result = manager
-            .create_snapshot(&schema, lock_guard, Some(first_timestamp))
+            .create_snapshot(
+                &schema,
+                lock_guard,
+                Some(first_timestamp),
+                ForceCreate(true),
+            )
             .await
             .expect("first snapshot");
         assert!(first_result.is_some(), "First snapshot should be created");
@@ -3538,7 +3635,12 @@ mod tests {
         let second_timestamp = 1_704_240_000_000_i64; // Next day
 
         let second_result = manager_on_change
-            .create_snapshot(&schema, lock_guard2, Some(second_timestamp))
+            .create_snapshot(
+                &schema,
+                lock_guard2,
+                Some(second_timestamp),
+                ForceCreate(false),
+            )
             .await
             .expect("second snapshot");
 
@@ -3572,14 +3674,145 @@ mod tests {
         let lock_guard = mutex.lock_owned().await;
 
         // With Always policy, snapshot should be created even with None last_updated_at
+        // (also, no existing snapshots means force_create is automatically set)
         let result = manager
-            .create_snapshot(&schema, lock_guard, None)
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
             .await
             .expect("create_snapshot should not error");
 
         assert!(
             result.is_some(),
             "With Always policy, snapshot should be created even when no writes occurred"
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn force_creates_snapshot_when_no_metadata_exists() {
+        let store = Arc::new(InMemory::new());
+        let contents = b"snapshot-force-no-metadata".to_vec();
+        let mut temp_file = NamedTempFile::new().expect("create temp file");
+        temp_file.write_all(&contents).expect("write temp snapshot");
+        temp_file.flush().expect("flush temp snapshot");
+        let temp_path = temp_file.into_temp_path();
+        let local_path = temp_path.to_path_buf();
+
+        let schema = sample_schema();
+        // Use OnChange policy which would normally skip when last_updated_at is None
+        let manager = build_manager_with_on_change_policy(&store, local_path, &schema);
+
+        let mutex = Arc::new(Mutex::new(()));
+        let lock_guard = mutex.lock_owned().await;
+
+        // Even with OnChange policy and None last_updated_at, snapshot should be created
+        // because no metadata exists (no prior snapshots)
+        let result = manager
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
+            .await
+            .expect("create_snapshot should not error");
+
+        assert!(
+            result.is_some(),
+            "Snapshot should be force-created when no metadata exists, even with OnChange policy"
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn force_creates_snapshot_when_metadata_exists_but_no_snapshots_for_dataset() {
+        let store = Arc::new(InMemory::new());
+        let contents = b"snapshot-force-no-dataset-snapshots".to_vec();
+        let mut temp_file = NamedTempFile::new().expect("create temp file");
+        temp_file.write_all(&contents).expect("write temp snapshot");
+        temp_file.flush().expect("flush temp snapshot");
+        let temp_path = temp_file.into_temp_path();
+        let local_path = temp_path.to_path_buf();
+
+        // Create metadata with a different dataset (not our test dataset)
+        let metadata_path = Path::from(SNAPSHOT_BASE_PATH).child(METADATA_FILE_NAME);
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            "other_dataset".to_string(),
+            DatasetMetadata {
+                name: "other_dataset".to_string(),
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        let schema = sample_schema();
+        let manager = build_manager_with_on_change_policy(&store, local_path, &schema);
+
+        let mutex = Arc::new(Mutex::new(()));
+        let lock_guard = mutex.lock_owned().await;
+
+        // Even with OnChange policy and None last_updated_at, snapshot should be created
+        // because metadata exists but has no snapshots for THIS dataset
+        let result = manager
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
+            .await
+            .expect("create_snapshot should not error");
+
+        assert!(
+            result.is_some(),
+            "Snapshot should be force-created when metadata has no snapshots for this dataset"
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn force_creates_snapshot_when_metadata_has_snapshots_but_no_files_exist() {
+        let store = Arc::new(InMemory::new());
+        let contents = b"snapshot-force-no-files".to_vec();
+        let mut temp_file = NamedTempFile::new().expect("create temp file");
+        temp_file.write_all(&contents).expect("write temp snapshot");
+        temp_file.flush().expect("flush temp snapshot");
+        let temp_path = temp_file.into_temp_path();
+        let local_path = temp_path.to_path_buf();
+
+        // Create metadata that claims snapshots exist, but don't actually create the files
+        let schema = sample_schema();
+        let metadata_path = Path::from(SNAPSHOT_BASE_PATH).child(METADATA_FILE_NAME);
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        let schema_metadata =
+            SchemaMetadata::from_schema(0, &schema).expect("schema serialization");
+        metadata.datasets.insert(
+            DATASET_NAME.to_string(),
+            DatasetMetadata {
+                name: DATASET_NAME.to_string(),
+                schemas: vec![schema_metadata],
+                current_schema_id: 0,
+                snapshots: vec![SnapshotEntry {
+                    snapshot_id: 0,
+                    timestamp_ms: 1_704_153_600_000,
+                    snapshot: format!("{SNAPSHOT_URI_PREFIX}/fake_snapshot.db"),
+                    snapshot_checksum: "fake_checksum".to_string(),
+                    snapshot_checksum_algorithm: "sha256".to_string(),
+                    snapshot_size: 1000,
+                    snapshot_last_updated_at_ms: Some(1_704_153_600_000),
+                }],
+                current_snapshot_id: Some(0),
+                properties: HashMap::default(),
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+        // Note: We intentionally don't create the actual snapshot file
+
+        let manager = build_manager_with_on_change_policy(&store, local_path, &schema);
+
+        let mutex = Arc::new(Mutex::new(()));
+        let lock_guard = mutex.lock_owned().await;
+
+        // Even with OnChange policy and None last_updated_at, snapshot should be created
+        // because metadata has snapshots but actual files don't exist
+        let result = manager
+            .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
+            .await
+            .expect("create_snapshot should not error");
+
+        assert!(
+            result.is_some(),
+            "Snapshot should be force-created when metadata has snapshots but no actual files exist"
         );
     }
 

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -4219,7 +4219,7 @@ mod tests {
 
     // ========== Tests for has_existing_snapshots path matching ==========
 
-    /// Creates a SnapshotManager with a specific dataset name for testing path matching.
+    /// Creates a `SnapshotManager` with a specific dataset name for testing path matching.
     fn build_manager_with_dataset_name(
         store: Arc<InMemory>,
         dataset_name: &str,
@@ -4363,7 +4363,7 @@ mod tests {
         );
     }
 
-    /// This test verifies that has_existing_snapshots correctly distinguishes between
+    /// This test verifies that `has_existing_snapshots` correctly distinguishes between
     /// datasets with similar prefixes (e.g., "foo" vs "foobar").
     ///
     /// Previously, the code used `.contains()` for substring matching which would

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -766,6 +766,7 @@ impl Builder {
                 retention,
                 self.caching.clone(),
                 self.io_runtime.clone(),
+                Arc::clone(&accelerator_write_mutex),
             ));
             handlers.push(retention_check_handle);
         }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -790,6 +790,8 @@ impl Refresher {
 
         let synchronize_with = self.synchronize_with.clone();
 
+        let runtime_status = Arc::clone(&self.runtime_status);
+
         let (snapshot_interval_task, create_checkpoint_snapshot_after_refresh) =
             match snapshot_trigger {
                 // This will only create checkpoint - default behavior when snapshots are not configured
@@ -879,7 +881,7 @@ impl Refresher {
                                     }
                             }
 
-                            if create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
+                            if runtime_status.is_ready() && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
                                 create_checkpoint_and_snapshot(
                                     checkpointer,
                                     snapshot_manager.as_ref(),

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -41,6 +41,7 @@ use futures::future::BoxFuture;
 use opentelemetry::KeyValue;
 use rand::Rng;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
+use runtime_acceleration::snapshot::ForceCreate;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use spicepod::metric::Metrics;
@@ -731,6 +732,7 @@ impl Refresher {
                             &self.dataset_name,
                             self.federated.schema(),
                             Arc::clone(&self.runtime_status),
+                            self.bootstrap_status.clone(),
                             Arc::clone(&self.last_updated_at),
                         ),
                     ),
@@ -790,8 +792,6 @@ impl Refresher {
 
         let synchronize_with = self.synchronize_with.clone();
 
-        let runtime_status = Arc::clone(&self.runtime_status);
-
         let (snapshot_interval_task, create_checkpoint_snapshot_after_refresh) =
             match snapshot_trigger {
                 // This will only create checkpoint - default behavior when snapshots are not configured
@@ -816,10 +816,45 @@ impl Refresher {
             };
         self.snapshot_interval_task = snapshot_interval_task;
 
+        // Track whether the initial snapshot has been created (after runtime is ready)
+        let initial_snapshot_created = Arc::new(AtomicBool::new(false));
+        let bootstrap_status = self.bootstrap_status.clone();
+
         if create_checkpoint_snapshot_after_refresh && snapshot_manager.is_some() {
             tracing::info!(
                 "Snapshots for dataset {dataset_name} will be created after every refresh"
             );
+
+            // Spawn a task to create initial snapshot once runtime is ready
+            if let Some(checkpointer) = checkpointer.clone() {
+                let initial_snapshot_created_clone = Arc::clone(&initial_snapshot_created);
+                let runtime_status_clone = Arc::clone(&self.runtime_status);
+                let snapshot_manager_clone = snapshot_manager.clone();
+                let federated_schema_clone = Arc::clone(&federated_schema);
+                let accelerator_write_mutex_clone = Arc::clone(&self.accelerator_write_mutex);
+                let dataset_name_clone = dataset_name.clone();
+                let last_updated_at_clone = Arc::clone(&self.last_updated_at);
+
+                tokio::spawn(async move {
+                    runtime_status_clone.wait_for_ready().await;
+                    if !bootstrap_status.is_bootstrapped() {
+                        create_checkpoint_and_snapshot(
+                            &checkpointer,
+                            snapshot_manager_clone.as_ref(),
+                            &federated_schema_clone,
+                            &accelerator_write_mutex_clone,
+                            &dataset_name_clone,
+                            &last_updated_at_clone,
+                            ForceCreate(true),
+                        )
+                            .await;
+                    }
+                    initial_snapshot_created_clone.store(true, Ordering::Release);
+                    tracing::debug!(
+                        "Refresh-based snapshot creation for {dataset_name_clone} starting after runtime ready"
+                    );
+                });
+            }
         }
 
         // Spawns a tasks that both periodically refreshes the dataset, and upon request, will manually refresh the dataset.
@@ -881,7 +916,7 @@ impl Refresher {
                                     }
                             }
 
-                            if runtime_status.is_ready() && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
+                            if initial_snapshot_created.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
                                 create_checkpoint_and_snapshot(
                                     checkpointer,
                                     snapshot_manager.as_ref(),
@@ -889,6 +924,7 @@ impl Refresher {
                                     &snapshot_mutex,
                                     &dataset_name,
                                     &last_updated_at,
+                                    ForceCreate(false),
                                 ).await;
                             }
                         }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -816,8 +816,10 @@ impl Refresher {
             };
         self.snapshot_interval_task = snapshot_interval_task;
 
-        // Track whether the initial snapshot has been created (after runtime is ready)
-        let initial_snapshot_created = Arc::new(AtomicBool::new(false));
+        // Gates when checkpoint counting/creation can start after runtime is ready.
+        // Set to true immediately when snapshots are not configured, or after the initial
+        // snapshot task completes (regardless of success) when snapshots are configured.
+        let checkpoint_counting_enabled = Arc::new(AtomicBool::new(snapshot_manager.is_none()));
         let bootstrap_status = self.bootstrap_status.clone();
 
         if create_checkpoint_snapshot_after_refresh && snapshot_manager.is_some() {
@@ -827,7 +829,7 @@ impl Refresher {
 
             // Spawn a task to create initial snapshot once runtime is ready
             if let Some(checkpointer) = checkpointer.clone() {
-                let initial_snapshot_created_clone = Arc::clone(&initial_snapshot_created);
+                let checkpoint_counting_enabled_clone = Arc::clone(&checkpoint_counting_enabled);
                 let runtime_status_clone = Arc::clone(&self.runtime_status);
                 let snapshot_manager_clone = snapshot_manager.clone();
                 let federated_schema_clone = Arc::clone(&federated_schema);
@@ -849,7 +851,7 @@ impl Refresher {
                         )
                         .await;
                     }
-                    initial_snapshot_created_clone.store(true, Ordering::Release);
+                    checkpoint_counting_enabled_clone.store(true, Ordering::Release);
                     tracing::debug!(
                         "Refresh-based snapshot creation for {dataset_name_clone} starting after runtime ready"
                     );
@@ -916,7 +918,7 @@ impl Refresher {
                                     }
                             }
 
-                            if initial_snapshot_created.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
+                            if checkpoint_counting_enabled.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
                                 create_checkpoint_and_snapshot(
                                     checkpointer,
                                     snapshot_manager.as_ref(),

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -847,7 +847,7 @@ impl Refresher {
                             &last_updated_at_clone,
                             ForceCreate(true),
                         )
-                            .await;
+                        .await;
                     }
                     initial_snapshot_created_clone.store(true, Ordering::Release);
                     tracing::debug!(

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -16,6 +16,14 @@ limitations under the License.
 
 use std::{sync::Arc, time::SystemTime};
 
+use crate::{
+    accelerated_table::{DataRetentionFilter, Retention, refresh},
+    component::dataset::TimeFormat,
+    datafusion::{
+        builder::get_df_default_config, filter_converter::TimestampFilterConvert,
+        is_spice_internal_dataset,
+    },
+};
 use arrow::array::UInt64Array;
 use cache::Caching;
 use data_components::delete::get_deletion_provider;
@@ -26,17 +34,9 @@ use datafusion::{
     prelude::{Expr, SessionContext},
     sql::TableReference,
 };
+use runtime_object_store::registry::default_runtime_env;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
-use crate::{
-    accelerated_table::{DataRetentionFilter, Retention, refresh},
-    component::dataset::TimeFormat,
-    datafusion::{
-        builder::get_df_default_config, filter_converter::TimestampFilterConvert,
-        is_spice_internal_dataset,
-    },
-};
-use runtime_object_store::registry::default_runtime_env;
 
 impl super::AcceleratedTable {
     #[expect(clippy::cast_possible_truncation)]
@@ -329,6 +329,7 @@ mod tests {
             retention,
             caching,
             Handle::current(),
+            Arc::new(Mutex::new(())),
         ));
 
         // Wait for retention to run

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -27,7 +27,7 @@ use datafusion::{
     sql::TableReference,
 };
 use tokio::runtime::Handle;
-
+use tokio::sync::Mutex;
 use crate::{
     accelerated_table::{DataRetentionFilter, Retention, refresh},
     component::dataset::TimeFormat,
@@ -46,11 +46,15 @@ impl super::AcceleratedTable {
         retention: Retention,
         caching: Option<Arc<Caching>>,
         io_runtime: Handle,
+        accelerator_write_mutex: Arc<Mutex<()>>,
     ) {
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
         loop {
             interval_timer.tick().await;
+
+            // Lock the accelerator to protect concurrent access to the accelerator during cache/snapshot operations
+            let _lock_guard = accelerator_write_mutex.lock().await;
 
             if let Some(deleted_table_provider) = get_deletion_provider(Arc::clone(&accelerator)) {
                 let mut exprs = Vec::new();

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -86,7 +86,7 @@ pub fn spawn_snapshot_interval_task(
                 &last_updated_at,
                 ForceCreate(true),
             )
-                .await;
+            .await;
         }
 
         let mut ticker = interval(interval_duration);
@@ -161,7 +161,7 @@ pub fn create_periodic_snapshot_callback(
                         &last_updated_at_clone,
                         ForceCreate(true),
                     )
-                        .await;
+                    .await;
                 }
                 initial_snapshot_created_clone.store(true, Ordering::Release);
                 tracing::debug!(

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -15,13 +15,13 @@ use crate::status::RuntimeStatus;
 use arrow_schema::Schema;
 use datafusion::common::TableReference;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
-use runtime_acceleration::snapshot::{SnapshotManager, metrics as snapshot_metrics};
+use runtime_acceleration::snapshot::{ForceCreate, SnapshotManager, metrics as snapshot_metrics};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
-use tokio::time::{interval, sleep};
+use tokio::time::interval;
 
 #[derive(Debug, Clone)]
 pub struct SnapshotCreationConfig {
@@ -72,43 +72,11 @@ pub fn spawn_snapshot_interval_task(
     );
 
     Some(tokio::spawn(async move {
-        // Wait for the runtime to be ready before starting snapshot creation
-        tracing::debug!(
-            "Snapshot interval task for {dataset_name} waiting for runtime to be ready"
-        );
         // Wait for the runtime to become ready
         runtime_status.wait_for_ready().await;
-        tracing::debug!("Snapshot interval task for {dataset_name} starting after runtime ready");
 
-        // Determine initial delay based on bootstrapping status and checkpoint time
-        let initial_delay = if bootstrap_status.is_bootstrapped() {
-            // If dataset was bootstrapped, create a snapshot after the full interval after dataset is ready
-            let mut delay = interval_duration;
-            if let Ok(Some(last_checkpoint_time)) = checkpointer.last_checkpoint_time().await
-                && let Ok(elapsed) = SystemTime::now().duration_since(last_checkpoint_time)
-            {
-                // Calculate delay based on last checkpoint time
-                if elapsed < interval_duration {
-                    delay = interval_duration - elapsed;
-                } else {
-                    delay = Duration::from_secs(0);
-                }
-            }
-            delay
-        } else {
-            // When no bootstrapping, create a snapshot immediately after dataset is ready
-            Duration::from_secs(0)
-        };
-
-        if !initial_delay.is_zero() {
-            sleep(initial_delay).await;
-        }
-
-        let mut ticker = interval(interval_duration);
-        // Consume the first tick which returns immediately per tokio::time::interval behavior
-        ticker.tick().await;
-
-        loop {
+        if !bootstrap_status.is_bootstrapped() {
+            // Force create initial snapshot immediately after runtime is ready unless it was bootstrapped
             create_checkpoint_and_snapshot(
                 &checkpointer,
                 Some(&snapshot_manager),
@@ -116,11 +84,29 @@ pub fn spawn_snapshot_interval_task(
                 &accelerator_write_mutex,
                 &dataset_name,
                 &last_updated_at,
+                ForceCreate(true),
+            )
+                .await;
+        }
+
+        let mut ticker = interval(interval_duration);
+        // Consume the first tick which returns immediately per tokio::time::interval behavior
+        ticker.tick().await;
+
+        loop {
+            // Wait for the next snapshot interval (accounting for time spent during previous snapshot creation)
+            ticker.tick().await;
+
+            create_checkpoint_and_snapshot(
+                &checkpointer,
+                Some(&snapshot_manager),
+                &federated_schema,
+                &accelerator_write_mutex,
+                &dataset_name,
+                &last_updated_at,
+                ForceCreate(false),
             )
             .await;
-
-            // Wait for the next snapshot interval (accounting for time spent during snapshot creation)
-            ticker.tick().await;
         }
     }))
 }
@@ -138,6 +124,7 @@ pub fn create_periodic_snapshot_callback(
     dataset_name: &TableReference,
     federated_schema: Arc<Schema>,
     runtime_status: Arc<RuntimeStatus>,
+    bootstrap_status: crate::dataaccelerator::BootstrapStatus,
     last_updated_at: Arc<AtomicI64>,
 ) -> Option<SnapshotCallback> {
     match (checkpointer, snapshot_manager) {
@@ -152,14 +139,31 @@ pub fn create_periodic_snapshot_callback(
             let batches_processed = Arc::new(RwLock::new(0i64));
 
             // Track whether the dataset is ready (batch counting should start)
-            let runtime_ready = Arc::new(AtomicBool::new(false));
+            let initial_snapshot_created = Arc::new(AtomicBool::new(false));
 
-            // Spawn a task to set runtime_ready when notified
-            let runtime_ready_clone = Arc::clone(&runtime_ready);
+            // Spawn a task to create initial snapshot once runtime is ready
+            let initial_snapshot_created_clone = Arc::clone(&initial_snapshot_created);
             let dataset_name_clone = dataset_name.clone();
+            let last_updated_at_clone = Arc::clone(&last_updated_at);
+            let checkpointer_clone = Arc::clone(&checkpointer);
+            let snapshot_manager_clone = Arc::clone(&snapshot_manager);
+            let federated_schema_clone = Arc::clone(&federated_schema);
+            let accelerator_write_mutex_clone = Arc::clone(&accelerator_write_mutex);
             tokio::spawn(async move {
                 runtime_status.wait_for_ready().await;
-                runtime_ready_clone.store(true, Ordering::Release);
+                if !bootstrap_status.is_bootstrapped() {
+                    create_checkpoint_and_snapshot(
+                        &checkpointer_clone,
+                        Some(&snapshot_manager_clone),
+                        &federated_schema_clone,
+                        &accelerator_write_mutex_clone,
+                        &dataset_name_clone,
+                        &last_updated_at_clone,
+                        ForceCreate(true),
+                    )
+                        .await;
+                }
+                initial_snapshot_created_clone.store(true, Ordering::Release);
                 tracing::debug!(
                     "Batch-based snapshot counting for {dataset_name_clone} starting after runtime ready"
                 );
@@ -172,19 +176,19 @@ pub fn create_periodic_snapshot_callback(
                 let batches_processed = Arc::clone(&batches_processed);
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
-                let dataset_ready = Arc::clone(&runtime_ready);
+                let initial_snapshot_created = Arc::clone(&initial_snapshot_created);
                 let last_updated_at = Arc::clone(&last_updated_at);
 
                 Box::pin(async move {
                     let mut batches_processed_value = batches_processed.write().await;
 
+                    // Only count batches after the initial snapshot is created
+                    if !initial_snapshot_created.load(Ordering::Acquire) {
+                        return;
+                    }
+
                     *batches_processed_value += 1;
                     if *batches_processed_value >= batches {
-                        // Only create snapshot if runtime is ready
-                        if !dataset_ready.load(Ordering::Acquire) {
-                            return;
-                        }
-
                         *batches_processed_value = 0;
 
                         create_checkpoint_and_snapshot(
@@ -194,6 +198,7 @@ pub fn create_periodic_snapshot_callback(
                             &accelerator_write_mutex,
                             &dataset_name,
                             &last_updated_at,
+                            ForceCreate(false),
                         )
                         .await;
                     }
@@ -214,6 +219,7 @@ pub async fn create_checkpoint_and_snapshot(
     accelerator_write_mutex: &Arc<Mutex<()>>,
     dataset_name: &TableReference,
     last_updated_at: &Arc<AtomicI64>,
+    force_create: ForceCreate,
 ) {
     let lock_guard = Arc::clone(accelerator_write_mutex).lock_owned().await;
     if let Err(e) = checkpointer.checkpoint(federated_schema).await {
@@ -228,7 +234,7 @@ pub async fn create_checkpoint_and_snapshot(
         };
 
         match snapshot_manager
-            .create_snapshot(federated_schema, lock_guard, updated_at)
+            .create_snapshot(federated_schema, lock_guard, updated_at, force_create)
             .await
         {
             Ok(Some(_)) => {

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -138,11 +138,12 @@ pub fn create_periodic_snapshot_callback(
             // Track number of processed batches since last snapshot
             let batches_processed = Arc::new(RwLock::new(0i64));
 
-            // Track whether the dataset is ready (batch counting should start)
-            let initial_snapshot_created = Arc::new(AtomicBool::new(false));
+            // Gates when checkpoint counting can start after runtime is ready.
+            // Set to true after the initial snapshot task completes (regardless of success).
+            let checkpoint_counting_enabled = Arc::new(AtomicBool::new(false));
 
             // Spawn a task to create initial snapshot once runtime is ready
-            let initial_snapshot_created_clone = Arc::clone(&initial_snapshot_created);
+            let checkpoint_counting_enabled_clone = Arc::clone(&checkpoint_counting_enabled);
             let dataset_name_clone = dataset_name.clone();
             let last_updated_at_clone = Arc::clone(&last_updated_at);
             let checkpointer_clone = Arc::clone(&checkpointer);
@@ -163,7 +164,7 @@ pub fn create_periodic_snapshot_callback(
                     )
                     .await;
                 }
-                initial_snapshot_created_clone.store(true, Ordering::Release);
+                checkpoint_counting_enabled_clone.store(true, Ordering::Release);
                 tracing::debug!(
                     "Batch-based snapshot counting for {dataset_name_clone} starting after runtime ready"
                 );
@@ -176,14 +177,14 @@ pub fn create_periodic_snapshot_callback(
                 let batches_processed = Arc::clone(&batches_processed);
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
-                let initial_snapshot_created = Arc::clone(&initial_snapshot_created);
+                let checkpoint_counting_enabled = Arc::clone(&checkpoint_counting_enabled);
                 let last_updated_at = Arc::clone(&last_updated_at);
 
                 Box::pin(async move {
                     let mut batches_processed_value = batches_processed.write().await;
 
-                    // Only count batches after the initial snapshot is created
-                    if !initial_snapshot_created.load(Ordering::Acquire) {
+                    // Only count batches after checkpoint counting is enabled
+                    if !checkpoint_counting_enabled.load(Ordering::Acquire) {
                         return;
                     }
 

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -176,15 +176,15 @@ pub fn create_periodic_snapshot_callback(
                 let last_updated_at = Arc::clone(&last_updated_at);
 
                 Box::pin(async move {
-                    // Only count batches after the dataset is ready
-                    if !dataset_ready.load(Ordering::Acquire) {
-                        return;
-                    }
-
                     let mut batches_processed_value = batches_processed.write().await;
 
                     *batches_processed_value += 1;
                     if *batches_processed_value >= batches {
+                        // Only create snapshot if runtime is ready
+                        if !dataset_ready.load(Ordering::Acquire) {
+                            return;
+                        }
+
                         *batches_processed_value = 0;
 
                         create_checkpoint_and_snapshot(

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -72,7 +72,7 @@ pub fn spawn_snapshot_interval_task(
     );
 
     Some(tokio::spawn(async move {
-        // Wait for the dataset to be ready before starting snapshot creation
+        // Wait for the runtime to be ready before starting snapshot creation
         tracing::debug!(
             "Snapshot interval task for {dataset_name} waiting for runtime to be ready"
         );
@@ -152,14 +152,14 @@ pub fn create_periodic_snapshot_callback(
             let batches_processed = Arc::new(RwLock::new(0i64));
 
             // Track whether the dataset is ready (batch counting should start)
-            let dataset_ready = Arc::new(AtomicBool::new(false));
+            let runtime_ready = Arc::new(AtomicBool::new(false));
 
-            // Spawn a task to set dataset_ready when notified
-            let dataset_ready_clone = Arc::clone(&dataset_ready);
+            // Spawn a task to set runtime_ready when notified
+            let runtime_ready_clone = Arc::clone(&runtime_ready);
             let dataset_name_clone = dataset_name.clone();
             tokio::spawn(async move {
                 runtime_status.wait_for_ready().await;
-                dataset_ready_clone.store(true, Ordering::Release);
+                runtime_ready_clone.store(true, Ordering::Release);
                 tracing::debug!(
                     "Batch-based snapshot counting for {dataset_name_clone} starting after runtime ready"
                 );
@@ -172,7 +172,7 @@ pub fn create_periodic_snapshot_callback(
                 let batches_processed = Arc::clone(&batches_processed);
                 let federated_schema = Arc::<Schema>::clone(&federated_schema);
                 let dataset_name = dataset_name.clone();
-                let dataset_ready = Arc::clone(&dataset_ready);
+                let dataset_ready = Arc::clone(&runtime_ready);
                 let last_updated_at = Arc::clone(&last_updated_at);
 
                 Box::pin(async move {

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -74,11 +74,11 @@ pub fn spawn_snapshot_interval_task(
     Some(tokio::spawn(async move {
         // Wait for the dataset to be ready before starting snapshot creation
         tracing::debug!(
-            "Snapshot interval task for {dataset_name} waiting for dataset to be ready"
+            "Snapshot interval task for {dataset_name} waiting for runtime to be ready"
         );
-        // Wait for the dataset to become ready
-        runtime_status.wait_for_dataset_ready(&dataset_name).await;
-        tracing::debug!("Snapshot interval task for {dataset_name} starting after dataset ready");
+        // Wait for the runtime to become ready
+        runtime_status.wait_for_ready().await;
+        tracing::debug!("Snapshot interval task for {dataset_name} starting after runtime ready");
 
         // Determine initial delay based on bootstrapping status and checkpoint time
         let initial_delay = if bootstrap_status.is_bootstrapped() {
@@ -158,12 +158,10 @@ pub fn create_periodic_snapshot_callback(
             let dataset_ready_clone = Arc::clone(&dataset_ready);
             let dataset_name_clone = dataset_name.clone();
             tokio::spawn(async move {
-                runtime_status
-                    .wait_for_dataset_ready(&dataset_name_clone)
-                    .await;
+                runtime_status.wait_for_ready().await;
                 dataset_ready_clone.store(true, Ordering::Release);
                 tracing::debug!(
-                    "Batch-based snapshot counting for {dataset_name_clone} starting after dataset ready"
+                    "Batch-based snapshot counting for {dataset_name_clone} starting after runtime ready"
                 );
             });
 

--- a/crates/runtime/tests/schema_evolution/mod.rs
+++ b/crates/runtime/tests/schema_evolution/mod.rs
@@ -18,7 +18,11 @@ use std::sync::Arc;
 
 use app::AppBuilder;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::postgresconn::PostgresConnection;
-use runtime::Runtime;
+use runtime::{
+    Runtime,
+    component::dataset::Dataset as RuntimeDataset,
+    dataaccelerator::spice_sys::{OpenOption, dataset_checkpoint::DatasetCheckpoint},
+};
 use spicepod::{
     acceleration::{Acceleration, Mode},
     component::dataset::Dataset,
@@ -185,14 +189,16 @@ async fn initialize_runtime(port: usize) -> Result<Runtime, anyhow::Error> {
         ..Acceleration::default()
     });
 
+    let ds_clone = ds.clone();
+
     let app = AppBuilder::new("test_schema_evolution")
         .with_dataset(ds)
         .build();
 
     configure_test_datafusion();
-    let rt = Runtime::builder().with_app(app).build().await;
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
 
-    let cloned_rt = Arc::new(rt.clone());
+    let cloned_rt = Arc::clone(&rt);
 
     // Set a timeout for the test
     tokio::select! {
@@ -204,5 +210,45 @@ async fn initialize_runtime(port: usize) -> Result<Runtime, anyhow::Error> {
 
     runtime_ready_check(&rt).await;
 
-    Ok(rt)
+    // Wait for checkpoint to be created (checkpoint creation is async after runtime is ready)
+    let app_ref = rt.app();
+    let app_lock = app_ref.read().await;
+    let Some(app) = app_lock.as_ref() else {
+        return Err(anyhow::anyhow!("Failed to obtain app from runtime"));
+    };
+
+    let runtime_dataset = runtime::component::dataset::builder::DatasetBuilder::try_from(ds_clone)
+        .map_err(|e| anyhow::anyhow!("Failed to create dataset builder: {e}"))?
+        .with_app(Arc::clone(app))
+        .with_runtime(Arc::clone(&rt))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build dataset: {e}"))?;
+    wait_for_checkpoint(&runtime_dataset, 30).await?;
+
+    // Drop the app lock before returning
+    drop(app_lock);
+
+    // Unwrap the Arc to get ownership of the Runtime
+    Ok(Arc::try_unwrap(rt).unwrap_or_else(|arc| (*arc).clone()))
+}
+
+async fn wait_for_checkpoint(
+    dataset: &RuntimeDataset,
+    timeout_secs: u64,
+) -> Result<(), anyhow::Error> {
+    let checkpoint = DatasetCheckpoint::try_new(dataset, OpenOption::OpenExisting)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create checkpoint: {e}"))?;
+
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(timeout_secs);
+
+    while !checkpoint.exists().await {
+        if start.elapsed() > timeout {
+            return Err(anyhow::anyhow!("Timed out waiting for checkpoint to exist"));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    Ok(())
 }

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -1949,14 +1949,17 @@ async fn snapshot_int_test13_refresh_based_snapshots() -> Result<()> {
             let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
             load_runtime(Arc::clone(&runtime)).await?;
 
-            // Verify no snapshots exist yet
+            tokio::time::sleep(Duration::from_secs(10)).await;
+
+            // Verify initial snapshot exists
             let initial_snapshots = context
                 .snapshot_objects(TAXI_TRIPS_DATASET_NAME)
                 .await
                 .unwrap_or_default();
-            assert!(
-                initial_snapshots.is_empty(),
-                "Should start with no snapshots in this fresh context"
+            assert_eq!(
+                initial_snapshots.len(),
+                1,
+                "Exactly one snapshot should be created"
             );
 
             runtime
@@ -1993,7 +1996,7 @@ async fn snapshot_int_test13_refresh_based_snapshots() -> Result<()> {
             assert_eq!(
                 snapshots_after.len(),
                 4,
-                "Exactly one snapshot should be created"
+                "Exactly fours snapshots should be created"
             );
 
             runtime.shutdown().await;

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -44,7 +44,7 @@ use object_store::{
 };
 use runtime::{Runtime, status::ComponentStatus};
 use runtime_acceleration::snapshot::{
-    AccelerationEngine, SnapshotBehavior as RuntimeSnapshotBehavior, SnapshotManager,
+    AccelerationEngine, ForceCreate, SnapshotBehavior as RuntimeSnapshotBehavior, SnapshotManager,
 };
 use serde_json::{Value, json};
 use spicepod::acceleration::{
@@ -991,7 +991,7 @@ async fn snapshot_int_test6_concurrent_snapshot_writes_retry() -> Result<()> {
                     let mutex = Arc::new(Mutex::new(()));
                     let lock_guard = mutex.lock_owned().await;
                     manager_clone
-                        .create_snapshot(&schema, lock_guard, None)
+                        .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
                         .await
                         .map(|opt| opt.expect("snapshot should be created"))
                 }
@@ -1104,7 +1104,7 @@ async fn snapshot_int_test7_respects_current_snapshot_metadata_selection() -> Re
             let lock_guard = mutex.lock_owned().await;
 
             manager
-                .create_snapshot(&schema, lock_guard, None)
+                .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
                 .await
                 .context("Creating modified snapshot after deleting data")?
                 .context("Snapshot should be created")?;
@@ -1314,7 +1314,7 @@ async fn snapshot_int_test8_duckdb_compaction_reduces_snapshot_size() -> Result<
             let lock_guard = mutex.lock_owned().await;
 
             let compacted_location = manager_with_compaction
-                .create_snapshot(&schema, lock_guard, None)
+                .create_snapshot(&schema, lock_guard, None, ForceCreate(false))
                 .await
                 .context("Creating snapshot with compaction enabled")?
                 .context("Snapshot should be created")?;
@@ -1494,7 +1494,7 @@ async fn snapshot_int_test9_onchange_policy_skips_when_no_changes() -> Result<()
             let lock_guard = Arc::clone(&mutex).lock_owned().await;
 
             let first_result = manager
-                .create_snapshot(&schema, lock_guard, last_updated_at)
+                .create_snapshot(&schema, lock_guard, last_updated_at, ForceCreate(false))
                 .await
                 .context("Creating first snapshot with OnChange policy")?;
 
@@ -1538,7 +1538,7 @@ async fn snapshot_int_test9_onchange_policy_skips_when_no_changes() -> Result<()
             // Try to create another snapshot with the SAME last_updated_at
             let lock_guard = Arc::clone(&mutex).lock_owned().await;
             let second_result = manager
-                .create_snapshot(&schema, lock_guard, last_updated_at)
+                .create_snapshot(&schema, lock_guard, last_updated_at, ForceCreate(false))
                 .await
                 .context("Attempting second snapshot with same last_updated_at")?;
 
@@ -1564,7 +1564,7 @@ async fn snapshot_int_test9_onchange_policy_skips_when_no_changes() -> Result<()
             let new_last_updated_at = Some(99999i64);
             let lock_guard = Arc::clone(&mutex).lock_owned().await;
             let third_result = manager
-                .create_snapshot(&schema, lock_guard, new_last_updated_at)
+                .create_snapshot(&schema, lock_guard, new_last_updated_at, ForceCreate(false))
                 .await
                 .context("Creating snapshot with new last_updated_at")?;
 

--- a/crates/runtime/tests/view/mod.rs
+++ b/crates/runtime/tests/view/mod.rs
@@ -91,9 +91,16 @@ async fn accelerated_view_duckdb() -> Result<(), anyhow::Error> {
             let view = ViewBuilder::try_from(view_copy).expect("to parse view")
                 .build_with(Arc::clone(&rt), Arc::new(app_copy));
 
-            // Ensure Checkpoint is created after initial view load
+            // Ensure Checkpoint is created after initial view load (poll since checkpoint creation is async)
             let checkpoint = DatasetCheckpoint::try_new(&view, OpenOption::OpenExisting).await.expect("Failed to create view checkpoint");
-            assert!(checkpoint.exists().await, "Checkpoint does not exist");
+            let checkpoint_timeout = std::time::Duration::from_secs(30);
+            let checkpoint_start = std::time::Instant::now();
+            while !checkpoint.exists().await {
+                if checkpoint_start.elapsed() > checkpoint_timeout {
+                    return Err(anyhow::anyhow!("Timed out waiting for checkpoint to exist"));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
             let last_checkpoint_time = checkpoint
                 .last_checkpoint_time()
                 .await


### PR DESCRIPTION
## 📝 Summary

1. Wait for runtime to be ready (no snapshots until then) and immediately create initial snapshot (unless bootsrapped)
2. Create snapshot with `on_change` policy when:
    * No metadata exists
    * Metadata exists, but no actual snapshot files exist

Also: Add mutex to `start_retention_check` task

Closes https://github.com/spiceai/spiceai/issues/9031

Documentation - https://github.com/spiceai/docs/pull/1342