### PR TITLE
Log health check issues as warnings instead of failing benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7117,7 +7117,7 @@ dependencies = [
  "arrow-flight",
  "arrow-schema",
  "bytes",
- "clap 4.5.54",
+ "clap",
  "futures",
  "prost 0.14.3",
  "tokio",

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -208,7 +208,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     }
 
     if let Some(message) = health_report.failure_message() {
-        error_messages.push(message);
+        eprintln!("Warning: {message}");
     }
 
     if !error_messages.is_empty() {

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -106,7 +106,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let health_report = health_report?;
 
     if let Some(message) = health_report.failure_message() {
-        return Err(anyhow::anyhow!(message));
+        eprintln!("Warning: {message}");
     }
 
     println!(


### PR DESCRIPTION
During intensive benchmark/throughput runs, health check latency can spike due to CPU utilization, causing false positive failures. This change logs the health check issues as warnings instead of failing the entire test run.

The health check metrics are still recorded via OpenTelemetry for monitoring purposes.

## Changes

- **`tools/testoperator/src/commands/bench/mod.rs`**: Changed health check failure handling from adding to `error_messages` (which would fail the benchmark) to printing a warning via `eprintln!`.

- **`tools/testoperator/src/commands/throughput/mod.rs`**: Changed health check failure handling from returning an error (which would fail the throughput test) to printing a warning via `eprintln!`.