### PR TITLE
Fix Databricks struct field names for reserved keywords

### DIFF
--- a/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
+++ b/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
@@ -256,7 +256,7 @@ impl<'input> Parser<'input> {
         Ok(ArrowDataType::Struct(fields.into()))
     }
 
-    fn token_is_identifier(&self, token: &Token<'input>) -> bool {
+    fn token_is_identifier(token: &Token<'input>) -> bool {
         matches!(
             token,
             Token::BigInt
@@ -289,7 +289,7 @@ impl<'input> Parser<'input> {
                 self.advance();
                 name.to_string()
             }
-            Some(Ok(token)) if self.token_is_identifier(&token) => {
+            Some(Ok(token)) if Self::token_is_identifier(&token) => {
                 let name = self.lexer.slice().to_string();
                 self.advance();
                 name

--- a/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
+++ b/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
@@ -256,12 +256,45 @@ impl<'input> Parser<'input> {
         Ok(ArrowDataType::Struct(fields.into()))
     }
 
+    fn token_is_identifier(&self, token: &Token<'input>) -> bool {
+        matches!(
+            token,
+            Token::BigInt
+                | Token::Binary
+                | Token::Boolean
+                | Token::Date
+                | Token::Decimal
+                | Token::Double
+                | Token::Float
+                | Token::Int
+                | Token::Void
+                | Token::SmallInt
+                | Token::String
+                | Token::Timestamp
+                | Token::TimestampNtz
+                | Token::TinyInt
+                | Token::Array
+                | Token::Map
+                | Token::Struct
+                | Token::Variant
+                | Token::Not
+                | Token::Null
+                | Token::Comment
+        )
+    }
+
     fn parse_field(&mut self) -> Result<ArrowField, String> {
-        let name = if let Some(Ok(Token::Identifier(name))) = self.current.clone() {
-            self.advance();
-            name.to_string()
-        } else {
-            return Err("Expected identifier for field name".to_string());
+        let name = match self.current.clone() {
+            Some(Ok(Token::Identifier(name))) => {
+                self.advance();
+                name.to_string()
+            }
+            Some(Ok(token)) if self.token_is_identifier(&token) => {
+                let name = self.lexer.slice().to_string();
+                self.advance();
+                name
+            }
+            _ => return Err("Expected identifier for field name".to_string()),
         };
         self.expect(&Token::Colon)?;
         let data_type = self.parse_data_type()?;
@@ -387,6 +420,23 @@ mod tests {
             let result = parser.parse().expect("parse success");
             assert_eq!(result, expected, "Failed for input: {input}");
         }
+    }
+
+    #[test]
+    fn test_struct_reserved_field_names() {
+        let input = "STRUCT<date: STRING, value: INT>";
+
+        let expected = ArrowDataType::Struct(
+            vec![
+                ArrowField::new("date", ArrowDataType::Utf8, true),
+                ArrowField::new("value", ArrowDataType::Int32, true),
+            ]
+            .into(),
+        );
+
+        let mut parser = Parser::new(input);
+        let result = parser.parse().expect("parse success");
+        assert_eq!(result, expected, "Failed for input: {input}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow reserved keyword tokens to be used as struct field names in the Databricks SQL Warehouse datatype parser
- add a regression test for reserved field names
- Closes #9181