### PR TITLE
Update release notes: remove Cayenne `on_conflict` support

### DIFF
--- a/docs/release_notes/v1.11.0.md
+++ b/docs/release_notes/v1.11.0.md
@@ -13,7 +13,6 @@ This release also adds new **SMB, NFS, and ScyllaDB Data Connectors (Alpha)**, *
 **Key Enhancements**:
 
 - **Key-based Deletion Vectors**: Improved deletion vector support using key-based lookups for more efficient data management and faster delete operations. Key-based deletion vectors are more memory-efficient than positional vectors for sparse deletions.
-- **Primary Key On-Conflict Handling**: New `on_conflict` configuration for Cayenne tables with primary keys enables upsert behavior (`upsert` to replace existing rows) or duplicate-ignore behavior (`drop` to silently skip conflicting rows) during insert operations.
 - **S3 Express One Zone Support**: Store Cayenne data files in [S3 Express One Zone](https://aws.amazon.com/s3/storage-classes/express-one-zone/) for single-digit millisecond latency, ideal for latency-sensitive query workloads that require persistence.
 
 **Improved Reliability**:


### PR DESCRIPTION
## 📝 Summary

Update release notes: remove Cayenne `on_conflict` support due to https://github.com/spiceai/spiceai/issues/9183