### PR TITLE
Add UDTF serialization support for distributed Ballista execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15943,6 +15943,7 @@ dependencies = [
  "llms",
  "runtime-datafusion-index",
  "runtime-table-partition",
+ "serde",
  "serde_json",
  "snafu",
  "tantivy",

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/ensure_supported_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/ensure_supported_file_scan.rs
@@ -105,7 +105,7 @@ impl PhysicalOptimizerRule for EnsureSupportedFileScan {
 /// A visitor that collects `DataSourceExec` nodes for validation, skipping
 /// those that are children of `UdtfExec` nodes.
 struct DataSourceExecValidator {
-    /// Tracks how deep we are inside UdtfExec nodes (can be nested).
+    /// Tracks how deep we are inside `UdtfExec` nodes (can be nested).
     udtf_depth: usize,
     /// Accumulated validation result.
     result: Result<()>,
@@ -130,11 +130,12 @@ impl TreeNodeVisitor<'_> for DataSourceExecValidator {
         }
 
         // Only validate DataSourceExec nodes that are NOT inside a UdtfExec
-        if self.udtf_depth == 0 && concrete!(node, DataSourceExec).is_some() {
-            if let Err(e) = EnsureSupportedFileScan::validate(node) {
-                self.result = Err(e);
-                return Ok(TreeNodeRecursion::Stop);
-            }
+        if self.udtf_depth == 0
+            && concrete!(node, DataSourceExec).is_some()
+            && let Err(e) = EnsureSupportedFileScan::validate(node)
+        {
+            self.result = Err(e);
+            return Ok(TreeNodeRecursion::Stop);
         }
 
         Ok(TreeNodeRecursion::Continue)
@@ -168,7 +169,7 @@ mod tests {
     use std::any::Any;
     use std::fmt;
 
-    /// A mock execution plan that pretends to be UdtfExec for testing purposes.
+    /// A mock execution plan that pretends to be `UdtfExec` for testing purposes.
     #[derive(Debug)]
     struct MockUdtfExec {
         inner: Arc<dyn ExecutionPlan>,
@@ -295,7 +296,9 @@ mod tests {
             None
         }
 
-        fn cardinality_effect(&self) -> datafusion::physical_plan::execution_plan::CardinalityEffect {
+        fn cardinality_effect(
+            &self,
+        ) -> datafusion::physical_plan::execution_plan::CardinalityEffect {
             datafusion::physical_plan::execution_plan::CardinalityEffect::Equal
         }
 
@@ -324,10 +327,12 @@ mod tests {
 
         let result = optimizer.optimize(data_source_exec, &config);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("MemorySourceConfig cannot be distributed"));
+        assert!(
+            result
+                .expect_err("expected error for MemorySourceConfig")
+                .to_string()
+                .contains("MemorySourceConfig cannot be distributed")
+        );
     }
 
     #[test]

--- a/crates/datafusion-optimizer-rules/src/physical_plan/cluster/ensure_supported_file_scan.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/cluster/ensure_supported_file_scan.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2025-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::common::search_visitor::SearchVisitor;
 use crate::concrete;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion::common::{Result, plan_err};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
@@ -25,8 +25,20 @@ use datafusion_datasource::memory::MemorySourceConfig;
 use datafusion_datasource::source::DataSourceExec;
 use std::sync::Arc;
 
+/// Name of the `UdtfExec` execution plan.
+///
+/// We use name-based detection to avoid circular dependencies between
+/// `datafusion-optimizer-rules` and `runtime` crates.
+const UDTF_EXEC_NAME: &str = "UdtfExec";
+
 /// An optimizer to sanity check `DataSourceExec` encapsulate the kinds of plans
-/// we can distribute
+/// we can distribute.
+///
+/// This optimizer validates that all `DataSourceExec` nodes in the plan use
+/// file-based or remote data sources that can be serialized for distributed
+/// execution. In-memory sources (`MemorySourceConfig`) cannot be distributed
+/// unless they are part of a UDTF execution (wrapped in `UdtfExec`), which
+/// will be reconstructed on remote executors.
 #[derive(Debug, Clone)]
 pub struct EnsureSupportedFileScan {}
 
@@ -73,10 +85,10 @@ impl PhysicalOptimizerRule for EnsureSupportedFileScan {
         plan: Arc<dyn ExecutionPlan>,
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let _ = SearchVisitor::collect_concrete_down::<DataSourceExec>(&plan)?
-            .into_iter()
-            .map(|p| Self::validate(&p))
-            .collect::<Result<Vec<_>>>()?;
+        // Use a custom visitor that skips children of UdtfExec nodes
+        let mut visitor = DataSourceExecValidator::default();
+        plan.visit(&mut visitor)?;
+        visitor.result?;
 
         Ok(plan)
     }
@@ -87,5 +99,252 @@ impl PhysicalOptimizerRule for EnsureSupportedFileScan {
 
     fn schema_check(&self) -> bool {
         true
+    }
+}
+
+/// A visitor that collects `DataSourceExec` nodes for validation, skipping
+/// those that are children of `UdtfExec` nodes.
+struct DataSourceExecValidator {
+    /// Tracks how deep we are inside UdtfExec nodes (can be nested).
+    udtf_depth: usize,
+    /// Accumulated validation result.
+    result: Result<()>,
+}
+
+impl Default for DataSourceExecValidator {
+    fn default() -> Self {
+        Self {
+            udtf_depth: 0,
+            result: Ok(()),
+        }
+    }
+}
+
+impl TreeNodeVisitor<'_> for DataSourceExecValidator {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion> {
+        // Check if we're entering a UdtfExec
+        if node.name() == UDTF_EXEC_NAME {
+            self.udtf_depth += 1;
+        }
+
+        // Only validate DataSourceExec nodes that are NOT inside a UdtfExec
+        if self.udtf_depth == 0 && concrete!(node, DataSourceExec).is_some() {
+            if let Err(e) = EnsureSupportedFileScan::validate(node) {
+                self.result = Err(e);
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        }
+
+        Ok(TreeNodeRecursion::Continue)
+    }
+
+    fn f_up(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion> {
+        // Check if we're leaving a UdtfExec
+        if node.name() == UDTF_EXEC_NAME {
+            self.udtf_depth = self.udtf_depth.saturating_sub(1);
+        }
+
+        Ok(TreeNodeRecursion::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::common::Statistics;
+    use datafusion::config::ConfigOptions;
+    use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+    use datafusion::physical_expr::{EquivalenceProperties, OrderingRequirements};
+    use datafusion::physical_plan::execution_plan::InvariantLevel;
+    use datafusion::physical_plan::metrics::MetricsSet;
+    use datafusion::physical_plan::projection::ProjectionExec;
+    use datafusion::physical_plan::{
+        DisplayAs, DisplayFormatType, Distribution, ExecutionPlanProperties, PlanProperties,
+    };
+    use std::any::Any;
+    use std::fmt;
+
+    /// A mock execution plan that pretends to be UdtfExec for testing purposes.
+    #[derive(Debug)]
+    struct MockUdtfExec {
+        inner: Arc<dyn ExecutionPlan>,
+        properties: PlanProperties,
+    }
+
+    impl MockUdtfExec {
+        fn new(inner: Arc<dyn ExecutionPlan>) -> Self {
+            let schema = inner.schema();
+            let eq_properties = EquivalenceProperties::new(schema);
+            let properties = PlanProperties::new(
+                eq_properties,
+                inner.output_partitioning().clone(),
+                inner.pipeline_behavior(),
+                inner.boundedness(),
+            );
+            Self { inner, properties }
+        }
+    }
+
+    impl DisplayAs for MockUdtfExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "UdtfExec")
+        }
+    }
+
+    impl ExecutionPlan for MockUdtfExec {
+        fn name(&self) -> &'static str {
+            "UdtfExec" // Matches UDTF_EXEC_NAME
+        }
+
+        fn static_name() -> &'static str
+        where
+            Self: Sized,
+        {
+            "UdtfExec"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn properties(&self) -> &PlanProperties {
+            &self.properties
+        }
+
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![&self.inner]
+        }
+
+        fn with_new_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(MockUdtfExec::new(Arc::clone(&children[0]))))
+        }
+
+        fn execute(
+            &self,
+            partition: usize,
+            context: Arc<TaskContext>,
+        ) -> Result<SendableRecordBatchStream> {
+            self.inner.execute(partition, context)
+        }
+
+        fn statistics(&self) -> Result<Statistics> {
+            #[expect(deprecated)]
+            self.inner.statistics()
+        }
+
+        fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+            self.inner.partition_statistics(partition)
+        }
+
+        fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+
+        fn check_invariants(&self, level: InvariantLevel) -> Result<()> {
+            datafusion::physical_plan::execution_plan::check_default_invariants(self, level)
+        }
+
+        fn schema(&self) -> SchemaRef {
+            self.inner.schema()
+        }
+
+        fn required_input_distribution(&self) -> Vec<Distribution> {
+            vec![]
+        }
+
+        fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+            vec![]
+        }
+
+        fn maintains_input_order(&self) -> Vec<bool> {
+            vec![true]
+        }
+
+        fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+            vec![false]
+        }
+
+        fn repartitioned(
+            &self,
+            _target_partitions: usize,
+            _config: &ConfigOptions,
+        ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+            Ok(None)
+        }
+
+        fn metrics(&self) -> Option<MetricsSet> {
+            None
+        }
+
+        fn supports_limit_pushdown(&self) -> bool {
+            false
+        }
+
+        fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+            None
+        }
+
+        fn fetch(&self) -> Option<usize> {
+            None
+        }
+
+        fn cardinality_effect(&self) -> datafusion::physical_plan::execution_plan::CardinalityEffect {
+            datafusion::physical_plan::execution_plan::CardinalityEffect::Equal
+        }
+
+        fn try_swapping_with_projection(
+            &self,
+            _projection: &ProjectionExec,
+        ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+            Ok(None)
+        }
+    }
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    #[test]
+    fn test_memory_source_fails_without_udtf_wrapper() {
+        let schema = test_schema();
+        let batch = RecordBatch::new_empty(Arc::clone(&schema));
+        let memory_source =
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).expect("memory source");
+        let data_source_exec = Arc::new(DataSourceExec::new(Arc::new(memory_source)));
+
+        let optimizer = EnsureSupportedFileScan::new();
+        let config = ConfigOptions::default();
+
+        let result = optimizer.optimize(data_source_exec, &config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("MemorySourceConfig cannot be distributed"));
+    }
+
+    #[test]
+    fn test_memory_source_succeeds_with_udtf_wrapper() {
+        let schema = test_schema();
+        let batch = RecordBatch::new_empty(Arc::clone(&schema));
+        let memory_source =
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).expect("memory source");
+        let data_source_exec = Arc::new(DataSourceExec::new(Arc::new(memory_source)));
+
+        // Wrap in MockUdtfExec
+        let udtf_exec = Arc::new(MockUdtfExec::new(data_source_exec));
+
+        let optimizer = EnsureSupportedFileScan::new();
+        let config = ConfigOptions::default();
+
+        let result = optimizer.optimize(udtf_exec, &config);
+        assert!(result.is_ok(), "Expected success when wrapped in UdtfExec");
     }
 }

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -145,6 +145,16 @@ message BytesProcessedExecNode {}
 
 message CayenneAccelerationExecNode {}
 
