### PR TITLE
fix: Set query set properly on benchmarks telemetry metrics attributes

### DIFF
--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -90,13 +90,14 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let testoperator_commit_sha = git::get_commit_sha();
     let branch_name = git::get_branch_name();
 
+    let query_set = args.load_query_set()?;
     let benchmark_resource = Resource::builder_empty()
         .with_attributes(vec![
             KeyValue::new("service.name", "testoperator"),
             KeyValue::new("type", "benchmark_query"),
             KeyValue::new("name", app.name.clone()),
             KeyValue::new("spiced_version", spiced_version),
-            KeyValue::new("query_set", format!("{:?}", args.query_set)),
+            KeyValue::new("query_set", query_set.to_string()),
             KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
             KeyValue::new("spiced_commit_sha", spiced_commit_sha),
             KeyValue::new("branch_name", branch_name),
@@ -119,7 +120,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     // baseline run
     println!("Running benchmark test");
 
-    let (_query_set, test_builder) = super::build_test_with_validation(
+    let (_, test_builder) = super::build_test_with_validation(
         args,
         NotStarted::new()
             .with_parallel_count(1)

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -76,13 +76,14 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     let branch_name = git::get_branch_name();
     let spicepod = args.test_args.common.spicepod_path.display().to_string();
 
+    let query_set = args.test_args.load_query_set()?;
     let load_resource = Resource::builder_empty()
         .with_attributes(vec![
             KeyValue::new("service.name", "testoperator"),
             KeyValue::new("type", "load_test"),
             KeyValue::new("name", app.name.clone()),
             KeyValue::new("spiced_version", spiced_version),
-            KeyValue::new("query_set", format!("{:?}", args.test_args.query_set)),
+            KeyValue::new("query_set", query_set.to_string()),
             KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
             KeyValue::new("spiced_commit_sha", spiced_commit_sha),
             KeyValue::new("branch_name", branch_name),
@@ -148,7 +149,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     // baseline run
     println!("Running baseline throughput test for {baseline_duration_secs}s",);
 
-    let (_query_set, test_builder) = super::build_test_with_validation(
+    let (_, test_builder) = super::build_test_with_validation(
         &args.test_args,
         NotStarted::new()
             .with_parallel_count(args.test_args.common.concurrency)

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -71,7 +71,7 @@ pub(crate) fn create_telemetry_with_resource(common: &CommonArgs, resource: Reso
 /// 4. Adds reference schema for validation against known good tables
 ///
 /// # Returns
-/// Tuple of (`QuerySet`, Vec<Query>, `NotStarted` builder)
+/// Tuple of (`QuerySet`, `NotStarted` builder)
 pub(crate) async fn build_test_with_validation(
     args: &DatasetTestArgs,
     test_builder: NotStarted,


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Sets the `query_set` parameter on benchmarks telemetry resource attributes correctly, to ensure they format as expected.
* See previous format: https://github.com/spiceai/spiceai/pull/9054/changes#diff-ad88502cdc3c2475baae2477516c93aef6f7800c5f9576bd73506102b5bb7c5cL137
