### PR TITLE
Fix Windows build by gating cayenne usage with #[cfg(not(windows))]

### DIFF
--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -18,6 +18,7 @@ use crate::Runtime;
 use crate::metrics::telemetry::track_bytes_processed;
 use arrow_schema::Schema;
 use ballista_core::serde::BallistaPhysicalExtensionCodec;
+#[cfg(not(windows))]
 use cayenne::provider::CayenneAccelerationExec;
 use datafusion::common::{DataFusionError, Result, exec_err};
 use datafusion::execution::{FunctionRegistry, TaskContext};
@@ -90,9 +91,16 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 .fallback_to_new_context(),
             ))
         } else if CayenneAccelerationExecNode::decode(buf).is_ok() {
-            Ok(Arc::new(CayenneAccelerationExec::new(Arc::clone(
-                &inputs[0],
-            ))))
+            #[cfg(not(windows))]
+            {
+                Ok(Arc::new(CayenneAccelerationExec::new(Arc::clone(
+                    &inputs[0],
+                ))))
+            }
+            #[cfg(windows)]
+            {
+                exec_err!("CayenneAccelerationExec is not supported on Windows")
+            }
         } else {
             exec_err!("Cannot deserialize unknown execution plan")
         }
@@ -113,16 +121,23 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             let node = BytesProcessedExecNode {};
             node.encode(buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        } else if node
-            .as_any()
-            .downcast_ref::<CayenneAccelerationExec>()
-            .is_some()
-        {
-            let node = CayenneAccelerationExecNode {};
-            node.encode(buf)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
         } else {
-            return self.inner.try_encode(node, buf);
+            #[cfg(not(windows))]
+            if node
+                .as_any()
+                .downcast_ref::<CayenneAccelerationExec>()
+                .is_some()
+            {
+                let node = CayenneAccelerationExecNode {};
+                node.encode(buf)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            } else {
+                return self.inner.try_encode(node, buf);
+            }
+            #[cfg(windows)]
+            {
+                return self.inner.try_encode(node, buf);
+            }
         }
 
         Ok(())

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1383,6 +1383,7 @@ impl DataFusion {
 
         // Check if this is an S3 Express One Zone acceleration (Cayenne with S3 Express config)
         // This is used for better error messages when S3 Express upload fails
+        #[cfg(not(windows))]
         let is_s3_express_acceleration = acceleration_settings.engine == Engine::Cayenne
             && (acceleration_settings
                 .params
@@ -1393,6 +1394,8 @@ impl DataFusion {
                 || acceleration_settings
                     .params
                     .contains_key("cayenne_s3_zone_ids"));
+        #[cfg(windows)]
+        let is_s3_express_acceleration = false;
         accelerated_table_builder.s3_express_acceleration(is_s3_express_acceleration);
 
         accelerated_table_builder


### PR DESCRIPTION
## Summary

- Gate `cayenne` imports and usage with `#[cfg(not(windows))]` to fix Windows build errors
- The `cayenne` module is already gated in `dataaccelerator/mod.rs`, but references to it in `spice_physical_codec.rs` and `datafusion/mod.rs` were not gated

## Changes

- `spice_physical_codec.rs`: Gate `CayenneAccelerationExec` import and encode/decode logic
- `datafusion/mod.rs`: Gate S3 Express acceleration check (defaults to `false` on Windows)