+// Execution plan node for UDTFs.
+// This allows UDTF results to be distributed across a cluster by serializing
+// the UDTF arguments and re-invoking the UDTF on remote executors.
+message UdtfExecNode {
+    // The UDTF arguments needed to reconstruct the results.
+    UdtfArgs args = 1;
+    // The schema of the UDTF results (Arrow IPC-encoded Schema).
+    bytes schema = 2;
+}
+
 // UDTF (User-Defined Table Function) serialization for distributed execution.
 // These messages enable serializing UDTF-produced TableProviders so they can
 // be reconstructed on remote executors in a Ballista cluster.

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -144,3 +144,88 @@ message SchemaCastScanExecNode {
 message BytesProcessedExecNode {}
 
 message CayenneAccelerationExecNode {}
+
+// UDTF (User-Defined Table Function) serialization for distributed execution.
+// These messages enable serializing UDTF-produced TableProviders so they can
+// be reconstructed on remote executors in a Ballista cluster.
+
+// Top-level enum for all supported UDTF argument types.
+message UdtfArgs {
+    oneof args {
+        ListUdfsArgs list_udfs = 1;
+        TextSearchArgs text_search = 2;
+        VectorSearchArgs vector_search = 3;
+        RrfArgs rrf = 4;
+    }
+}
+
+// Arguments for list_udfs() - no arguments needed, marker message only.
+message ListUdfsArgs {}
+
+// Arguments for text_search(tbl, query, [col], [limit], [include_score]).
+message TextSearchArgs {
+    // The table reference as a string (e.g., "catalog.schema.table" or just "table").
+    string table = 1;
+    // The search query string.
+    string query = 2;
+    // Optional column to search on (if table has multiple searchable columns).
+    optional string column = 3;
+    // Optional limit on number of results.
+    optional uint64 limit = 4;
+    // Whether to include the score column in results (default: true).
+    optional bool include_score = 5;
+}
+
+// Arguments for vector_search(tbl, query, [col], [limit], [include_score]).
+message VectorSearchArgs {
+    // The table reference as a string.
+    string table = 1;
+    // The search query string (will be embedded).
+    string query = 2;
+    // Optional column containing embeddings to search.
+    optional string column = 3;
+    // Optional limit on number of results.
+    optional uint64 limit = 4;
+    // Whether to include the score column in results (default: true).
+    optional bool include_score = 5;
+}
+
+// Arguments for rrf(query1, query2, ..., [k], [join_key], [time_column], ...).
+message RrfArgs {
+    // Nested UDTF invocations (text_search or vector_search only).
+    repeated RrfNestedQuery queries = 1;
+    // RRF smoothing parameter (default: 60.0).
+    optional double k = 2;
+    // Column name to use for joining results instead of auto-generated row ID.
+    optional string join_key = 3;
+    // Column name containing timestamps for recency boosting.
+    optional string time_column = 4;
+    // Type of decay function: "linear" or "exponential" (default: "exponential").
+    optional string recency_decay = 5;
+    // Decay rate constant for exponential decay (default: 0.01).
+    optional double decay_constant = 6;
+    // Time scale in seconds for decay calculation (default: 86400).
+    optional int64 decay_scale_secs = 7;
+    // Window size for linear decay function (default: 86400).
+    optional int64 decay_window_secs = 8;
+}
+
+// A nested query within an RRF invocation.
+message RrfNestedQuery {
+    oneof query {
+        RrfTextSearchQuery text_search = 1;
+        RrfVectorSearchQuery vector_search = 2;
+    }
+}
+
+// A nested text_search invocation with optional rank weight.
+message RrfTextSearchQuery {
+    TextSearchArgs args = 1;
+    optional double rank_weight = 2;
+}
+
+// A nested vector_search invocation with optional rank weight.
+message RrfVectorSearchQuery {
+    VectorSearchArgs args = 1;
+    optional double rank_weight = 2;
+}

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -205,9 +205,9 @@ message RrfArgs {
     // Decay rate constant for exponential decay (default: 0.01).
     optional double decay_constant = 6;
     // Time scale in seconds for decay calculation (default: 86400).
-    optional int64 decay_scale_secs = 7;
+    optional double decay_scale_secs = 7;
     // Window size for linear decay function (default: 86400).
-    optional int64 decay_window_secs = 8;
+    optional double decay_window_secs = 8;
 }
 
 // A nested query within an RRF invocation.

--- a/crates/runtime/src/cluster/datafusion/codec/mod.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/mod.rs
@@ -16,3 +16,4 @@ limitations under the License.
 
 pub mod spice_logical_codec;
 pub mod spice_physical_codec;
+pub mod udtf_args;

--- a/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
@@ -84,7 +84,7 @@ impl SpiceLogicalCodec {
 
     /// Reconstructs a UDTF-produced `TableProvider` by re-invoking the UDTF with
     /// the serialized arguments.
-    fn invoke_udtf(udtf_args: UdtfArgs, runtime: &Arc<Runtime>) -> Result<Arc<dyn TableProvider>> {
+    pub fn invoke_udtf(udtf_args: UdtfArgs, runtime: &Arc<Runtime>) -> Result<Arc<dyn TableProvider>> {
         use datafusion::catalog::TableFunctionImpl;
 
         let Some(args) = udtf_args.args else {

--- a/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
@@ -84,7 +84,10 @@ impl SpiceLogicalCodec {
 
     /// Reconstructs a UDTF-produced `TableProvider` by re-invoking the UDTF with
     /// the serialized arguments.
-    pub fn invoke_udtf(udtf_args: UdtfArgs, runtime: &Arc<Runtime>) -> Result<Arc<dyn TableProvider>> {
+    pub(crate) fn invoke_udtf(
+        udtf_args: UdtfArgs,
+        runtime: &Arc<Runtime>,
+    ) -> Result<Arc<dyn TableProvider>> {
         use datafusion::catalog::TableFunctionImpl;
 
         let Some(args) = udtf_args.args else {
@@ -138,7 +141,7 @@ impl SpiceLogicalCodec {
         // Convert nested queries to expressions
         for nested in &rrf_args.queries {
             let Some(query) = &nested.query else {
-                continue;
+                return exec_err!("RRF nested query missing query field");
             };
 
             let (search_exprs, rank_weight) = match query {
@@ -355,12 +358,13 @@ impl LogicalExtensionCodec for SpiceLogicalCodec {
 
         // Check for VectorSearchUDTFProvider (vector_search without index)
         if let Some(vector_provider) = any.downcast_ref::<VectorSearchUDTFProvider>() {
+            let provider_args = vector_provider.args();
             let args = UdtfArgs::vector_search(VectorSearchArgs {
-                table: vector_provider.args.tbl.to_string(),
-                query: vector_provider.args.query.clone(),
-                column: vector_provider.args.column.clone(),
-                limit: vector_provider.args.limit.map(|l| l as u64),
-                include_score: vector_provider.args.include_score,
+                table: provider_args.tbl.to_string(),
+                query: provider_args.query.clone(),
+                column: provider_args.column.clone(),
+                limit: provider_args.limit.map(|l| l as u64),
+                include_score: provider_args.include_score,
             });
             buf.extend_from_slice(&args.encode_to_vec());
             return Ok(());

--- a/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2025-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,14 +15,29 @@ limitations under the License.
 */
 
 use crate::Runtime;
+use crate::cluster::datafusion::codec::udtf_args::{
+    RrfArgs, TextSearchArgs, UdtfArgs, UdtfArgsExt, VectorSearchArgs,
+};
+use crate::embeddings::udtf::{
+    VectorSearchTableFunc, VectorSearchTableFuncArgs, VectorSearchUDTFProvider,
+};
+use crate::search::full_text::udtf::{TextSearchTableFunc, TextSearchTableFuncArgs};
+use crate::search::rrf::ReciprocalRankFusion;
+use crate::udtfs::{ListUDFTable, ListUDFTableFunc};
 use arrow_schema::SchemaRef;
 use ballista_core::serde::BallistaLogicalExtensionCodec;
 use datafusion::catalog::TableProvider;
-use datafusion::common::{DataFusionError, Result, TableReference, exec_err};
+use datafusion::common::{DataFusionError, Result, ScalarValue, TableReference, exec_err};
 use datafusion::execution::TaskContext;
+use datafusion::sql::TableReference as SqlTableReference;
 use datafusion_expr::registry::FunctionRegistry;
 use datafusion_expr::{Extension, LogicalPlan, ScalarUDF};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
+use prost::Message;
+use runtime_proto::rrf_nested_query::Query;
+use runtime_proto::udtf_args::Args;
+use search::provider::{SearchQueryProvider, UdtfSource};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -60,6 +75,175 @@ impl SpiceLogicalCodec {
             "SpiceLogicalCodec did not bind a Runtime handle. Report this bug on GitHub: https://github.com/spiceai/spiceai/issues".to_string(),
         ))
     }
+
+    /// Reconstructs a UDTF-produced `TableProvider` by re-invoking the UDTF with
+    /// the serialized arguments.
+    #[allow(clippy::cast_possible_truncation)]
+    fn invoke_udtf(
+        &self,
+        udtf_args: UdtfArgs,
+        runtime: &Arc<Runtime>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        use datafusion::catalog::TableFunctionImpl;
+
+        let Some(args) = udtf_args.args else {
+            return exec_err!("UDTF args missing inner args field");
+        };
+
+        match args {
+            Args::ListUdfs(_) => {
+                let udtf = ListUDFTableFunc::new(Arc::clone(&runtime.df.ctx));
+                udtf.call(&[])
+            }
+            Args::TextSearch(text_args) => {
+                let udtf = TextSearchTableFunc::new(Arc::downgrade(&runtime.df));
+                let exprs = TextSearchTableFunc::to_expr(&TextSearchTableFuncArgs {
+                    tbl: SqlTableReference::parse_str(&text_args.table),
+                    query: text_args.query,
+                    column: text_args.column,
+                    limit: text_args.limit.map(|l| l as usize),
+                    include_score: text_args.include_score,
+                });
+                udtf.call(&exprs)
+            }
+            Args::VectorSearch(vector_args) => {
+                let udtf = VectorSearchTableFunc::new(
+                    Arc::downgrade(&runtime.df),
+                    HashMap::new(), // explicit_pks - will be inferred from table
+                );
+                let exprs = VectorSearchTableFunc::to_expr(&VectorSearchTableFuncArgs {
+                    tbl: SqlTableReference::parse_str(&vector_args.table),
+                    query: vector_args.query,
+                    column: vector_args.column,
+                    limit: vector_args.limit.map(|l| l as usize),
+                    include_score: vector_args.include_score,
+                });
+                udtf.call(&exprs)
+            }
+            Args::Rrf(rrf_args) => self.invoke_rrf(rrf_args, runtime),
+        }
+    }
+
+    /// Reconstructs an RRF (Reciprocal Rank Fusion) `TableProvider` by re-invoking
+    /// the nested search UDTFs and then the RRF UDTF.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    fn invoke_rrf(
+        &self,
+        rrf_args: RrfArgs,
+        runtime: &Arc<Runtime>,
+    ) -> Result<Arc<dyn TableProvider>> {
+        use datafusion::catalog::TableFunctionImpl;
+        use datafusion::logical_expr::expr::FieldMetadata;
+        use datafusion::prelude::Expr;
+        use std::collections::BTreeMap;
+
+        let mut exprs: Vec<Expr> = Vec::new();
+
+        // Convert nested queries to expressions
+        for nested in &rrf_args.queries {
+            let Some(query) = &nested.query else {
+                continue;
+            };
+
+            let (search_exprs, rank_weight) = match query {
+                Query::TextSearch(ts) => {
+                    let Some(args) = &ts.args else {
+                        return exec_err!("TextSearch nested query missing args");
+                    };
+                    let text_exprs = TextSearchTableFunc::to_expr(&TextSearchTableFuncArgs {
+                        tbl: SqlTableReference::parse_str(&args.table),
+                        query: args.query.clone(),
+                        column: args.column.clone(),
+                        limit: args.limit.map(|l| l as usize),
+                        include_score: args.include_score,
+                    });
+                    (text_exprs, ts.rank_weight)
+                }
+                Query::VectorSearch(vs) => {
+                    let Some(args) = &vs.args else {
+                        return exec_err!("VectorSearch nested query missing args");
+                    };
+                    let vector_exprs = VectorSearchTableFunc::to_expr(&VectorSearchTableFuncArgs {
+                        tbl: SqlTableReference::parse_str(&args.table),
+                        query: args.query.clone(),
+                        column: args.column.clone(),
+                        limit: args.limit.map(|l| l as usize),
+                        include_score: args.include_score,
+                    });
+                    (vector_exprs, vs.rank_weight)
+                }
+            };
+
+            // Add rank_weight as a named parameter if specified
+            let mut final_exprs = search_exprs;
+            if let Some(weight) = rank_weight {
+                let meta = FieldMetadata::new(BTreeMap::from([(
+                    "spice.parameter_name".to_string(),
+                    "rank_weight".to_string(),
+                )]));
+                let weight_expr = Expr::Literal(ScalarValue::Float64(Some(weight)), Some(meta));
+                final_exprs.push(weight_expr);
+            }
+            exprs.extend(final_exprs);
+        }
+
+        // Add RRF named parameters
+        if let Some(k) = rrf_args.k {
+            exprs.push(Self::named_literal("k", ScalarValue::Float64(Some(k))));
+        }
+        if let Some(join_key) = &rrf_args.join_key {
+            exprs.push(Self::named_literal(
+                "join_key",
+                ScalarValue::Utf8(Some(join_key.clone())),
+            ));
+        }
+        if let Some(time_column) = &rrf_args.time_column {
+            exprs.push(Self::named_literal(
+                "time_column",
+                ScalarValue::Utf8(Some(time_column.clone())),
+            ));
+        }
+        if let Some(recency_decay) = &rrf_args.recency_decay {
+            exprs.push(Self::named_literal(
+                "recency_decay",
+                ScalarValue::Utf8(Some(recency_decay.clone())),
+            ));
+        }
+        if let Some(decay_constant) = rrf_args.decay_constant {
+            exprs.push(Self::named_literal(
+                "decay_constant",
+                ScalarValue::Float64(Some(decay_constant)),
+            ));
+        }
+        if let Some(decay_scale_secs) = rrf_args.decay_scale_secs {
+            exprs.push(Self::named_literal(
+                "decay_scale_secs",
+                ScalarValue::Float64(Some(decay_scale_secs as f64)),
+            ));
+        }
+        if let Some(decay_window_secs) = rrf_args.decay_window_secs {
+            exprs.push(Self::named_literal(
+                "decay_window_secs",
+                ScalarValue::Float64(Some(decay_window_secs as f64)),
+            ));
+        }
+
+        // Invoke the RRF UDTF
+        let rrf_udtf = ReciprocalRankFusion::from_ctx(&runtime.df.ctx);
+        rrf_udtf.call(&exprs)
+    }
+
+    /// Creates a literal expression with spice.parameter_name metadata.
+    fn named_literal(name: &str, value: ScalarValue) -> datafusion::prelude::Expr {
+        use datafusion::logical_expr::expr::FieldMetadata;
+        use std::collections::BTreeMap;
+
+        let meta = FieldMetadata::new(BTreeMap::from([(
+            "spice.parameter_name".to_string(),
+            name.to_string(),
+        )]));
+        datafusion::prelude::Expr::Literal(value, Some(meta))
+    }
 }
 
 impl LogicalExtensionCodec for SpiceLogicalCodec {
@@ -93,31 +277,109 @@ impl LogicalExtensionCodec for SpiceLogicalCodec {
         Ok(())
     }
 
-    // Look up the table ref in the context instead of ser/de
+    // Look up the table ref in the context or reconstruct UDTF-produced providers
     fn try_decode_table_provider(
         &self,
-        _buf: &[u8],
+        buf: &[u8],
         table_ref: &TableReference,
         _schema: SchemaRef,
         _ctx: &TaskContext,
     ) -> Result<Arc<dyn TableProvider>> {
-        if let Some(table_provider) = self.runtime()?.df.get_table_sync(table_ref) {
-            Ok(table_provider)
-        } else {
-            exec_err!(
-                "SpiceLogicalCodec could not resolve table reference {}. Report this bug on GitHub: https://github.com/spiceai/spiceai/issues",
-                table_ref
-            )
+        let runtime = self.runtime()?;
+
+        // Try to deserialize as UDTF args first (using protobuf)
+        if !buf.is_empty()
+            && let Ok(udtf_args) = UdtfArgs::decode(buf)
+        {
+            return self.invoke_udtf(udtf_args, &runtime);
         }
+
+        // Fall back to regular table lookup
+        if let Some(table_provider) = runtime.df.get_table_sync(table_ref) {
+            return Ok(table_provider);
+        }
+
+        exec_err!(
+            "SpiceLogicalCodec could not resolve table reference {}. Report this bug on GitHub: https://github.com/spiceai/spiceai/issues",
+            table_ref
+        )
     }
 
-    // no-op
+    // Encode UDTF-produced table providers for distributed execution (using protobuf)
     fn try_encode_table_provider(
         &self,
         _table_ref: &TableReference,
-        _node: Arc<dyn TableProvider>,
-        _buf: &mut Vec<u8>,
+        node: Arc<dyn TableProvider>,
+        buf: &mut Vec<u8>,
     ) -> Result<()> {
+        let any = node.as_any();
+
+        // Check for ListUDFTable
+        if any.downcast_ref::<ListUDFTable>().is_some() {
+            let args = UdtfArgs::list_udfs();
+            buf.extend_from_slice(&args.encode_to_vec());
+            return Ok(());
+        }
+
+        // Check for SearchQueryProvider (text_search/vector_search via index)
+        if let Some(search_provider) = any.downcast_ref::<SearchQueryProvider>()
+            && let Some(source) = &search_provider.udtf_source
+        {
+            let args = match source {
+                UdtfSource::TextSearch {
+                    table,
+                    query,
+                    column,
+                    limit,
+                    include_score,
+                } => UdtfArgs::text_search(TextSearchArgs {
+                    table: table.clone(),
+                    query: query.clone(),
+                    column: column.clone(),
+                    limit: limit.map(|l| l as u64),
+                    include_score: *include_score,
+                }),
+                UdtfSource::VectorSearch {
+                    table,
+                    query,
+                    column,
+                    limit,
+                    include_score,
+                } => UdtfArgs::vector_search(VectorSearchArgs {
+                    table: table.clone(),
+                    query: query.clone(),
+                    column: column.clone(),
+                    limit: limit.map(|l| l as u64),
+                    include_score: *include_score,
+                }),
+            };
+            buf.extend_from_slice(&args.encode_to_vec());
+            return Ok(());
+        }
+
+        // Check for VectorSearchUDTFProvider (vector_search without index)
+        if let Some(vector_provider) = any.downcast_ref::<VectorSearchUDTFProvider>() {
+            let args = UdtfArgs::vector_search(VectorSearchArgs {
+                table: vector_provider.args.tbl.to_string(),
+                query: vector_provider.args.query.clone(),
+                column: vector_provider.args.column.clone(),
+                limit: vector_provider.args.limit.map(|l| l as u64),
+                include_score: vector_provider.args.include_score,
+            });
+            buf.extend_from_slice(&args.encode_to_vec());
+            return Ok(());
+        }
+
+        // Check for ReciprocalRankFusion (rrf)
+        if let Some(rrf_provider) = any.downcast_ref::<ReciprocalRankFusion>()
+            && let Some(source) = &rrf_provider.rrf_source
+        {
+            let args = UdtfArgs::rrf(source.clone());
+            buf.extend_from_slice(&args.encode_to_vec());
+            return Ok(());
+        }
+
+        // Fall through for regular tables - no-op
         Ok(())
     }
 

--- a/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
@@ -76,14 +76,15 @@ impl SpiceLogicalCodec {
         ))
     }
 
+    fn limit_from_u64(value: u64) -> Result<usize> {
+        usize::try_from(value).map_err(|_| {
+            DataFusionError::Plan(format!("UDTF limit value {value} exceeds usize range."))
+        })
+    }
+
     /// Reconstructs a UDTF-produced `TableProvider` by re-invoking the UDTF with
     /// the serialized arguments.
-    #[allow(clippy::cast_possible_truncation)]
-    fn invoke_udtf(
-        &self,
-        udtf_args: UdtfArgs,
-        runtime: &Arc<Runtime>,
-    ) -> Result<Arc<dyn TableProvider>> {
+    fn invoke_udtf(udtf_args: UdtfArgs, runtime: &Arc<Runtime>) -> Result<Arc<dyn TableProvider>> {
         use datafusion::catalog::TableFunctionImpl;
 
         let Some(args) = udtf_args.args else {
@@ -101,7 +102,7 @@ impl SpiceLogicalCodec {
                     tbl: SqlTableReference::parse_str(&text_args.table),
                     query: text_args.query,
                     column: text_args.column,
-                    limit: text_args.limit.map(|l| l as usize),
+                    limit: text_args.limit.map(Self::limit_from_u64).transpose()?,
                     include_score: text_args.include_score,
                 });
                 udtf.call(&exprs)
@@ -115,23 +116,18 @@ impl SpiceLogicalCodec {
                     tbl: SqlTableReference::parse_str(&vector_args.table),
                     query: vector_args.query,
                     column: vector_args.column,
-                    limit: vector_args.limit.map(|l| l as usize),
+                    limit: vector_args.limit.map(Self::limit_from_u64).transpose()?,
                     include_score: vector_args.include_score,
                 });
                 udtf.call(&exprs)
             }
-            Args::Rrf(rrf_args) => self.invoke_rrf(rrf_args, runtime),
+            Args::Rrf(rrf_args) => Self::invoke_rrf(&rrf_args, runtime),
         }
     }
 
     /// Reconstructs an RRF (Reciprocal Rank Fusion) `TableProvider` by re-invoking
     /// the nested search UDTFs and then the RRF UDTF.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-    fn invoke_rrf(
-        &self,
-        rrf_args: RrfArgs,
-        runtime: &Arc<Runtime>,
-    ) -> Result<Arc<dyn TableProvider>> {
+    fn invoke_rrf(rrf_args: &RrfArgs, runtime: &Arc<Runtime>) -> Result<Arc<dyn TableProvider>> {
         use datafusion::catalog::TableFunctionImpl;
         use datafusion::logical_expr::expr::FieldMetadata;
         use datafusion::prelude::Expr;
@@ -154,7 +150,7 @@ impl SpiceLogicalCodec {
                         tbl: SqlTableReference::parse_str(&args.table),
                         query: args.query.clone(),
                         column: args.column.clone(),
-                        limit: args.limit.map(|l| l as usize),
+                        limit: args.limit.map(Self::limit_from_u64).transpose()?,
                         include_score: args.include_score,
                     });
                     (text_exprs, ts.rank_weight)
@@ -167,7 +163,7 @@ impl SpiceLogicalCodec {
                         tbl: SqlTableReference::parse_str(&args.table),
                         query: args.query.clone(),
                         column: args.column.clone(),
-                        limit: args.limit.map(|l| l as usize),
+                        limit: args.limit.map(Self::limit_from_u64).transpose()?,
                         include_score: args.include_score,
                     });
                     (vector_exprs, vs.rank_weight)
@@ -218,13 +214,13 @@ impl SpiceLogicalCodec {
         if let Some(decay_scale_secs) = rrf_args.decay_scale_secs {
             exprs.push(Self::named_literal(
                 "decay_scale_secs",
-                ScalarValue::Float64(Some(decay_scale_secs as f64)),
+                ScalarValue::Float64(Some(decay_scale_secs)),
             ));
         }
         if let Some(decay_window_secs) = rrf_args.decay_window_secs {
             exprs.push(Self::named_literal(
                 "decay_window_secs",
-                ScalarValue::Float64(Some(decay_window_secs as f64)),
+                ScalarValue::Float64(Some(decay_window_secs)),
             ));
         }
 
@@ -233,7 +229,7 @@ impl SpiceLogicalCodec {
         rrf_udtf.call(&exprs)
     }
 
-    /// Creates a literal expression with spice.parameter_name metadata.
+    /// Creates a literal expression with `spice.parameter_name` metadata.
     fn named_literal(name: &str, value: ScalarValue) -> datafusion::prelude::Expr {
         use datafusion::logical_expr::expr::FieldMetadata;
         use std::collections::BTreeMap;
@@ -291,7 +287,7 @@ impl LogicalExtensionCodec for SpiceLogicalCodec {
         if !buf.is_empty()
             && let Ok(udtf_args) = UdtfArgs::decode(buf)
         {
-            return self.invoke_udtf(udtf_args, &runtime);
+            return Self::invoke_udtf(udtf_args, &runtime);
         }
 
         // Fall back to regular table lookup

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2025-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use crate::Runtime;
+use crate::execution_plan::UdtfExec;
 use crate::metrics::telemetry::track_bytes_processed;
 use arrow_schema::Schema;
 use ballista_core::serde::BallistaPhysicalExtensionCodec;
@@ -29,9 +30,13 @@ use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
-use runtime_proto::{BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode};
+use runtime_proto::{
+    BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode, UdtfExecNode,
+};
 use std::fmt::Debug;
 use std::sync::Arc;
+
+use super::spice_logical_codec::SpiceLogicalCodec;
 
 /// Serialization support for custom Spice execution nodes
 pub struct SpicePhysicalCodec {
@@ -101,6 +106,25 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             {
                 exec_err!("CayenneAccelerationExec is not supported on Windows")
             }
+        } else if let Ok(node) = UdtfExecNode::decode(buf) {
+            // Decode the UdtfExec by re-invoking the UDTF
+            let runtime = self.runtime()?;
+            let Some(args) = node.args else {
+                return exec_err!("UdtfExecNode missing args");
+            };
+
+            // Re-invoke the UDTF to get the TableProvider
+            let table_provider = SpiceLogicalCodec::invoke_udtf(args.clone(), &runtime)?;
+
+            // Get the execution plan from the TableProvider using the runtime's session state
+            let session_state = runtime.df.ctx.state();
+            let inner_plan = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    table_provider.scan(&session_state, None, &[], None).await
+                })
+            })?;
+
+            Ok(Arc::new(UdtfExec::new(args, inner_plan)))
         } else {
             exec_err!("Cannot deserialize unknown execution plan")
         }
@@ -119,6 +143,20 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         } else if node.as_any().downcast_ref::<BytesProcessedExec>().is_some() {
             let node = BytesProcessedExecNode {};
+            node.encode(buf)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        } else if let Some(udtf_exec) = node.as_any().downcast_ref::<UdtfExec>() {
+            // Serialize the UdtfExec with its args and schema
+            let mut schema_buf = vec![];
+            let serialized_schema = datafusion_common::Schema::try_from(udtf_exec.schema())?;
+            serialized_schema
+                .encode(&mut schema_buf)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            let node = UdtfExecNode {
+                args: Some(udtf_exec.args().clone()),
+                schema: schema_buf,
+            };
             node.encode(buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         } else {

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -118,10 +118,13 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 
             // Get the execution plan from the TableProvider using the runtime's session state
             let session_state = runtime.df.ctx.state();
+            // NOTE: The codec deserialization API is synchronous, but DataFusion's
+            // TableProvider::scan is async. To reconstruct the physical plan we must
+            // synchronously wait for the scan to complete. This path is only taken during
+            // plan deserialization on executor startup, so the blocking cost is acceptable.
             let inner_plan = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    table_provider.scan(&session_state, None, &[], None).await
-                })
+                tokio::runtime::Handle::current()
+                    .block_on(async { table_provider.scan(&session_state, None, &[], None).await })
             })?;
 
             Ok(Arc::new(UdtfExec::new(args, inner_plan)))

--- a/crates/runtime/src/cluster/datafusion/codec/udtf_args.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/udtf_args.rs
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Serializable argument types for UDTFs (User-Defined Table Functions).
+//!
+//! This module re-exports the protobuf-generated types from `runtime_proto` and
+//! provides convenience conversions for UDTF arguments during distributed query
+//! execution with Ballista.
+//!
+//! When a query containing a UDTF is distributed across a cluster, the UDTF
+//! arguments are serialized using protobuf and sent to executors so they can
+//! reconstruct the `TableProvider`.
+
+// Re-export the protobuf types for use in the codec
+pub use runtime_proto::{
+    ListUdfsArgs, RrfArgs, RrfNestedQuery, RrfTextSearchQuery, RrfVectorSearchQuery,
+    TextSearchArgs, UdtfArgs, VectorSearchArgs,
+};
+
+use runtime_proto::rrf_nested_query::Query;
+use runtime_proto::udtf_args::Args;
+
+/// Extension trait for `UdtfArgs` to provide convenient construction.
+pub trait UdtfArgsExt {
+    /// Create a `ListUdfs` variant.
+    fn list_udfs() -> UdtfArgs;
+
+    /// Create a `TextSearch` variant.
+    fn text_search(args: TextSearchArgs) -> UdtfArgs;
+
+    /// Create a `VectorSearch` variant.
+    fn vector_search(args: VectorSearchArgs) -> UdtfArgs;
+
+    /// Create an `Rrf` variant.
+    fn rrf(args: RrfArgs) -> UdtfArgs;
+}
+
+impl UdtfArgsExt for UdtfArgs {
+    fn list_udfs() -> UdtfArgs {
+        UdtfArgs {
+            args: Some(Args::ListUdfs(ListUdfsArgs {})),
+        }
+    }
+
+    fn text_search(args: TextSearchArgs) -> UdtfArgs {
+        UdtfArgs {
+            args: Some(Args::TextSearch(args)),
+        }
+    }
+
+    fn vector_search(args: VectorSearchArgs) -> UdtfArgs {
+        UdtfArgs {
+            args: Some(Args::VectorSearch(args)),
+        }
+    }
+
+    fn rrf(args: RrfArgs) -> UdtfArgs {
+        UdtfArgs {
+            args: Some(Args::Rrf(args)),
+        }
+    }
+}
+
+/// Extension trait for `RrfNestedQuery` to provide convenient construction.
+pub trait RrfNestedQueryExt {
+    /// Create a text search nested query.
+    fn text_search(args: TextSearchArgs, rank_weight: Option<f64>) -> RrfNestedQuery;
+
+    /// Create a vector search nested query.
+    fn vector_search(args: VectorSearchArgs, rank_weight: Option<f64>) -> RrfNestedQuery;
+}
+
+impl RrfNestedQueryExt for RrfNestedQuery {
+    fn text_search(args: TextSearchArgs, rank_weight: Option<f64>) -> RrfNestedQuery {
+        RrfNestedQuery {
+            query: Some(Query::TextSearch(RrfTextSearchQuery {
+                args: Some(args),
+                rank_weight,
+            })),
+        }
+    }
+
+    fn vector_search(args: VectorSearchArgs, rank_weight: Option<f64>) -> RrfNestedQuery {
+        RrfNestedQuery {
+            query: Some(Query::VectorSearch(RrfVectorSearchQuery {
+                args: Some(args),
+                rank_weight,
+            })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn test_list_udfs_serialization() {
+        let args = UdtfArgs::list_udfs();
+        let bytes = args.encode_to_vec();
+        let deserialized = UdtfArgs::decode(bytes.as_slice()).expect("decode");
+        assert!(matches!(deserialized.args, Some(Args::ListUdfs(_))));
+    }
+
+    #[test]
+    fn test_text_search_serialization() {
+        let args = UdtfArgs::text_search(TextSearchArgs {
+            table: "my_catalog.my_schema.my_table".to_string(),
+            query: "hello world".to_string(),
+            column: Some("content".to_string()),
+            limit: Some(10),
+            include_score: Some(true),
+        });
+        let bytes = args.encode_to_vec();
+        let deserialized = UdtfArgs::decode(bytes.as_slice()).expect("decode");
+
+        if let Some(Args::TextSearch(text_args)) = deserialized.args {
+            assert_eq!(text_args.table, "my_catalog.my_schema.my_table");
+            assert_eq!(text_args.query, "hello world");
+            assert_eq!(text_args.column, Some("content".to_string()));
+            assert_eq!(text_args.limit, Some(10));
+            assert_eq!(text_args.include_score, Some(true));
+        } else {
+            panic!("Expected TextSearch variant");
+        }
+    }
+
+    #[test]
+    fn test_vector_search_serialization() {
+        let args = UdtfArgs::vector_search(VectorSearchArgs {
+            table: "embeddings_table".to_string(),
+            query: "semantic query".to_string(),
+            column: None,
+            limit: Some(5),
+            include_score: None,
+        });
+        let bytes = args.encode_to_vec();
+        let deserialized = UdtfArgs::decode(bytes.as_slice()).expect("decode");
+
+        if let Some(Args::VectorSearch(vector_args)) = deserialized.args {
+            assert_eq!(vector_args.table, "embeddings_table");
+            assert_eq!(vector_args.query, "semantic query");
+            assert_eq!(vector_args.column, None);
+            assert_eq!(vector_args.limit, Some(5));
+            assert_eq!(vector_args.include_score, None);
+        } else {
+            panic!("Expected VectorSearch variant");
+        }
+    }
+
+    #[test]
+    fn test_rrf_serialization() {
+        let args = UdtfArgs::rrf(RrfArgs {
+            queries: vec![
+                RrfNestedQuery::text_search(
+                    TextSearchArgs {
+                        table: "docs".to_string(),
+                        query: "rust programming".to_string(),
+                        column: None,
+                        limit: Some(10),
+                        include_score: Some(true),
+                    },
+                    Some(1.0),
+                ),
+                RrfNestedQuery::vector_search(
+                    VectorSearchArgs {
+                        table: "docs".to_string(),
+                        query: "rust programming".to_string(),
+                        column: Some("embedding".to_string()),
+                        limit: Some(10),
+                        include_score: Some(true),
+                    },
+                    Some(2.0),
+                ),
+            ],
+            k: Some(60.0),
+            join_key: Some("id".to_string()),
+            time_column: None,
+            recency_decay: None,
+            decay_constant: None,
+            decay_scale_secs: None,
+            decay_window_secs: None,
+        });
+        let bytes = args.encode_to_vec();
+        let deserialized = UdtfArgs::decode(bytes.as_slice()).expect("decode");
+
+        if let Some(Args::Rrf(rrf_args)) = deserialized.args {
+            assert_eq!(rrf_args.queries.len(), 2);
+            assert_eq!(rrf_args.k, Some(60.0));
+            assert_eq!(rrf_args.join_key, Some("id".to_string()));
+        } else {
+            panic!("Expected Rrf variant");
+        }
+    }
+}

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -81,9 +81,11 @@ use runtime_request_context::{AsyncMarker, RequestContext};
 
 #[cfg(feature = "s3_vectors")]
 use {
-    crate::search::util::find_index_in_table_provider, search::index::SearchIndex,
-    search::index::chunking::ChunkedSearchIndex, search::index::s3_vectors::S3Vector,
-    search::provider::SearchQueryProvider,
+    crate::search::util::find_index_in_table_provider,
+    search::index::SearchIndex,
+    search::index::chunking::ChunkedSearchIndex,
+    search::index::s3_vectors::S3Vector,
+    search::provider::{SearchQueryProvider, UdtfSource},
 };
 
 use tokio::sync::RwLock;
@@ -404,6 +406,13 @@ impl VectorSearchTableFunc {
                 args.query.as_str(),
                 args.limit,
             )?
+            .with_udtf_source(UdtfSource::VectorSearch {
+                table: args.tbl.to_string(),
+                query: args.query.clone(),
+                column: args.column.clone(),
+                limit: args.limit,
+                include_score: args.include_score,
+            })
             .call_on_scan(Arc::new(|| {
                 async {
                     let request_context = RequestContext::current(AsyncMarker::new().await);
@@ -515,8 +524,11 @@ impl ScalarUDFImpl for VectorSearchTableFunc {
 }
 
 /// The [`TableProvider`] produced from the [`VECTOR_SEARCH_UDTF_NAME`] UDTF.
+///
+/// This provider computes vector similarity scores on-the-fly using the embedding model,
+/// without relying on a pre-built vector index.
 #[derive(Debug, Clone)]
-pub(super) struct VectorSearchUDTFProvider {
+pub struct VectorSearchUDTFProvider {
     pub args: VectorSearchTableFuncArgs,
     underlying: Arc<dyn TableProvider>,
     embedded_columns: HashMap<String, EmbeddingColumnConfig>,

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -529,13 +529,19 @@ impl ScalarUDFImpl for VectorSearchTableFunc {
 /// without relying on a pre-built vector index.
 #[derive(Debug, Clone)]
 pub struct VectorSearchUDTFProvider {
-    pub args: VectorSearchTableFuncArgs,
+    args: VectorSearchTableFuncArgs,
     underlying: Arc<dyn TableProvider>,
     embedded_columns: HashMap<String, EmbeddingColumnConfig>,
     embedding_models: Arc<RwLock<EmbeddingModelStore>>,
 }
 
 impl VectorSearchUDTFProvider {
+    /// Returns the arguments used to create this provider.
+    #[must_use]
+    pub fn args(&self) -> &VectorSearchTableFuncArgs {
+        &self.args
+    }
+
     /// Embed the query argument and convert to [`Float32Array`].
     async fn vector(
         &self,

--- a/crates/runtime/src/execution_plan/mod.rs
+++ b/crates/runtime/src/execution_plan/mod.rs
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Custom execution plans for the Spice runtime.
+
+pub mod udtf_exec;
+
+pub use udtf_exec::UdtfExec;

--- a/crates/runtime/src/execution_plan/udtf_exec.rs
+++ b/crates/runtime/src/execution_plan/udtf_exec.rs
@@ -56,7 +56,7 @@ use std::sync::Arc;
 pub struct UdtfExec {
     /// The UDTF arguments (serializable via protobuf).
     args: UdtfArgs,
-    /// The inner execution plan from the UDTF's TableProvider.
+    /// The inner execution plan from the UDTF's `TableProvider`.
     inner: Arc<dyn ExecutionPlan>,
     /// Cached plan properties.
     properties: PlanProperties,
@@ -88,6 +88,9 @@ impl UdtfExec {
     ///
     /// This is used when decoding a serialized plan - the inner plan will be
     /// reconstructed by re-invoking the UDTF.
+    ///
+    /// # Note
+    /// This method is currently unused but reserved for future serialization enhancements.
     #[must_use]
     pub fn placeholder(args: UdtfArgs, schema: SchemaRef) -> Self {
         let eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
@@ -125,10 +128,9 @@ impl UdtfExec {
 impl DisplayAs for UdtfExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
         match t {
-            DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "UdtfExec")
-            }
-            DisplayFormatType::TreeRender => {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
                 write!(f, "UdtfExec")
             }
         }
@@ -190,7 +192,10 @@ impl ExecutionPlan for UdtfExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() == 1 {
-            Ok(Arc::new(Self::new(self.args.clone(), Arc::clone(&children[0]))))
+            Ok(Arc::new(Self::new(
+                self.args.clone(),
+                Arc::clone(&children[0]),
+            )))
         } else {
             Err(DataFusionError::Execution(
                 "UdtfExec expects exactly one child".to_string(),

--- a/crates/runtime/src/execution_plan/udtf_exec.rs
+++ b/crates/runtime/src/execution_plan/udtf_exec.rs
@@ -1,0 +1,459 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A serializable execution plan for UDTFs (User-Defined Table Functions).
+//!
+//! This execution plan wraps a UDTF invocation and can be serialized/deserialized
+//! for distributed query execution. When executed on a remote node, the UDTF is
+//! re-invoked with the stored arguments to produce results.
+
+use arrow_schema::SchemaRef;
+use datafusion::common::{Result, Statistics};
+use datafusion::config::ConfigOptions;
+use datafusion::error::DataFusionError;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{EquivalenceProperties, OrderingRequirements};
+use datafusion::physical_plan::execution_plan::{
+    CardinalityEffect, InvariantLevel, check_default_invariants,
+};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+};
+use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, Distribution, EmptyRecordBatchStream, ExecutionPlan,
+    ExecutionPlanProperties, Partitioning, PhysicalExpr, PlanProperties,
+};
+use runtime_proto::UdtfArgs;
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+/// An execution plan that wraps a UDTF invocation.
+///
+/// This plan stores the UDTF arguments and the inner execution plan produced by
+/// the UDTF. The arguments enable serialization for distributed execution - when
+/// deserialized on a remote executor, the UDTF can be re-invoked to produce the
+/// same results.
+///
+/// The inner plan is the actual execution plan produced by `TableProvider::scan()`
+/// on the UDTF's result table.
+#[derive(Debug)]
+pub struct UdtfExec {
+    /// The UDTF arguments (serializable via protobuf).
+    args: UdtfArgs,
+    /// The inner execution plan from the UDTF's TableProvider.
+    inner: Arc<dyn ExecutionPlan>,
+    /// Cached plan properties.
+    properties: PlanProperties,
+}
+
+impl UdtfExec {
+    /// Creates a new `UdtfExec` wrapping the given inner plan with UDTF arguments.
+    #[must_use]
+    pub fn new(args: UdtfArgs, inner: Arc<dyn ExecutionPlan>) -> Self {
+        let schema = inner.schema();
+        let eq_properties = EquivalenceProperties::new(schema);
+        let emission_type = inner.pipeline_behavior();
+        let boundedness = inner.boundedness();
+        let properties = PlanProperties::new(
+            eq_properties,
+            inner.output_partitioning().clone(),
+            emission_type,
+            boundedness,
+        );
+
+        Self {
+            args,
+            inner,
+            properties,
+        }
+    }
+
+    /// Creates a placeholder `UdtfExec` for deserialization.
+    ///
+    /// This is used when decoding a serialized plan - the inner plan will be
+    /// reconstructed by re-invoking the UDTF.
+    #[must_use]
+    pub fn placeholder(args: UdtfArgs, schema: SchemaRef) -> Self {
+        let eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
+        let properties = PlanProperties::new(
+            eq_properties,
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+
+        // Create a placeholder inner plan - this will be replaced when the
+        // plan is actually executed after reconstruction
+        let placeholder_inner = Arc::new(PlaceholderExec::new(schema));
+
+        Self {
+            args,
+            inner: placeholder_inner,
+            properties,
+        }
+    }
+
+    /// Returns the UDTF arguments.
+    #[must_use]
+    pub fn args(&self) -> &UdtfArgs {
+        &self.args
+    }
+
+    /// Returns the inner execution plan.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.inner
+    }
+}
+
+impl DisplayAs for UdtfExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "UdtfExec")
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "UdtfExec")
+            }
+        }
+    }
+}
+
+#[deny(clippy::missing_trait_methods)]
+impl ExecutionPlan for UdtfExec {
+    fn name(&self) -> &'static str {
+        "UdtfExec"
+    }
+
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
+        "UdtfExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn check_invariants(&self, check: InvariantLevel) -> Result<()> {
+        check_default_invariants(self, check)
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![]
+    }
+
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        vec![]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        // Return inner as a child so optimizers can traverse it
+        vec![&self.inner]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() == 1 {
+            Ok(Arc::new(Self::new(self.args.clone(), Arc::clone(&children[0]))))
+        } else {
+            Err(DataFusionError::Execution(
+                "UdtfExec expects exactly one child".to_string(),
+            ))
+        }
+    }
+
+    fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _config: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // Delegate execution to the inner plan
+        self.inner.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        self.inner.metrics()
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        #[expect(deprecated)]
+        self.inner.statistics()
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.inner.partition_statistics(partition)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+
+    fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        None
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        _projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        // UDTFs don't support filter pushdown - mark all filters as unsupported
+        Ok(FilterDescription::all_unsupported(
+            &parent_filters,
+            &self.children(),
+        ))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+
+    fn with_new_state(&self, _state: Arc<dyn Any + Send + Sync>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+}
+
+/// A placeholder execution plan used during deserialization.
+///
+/// This plan should never actually be executed - it exists only as a placeholder
+/// until the real inner plan is reconstructed by re-invoking the UDTF.
+#[derive(Debug)]
+struct PlaceholderExec {
+    schema: SchemaRef,
+    properties: PlanProperties,
+}
+
+impl PlaceholderExec {
+    fn new(schema: SchemaRef) -> Self {
+        let eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
+        let properties = PlanProperties::new(
+            eq_properties,
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self { schema, properties }
+    }
+}
+
+impl DisplayAs for PlaceholderExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PlaceholderExec")
+    }
+}
+
+#[deny(clippy::missing_trait_methods)]
+impl ExecutionPlan for PlaceholderExec {
+    fn name(&self) -> &'static str {
+        "PlaceholderExec"
+    }
+
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
+        "PlaceholderExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn check_invariants(&self, check: InvariantLevel) -> Result<()> {
+        check_default_invariants(self, check)
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![]
+    }
+
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        vec![]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Execution(
+                "PlaceholderExec expects no children".to_string(),
+            ))
+        }
+    }
+
+    fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _config: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // Return an empty stream - this should never be called in practice
+        // as the placeholder should be replaced before execution
+        Ok(Box::pin(EmptyRecordBatchStream::new(Arc::clone(
+            &self.schema,
+        ))))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        Ok(Statistics::new_unknown(&self.schema))
+    }
+
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
+        Ok(Statistics::new_unknown(&self.schema))
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+
+    fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        None
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        _projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        Ok(FilterDescription::all_unsupported(
+            &parent_filters,
+            &self.children(),
+        ))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+
+    fn with_new_state(&self, _state: Arc<dyn Any + Send + Sync>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -92,6 +92,7 @@ pub mod datafusion;
 pub mod datasets_health_monitor;
 pub mod dataupdate;
 pub mod embeddings;
+pub mod execution_plan;
 pub mod extension;
 pub mod federated_table;
 pub mod flight;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1174,7 +1174,7 @@ impl Runtime {
 
         let ctx = &self.datafusion().ctx;
         ctx.register_udtf(
-            "list_udfs",
+            udtfs::LIST_UDFS_UDTF_NAME,
             Arc::new(ListUDFTableFunc::new(Arc::clone(ctx))),
         );
 

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -42,8 +42,9 @@ use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl};
 
 use moka::future::FutureExt;
 use search::{
-    generation::text_search::index::FullTextDatabaseIndex, index::SearchIndex,
-    provider::SearchQueryProvider,
+    generation::text_search::index::FullTextDatabaseIndex,
+    index::SearchIndex,
+    provider::{SearchQueryProvider, UdtfSource},
 };
 use std::any::Any;
 use std::sync::LazyLock;
@@ -316,7 +317,16 @@ impl TableFunctionImpl for TextSearchTableFunc {
         // Select single column if needed.
         let column = args.column(&fts_index.search_fields)?;
         let mut fts_index = fts_index.clone();
-        fts_index.search_fields = vec![column];
+        fts_index.search_fields = vec![column.clone()];
+
+        // Create UDTF source for distributed serialization
+        let udtf_source = UdtfSource::TextSearch {
+            table: args.tbl.to_string(),
+            query: args.query.clone(),
+            column: Some(column),
+            limit: args.limit,
+            include_score: args.include_score,
+        };
 
         Ok(Arc::new(
             SearchQueryProvider::try_from_index(
@@ -325,6 +335,7 @@ impl TableFunctionImpl for TextSearchTableFunc {
                 args.query.as_str(),
                 args.limit,
             )?
+            .with_udtf_source(udtf_source)
             .call_on_scan(Arc::new(|| {
                 async {
                     let request_context = RequestContext::current(AsyncMarker::new().await);

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -45,6 +45,7 @@ use crate::cluster::datafusion::codec::udtf_args::{
 };
 use crate::embeddings::udtf::VECTOR_SEARCH_UDTF_NAME;
 use crate::search::full_text::udtf::TEXT_SEARCH_UDTF_NAME;
+use crate::search::util::table_ref_from_column_expr;
 
 pub static RRF_UDF_NAME: &str = "rrf";
 pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
@@ -211,6 +212,8 @@ struct ReciprocalRankFusionArgs {
     pub decay_window_secs: Option<f64>,
 }
 
+type SearchUdtfArgs = (String, String, Option<String>, Option<usize>, Option<bool>);
+
 impl ReciprocalRankFusionArgs {
     /// Constructs `ReciprocalRankFusionArgs` from an rrf UDTF invocation, which is a `TableScan` node
     /// that looks like this...
@@ -282,7 +285,6 @@ impl ReciprocalRankFusionArgs {
     ///
     /// This extracts the nested search UDTF invocations and converts them to `RrfNestedQuery`
     /// variants that can be serialized and sent to remote executors.
-    #[allow(clippy::cast_possible_truncation)]
     fn to_serializable(&self) -> Result<SerializableRrfArgs> {
         let queries = self
             .search_udtf_exprs
@@ -303,8 +305,8 @@ impl ReciprocalRankFusionArgs {
                 RecencyDecay::Exponential => "exponential".to_string(),
             }),
             decay_constant: self.decay_constant,
-            decay_scale_secs: self.decay_scale_secs.map(|s| s as i64),
-            decay_window_secs: self.decay_window_secs.map(|s| s as i64),
+            decay_scale_secs: self.decay_scale_secs,
+            decay_window_secs: self.decay_window_secs,
         })
     }
 
@@ -348,13 +350,31 @@ impl ReciprocalRankFusionArgs {
         }
     }
 
+    fn parse_limit_u64(value: u64) -> Result<usize> {
+        usize::try_from(value).map_err(|_| {
+            DataFusionError::Plan(format!(
+                "{RRF_UDF_NAME} limit value {value} exceeds usize range."
+            ))
+        })
+    }
+
+    fn parse_limit_i64(value: i64) -> Result<usize> {
+        if value < 0 {
+            return exec_err!("{RRF_UDF_NAME} limit value {value} must be non-negative");
+        }
+
+        let value = u64::try_from(value).map_err(|_| {
+            DataFusionError::Plan(format!(
+                "{RRF_UDF_NAME} limit value {value} exceeds usize range."
+            ))
+        })?;
+        Self::parse_limit_u64(value)
+    }
+
     /// Parses common search UDTF arguments from expressions.
     ///
     /// Returns: (table, query, column, limit, `include_score`)
-    #[allow(clippy::type_complexity)]
-    fn parse_search_args(
-        args: &[Expr],
-    ) -> Result<(String, String, Option<String>, Option<usize>, Option<bool>)> {
+    fn parse_search_args(args: &[Expr]) -> Result<SearchUdtfArgs> {
         // Filter out passthrough parameters (those with spice.parameter_name metadata)
         let args: Vec<_> = args
             .iter()
@@ -365,13 +385,7 @@ impl ReciprocalRankFusionArgs {
 
         // Extract table reference from first arg
         let table = match args.first() {
-            Some(Expr::Column(c)) => {
-                // Reconstruct table reference from column expression
-                match (&c.relation, &c.name) {
-                    (Some(rel), name) => format!("{rel}.{name}"),
-                    (None, name) => name.clone(),
-                }
-            }
+            Some(Expr::Column(c)) => table_ref_from_column_expr(c).to_quoted_string(),
             _ => {
                 return exec_err!("First argument to search UDTF must be a table reference");
             }
@@ -390,17 +404,16 @@ impl ReciprocalRankFusionArgs {
         let mut limit = None;
         let mut include_score = None;
 
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         for arg in args.iter().skip(2) {
             match arg {
                 Expr::Column(Column { name, .. }) => {
                     column = Some(name.clone());
                 }
                 Expr::Literal(ScalarValue::UInt64(Some(l)), _) => {
-                    limit = Some(*l as usize);
+                    limit = Some(Self::parse_limit_u64(*l)?);
                 }
                 Expr::Literal(ScalarValue::Int64(Some(l)), _) => {
-                    limit = Some(*l as usize);
+                    limit = Some(Self::parse_limit_i64(*l)?);
                 }
                 Expr::Literal(ScalarValue::Boolean(Some(b)), _) => {
                     include_score = Some(*b);

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -39,6 +39,13 @@ use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
+use crate::cluster::datafusion::codec::udtf_args::{
+    RrfArgs as SerializableRrfArgs, RrfNestedQuery, RrfNestedQueryExt, TextSearchArgs,
+    VectorSearchArgs,
+};
+use crate::embeddings::udtf::VECTOR_SEARCH_UDTF_NAME;
+use crate::search::full_text::udtf::TEXT_SEARCH_UDTF_NAME;
+
 pub static RRF_UDF_NAME: &str = "rrf";
 pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation {
@@ -270,6 +277,140 @@ impl ReciprocalRankFusionArgs {
             decay_window_secs: extract_f64!(rrf_args, "decay_window_secs"),
         })
     }
+
+    /// Converts the internal RRF arguments to a serializable form for distributed execution.
+    ///
+    /// This extracts the nested search UDTF invocations and converts them to `RrfNestedQuery`
+    /// variants that can be serialized and sent to remote executors.
+    #[allow(clippy::cast_possible_truncation)]
+    fn to_serializable(&self) -> Result<SerializableRrfArgs> {
+        let queries = self
+            .search_udtf_exprs
+            .iter()
+            .zip(self.rrf_subquery_arguments.iter())
+            .map(|(expr, subquery_args)| {
+                Self::expr_to_nested_query(expr, subquery_args.rank_weight)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(SerializableRrfArgs {
+            queries,
+            k: Some(self.k),
+            join_key: self.join_key.as_ref().map(|e| e.qualified_name().1),
+            time_column: self.time_column.as_ref().map(|e| e.qualified_name().1),
+            recency_decay: self.recency_decay.as_ref().map(|rd| match rd {
+                RecencyDecay::Linear => "linear".to_string(),
+                RecencyDecay::Exponential => "exponential".to_string(),
+            }),
+            decay_constant: self.decay_constant,
+            decay_scale_secs: self.decay_scale_secs.map(|s| s as i64),
+            decay_window_secs: self.decay_window_secs.map(|s| s as i64),
+        })
+    }
+
+    /// Converts a scalar function expression to an `RrfNestedQuery`.
+    fn expr_to_nested_query(expr: &Expr, rank_weight: Option<f64>) -> Result<RrfNestedQuery> {
+        let Expr::ScalarFunction(ScalarFunction { func, args }) = expr else {
+            return exec_err!("Expected scalar function expression for nested RRF query");
+        };
+
+        let func_name = func.name();
+        match func_name {
+            name if name == TEXT_SEARCH_UDTF_NAME => {
+                let search_args = Self::parse_search_args(args)?;
+                Ok(RrfNestedQuery::text_search(
+                    TextSearchArgs {
+                        table: search_args.0,
+                        query: search_args.1,
+                        column: search_args.2,
+                        limit: search_args.3.map(|l| l as u64),
+                        include_score: search_args.4,
+                    },
+                    rank_weight,
+                ))
+            }
+            name if name == VECTOR_SEARCH_UDTF_NAME => {
+                let search_args = Self::parse_search_args(args)?;
+                Ok(RrfNestedQuery::vector_search(
+                    VectorSearchArgs {
+                        table: search_args.0,
+                        query: search_args.1,
+                        column: search_args.2,
+                        limit: search_args.3.map(|l| l as u64),
+                        include_score: search_args.4,
+                    },
+                    rank_weight,
+                ))
+            }
+            _ => exec_err!(
+                "{RRF_UDF_NAME} only supports {TEXT_SEARCH_UDTF_NAME} and {VECTOR_SEARCH_UDTF_NAME} nested queries, got: {func_name}"
+            ),
+        }
+    }
+
+    /// Parses common search UDTF arguments from expressions.
+    ///
+    /// Returns: (table, query, column, limit, `include_score`)
+    #[allow(clippy::type_complexity)]
+    fn parse_search_args(
+        args: &[Expr],
+    ) -> Result<(String, String, Option<String>, Option<usize>, Option<bool>)> {
+        // Filter out passthrough parameters (those with spice.parameter_name metadata)
+        let args: Vec<_> = args
+            .iter()
+            .filter(|arg| {
+                !matches!(arg, Expr::Literal(_, Some(meta)) if meta.inner().contains_key("spice.parameter_name"))
+            })
+            .collect();
+
+        // Extract table reference from first arg
+        let table = match args.first() {
+            Some(Expr::Column(c)) => {
+                // Reconstruct table reference from column expression
+                match (&c.relation, &c.name) {
+                    (Some(rel), name) => format!("{rel}.{name}"),
+                    (None, name) => name.clone(),
+                }
+            }
+            _ => {
+                return exec_err!("First argument to search UDTF must be a table reference");
+            }
+        };
+
+        // Extract query string from second arg
+        let query = match args.get(1) {
+            Some(Expr::Literal(ScalarValue::Utf8(Some(q)), _)) => q.clone(),
+            _ => {
+                return exec_err!("Second argument to search UDTF must be a query string");
+            }
+        };
+
+        // Extract optional column, limit, include_score from remaining args
+        let mut column = None;
+        let mut limit = None;
+        let mut include_score = None;
+
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        for arg in args.iter().skip(2) {
+            match arg {
+                Expr::Column(Column { name, .. }) => {
+                    column = Some(name.clone());
+                }
+                Expr::Literal(ScalarValue::UInt64(Some(l)), _) => {
+                    limit = Some(*l as usize);
+                }
+                Expr::Literal(ScalarValue::Int64(Some(l)), _) => {
+                    limit = Some(*l as usize);
+                }
+                Expr::Literal(ScalarValue::Boolean(Some(b)), _) => {
+                    include_score = Some(*b);
+                }
+                _ => {}
+            }
+        }
+
+        Ok((table, query, column, limit, include_score))
+    }
 }
 
 impl Debug for ReciprocalRankFusion {
@@ -283,6 +424,11 @@ pub struct ReciprocalRankFusion {
     // store a pointer to use for Hash/Eq since UDTF impls require this trait bound but we cannot feasibly make `SessionContext` implement them.
     session_ptr: u64,
     df: Option<DataFrame>,
+    /// Stores the original RRF arguments for distributed serialization.
+    ///
+    /// This is set when the provider is created via the `rrf()` UDTF and enables
+    /// `SpiceLogicalCodec` to serialize and reconstruct this provider on remote executors.
+    pub rrf_source: Option<SerializableRrfArgs>,
 }
 
 impl PartialEq for ReciprocalRankFusion {
@@ -309,6 +455,7 @@ impl ReciprocalRankFusion {
             session_context: Arc::clone(session_context),
             session_ptr: ptr,
             df: None,
+            rrf_source: None,
         }
     }
 
@@ -320,6 +467,13 @@ impl ReciprocalRankFusion {
     #[must_use]
     pub fn with_df(mut self, df: DataFrame) -> Self {
         self.df = Some(df);
+        self
+    }
+
+    /// Sets the RRF source for distributed serialization.
+    #[must_use]
+    pub fn with_rrf_source(mut self, source: SerializableRrfArgs) -> Self {
+        self.rrf_source = Some(source);
         self
     }
 
@@ -652,9 +806,12 @@ impl ScalarUDFImpl for ReciprocalRankFusion {
 impl TableFunctionImpl for ReciprocalRankFusion {
     fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         let rrf_args = ReciprocalRankFusionArgs::from_udtf_exprs(args)?;
+        let serializable_args = rrf_args.to_serializable()?;
         let rerank_and_fuse_df = self.rerank_and_fuse_df(&rrf_args)?;
         Ok(Arc::new(
-            ReciprocalRankFusion::from_ctx(&self.session_context).with_df(rerank_and_fuse_df),
+            ReciprocalRankFusion::from_ctx(&self.session_context)
+                .with_df(rerank_and_fuse_df)
+                .with_rrf_source(serializable_args),
         ))
     }
 }

--- a/crates/runtime/src/udtfs.rs
+++ b/crates/runtime/src/udtfs.rs
@@ -12,8 +12,12 @@ use datafusion::logical_expr::{Expr, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_datasource::memory::MemorySourceConfig;
 use datafusion_datasource::source::DataSourceExec;
+use runtime_proto::UdtfArgs;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+
+use crate::cluster::datafusion::codec::udtf_args::UdtfArgsExt;
+use crate::execution_plan::UdtfExec;
 
 /// UDTF name constant for `list_udfs`
 pub const LIST_UDFS_UDTF_NAME: &str = "list_udfs";
@@ -86,8 +90,12 @@ impl TableProvider for ListUDFTable {
         let memory_source =
             MemorySourceConfig::try_new(&[vec![batch]], Arc::clone(&self.schema), None)?;
 
-        let data_source_exec = DataSourceExec::new(Arc::new(memory_source));
+        let inner_exec = Arc::new(DataSourceExec::new(Arc::new(memory_source)));
 
-        Ok(Arc::new(data_source_exec))
+        // Wrap in UdtfExec for distributed execution support.
+        // The UdtfArgs allow the UDTF to be re-invoked on remote executors.
+        let udtf_exec = UdtfExec::new(UdtfArgs::list_udfs(), inner_exec);
+
+        Ok(Arc::new(udtf_exec))
     }
 }

--- a/crates/runtime/src/udtfs.rs
+++ b/crates/runtime/src/udtfs.rs
@@ -15,6 +15,9 @@ use datafusion_datasource::source::DataSourceExec;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
+/// UDTF name constant for `list_udfs`
+pub const LIST_UDFS_UDTF_NAME: &str = "list_udfs";
+
 pub struct ListUDFTableFunc {
     context: Arc<SessionContext>,
 }
@@ -38,14 +41,17 @@ impl TableFunctionImpl for ListUDFTableFunc {
     }
 }
 
+/// The `TableProvider` produced by the `list_udfs()` UDTF.
+///
+/// This table contains a single column "name" with all registered UDF names.
 #[derive(Debug)]
-struct ListUDFTable {
+pub struct ListUDFTable {
     schema: SchemaRef,
     udf_names: Vec<String>,
 }
 
 impl ListUDFTable {
-    fn new(udf_names: Vec<String>) -> Self {
+    pub fn new(udf_names: Vec<String>) -> Self {
         Self {
             schema: Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)])),
             udf_names,

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -26,6 +26,7 @@ itertools.workspace = true
 llms = { path = "../llms", default-features = false, optional = true }
 runtime-datafusion-index = { path = "../runtime-datafusion-index" }
 runtime-table-partition = { path = "../runtime-table-partition" }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 snafu.workspace = true
 tantivy = { workspace = true, optional = true }

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -37,11 +37,35 @@ use datafusion::{
 use datafusion_expr::select_expr::SelectExpr;
 use futures::future::BoxFuture;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     SEARCH_MATCH_COLUMN_NAME, SEARCH_SCORE_COLUMN_NAME,
     index::{SearchIndex, chunking::ChunkedSearchIndex},
 };
+
+/// Tracks the original UDTF invocation that produced this `SearchQueryProvider`.
+///
+/// This is used for serialization during distributed query execution with Ballista.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UdtfSource {
+    /// Created by `text_search(tbl, query, [col], [limit], [include_score])`
+    TextSearch {
+        table: String,
+        query: String,
+        column: Option<String>,
+        limit: Option<usize>,
+        include_score: Option<bool>,
+    },
+    /// Created by `vector_search(tbl, query, [col], [limit], [include_score])`
+    VectorSearch {
+        table: String,
+        query: String,
+        column: Option<String>,
+        limit: Option<usize>,
+        include_score: Option<bool>,
+    },
+}
 
 /// Performs a search on a given [`SearchIndex`] and combine with the underlying [`TableProvider`]
 /// if required by filters or additional columns in the projection.
@@ -59,6 +83,11 @@ pub struct SearchQueryProvider {
     /// immediately before the provider executes a scan operation. The callback is asynchronous and
     /// will be awaited before the scan proceeds. If `None`, no callback is invoked.
     pub scan_callback: Option<Arc<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>>,
+    /// Tracks the original UDTF invocation for distributed serialization.
+    ///
+    /// This is set when the provider is created via a UDTF like `text_search()` or `vector_search()`.
+    /// It enables `SpiceLogicalCodec` to serialize and reconstruct this provider on remote executors.
+    pub udtf_source: Option<UdtfSource>,
 }
 
 impl std::fmt::Debug for SearchQueryProvider {
@@ -69,6 +98,7 @@ impl std::fmt::Debug for SearchQueryProvider {
             .field("search_column", &self.search_column)
             .field("primary_key", &self.primary_key)
             .field("pre_limit", &self.pre_limit)
+            .field("udtf_source", &self.udtf_source)
             .finish_non_exhaustive()
     }
 }
@@ -89,6 +119,7 @@ impl SearchQueryProvider {
             pre_limit,
             scan_callback: None,
             constraints: None,
+            udtf_source: None,
         };
 
         // Create `constraints` based on [`Self::schema`]
@@ -116,6 +147,13 @@ impl SearchQueryProvider {
         func: Arc<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>,
     ) -> Self {
         self.scan_callback = Some(func);
+        self
+    }
+
+    /// Sets the UDTF source for distributed serialization.
+    #[must_use]
+    pub fn with_udtf_source(mut self, source: UdtfSource) -> Self {
+        self.udtf_source = Some(source);
         self
     }
 


### PR DESCRIPTION
Implement protobuf-based serialization for UDTFs (list_udfs, text_search, vector_search, rrf) to enable distributed query execution in Ballista clusters.

When queries with UDTFs are sent to remote executors, SpiceLogicalCodec now:
- Encodes UDTF arguments to protobuf in try_encode_table_provider
- Decodes and re-invokes the UDTF on the executor in try_decode_table_provider

This fixes the error: 'SpiceLogicalCodec could not resolve table reference' when running UDTF queries in distributed mode.

- Closes #9138 
