### PR TITLE
Reduce executor heartbeat timeout from 180s to 30s

### DIFF
--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -42,7 +42,7 @@ use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
 use crate::metrics_reader::MetricsReader;
 
 const CONTROL_STREAM_BACKOFF_MAX: Duration = Duration::from_secs(10);
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Handle for a single control stream connection to a scheduler.
 struct ControlStreamHandle {

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1307,6 +1307,9 @@ async fn create_scheduler_server(
         override_create_grpc_client_endpoint,
         override_metrics_collector: Some(scheduler_metrics_collector),
         on_work_available: Some(on_work_available),
+
+        // Faster failure detection: 30s timeout with 10s heartbeat interval
+        executor_timeout_seconds: 30,
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

Reduce heartbeat interval from 30s to 10s and executor timeout from 180s to 30s for faster failure detection and task reassignment when executors go down.

## Changes

- `crates/runtime/src/cluster/control_stream_client.rs`: Reduce `HEARTBEAT_INTERVAL` from 30s to 10s
- `crates/runtime/src/cluster/mod.rs`: Set `executor_timeout_seconds: 30` in `SchedulerConfig` (default was 180s)

## Rationale

With 10s heartbeat interval and 30s timeout, executors are detected as dead after missing ~3 consecutive heartbeats. This aligns with ballista's recommendation: "Only after missing two or three consecutive heartbeats from an executor, the executor is marked to be dead"

## Testing

- Code compiles with `cargo check -p runtime`
- Manual verification with cluster

Fixes #9288