### PR TITLE
Add additional OpenAI model tests

### DIFF
--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -471,6 +471,121 @@ async fn openai_test_chat_completion() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+async fn openai_test_chat_completion_gpt5_mini() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+
+    test_request_context().scope(async {
+        verify_env_secret_exists("SPICE_OPENAI_API_KEY")
+            .await
+            .map_err(anyhow::Error::msg)?;
+
+        let mut model_with_tools = get_openai_model("gpt-5-mini", "openai_model");
+        model_with_tools
+            .params
+            .insert("tools".to_string(), "auto".into());
+
+        let app = AppBuilder::new("text-to-sql")
+            .with_dataset(get_taxi_trips_dataset())
+            .with_model(model_with_tools)
+            .build();
+
+        let api_config = create_api_bindings_config();
+        let http_base_url = format!("http://{}", api_config.http_bind_address);
+        let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+        let rt_ref_copy = Arc::clone(&rt);
+        tokio::spawn(async move {
+            Box::pin(rt_ref_copy.start_servers(api_config, None, EndpointAuth::no_auth())).await
+        });
+
+        tokio::select! {
+            () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                return Err(anyhow::anyhow!("Timed out waiting for components to load"));
+            }
+            () = Arc::clone(&rt).load_components() => {}
+        }
+
+        runtime_ready_check(&rt).await;
+
+        let response = send_chat_completions_request(
+            http_base_url.as_str(),
+            vec![
+                ("system".to_string(), "You are an assistant that responds to queries by providing only the requested data values without extra explanation.".to_string()),
+                ("user".to_string(), "Provide the total number of records in the taxi trips dataset. If known, return a single numeric value.".to_string()),
+            ],
+            "openai_model",
+            false,
+        ).await?;
+
+        insta::assert_snapshot!(
+            "chat_completion_gpt5_mini",
+            normalize_chat_completion_response(response, false)
+        );
+
+        Ok(())
+    }).await
+}
+
+#[tokio::test]
+async fn openai_test_chat_completion_gpt5_mini_with_endpoint() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+
+    test_request_context().scope(async {
+        verify_env_secret_exists("SPICE_OPENAI_API_KEY")
+            .await
+            .map_err(anyhow::Error::msg)?;
+
+        let mut model_with_tools = get_openai_model("gpt-5-mini", "openai_model");
+        model_with_tools
+            .params
+            .insert("tools".to_string(), "auto".into());
+        model_with_tools
+            .params
+            .insert("endpoint".to_string(), "https://api.openai.com/v1".into());
+
+        let app = AppBuilder::new("text-to-sql")
+            .with_dataset(get_taxi_trips_dataset())
+            .with_model(model_with_tools)
+            .build();
+
+        let api_config = create_api_bindings_config();
+        let http_base_url = format!("http://{}", api_config.http_bind_address);
+        let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+        let rt_ref_copy = Arc::clone(&rt);
+        tokio::spawn(async move {
+            Box::pin(rt_ref_copy.start_servers(api_config, None, EndpointAuth::no_auth())).await
+        });
+
+        tokio::select! {
+            () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                return Err(anyhow::anyhow!("Timed out waiting for components to load"));
+            }
+            () = Arc::clone(&rt).load_components() => {}
+        }
+
+        runtime_ready_check(&rt).await;
+
+        let response = send_chat_completions_request(
+            http_base_url.as_str(),
+            vec![
+                ("system".to_string(), "You are an assistant that responds to queries by providing only the requested data values without extra explanation.".to_string()),
+                ("user".to_string(), "Provide the total number of records in the taxi trips dataset. If known, return a single numeric value.".to_string()),
+            ],
+            "openai_model",
+            false,
+        ).await?;
+
+        insta::assert_snapshot!(
+            "chat_completion_gpt5_mini_with_endpoint",
+            normalize_chat_completion_response(response, false)
+        );
+
+        Ok(())
+    }).await
+}
+
+#[tokio::test]
 async fn openai_test_chat_messages() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);
 

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini.snap
@@ -1,0 +1,29 @@
+---
+source: crates/runtime/tests/models/openai.rs
+expression: "normalize_chat_completion_response(response, false)"
+---
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "10",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": "created_val",
+  "id": "id_val",
+  "model": "openai_model",
+  "object": "chat.completion",
+  "service_tier": "default",
+  "usage": {
+    "completion_tokens": "completion_tokens_val",
+    "completion_tokens_details": "completion_tokens_details_val",
+    "prompt_tokens": "prompt_tokens_val",
+    "prompt_tokens_details": "prompt_tokens_details_val",
+    "total_tokens": "total_tokens_val"
+  }
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini_with_endpoint.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini_with_endpoint.snap
@@ -1,0 +1,29 @@
+---
+source: crates/runtime/tests/models/openai.rs
+expression: "normalize_chat_completion_response(response, false)"
+---
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "10",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": "created_val",
+  "id": "id_val",
+  "model": "openai_model",
+  "object": "chat.completion",
+  "service_tier": "default",
+  "usage": {
+    "completion_tokens": "completion_tokens_val",
+    "completion_tokens_details": "completion_tokens_details_val",
+    "prompt_tokens": "prompt_tokens_val",
+    "prompt_tokens_details": "prompt_tokens_details_val",
+    "total_tokens": "total_tokens_val"
+  }
+}


### PR DESCRIPTION
This pull request adds new integration tests for the OpenAI GPT-5 Mini model within the chat completion workflow, ensuring coverage for both the default API configuration and a custom endpoint. Snapshot files are also introduced to verify the expected responses from these tests.

**New integration tests for GPT-5 Mini:**

* Added `openai_test_chat_completion_gpt5_mini` test to validate chat completion using the GPT-5 Mini model with automatic tool selection. (`crates/runtime/tests/models/openai.rs`)
* Added `openai_test_chat_completion_gpt5_mini_with_endpoint` test to validate chat completion using the GPT-5 Mini model with a specified OpenAI API endpoint. (`crates/runtime/tests/models/openai.rs`)

**Snapshot testing for responses:**

* Introduced snapshot files to assert and document the expected chat completion responses for both new tests. (`crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini.snap`, `crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion_gpt5_mini_with_endpoint.snap`)