### PR TITLE
Add distributed query mode support to testoperator

### DIFF
--- a/crates/test-framework/src/constants.rs
+++ b/crates/test-framework/src/constants.rs
@@ -37,6 +37,9 @@ pub const SQL_ENDPOINT: &str = "/v1/sql";
 /// Search endpoint path (relative to `HTTP_BASE_URL`)
 pub const SEARCH_ENDPOINT: &str = "/v1/search";
 
+/// Async queries endpoint path for distributed query mode (relative to `HTTP_BASE_URL`)
+pub const QUERIES_ENDPOINT: &str = "/v1/queries";
+
 /// Evals endpoint path template (relative to `HTTP_BASE_URL`)
 /// Use `format!("{HTTP_BASE_URL}/v1/evals/{eval_name}")`
 pub const EVALS_ENDPOINT_PREFIX: &str = "/v1/evals";

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -64,6 +64,7 @@ impl EndCondition {
 }
 
 #[derive(Default)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct NotStarted {
     query_set: Vec<Query>,
     end_condition: EndCondition,
@@ -73,6 +74,7 @@ pub struct NotStarted {
     disable_caching: bool,
     scale_factor: f64,
     http_client: bool,
+    distributed_mode: bool,
     validation_data: Option<HashMap<Arc<str>, Vec<RecordBatch>>>,
     reference_schema: Option<String>,
     streaming_metrics_sender: Option<mpsc::Sender<QueryMetricEvent>>,
@@ -127,6 +129,12 @@ impl NotStarted {
     #[must_use]
     pub fn with_http_client(mut self, http_client: bool) -> Self {
         self.http_client = http_client;
+        self
+    }
+
+    #[must_use]
+    pub fn with_distributed_mode(mut self, distributed_mode: bool) -> Self {
+        self.distributed_mode = distributed_mode;
         self
     }
 
@@ -276,7 +284,12 @@ impl SpiceTest<NotStarted> {
                 worker = worker.with_progress_bar(multi.add(self.get_new_progress_bar()));
             }
 
-            if self.state.http_client {
+            if self.state.distributed_mode {
+                // Distributed mode uses the /v1/queries async API
+                worker = worker
+                    .with_http_client(http_client.clone())
+                    .with_distributed_mode(true);
+            } else if self.state.http_client {
                 worker = worker.with_http_client(http_client.clone());
             } else {
                 let spice_client = self

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -31,7 +31,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::constants::{HTTP_BASE_URL, SQL_ENDPOINT};
+use crate::constants::{HTTP_BASE_URL, QUERIES_ENDPOINT, SQL_ENDPOINT};
 use crate::telemetry::streaming::QueryMetricEvent;
 
 use crate::{
@@ -42,6 +42,12 @@ use crate::{
 
 use super::EndCondition;
 
+/// Maximum interval between status polls for distributed queries (caps exponential backoff)
+const MAX_POLL_INTERVAL: Duration = Duration::from_millis(5000);
+/// Maximum time to wait for a distributed query to complete (1 hour)
+const POLL_TIMEOUT: Duration = Duration::from_secs(3600);
+
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct SpiceTestQueryWorker {
     id: usize,
     query_set: Vec<Query>,
@@ -54,6 +60,8 @@ pub(crate) struct SpiceTestQueryWorker {
     scale_factor: f64,
     spice_client: Option<Arc<SpiceClient>>,
     http_client: Option<reqwest::Client>,
+    /// Whether to use distributed query mode via /v1/queries API
+    distributed_mode: bool,
     /// Optional custom validation data for scenario queries
     validation_data: Option<HashMap<Arc<str>, Vec<RecordBatch>>>,
     /// Optional reference schema for validating against known good tables
@@ -124,6 +132,7 @@ impl SpiceTestQueryWorker {
             validate: false,
             scale_factor: 1.0,
             http_client: None,
+            distributed_mode: false,
             validation_data: None,
             reference_schema: None,
             skip_row_count_validation: default_row_count_validation_skip_queries(),
@@ -136,6 +145,11 @@ impl SpiceTestQueryWorker {
 
     pub fn with_http_client(mut self, http_client: reqwest::Client) -> Self {
         self.http_client = Some(http_client);
+        self
+    }
+
+    pub fn with_distributed_mode(mut self, distributed_mode: bool) -> Self {
+        self.distributed_mode = distributed_mode;
         self
     }
 
@@ -835,6 +849,209 @@ impl SpiceTestQueryWorker {
         Ok(())
     }
 
+    /// Execute a query using the distributed query API (`/v1/queries`).
+    ///
+    /// This method:
+    /// 1. Submits the query via `POST /v1/queries`
+    /// 2. Polls `/v1/queries/{query_id}/status` until completion
+    /// 3. Fetches results from `/v1/queries/{query_id}/results`
+    ///
+    /// The distributed query API is only available when spiced is running in cluster mode
+    /// with the scheduler role.
+    async fn execute_distributed(
+        &self,
+        query: &Query,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
+        row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
+    ) -> Result<()> {
+        let Some(http_client) = self.http_client.as_ref() else {
+            return Err(anyhow::anyhow!(
+                "Failed to execute distributed query '{}': HTTP client is not configured. Ensure distributed mode is only enabled when an HTTP client is available",
+                query.name
+            ));
+        };
+
+        let query_start = Instant::now();
+        let sql_text = query.to_sql_with_inlined_params();
+        let queries_url = format!("{HTTP_BASE_URL}{QUERIES_ENDPOINT}");
+
+        // Step 1: Submit the query
+        let submit_body = serde_json::json!({
+            "sql": sql_text,
+        });
+
+        let submit_response = http_client
+            .post(&queries_url)
+            .header("Content-Type", "application/json")
+            .json(&submit_body)
+            .send()
+            .await?;
+
+        let submit_status = submit_response.status();
+        if !submit_status.is_success() {
+            let error_text = submit_response.text().await.unwrap_or_default();
+            let duration = query_start.elapsed();
+            self.send_streaming_metric(&query.name, duration, false);
+            eprintln!(
+                "{} FAIL - Worker {} - Query '{}' distributed submit failed: {submit_status} - {error_text}",
+                chrono::Utc::now(),
+                self.id,
+                query.name,
+            );
+            return Err(anyhow::anyhow!(
+                "Query distributed submit failed: {submit_status}"
+            ));
+        }
+
+        let submit_json: serde_json::Value = submit_response.json().await?;
+        let query_id = submit_json
+            .get("query_id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("No query_id in submit response"))?;
+
+        // Step 2: Poll for completion
+        let status_url = format!("{queries_url}/{query_id}/status");
+        let mut poll_interval = Duration::from_millis(100);
+
+        let poll_start = Instant::now();
+        loop {
+            if poll_start.elapsed() > POLL_TIMEOUT {
+                let duration = query_start.elapsed();
+                self.send_streaming_metric(&query.name, duration, false);
+                return Err(anyhow::anyhow!(
+                    "Query '{}' timed out waiting for distributed execution",
+                    query.name
+                ));
+            }
+
+            let status_response = http_client.get(&status_url).send().await?;
+
+            if !status_response.status().is_success() {
+                let error_text = status_response.text().await.unwrap_or_default();
+                let duration = query_start.elapsed();
+                self.send_streaming_metric(&query.name, duration, false);
+                return Err(anyhow::anyhow!(
+                    "Query '{}' status check failed: {error_text}",
+                    query.name
+                ));
+            }
+
+            let status_json: serde_json::Value = status_response.json().await?;
+            let state = status_json
+                .get("state")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+
+            match state {
+                "succeeded" => break,
+                "failed" => {
+                    let error_msg = status_json
+                        .get("error")
+                        .and_then(|e| e.get("message"))
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("Unknown error");
+                    let duration = query_start.elapsed();
+                    self.send_streaming_metric(&query.name, duration, false);
+                    eprintln!(
+                        "{} FAIL - Worker {} - Query '{}' distributed execution failed: {error_msg}",
+                        chrono::Utc::now(),
+                        self.id,
+                        query.name,
+                    );
+                    return Err(anyhow::anyhow!(
+                        "Query distributed execution failed: {error_msg}"
+                    ));
+                }
+                "cancelled" => {
+                    let duration = query_start.elapsed();
+                    self.send_streaming_metric(&query.name, duration, false);
+                    return Err(anyhow::anyhow!("Query '{}' was cancelled", query.name));
+                }
+                "closed" => {
+                    let duration = query_start.elapsed();
+                    self.send_streaming_metric(&query.name, duration, false);
+                    return Err(anyhow::anyhow!(
+                        "Query '{}' results expired before retrieval",
+                        query.name
+                    ));
+                }
+                "pending" | "running" => {
+                    // Continue polling with exponential backoff
+                    tokio::time::sleep(poll_interval).await;
+                    poll_interval = std::cmp::min(poll_interval * 2, MAX_POLL_INTERVAL);
+                }
+                _ => {
+                    // Unknown state, continue polling
+                    tokio::time::sleep(poll_interval).await;
+                    poll_interval = std::cmp::min(poll_interval * 2, MAX_POLL_INTERVAL);
+                }
+            }
+        }
+
+        // Step 3: Fetch results (first chunk to get row count)
+        let results_url = format!("{queries_url}/{query_id}/results");
+        let results_response = http_client.get(&results_url).send().await?;
+
+        let results_status = results_response.status();
+        if !results_status.is_success() {
+            let error_text = results_response.text().await.unwrap_or_default();
+            let duration = query_start.elapsed();
+            self.send_streaming_metric(&query.name, duration, false);
+            return Err(anyhow::anyhow!(
+                "Query '{}' results fetch failed: {results_status} - {error_text}",
+                query.name
+            ));
+        }
+
+        let results_json: serde_json::Value = results_response.json().await?;
+
+        // Get total row count from manifest; treat missing or invalid values as errors
+        let manifest = results_json.get("manifest").ok_or_else(|| {
+            anyhow::anyhow!(
+                "Query '{}' results response missing 'manifest' field",
+                query.name
+            )
+        })?;
+
+        let total_row_count_value = manifest.get("total_row_count").ok_or_else(|| {
+            anyhow::anyhow!(
+                "Query '{}' results manifest missing 'total_row_count' field",
+                query.name
+            )
+        })?;
+
+        let total_row_count_u64 = total_row_count_value.as_u64().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Query '{}' results manifest 'total_row_count' field is not a valid u64",
+                query.name
+            )
+        })?;
+
+        #[expect(clippy::cast_possible_truncation)]
+        let row_count = total_row_count_u64 as usize;
+
+        let duration = query_start.elapsed();
+
+        // Send streaming metric for successful distributed query
+        self.send_streaming_metric(&query.name, duration, true);
+
+        query_durations
+            .entry(Arc::clone(&query.name))
+            .or_default()
+            .push(duration);
+
+        row_counts
+            .entry(Arc::clone(&query.name))
+            .or_default()
+            .push(row_count);
+
+        if let Some(pb) = self.progress_bar.as_ref() {
+            pb.inc(1);
+        }
+
+        Ok(())
+    }
+
     async fn execute_query(
         &self,
         query: &Query,
@@ -843,6 +1060,13 @@ impl SpiceTestQueryWorker {
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
+        // Use distributed mode if enabled
+        if self.distributed_mode {
+            return self
+                .execute_distributed(query, query_durations, row_counts)
+                .await;
+        }
+
         let mut http_row_counts: BTreeMap<Arc<str>, Vec<usize>> = BTreeMap::new();
 
         futures::future::try_join(

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -23,6 +23,7 @@ use test_framework::queries::{QueryOverrides, QuerySet};
 use super::CommonArgs;
 
 #[derive(Parser, Debug, Clone)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct QueryArgs {
     /// The expected scale factor for the test, used in metrics calculation
     #[arg(long)]
@@ -53,9 +54,14 @@ pub struct QueryArgs {
     /// Whether to add HTTP clients for the test
     #[arg(long)]
     pub(crate) http_clients: bool,
+
+    /// Use distributed query mode via /v1/queries API (requires cluster mode with scheduler role)
+    #[arg(long)]
+    pub(crate) distributed: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct DatasetTestArgs {
     #[command(flatten)]
     pub(crate) common: CommonArgs,
@@ -89,6 +95,10 @@ pub struct DatasetTestArgs {
     /// Whether to add HTTP clients for the test
     #[arg(long)]
     pub(crate) http_clients: bool,
+
+    /// Use distributed query mode via /v1/queries API (requires cluster mode with scheduler role)
+    #[arg(long)]
+    pub(crate) distributed: bool,
 
     /// Random parameter set count for parameterized queries (tests with different random parameters each run).
     /// If not specified or 0, fixed parameters are used (no randomization).

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -195,6 +195,8 @@ pub struct LoadArgs {
     pub random_param_set_count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub http_clients: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distributed: Option<bool>,
 }
 
 /// Append workflow arguments, defined in the test files
@@ -229,6 +231,7 @@ impl<'de> Deserialize<'de> for LoadArgs {
             concurrency: Option<u64>,
             random_param_set_count: Option<usize>,
             http_clients: Option<bool>,
+            distributed: Option<bool>,
         }
 
         let mut helper = LoadArgsHelper::deserialize(deserializer)?;
@@ -253,6 +256,7 @@ impl<'de> Deserialize<'de> for LoadArgs {
             concurrency: helper.concurrency,
             random_param_set_count: helper.random_param_set_count,
             http_clients: helper.http_clients,
+            distributed: helper.distributed,
         })
     }
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -128,7 +128,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
             .with_validate(args.validate)
             .with_disable_caching(args.disable_caching)
             .with_scale_factor(args.scale_factor.unwrap_or(1.0))
-            .with_http_client(args.http_clients),
+            .with_http_client(args.http_clients)
+            .with_distributed_mode(args.distributed),
     )
     .await?;
 

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -37,6 +37,7 @@ use test_framework::{
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     if args.test_args.common.concurrency < 2 {
         return Err(anyhow::anyhow!(
@@ -128,7 +129,8 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(args.test_args.common.concurrency)
             .with_end_condition(EndCondition::QuerySetCompleted(1))
             .with_disable_caching(args.test_args.disable_caching)
-            .with_http_client(args.test_args.http_clients),
+            .with_http_client(args.test_args.http_clients)
+            .with_distributed_mode(args.test_args.distributed),
     )
     .await?;
 
@@ -155,7 +157,8 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(args.test_args.common.concurrency)
             .with_end_condition(EndCondition::Duration(baseline_duration))
             .with_disable_caching(args.test_args.disable_caching)
-            .with_http_client(args.test_args.http_clients),
+            .with_http_client(args.test_args.http_clients)
+            .with_distributed_mode(args.test_args.distributed),
     )
     .await?;
 
@@ -202,6 +205,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         .with_end_condition(load_end_condition)
         .with_disable_caching(args.test_args.disable_caching)
         .with_http_client(args.test_args.http_clients)
+        .with_distributed_mode(args.test_args.distributed)
         .with_query_duration_threshold(args.test_args.mark_query_failed_if_exceeds);
 
     // Add streaming metrics sender if exporter is configured

--- a/tools/testoperator/src/commands/query/mod.rs
+++ b/tools/testoperator/src/commands/query/mod.rs
@@ -59,6 +59,7 @@ pub(crate) async fn run(args: &QueryArgs) -> anyhow::Result<RowCounts> {
         .with_disable_caching(args.disable_caching)
         .with_scale_factor(args.scale_factor.unwrap_or(1.0))
         .with_http_client(args.http_clients)
+        .with_distributed_mode(args.distributed)
         .with_query_set(queries)
         .with_query_set_type(query_set.clone())
         .with_query_overrides(query_overrides);

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -54,7 +54,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(1)
             .with_end_condition(EndCondition::QuerySetCompleted(6))
             .with_disable_caching(args.disable_caching)
-            .with_http_client(args.http_clients),
+            .with_http_client(args.http_clients)
+            .with_distributed_mode(args.distributed),
     )
     .await?;
 
@@ -78,7 +79,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(args.common.concurrency)
             .with_end_condition(EndCondition::QuerySetCompleted(2))
             .with_disable_caching(args.disable_caching)
-            .with_http_client(args.http_clients),
+            .with_http_client(args.http_clients)
+            .with_distributed_mode(args.distributed),
     )
     .await?;
 


### PR DESCRIPTION
Adds `--distributed` flag to testoperator commands (bench, query, throughput, load) to enable benchmarking queries via the `/v1/queries` async API used for distributed query execution in cluster mode.

- Part of #9216

## Changes

- Add `QUERIES_ENDPOINT` constant in `test-framework/constants.rs`
- Add `--distributed` CLI flag to `QueryArgs` and `DatasetTestArgs`
- Add `distributed_mode` field to `NotStarted` test builder and `SpiceTestQueryWorker`
- Implement `execute_distributed()` method that:
  - Submits query via `POST /v1/queries`
  - Polls `/v1/queries/{query_id}/status` until completion
  - Fetches results from `/v1/queries/{query_id}/results`
- Update `execute_query()` to route to distributed mode when enabled
- Update all commands (bench, query, throughput, load) to pass distributed flag
- Add `distributed` field to dispatch `LoadArgs` for workflow configuration

## Usage

```bash
# Run benchmark in distributed query mode
testoperator run bench -p ./spicepod.yaml --query-set tpch --distributed

# Run load test in distributed query mode
testoperator run load -p ./spicepod.yaml --query-set tpch --concurrency 10 --distributed
```

## Notes

- The `/v1/queries` API is only available when spiced is running in cluster mode with the scheduler role (`spiced --role scheduler`)
- The implementation uses exponential backoff when polling for query completion (100ms to 5s)
- Query timeout is set to 1 hour maximum