### PR TITLE
fix(ci): remove non-existent Makefile targets from workflow

### DIFF
--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -59,10 +59,6 @@ jobs:
         run: |
           make install-runtime
 
-      - name: make install-with-models
+      - name: make install-odbc
         run: |
-          make install-with-models
-
-      - name: make install-with-odbc
-        run: |
-          make install-with-odbc
+          make install-odbc


### PR DESCRIPTION
## Summary
- Remove `install-with-models` target from makefile_targets.yml workflow (target never existed)
- Fix `install-with-odbc` to `install-odbc` (correct Makefile target name)

## Changes
The workflow was referencing Makefile targets that don't exist:
- `make install-with-models` - no such target in Makefile
- `make install-with-odbc` - should be `make install-odbc`

Verified remaining targets all exist in Makefile:
- `install-dev` (line 223)
- `install` (line 217)
- `install-cli` (line 284)
- `install-runtime` (line 289)
- `install-odbc` (line 265)