### PR TITLE
fix: Respect timeout_seconds and maximum_size for async jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12505,6 +12505,7 @@ dependencies = [
  "snafu",
  "spicepod",
  "tracing",
+ "yaml",
  "zip 7.2.0",
 ]
 
@@ -16952,6 +16953,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "yaml",
  "zip 7.2.0",
 ]
 

--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -360,7 +360,7 @@ pub async fn handle_cancel_async_query(body: &[u8]) -> Result<Vec<u8>, Status> {
 
 fn job_state_to_status_response(state: &JobState) -> GetAsyncQueryStatusResponse {
     let error = state.error.as_ref().map(|e| AsyncQueryError {
-        error_code: e.error_code.clone(),
+        error_code: e.error_code,
         message: e.message.clone(),
     });
 

--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -31,7 +31,8 @@ use serde::{Deserialize, Serialize};
 use tonic::Status;
 
 use crate::datafusion::job_executor_context_extension::get_job_executor;
-use crate::jobs::{JobState, JobStatus};
+use crate::http::v1::queries::SubmitQueryRequest;
+use crate::jobs::{JobErrorCode, JobState, JobStatus};
 use runtime_request_context::{AsyncMarker, RequestContext};
 
 /// Action types for async query operations.
@@ -163,16 +164,6 @@ impl fmt::Display for QueryId {
     }
 }
 
-/// Request to submit an async query.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SubmitAsyncQueryRequest {
-    /// The SQL query to execute.
-    pub sql: String,
-    /// Optional query parameters as JSON.
-    #[serde(default)]
-    pub parameters: Option<serde_json::Value>,
-}
-
 /// Response from submitting an async query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitAsyncQueryResponse {
@@ -208,7 +199,7 @@ pub struct GetAsyncQueryStatusResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AsyncQueryError {
     /// Error code.
-    pub error_code: String,
+    pub error_code: JobErrorCode,
     /// Error message.
     pub message: String,
 }
