### PR TITLE
Support multiple partition expressions in partition_by configuration

### DIFF
--- a/crates/runtime-table-partition/src/creator.rs
+++ b/crates/runtime-table-partition/src/creator.rs
@@ -44,11 +44,18 @@ pub enum Error {
 
 #[async_trait]
 pub trait PartitionCreator: Debug + Send + Sync {
-    /// Create a new [`Partition`] using the `partition_value`.
+    /// Create a new [`Partition`] using the given partition values.
+    ///
+    /// For single-column partitions, pass a single-element vector.
+    /// For composite partitions (e.g., `partition_by: [year, month]`), pass
+    /// multiple values in the same order as the partition expressions.
     ///
     /// # Errors
     /// Returns an error when creating a [`Partition`] is unsuccessful.
-    async fn create_partition(&self, partition_value: ScalarValue) -> Result<Partition, Error>;
+    async fn create_partition(
+        &self,
+        partition_values: Vec<ScalarValue>,
+    ) -> Result<Partition, Error>;
 
     /// Find and load previously created [`Partition`]s
     ///

--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -99,6 +99,26 @@ pub fn encode_key(key: &ScalarValue) -> Result<String, Error> {
     Ok(key.unwrap_or("none".to_string()))
 }
 
+/// Encodes multiple [`ScalarValue`] partition keys into a composite key string.
+///
+/// This is used for hierarchical partitions where the partition is identified
+/// by multiple values (e.g., year=2025 and month=10).
+///
+/// The composite key is encoded by joining individual keys with "/",
+/// e.g., `"2025/10"` for the example above. This provides a unique, stable
+/// identifier for the partition that can be used as a `HashMap` key.
+///
+/// Note: This function produces a compact key format (e.g., "2025/10") without
+/// column names. For Hive-style partition directories with column names
+/// (e.g., "year=2025/month=10"), see [`to_hive_partition_dir`].
+///
+/// # Errors
+/// Returns [`Error::UnsupportedPartitionKey`] if any scalar value type is not supported.
+pub fn encode_composite_key(keys: &[ScalarValue]) -> Result<String, Error> {
+    let encoded: Result<Vec<String>, Error> = keys.iter().map(encode_key).collect();
+    Ok(encoded?.join("/"))
+}
+
 /// Discover hive style partitions in the `base_dir` recursively.
 ///
 /// # Errors

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -47,16 +47,18 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::Partition;
 use crate::creator::PartitionCreator;
-use crate::creator::filename::encode_key;
+use crate::creator::filename::encode_composite_key;
 use crate::expression::PartitionedBy;
-use crate::provider::ScalarValueString;
+use crate::provider::CompositePartitionKey;
 
 #[derive(Debug)]
 pub struct PartitionerExec {
     input: Arc<dyn ExecutionPlan>,
     creator: Arc<dyn PartitionCreator>,
-    partitions: Arc<RwLock<HashMap<String, Partition>>>,
-    partition_by: PartitionedBy,
+    partitions: Arc<RwLock<HashMap<CompositePartitionKey, Partition>>>,
+    /// The partition expressions. For hierarchical partitions (e.g., year/month),
+    /// this contains multiple expressions in order.
+    partition_by: Vec<PartitionedBy>,
     insert_op: InsertOp,
     schema: SchemaRef,
     properties: PlanProperties,
@@ -65,9 +67,9 @@ pub struct PartitionerExec {
 impl PartitionerExec {
     pub(crate) fn new(
         input: Arc<dyn ExecutionPlan>,
-        partition_by: PartitionedBy,
+        partition_by: Vec<PartitionedBy>,
         creator: Arc<dyn PartitionCreator>,
-        partitions: Arc<RwLock<HashMap<String, Partition>>>,
+        partitions: Arc<RwLock<HashMap<CompositePartitionKey, Partition>>>,
         insert_op: InsertOp,
         schema: SchemaRef,
     ) -> Self {
@@ -95,12 +97,16 @@ impl DisplayAs for PartitionerExec {
         _t: datafusion::physical_plan::DisplayFormatType,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
+        let partition_strs: Vec<_> = self
+            .partition_by
+            .iter()
+            .map(|p| format!("{} AS {}", p.expression, p.name))
+            .collect();
         write!(
             f,
-            "{} (partition_by = {} AS {}, insert_op = {})",
+            "{} (partition_by = [{}], insert_op = {})",
             self.name(),
-            self.partition_by.expression,
-            self.partition_by.name,
+            partition_strs.join(", "),
             self.insert_op
         )
     }
@@ -160,7 +166,12 @@ impl ExecutionPlan for PartitionerExec {
             let schema = self.schema();
             let row_count_schema = Arc::clone(&row_count_schema);
             let input = Arc::clone(&self.input);
-            let physical_expr = create_physical_expr(&self.partition_by.expression, self.schema())?;
+            // Create physical expressions for all partition columns
+            let physical_exprs: Vec<Arc<dyn PhysicalExpr>> = self
+                .partition_by
+                .iter()
+                .map(|p| create_physical_expr(&p.expression, Arc::clone(&schema)))
+                .collect::<Result<Vec<_>, _>>()?;
             let creator = Arc::clone(&self.creator);
             let partition_providers = Arc::clone(&self.partitions);
             let insert_op = self.insert_op;
@@ -181,11 +192,11 @@ impl ExecutionPlan for PartitionerExec {
                         continue;
                     }
 
-                    // Partition the batch using the partition_by expression
-                    // into multiple batches
-                    let batches = partition_batch(&batch, physical_expr.as_ref())?;
+                    // Partition the batch using all partition_by expressions
+                    // into multiple batches based on composite keys
+                    let batches = partition_batch_composite(&batch, &physical_exprs)?;
 
-                    for (partition_key, (partition_value, batch)) in batches {
+                    for (partition_key, (partition_values, batch)) in batches {
                         let tx = if let Some(tx) = partition_senders.get(&partition_key) {
                             tx.clone()
                         } else {
@@ -203,7 +214,7 @@ impl ExecutionPlan for PartitionerExec {
                                     drop(providers);
 
                                     let partition = creator
-                                        .create_partition(partition_value)
+                                        .create_partition(partition_values)
                                         .await
                                         .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                                     let new_provider = Arc::clone(&partition.table_provider);
@@ -409,45 +420,126 @@ impl DisplayAs for PartitionInputExec {
 /// created for each unique value produced by evaluating the expression
 /// containing the rows that produced that unique partition value.
 ///
+/// This is a single-expression version for backward compatibility.
+/// For multiple partition expressions, use [`partition_batch_composite`].
+///
 /// # Errors
 /// Returns an error when the expressions cannot be evaluated, the batch cannot
 /// be partitioned, Arrays cannot be created or the batch cannot be filtered.
 pub fn partition_batch(
     batch: &RecordBatch,
     physical_expr: &dyn PhysicalExpr,
-) -> Result<HashMap<String, (ScalarValue, RecordBatch)>, DataFusionError> {
+) -> Result<HashMap<String, (Vec<ScalarValue>, RecordBatch)>, DataFusionError> {
+    // Evaluate the partition expression to get an array
     let column = physical_expr.evaluate(batch)?;
     let array = match column {
         ColumnarValue::Array(array) => array,
         ColumnarValue::Scalar(_) => {
             return Err(DataFusionError::Execution(
-                "Invalid partition expression".to_string(),
+                "Invalid partition expression: expected array, got scalar".to_string(),
             ));
         }
     };
 
+    // Use arrow's partition function
     let partitions = compute::partition(&[Arc::clone(&array)])?;
     let mut batches = HashMap::with_capacity(partitions.len());
 
-    // Group indices by partition value
-    let mut value_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    // Group indices by partition key
+    let mut key_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
     for partition in partitions.ranges() {
         let partition_value = ScalarValue::try_from_array(&array, partition.start)?;
-        let partition_key = encode_key(&partition_value).map_err(|e| {
+        let partition_key = encode_composite_key(&[partition_value]).map_err(|e| {
             DataFusionError::Execution(format!("Failed to encode partition key: {e}"))
         })?;
-        let value_indices = value_to_indices.entry(partition_key.clone()).or_default();
+
+        let value_indices = key_to_indices.entry(partition_key).or_default();
         partition.into_iter().for_each(|i| value_indices.push(i));
     }
 
     // Create batches for each partition
-    for (partition_key, indices) in value_to_indices {
+    for (partition_key, indices) in key_to_indices {
         if indices.is_empty() {
             continue;
         }
+
         let partition_value = ScalarValue::try_from_array(&array, indices[0])?;
         let new_batch = filter_batch_by_indices(batch, &indices)?;
-        batches.insert(partition_key, (partition_value, new_batch));
+        batches.insert(partition_key, (vec![partition_value], new_batch));
+    }
+
+    Ok(batches)
+}
+
+/// Evaluate multiple `physical_exprs` for each row in `batch`. A partition batch is
+/// created for each unique combination of values produced by evaluating the expressions,
+/// containing the rows that produced that unique combination.
+///
+/// For hierarchical partitions (e.g., year/month/day), this groups rows by their
+/// composite partition key.
+///
+/// # Errors
+/// Returns an error when the expressions cannot be evaluated, the batch cannot
+/// be partitioned, Arrays cannot be created or the batch cannot be filtered.
+pub fn partition_batch_composite(
+    batch: &RecordBatch,
+    physical_exprs: &[Arc<dyn PhysicalExpr>],
+) -> Result<HashMap<String, (Vec<ScalarValue>, RecordBatch)>, DataFusionError> {
+    if physical_exprs.is_empty() {
+        return Err(DataFusionError::Execution(
+            "At least one partition expression is required".to_string(),
+        ));
+    }
+
+    // Evaluate all partition expressions to get arrays
+    let arrays: Vec<Arc<dyn Array>> = physical_exprs
+        .iter()
+        .map(|expr| {
+            let column = expr.evaluate(batch)?;
+            match column {
+                ColumnarValue::Array(array) => Ok(array),
+                ColumnarValue::Scalar(_) => Err(DataFusionError::Execution(
+                    "Invalid partition expression: expected array, got scalar".to_string(),
+                )),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Use arrow's partition function with all arrays to group by composite key
+    let partitions = compute::partition(&arrays)?;
+    let mut batches = HashMap::with_capacity(partitions.len());
+
+    // Group indices by composite partition key
+    let mut key_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    for partition in partitions.ranges() {
+        // Extract partition values for this partition (one value per expression)
+        let partition_values: Vec<ScalarValue> = arrays
+            .iter()
+            .map(|array| ScalarValue::try_from_array(array, partition.start))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let partition_key = encode_composite_key(&partition_values).map_err(|e| {
+            DataFusionError::Execution(format!("Failed to encode partition key: {e}"))
+        })?;
+
+        let value_indices = key_to_indices.entry(partition_key).or_default();
+        partition.into_iter().for_each(|i| value_indices.push(i));
+    }
+
+    // Create batches for each partition
+    for (partition_key, indices) in key_to_indices {
+        if indices.is_empty() {
+            continue;
+        }
+
+        // Extract partition values from the first index of this partition
+        let partition_values: Vec<ScalarValue> = arrays
+            .iter()
+            .map(|array| ScalarValue::try_from_array(array, indices[0]))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let new_batch = filter_batch_by_indices(batch, &indices)?;
+        batches.insert(partition_key, (partition_values, new_batch));
     }
 
     Ok(batches)
@@ -477,8 +569,10 @@ pub trait InsertStrategy: Send + Sync + std::fmt::Debug {
 #[derive(Debug)]
 pub struct PartitionContext {
     pub creator: Arc<dyn PartitionCreator>,
-    pub partition_by: PartitionedBy,
-    pub partitions: Arc<RwLock<HashMap<ScalarValueString, Partition>>>,
+    /// The partition expressions. For hierarchical partitions (e.g., year/month),
+    /// this contains multiple expressions in order.
+    pub partition_by: Vec<PartitionedBy>,
+    pub partitions: Arc<RwLock<HashMap<CompositePartitionKey, Partition>>>,
     pub schema: SchemaRef,
 }
 
@@ -525,12 +619,13 @@ mod tests {
 
         let physical_expr = create_physical_expr(&expr, batch.schema())?;
 
-        let partitions = partition_batch(&batch, physical_expr.as_ref())?;
+        let partitions = partition_batch_composite(&batch, &[physical_expr])?;
 
         assert_eq!(partitions.len(), 1);
 
-        for (partition_value, partitioned_batch) in partitions.into_values() {
-            assert_eq!(partition_value, ScalarValue::Boolean(Some(true)));
+        for (partition_values, partitioned_batch) in partitions.into_values() {
+            assert_eq!(partition_values.len(), 1);
+            assert_eq!(partition_values[0], ScalarValue::Boolean(Some(true)));
             assert_eq!(batch, partitioned_batch);
         }
 
@@ -559,12 +654,13 @@ mod tests {
 
         let physical_expr = create_physical_expr(&expr, batch.schema())?;
 
-        let partitions = partition_batch(&batch, physical_expr.as_ref())?;
+        let partitions = partition_batch_composite(&batch, &[physical_expr])?;
 
         assert_eq!(partitions.len(), 2);
 
-        for (partition_value, partitioned_batch) in partitions.into_values() {
-            if partition_value == ScalarValue::Boolean(Some(true)) {
+        for (partition_values, partitioned_batch) in partitions.into_values() {
+            assert_eq!(partition_values.len(), 1);
+            if partition_values[0] == ScalarValue::Boolean(Some(true)) {
                 assert_eq!(
                     record_batch!(
                         ("id", Int64, [1, 4]),
@@ -584,6 +680,50 @@ mod tests {
                     )?,
                     partitioned_batch
                 );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_partition_batch_composite() -> Result<(), DataFusionError> {
+        // Test partitioning by multiple columns (year, month)
+        let batch = record_batch!(
+            ("id", Int64, [1, 2, 3, 4, 5, 6]),
+            ("year", Int32, [2024, 2024, 2024, 2025, 2025, 2025]),
+            ("month", Int32, [1, 1, 2, 1, 1, 2])
+        )?;
+
+        let year_expr = create_physical_expr(&col("year"), batch.schema())?;
+        let month_expr = create_physical_expr(&col("month"), batch.schema())?;
+
+        let partitions = partition_batch_composite(&batch, &[year_expr, month_expr])?;
+
+        // Should have 4 partitions: (2024, 1), (2024, 2), (2025, 1), (2025, 2)
+        assert_eq!(partitions.len(), 4);
+
+        // Check that each partition has correct values
+        for (key, (partition_values, partitioned_batch)) in &partitions {
+            assert_eq!(partition_values.len(), 2, "Should have 2 partition values");
+
+            let year = match &partition_values[0] {
+                ScalarValue::Int32(Some(y)) => *y,
+                _ => panic!("Expected Int32 for year"),
+            };
+            let month = match &partition_values[1] {
+                ScalarValue::Int32(Some(m)) => *m,
+                _ => panic!("Expected Int32 for month"),
+            };
+
+            // Verify key format
+            assert_eq!(*key, format!("{year}/{month}"));
+
+            // Verify row counts
+            match (year, month) {
+                (2024 | 2025, 1) => assert_eq!(partitioned_batch.num_rows(), 2),
+                (2024 | 2025, 2) => assert_eq!(partitioned_batch.num_rows(), 1),
+                _ => panic!("Unexpected partition: year={year}, month={month}"),
             }
         }
 

--- a/crates/runtime-table-partition/src/lib.rs
+++ b/crates/runtime-table-partition/src/lib.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2024-2025 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,8 +22,47 @@ pub mod expression;
 pub mod insert;
 pub mod provider;
 
+/// Represents a partition in a partitioned table.
+///
+/// For single-column partitions, `partition_values` contains one value.
+/// For composite/hierarchical partitions (e.g., `partition_by: [year, month]`),
+/// `partition_values` contains multiple values in the order they were defined.
 #[derive(Debug, Clone)]
 pub struct Partition {
-    pub partition_value: ScalarValue,
+    /// The partition key values, one per partition expression.
+    /// For hierarchical partitions like `year=2025/month=10`, this would be
+    /// `[ScalarValue::Int32(2025), ScalarValue::Int32(10)]`.
+    pub partition_values: Vec<ScalarValue>,
     pub table_provider: Arc<dyn TableProvider>,
+}
+
+impl Partition {
+    /// Creates a new partition with a single partition value.
+    /// This is a convenience constructor for single-expression partitions.
+    #[must_use]
+    pub fn new_single(
+        partition_value: ScalarValue,
+        table_provider: Arc<dyn TableProvider>,
+    ) -> Self {
+        Self {
+            partition_values: vec![partition_value],
+            table_provider,
+        }
+    }
+
+    /// Creates a new partition with multiple partition values.
+    /// Used for hierarchical partitions (e.g., year/month/day).
+    #[must_use]
+    pub fn new(partition_values: Vec<ScalarValue>, table_provider: Arc<dyn TableProvider>) -> Self {
+        Self {
+            partition_values,
+            table_provider,
+        }
+    }
+
+    /// Returns the first partition value, if any.
+    #[must_use]
+    pub fn first_value(&self) -> Option<&ScalarValue> {
+        self.partition_values.first()
+    }
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -51,7 +51,7 @@ use tokio::sync::RwLock;
 use crate::{
     Partition,
     creator::PartitionCreator,
-    creator::filename::encode_key,
+    creator::filename::encode_composite_key,
     expression::{PartitionedBy, validate_scalar_compatibility},
     insert::{DefaultInsertStrategy, InsertStrategy, PartitionContext},
 };
@@ -60,10 +60,8 @@ pub mod pruning;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display(
-        "Only a single 'partition_by' expression is supported, but {num_partition_by} were given."
-    ))]
-    PartitionByViolation { num_partition_by: usize },
+    #[snafu(display("At least one 'partition_by' expression is required, but none were given."))]
+    PartitionByRequired,
     #[snafu(display("Creating partition failed: {source}"))]
     CreatingPartition { source: super::creator::Error },
     #[snafu(display("Validating expressions failed: {source}"))]
@@ -72,59 +70,68 @@ pub enum Error {
     SchemaConversion { source: DataFusionError },
     #[snafu(display("Expected array from partition expression, got scalar"))]
     InvalidPartitionExpression,
+    #[snafu(display(
+        "Partition has {actual} values but expected {expected} (one per partition_by expression)"
+    ))]
+    PartitionValueCountMismatch { expected: usize, actual: usize },
 }
 
-pub(crate) type ScalarValueString = String;
+/// Composite partition key string, used as `HashMap` key.
+/// For a single partition expression, this is just the encoded value (e.g., "us-east-1").
+/// For multiple partition expressions, this is a path-like string (e.g., "2025/10/15").
+pub(crate) type CompositePartitionKey = String;
 
 #[derive(Debug)]
 pub struct PartitionTableProvider {
     creator: Arc<dyn PartitionCreator>,
-    partition_by: PartitionedBy,
-    partitions: Arc<RwLock<HashMap<ScalarValueString, Partition>>>,
+    /// The partition expressions. For hierarchical partitions like
+    /// `partition_by: [year, month]`, this contains all expressions in order.
+    partition_by: Vec<PartitionedBy>,
+    partitions: Arc<RwLock<HashMap<CompositePartitionKey, Partition>>>,
     schema: SchemaRef,
     insert_strategy: Arc<dyn InsertStrategy>,
 }
 
 impl PartitionTableProvider {
-    /// Checks if a filter expression contains or references the partition expression.
+    /// Checks if a filter expression contains or references any of the partition expressions.
     /// This is used to identify filters that can be used for partition pruning.
-    fn filter_contains_partition_expr(filter: &Expr, partition_expr: &Expr) -> bool {
+    fn filter_contains_any_partition_expr(
+        filter: &Expr,
+        partition_exprs: &[PartitionedBy],
+    ) -> bool {
         use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 
-        // Check if filter contains the partition expression
         let mut contains = false;
         let _ = filter.apply(|expr| {
-            if expr == partition_expr {
-                contains = true;
-                Ok(TreeNodeRecursion::Stop)
-            } else {
-                Ok(TreeNodeRecursion::Continue)
+            for p in partition_exprs {
+                if expr == &p.expression {
+                    contains = true;
+                    return Ok(TreeNodeRecursion::Stop);
+                }
             }
+            Ok(TreeNodeRecursion::Continue)
         });
         contains
     }
 
     /// Creates a new [`PartitionTableProvider`] that partitions the data using
-    /// the first expression in `partition_by`.
+    /// the given partition expressions.
+    ///
+    /// For hierarchical partitioning (e.g., year/month/day), pass multiple expressions
+    /// in the order they should be applied.
     ///
     /// # Errors
-    /// This function will return an Error when the `partition_by` expression
-    /// validation fails.
+    /// This function will return an Error when:
+    /// - No partition expressions are provided
+    /// - Partition expression validation fails
+    /// - Existing partitions have incompatible values
     pub async fn new(
         creator: Arc<dyn PartitionCreator>,
-        mut partition_by: Vec<PartitionedBy>,
+        partition_by: Vec<PartitionedBy>,
         schema: SchemaRef,
     ) -> Result<Self, Error> {
-        let num_partition_by = partition_by.len();
-        if num_partition_by > 1 {
-            tracing::warn!(
-                "Multiple 'partition_by' expressions are not yet supported. Only the last expression will be used for partitioning."
-            );
-        }
+        ensure!(!partition_by.is_empty(), PartitionByRequiredSnafu);
 
-        let partition_by = partition_by
-            .pop()
-            .context(PartitionByViolationSnafu { num_partition_by })?;
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
 
         let partitions = creator
@@ -135,24 +142,33 @@ impl PartitionTableProvider {
         let partitions: Result<HashMap<_, _>, Error> = partitions
             .into_iter()
             .map(|p| {
-                validate_scalar_compatibility(
-                    &partition_by.expression,
-                    &p.partition_value,
-                    &df_schema,
-                )
-                .context(ValidatingExpressionsSnafu)?;
-                let key = encode_key(&p.partition_value).map_err(|e| Error::CreatingPartition {
-                    source: crate::creator::Error::CreatePartition {
-                        source: Box::new(e) as Box<dyn std::error::Error + Send + Sync>,
-                    },
+                // Validate that partition has the correct number of values
+                ensure!(
+                    p.partition_values.len() == partition_by.len(),
+                    PartitionValueCountMismatchSnafu {
+                        expected: partition_by.len(),
+                        actual: p.partition_values.len(),
+                    }
+                );
+
+                // Validate each partition value is compatible with its expression
+                for (expr, value) in partition_by.iter().zip(p.partition_values.iter()) {
+                    validate_scalar_compatibility(&expr.expression, value, &df_schema)
+                        .context(ValidatingExpressionsSnafu)?;
+                }
+
+                let key = encode_composite_key(&p.partition_values).map_err(|e| {
+                    Error::CreatingPartition {
+                        source: crate::creator::Error::CreatePartition {
+                            source: Box::new(e) as Box<dyn std::error::Error + Send + Sync>,
+                        },
+                    }
                 })?;
                 Ok((key, p))
             })
             .collect();
 
-        let partitions = partitions?;
-
-        let partitions = Arc::new(RwLock::new(partitions));
+        let partitions = Arc::new(RwLock::new(partitions?));
 
         Ok(Self {
             creator,
@@ -168,6 +184,14 @@ impl PartitionTableProvider {
     pub fn with_insert_strategy(mut self, insert_strategy: Arc<dyn InsertStrategy>) -> Self {
         self.insert_strategy = insert_strategy;
         self
+    }
+
+    /// Collects all partition column references from all partition expressions.
+    fn all_partition_columns(&self) -> std::collections::HashSet<&datafusion::common::Column> {
+        self.partition_by
+            .iter()
+            .flat_map(|p| p.expression.column_refs())
+            .collect()
     }
 }
 
@@ -205,13 +229,14 @@ impl TableProvider for PartitionTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         // Split filters into partition filters (for pruning) and data filters (for partition scans)
         // NOTE: Filters can be BOTH partition filters AND data filters for transform partitions
-        let partition_columns = self.partition_by.expression.column_refs();
+        let partition_columns = self.all_partition_columns();
 
         // Pre-compute column references for all filters to avoid repeated expression tree traversals
         let filter_columns_cache: Vec<_> =
             filters.iter().map(|filter| filter.column_refs()).collect();
 
         // Collect partition filters (used for pruning)
+        // A filter can prune partitions if it involves ANY of the partition columns
         let partition_filters: Vec<_> = filters
             .iter()
             .cloned()
@@ -220,7 +245,7 @@ impl TableProvider for PartitionTableProvider {
                 // A filter is a partition filter (for pruning) if:
                 // 1. It has no column references (constant expression like WHERE true), OR
                 // 2. All its column references are in the partition expression columns, OR
-                // 3. The filter directly involves the partition expression itself
+                // 3. The filter directly involves any partition expression itself
                 if filter_columns.is_empty() {
                     return Some(filter);
                 }
@@ -232,8 +257,8 @@ impl TableProvider for PartitionTableProvider {
                     return Some(filter);
                 }
 
-                // Check if the filter contains the partition expression
-                if Self::filter_contains_partition_expr(&filter, &self.partition_by.expression) {
+                // Check if the filter contains any partition expression
+                if Self::filter_contains_any_partition_expr(&filter, &self.partition_by) {
                     return Some(filter);
                 }
 
@@ -242,22 +267,33 @@ impl TableProvider for PartitionTableProvider {
             .collect();
 
         // Collect data filters (applied to partition scans)
-        // Exclude filters that are simple column filters matching the partition expression exactly
+        // Exclude filters that are simple column filters matching a simple partition expression exactly
         // For example, with partition_by region:
         //   - WHERE region = 'us-east-1' should NOT be a data filter (partition handles it)
         // But with partition_by bucket(3, user_id):
         //   - WHERE user_id = 100 SHOULD be a data filter (partition only determines bucket)
+        let simple_partition_cols: std::collections::HashSet<_> = self
+            .partition_by
+            .iter()
+            .filter_map(|p| {
+                if let Expr::Column(col) = &p.expression {
+                    Some(col)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let data_filters: Vec<_> = filters
             .iter()
             .zip(filter_columns_cache.iter())
             .filter(|(_filter, filter_cols)| {
-                // If the partition expression is just a simple column reference,
-                // and this filter is on that exact column, exclude it from data filters
-                if let Expr::Column(partition_col) = &self.partition_by.expression {
-                    // Check if this filter references only the partition column
-                    if filter_cols.len() == 1 && filter_cols.iter().next() == Some(&partition_col) {
-                        return false; // Exclude from data filters
-                    }
+                // If this filter references only a simple partition column, exclude it
+                if filter_cols.len() == 1
+                    && let Some(col) = filter_cols.iter().next()
+                    && simple_partition_cols.contains(col)
+                {
+                    return false; // Exclude from data filters
                 }
                 // For all other cases (transform expressions, multiple columns, etc.), keep as data filter
                 true
@@ -268,14 +304,29 @@ impl TableProvider for PartitionTableProvider {
         let partitions = self.partitions.read().await;
         let mut plans = Vec::with_capacity(partitions.len());
         for partition in partitions.values() {
-            if prune_partition(
-                &partition_filters,
-                &self.partition_by.expression,
-                &partition.partition_value,
-                &self.schema,
-            )? {
+            // Check if this partition should be pruned based on ANY partition expression
+            let mut should_prune = false;
+            for (idx, partition_expr) in self.partition_by.iter().enumerate() {
+                // Get the partition value for this expression
+                let partition_value = partition.partition_values.get(idx).ok_or_else(|| {
+                    DataFusionError::Internal(format!("Partition missing value at index {idx}"))
+                })?;
+
+                if prune_partition(
+                    &partition_filters,
+                    &partition_expr.expression,
+                    partition_value,
+                    &self.schema,
+                )? {
+                    should_prune = true;
+                    break;
+                }
+            }
+
+            if should_prune {
                 continue;
             }
+
             let plan = partition
                 .table_provider
                 .scan(state, projection, &data_filters, limit)
@@ -400,7 +451,7 @@ impl DeletionSink for PartitionedDeletionSink {
                 }
             } else {
                 tracing::warn!(
-                    partition_value = %partition.partition_value,
+                    partition_values = ?partition.partition_values,
                     "Partition table provider does not support deletion. Skipping."
                 );
             }
@@ -602,7 +653,7 @@ mod tests {
     impl PartitionCreator for MockCreator {
         async fn create_partition(
             &self,
-            _partition_value: ScalarValue,
+            _partition_values: Vec<ScalarValue>,
         ) -> Result<Partition, super::super::creator::Error> {
             unreachable!("create_partition not needed for scan tests")
         }
@@ -614,7 +665,7 @@ mod tests {
             Ok(data
                 .iter()
                 .map(|(val, provider)| Partition {
-                    partition_value: val.clone(),
+                    partition_values: vec![val.clone()],
                     table_provider: Arc::clone(provider),
                 })
                 .collect())

--- a/crates/runtime-table-partition/tests/partition_table_provider.rs
+++ b/crates/runtime-table-partition/tests/partition_table_provider.rs
@@ -50,7 +50,7 @@ use runtime_table_partition::{Partition, creator::PartitionCreator};
 #[derive(Debug)]
 struct PartitionMemTable {
     mem_table: Arc<MemTable>,
-    partition_value: ScalarValue,
+    partition_values: Vec<ScalarValue>,
 }
 
 #[async_trait]
@@ -87,7 +87,7 @@ impl TableProvider for PartitionMemTable {
             .await?;
         Ok(Arc::new(PartitionMemTableExec {
             mem_table_exec,
-            partition_value: self.partition_value.clone(),
+            partition_values: self.partition_values.clone(),
             filters: filters.to_vec(),
             limit,
         }))
@@ -106,7 +106,7 @@ impl TableProvider for PartitionMemTable {
 #[derive(Debug)]
 struct PartitionMemTableExec {
     mem_table_exec: Arc<dyn ExecutionPlan>,
-    partition_value: ScalarValue,
+    partition_values: Vec<ScalarValue>,
     filters: Vec<Expr>,
     limit: Option<usize>,
 }
@@ -132,13 +132,13 @@ impl ExecutionPlan for PartitionMemTableExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let partition_value = self.partition_value.clone();
+        let partition_values = self.partition_values.clone();
         let filters = self.filters.clone();
         let limit = self.limit;
         let new_mem_table_exec = Arc::clone(&self.mem_table_exec).with_new_children(children)?;
         Ok(Arc::new(PartitionMemTableExec {
             mem_table_exec: new_mem_table_exec,
-            partition_value,
+            partition_values,
             filters,
             limit,
         }))
@@ -165,9 +165,9 @@ impl DisplayAs for PartitionMemTableExec {
     ) -> std::fmt::Result {
         write!(
             f,
-            "{}: partition_value={}",
+            "{}: partition_values={:?}",
             self.name(),
-            self.partition_value
+            self.partition_values
         )?;
 
         if !self.filters.is_empty() {
@@ -212,8 +212,16 @@ impl TestPartitionCreator {
 impl PartitionCreator for TestPartitionCreator {
     async fn create_partition(
         &self,
-        partition_value: ScalarValue,
+        partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
+        // For test purposes, we only use single-value partitions
+        let partition_value = partition_values
+            .first()
+            .ok_or_else(|| creator::Error::CreatePartition {
+                source: "At least one partition value is required".into(),
+            })?
+            .clone();
+
         let empty_columns: Vec<ArrayRef> = self
             .schema
             .fields()
@@ -230,14 +238,14 @@ impl PartitionCreator for TestPartitionCreator {
         );
         let partition_mem_table = Arc::new(PartitionMemTable {
             mem_table,
-            partition_value: partition_value.clone(),
+            partition_values: vec![partition_value.clone()],
         });
         self.partitions.write().await.insert(
             partition_value.to_string(),
             Arc::clone(&partition_mem_table),
         );
         Ok(Partition {
-            partition_value,
+            partition_values: vec![partition_value],
             table_provider: partition_mem_table,
         })
     }
@@ -258,7 +266,10 @@ impl PartitionCreator for TestPartitionCreator {
 fn collect_partition_values(plan: &Arc<dyn ExecutionPlan>) -> Vec<ScalarValue> {
     let mut values = Vec::new();
     if let Some(partition_exec) = plan.as_any().downcast_ref::<PartitionMemTableExec>() {
-        values.push(partition_exec.partition_value.clone());
+        // For single-column partitions in tests, just take the first value
+        if let Some(first) = partition_exec.partition_values.first() {
+            values.push(first.clone());
+        }
     }
     for child in plan.children() {
         values.extend(collect_partition_values(child));
@@ -1575,8 +1586,15 @@ impl DeletableTestPartitionCreator {
 impl PartitionCreator for DeletableTestPartitionCreator {
     async fn create_partition(
         &self,
-        partition_value: ScalarValue,
+        partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
+        let partition_value = partition_values
+            .first()
+            .ok_or_else(|| creator::Error::CreatePartition {
+                source: "At least one partition value is required".into(),
+            })?
+            .clone();
+
         let empty_columns: Vec<ArrayRef> = self
             .schema
             .fields()
@@ -1603,7 +1621,7 @@ impl PartitionCreator for DeletableTestPartitionCreator {
         let adapted_table: Arc<dyn TableProvider> =
             Arc::new(DeletionTableProviderAdapter::new(deletable_mem_table));
         Ok(Partition {
-            partition_value,
+            partition_values: vec![partition_value],
             table_provider: adapted_table,
         })
     }
@@ -1910,8 +1928,15 @@ impl NonDeletablePartitionCreator {
 impl PartitionCreator for NonDeletablePartitionCreator {
     async fn create_partition(
         &self,
-        partition_value: ScalarValue,
+        partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
+        let partition_value = partition_values
+            .first()
+            .ok_or_else(|| creator::Error::CreatePartition {
+                source: "At least one partition value is required".into(),
+            })?
+            .clone();
+
         let empty_columns: Vec<ArrayRef> = self
             .schema
             .fields()
@@ -1928,7 +1953,7 @@ impl PartitionCreator for NonDeletablePartitionCreator {
         );
         // Return MemTable directly without wrapping - doesn't support deletion
         Ok(Partition {
-            partition_value,
+            partition_values: vec![partition_value],
             table_provider: mem_table,
         })
     }

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_data_filter_all_partitions.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_data_filter_all_partitions.snap
@@ -3,7 +3,7 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=0, filters=[value > Int64(40)]
-  PartitionMemTableExec: partition_value=1, filters=[value > Int64(40)]
-  PartitionMemTableExec: partition_value=2, filters=[value > Int64(40)]
-  PartitionMemTableExec: partition_value=3, filters=[value > Int64(40)]
+  PartitionMemTableExec: partition_values=[Int32(0)], filters=[value > Int64(40)]
+  PartitionMemTableExec: partition_values=[Int32(1)], filters=[value > Int64(40)]
+  PartitionMemTableExec: partition_values=[Int32(2)], filters=[value > Int64(40)]
+  PartitionMemTableExec: partition_values=[Int32(3)], filters=[value > Int64(40)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_inequality_range.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_inequality_range.snap
@@ -3,11 +3,11 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=0, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=1, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=3, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=4, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=5, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=6, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=7, filters=[user_id > Int32(50), user_id <= Int32(70)]
-  PartitionMemTableExec: partition_value=8, filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(0)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(1)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(3)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(4)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(5)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(6)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(7)], filters=[user_id > Int32(50), user_id <= Int32(70)]
+  PartitionMemTableExec: partition_values=[Int32(8)], filters=[user_id > Int32(50), user_id <= Int32(70)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_inequality_unbounded.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_inequality_unbounded.snap
@@ -3,13 +3,13 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=0, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=1, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=2, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=3, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=4, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=5, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=6, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=7, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=8, filters=[user_id > Int32(80)]
-  PartitionMemTableExec: partition_value=9, filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(0)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(1)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(2)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(3)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(4)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(5)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(6)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(7)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(8)], filters=[user_id > Int32(80)]
+  PartitionMemTableExec: partition_values=[Int32(9)], filters=[user_id > Int32(80)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_partition_id_filter.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_partition_id_filter.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=0, filters=[id = Int64(5)]
+PartitionMemTableExec: partition_values=[Int32(0)], filters=[id = Int64(5)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_partition_with_data_filter.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__bucket_partition_with_data_filter.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=0, filters=[id = Int64(5), value > Int64(40)]
+PartitionMemTableExec: partition_values=[Int32(0)], filters=[id = Int64(5), value > Int64(40)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__data_filter_only.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__data_filter_only.snap
@@ -3,6 +3,6 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=eu-west-1, filters=[value > Int64(20)]
-  PartitionMemTableExec: partition_value=us-east-1, filters=[value > Int64(20)]
-  PartitionMemTableExec: partition_value=us-west-1, filters=[value > Int64(20)]
+  PartitionMemTableExec: partition_values=[Utf8("eu-west-1")], filters=[value > Int64(20)]
+  PartitionMemTableExec: partition_values=[Utf8("us-east-1")], filters=[value > Int64(20)]
+  PartitionMemTableExec: partition_values=[Utf8("us-west-1")], filters=[value > Int64(20)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_equality.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_equality.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=1736985600000000000, filters=[timestamp = TimestampNanosecond(1737023400000000000, None)]
+PartitionMemTableExec: partition_values=[TimestampNanosecond(1736985600000000000, None)], filters=[timestamp = TimestampNanosecond(1737023400000000000, None)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_greater_than.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_greater_than.snap
@@ -3,6 +3,6 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=1736985600000000000, filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]
-  PartitionMemTableExec: partition_value=1737072000000000000, filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]
-  PartitionMemTableExec: partition_value=1737158400000000000, filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]
+  PartitionMemTableExec: partition_values=[TimestampNanosecond(1736985600000000000, None)], filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]
+  PartitionMemTableExec: partition_values=[TimestampNanosecond(1737072000000000000, None)], filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]
+  PartitionMemTableExec: partition_values=[TimestampNanosecond(1737158400000000000, None)], filters=[timestamp > TimestampNanosecond(1737028800000000000, None)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_range.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__date_trunc_range.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=1736985600000000000, filters=[timestamp >= TimestampNanosecond(1736985600000000000, None), timestamp < TimestampNanosecond(1737072000000000000, None)]
+PartitionMemTableExec: partition_values=[TimestampNanosecond(1736985600000000000, None)], filters=[timestamp >= TimestampNanosecond(1736985600000000000, None), timestamp < TimestampNanosecond(1737072000000000000, None)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_equality.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_equality.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=3, filters=[value = Int32(23)]
+PartitionMemTableExec: partition_values=[Int32(3)], filters=[value = Int32(23)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_greater_than.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_greater_than.snap
@@ -3,13 +3,13 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=0, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=1, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=2, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=3, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=4, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=5, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=6, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=7, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=8, filters=[value > Int32(45)]
-  PartitionMemTableExec: partition_value=9, filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(0)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(1)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(2)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(3)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(4)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(5)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(6)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(7)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(8)], filters=[value > Int32(45)]
+  PartitionMemTableExec: partition_values=[Int32(9)], filters=[value > Int32(45)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_less_than.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__modulo_less_than.snap
@@ -3,8 +3,8 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=0, filters=[value < Int32(5)]
-  PartitionMemTableExec: partition_value=1, filters=[value < Int32(5)]
-  PartitionMemTableExec: partition_value=2, filters=[value < Int32(5)]
-  PartitionMemTableExec: partition_value=3, filters=[value < Int32(5)]
-  PartitionMemTableExec: partition_value=4, filters=[value < Int32(5)]
+  PartitionMemTableExec: partition_values=[Int32(0)], filters=[value < Int32(5)]
+  PartitionMemTableExec: partition_values=[Int32(1)], filters=[value < Int32(5)]
+  PartitionMemTableExec: partition_values=[Int32(2)], filters=[value < Int32(5)]
+  PartitionMemTableExec: partition_values=[Int32(3)], filters=[value < Int32(5)]
+  PartitionMemTableExec: partition_values=[Int32(4)], filters=[value < Int32(5)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_and_data_filters.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_and_data_filters.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=us-east-1, filters=[value > Int64(20)]
+PartitionMemTableExec: partition_values=[Utf8("us-east-1")], filters=[value > Int64(20)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_filter_in_list.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_filter_in_list.snap
@@ -3,5 +3,5 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=eu-west-1
-  PartitionMemTableExec: partition_value=us-east-1
+  PartitionMemTableExec: partition_values=[Utf8("eu-west-1")]
+  PartitionMemTableExec: partition_values=[Utf8("us-east-1")]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_filter_only.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__partition_filter_only.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=us-east-1
+PartitionMemTableExec: partition_values=[Utf8("us-east-1")]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_equality.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_equality.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=20
+PartitionMemTableExec: partition_values=[Int32(20)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_greater_than.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_greater_than.snap
@@ -3,5 +3,5 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=30
-  PartitionMemTableExec: partition_value=40
+  PartitionMemTableExec: partition_values=[Int32(30)]
+  PartitionMemTableExec: partition_values=[Int32(40)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_range.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__simple_column_range.snap
@@ -3,5 +3,5 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=20
-  PartitionMemTableExec: partition_value=30
+  PartitionMemTableExec: partition_values=[Int32(20)]
+  PartitionMemTableExec: partition_values=[Int32(30)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_equality.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_equality.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=1000, filters=[sales = Int64(1500)]
+PartitionMemTableExec: partition_values=[Int64(1000)], filters=[sales = Int64(1500)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_greater_than.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_greater_than.snap
@@ -3,5 +3,5 @@ source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
 PartitionedUnionExec
-  PartitionMemTableExec: partition_value=2000, filters=[sales > Int64(2500)]
-  PartitionMemTableExec: partition_value=3000, filters=[sales > Int64(2500)]
+  PartitionMemTableExec: partition_values=[Int64(2000)], filters=[sales > Int64(2500)]
+  PartitionMemTableExec: partition_values=[Int64(3000)], filters=[sales > Int64(2500)]

--- a/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_range.snap
+++ b/crates/runtime-table-partition/tests/snapshots/partition_table_provider__truncate_range.snap
@@ -2,4 +2,4 @@
 source: crates/runtime-table-partition/tests/partition_table_provider.rs
 expression: explain_plan
 ---
-PartitionMemTableExec: partition_value=1000, filters=[sales >= Int64(1000), sales < Int64(2000)]
+PartitionMemTableExec: partition_values=[Int64(1000)], filters=[sales >= Int64(1000), sales < Int64(2000)]

--- a/crates/runtime/src/dataaccelerator/cayenne.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne.rs
@@ -1996,7 +1996,18 @@ impl DataAccelerator for CayenneAccelerator {
 
             Ok(table_provider as Arc<dyn TableProvider>)
         } else {
-            let partition_by_last = partition_by.last().cloned().ok_or_else(|| {
+            // Cayenne currently only supports single-column partitioning due to catalog schema limitations
+            if partition_by.len() > 1 {
+                return Err(Box::new(Error::InvalidConfiguration {
+                    detail: Arc::from(format!(
+                        "Cayenne partitioning supports exactly one partition column, but {} were provided. Multi-column partitioning is not yet supported for Cayenne.",
+                        partition_by.len()
+                    )),
+                })
+                    as Box<dyn std::error::Error + Send + Sync>);
+            }
+
+            let partition_by_single = partition_by.first().cloned().ok_or_else(|| {
                 Box::new(Error::PartitionByRequired) as Box<dyn std::error::Error + Send + Sync>
             })?;
 
@@ -2090,7 +2101,7 @@ impl DataAccelerator for CayenneAccelerator {
             let creator = Arc::new(CayennePartitionCreator::new(
                 table_name,
                 PathBuf::from(&dir_path),
-                partition_by_last,
+                partition_by_single,
                 Arc::clone(&arrow_schema),
                 catalog,
                 table_metadata.table_id,
@@ -2266,8 +2277,30 @@ impl CayennePartitionCreator {
 impl PartitionCreator for CayennePartitionCreator {
     async fn create_partition(
         &self,
-        partition_value: ScalarValue,
+        partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
+        // Cayenne only supports single-column partitions
+        if partition_values.is_empty() {
+            return Err(creator::Error::CreatePartition {
+                source: "At least one partition value is required".into(),
+            });
+        }
+
+        if partition_values.len() > 1 {
+            return Err(creator::Error::CreatePartition {
+                source: format!(
+                    "Cayenne partitioning supports exactly one partition column, but {} values were provided",
+                    partition_values.len()
+                )
+                .into(),
+            });
+        }
+
+        // SAFETY: We verified partition_values.len() == 1 above, so first() will always succeed
+        let Some(partition_value) = partition_values.into_iter().next() else {
+            unreachable!("partition_values length was verified to be exactly 1")
+        };
+
         let partition_dir = self.partition_dir(&partition_value)?;
         let partition_path = partition_dir.to_string_lossy().to_string();
 
@@ -2331,7 +2364,7 @@ impl PartitionCreator for CayennePartitionCreator {
                 })?;
 
         Ok(Partition {
-            partition_value,
+            partition_values: vec![partition_value],
             table_provider: Arc::new(cayenne_table),
         })
     }
@@ -2383,7 +2416,7 @@ impl PartitionCreator for CayennePartitionCreator {
             })?;
 
             result.push(Partition {
-                partition_value,
+                partition_values: vec![partition_value],
                 table_provider: Arc::new(cayenne_table),
             });
         }

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -287,10 +287,7 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         self.is_initialized.store(false, Ordering::Release);
 
-        let partition_by_last = partition_by
-            .last()
-            .context(PartitionByRequiredSnafu)?
-            .clone();
+        ensure!(!partition_by.is_empty(), PartitionByRequiredSnafu);
 
         let source = source.context(ExpectedAccelerationSourceSnafu)?;
 
@@ -302,7 +299,7 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         let creator = Arc::new(DuckDBPartitionCreator::new(
             partition_dir(source),
             cmd,
-            partition_by_last,
+            partition_by.clone(),
             Arc::clone(&schema),
         ));
         let table_provider =
@@ -328,7 +325,7 @@ pub(crate) struct DuckDBPartitionCreator {
     cmd: CreateExternalTable,
     duckdb_factory: DuckDBTableProviderFactory,
     partition_dir: PathBuf,
-    partition_by: PartitionedBy,
+    partition_by: Vec<PartitionedBy>,
     schema: SchemaRef,
 }
 
@@ -336,7 +333,7 @@ impl DuckDBPartitionCreator {
     pub(crate) fn new(
         partition_dir: PathBuf,
         cmd: CreateExternalTable,
-        partition_by: PartitionedBy,
+        partition_by: Vec<PartitionedBy>,
         schema: SchemaRef,
     ) -> Self {
         let duckdb_factory = create_factory();
@@ -357,11 +354,16 @@ impl DuckDBPartitionCreator {
     fn add_open(
         &self,
         cmd: &mut CreateExternalTable,
-        partition_value: &ScalarValue,
+        partition_values: &[ScalarValue],
     ) -> Result<String, creator::Error> {
-        let hive_path =
-            to_hive_partition_dir(&[(self.partition_by.clone(), partition_value.clone())])
-                .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+        let pairings: Vec<(PartitionedBy, ScalarValue)> = self
+            .partition_by
+            .iter()
+            .cloned()
+            .zip(partition_values.iter().cloned())
+            .collect();
+        let hive_path = to_hive_partition_dir(&pairings)
+            .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
         let duckdb_path = self.partition_dir.join(&hive_path);
         if !duckdb_path.is_dir() {
             std::fs::create_dir_all(&duckdb_path)
@@ -379,11 +381,28 @@ impl DuckDBPartitionCreator {
 impl PartitionCreator for DuckDBPartitionCreator {
     async fn create_partition(
         &self,
-        partition_value: ScalarValue,
+        partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
+        if partition_values.is_empty() {
+            return Err(creator::Error::CreatePartition {
+                source: "At least one partition value is required".into(),
+            });
+        }
+
+        if partition_values.len() != self.partition_by.len() {
+            return Err(creator::Error::CreatePartition {
+                source: format!(
+                    "Expected {} partition values but got {}",
+                    self.partition_by.len(),
+                    partition_values.len()
+                )
+                .into(),
+            });
+        }
+
         let mut cmd = self.cmd.clone();
         let duckdb_path = self
-            .add_open(&mut cmd, &partition_value)
+            .add_open(&mut cmd, &partition_values)
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
         tracing::debug!("creating partition at {duckdb_path}");
@@ -393,7 +412,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
             .map_err(|e| creator::Error::CreatePartition { source: e })?;
 
         let partition = Partition {
-            partition_value,
+            partition_values,
             table_provider,
         };
 
@@ -410,25 +429,19 @@ impl PartitionCreator for DuckDBPartitionCreator {
 
         let schema = DFSchema::try_from(Arc::clone(&self.schema))
             .map_err(|e| creator::Error::InferringPartitions { source: e.into() })?;
-        let hive_partitions = discover_hive_partitions(
-            &schema,
-            &self.partition_dir,
-            std::slice::from_ref(&self.partition_by),
-        )
-        .map_err(|e| creator::Error::InferringPartitions { source: e.into() })?;
+        let hive_partitions =
+            discover_hive_partitions(&schema, &self.partition_dir, &self.partition_by)
+                .map_err(|e| creator::Error::InferringPartitions { source: e.into() })?;
 
         let mut partitions = Vec::with_capacity(hive_partitions.len());
-        for (mut keys, path) in hive_partitions {
-            if keys.len() != 1 {
+        for (partition_values, path) in hive_partitions {
+            // Only include partitions that have all expected partition columns
+            if partition_values.len() != self.partition_by.len() {
                 continue;
             }
 
-            let Some(partition_value) = keys.pop() else {
-                continue;
-            };
-
             let mut cmd = self.cmd.clone();
-            self.add_open(&mut cmd, &partition_value)
+            self.add_open(&mut cmd, &partition_values)
                 .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
             let duckdb_path = path.display().to_string();
@@ -441,7 +454,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
                 .map_err(|e| creator::Error::InferringPartitions { source: e })?;
 
             partitions.push(Partition {
-                partition_value,
+                partition_values,
                 table_provider,
             });
         }

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/insert.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/insert.rs
@@ -39,7 +39,7 @@ use datafusion_table_providers::{
 };
 use futures::StreamExt;
 use runtime_table_partition::{
-    creator::filename::encode_key,
+    creator::filename::encode_composite_key,
     expression::PartitionedBy,
     insert::{InsertStrategy, PartitionContext, partition_batch},
 };
@@ -133,13 +133,12 @@ impl DuckDBPartitionedInsertStrategy {
                                         let partitions_map = partitions
                                             .into_iter()
                                             .map(|p| {
-                                                let key = encode_key(&p.partition_value).map_err(
-                                                    |e| {
+                                                let key = encode_composite_key(&p.partition_values)
+                                                    .map_err(|e| {
                                                         DataFusionError::Execution(format!(
                                                             "Failed to encode partition key: {e}"
                                                         ))
-                                                    },
-                                                )?;
+                                                    })?;
                                                 Ok((key, p))
                                             })
                                             .collect::<Result<HashMap<_, _>, DataFusionError>>();
@@ -190,10 +189,25 @@ impl InsertStrategy for DuckDBPartitionedInsertStrategy {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let schema = Arc::clone(&ctx.schema);
 
+        // DuckDB table-based inserts support exactly one partition column
+        let partition_by = match ctx.partition_by.as_slice() {
+            [] => {
+                return Err(DataFusionError::Configuration(
+                    "Partition configuration required".to_string(),
+                ));
+            }
+            [single] => single,
+            _ => {
+                return Err(DataFusionError::Configuration(
+                    "DuckDB table-based inserts support exactly one partition column; multi-column partitioning is not supported".to_string(),
+                ));
+            }
+        };
+
         let partitioner = Arc::new(BatchPartitioner::new(
-            &ctx.partition_by.expression,
+            &partition_by.expression,
             Arc::clone(&schema),
-            &ctx.partition_by,
+            partition_by,
         )?);
 
         let data_sink = DuckDBPartitionedDataSink::new(

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -354,7 +354,7 @@ impl DuckDBPartitionCreator {
 impl PartitionCreator for DuckDBPartitionCreator {
     async fn create_partition(
         &self,
-        _partition_value: ScalarValue,
+        _partition_values: Vec<ScalarValue>,
     ) -> Result<Partition, creator::Error> {
         Err(creator::Error::CreatePartition {
             source: "Table-based partitions must not be manually created".into(),
@@ -409,7 +409,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
                 .map_err(|e| creator::Error::InferringPartitions { source: e })?;
 
             partitions.push(Partition {
-                partition_value,
+                partition_values: vec![partition_value],
                 table_provider,
             });
         }

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -156,7 +156,20 @@ impl SearchIndex for S3Vector {
                 let partitions = partition_batch(&record, physical_expr.as_ref())?;
 
                 let mut data = vec![];
-                for (partition_value, partition_record) in partitions.into_values() {
+                for (partition_values, partition_record) in partitions.into_values() {
+                    // S3 vector search only supports single-column partitioning
+                    if partition_values.is_empty() {
+                        return Err(Box::new(DataFusionError::Execution(
+                            "Expected at least one partition value".to_string(),
+                        )));
+                    }
+                    if partition_values.len() > 1 {
+                        return Err(Box::new(DataFusionError::Configuration(format!(
+                            "S3 vector search partitioning supports exactly one partition column, but {} values were provided",
+                            partition_values.len()
+                        ))));
+                    }
+                    let partition_value = &partition_values[0];
                     // change the index name to a partition name
                     let id = match Arc::unwrap_or_clone(Arc::clone(&self.table.idx)) {
                         S3VectorIdentifier::IndexArn(_) => {
@@ -183,7 +196,7 @@ impl SearchIndex for S3Vector {
                                 &index_name,
                                 &self.embedded_column,
                                 &self.partition_by,
-                                &partition_value,
+                                partition_value,
                             )?;
                             let index_name = partitioned_index_name.to_index_name();
                             tracing::trace!(


### PR DESCRIPTION
## Summary

Implements hierarchical/composite partitioning support for the runtime-table-partition crate. This allows users to specify multiple partition expressions (e.g., `partition_by: [region, category]`) and have data partitioned by all specified expressions. This is currently only implemented for DuckDB file mode, with the runtime offering clear error messages when used with other accelerators.

## Multi-column Partitioning Support

| Accelerator | Multi-column Support | Notes |
|------------|---------------------|-------|
| DuckDB (file mode) | ✅ Yes | Creates nested Hive-style directories (e.g., `expr0=us-east/expr1=electronics/data.db`) |
| DuckDB (tables mode) | ❌ No | Different architecture - creates separate DuckDB tables per partition value |
| Cayenne | ❌ No | Catalog schema limitation - `PartitionMetadata` stores single `partition_column`/`partition_value` |
| S3 Vector Search | ❌ No | Single-column only |

Multi-column support is currently only implemented for **DuckDB file mode** because:
1. It uses a simple file-based approach where partition paths can be nested hierarchically
2. No catalog schema changes required - partition values are encoded in directory names
3. The `discover_hive_partitions()` function already supports recursive discovery of nested partition directories

Extending other accelerators would require:
- **Cayenne**: Modifying `PartitionMetadata` to use vectors for partition columns/values, updating SQLite catalog schema
- **DuckDB tables mode**: Rearchitecting how partition tables are named and managed

## Key Changes

- Changed `Partition` struct from `partition_value: ScalarValue` to `partition_values: Vec<ScalarValue>`
- Updated `PartitionCreator` trait: `create_partition` now accepts `Vec<ScalarValue>`
- Added `encode_composite_key()` function to encode multiple partition values as a path-like key (e.g., "2025/10/15")
- Updated `PartitionTableProvider` to handle `Vec<PartitionedBy>` for multiple partition expressions
- Updated `scan()` pruning logic to prune if ANY partition expression's filter excludes the partition
- Updated data filter logic to exclude filters on any simple partition column
- Added `partition_batch_composite()` for multi-expression partitioning
- Updated DuckDB file-based accelerator to support multiple partition columns
- Added explicit validation with clear error messages for accelerators that don't support multi-column partitioning

## Design

The composite key encoding uses "/" as separator, creating hierarchical partition paths like "region=us-east/category=electronics".

Partition pruning logic: a partition is pruned if **any** partition expression's filter excludes it (AND semantics across expressions).

### Example

```yaml
datasets:
  - from: file:sales.csv
    name: sales
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
      partition_by:
        - region
        - category
```

Creates directory structure:
```
.spice/data/sales/
├── expr0=eu-west/
│   ├── expr1=clothing/data.db
│   └── expr1=electronics/data.db
├── expr0=us-east/
│   ├── expr1=clothing/data.db
│   └── expr1=electronics/data.db
└── expr0=us-west/
    ├── expr1=clothing/data.db
    └── expr1=electronics/data.db
```

Query with `WHERE region = 'us-east' AND category = 'electronics'` reads only 1 partition instead of 6.

## Testing

- Updated all existing unit tests in runtime-table-partition crate
- Updated snapshot tests with new partition display format
- All tests pass with `cargo test -p runtime-table-partition`
- Manual testing confirms partition pruning works correctly

## Related

- Closes #8539