### PR TITLE
fix: Cayenne TPCH SF100 benchmark shouldn't validate results

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf100/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf100/accelerated/s3[parquet]-cayenne[file].yaml
@@ -5,4 +5,3 @@ tests:
     runner_type: spiceai-dev-large-runners
     ready_wait: 6000
     scale_factor: 100
-    validate_results: true


### PR DESCRIPTION
Removes `validate_results: true` from the Cayenne TPCH SF100 benchmark configuration. We only have results validation for SF1