@@ -256,12 +247,12 @@ pub async fn handle_submit_async_query(body: &[u8]) -> Result<Vec<u8>, Status> {
     let executor = get_job_executor(&context)
         .ok_or_else(|| Status::unavailable("Async queries are only available in cluster mode"))?;
 
-    let request: SubmitAsyncQueryRequest = serde_json::from_slice(body).map_err(|e| {
-        Status::invalid_argument(format!("Failed to parse SubmitAsyncQueryRequest: {e}"))
+    let request: SubmitQueryRequest = serde_json::from_slice(body).map_err(|e| {
+        Status::invalid_argument(format!("Failed to parse SubmitQueryRequest: {e}"))
     })?;
 
     let state = executor
-        .submit(request.sql, request.parameters)
+        .submit(request)
         .await
         .map_err(|e| Status::internal(format!("Failed to submit query: {e}")))?;
 

--- a/crates/runtime/src/http/v1/iceberg/namespace.rs
+++ b/crates/runtime/src/http/v1/iceberg/namespace.rs
@@ -32,10 +32,12 @@ impl Namespace {
         Self { parts }
     }
 
+    #[must_use]
     pub fn from_single_part(part: String) -> Self {
         Self { parts: vec![part] }
     }
 
+    #[must_use]
     pub fn from_parts(parts: Vec<String>) -> Self {
         Self { parts }
     }

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -122,10 +122,12 @@ pub struct ResponseMetadata {
 
 impl ResponseMetadata {
     /// Creates an empty `ResponseMetadata`
+    #[must_use]
     pub fn empty() -> Self {
         Self { sql: None }
     }
 
+    #[must_use]
     pub fn with_sql(mut self, sql: impl Into<String>) -> Self {
         self.sql = Some(sql.into());
         self
@@ -138,6 +140,7 @@ pub(crate) fn accept_header_types(accept: &TypedHeader<Accept>) -> Vec<String> {
 }
 
 impl ResponseMimeType {
+    #[must_use]
     pub fn to_accept_header(self) -> Option<http::HeaderValue> {
         let media_type = match self {
             Self::Json => "application/json",
@@ -149,6 +152,7 @@ impl ResponseMimeType {
         HeaderValue::from_str(media_type).ok()
     }
 
+    #[must_use]
     pub fn from_accept_header(accept: Option<&TypedHeader<Accept>>) -> ResponseMimeType {
         accept.map_or(ResponseMimeType::default(), |header| {
             accept_header_types(header)

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -88,11 +88,11 @@ pub struct SubmitQueryRequest {
     #[serde(default)]
     pub parameters: Option<serde_json::Value>,
     /// Optional timeout for async jobs.
-    /// Jobs running for longer than this will be automatically cancelled.
+    /// Jobs running for longer than this will automatically timeout and fail.
     #[serde(default)]
     pub timeout_seconds: Option<u64>,
     /// Optional maximum size of results for async jobs.
-    /// Jobs with results larger than this will be automatically cancelled.
+    /// Jobs with results larger than this will be failed with an error for exceeding the maximum size.
     #[serde(default)]
     pub maximum_size: Option<u64>,
 }
@@ -301,7 +301,7 @@ pub(crate) async fn submit(
                 query_id: query_id.clone(),
                 status: state.status,
                 error: state.error.as_ref().map(|e| ErrorResponse {
-                    error_code: e.error_code.clone(),
+                    error_code: e.error_code,
                     message: e.message.clone(),
                     sql_state: e.sql_state.clone(),
                 }),
@@ -393,7 +393,7 @@ pub(crate) async fn get_status(
     match result {
         Ok(state) => {
             let error = state.error.as_ref().map(|e| ErrorResponse {
-                error_code: e.error_code.clone(),
+                error_code: e.error_code,
                 message: e.message.clone(),
                 sql_state: e.sql_state.clone(),
             });
@@ -690,7 +690,7 @@ pub(crate) async fn list(
 
 fn job_state_to_response(state: &JobState) -> QueryResponse {
     let error = state.error.as_ref().map(|e| ErrorResponse {
-        error_code: e.error_code.clone(),
+        error_code: e.error_code,
         message: e.message.clone(),
         sql_state: e.sql_state.clone(),
     });

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Runtime;
 use crate::config::ClusterRole;
-use crate::jobs::{JobExecutor, JobState, JobStatus};
+use crate::jobs::{JobErrorCode, JobExecutor, JobState, JobStatus};
 
 /// Check if cluster mode with scheduler role is enabled.
 /// Returns 503 error response if not in scheduler cluster mode.
@@ -87,15 +87,14 @@ pub struct SubmitQueryRequest {
     /// Optional query parameters (bind variables).
     #[serde(default)]
     pub parameters: Option<serde_json::Value>,
-    /// Optional timeout for sync wait (0 = fully async). In seconds.
-    /// If > 0, the server will wait up to this long for results before returning.
+    /// Optional timeout for async jobs.
+    /// Jobs running for longer than this will be automatically cancelled.
     #[serde(default)]
-    #[expect(dead_code)]
     pub timeout_seconds: Option<u64>,
-    /// Optional target dataset or namespace.
+    /// Optional maximum size of results for async jobs.
+    /// Jobs with results larger than this will be automatically cancelled.
     #[serde(default)]
-    #[expect(dead_code)]
-    pub dataset: Option<String>,
+    pub maximum_size: Option<u64>,
 }
 
 /// Response for query submission.
@@ -105,22 +104,14 @@ pub struct SubmitQueryResponse {
     /// Unique identifier for the query.
     pub query_id: String,
     /// Current status of the query.
-    pub status: StatusResponse,
+    pub status: JobStatus,
+    /// Optional error details if the query failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorResponse>,
     /// URL to check status.
     pub status_url: String,
     /// URL to get results (once completed).
     pub results_url: String,
-}
-
-/// Status information within responses.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct StatusResponse {
-    /// Current state of the query.
-    pub state: String,
-    /// Error details if the query failed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<ErrorResponse>,
 }
 
 /// Error details in responses.
@@ -128,7 +119,7 @@ pub struct StatusResponse {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ErrorResponse {
     /// Error code categorizing the failure.
-    pub error_code: String,
+    pub error_code: JobErrorCode,
     /// Human-readable error message.
     pub message: String,
     /// SQL state code if applicable.
@@ -172,8 +163,6 @@ pub struct ManifestResponse {
     pub total_row_count: usize,
     /// Total number of chunks.
     pub total_chunk_count: usize,
-    /// Whether results were truncated.
-    pub truncated: bool,
 }
 
 /// Chunk information in result responses.
@@ -204,7 +193,10 @@ pub struct QueryResponse {
     /// Unique identifier for the query.
     pub query_id: String,
     /// Current status.
-    pub status: StatusResponse,
+    pub status: JobStatus,
+    /// Error details if the query failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorResponse>,
     /// Result manifest if completed successfully.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest: Option<ManifestResponse>,
@@ -251,12 +243,23 @@ pub struct ListQueriesResponse {
 pub struct QuerySummary {
     /// Query ID.
     pub query_id: String,
-    /// Current state.
-    pub state: String,
+    /// Current status.
+    pub status: JobStatus,
     /// SQL preview (first 100 chars).
     pub sql_preview: String,
     /// When created (ISO 8601).
     pub created_at: String,
+}
+
+/// Reponse object for the query status route
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StatusResponse {
+    /// Current status of the query.
+    pub status: JobStatus,
+    /// Optional error details if the query failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorResponse>,
 }
 
 /// Submit a new SQL query for async execution.
@@ -289,17 +292,19 @@ pub(crate) async fn submit(
         Ok(e) => e,
         Err(resp) => return resp,
     };
-    let result = executor.submit(request.sql, request.parameters).await;
+    let result = executor.submit(request).await;
 
     match result {
         Ok(state) => {
             let query_id = state.job_id.clone();
             let response = SubmitQueryResponse {
                 query_id: query_id.clone(),
-                status: StatusResponse {
-                    state: state.status.to_string(),
-                    error: None,
-                },
+                status: state.status,
+                error: state.error.as_ref().map(|e| ErrorResponse {
+                    error_code: e.error_code.clone(),
+                    message: e.message.clone(),
+                    sql_state: e.sql_state.clone(),
+                }),
                 status_url: format!("/v1/queries/{query_id}/status"),
                 results_url: format!("/v1/queries/{query_id}/results"),
             };
@@ -394,7 +399,7 @@ pub(crate) async fn get_status(
             });
 
             let status_response = StatusResponse {
-                state: state.status.to_string(),
+                status: state.status,
                 error,
             };
 
@@ -665,7 +670,7 @@ pub(crate) async fn list(
                     };
                     QuerySummary {
                         query_id: job.job_id,
-                        state: job.status.to_string(),
+                        status: job.status,
                         sql_preview,
                         created_at: ms_to_iso8601(job.created_at_ms),
                     }
@@ -709,15 +714,12 @@ fn job_state_to_response(state: &JobState) -> QueryResponse {
         },
         total_row_count: r.manifest.total_row_count,
         total_chunk_count: r.manifest.total_chunk_count,
-        truncated: r.manifest.truncated,
     });
 
     QueryResponse {
         query_id: state.job_id.clone(),
-        status: StatusResponse {
-            state: state.status.to_string(),
-            error,
-        },
+        status: state.status,
+        error,
         manifest,
         result: None,
         created_at: ms_to_iso8601(state.created_at_ms),

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -251,7 +251,7 @@ pub struct QuerySummary {
     pub created_at: String,
 }
 
-/// Reponse object for the query status route
+/// Response object for the query status route
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct StatusResponse {

--- a/crates/runtime/src/jobs/error.rs
+++ b/crates/runtime/src/jobs/error.rs
@@ -89,6 +89,11 @@ pub enum Error {
     StreamRead {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display(
+        "Failed to write results to object store. The maximum job size of '{maximum_size}' bytes was exceeded."
+    ))]
+    MaximumJobSizeExceeded { maximum_size: u64 },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -220,15 +220,13 @@ impl JobExecutor {
 
         drop(active);
 
-        let timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>> = state
-            .timeout_seconds
-            .map(|secs| {
+        let timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>> = state.timeout_seconds.map_or(
+            Box::pin(std::future::pending()) as Pin<Box<dyn Future<Output = ()> + Send>>,
+            |secs| {
                 Box::pin(tokio::time::sleep(Duration::from_secs(secs)))
                     as Pin<Box<dyn Future<Output = ()> + Send>>
-            })
-            .unwrap_or_else(|| {
-                Box::pin(std::future::pending()) as Pin<Box<dyn Future<Output = ()> + Send>>
-            });
+            },
+        );
 
         tokio::select! {
             () = cancel.cancelled() => {

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -17,12 +17,15 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use crate::datafusion::DataFusion;
 use crate::datafusion::query::{QueryBuilder, QueryHandle, QueryHandleError};
+use crate::http::v1::queries::SubmitQueryRequest;
+use crate::jobs::state::JobErrorCode;
 
 use super::Result;
 use super::state::{JobState, JobStatus};
@@ -71,12 +74,8 @@ impl JobExecutor {
     /// Submits a new query job for async execution.
     ///
     /// Returns the job state immediately. The query will be executed in the background.
-    pub async fn submit(
-        &self,
-        sql: String,
-        parameters: Option<serde_json::Value>,
-    ) -> Result<JobState> {
-        let state = self.job_store.create_job(sql, parameters).await?;
+    pub async fn submit(&self, request: SubmitQueryRequest) -> Result<JobState> {
+        let state = self.job_store.create_job(request).await?;
         let job_id = state.job_id.clone();
 
         // Create cancellation token for this job
@@ -184,7 +183,7 @@ impl JobExecutor {
                 }
                 Err(e) => {
                     job_store
-                        .fail_job(job_id, "INVALID_PARAMETERS", e.to_string())
+                        .fail_job(job_id, JobErrorCode::ParameterBindingFailed, e.to_string())
                         .await?;
                     return Ok(());
                 }
@@ -228,6 +227,14 @@ impl JobExecutor {
                 job_store.cancel_job(job_id).await?;
                 Ok(())
             },
+            () = tokio::time::sleep(Duration::from_secs(state.timeout_seconds.unwrap_or(u64::MAX))) => {
+                tracing::debug!(job_id = %job_id, "Job timed out");
+                if let Err(e) = query_handle.cancel().await {
+                    tracing::error!("Failed to cancel the timed-out query '{job_id}': {e}");
+                }
+                job_store.fail_job(job_id, JobErrorCode::Timeout, "Job execution timed out".to_string()).await?;
+                Ok(())
+            }
             result_stream = query_handle.into_stream() => {
                 // Wait for completion and get the result stream
                 let result_stream = match result_stream {
@@ -247,7 +254,7 @@ impl JobExecutor {
                     Ok(result) => result,
                     Err(e) => {
                         job_store
-                            .fail_job(job_id, "RESULT_FETCH", e.to_string())
+                            .fail_job(job_id, JobErrorCode::FetchingResultsFailed, e.to_string())
                             .await?;
                         return Ok(());
                     }
@@ -262,28 +269,33 @@ impl JobExecutor {
     }
 
     /// Converts a `Query::Error` to an error code string.
-    fn query_error_to_code(e: &crate::datafusion::query::Error) -> &'static str {
+    fn query_error_to_code(e: &crate::datafusion::query::Error) -> JobErrorCode {
         use crate::datafusion::query::Error;
         match e {
-            Error::SchedulerUnavailable => "SCHEDULER_UNAVAILABLE",
-            Error::SessionCreationFailed { .. } => "SESSION_ERROR",
-            Error::JobSubmissionFailed { .. } => "JOB_SUBMISSION",
-            Error::UnableToExecuteQuery { .. } => "QUERY_PLANNING",
-            Error::BindingParameters { .. } => "PARAMETER_BINDING",
-            Error::TableAccessDisallowed { .. } => "TABLE_ACCESS_DENIED",
-            _ => "INTERNAL_ERROR",
+            Error::SchedulerUnavailable => JobErrorCode::SchedulerUnavailable,
+            Error::SessionCreationFailed { message } => JobErrorCode::SubmissionFailed,
+            Error::JobSubmissionFailed { message } => JobErrorCode::SubmissionFailed,
+            Error::UnableToExecuteQuery { source } => JobErrorCode::ExecutionFailed,
+            Error::BindingParameters { source } => JobErrorCode::ParameterBindingFailed,
+            Error::TableAccessDisallowed { table } => JobErrorCode::ExecutionFailed,
+            Error::UnableToExecuteQuery { source } => JobErrorCode::ExecutionFailed,
+            _ => JobErrorCode::Internal,
         }
     }
 
     /// Converts a `QueryHandleError` to an error code string and message.
-    fn handle_error_to_code_and_msg(e: &QueryHandleError) -> (&'static str, String) {
+    fn handle_error_to_code_and_msg(e: &QueryHandleError) -> (JobErrorCode, String) {
         match e {
-            QueryHandleError::JobTimeout { .. } => ("JOB_TIMEOUT", e.to_string()),
-            QueryHandleError::JobCancelled => ("JOB_CANCELLED", e.to_string()),
-            QueryHandleError::JobFailed { message } => ("QUERY_EXECUTION", message.clone()),
-            QueryHandleError::StatusError { message } => ("STATUS_ERROR", message.clone()),
-            QueryHandleError::PartitionLocationError { .. } => ("PARTITION_ERROR", e.to_string()),
-            QueryHandleError::JobNotFound { .. } => ("JOB_NOT_FOUND", e.to_string()),
+            QueryHandleError::JobTimeout { .. } => (JobErrorCode::Timeout, e.to_string()),
+            QueryHandleError::JobCancelled => (JobErrorCode::Cancelled, e.to_string()),
+            QueryHandleError::JobFailed { message } => {
+                (JobErrorCode::ExecutionFailed, message.clone())
+            }
+            QueryHandleError::StatusError { message } => (JobErrorCode::Internal, message.clone()),
+            QueryHandleError::PartitionLocationError { .. } => {
+                (JobErrorCode::Internal, e.to_string())
+            }
+            QueryHandleError::JobNotFound { .. } => (JobErrorCode::NotFound, e.to_string()),
         }
     }
 }

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -273,12 +273,12 @@ impl JobExecutor {
         use crate::datafusion::query::Error;
         match e {
             Error::SchedulerUnavailable => JobErrorCode::SchedulerUnavailable,
-            Error::SessionCreationFailed { message } => JobErrorCode::SubmissionFailed,
-            Error::JobSubmissionFailed { message } => JobErrorCode::SubmissionFailed,
-            Error::UnableToExecuteQuery { source } => JobErrorCode::ExecutionFailed,
-            Error::BindingParameters { source } => JobErrorCode::ParameterBindingFailed,
-            Error::TableAccessDisallowed { table } => JobErrorCode::ExecutionFailed,
-            Error::UnableToExecuteQuery { source } => JobErrorCode::ExecutionFailed,
+            Error::SessionCreationFailed { .. } => JobErrorCode::SubmissionFailed,
+            Error::JobSubmissionFailed { .. } => JobErrorCode::SubmissionFailed,
+            Error::UnableToExecuteQuery { .. } => JobErrorCode::ExecutionFailed,
+            Error::BindingParameters { .. } => JobErrorCode::ParameterBindingFailed,
+            Error::TableAccessDisallowed { .. } => JobErrorCode::ExecutionFailed,
+            Error::UnableToExecuteQuery { .. } => JobErrorCode::ExecutionFailed,
             _ => JobErrorCode::Internal,
         }
     }

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -218,6 +218,14 @@ impl JobExecutor {
 
         drop(active);
 
+        let timeout_fut: Box<dyn Future<Output = ()>> = state
+            .timeout_seconds
+            .map(|secs| {
+                Box::new(tokio::time::sleep(Duration::from_secs(secs)))
+                    as Box<dyn Future<Output = ()>>
+            })
+            .unwrap_or_else(|| Box::new(std::future::pending()) as Box<dyn Future<Output = ()>>);
+
         tokio::select! {
             () = cancel.cancelled() => {
                 tracing::debug!(job_id = %job_id, "Job cancelled before completion");
@@ -227,7 +235,7 @@ impl JobExecutor {
                 job_store.cancel_job(job_id).await?;
                 Ok(())
             },
-            () = tokio::time::sleep(Duration::from_secs(state.timeout_seconds.unwrap_or(u64::MAX))) => {
+            () = timeout_fut => {
                 tracing::debug!(job_id = %job_id, "Job timed out");
                 if let Err(e) = query_handle.cancel().await {
                     tracing::error!("Failed to cancel the timed-out query '{job_id}': {e}");
@@ -273,12 +281,13 @@ impl JobExecutor {
         use crate::datafusion::query::Error;
         match e {
             Error::SchedulerUnavailable => JobErrorCode::SchedulerUnavailable,
-            Error::SessionCreationFailed { .. } => JobErrorCode::SubmissionFailed,
-            Error::JobSubmissionFailed { .. } => JobErrorCode::SubmissionFailed,
-            Error::UnableToExecuteQuery { .. } => JobErrorCode::ExecutionFailed,
+            Error::SessionCreationFailed { .. } | Error::JobSubmissionFailed { .. } => {
+                JobErrorCode::SubmissionFailed
+            }
+            Error::UnableToExecuteQuery { .. } | Error::TableAccessDisallowed { .. } => {
+                JobErrorCode::ExecutionFailed
+            }
             Error::BindingParameters { .. } => JobErrorCode::ParameterBindingFailed,
-            Error::TableAccessDisallowed { .. } => JobErrorCode::ExecutionFailed,
-            Error::UnableToExecuteQuery { .. } => JobErrorCode::ExecutionFailed,
             _ => JobErrorCode::Internal,
         }
     }

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
@@ -218,13 +220,15 @@ impl JobExecutor {
 
         drop(active);
 
-        let timeout_fut: Box<dyn Future<Output = ()>> = state
+        let timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>> = state
             .timeout_seconds
             .map(|secs| {
-                Box::new(tokio::time::sleep(Duration::from_secs(secs)))
-                    as Box<dyn Future<Output = ()>>
+                Box::pin(tokio::time::sleep(Duration::from_secs(secs)))
+                    as Pin<Box<dyn Future<Output = ()> + Send>>
             })
-            .unwrap_or_else(|| Box::new(std::future::pending()) as Box<dyn Future<Output = ()>>);
+            .unwrap_or_else(|| {
+                Box::pin(std::future::pending()) as Pin<Box<dyn Future<Output = ()> + Send>>
+            });
 
         tokio::select! {
             () = cancel.cancelled() => {

--- a/crates/runtime/src/jobs/mod.rs
+++ b/crates/runtime/src/jobs/mod.rs
@@ -29,5 +29,6 @@ mod store;
 
 pub use error::{Error, Result};
 pub use executor::JobExecutor;
+pub use state::JobErrorCode;
 pub use state::{DEFAULT_CHUNK_SIZE, JobResult, JobResultManifest, JobSchema, JobState, JobStatus};
 pub use store::JobStore;

--- a/crates/runtime/src/jobs/state.rs
+++ b/crates/runtime/src/jobs/state.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for JobStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum JobErrorCode {

--- a/crates/runtime/src/jobs/state.rs
+++ b/crates/runtime/src/jobs/state.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Version for job state schema, incremented on breaking changes

--- a/crates/runtime/src/jobs/state.rs
+++ b/crates/runtime/src/jobs/state.rs
@@ -30,6 +30,7 @@ pub const DEFAULT_CHUNK_SIZE: usize = 10_000;
 /// The current status of a job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum JobStatus {
     /// Job is queued but not yet running
     Pending,
@@ -58,11 +59,26 @@ impl std::fmt::Display for JobStatus {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum JobErrorCode {
+    SchedulerUnavailable,
+    SubmissionFailed,
+    ExecutionFailed,
+    FetchingResultsFailed,
+    Cancelled,
+    ParameterBindingFailed,
+    NotFound,
+    Internal,
+    Timeout,
+}
+
 /// Error details when a job fails.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobError {
     /// Error code categorizing the failure
-    pub error_code: String,
+    pub error_code: JobErrorCode,
     /// Human-readable error message
     pub message: String,
     /// SQL state code if applicable
@@ -109,11 +125,8 @@ pub struct JobResultManifest {
     pub total_row_count: usize,
     /// Total number of chunks
     pub total_chunk_count: usize,
-    /// Whether results were truncated due to limits
-    pub truncated: bool,
     /// Total size in bytes (approximate)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_byte_count: Option<usize>,
+    pub total_byte_count: usize,
 }
 
 /// Result information for a completed job.
@@ -139,9 +152,9 @@ pub struct JobState {
     /// Query parameters if any
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<serde_json::Value>,
-    /// Node that is executing this job
+    /// Node that is scheduling this job
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub executor_node: Option<String>,
+    pub scheduler_node: Option<String>,
     /// Error details if status is Failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<JobError>,
@@ -159,9 +172,12 @@ pub struct JobState {
     /// When results will expire (Unix timestamp ms)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at_ms: Option<u64>,
-    /// Custom labels/metadata
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub labels: HashMap<String, String>,
+    /// Optional timeout for the job in seconds
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    /// Optional maximum size of results for the job in bytes
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maximum_size: Option<u64>,
 }
 
 impl JobState {
@@ -175,21 +191,22 @@ impl JobState {
             status: JobStatus::Pending,
             sql,
             parameters,
-            executor_node: None,
+            scheduler_node: None,
             error: None,
             result: None,
             created_at_ms: now_ms,
             started_at_ms: None,
             completed_at_ms: None,
             expires_at_ms: None,
-            labels: HashMap::new(),
+            timeout_seconds: None,
+            maximum_size: None,
         }
     }
 
     /// Transitions job to running state.
     pub fn set_running(&mut self, executor_node: String) {
         self.status = JobStatus::Running;
-        self.executor_node = Some(executor_node);
+        self.scheduler_node = Some(executor_node);
         self.started_at_ms = Some(now_ms_or_zero());
     }
 
@@ -241,6 +258,18 @@ impl JobState {
     #[must_use]
     pub fn succeeded(&self) -> bool {
         self.status == JobStatus::Succeeded
+    }
+
+    #[must_use]
+    pub(crate) fn with_timeout_seconds(mut self, timeout_seconds: Option<u64>) -> Self {
+        self.timeout_seconds = timeout_seconds;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_maximum_size(mut self, maximum_size: Option<u64>) -> Self {
+        self.maximum_size = maximum_size;
+        self
     }
 }
 

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -28,6 +28,9 @@ use object_store::{Error as ObjectStoreError, ObjectStore};
 use snafu::prelude::*;
 use uuid::Uuid;
 
+use crate::http::v1::queries::SubmitQueryRequest;
+use crate::jobs::state::JobErrorCode;
+
 use super::error::{
     DeserializeChunkSnafu, DeserializeStateSnafu, ObjectStoreDeleteSnafu, ObjectStoreListSnafu,
     ObjectStoreReadSnafu, ObjectStoreWriteSnafu, Result, SerializeChunkSnafu, SerializeStateSnafu,
@@ -127,13 +130,11 @@ impl JobStore {
     }
 
     /// Creates a new pending job and stores it.
-    pub async fn create_job(
-        &self,
-        sql: String,
-        parameters: Option<serde_json::Value>,
-    ) -> Result<JobState> {
+    pub async fn create_job(&self, request: SubmitQueryRequest) -> Result<JobState> {
         let job_id = Self::generate_job_id();
-        let state = JobState::new_pending(job_id, sql, parameters);
+        let state = JobState::new_pending(job_id, request.sql, request.parameters)
+            .with_timeout_seconds(request.timeout_seconds)
+            .with_maximum_size(request.maximum_size);
         self.write_job_state(&state).await?;
         Ok(state)
     }
@@ -186,100 +187,6 @@ impl JobStore {
         Ok(state)
     }
 
-    /// Writes result chunks for a completed job.
-    ///
-    /// Takes a schema and an iterator of `RecordBatch`es and writes them as Arrow IPC chunks.
-    /// The schema is used for the result manifest even if no batches are provided,
-    /// ensuring empty result sets still have valid schema information.
-    ///
-    /// Returns the job result manifest.
-    pub async fn write_result_chunks(
-        &self,
-        job_id: &str,
-        schema: SchemaRef,
-        batches: Vec<RecordBatch>,
-    ) -> Result<JobResult> {
-        if batches.is_empty() {
-            // Empty result set - still include the schema
-            return Ok(Self::build_job_result(&schema, 0, 0, 0, vec![]));
-        }
-        let mut total_rows = 0usize;
-        let mut total_bytes = 0usize;
-        let mut chunk_indices = Vec::new();
-
-        // Group batches into chunks based on row count
-        let mut current_chunk_batches: Vec<RecordBatch> = Vec::new();
-        let mut current_chunk_rows = 0usize;
-        let mut chunk_index = 0usize;
-
-        for batch in batches {
-            let batch_rows = batch.num_rows();
-            total_rows = total_rows.checked_add(batch_rows).ok_or_else(|| {
-                super::error::Error::IntegerOverflow {
-                    field: "total_row_count".to_string(),
-                    left_value: total_rows,
-                    right_value: batch_rows,
-                }
-            })?;
-
-            current_chunk_batches.push(batch);
-            current_chunk_rows = current_chunk_rows.checked_add(batch_rows).ok_or_else(|| {
-                super::error::Error::IntegerOverflow {
-                    field: "chunk_row_count".to_string(),
-                    left_value: current_chunk_rows,
-                    right_value: batch_rows,
-                }
-            })?;
-
-            // Flush chunk if we've reached the chunk size
-            if current_chunk_rows >= self.chunk_size {
-                let bytes = self
-                    .write_chunk(job_id, chunk_index, &current_chunk_batches)
-                    .await?;
-                total_bytes = total_bytes.checked_add(bytes).ok_or_else(|| {
-                    super::error::Error::IntegerOverflow {
-                        field: "total_byte_count".to_string(),
-                        left_value: total_bytes,
-                        right_value: bytes,
-                    }
-                })?;
-                chunk_indices.push(chunk_index);
-                chunk_index = chunk_index.checked_add(1).ok_or_else(|| {
-                    super::error::Error::IntegerOverflow {
-                        field: "chunk_index".to_string(),
-                        left_value: chunk_index,
-                        right_value: 1,
-                    }
-                })?;
-                current_chunk_batches.clear();
-                current_chunk_rows = 0;
-            }
-        }
-
-        // Flush remaining batches
-        if !current_chunk_batches.is_empty() {
-            let bytes = self
-                .write_chunk(job_id, chunk_index, &current_chunk_batches)
-                .await?;
-            total_bytes = total_bytes.checked_add(bytes).ok_or_else(|| {
-                super::error::Error::IntegerOverflow {
-                    field: "total_byte_count".to_string(),
-                    left_value: total_bytes,
-                    right_value: bytes,
-                }
-            })?;
-            chunk_indices.push(chunk_index);
-        }
-
-        Ok(Self::build_job_result(
-            &schema,
-            total_rows,
-            total_bytes,
-            chunk_indices.len(),
-            chunk_indices,
-        ))
-    }
-
     /// Writes result chunks for a completed job from a stream of record batches.
     ///
     /// Streams `RecordBatch`es and writes them as Arrow IPC chunks as they arrive,
@@ -292,6 +199,8 @@ impl JobStore {
         job_id: &str,
         mut stream: SendableRecordBatchStream,
     ) -> Result<JobResult> {
+        let state = self.get_job(job_id).await?;
+
         let schema: SchemaRef = stream.schema();
 
         let mut total_rows = 0usize;
@@ -338,6 +247,13 @@ impl JobStore {
                         right_value: bytes,
                     }
                 })?;
+
+                if let Some(maximum_size) = state.maximum_size
+                    && (total_bytes as u64) > maximum_size
+                {
+                    return Err(super::error::Error::MaximumJobSizeExceeded { maximum_size });
+                }
+
                 chunk_indices.push(chunk_index);
                 chunk_index = chunk_index.checked_add(1).ok_or_else(|| {
                     super::error::Error::IntegerOverflow {
@@ -363,6 +279,13 @@ impl JobStore {
                     right_value: bytes,
                 }
             })?;
+
+            if let Some(maximum_size) = state.maximum_size
+                && (total_bytes as u64) > maximum_size
+            {
+                return Err(super::error::Error::MaximumJobSizeExceeded { maximum_size });
+            }
+
             chunk_indices.push(chunk_index);
         }
 
@@ -417,8 +340,7 @@ impl JobStore {
                 },
                 total_row_count: total_rows,
                 total_chunk_count: total_chunks,
-                truncated: false,
-                total_byte_count: Some(total_bytes),
+                total_byte_count: total_bytes,
             },
             chunk_indices,
         }
@@ -496,12 +418,12 @@ impl JobStore {
     pub async fn fail_job(
         &self,
         job_id: &str,
-        error_code: impl Into<String>,
+        error_code: JobErrorCode,
         message: impl Into<String>,
     ) -> Result<JobState> {
         let mut state = self.get_job(job_id).await?;
         state.set_failed(super::state::JobError {
-            error_code: error_code.into(),
+            error_code,
             message: message.into(),
             sql_state: None,
         });
@@ -738,13 +660,24 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use object_store::memory::InMemory;
 
+    use crate::http::v1::queries::SubmitQueryRequest;
+
+    fn make_request(sql: impl Into<String>) -> SubmitQueryRequest {
+        SubmitQueryRequest {
+            sql: sql.into(),
+            parameters: None,
+            timeout_seconds: None,
+            maximum_size: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_create_and_get_job() {
         let store = Arc::new(InMemory::new());
         let job_store = JobStore::new(store, "test", "node-1");
 
         let state = job_store
-            .create_job("SELECT 1".to_string(), None)
+            .create_job(make_request("SELECT 1"))
             .await
             .expect("to create job");
 
@@ -764,7 +697,7 @@ mod tests {
 
         // Create job
         let state = job_store
-            .create_job("SELECT * FROM test".to_string(), None)
+            .create_job(make_request("SELECT * FROM test"))
             .await
             .expect("to create job");
         let job_id = state.job_id.clone();
@@ -775,7 +708,7 @@ mod tests {
             .await
             .expect("to set running");
         assert_eq!(running.status, JobStatus::Running);
-        assert_eq!(running.executor_node.as_deref(), Some("node-1"));
+        assert_eq!(running.scheduler_node.as_deref(), Some("node-1"));
 
         // Complete with empty results
         let result = JobResult {
@@ -787,8 +720,7 @@ mod tests {
                 },
                 total_row_count: 0,
                 total_chunk_count: 0,
-                truncated: false,
-                total_byte_count: Some(0),
+                total_byte_count: 0,
             },
             chunk_indices: vec![],
         };
@@ -802,59 +734,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_and_read_chunks() {
-        let store = Arc::new(InMemory::new());
-        let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
-
-        let state = job_store
-            .create_job("SELECT * FROM test".to_string(), None)
-            .await
-            .expect("to create job");
-
-        // Create test batches
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-
-        let batch1 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![1, 2]))],
-        )
-        .expect("to create batch");
-
-        let batch2 = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![3, 4]))],
-        )
-        .expect("to create batch");
-
-        let result = job_store
-            .write_result_chunks(&state.job_id, Arc::clone(&schema), vec![batch1, batch2])
-            .await
-            .expect("to write chunks");
-
-        assert_eq!(result.manifest.total_row_count, 4);
-        assert_eq!(result.manifest.total_chunk_count, 2);
-
-        // Read chunks back
-        let chunk0 = job_store
-            .read_chunk(&state.job_id, 0)
-            .await
-            .expect("to read chunk 0");
-        assert!(!chunk0.is_empty());
-
-        let chunk1 = job_store
-            .read_chunk(&state.job_id, 1)
-            .await
-            .expect("to read chunk 1");
-        assert!(!chunk1.is_empty());
-    }
-
-    #[tokio::test]
     async fn test_cancel_job() {
         let store = Arc::new(InMemory::new());
         let job_store = JobStore::new(store, "test", "node-1");
 
         let state = job_store
-            .create_job("SELECT 1".to_string(), None)
+            .create_job(make_request("SELECT 1"))
             .await
             .expect("to create job");
 
@@ -882,45 +767,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_write_result_chunks_empty_with_schema() {
-        let store = Arc::new(InMemory::new());
-        let job_store = JobStore::new(store, "test", "node-1");
-
-        let state = job_store
-            .create_job("SELECT * FROM test WHERE 1=0".to_string(), None)
-            .await
-            .expect("to create job");
-
-        // Create a schema but no batches - simulating an empty result set
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("name", DataType::Utf8, true),
-        ]));
-
-        let result = job_store
-            .write_result_chunks(&state.job_id, Arc::clone(&schema), vec![])
-            .await
-            .expect("to write empty result with schema");
-
-        // Should have 0 rows but valid schema
-        assert_eq!(result.manifest.total_row_count, 0);
-        assert_eq!(result.manifest.total_chunk_count, 0);
-        assert!(result.chunk_indices.is_empty());
-
-        // Schema should be preserved even with no rows
-        assert_eq!(result.manifest.schema.column_count, 2);
-        assert_eq!(result.manifest.schema.columns.len(), 2);
-        assert_eq!(result.manifest.schema.columns[0].name, "id");
-        assert_eq!(result.manifest.schema.columns[0].type_name, "Int32");
-        assert!(!result.manifest.schema.columns[0].nullable);
-        assert_eq!(result.manifest.schema.columns[1].name, "name");
-        assert_eq!(result.manifest.schema.columns[1].type_name, "Utf8");
-        assert!(result.manifest.schema.columns[1].nullable);
-    }
-
     mod write_result_chunks_from_stream {
         use super::*;
+        use crate::jobs::Error;
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
         use futures::stream;
 
@@ -938,7 +787,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job("SELECT * FROM test WHERE 1=0".to_string(), None)
+                .create_job(make_request("SELECT * FROM test WHERE 1=0"))
                 .await
                 .expect("to create job");
 
@@ -970,7 +819,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(100);
 
             let state = job_store
-                .create_job("SELECT * FROM test".to_string(), None)
+                .create_job(make_request("SELECT * FROM test"))
                 .await
                 .expect("to create job");
 
@@ -1008,7 +857,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(100);
 
             let state = job_store
-                .create_job("SELECT * FROM test".to_string(), None)
+                .create_job(make_request("SELECT * FROM test"))
                 .await
                 .expect("to create job");
 
@@ -1046,7 +895,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
 
             let state = job_store
-                .create_job("SELECT * FROM test".to_string(), None)
+                .create_job(make_request("SELECT * FROM test"))
                 .await
                 .expect("to create job");
 
@@ -1103,7 +952,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job("SELECT * FROM test".to_string(), None)
+                .create_job(make_request("SELECT * FROM test"))
                 .await
                 .expect("to create job");
 
@@ -1132,7 +981,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job("SELECT * FROM test".to_string(), None)
+                .create_job(make_request("SELECT * FROM test"))
                 .await
                 .expect("to create job");
 
@@ -1153,9 +1002,167 @@ mod tests {
 
             // Verify byte count is tracked
             assert!(
-                result.manifest.total_byte_count.is_some_and(|b| b > 0),
+                result.manifest.total_byte_count > 0,
                 "Expected non-zero byte count"
             );
+        }
+
+        fn make_request_with_maximum_size(
+            sql: impl Into<String>,
+            maximum_size: Option<u64>,
+        ) -> SubmitQueryRequest {
+            SubmitQueryRequest {
+                sql: sql.into(),
+                parameters: None,
+                timeout_seconds: None,
+                maximum_size,
+            }
+        }
+
+        #[tokio::test]
+        async fn test_maximum_size_allows_within_limit() {
+            let store = Arc::new(InMemory::new());
+            let job_store = JobStore::new(store, "test", "node-1");
+
+            // Create job with a generous maximum size limit
+            let state = job_store
+                .create_job(make_request_with_maximum_size(
+                    "SELECT * FROM test",
+                    Some(10_000),
+                ))
+                .await
+                .expect("to create job");
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .expect("to create batch");
+
+            let stream = create_test_stream(Arc::clone(&schema), vec![batch]);
+
+            // Should succeed since results are within the maximum size limit
+            let result = job_store
+                .write_result_chunks_from_stream(&state.job_id, stream)
+                .await
+                .expect("to write stream within maximum size limit");
+
+            assert_eq!(result.manifest.total_row_count, 3);
+            assert!(result.manifest.total_byte_count > 0);
+            assert!(result.manifest.total_byte_count <= 10_000);
+        }
+
+        #[tokio::test]
+        async fn test_maximum_size_exceeds_limit() {
+            let store = Arc::new(InMemory::new());
+            // Use small chunk size to force chunk flush and trigger the size check
+            let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
+
+            // Create job with a very small maximum size limit (1 byte)
+            let state = job_store
+                .create_job(make_request_with_maximum_size(
+                    "SELECT * FROM test",
+                    Some(1),
+                ))
+                .await
+                .expect("to create job");
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+            // Create batches that will exceed the 1 byte limit
+            let batch1 = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(vec![1, 2]))],
+            )
+            .expect("to create batch");
+
+            let batch2 = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(vec![3, 4]))],
+            )
+            .expect("to create batch");
+
+            let stream = create_test_stream(Arc::clone(&schema), vec![batch1, batch2]);
+
+            // Should fail because results exceed the maximum size limit
+            let result = job_store
+                .write_result_chunks_from_stream(&state.job_id, stream)
+                .await;
+
+            assert!(
+                matches!(result, Err(Error::MaximumJobSizeExceeded { .. })),
+                "Expected MaximumJobSizeExceeded error, got: {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_maximum_size_exceeds_on_final_flush() {
+            let store = Arc::new(InMemory::new());
+            // Large chunk size to ensure flush happens at the end
+            let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(100);
+
+            // Create job with a very small maximum size limit
+            let state = job_store
+                .create_job(make_request_with_maximum_size(
+                    "SELECT * FROM test",
+                    Some(1),
+                ))
+                .await
+                .expect("to create job");
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .expect("to create batch");
+
+            let stream = create_test_stream(Arc::clone(&schema), vec![batch]);
+
+            // Should fail on final flush because results exceed the maximum size limit
+            let result = job_store
+                .write_result_chunks_from_stream(&state.job_id, stream)
+                .await;
+
+            assert!(
+                matches!(result, Err(Error::MaximumJobSizeExceeded { .. })),
+                "Expected MaximumJobSizeExceeded error, got: {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_maximum_size_none_allows_any_size() {
+            let store = Arc::new(InMemory::new());
+            let job_store = JobStore::new(store, "test", "node-1");
+
+            // Create job without a maximum size limit
+            let state = job_store
+                .create_job(make_request_with_maximum_size("SELECT * FROM test", None))
+                .await
+                .expect("to create job");
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+            // Create a larger batch
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from((0..1000).collect::<Vec<_>>()))],
+            )
+            .expect("to create batch");
+
+            let stream = create_test_stream(Arc::clone(&schema), vec![batch]);
+
+            // Should succeed since there's no maximum size limit
+            let result = job_store
+                .write_result_chunks_from_stream(&state.job_id, stream)
+                .await
+                .expect("to write stream without maximum size limit");
+
+            assert_eq!(result.manifest.total_row_count, 1000);
+            assert!(result.manifest.total_byte_count > 0);
         }
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub mod execution_plan;
 pub mod extension;
 pub mod federated_table;
 pub mod flight;
-mod http;
+pub mod http;
 mod init;
 pub mod internal_table;
 pub mod jobs;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -96,7 +96,12 @@ pub mod execution_plan;
 pub mod extension;
 pub mod federated_table;
 pub mod flight;
-pub mod http;
+mod http;
+
+pub mod http_types {
+    pub use crate::http::v1::queries::SubmitQueryRequest;
+}
+
 mod init;
 pub mod internal_table;
 pub mod jobs;

--- a/crates/runtime/tests/cluster/job_store.rs
+++ b/crates/runtime/tests/cluster/job_store.rs
@@ -23,6 +23,7 @@ use object_store::{ObjectStore, path::Path};
 use runtime::Runtime;
 use runtime::cluster::ResolvedClusterConfig;
 use runtime::config::ClusterConfig;
+use runtime::http::v1::queries::SubmitQueryRequest;
 use runtime::jobs::{JobExecutor, JobStore};
 use runtime::{auth::EndpointAuth, config::Config};
 use rustls::crypto::{CryptoProvider, aws_lc_rs};
@@ -40,6 +41,15 @@ use crate::{
 };
 
 const NAMES_CSV: &str = include_str!("../acceleration/data/names.csv");
+
+fn make_request(sql: impl Into<String>) -> SubmitQueryRequest {
+    SubmitQueryRequest {
+        sql: sql.into(),
+        parameters: None,
+        timeout_seconds: None,
+        maximum_size: None,
+    }
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_simple_job_store() -> Result<(), anyhow::Error> {
@@ -215,10 +225,9 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
             );
 
             let result = job_executor
-                .submit(
-                    "SELECT id, name, age, city, score FROM names ORDER BY id".to_string(),
-                    None,
-                )
+                .submit(make_request(
+                    "SELECT id, name, age, city, score FROM names ORDER BY id",
+                ))
                 .await
                 .expect("should submit job");
 

--- a/crates/runtime/tests/cluster/job_store.rs
+++ b/crates/runtime/tests/cluster/job_store.rs
@@ -23,7 +23,7 @@ use object_store::{ObjectStore, path::Path};
 use runtime::Runtime;
 use runtime::cluster::ResolvedClusterConfig;
 use runtime::config::ClusterConfig;
-use runtime::http::v1::queries::SubmitQueryRequest;
+use runtime::http_types::SubmitQueryRequest;
 use runtime::jobs::{JobExecutor, JobStore};
 use runtime::{auth::EndpointAuth, config::Config};
 use rustls::crypto::{CryptoProvider, aws_lc_rs};


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Respect the specified `timeout_seconds` provided from the `SubmitQueryRequest` - alters the behaviour as defined by the comment: the async API will never return results synchronously, so the `timeout_seconds` modifies when the `JobExecutor` will short-circuit the execution and cancel the job.
* Adds a `maximum_size` property for `SubmitQueryRequest`. When results are streamed into the `JobStore` and they exceed the specified `maximum_size`, the job will be failed with a corresponding error that the maximum size was exceeded.

* Once #9134 is addressed, these cancelled jobs would have their partially written results lazily cleaned up.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #9132
* Closes #9136
