### PR TITLE
fix(testoperator): Increase health check latency threshold to reduce false positives

### DIFF
--- a/tools/testoperator/src/health.rs
+++ b/tools/testoperator/src/health.rs
@@ -30,7 +30,10 @@ use test_framework::{
 
 const ENDPOINTS: [&str; 2] = [HEALTH_ENDPOINT, READY_ENDPOINT];
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(100);
-const LATENCY_THRESHOLD: Duration = Duration::from_millis(50);
+
+// Use a large latency threshold for health endpoints as latency can spike when the CPU is fully utilized during
+// intensive benchmark runs. This reduces noise from false positives. See <https://github.com/spiceai/spiceai/issues/7766>
+const LATENCY_THRESHOLD: Duration = Duration::from_millis(125);
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct EndpointStats {
@@ -99,7 +102,7 @@ impl HealthMonitor {
         let task_token = cancel_token.clone();
 
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_millis(100))
+            .timeout(Duration::from_millis(200))
             .build()
             .context("Failed to create health monitor HTTP client")?;
 


### PR DESCRIPTION
## 📝 Summary

Benchmark tests frequently fail due to health check latency threshold violations during CPU-intensive runs. The current 50ms threshold is too aggressive when the system is under heavy load from benchmark queries (see https://github.com/spiceai/spiceai/issues/7766).

This change increases the latency threshold to `125ms` (based on my observations of previos failures) to reduce noise from false positive failures, allowing us to focus on actual issues rather than transient CPU spikes during benchmarks.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
