### PR TITLE
fix(flightrepl): Add chrono-tz feature to flightrepl for timezone formatting

### DIFF
--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 ansi_colors = { path = "../ansi_colors" }
-arrow.workspace = true
+arrow = { workspace = true, features = ["chrono-tz"] }
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 arrow-json.workspace = true
 clap.workspace = true


### PR DESCRIPTION
## 📝 Summary

Fixes "Invalid timezone 'UTC': only offset based timezones supported without chrono-tz feature" error when displaying query results with timestamp columns.

The CLI builds fix (#9145) removed the datafusion dependency from flightrepl, which transitively provided the chrono-tz feature for arrow's pretty_format_batches. This adds the feature explicitly.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
