### PR TITLE
fix(delta_lake): Preserve container name in ABFSS URLs for Azure Delta Lake tables

### DIFF
--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -306,10 +306,11 @@ impl DeltaTable {
             .with_predicate(Arc::clone(physical_expr));
 
         // Matches keying used by `ObjectStoreRegistry::get_url_key`
+        // Use BeforeUsername to preserve userinfo (e.g., container name in abfss://container@account.dfs.core.windows.net/)
         let object_store_url = ObjectStoreUrl::parse(format!(
             "{}://{}",
             self.table_url.scheme(),
-            &self.table_url[url::Position::BeforeHost..url::Position::AfterPort]
+            &self.table_url[url::Position::BeforeUsername..url::Position::AfterPort]
         ))
         .context(DeltaTableExecutionSnafu)?;
 


### PR DESCRIPTION
## 📝 Summary

Delta Lake queries against Azure ABFSS storage fail with:

An internal error occurred. Object Store error: Generic MicrosoftAzure error: URL did not match any known pattern for scheme: abfss://....dfs.core.windows.net/

### Root Cause
When constructing `ObjectStoreUrl`, we used `url::Position::BeforeHost` which strips the userinfo portion of the URL. For ABFSS URLs (`abfss://container@account.dfs.core.windows.net/path`), the container is stored as userinfo.

### Fix
Changed to `url::Position::BeforeUsername` to preserve the full authority including the container name.

| URL Position | Result for `abfss://container@account.dfs.core.windows.net/` |
|--------------|--------------------------------------------------------------|
| `BeforeHost..AfterPort` (before) | `account.dfs.core.windows.net` ❌ |
| `BeforeUsername..AfterPort` (after) | `container@account.dfs.core.windows.net` ✅ |

This is safe for S3/GCS/MinIO URLs which have no userinfo—`BeforeUsername` equals `BeforeHost` when userinfo is absent.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
