### PR TITLE
Fix install-dev to use debug build path for spice binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ install: build
 .PHONY: install-dev
 install-dev: build-dev
 	mkdir -p ~/.spice/bin
-	install -m 755 target/release/spice ~/.spice/bin/spice
+	install -m 755 target/debug/spice ~/.spice/bin/spice
 	install -m 755 target/debug/spiced ~/.spice/bin/spiced
 
 # Data-only variants (without models)


### PR DESCRIPTION
## Summary

- Fix `install-dev` target to use `target/debug/spice` instead of `target/release/spice`

The `install-dev` target depends on `build-dev` which creates binaries in `target/debug/`, but line 226 was incorrectly trying to install from `target/release/spice`. This caused all "Makefile Targets" CI runs to fail.