### PR TITLE
Fix NOW() evaluation in `simplify_expr` by setting query execution start time

### DIFF
--- a/crates/runtime/src/datafusion/expr_utils.rs
+++ b/crates/runtime/src/datafusion/expr_utils.rs
@@ -47,7 +47,7 @@ use datafusion::{
 pub(crate) fn simplify_expr(expr: Expr, schema: &SchemaRef) -> Result<Expr, DataFusionError> {
     let df_schema = DFSchema::try_from(schema.as_ref().clone())?;
 
-    let execution_props = ExecutionProps::new();
+    let execution_props = ExecutionProps::new().with_query_execution_start_time(chrono::Utc::now()); // required to correctly evaluate now()
     let simplify_context = SimplifyContext::new(&execution_props).with_schema(Arc::new(df_schema));
     let simplifier = ExprSimplifier::new(simplify_context);
 


### PR DESCRIPTION
Updated execution properties to include query execution start time for correct evaluation of 'now()'.

## 📝 Summary

`ExecutionProps::new` sets `query_execution_start_time: None`, causing NOW() to not be simplified during expression simplification. This broke retention expressions like `DELETE FROM test WHERE timestamp_col < to_unixtime(NOW() - INTERVAL '7 days')` since the `NOW()` function remained unevaluated.

Note: in retention we don't use `now()` expr, we receive system time, but it still can be used via `retention_sql`


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
