### PR TITLE
fix(cayenne): Fix upsert with pending deletions causing duplicate PKs

### DIFF
--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -58,6 +58,60 @@ use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
+// ============================================================================
+// PK Visibility Helpers
+// ============================================================================
+//
+// These helper functions determine whether a row is visible (not deleted) based on
+// the deletion and insert caches. A row is visible if:
+// - It was never deleted (not in deletion cache), OR
+// - It was deleted but re-inserted with a higher sequence number (upsert)
+//
+// The sequence-based ordering follows Iceberg semantics where:
+// - `delete_sequence` records when a PK was marked for deletion
+// - `insert_sequence` records when a PK was re-inserted (upsert)
+// - If `insert_sequence > delete_sequence`, the row is visible (re-inserted after delete)
+
+/// Check if a row with the given Int64 PK is visible (not deleted or re-inserted after deletion).
+///
+/// Returns `true` if the row should be visible in queries.
+#[inline]
+pub(crate) fn is_pk_visible_i64(
+    pk: i64,
+    deleted_pks: &HashMap<i64, i64>,
+    insert_records: Option<&HashMap<i64, i64>>,
+) -> bool {
+    match deleted_pks.get(&pk) {
+        None => true, // Not deleted, row is visible
+        Some(&delete_seq) => {
+            // Deleted - check if re-inserted with higher sequence
+            insert_records
+                .and_then(|cache| cache.get(&pk))
+                .is_some_and(|&insert_seq| insert_seq > delete_seq)
+        }
+    }
+}
+
+/// Check if a row with the given byte key is visible (not deleted or re-inserted after deletion).
+///
+/// Returns `true` if the row should be visible in queries.
+#[inline]
+pub(crate) fn is_pk_visible_row_key(
+    key: &[u8],
+    deleted_keys: &HashMap<Box<[u8]>, i64>,
+    insert_records: Option<&HashMap<Box<[u8]>, i64>>,
+) -> bool {
+    match deleted_keys.get(key) {
+        None => true, // Not deleted, row is visible
+        Some(&delete_seq) => {
+            // Deleted - check if re-inserted with higher sequence
+            insert_records
+                .and_then(|cache| cache.get(key))
+                .is_some_and(|&insert_seq| insert_seq > delete_seq)
+        }
+    }
+}
+
 /// Execution plan that filters out deleted rows based on deletion vectors.
 ///
 /// This wraps another execution plan and removes rows whose positions
@@ -515,26 +569,14 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     };
 
                     // Build keep mask by checking each row's key against deleted map
-                    // A row is deleted only if:
-                    // 1. Key is in deleted map, AND
-                    // 2. Either key is not in insert_records, OR insert_seq < delete_seq
                     let mut keep_mask = Vec::with_capacity(batch_size);
                     for row in &rows {
                         let key: &[u8] = row.as_ref();
-                        let keep = if let Some(&delete_seq) = self.deleted_row_keys.get(key) {
-                            // Key is in deletions - check if it was re-inserted with higher sequence
-                            if let Some(&insert_seq) = self.insert_records.get(key) {
-                                // Keep if insert happened after delete
-                                insert_seq > delete_seq
-                            } else {
-                                // No re-insert, row is deleted
-                                false
-                            }
-                        } else {
-                            // Not in deletions, keep the row
-                            true
-                        };
-                        keep_mask.push(keep);
+                        keep_mask.push(is_pk_visible_row_key(
+                            key,
+                            &self.deleted_row_keys,
+                            Some(&self.insert_records),
+                        ));
                     }
 
                     // Count how many rows we're keeping
@@ -773,27 +815,14 @@ impl futures::Stream for Int64PkDeletionFilterStream {
                             })?;
 
                     // Build keep mask by checking each row's PK value against deleted map
