### PR TITLE
fix: Set MISTRALRS_METAL_PRECOMPILE=0 when metal feature is enabled

### DIFF
--- a/bin/spiced/Makefile
+++ b/bin/spiced/Makefile
@@ -29,8 +29,10 @@ endif
 
 .PHONY: all
 all:
-# If "metal" is not in SPICED_FEATURES, set MISTRALRS_METAL_PRECOMPILE=0
-ifneq ($(filter metal,$(subst ,, ,$(SPICED_FEATURES))),metal)
-	$(eval export MISTRALRS_METAL_PRECOMPILE=0)
+# When building with metal feature, skip Metal kernel precompilation to avoid requiring
+# Xcode Metal Toolchain. Kernels are compiled at runtime instead.
+# Set MISTRALRS_METAL_PRECOMPILE=1 to precompile (requires: xcodebuild -downloadComponent MetalToolchain)
+ifneq ($(findstring metal,$(SPICED_NON_DEFAULT_FEATURES)$(SPICED_CUSTOM_FEATURES)),)
+	$(eval export MISTRALRS_METAL_PRECOMPILE ?= 0)
 endif
 	cargo build ${OPT_LEVEL} $(SPICED_FEATURES) --target-dir $(TARGET_DIR) $(CUSTOM_FEATURES)


### PR DESCRIPTION
## 📝 Summary

Fixes `make install-metal` (avoid requiring Xcode Metal Toolchain). Build workflows explicitly set `MISTRALRS_METAL_PRECOMPILE=0` to fix this so this does NOT change CI build behavior

Fixes the condition in `bin/spiced/Makefile` that was setting `MISTRALRS_METAL_PRECOMPILE=0` when metal was **NOT** in features (inverted logic).

The correct behavior is to skip Metal kernel precompilation when building **with** the metal feature, allowing runtime JIT compilation instead of requiring the Xcode Metal Toolchain (`xcodebuild -downloadComponent MetalToolchain`).

**Before (broken):** Set env var when metal NOT specified (no effect)
**After (fixed):** Set env var when metal IS specified (skips precompile)

Notes:
1. Introduced in #6652 (commit 16677a5eb).
1. Setting manually `MISTRALRS_METAL_PRECOMPILE=1` is still supported as PR uses `$(eval export MISTRALRS_METAL_PRECOMPILE ?= 0)` to respect `MISTRALRS_METAL_PRECOMPILE` if provided


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
