### PR TITLE
fix: Pass aws_allow_http to executors for Delta Lake distributed queries

### DIFF
--- a/crates/runtime-parameters/src/lib.rs
+++ b/crates/runtime-parameters/src/lib.rs
@@ -23,12 +23,13 @@ use tokio::sync::RwLock;
 
 pub type AnyErrorResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-const AWS_PREFIXED_FRAGMENT_PARAMS: &[(&str, &str); 5] = &[
+const AWS_PREFIXED_FRAGMENT_PARAMS: &[(&str, &str); 6] = &[
     ("aws_access_key_id", "key"),
     ("aws_secret_access_key", "secret"),
     ("aws_region", "region"),
     ("aws_session_token", "session_token"),
     ("aws_endpoint", "endpoint"),
+    ("aws_allow_http", "allow_http"),
 ];
 
 /// Maps Azure-prefixed parameter names (used by Delta Lake and other connectors)


### PR DESCRIPTION
## 📝 Summary

Fixes #9099

## Problem
In distributed mode, Delta Lake queries fail with `BadScheme` error when using HTTP endpoints (e.g., minio) because `delta_lake_aws_allow_http: true` is not passed to executors.

## Root Cause

`AWS_PREFIXED_FRAGMENT_PARAMS` was missing the `aws_allow_http` → `allow_http` mapping. When executors bind object stores via `executor_bind_object_stores()`, `canonicalize_s3_fragments()` didn't translate this parameter, so the object store registry never received the `allow_http` setting.

## 🔗 Related

Fixes #9099

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

