### PR TITLE
FlightSQL: add cookie middleware support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12527,6 +12527,7 @@ dependencies = [
  "snafu",
  "spicepod",
  "tracing",
+ "yaml",
  "zip 7.2.0",
 ]
 
@@ -16974,6 +16975,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "yaml",
  "zip 7.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7169,11 +7169,14 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
+ "http 1.4.0",
+ "parking_lot 0.12.5",
  "rustls-native-certs 0.8.3",
  "secrecy",
  "snafu",
  "tokio",
  "tonic",
+ "tower 0.5.3",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7161,6 +7161,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "flight-cookie-server"
+version = "2.0.0-unstable"
+dependencies = [
+ "arrow-array",
+ "arrow-flight",
+ "arrow-schema",
+ "bytes",
+ "clap 4.5.54",
+ "futures",
+ "prost 0.14.3",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "flight_client"
 version = "2.0.0-unstable"
 dependencies = [
@@ -7175,6 +7193,7 @@ dependencies = [
  "secrecy",
  "snafu",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower 0.5.3",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "tools/evalconverter",
     "tools/flightpublisher/",
     "tools/flightsubscriber/",
+    "tools/flight-cookie-server/",
     "tools/otelpublisher/",
     "tools/spicepodschema/",
     "tools/spiceschema",

--- a/crates/data-connectors/connector-flightsql/src/lib.rs
+++ b/crates/data-connectors/connector-flightsql/src/lib.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use data_components::Read;
 use data_components::flightsql::FlightSQLFactory as DataComponentFlightSQLFactory;
 use datafusion::datasource::TableProvider;
+use flight_client::cookie::{CookieService, CookieStore};
 use flight_client::tls::new_tls_flight_channel;
 use flight_client::{MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE};
 use runtime::component::dataset::Dataset;
@@ -113,9 +114,11 @@ impl DataConnectorFactory for FlightSQLFactory {
                 .ok()
                 .map(PathBuf::from);
 
+            let cookie_store = Arc::new(CookieStore::new());
             let flight_channel = new_tls_flight_channel(&endpoint, ca_certificate_path.as_deref())
                 .await
                 .context(UnableToConstructTlsChannelSnafu)?;
+            let flight_channel = CookieService::new(flight_channel, Arc::clone(&cookie_store));
 
             let max_message_size =
                 match params
@@ -145,7 +148,8 @@ impl DataConnectorFactory for FlightSQLFactory {
                     .await
                     .context(UnableToPerformHandshakeSnafu)?;
             }
-            let flightsql_factory = DataComponentFlightSQLFactory::new(client, endpoint);
+            let flightsql_factory =
+                DataComponentFlightSQLFactory::new(client, endpoint, cookie_store);
             Ok(Arc::new(FlightSQL { flightsql_factory }) as Arc<dyn DataConnector>)
         })
     }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -171,6 +171,8 @@ ctor = "0.6.3"
 iceberg_test_utils = { workspace = true, features = ["tests"] }
 insta.workspace = true
 object_store = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt", "sync"] }
+tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -589,3 +589,233 @@ pub async fn get_client_for_flight_endpoint(
         Ok(FlightSqlServiceClient::new(channel))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{FlightSqlClient, query_to_stream};
+    use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+    use arrow_flight::{
+        Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint,
+        FlightInfo, Location, PollInfo, PutResult, SchemaResult, Ticket,
+    };
+    use bytes::Bytes;
+    use flight_client::cookie::{CookieService, CookieStore};
+    use futures::TryStreamExt;
+    use std::net::SocketAddr;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio::task::JoinHandle;
+    use tokio_stream::Empty as EmptyStream;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Channel;
+    use tonic::{Request, Response, Status, async_trait};
+
+    const COOKIE_VALUE: &str = "AWSALB=abc123";
+
+    struct TestServer {
+        addr: SocketAddr,
+        shutdown: Option<oneshot::Sender<()>>,
+        handle: JoinHandle<Result<(), tonic::transport::Error>>,
+    }
+
+    impl TestServer {
+        async fn start(cookie_seen: Arc<AtomicBool>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("listener should bind");
+            let addr = listener.local_addr().expect("listener should have addr");
+            let location = format!("http://{addr}");
+            let service = CookieFlightSqlService::new(cookie_seen, location);
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+            let handle = tokio::spawn(async move {
+                tonic::transport::Server::builder()
+                    .add_service(FlightServiceServer::new(service))
+                    .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await
+            });
+            Self {
+                addr,
+                shutdown: Some(shutdown_tx),
+                handle,
+            }
+        }
+
+        async fn shutdown(mut self) {
+            if let Some(shutdown) = self.shutdown.take() {
+                let _ = shutdown.send(());
+            }
+            self.handle
+                .await
+                .expect("server task should finish")
+                .expect("server should exit cleanly");
+        }
+    }
+
+    #[derive(Clone)]
+    struct CookieFlightSqlService {
+        cookie_required: Arc<AtomicBool>,
+        cookie_seen: Arc<AtomicBool>,
+        location: String,
+    }
+
+    impl CookieFlightSqlService {
+        fn new(cookie_seen: Arc<AtomicBool>, location: String) -> Self {
+            Self {
+                cookie_required: Arc::new(AtomicBool::new(false)),
+                cookie_seen,
+                location,
+            }
+        }
+    }
+
+    type EmptyResponseStream<T> = EmptyStream<Result<T, Status>>;
+
+    #[async_trait]
+    impl FlightService for CookieFlightSqlService {
+        type HandshakeStream = EmptyResponseStream<arrow_flight::HandshakeResponse>;
+        type ListFlightsStream = EmptyResponseStream<FlightInfo>;
+        type DoGetStream = EmptyResponseStream<FlightData>;
+        type DoPutStream = EmptyResponseStream<PutResult>;
+        type DoExchangeStream = EmptyResponseStream<FlightData>;
+        type DoActionStream = EmptyResponseStream<arrow_flight::Result>;
+        type ListActionsStream = EmptyResponseStream<ActionType>;
+
+        async fn handshake(
+            &self,
+            _request: Request<tonic::Streaming<arrow_flight::HandshakeRequest>>,
+        ) -> Result<Response<Self::HandshakeStream>, Status> {
+            Err(Status::unimplemented("handshake"))
+        }
+
+        async fn list_flights(
+            &self,
+            _request: Request<Criteria>,
+        ) -> Result<Response<Self::ListFlightsStream>, Status> {
+            Err(Status::unimplemented("list_flights"))
+        }
+
+        async fn get_flight_info(
+            &self,
+            _request: Request<FlightDescriptor>,
+        ) -> Result<Response<FlightInfo>, Status> {
+            self.cookie_required.store(true, Ordering::SeqCst);
+            let endpoint = FlightEndpoint {
+                ticket: Some(Ticket {
+                    ticket: Bytes::from_static(b"ticket"),
+                }),
+                location: vec![Location {
+                    uri: self.location.clone(),
+                }],
+                expiration_time: None,
+                app_metadata: Bytes::new(),
+            };
+
+            let mut response = Response::new(FlightInfo {
+                schema: Bytes::new(),
+                flight_descriptor: None,
+                endpoint: vec![endpoint],
+                total_records: -1,
+                total_bytes: -1,
+                ordered: false,
+                app_metadata: Bytes::new(),
+            });
+            response.metadata_mut().insert(
+                "set-cookie",
+                format!("{COOKIE_VALUE}; Path=/")
+                    .parse()
+                    .expect("cookie header should be valid"),
+            );
+            Ok(response)
+        }
+
+        async fn poll_flight_info(
+            &self,
+            _request: Request<FlightDescriptor>,
+        ) -> Result<Response<PollInfo>, Status> {
+            Err(Status::unimplemented("poll_flight_info"))
+        }
+
+        async fn get_schema(
+            &self,
+            _request: Request<FlightDescriptor>,
+        ) -> Result<Response<SchemaResult>, Status> {
+            Err(Status::unimplemented("get_schema"))
+        }
+
+        async fn do_get(
+            &self,
+            request: Request<Ticket>,
+        ) -> Result<Response<Self::DoGetStream>, Status> {
+            if self.cookie_required.load(Ordering::SeqCst) {
+                let cookie_header = request
+                    .metadata()
+                    .get("cookie")
+                    .and_then(|value| value.to_str().ok())
+                    .ok_or_else(|| Status::unauthenticated("cookie missing"))?;
+                if !cookie_header.contains(COOKIE_VALUE) {
+                    return Err(Status::unauthenticated("cookie missing"));
+                }
+            }
+            self.cookie_seen.store(true, Ordering::SeqCst);
+            Ok(Response::new(tokio_stream::empty()))
+        }
+
+        async fn do_put(
+            &self,
+            _request: Request<tonic::Streaming<FlightData>>,
+        ) -> Result<Response<Self::DoPutStream>, Status> {
+            Err(Status::unimplemented("do_put"))
+        }
+
+        async fn do_exchange(
+            &self,
+            _request: Request<tonic::Streaming<FlightData>>,
+        ) -> Result<Response<Self::DoExchangeStream>, Status> {
+            Err(Status::unimplemented("do_exchange"))
+        }
+
+        async fn do_action(
+            &self,
+            _request: Request<Action>,
+        ) -> Result<Response<Self::DoActionStream>, Status> {
+            Err(Status::unimplemented("do_action"))
+        }
+
+        async fn list_actions(
+            &self,
+            _request: Request<Empty>,
+        ) -> Result<Response<Self::ListActionsStream>, Status> {
+            Err(Status::unimplemented("list_actions"))
+        }
+    }
+
+    #[tokio::test]
+    async fn query_to_stream_sends_cookie_to_endpoint_client() {
+        let cookie_seen = Arc::new(AtomicBool::new(false));
+        let server = TestServer::start(Arc::clone(&cookie_seen)).await;
+        let cookie_store = Arc::new(CookieStore::new());
+        let channel = Channel::from_shared(format!("http://{}", server.addr))
+            .expect("channel should parse")
+            .connect()
+            .await
+            .expect("channel should connect");
+        let channel = CookieService::new(channel, Arc::clone(&cookie_store));
+        let client: FlightSqlClient =
+            arrow_flight::sql::client::FlightSqlServiceClient::new(channel);
+
+        let batches = query_to_stream(client, "SELECT 1".to_string(), Arc::clone(&cookie_store))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("query should succeed");
+        assert!(batches.is_empty());
+        assert!(cookie_seen.load(Ordering::SeqCst));
+
+        server.shutdown().await;
+    }
+}

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -22,7 +22,9 @@ use async_stream::stream;
 use async_trait::async_trait;
 use datafusion_table_providers::sql::sql_provider_datafusion::expr;
 use flight_client::{
-    MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE, tls::new_tls_flight_channel,
+    MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE,
+    cookie::{CookieService, CookieStore},
+    tls::new_tls_flight_channel,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use snafu::prelude::*;
@@ -106,16 +108,23 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+type FlightSqlClient = FlightSqlServiceClient<CookieService<Channel>>;
+
 #[derive(Debug, Clone)]
 pub struct FlightSQLFactory {
-    client: FlightSqlServiceClient<Channel>,
+    client: FlightSqlClient,
     endpoint: String,
+    cookie_store: Arc<CookieStore>,
 }
 
 impl FlightSQLFactory {
     #[must_use]
-    pub fn new(client: FlightSqlServiceClient<Channel>, endpoint: String) -> Self {
-        Self { client, endpoint }
+    pub fn new(client: FlightSqlClient, endpoint: String, cookie_store: Arc<CookieStore>) -> Self {
+        Self {
+            client,
+            endpoint,
+            cookie_store,
+        }
     }
 }
 
@@ -131,6 +140,7 @@ impl Read for FlightSQLFactory {
                 &self.endpoint,
                 self.client.clone(),
                 table_reference,
+                Arc::clone(&self.cookie_store),
             )
             .await?,
         );
@@ -145,9 +155,10 @@ impl Read for FlightSQLFactory {
 pub struct FlightSQLTable {
     name: &'static str,
     join_push_down_context: String,
-    client: FlightSqlServiceClient<Channel>,
+    client: FlightSqlClient,
     table_reference: TableReference,
     schema: SchemaRef,
+    cookie_store: Arc<CookieStore>,
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -155,8 +166,9 @@ impl FlightSQLTable {
     pub async fn create(
         name: &'static str,
         endpoint: &str,
-        client: FlightSqlServiceClient<Channel>,
+        client: FlightSqlClient,
         table_reference: impl Into<TableReference>,
+        cookie_store: Arc<CookieStore>,
     ) -> Result<Self> {
         let table_reference: TableReference = table_reference.into();
         let schema = Self::get_schema(client.clone(), table_reference.clone()).await?;
@@ -166,15 +178,17 @@ impl FlightSQLTable {
             table_reference,
             schema,
             join_push_down_context: format!("endpoint={endpoint}"),
+            cookie_store,
         })
     }
 
     pub fn create_with_schema(
         name: &'static str,
         endpoint: &str,
-        client: FlightSqlServiceClient<Channel>,
+        client: FlightSqlClient,
         table_reference: impl Into<TableReference>,
         schema: SchemaRef,
+        cookie_store: Arc<CookieStore>,
     ) -> Self {
         let table_reference: TableReference = table_reference.into();
         Self {
@@ -183,6 +197,7 @@ impl FlightSQLTable {
             table_reference,
             schema,
             join_push_down_context: format!("endpoint={endpoint}"),
+            cookie_store,
         }
     }
 
@@ -190,10 +205,12 @@ impl FlightSQLTable {
         s: &'static str,
         table_reference: impl Into<TableReference>,
     ) -> Result<Self> {
+        let cookie_store = Arc::new(CookieStore::new());
         let channel = channel::Endpoint::from_static(s)
             .connect()
             .await
             .context(UnableToConnectToServerSnafu)?;
+        let channel = CookieService::new(channel, Arc::clone(&cookie_store));
 
         let flight_client = FlightServiceClient::new(channel)
             .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
@@ -204,6 +221,7 @@ impl FlightSQLTable {
             s,
             FlightSqlServiceClient::new_from_inner(flight_client),
             table_reference.into(),
+            cookie_store,
         )
         .await
     }
@@ -280,7 +298,7 @@ impl FlightSQLTable {
     }
 
     pub async fn get_schema(
-        mut client: FlightSqlServiceClient<Channel>,
+        mut client: FlightSqlClient,
         table_reference: TableReference,
     ) -> Result<SchemaRef> {
         let flight_info = client
@@ -350,6 +368,7 @@ impl FlightSQLTable {
             self.client.clone(),
             filters,
             limit,
+            Arc::clone(&self.cookie_store),
         )?))
     }
 }
@@ -398,10 +417,11 @@ impl TableProvider for FlightSQLTable {
 struct FlightSqlExec {
     projected_schema: SchemaRef,
     table_reference: TableReference,
-    client: FlightSqlServiceClient<Channel>,
+    client: FlightSqlClient,
     filters: Vec<Expr>,
     limit: Option<usize>,
     properties: PlanProperties,
+    cookie_store: Arc<CookieStore>,
 }
 
 impl FlightSqlExec {
@@ -409,9 +429,10 @@ impl FlightSqlExec {
         projections: Option<&Vec<usize>>,
         schema: &SchemaRef,
         table_reference: &TableReference,
-        client: FlightSqlServiceClient<Channel>,
+        client: FlightSqlClient,
         filters: &[Expr],
         limit: Option<usize>,
+        cookie_store: Arc<CookieStore>,
     ) -> DataFusionResult<Self> {
         let projected_schema = project_schema(schema, projections)?;
         Ok(Self {
@@ -426,6 +447,7 @@ impl FlightSqlExec {
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             ),
+            cookie_store,
         })
     }
 
@@ -510,16 +532,19 @@ impl ExecutionPlan for FlightSqlExec {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let sql = self.sql().map_err(to_execution_error)?;
 
-        let stream_adapter =
-            RecordBatchStreamAdapter::new(self.schema(), query_to_stream(self.client.clone(), sql));
+        let stream_adapter = RecordBatchStreamAdapter::new(
+            self.schema(),
+            query_to_stream(self.client.clone(), sql, Arc::clone(&self.cookie_store)),
+        );
 
         Ok(Box::pin(stream_adapter))
     }
 }
 
 fn query_to_stream(
-    mut client: FlightSqlServiceClient<Channel>,
+    mut client: FlightSqlClient,
     sql: String,
+    cookie_store: Arc<CookieStore>,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
     stream! {
         let flight_info = client
@@ -529,7 +554,7 @@ fn query_to_stream(
 
         for ep in flight_info.endpoint {
             if let Some(tkt) = ep.clone().ticket {
-                match get_client_for_flight_endpoint(&client, ep).await
+                match get_client_for_flight_endpoint(&client, ep, &cookie_store).await
                     .map_err(to_execution_error)?
                     .do_get(tkt.clone()).await {
                         Ok(mut flight_stream) => {
@@ -552,13 +577,15 @@ fn to_execution_error(e: impl Into<Box<dyn std::error::Error>>) -> DataFusionErr
 }
 
 pub async fn get_client_for_flight_endpoint(
-    client: &FlightSqlServiceClient<Channel>,
+    client: &FlightSqlClient,
     ep: FlightEndpoint,
-) -> Result<FlightSqlServiceClient<Channel>, Box<dyn std::error::Error>> {
+    cookie_store: &Arc<CookieStore>,
+) -> Result<FlightSqlClient, Box<dyn std::error::Error>> {
     if ep.location.is_empty() {
         Ok(client.clone())
     } else {
         let channel = new_tls_flight_channel(&ep.location[0].uri, None).await?;
+        let channel = CookieService::new(channel, Arc::clone(cookie_store));
         Ok(FlightSqlServiceClient::new(channel))
     }
 }

--- a/crates/data_components/src/flightsql/federation.rs
+++ b/crates/data_components/src/flightsql/federation.rs
@@ -74,7 +74,11 @@ impl SQLExecutor for FlightSQLTable {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
-            query_to_stream(self.client.clone(), query.to_string()),
+            query_to_stream(
+                self.client.clone(),
+                query.to_string(),
+                Arc::clone(&self.cookie_store),
+            ),
         )))
     }
 

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -16,6 +16,8 @@ arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 base64.workspace = true
 bytes.workspace = true
 futures.workspace = true
+http.workspace = true
+parking_lot.workspace = true
 rustls-native-certs = "0.8.2"
 secrecy.workspace = true
 snafu.workspace = true
@@ -25,6 +27,7 @@ tonic = { workspace = true, features = [
     "tls-ring",
     "tls-native-roots",
 ] }
+tower.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -31,4 +31,5 @@ tower.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "sync"] }
+tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/flight_client/src/cookie.rs
+++ b/crates/flight_client/src/cookie.rs
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use http::header::{COOKIE, SET_COOKIE};
+use http::{HeaderMap, HeaderValue};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Debug, Default)]
+pub struct CookieStore {
+    cookies: RwLock<HashMap<String, String>>,
+}
+
+impl CookieStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cookies: RwLock::new(HashMap::new()),
+        }
+    }
+
+    #[must_use]
+    pub fn cookie_header_value(&self) -> Option<HeaderValue> {
+        let cookies = self.cookies.read();
+        if cookies.is_empty() {
+            return None;
+        }
+
+        let mut header = String::new();
+        for (index, (name, value)) in cookies.iter().enumerate() {
+            if index > 0 {
+                header.push_str("; ");
+            }
+            header.push_str(name);
+            header.push('=');
+            header.push_str(value);
+        }
+
+        HeaderValue::from_str(&header).ok()
+    }
+
+    pub fn update_from_headers(&self, headers: &HeaderMap) {
+        let mut cookies = self.cookies.write();
+        for value in headers.get_all(SET_COOKIE) {
+            if let Ok(value) = value.to_str()
+                && let Some((name, val)) = parse_set_cookie(value)
+            {
+                cookies.insert(name, val);
+            }
+        }
+    }
+}
+
+fn parse_set_cookie(value: &str) -> Option<(String, String)> {
+    let entry = value.split(';').next()?.trim();
+    let (name, val) = entry.split_once('=')?;
+    if name.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), val.to_string()))
+}
+
+#[derive(Debug, Clone)]
+pub struct CookieLayer {
+    store: Arc<CookieStore>,
+}
+
+impl CookieLayer {
+    #[must_use]
+    pub fn new(store: Arc<CookieStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl<S> Layer<S> for CookieLayer {
+    type Service = CookieService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CookieService::new(inner, Arc::clone(&self.store))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CookieService<S> {
+    inner: S,
+    store: Arc<CookieStore>,
+}
+
+impl<S> CookieService<S> {
+    #[must_use]
+    pub fn new(inner: S, store: Arc<CookieStore>) -> Self {
+        Self { inner, store }
+    }
+
+    #[must_use]
+    pub fn cookie_store(&self) -> Arc<CookieStore> {
+        Arc::clone(&self.store)
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for CookieService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Send,
+    S::Future: Send + 'static,
+{
+    type Response = http::Response<ResBody>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        if let Some(cookie_header) = self.store.cookie_header_value() {
+            req.headers_mut().insert(COOKIE, cookie_header);
+        }
+
+        let store = Arc::clone(&self.store);
+        let fut = self.inner.call(req);
+        Box::pin(async move {
+            let response = fut.await?;
+            store.update_from_headers(response.headers());
+            Ok(response)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::HeaderMap;
+
+    #[test]
+    fn cookie_store_builds_header() {
+        let store = CookieStore::new();
+        let mut headers = HeaderMap::new();
+        headers.append(
+            SET_COOKIE,
+            HeaderValue::from_static("AWSALB=abc123; Path=/"),
+        );
+        headers.append(
+            SET_COOKIE,
+            HeaderValue::from_static("AWSALBTG=def456; Path=/"),
+        );
+        store.update_from_headers(&headers);
+        let header = store
+            .cookie_header_value()
+            .expect("cookie header should be present")
+            .to_str()
+            .expect("cookie header should be valid UTF-8")
+            .to_string();
+        assert!(header.contains("AWSALB=abc123"));
+        assert!(header.contains("AWSALBTG=def456"));
+    }
+}

--- a/crates/flight_client/src/cookie.rs
+++ b/crates/flight_client/src/cookie.rs
@@ -72,9 +72,11 @@ impl CookieStore {
 fn parse_set_cookie(value: &str) -> Option<(String, String)> {
     let entry = value.split(';').next()?.trim();
     let (name, val) = entry.split_once('=')?;
+    let name = name.trim();
     if name.is_empty() {
         return None;
     }
+    let val = val.trim();
     Some((name.to_string(), val.to_string()))
 }
 
@@ -170,5 +172,53 @@ mod tests {
             .to_string();
         assert!(header.contains("AWSALB=abc123"));
         assert!(header.contains("AWSALBTG=def456"));
+    }
+
+    #[test]
+    fn cookie_store_overwrites_cookie() {
+        let store = CookieStore::new();
+        let mut headers = HeaderMap::new();
+        headers.append(SET_COOKIE, HeaderValue::from_static("AWSALB=old; Path=/"));
+        store.update_from_headers(&headers);
+
+        let mut updated_headers = HeaderMap::new();
+        updated_headers.append(SET_COOKIE, HeaderValue::from_static("AWSALB=new; Path=/"));
+        store.update_from_headers(&updated_headers);
+
+        let header = store
+            .cookie_header_value()
+            .expect("cookie header should be present")
+            .to_str()
+            .expect("cookie header should be valid UTF-8")
+            .to_string();
+        assert!(header.contains("AWSALB=new"));
+        assert!(!header.contains("AWSALB=old"));
+    }
+
+    #[test]
+    fn cookie_store_trims_cookie_parts() {
+        let store = CookieStore::new();
+        let mut headers = HeaderMap::new();
+        headers.append(
+            SET_COOKIE,
+            HeaderValue::from_static(" name = value ; Path=/"),
+        );
+        store.update_from_headers(&headers);
+        let header = store
+            .cookie_header_value()
+            .expect("cookie header should be present")
+            .to_str()
+            .expect("cookie header should be valid UTF-8")
+            .to_string();
+        assert!(header.contains("name=value"));
+    }
+
+    #[test]
+    fn cookie_store_ignores_invalid_set_cookie() {
+        let store = CookieStore::new();
+        let mut headers = HeaderMap::new();
+        headers.append(SET_COOKIE, HeaderValue::from_static("invalid"));
+        store.update_from_headers(&headers);
+        assert!(store.cookie_header_value().is_none());
     }
 }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -45,6 +45,7 @@ use tonic::IntoStreamingRequest;
 use tonic::transport::Channel;
 
 pub mod arrow_flight_factory;
+pub mod cookie;
 pub mod tls;
 
 pub const MAX_ENCODING_MESSAGE_SIZE: usize = 100 * 1024 * 1024;

--- a/crates/flight_client/tests/cookie_middleware.rs
+++ b/crates/flight_client/tests/cookie_middleware.rs
@@ -1,0 +1,237 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightDescriptor, FlightEndpoint, FlightInfo, Location,
+    PollInfo, SchemaResult, Ticket,
+};
+use flight_client::cookie::{CookieService, CookieStore};
+use std::net::SocketAddr;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio_stream::Empty as EmptyStream;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Channel;
+use tonic::{Request, Response, Status, async_trait};
+
+const COOKIE_VALUE: &str = "AWSALB=abc123";
+
+struct TestServer {
+    addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+impl TestServer {
+    async fn start(service: CookieFlightService) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener should have addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(FlightServiceServer::new(service))
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        });
+        Self {
+            addr,
+            shutdown: Some(shutdown_tx),
+            handle,
+        }
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        self.handle
+            .await
+            .expect("server task should finish")
+            .expect("server should exit cleanly");
+    }
+}
+
+#[derive(Clone)]
+struct CookieFlightService {
+    cookie_required: Arc<AtomicBool>,
+    cookie_seen: Arc<AtomicBool>,
+}
+
+impl CookieFlightService {
+    fn new(cookie_seen: Arc<AtomicBool>) -> Self {
+        Self {
+            cookie_required: Arc::new(AtomicBool::new(false)),
+            cookie_seen,
+        }
+    }
+}
+
+type EmptyResponseStream<T> = EmptyStream<Result<T, Status>>;
+
+#[async_trait]
+impl FlightService for CookieFlightService {
+    type HandshakeStream = EmptyResponseStream<arrow_flight::HandshakeResponse>;
+    type ListFlightsStream = EmptyResponseStream<FlightInfo>;
+    type DoGetStream = EmptyResponseStream<arrow_flight::FlightData>;
+    type DoPutStream = EmptyResponseStream<arrow_flight::PutResult>;
+    type DoExchangeStream = EmptyResponseStream<arrow_flight::FlightData>;
+    type DoActionStream = EmptyResponseStream<arrow_flight::Result>;
+    type ListActionsStream = EmptyResponseStream<ActionType>;
+
+    async fn handshake(
+        &self,
+        _request: Request<tonic::Streaming<arrow_flight::HandshakeRequest>>,
+    ) -> Result<Response<Self::HandshakeStream>, Status> {
+        Err(Status::unimplemented("handshake"))
+    }
+
+    async fn list_flights(
+        &self,
+        _request: Request<Criteria>,
+    ) -> Result<Response<Self::ListFlightsStream>, Status> {
+        Err(Status::unimplemented("list_flights"))
+    }
+
+    async fn get_flight_info(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
+        if self.cookie_required.load(Ordering::SeqCst) {
+            let cookie_header = request
+                .metadata()
+                .get("cookie")
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| Status::unauthenticated("cookie missing"))?;
+            if !cookie_header.contains(COOKIE_VALUE) {
+                return Err(Status::unauthenticated("cookie missing"));
+            }
+            self.cookie_seen.store(true, Ordering::SeqCst);
+        }
+        self.cookie_required.store(true, Ordering::SeqCst);
+
+        let mut response = Response::new(FlightInfo {
+            schema: bytes::Bytes::new(),
+            flight_descriptor: None,
+            endpoint: vec![FlightEndpoint {
+                ticket: Some(Ticket {
+                    ticket: bytes::Bytes::from_static(b"noop"),
+                }),
+                location: vec![Location { uri: String::new() }],
+                expiration_time: None,
+                app_metadata: bytes::Bytes::new(),
+            }],
+            total_records: -1,
+            total_bytes: -1,
+            ordered: false,
+            app_metadata: bytes::Bytes::new(),
+        });
+        response.metadata_mut().insert(
+            "set-cookie",
+            format!("{COOKIE_VALUE}; Path=/")
+                .parse()
+                .expect("cookie header should be valid"),
+        );
+        Ok(response)
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("poll_flight_info"))
+    }
+
+    async fn get_schema(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<SchemaResult>, Status> {
+        Err(Status::unimplemented("get_schema"))
+    }
+
+    async fn do_get(
+        &self,
+        _request: Request<Ticket>,
+    ) -> Result<Response<Self::DoGetStream>, Status> {
+        Err(Status::unimplemented("do_get"))
+    }
+
+    async fn do_put(
+        &self,
+        _request: Request<tonic::Streaming<arrow_flight::FlightData>>,
+    ) -> Result<Response<Self::DoPutStream>, Status> {
+        Err(Status::unimplemented("do_put"))
+    }
+
+    async fn do_exchange(
+        &self,
+        _request: Request<tonic::Streaming<arrow_flight::FlightData>>,
+    ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        Err(Status::unimplemented("do_exchange"))
+    }
+
+    async fn do_action(
+        &self,
+        _request: Request<Action>,
+    ) -> Result<Response<Self::DoActionStream>, Status> {
+        Err(Status::unimplemented("do_action"))
+    }
+
+    async fn list_actions(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<Self::ListActionsStream>, Status> {
+        Err(Status::unimplemented("list_actions"))
+    }
+}
+
+#[tokio::test]
+async fn cookie_middleware_persists_cookie_across_requests() {
+    let cookie_seen = Arc::new(AtomicBool::new(false));
+    let service = CookieFlightService::new(Arc::clone(&cookie_seen));
+    let server = TestServer::start(service).await;
+
+    let cookie_store = Arc::new(CookieStore::new());
+    let channel = Channel::from_shared(format!("http://{}", server.addr))
+        .expect("channel should parse")
+        .connect()
+        .await
+        .expect("channel should connect");
+    let channel = CookieService::new(channel, Arc::clone(&cookie_store));
+    let mut client = arrow_flight::flight_service_client::FlightServiceClient::new(channel);
+
+    let descriptor = FlightDescriptor::new_path(vec!["cookie".to_string()]);
+    client
+        .get_flight_info(descriptor.clone())
+        .await
+        .expect("first request should succeed");
+    client
+        .get_flight_info(descriptor)
+        .await
+        .expect("second request should include cookie");
+
+    assert!(cookie_seen.load(Ordering::SeqCst));
+    server.shutdown().await;
+}

--- a/tools/flight-cookie-server/Cargo.toml
+++ b/tools/flight-cookie-server/Cargo.toml
@@ -9,10 +9,13 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-arrow-flight.workspace = true
+arrow-array.workspace = true
+arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
+arrow-schema.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures.workspace = true
+prost.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic = { workspace = true, features = ["transport"] }

--- a/tools/flight-cookie-server/Cargo.toml
+++ b/tools/flight-cookie-server/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+description = "Spice OSS Flight cookie test server"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "flight-cookie-server"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+arrow-flight.workspace = true
+bytes.workspace = true
+clap = { workspace = true, features = ["derive"] }
+futures.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tonic = { workspace = true, features = ["transport"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/tools/flight-cookie-server/src/main.rs
+++ b/tools/flight-cookie-server/src/main.rs
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
+    HandshakeResponse, Location, PollInfo, PutResult, SchemaResult, Ticket,
+};
+use bytes::Bytes;
+use clap::Parser;
+use futures::Stream;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, async_trait};
+
+#[derive(Parser, Debug)]
+#[clap(about = "Spice.ai Flight cookie test server")]
+struct Args {
+    #[arg(long, default_value = "127.0.0.1:50051")]
+    addr: String,
+
+    #[arg(long, default_value = "AWSALB=abc123")]
+    cookie: String,
+
+    #[arg(long, default_value_t = true)]
+    require_cookie: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let addr: SocketAddr = args.addr.parse().map_err(|err| {
+        format!("Invalid address '{}': {err}", args.addr)
+    })?;
+    let location = format!("http://{addr}");
+
+    let service = CookieFlightService::new(args.cookie, args.require_cookie, location);
+
+    tracing::info!("Starting Flight cookie server on {addr}");
+    let listener = TcpListener::bind(addr).await?;
+    tonic::transport::Server::builder()
+        .add_service(FlightServiceServer::new(service))
+        .serve_with_incoming(TcpListenerStream::new(listener))
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct CookieFlightService {
+    cookie: String,
+    require_cookie: bool,
+    location: String,
+}
+
+impl CookieFlightService {
+    fn new(cookie: String, require_cookie: bool, location: String) -> Self {
+        Self {
+            cookie,
+            require_cookie,
+            location,
+        }
+    }
+}
+
+type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send>>;
+
+#[async_trait]
+impl FlightService for CookieFlightService {
+    type HandshakeStream = ResponseStream<arrow_flight::HandshakeResponse>;
+    type ListFlightsStream = ResponseStream<FlightInfo>;
+    type DoGetStream = ResponseStream<FlightData>;
+    type DoPutStream = ResponseStream<PutResult>;
+    type DoExchangeStream = ResponseStream<FlightData>;
+    type DoActionStream = ResponseStream<arrow_flight::Result>;
+    type ListActionsStream = ResponseStream<ActionType>;
+
+    async fn handshake(
+        &self,
+        _request: Request<tonic::Streaming<arrow_flight::HandshakeRequest>>,
+    ) -> Result<Response<Self::HandshakeStream>, Status> {
+        let response_stream: Self::HandshakeStream = Box::pin(tokio_stream::iter(vec![Ok(
+            HandshakeResponse {
+                protocol_version: 0,
+                payload: Bytes::new(),
+            },
+        )]));
+        let mut response = Response::new(response_stream);
+        response.metadata_mut().insert(
+            "set-cookie",
+            format!("{}; Path=/", self.cookie)
+                .parse()
+                .map_err(|_| Status::internal("invalid cookie header"))?,
+        );
+        Ok(response)
+    }
+
+    async fn list_flights(
+        &self,
+        _request: Request<Criteria>,
+    ) -> Result<Response<Self::ListFlightsStream>, Status> {
+        Ok(Response::new(Box::pin(tokio_stream::empty())))
+    }
+
+    async fn get_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
+        let endpoint = FlightEndpoint {
+            ticket: Some(Ticket {
+                ticket: Bytes::from_static(b"cookie"),
+            }),
+            location: vec![Location {
+                uri: self.location.clone(),
+            }],
+            expiration_time: None,
+            app_metadata: Bytes::new(),
+        };
+
+        let mut response = Response::new(FlightInfo {
+            schema: Bytes::new(),
+            flight_descriptor: None,
+            endpoint: vec![endpoint],
+            total_records: -1,
+            total_bytes: -1,
+            ordered: false,
+            app_metadata: Bytes::new(),
+        });
+        response.metadata_mut().insert(
+            "set-cookie",
+            format!("{}; Path=/", self.cookie)
+                .parse()
+                .map_err(|_| Status::internal("invalid cookie header"))?,
+        );
+        Ok(response)
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("poll_flight_info"))
+    }
+
+    async fn get_schema(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<SchemaResult>, Status> {
+        Err(Status::unimplemented("get_schema"))
+    }
+
+    async fn do_get(&self, request: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
+        if self.require_cookie {
+            let cookie_header = request
+                .metadata()
+                .get("cookie")
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| Status::unauthenticated("cookie missing"))?;
+            if !cookie_header.contains(&self.cookie) {
+                return Err(Status::unauthenticated("cookie missing"));
+            }
+            tracing::info!("Received cookie header: {cookie_header}");
+        }
+
+        Ok(Response::new(Box::pin(tokio_stream::empty())))
+    }
+
+    async fn do_put(
+        &self,
+        _request: Request<tonic::Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoPutStream>, Status> {
+        Err(Status::unimplemented("do_put"))
+    }
+
+    async fn do_exchange(
+        &self,
+        _request: Request<tonic::Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        Err(Status::unimplemented("do_exchange"))
+    }
+
+    async fn do_action(
+        &self,
+        _request: Request<Action>,
+    ) -> Result<Response<Self::DoActionStream>, Status> {
+        Err(Status::unimplemented("do_action"))
+    }
+
+    async fn list_actions(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<Self::ListActionsStream>, Status> {
+        Ok(Response::new(Box::pin(tokio_stream::empty())))
+    }
+}

--- a/tools/flight-cookie-server/src/main.rs
+++ b/tools/flight-cookie-server/src/main.rs
@@ -14,19 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow_array::{ArrayRef, Int32Array, RecordBatch};
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::sql::metadata::GetTablesBuilder;
+use arrow_flight::sql::{Any, Command};
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
     HandshakeResponse, Location, PollInfo, PutResult, SchemaResult, Ticket,
 };
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use bytes::Bytes;
 use clap::Parser;
-use futures::Stream;
+use futures::{Stream, TryStreamExt};
+use prost::Message;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status, async_trait};
+
+const TABLES_TICKET: &[u8] = b"tables";
+const QUERY_TICKET: &[u8] = b"query";
 
 #[derive(Parser, Debug)]
 #[clap(about = "Spice.ai Flight cookie test server")]
@@ -39,6 +50,18 @@ struct Args {
 
     #[arg(long, default_value_t = true)]
     require_cookie: bool,
+
+    #[arg(long, default_value = "default")]
+    catalog: String,
+
+    #[arg(long, default_value = "public")]
+    schema: String,
+
+    #[arg(long, default_value = "cookies")]
+    table: String,
+
+    #[arg(long, default_value = "value")]
+    column: String,
 }
 
 #[tokio::main]
@@ -46,12 +69,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
     let args = Args::parse();
 
-    let addr: SocketAddr = args.addr.parse().map_err(|err| {
-        format!("Invalid address '{}': {err}", args.addr)
-    })?;
+    let addr: SocketAddr = args
+        .addr
+        .parse()
+        .map_err(|err| format!("Invalid address '{}': {err}", args.addr))?;
     let location = format!("http://{addr}");
 
-    let service = CookieFlightService::new(args.cookie, args.require_cookie, location);
+    let table_info = Arc::new(TableInfo::new(
+        args.catalog,
+        args.schema,
+        args.table,
+        args.column,
+    )?);
+
+    let service = CookieFlightService::new(args.cookie, args.require_cookie, location, table_info);
 
     tracing::info!("Starting Flight cookie server on {addr}");
     let listener = TcpListener::bind(addr).await?;
@@ -64,18 +95,67 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[derive(Clone)]
+struct TableInfo {
+    table_schema: SchemaRef,
+    tables_batch: RecordBatch,
+    query_batches: Vec<RecordBatch>,
+}
+
+impl TableInfo {
+    fn new(
+        catalog: String,
+        schema: String,
+        table: String,
+        column: String,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let table_schema = Arc::new(Schema::new(vec![Field::new(
+            column,
+            DataType::Int32,
+            false,
+        )]));
+        let query_batch = RecordBatch::try_new(
+            Arc::clone(&table_schema),
+            vec![Arc::new(Int32Array::from(vec![1])) as ArrayRef],
+        )?;
+
+        let mut tables_builder = GetTablesBuilder::new(
+            None::<String>,
+            None::<String>,
+            None::<String>,
+            Vec::<String>::new(),
+            true,
+        );
+        tables_builder.append(&catalog, &schema, &table, "TABLE", table_schema.as_ref())?;
+        let tables_batch = tables_builder.build()?;
+
+        Ok(Self {
+            table_schema,
+            tables_batch,
+            query_batches: vec![query_batch],
+        })
+    }
+}
+
+#[derive(Clone)]
 struct CookieFlightService {
     cookie: String,
     require_cookie: bool,
     location: String,
+    table_info: Arc<TableInfo>,
 }
 
 impl CookieFlightService {
-    fn new(cookie: String, require_cookie: bool, location: String) -> Self {
+    fn new(
+        cookie: String,
+        require_cookie: bool,
+        location: String,
+        table_info: Arc<TableInfo>,
+    ) -> Self {
         Self {
             cookie,
             require_cookie,
             location,
+            table_info,
         }
     }
 }
@@ -121,11 +201,17 @@ impl FlightService for CookieFlightService {
 
     async fn get_flight_info(
         &self,
-        _request: Request<FlightDescriptor>,
+        request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        let descriptor = request.into_inner();
+        let ticket = match decode_command(&descriptor) {
+            Some(Command::CommandGetTables(_)) => TABLES_TICKET,
+            _ => QUERY_TICKET,
+        };
+
         let endpoint = FlightEndpoint {
             ticket: Some(Ticket {
-                ticket: Bytes::from_static(b"cookie"),
+                ticket: Bytes::from_static(ticket),
             }),
             location: vec![Location {
                 uri: self.location.clone(),
@@ -136,7 +222,7 @@ impl FlightService for CookieFlightService {
 
         let mut response = Response::new(FlightInfo {
             schema: Bytes::new(),
-            flight_descriptor: None,
+            flight_descriptor: Some(descriptor),
             endpoint: vec![endpoint],
             total_records: -1,
             total_bytes: -1,
@@ -166,7 +252,10 @@ impl FlightService for CookieFlightService {
         Err(Status::unimplemented("get_schema"))
     }
 
-    async fn do_get(&self, request: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
+    async fn do_get(
+        &self,
+        request: Request<Ticket>,
+    ) -> Result<Response<Self::DoGetStream>, Status> {
         if self.require_cookie {
             let cookie_header = request
                 .metadata()
@@ -179,7 +268,28 @@ impl FlightService for CookieFlightService {
             tracing::info!("Received cookie header: {cookie_header}");
         }
 
-        Ok(Response::new(Box::pin(tokio_stream::empty())))
+        let ticket = request.into_inner().ticket;
+        let (schema, batches) = if ticket.as_ref() == TABLES_TICKET {
+            (
+                self.table_info.tables_batch.schema(),
+                vec![self.table_info.tables_batch.clone()],
+            )
+        } else {
+            (
+                Arc::clone(&self.table_info.table_schema),
+                self.table_info.query_batches.clone(),
+            )
+        };
+
+        let stream = FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .build(futures::stream::iter(
+                batches
+                    .into_iter()
+                    .map(|batch| Ok::<_, FlightError>(batch)),
+            ))
+            .map_err(Status::from);
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn do_put(
@@ -209,4 +319,12 @@ impl FlightService for CookieFlightService {
     ) -> Result<Response<Self::ListActionsStream>, Status> {
         Ok(Response::new(Box::pin(tokio_stream::empty())))
     }
+}
+
+fn decode_command(descriptor: &FlightDescriptor) -> Option<Command> {
+    if descriptor.cmd.is_empty() {
+        return None;
+    }
+    let any = Any::decode(descriptor.cmd.as_ref()).ok()?;
+    Command::try_from(any).ok()
 }

--- a/tools/flight-cookie-server/src/main.rs
+++ b/tools/flight-cookie-server/src/main.rs
@@ -176,12 +176,11 @@ impl FlightService for CookieFlightService {
         &self,
         _request: Request<tonic::Streaming<arrow_flight::HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        let response_stream: Self::HandshakeStream = Box::pin(tokio_stream::iter(vec![Ok(
-            HandshakeResponse {
+        let response_stream: Self::HandshakeStream =
+            Box::pin(tokio_stream::iter(vec![Ok(HandshakeResponse {
                 protocol_version: 0,
                 payload: Bytes::new(),
-            },
-        )]));
+            })]));
         let mut response = Response::new(response_stream);
         response.metadata_mut().insert(
             "set-cookie",
@@ -284,9 +283,7 @@ impl FlightService for CookieFlightService {
         let stream = FlightDataEncoderBuilder::new()
             .with_schema(schema)
             .build(futures::stream::iter(
-                batches
-                    .into_iter()
-                    .map(|batch| Ok::<_, FlightError>(batch)),
+                batches.into_iter().map(|batch| Ok::<_, FlightError>(batch)),
             ))
             .map_err(Status::from);
         Ok(Response::new(Box::pin(stream)))

--- a/tools/flight-cookie-server/src/main.rs
+++ b/tools/flight-cookie-server/src/main.rs
@@ -76,10 +76,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let location = format!("http://{addr}");
 
     let table_info = Arc::new(TableInfo::new(
-        args.catalog,
-        args.schema,
-        args.table,
-        args.column,
+        &args.catalog,
+        &args.schema,
+        &args.table,
+        &args.column,
     )?);
 
     let service = CookieFlightService::new(args.cookie, args.require_cookie, location, table_info);
@@ -103,10 +103,10 @@ struct TableInfo {
 
 impl TableInfo {
     fn new(
-        catalog: String,
-        schema: String,
-        table: String,
-        column: String,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        column: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let table_schema = Arc::new(Schema::new(vec![Field::new(
             column,
@@ -125,7 +125,7 @@ impl TableInfo {
             Vec::<String>::new(),
             true,
         );
-        tables_builder.append(&catalog, &schema, &table, "TABLE", table_schema.as_ref())?;
+        tables_builder.append(catalog, schema, table, "TABLE", table_schema.as_ref())?;
         let tables_batch = tables_builder.build()?;
 
         Ok(Self {
@@ -283,7 +283,7 @@ impl FlightService for CookieFlightService {
         let stream = FlightDataEncoderBuilder::new()
             .with_schema(schema)
             .build(futures::stream::iter(
-                batches.into_iter().map(|batch| Ok::<_, FlightError>(batch)),
+                batches.into_iter().map(Ok::<_, FlightError>),
             ))
             .map_err(Status::from);
         Ok(Response::new(Box::pin(stream)))


### PR DESCRIPTION
## Problem
FlightSQL sessions break behind load balancers that rely on sticky cookies (for example AWS ALB). The FlightSQL client does not persist cookies, so the handshake lands on one backend and subsequent requests are routed elsewhere, resulting in session errors.

- Closes #9273

## Solution
- Add a cookie middleware for Flight clients to capture Set-Cookie headers and attach Cookie on subsequent requests.
- Wire the cookie store through the FlightSQL connector and federation execution path so endpoint clients reuse the same cookies.
- Add unit/integration tests for cookie parsing, middleware behavior, and FlightSQL query paths.
- Add a manual test tool () for ad-hoc verification.
