### PR TITLE
fix: Use GreedyMemoryPool instead of FairSpillPool for concurrent query handling

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -33,7 +33,7 @@ use datafusion::{
     execution::{
         DiskManager, SessionStateBuilder,
         disk_manager::DiskManagerMode,
-        memory_pool::{FairSpillPool, MemoryPool, TrackConsumersPool, UnboundedMemoryPool},
+        memory_pool::{GreedyMemoryPool, MemoryPool, TrackConsumersPool, UnboundedMemoryPool},
         runtime_env::{RuntimeEnv, RuntimeEnvBuilder},
     },
     optimizer::{
@@ -523,7 +523,17 @@ pub(crate) fn runtime_env(
             unreachable!("Memory pool TopN must be greater than 0");
         };
 
-        Arc::new(TrackConsumersPool::new(FairSpillPool::new(limit), topn))
+        // Use GreedyMemoryPool instead of FairSpillPool for better handling of concurrent queries.
+        // FairSpillPool divides memory equally among all spillable consumers, which causes issues when:
+        // 1. Many queries run concurrently (e.g., throughput tests)
+        // 2. Each query creates multiple spillable consumers (partitions)
+        // 3. The per-consumer share becomes too small to hold even batch_size groups
+        //
+        // GreedyMemoryPool uses first-come-first-served allocation, which:
+        // - Allows consumers to use available memory as needed
+        // - Triggers spilling when actual memory pressure occurs
+        // - Better handles variable concurrent workloads
+        Arc::new(TrackConsumersPool::new(GreedyMemoryPool::new(limit), topn))
     } else {
         let Some(topn) = NonZeroUsize::new(5) else {
             unreachable!("Memory pool TopN must be greater than 0");


### PR DESCRIPTION
## Problem

During throughput tests for clickbench using `federated/s3[parquet].yaml`, some queries (e.g., `clickbench_q17`) were failing with `ResourcesExhausted` errors:

```
Failed to process query stream: Tonic error: status: 'Internal error', self: "Shared DataFusion error: Resources exhausted: Additional allocation failed for GroupedHashAggregateStream[6] (count(1)) with top memory consumers (across reservations) as:
  GroupedHashAggregateStream[31] (count(1))#28230(can spill: true) consumed 70.1 MB, peak 70.1 MB,
  ...
Error: Failed to allocate additional 134.9 KB for GroupedHashAggregateStream[6] (count(1)) with 60.2 MB already allocated for this reservation - 57.0 MB remain available for the total pool"
```

## Root Cause

The runtime was using `FairSpillPool` for memory management, which divides available memory equally among all spillable consumers (`available = pool_size / num_spillable_consumers`).

During throughput tests with concurrent queries:
1. Multiple concurrent queries created many `GroupedHashAggregateStream` instances
2. Each stream registered as a spillable consumer with the pool
3. The "fair share" of memory per consumer became very small (e.g., ~70MB each with 32+ concurrent streams)
4. When a stream tried to allocate beyond its fair share, it received a `ResourcesExhausted` error
5. DataFusion's spill logic expects at least `batch_size` groups (8192) to fit in memory before spilling
6. When the fair share was too small for even `batch_size` groups, the error propagated and the query failed

## Solution

Changed from `FairSpillPool` to `GreedyMemoryPool`:

- **GreedyMemoryPool**: First-come-first-served allocation. Consumers can use as much memory as available until the pool is exhausted. When a consumer can't allocate more, it triggers spilling. This works better for concurrent workloads where memory usage varies dynamically.

- **FairSpillPool**: Best suited for scenarios where all spillable operators need to spill simultaneously and fairness is required. Not ideal for variable concurrent workloads.

## Trade-offs

- With `GreedyMemoryPool`, earlier queries may consume more memory, potentially causing later queries to spill sooner
- However, this is the expected behavior for most database workloads and better handles variable concurrent query patterns
- The total memory usage is still bounded by the pool limit, ensuring the system doesn't run out of memory