### PR TITLE
fix: update Ballista fork to include executor timeout fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d8277697a3334e128dada15242ed521d01f98be0#d8277697a3334e128dada15242ed521d01f98be0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=626181fbc04a6f964abc459f99f62cf7742f75b4#626181fbc04a6f964abc459f99f62cf7742f75b4"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d8277697a3334e128dada15242ed521d01f98be0#d8277697a3334e128dada15242ed521d01f98be0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=626181fbc04a6f964abc459f99f62cf7742f75b4#626181fbc04a6f964abc459f99f62cf7742f75b4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d8277697a3334e128dada15242ed521d01f98be0#d8277697a3334e128dada15242ed521d01f98be0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=626181fbc04a6f964abc459f99f62cf7742f75b4#626181fbc04a6f964abc459f99f62cf7742f75b4"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,9 +352,9 @@ datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1de
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "8cff5241923989720f86687bdf7d0b3c9c7dad2f" } # spiceai-51
 
 # Spiceai fork of datafusion-ballista with Vortex shuffle format support and PollNow interrupt
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d8277697a3334e128dada15242ed521d01f98be0" } # branch: spiceai-51
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d8277697a3334e128dada15242ed521d01f98be0" } # branch: spiceai-51
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d8277697a3334e128dada15242ed521d01f98be0" } # branch: spiceai-51
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "626181fbc04a6f964abc459f99f62cf7742f75b4" }      # branch: spiceai-51
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "626181fbc04a6f964abc459f99f62cf7742f75b4" }  # branch: spiceai-51
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "626181fbc04a6f964abc459f99f62cf7742f75b4" } # branch: spiceai-51
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "4ce55c37be6f394675457545e806c503c813b34e" } # spiceai-0.17.0
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers


### PR DESCRIPTION
Update datafusion-ballista to rev 626181fbc04a6f964abc459f99f62cf7742f75b4 (https://github.com/spiceai/datafusion-ballista/pull/13) which includes the fix for executor timeout due to lock contention in the scheduler event loop.

- Closes #9121