-                    // A row is deleted only if:
-                    // 1. PK is in deleted map, AND
-                    // 2. Either PK is not in insert_records, OR insert_seq < delete_seq
                     let mut keep_mask = Vec::with_capacity(batch_size);
                     for i in 0..batch_size {
                         let pk_value = pk_array.value(i);
-                        let keep = if let Some(&delete_seq) = self.deleted_pk_values.get(&pk_value)
-                        {
-                            // PK is in deletions - check if it was re-inserted with higher sequence
-                            if let Some(&insert_seq) = self.insert_records.get(&pk_value) {
-                                // Keep if insert happened after delete
-                                insert_seq > delete_seq
-                            } else {
-                                // No re-insert, row is deleted
-                                false
-                            }
-                        } else {
-                            // Not in deletions, keep the row
-                            true
-                        };
-                        keep_mask.push(keep);
+                        keep_mask.push(is_pk_visible_i64(
+                            pk_value,
+                            &self.deleted_pk_values,
+                            Some(&self.insert_records),
+                        ));
                     }
 
                     // Count how many rows we're keeping

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -23,8 +23,8 @@ use super::constants::{
     DEFAULT_DATA_FILE_ID, DELETION_CACHE_LOCK_POISONED, LISTING_TABLE_LOCK_POISONED,
 };
 use super::delete::{
-    read_deletion_vectors, CayenneDeletionSink, DeletionFilterExec, Int64PkDeletionFilterExec,
-    KeyBasedDeletionFilterExec,
+    is_pk_visible_i64, is_pk_visible_row_key, read_deletion_vectors, CayenneDeletionSink,
+    DeletionFilterExec, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
 };
 use super::streaming::StreamingExec;
 use crate::catalog::{CatalogError, CatalogResult, MetadataCatalog};
