### PR TITLE
fix(cayenne): Include protected snapshots in conflict detection keyset scan

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1925,6 +1925,9 @@ impl CayenneTableProvider {
 
     /// Build the existing keyset (primary key bytes -> row location) for append-mode inserts.
     ///
+    /// This method scans BOTH the main listing table AND any protected snapshots to build
+    /// a complete keyset of all existing primary keys.
+    ///
     /// This method respects ALL deletion caches based on `pk_deletion_strategy`:
     /// - `Int64Pk`: Uses `cached_deleted_pk_i64` and `cached_insert_records_pk_i64`
     /// - `RowConverterBased`: Uses `cached_deleted_row_keys` and `cached_insert_records_row_keys`
@@ -1948,19 +1951,67 @@ impl CayenneTableProvider {
             Arc::clone(&guard)
         };
 
+        // Clone protected snapshots to avoid holding locks across await points
+        let protected_snapshots = {
+            let guard =
+                self.protected_snapshots
+                    .read()
+                    .map_err(|_| CatalogError::LockPoisoned {
+                        operation: "read protected snapshots in load_existing_keyset".to_string(),
+                    })?;
+            guard.clone()
+        };
+
         let ctx = SessionContext::new();
+        // Only read PK columns - no need to load all columns for keyset building
+        let pk_projection = pk_indices.to_vec();
         let scan_plan = listing_table
-            .scan(&ctx.state(), None, &[], None)
+            .scan(&ctx.state(), Some(&pk_projection), &[], None)
             .await
             .map_err(|err| CatalogError::InvalidOperationNoSource {
                 message: format!("Failed to scan listing table for primary keys: {err}"),
             })?;
 
-        let batches = collect(scan_plan, ctx.task_ctx()).await.map_err(|err| {
+        let mut all_batches = collect(scan_plan, ctx.task_ctx()).await.map_err(|err| {
             CatalogError::InvalidOperationNoSource {
                 message: format!("Failed to collect primary key scan: {err}"),
             }
         })?;
+
+        // Also collect batches from each protected snapshot
+        for snapshot_id in protected_snapshots.keys() {
+            let snapshot_url = Self::snapshot_dir_url(
+                &self.table_metadata.path,
+                self.table_metadata.table_id,
+                snapshot_id,
+            );
+
+            let snapshot_listing_table = Self::create_listing_table(
+                &snapshot_url,
+                Arc::clone(&self.table_metadata.schema),
+                self.context.file_format(),
+            )?;
+
+            // Only read PK columns - no need to load all columns for keyset building
+            let snapshot_plan = snapshot_listing_table
+                .scan(&ctx.state(), Some(&pk_projection), &[], None)
+                .await
+                .map_err(|err| CatalogError::InvalidOperationNoSource {
+                    message: format!(
+                        "Failed to scan protected snapshot {snapshot_id} for primary keys: {err}"
+                    ),
+                })?;
+
+            let snapshot_batches = collect(snapshot_plan, ctx.task_ctx())
+                .await
+                .map_err(|err| CatalogError::InvalidOperationNoSource {
+                    message: format!(
+                        "Failed to collect protected snapshot {snapshot_id} scan: {err}"
+                    ),
+                })?;
+
+            all_batches.extend(snapshot_batches);
+        }
 
         // Load the appropriate deletion cache based on pk_deletion_strategy.
         // This ensures keys that were previously deleted are not considered as conflicts.
@@ -2024,8 +2075,11 @@ impl CayenneTableProvider {
         let mut keyset = HashMap::with_capacity(1024);
         let mut row_id_base: i64 = 0;
 
-        for batch in batches {
-            let pk_columns: Vec<_> = pk_indices
+        // After projection, batch columns are at indices 0..pk_indices.len()
+        let projected_pk_indices: Vec<usize> = (0..pk_indices.len()).collect();
+
+        for batch in all_batches {
+            let pk_columns: Vec<_> = projected_pk_indices
                 .iter()
                 .map(|idx| Arc::clone(batch.column(*idx)))
                 .collect();
@@ -2041,7 +2095,7 @@ impl CayenneTableProvider {
                 == PkDeletionStrategy::Int64Pk
                 && pk_indices.len() == 1
             {
-                batch.column(pk_indices[0]).as_any().downcast_ref()
+                batch.column(0).as_any().downcast_ref()
             } else {
                 None
             };
@@ -2109,23 +2163,17 @@ impl CayenneTableProvider {
 
                 let key = rows.row(row_idx).owned();
 
-                if keyset
-                    .insert(
-                        key,
-                        RowLocation {
-                            data_file_id: DEFAULT_DATA_FILE_ID,
-                            row_id,
-                        },
-                    )
-                    .is_some()
-                {
-                    return Err(CatalogError::InvalidOperationNoSource {
-                        message: format!(
-                            "Existing data for table {} violates primary key uniqueness",
-                            self.table_metadata.table_name
-                        ),
-                    });
-                }
+                // Insert or update the key in the keyset.
+                // Keys from protected snapshots may override keys from the main listing table
+                // because protected snapshots contain data inserted at higher sequence numbers.
+                // This is expected behavior for upserts.
+                keyset.insert(
+                    key,
+                    RowLocation {
+                        data_file_id: DEFAULT_DATA_FILE_ID,
+                        row_id,
+                    },
+                );
             }
 
             row_id_base += i64::try_from(batch.num_rows()).map_err(|_| {
@@ -3376,6 +3424,17 @@ impl CayenneTableProvider {
             *guard = Arc::new(HashMap::new());
         }
 
+        // Clear protected snapshots - after compaction all data is in the main snapshot
+        {
+            let mut guard =
+                self.protected_snapshots
+                    .write()
+                    .map_err(|_| CatalogError::LockPoisoned {
+                        operation: "clear protected snapshots".to_string(),
+                    })?;
+            guard.clear();
+        }
+
         tracing::debug!(
             "Cleared all deletion and insert records caches for table {}",
             self.table_metadata.table_name
@@ -4262,7 +4321,7 @@ impl CayenneTableProvider {
                         plan,
                         Arc::new(filtered_deletions),
                         empty_insert_records,
-                        self.pk_column_indices.clone(),
+                        pk_indices_in_projection.to_vec(),
                         Arc::clone(row_converter),
                     )))
                 } else {

--- a/crates/cayenne/tests/protected_snapshot_projection_test.rs
+++ b/crates/cayenne/tests/protected_snapshot_projection_test.rs
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Tests for scanning protected snapshots with column projections.
+//!
+//! Validates that queries with column projections work correctly when protected
+//! snapshots exist and newer deletions need to be applied to them.
+//!
+//! The key scenario is when a projection reorders columns differently from the
+//! original schema. For example, with schema (id, name, value) and a projection
+//! SELECT value, id, the batch has value at index 0 and id at index 1. The
+//! deletion filter must use the adjusted PK indices in the projection, not the
+//! original schema indices.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalog};
+use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionContext;
+use datafusion::prelude::*;
+use std::sync::Arc;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Create a schema with Int32 PK to trigger RowConverter-based deletion strategy.
+/// Schema: id (Int32 PK), name (Utf8), value (Int64)
+fn create_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+async fn setup_table(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<(Arc<CayenneTableProvider>, SessionContext, Arc<Schema>)> {
+    let schema = create_schema();
+
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: None,
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let table = Arc::new(CayenneTableProvider::create_table(catalog, table_options).await?);
+    let ctx = SessionContext::new();
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    Ok((table, ctx, schema))
+}
+
+async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> TestResult<u64> {
+    common::insert_batch(table.as_ref(), batch)
+        .await
+        .map_err(Into::into)
+}
+
+async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
+    let ctx = SessionContext::new();
+    let plan = table.delete_from(&ctx.state(), &[filter]).await?;
+    let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
+}
+
+// =============================================================================
+// Test: Protected snapshot scan with projection that excludes PK column
+// =============================================================================
+//
+// Validates that queries with column projections work correctly when protected
+// snapshots exist and newer deletions need to be applied to them.
+async fn test_protected_snapshot_projection_reorder_impl(fixture: TestFixture) -> TestResult<()> {
+    let (table, ctx, schema) = setup_table(&fixture, "projection_reorder").await?;
+
+    // Step 1: Insert initial data (ids 1, 2, 3)
+    let batch1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["alpha", "bravo", "charlie"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+        ],
+    )?;
+    insert_batch(&table, batch1).await?;
+
+    // Step 2: Delete id=2 to create pending deletions (deletion seq=1)
+    let deleted = delete_records(&table, col("id").eq(lit(2_i32))).await?;
+    assert_eq!(deleted, 1, "Should delete 1 row");
+
+    // Step 3: Insert new data (ids 4, 5) - creates protected snapshot with max_delete_seq=1
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int32Array::from(vec![4, 5])),
+            Arc::new(StringArray::from(vec!["delta", "echo"])),
+            Arc::new(Int64Array::from(vec![400, 500])),
+        ],
+    )?;
+    insert_batch(&table, batch2).await?;
+
+    // Step 4: Delete id=4 AFTER the protected snapshot was created (deletion seq=2)
+    // This deletion has seq > max_delete_seq_at_creation, so it WILL be applied
+    // to the protected snapshot during scan. This exercises the partial deletion
+    // filter code path with column projection.
+    let deleted2 = delete_records(&table, col("id").eq(lit(4_i32))).await?;
+    assert_eq!(deleted2, 1, "Should delete 1 row");
+
+    // Step 5: Query with projection that EXCLUDES the PK column (id)
+    // The system must add id internally for deletion filtering, then strip it
+    let df = ctx
+        .sql("SELECT name, value FROM projection_reorder ORDER BY value")
+        .await?;
+
+    let results = df.collect().await?;
+
+    // Verify we got the correct results
+    // Expected: rows for ids 1, 3, 5 (id=2 deleted before snapshot, id=4 deleted after snapshot)
+    let total_rows: usize = results.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(
+        total_rows, 3,
+        "Should have 3 rows (for ids 1, 3, 5 - not id 2 or 4 which were deleted)"
+    );
+
+    // Verify the name column values are correct (name is at index 0 in projection)
+    let mut names = Vec::new();
+    for batch in &results {
+        let name_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name column should be StringArray");
+        for i in 0..name_col.len() {
+            names.push(name_col.value(i).to_string());
+        }
+    }
+    // Ordered by value: 100 (alpha), 300 (charlie), 500 (echo)
+    assert_eq!(
+        names,
+        vec!["alpha", "charlie", "echo"],
+        "Should have names alpha, charlie, echo in order by value"
+    );
+
+    Ok(())
+}
+
+test_with_backends!(test_protected_snapshot_projection_reorder_impl);

--- a/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
@@ -469,8 +469,7 @@ async fn test_new_key_in_protected_snapshot_detected_as_conflict_impl(
     assert_eq!(
         ids,
         vec![0, 1, 2, 3, 4],
-        "Should have unique PKs 0-4, but got duplicates: {:?}",
-        ids
+        "Should have unique PKs 0-4, but got duplicates: {ids:?}"
     );
 
     // Verify PK 3 has the latest value (131 from step 3)

--- a/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
@@ -369,3 +369,133 @@ async fn test_many_consecutive_upsert_cycles_impl(fixture: TestFixture) -> TestR
 }
 
 test_with_backends!(test_many_consecutive_upsert_cycles_impl);
+
+// =============================================================================
+// Test: New key in protected snapshot must be detected as conflict in next insert
+// =============================================================================
+//
+// When pending deletions exist from a prior upsert, new data is written to a
+// "protected snapshot" rather than the main listing table. Subsequent inserts
+// must detect keys from protected snapshots as conflicts to prevent duplicates.
+//
+// Scenario:
+// 1. Initial: PKs 0,1,2 loaded to main listing table
+// 2. Refresh 1: upsert PK 2 + insert NEW PK 3
+//    - PK 2 triggers upsert → creates pending deletion
+//    - PK 3 is new → written to protected snapshot (because pending deletion exists)
+// 3. Refresh 2: insert PK 3 again + NEW PK 4
+//    - PK 3 already exists in protected snapshot from step 2
+//    - Conflict detection must find PK 3 in protected snapshot
+//    - PK 3 should be upserted (not duplicated)
+//
+// Expected: After step 3, table should have exactly 5 unique PKs (0,1,2,3,4)
+// with PK 3 containing the value from step 3 (131, not 130).
+
+async fn test_new_key_in_protected_snapshot_detected_as_conflict_impl(
+    fixture: TestFixture,
+) -> TestResult<()> {
+    let (table, ctx, schema) = setup_upsert_table(&fixture, "protected_conflict").await?;
+
+    // Step 1: Initial insert - PKs 0, 1, 2
+    let batch1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0, 1, 2])),
+            Arc::new(StringArray::from(vec!["r0", "r1", "r2"])),
+            Arc::new(Int64Array::from(vec![100, 110, 120])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_700_000_000_000_000_i64,
+                1_700_000_000_000_000_i64,
+                1_700_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch1).await?;
+    assert_eq!(
+        get_row_count(&ctx, "protected_conflict").await?,
+        3,
+        "After step 1: should have 3 rows (PKs 0,1,2)"
+    );
+
+    // Step 2: Upsert PK 2 + insert NEW PK 3
+    // - PK 2 triggers upsert → creates pending deletion
+    // - PK 3 is NEW → written to protected snapshot (because pending deletion exists)
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2, 3])),
+            Arc::new(StringArray::from(vec!["r2_v1", "r3_v1"])),
+            Arc::new(Int64Array::from(vec![121, 130])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_705_000_000_000_000_i64,
+                1_705_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch2).await?;
+    assert_eq!(
+        get_row_count(&ctx, "protected_conflict").await?,
+        4,
+        "After step 2: should have 4 rows (PKs 0,1,2,3)"
+    );
+
+    // Step 3: Insert PK 3 again + NEW PK 4
+    // - PK 3 already exists in protected snapshot from step 2
+    // - Conflict detection must include protected snapshots
+    // - PK 3 should be upserted, not inserted as duplicate
+    let batch3 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![3, 4])),
+            Arc::new(StringArray::from(vec!["r3_v2", "r4_v1"])),
+            Arc::new(Int64Array::from(vec![131, 140])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_710_000_000_000_000_i64,
+                1_710_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch3).await?;
+
+    // CRITICAL ASSERTION: Should have 5 rows, not 6 (PK 3 must be upserted, not duplicated)
+    let count = get_row_count(&ctx, "protected_conflict").await?;
+    assert_eq!(
+        count, 5,
+        "After step 3: should have 5 rows (PKs 0,1,2,3,4), got {count}"
+    );
+
+    // Verify no duplicate PKs
+    let ids = get_ids(&ctx, "protected_conflict").await?;
+    assert_eq!(
+        ids,
+        vec![0, 1, 2, 3, 4],
+        "Should have unique PKs 0-4, but got duplicates: {:?}",
+        ids
+    );
+
+    // Verify PK 3 has the latest value (131 from step 3)
+    let df = ctx
+        .sql("SELECT id, value FROM protected_conflict WHERE id = 3")
+        .await?;
+    let results = df.collect().await?;
+    assert_eq!(
+        results[0].num_rows(),
+        1,
+        "PK 3 should appear exactly once, but got {} rows",
+        results[0].num_rows()
+    );
+    let values = results[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("value column");
+    assert_eq!(
+        values.value(0),
+        131,
+        "PK 3 should have latest value 131 from step 3"
+    );
+
+    Ok(())
+}
+
+test_with_backends!(test_new_key_in_protected_snapshot_detected_as_conflict_impl);


### PR DESCRIPTION
## Summary

PR fixes duplicate key creation during append refresh when keys exist in protected snapshots: https://github.com/spiceai/spiceai/issues/9103

## Problem

`load_existing_keyset()` only scanned the main listing table, missing keys in protected snapshots. This caused new inserts to not detect conflicts for PKs that existed in protected snapshots, creating duplicates.

## Changes

- `load_existing_keyset()` now scans both main listing table AND all protected snapshots

Other improvements
- `load_existing_keyset()` now projects only PK columns instead of reading all columns (performance optimization)
- Fixed `RowConverter` column schema mismatch error when querying with column projections that exclude or reorder PK columns. In `apply_partial_deletion_filter()`, the `KeyBasedDeletionFilterExec` now uses `pk_indices_in_projection` (adjusted for projected batch) instead of `pk_column_indices` (original schema indices).
- `clear_all_deletion_caches()` now clears `protected_snapshots` map after compaction

## Test

`test_new_key_in_protected_snapshot_detected_as_conflict` validates the main fix.
`test_protected_snapshot_projection_reorder_impl` validates the projection fix

## 🔗 Related

Fixes 
- https://github.com/spiceai/spiceai/issues/9103

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