@@ -1119,6 +1119,10 @@ impl CayenneTableProvider {
         // with a higher sequence number. This ensures proper Iceberg-style ordering:
         // - Deletions apply to snapshots with sequence <= delete_sequence
         // - New data in snapshots with sequence > delete_sequence is visible
+        //
+        // We still need to run validate_on_conflict() on the incoming stream
+        // to handle upserts for PKs that already exist in the table. Without this,
+        // duplicate PKs would appear in query results.
         if has_pending_deletions {
             let new_sequence = self
                 .catalog
@@ -1129,9 +1133,26 @@ impl CayenneTableProvider {
                 self.table_metadata.table_name,
                 new_sequence
             );
-            return self
-                .insert_to_new_snapshot_with_sequence(stream, new_sequence)
-                .await;
+
+            let (prepared_stream, delete_specs, deleted_pk_i64, deleted_row_keys) =
+                self.prepare_stream_for_insert(stream).await?;
+
+            tracing::debug!(
+                "insert() with pending deletions: delete_specs={} files, deleted_pk_i64={} keys",
+                delete_specs.len(),
+                deleted_pk_i64.len()
+            );
+
+            // Write to new snapshot with the prepared (deduplicated) stream
+            let total_rows = self
+                .insert_to_new_snapshot_with_sequence(prepared_stream, new_sequence)
+                .await?;
+
+            // Update deletion caches for the upserted PKs
+            self.apply_on_conflict_deletions(delete_specs, deleted_pk_i64, deleted_row_keys)
+                .await?;
+
+            return Ok(total_rows);
         }
 
         let target_size_bytes = self.context.target_file_size_bytes();
@@ -1139,32 +1160,13 @@ impl CayenneTableProvider {
         // If a primary key is configured, enforce on_conflict behavior by materializing
         // the incoming stream, validating keys, and preparing deletion vectors.
         let (prepared_stream, delete_specs, deleted_pk_i64, deleted_row_keys) =
-            if let Some(pk_indices) = self.primary_key_indices()? {
-                let converter = self.build_pk_converter(&pk_indices)?;
-                let mut existing_keys = self.load_existing_keyset(&pk_indices, &converter).await?;
-                let validation_result = self
-                    .validate_on_conflict(stream, &pk_indices, &converter, &mut existing_keys)
-                    .await?;
+            self.prepare_stream_for_insert(stream).await?;
 
-                // Build a new stream from the validated batches.
-                let schema = validation_result.filtered_batches.first().map_or_else(
-                    || Arc::clone(&self.table_metadata.schema),
-                    RecordBatch::schema,
-                );
-                let validated_stream = RecordBatchStreamAdapter::new(
-                    Arc::clone(&schema),
-                    futures::stream::iter(validation_result.filtered_batches.into_iter().map(Ok)),
-                );
-
-                (
-                    Box::pin(validated_stream) as SendableRecordBatchStream,
-                    validation_result.delete_specs,
-                    validation_result.deleted_pk_i64,
-                    validation_result.deleted_row_keys,
-                )
-            } else {
-                (stream, HashMap::new(), Vec::new(), Vec::new())
-            };
+        tracing::debug!(
+            "insert(): delete_specs={} files, deleted_pk_i64={} keys",
+            delete_specs.len(),
+            deleted_pk_i64.len()
+        );
 
         // Process stream in chunks and write them in parallel with bounded concurrency
         let (total_rows, chunk_count) = self
@@ -1924,9 +1926,12 @@ impl CayenneTableProvider {
     /// Build the existing keyset (primary key bytes -> row location) for append-mode inserts.
     ///
     /// This method respects ALL deletion caches based on `pk_deletion_strategy`:
-    /// - `Int64Pk`: Uses `cached_deleted_pk_i64` (single Int64 primary key)
-    /// - `RowConverterBased`: Uses `cached_deleted_row_keys` (composite/non-integer PK)
+    /// - `Int64Pk`: Uses `cached_deleted_pk_i64` and `cached_insert_records_pk_i64`
+    /// - `RowConverterBased`: Uses `cached_deleted_row_keys` and `cached_insert_records_row_keys`
     /// - `PositionBased`: Uses `cached_deleted_row_ids` (no primary key)
+    ///
+    /// Rows marked as deleted are excluded unless they were re-inserted with a higher
+    /// sequence number (upsert semantics).
     async fn load_existing_keyset(
         &self,
         pk_indices: &[usize],
@@ -1979,6 +1984,18 @@ impl CayenneTableProvider {
             None
         };
 
+        // Load insert records cache for Int64Pk strategy to check re-insertions
+        let insert_records_pk_i64 = if self.pk_deletion_strategy == PkDeletionStrategy::Int64Pk {
+            let guard = self.cached_insert_records_pk_i64.read().map_err(|_| {
+                CatalogError::InvalidOperationNoSource {
+                    message: DELETION_CACHE_LOCK_POISONED.to_string(),
+                }
+            })?;
+            Some(Arc::clone(&guard))
+        } else {
+            None
+        };
+
         let deleted_row_keys = if self.pk_deletion_strategy == PkDeletionStrategy::RowConverterBased
         {
             let guard = self.cached_deleted_row_keys.read().map_err(|_| {
@@ -1990,6 +2007,19 @@ impl CayenneTableProvider {
         } else {
             None
         };
+
+        // Load insert records cache for RowConverterBased strategy to check re-insertions
+        let insert_records_row_keys =
+            if self.pk_deletion_strategy == PkDeletionStrategy::RowConverterBased {
+                let guard = self.cached_insert_records_row_keys.read().map_err(|_| {
+                    CatalogError::InvalidOperationNoSource {
+                        message: DELETION_CACHE_LOCK_POISONED.to_string(),
+                    }
+                })?;
+                Some(Arc::clone(&guard))
+            } else {
+                None
+            };
 
         let mut keyset = HashMap::with_capacity(1024);
         let mut row_id_base: i64 = 0;
@@ -2032,7 +2062,11 @@ impl CayenneTableProvider {
                             (int64_pk_array, &deleted_pk_i64)
                         {
                             let pk_value = pk_array.value(row_idx);
-                            deleted_pks.contains_key(&pk_value)
+                            !is_pk_visible_i64(
+                                pk_value,
+                                deleted_pks,
+                                insert_records_pk_i64.as_deref(),
+                            )
                         } else {
                             false
                         }
@@ -2040,7 +2074,11 @@ impl CayenneTableProvider {
                     PkDeletionStrategy::RowConverterBased => {
                         if let Some(deleted_keys) = &deleted_row_keys {
                             let key = rows.row(row_idx);
-                            deleted_keys.contains_key(key.as_ref())
+                            !is_pk_visible_row_key(
+                                key.as_ref(),
+                                deleted_keys,
+                                insert_records_row_keys.as_deref(),
+                            )
                         } else {
                             false
                         }
@@ -2099,6 +2137,57 @@ impl CayenneTableProvider {
         }
 
         Ok(keyset)
+    }
+
+    /// Prepare an incoming stream for insert by validating `on_conflict` constraints.
+    ///
+    /// If a primary key is configured, this method:
+    /// 1. Loads existing keys from the table (respecting deletion visibility)
+    /// 2. Validates incoming rows against `on_conflict` behavior (drop/upsert)
+    /// 3. Returns a prepared stream with conflicts resolved and deletion specs
+    ///
+    /// If no primary key is configured, returns the stream unchanged with empty deletion specs.
+    async fn prepare_stream_for_insert(
+        &self,
+        stream: SendableRecordBatchStream,
+    ) -> CatalogResult<(
+        SendableRecordBatchStream,
+        HashMap<i64, Vec<i64>>,
+        Vec<i64>,
+        Vec<Box<[u8]>>,
+    )> {
+        let Some(pk_indices) = self.primary_key_indices()? else {
+            return Ok((stream, HashMap::new(), Vec::new(), Vec::new()));
+        };
+
+        let converter = self.build_pk_converter(&pk_indices)?;
+        let mut existing_keys = self.load_existing_keyset(&pk_indices, &converter).await?;
+        tracing::debug!(
+            "prepare_stream_for_insert: loaded {} existing keys for table {}",
+            existing_keys.len(),
+            self.table_metadata.table_name
+        );
+
+        let validation_result = self
+            .validate_on_conflict(stream, &pk_indices, &converter, &mut existing_keys)
+            .await?;
+
+        // Build a new stream from the validated batches.
+        let schema = validation_result.filtered_batches.first().map_or_else(
+            || Arc::clone(&self.table_metadata.schema),
+            RecordBatch::schema,
+        );
+        let validated_stream = RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(validation_result.filtered_batches.into_iter().map(Ok)),
+        );
+
+        Ok((
+            Box::pin(validated_stream) as SendableRecordBatchStream,
+            validation_result.delete_specs,
+            validation_result.deleted_pk_i64,
+            validation_result.deleted_row_keys,
+        ))
     }
 
     /// Validate incoming batches against primary key uniqueness and configured on-conflict behavior.

--- a/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
@@ -1,0 +1,371 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Tests for upsert behavior when there are pending deletions from prior upserts.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalog};
+use common::TestFixture;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionContext;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+use std::sync::Arc;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+fn create_schema_with_timestamp() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new(
+            "updated_at",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+    ]))
+}
+
+async fn setup_upsert_table(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<(Arc<CayenneTableProvider>, SessionContext, Arc<Schema>)> {
+    let schema = create_schema_with_timestamp();
+
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string()
+        ]))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let table = Arc::new(CayenneTableProvider::create_table(catalog, table_options).await?);
+    let ctx = SessionContext::new();
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    Ok((table, ctx, schema))
+}
+
+async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> TestResult<u64> {
+    common::insert_batch(table.as_ref(), batch)
+        .await
+        .map_err(Into::into)
+}
+
+async fn get_row_count(ctx: &SessionContext, table_name: &str) -> TestResult<usize> {
+    let df = ctx.sql(&format!("SELECT * FROM {table_name}")).await?;
+    let results = df.collect().await?;
+    Ok(results.iter().map(RecordBatch::num_rows).sum())
+}
+
+async fn get_ids(ctx: &SessionContext, table_name: &str) -> TestResult<Vec<i64>> {
+    let df = ctx
+        .sql(&format!("SELECT id FROM {table_name} ORDER BY id"))
+        .await?;
+    let results = df.collect().await?;
+    let mut ids = Vec::new();
+    for batch in &results {
+        let id_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("id column should be Int64Array");
+        for i in 0..id_col.len() {
+            ids.push(id_col.value(i));
+        }
+    }
+    Ok(ids)
+}
+
+// =============================================================================
+// Test: Consecutive upserts should not create duplicate PKs
+// =============================================================================
+//
+// Verifies that multiple consecutive upserts with the same PKs correctly replace
+// rows rather than creating duplicates, even when pending deletions exist from
+// prior upsert operations.
+
+async fn test_consecutive_upserts_no_duplicates_impl(fixture: TestFixture) -> TestResult<()> {
+    let (table, ctx, schema) = setup_upsert_table(&fixture, "consecutive_upsert").await?;
+
+    // First insert: ids 1, 2, 3 with January timestamps
+    let batch1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_706_000_000_000_000_i64, // Jan 2024
+                1_706_000_000_000_000_i64,
+                1_706_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch1).await?;
+
+    // Verify: 3 rows
+    assert_eq!(
+        get_row_count(&ctx, "consecutive_upsert").await?,
+        3,
+        "Initial insert should have 3 rows"
+    );
+
+    // Second insert: same ids with February timestamps (UPSERT)
+    // This creates pending deletions for ids 1, 2, 3
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_709_000_000_000_000_i64, // Feb 2024
+                1_709_000_000_000_000_i64,
+                1_709_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch2).await?;
+
+    // Verify: still 3 rows (upsert replaced, not duplicated)
+    assert_eq!(
+        get_row_count(&ctx, "consecutive_upsert").await?,
+        3,
+        "After first upsert should have 3 rows (not 6)"
+    );
+
+    // Third insert: same ids AGAIN with March timestamps (UPSERT when pending deletions exist)
+    // This exercises the path where pending deletions exist from the prior upsert,
+    // and the incoming data also needs upsert validation.
+    let batch3 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_711_000_000_000_000_i64, // Mar 2024
+                1_711_000_000_000_000_i64,
+                1_711_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch3).await?;
+
+    // KEY ASSERTION: Upsert with pending deletions should correctly replace rows
+    assert_eq!(
+        get_row_count(&ctx, "consecutive_upsert").await?,
+        3,
+        "After upsert with pending deletions should still have 3 rows (no duplicates)"
+    );
+
+    // Verify unique IDs
+    let ids = get_ids(&ctx, "consecutive_upsert").await?;
+    assert_eq!(ids, vec![1, 2, 3], "Should have exactly ids 1, 2, 3");
+
+    Ok(())
+}
+
+test_with_backends!(test_consecutive_upserts_no_duplicates_impl);
+
+// =============================================================================
+// Test: Upsert with mix of new and existing PKs when pending deletions exist
+// =============================================================================
+
+async fn test_upsert_mixed_pks_with_pending_deletions_impl(fixture: TestFixture) -> TestResult<()> {
+    let (table, ctx, schema) = setup_upsert_table(&fixture, "mixed_upsert").await?;
+
+    // First insert: ids 1, 2, 3
+    let batch1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_706_000_000_000_000_i64,
+                1_706_000_000_000_000_i64,
+                1_706_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch1).await?;
+    assert_eq!(get_row_count(&ctx, "mixed_upsert").await?, 3);
+
+    // Second insert: id 1 (upsert) + id 4 (new) - creates pending deletions for id 1
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 4])),
+            Arc::new(StringArray::from(vec!["a_updated", "d"])),
+            Arc::new(Int64Array::from(vec![150, 400])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_709_000_000_000_000_i64,
+                1_709_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch2).await?;
+    assert_eq!(
+        get_row_count(&ctx, "mixed_upsert").await?,
+        4,
+        "After upsert id=1 and new id=4, should have 4 rows"
+    );
+
+    // Third insert: id 2 (upsert) + id 5 (new) - pending deletions exist from id 1
+    // This triggers the has_pending_deletions path
+    let batch3 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2, 5])),
+            Arc::new(StringArray::from(vec!["b_updated", "e"])),
+            Arc::new(Int64Array::from(vec![250, 500])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_711_000_000_000_000_i64,
+                1_711_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch3).await?;
+
+    // Should have 5 unique rows: ids 1, 2, 3, 4, 5
+    assert_eq!(
+        get_row_count(&ctx, "mixed_upsert").await?,
+        5,
+        "After mixed upsert with pending deletions should have 5 rows"
+    );
+
+    let ids = get_ids(&ctx, "mixed_upsert").await?;
+    assert_eq!(ids, vec![1, 2, 3, 4, 5], "Should have unique ids 1-5");
+
+    // Verify the updated values
+    let df = ctx
+        .sql("SELECT id, value FROM mixed_upsert ORDER BY id")
+        .await?;
+    let results = df.collect().await?;
+    let batch = &results[0];
+    let values = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("value column");
+
+    // id 1 -> 150 (updated), id 2 -> 250 (updated), id 3 -> 300 (original),
+    // id 4 -> 400 (new), id 5 -> 500 (new)
+    assert_eq!(values.value(0), 150, "id=1 should have updated value 150");
+    assert_eq!(values.value(1), 250, "id=2 should have updated value 250");
+    assert_eq!(values.value(2), 300, "id=3 should have original value 300");
+    assert_eq!(values.value(3), 400, "id=4 should have new value 400");
+    assert_eq!(values.value(4), 500, "id=5 should have new value 500");
+
+    Ok(())
+}
+
+test_with_backends!(test_upsert_mixed_pks_with_pending_deletions_impl);
+
+// =============================================================================
+// Test: Multiple consecutive upsert cycles
+// =============================================================================
+
+async fn test_many_consecutive_upsert_cycles_impl(fixture: TestFixture) -> TestResult<()> {
+    let (table, ctx, schema) = setup_upsert_table(&fixture, "many_cycles").await?;
+
+    // Initial insert
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["a", "b"])),
+            Arc::new(Int64Array::from(vec![100, 200])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_700_000_000_000_000_i64,
+                1_700_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(get_row_count(&ctx, "many_cycles").await?, 2);
+
+    // Run 5 upsert cycles - each should maintain exactly 2 rows
+    for cycle in 1..=5 {
+        let ts = 1_700_000_000_000_000_i64 + (cycle * 1_000_000_000_000_i64);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec![
+                    format!("a_v{cycle}"),
+                    format!("b_v{cycle}"),
+                ])),
+                Arc::new(Int64Array::from(vec![100 + cycle, 200 + cycle])),
+                Arc::new(TimestampMicrosecondArray::from(vec![ts, ts])),
+            ],
+        )?;
+        insert_batch(&table, batch).await?;
+
+        let count = get_row_count(&ctx, "many_cycles").await?;
+        assert_eq!(
+            count, 2,
+            "After upsert cycle {cycle}, should still have 2 rows, got {count}"
+        );
+    }
+
+    // Final verification
+    let ids = get_ids(&ctx, "many_cycles").await?;
+    assert_eq!(ids, vec![1, 2]);
+
+    // Verify final values (cycle 5: 105, 205)
+    let df = ctx.sql("SELECT value FROM many_cycles ORDER BY id").await?;
+    let results = df.collect().await?;
+    let values = results[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("value column");
+    assert_eq!(
+        values.value(0),
+        105,
+        "id=1 should have value 105 after cycle 5"
+    );
+    assert_eq!(
+        values.value(1),
+        205,
+        "id=2 should have value 205 after cycle 5"
+    );
+
+    Ok(())
+}
+
+test_with_backends!(test_many_consecutive_upsert_cycles_impl);


### PR DESCRIPTION
## 📝 Summary

Fixes bug #9103 where upsert operations would create duplicate primary keys when pending deletions existed. 
1. **Bypassed upsert validation** - When `has_pending_deletions=true`, the code path skipped `validate_on_conflict()` entirely, writing incoming rows without checking for existing PKs.

2. **Incorrect visibility check** - `load_existing_keyset()` only checked the deletion cache, not the insert_records cache. This caused re-inserted PKs (from prior upserts) to be incorrectly filtered out.

## Solution

- Added `validate_on_conflict()` call in the `has_pending_deletions` path
- Fixed visibility logic to check both deletion and insert_records caches using sequence-based ordering
- Extracted shared `is_pk_visible_i64()` and `is_pk_visible_row_key()` helper functions
- Consolidated duplicated code into `prepare_stream_for_insert()` helper

## 🔗 Related

Fixes
 - https://github.com/spiceai/spiceai/issues/9103

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
