### PR TITLE
Fix #9289: deregister executors on shutdown

### DIFF
--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -98,6 +98,7 @@ message ExecutorControlMessage {
     oneof message {
         ExecutorHeartbeat heartbeat = 2;
         MetricsResponse metrics = 3;
+        ExecutorShutdown shutdown = 4;
     }
 }
 
@@ -120,6 +121,14 @@ message PollNowCommand {
 // Heartbeat message sent by executor to scheduler.
 message ExecutorHeartbeat {
     int64 timestamp_ms = 1;
+}
+
+// Executor shutdown notification sent by executor to scheduler.
+message ExecutorShutdown {
+    // Ballista executor ID to deregister from the scheduler.
+    string ballista_executor_id = 1;
+    // Optional reason for shutdown (for debugging/logging).
+    string reason = 2;
 }
 
 // Request for metrics from an executor.

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -30,10 +30,10 @@ use futures::StreamExt;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
 use runtime_proto::scheduler_control_message::Message as SchedulerMessage;
 use runtime_proto::{
-    ExecutorControlMessage, ExecutorHeartbeat, MetricsResponse,
+    ExecutorControlMessage, ExecutorHeartbeat, ExecutorShutdown, MetricsResponse,
     executor_control_message::Message as ExecutorMessage,
 };
-use tokio::sync::{Notify, mpsc};
+use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tonic::transport::ClientTlsConfig;
@@ -48,6 +48,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 struct ControlStreamHandle {
     cancel: CancellationToken,
     task: tokio::task::JoinHandle<()>,
+    outbound_tx: Arc<RwLock<Option<mpsc::Sender<ExecutorControlMessage>>>>,
 }
 
 /// Spawns a control stream connection to a single scheduler.
@@ -64,9 +65,11 @@ fn spawn_control_stream(
     client_tls_config: Option<ClientTlsConfig>,
     metrics_reader: Option<Arc<MetricsReader>>,
     poll_now_notify: Arc<Notify>,
+    outbound_tx_state: Arc<RwLock<Option<mpsc::Sender<ExecutorControlMessage>>>>,
 ) -> ControlStreamHandle {
     let cancel = CancellationToken::new();
     let token = cancel.clone();
+    let outbound_tx_state_for_task = Arc::clone(&outbound_tx_state);
 
     let task = tokio::spawn(async move {
         let tls_enabled = client_tls_config.is_some();
@@ -139,6 +142,10 @@ fn spawn_control_stream(
 
             // Create channels for outbound messages
             let (outbound_tx, outbound_rx) = mpsc::channel::<ExecutorControlMessage>(32);
+            {
+                let mut outbound_guard = outbound_tx_state_for_task.write().await;
+                *outbound_guard = Some(outbound_tx.clone());
+            }
 
             // Spawn heartbeat sender
             let heartbeat_executor_id = executor_id.clone();
@@ -182,6 +189,8 @@ fn spawn_control_stream(
             };
             if outbound_tx.send(init_msg).await.is_err() {
                 heartbeat_task.abort();
+                let mut outbound_guard = outbound_tx_state_for_task.write().await;
+                *outbound_guard = None;
                 continue;
             }
 
@@ -196,6 +205,8 @@ fn spawn_control_stream(
                         "Failed to establish control stream to {scheduler_address}: {e}"
                     );
                     heartbeat_task.abort();
+                    let mut outbound_guard = outbound_tx_state_for_task.write().await;
+                    *outbound_guard = None;
                     if let Some(delay) = backoff.next_duration() {
                         tokio::select! {
                             () = token.cancelled() => break,
@@ -214,6 +225,10 @@ fn spawn_control_stream(
                 tokio::select! {
                     () = token.cancelled() => {
                         heartbeat_task.abort();
+                        {
+                            let mut outbound_guard = outbound_tx_state_for_task.write().await;
+                            *outbound_guard = None;
+                        }
                         tracing::debug!(
                             "Control stream to {scheduler_address} cancelled"
                         );
@@ -252,6 +267,10 @@ fn spawn_control_stream(
             }
 
             heartbeat_task.abort();
+            {
+                let mut outbound_guard = outbound_tx_state_for_task.write().await;
+                *outbound_guard = None;
+            }
             tracing::debug!("Control stream to {scheduler_address} disconnected, will reconnect");
 
             if let Some(delay) = backoff.next_duration() {
@@ -263,7 +282,11 @@ fn spawn_control_stream(
         }
     });
 
-    ControlStreamHandle { cancel, task }
+    ControlStreamHandle {
+        cancel,
+        task,
+        outbound_tx: outbound_tx_state,
+    }
 }
 
 /// Handles a message from the scheduler on the control stream.
@@ -329,6 +352,7 @@ fn normalize_scheduler_endpoint(address: &str, tls_enabled: bool) -> String {
 /// handle that is signaled when any scheduler sends a [`PollNow`] command.
 pub struct ControlStreamManager {
     executor_id: String,
+    ballista_executor_id: String,
     client_tls_config: Option<ClientTlsConfig>,
     metrics_reader: Option<Arc<MetricsReader>>,
     streams: HashMap<String, ControlStreamHandle>,
@@ -342,11 +366,13 @@ impl ControlStreamManager {
     #[must_use]
     pub fn new(
         executor_id: String,
+        ballista_executor_id: String,
         client_tls_config: Option<ClientTlsConfig>,
         metrics_reader: Option<MetricsReader>,
     ) -> Self {
         Self {
             executor_id,
+            ballista_executor_id,
             client_tls_config,
             metrics_reader: metrics_reader.map(Arc::new),
             streams: HashMap::new(),
@@ -362,6 +388,42 @@ impl ControlStreamManager {
     #[must_use]
     pub fn poll_now_notify(&self) -> Arc<Notify> {
         Arc::clone(&self.poll_now_notify)
+    }
+
+    /// Sends a shutdown notification to all connected schedulers.
+    pub async fn notify_shutdown(&self, reason: &str) {
+        if self.streams.is_empty() {
+            return;
+        }
+
+        let message = ExecutorControlMessage {
+            executor_id: self.executor_id.clone(),
+            message: Some(ExecutorMessage::Shutdown(ExecutorShutdown {
+                ballista_executor_id: self.ballista_executor_id.clone(),
+                reason: reason.to_string(),
+            })),
+        };
+
+        let mut sent = 0usize;
+        for (scheduler_address, handle) in &self.streams {
+            let outbound_tx = { handle.outbound_tx.read().await.clone() };
+            if let Some(outbound_tx) = outbound_tx {
+                match outbound_tx.try_send(message.clone()) {
+                    Ok(()) => {
+                        sent += 1;
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            "Failed to send shutdown to scheduler {scheduler_address}: {err}"
+                        );
+                    }
+                }
+            }
+        }
+
+        tracing::debug!(
+            "Sent executor shutdown notification to {sent} scheduler streams: {reason}"
+        );
     }
 
     /// Updates the set of schedulers and spawns/removes control streams as needed.
@@ -388,12 +450,14 @@ impl ControlStreamManager {
 
         // Spawn new control streams
         for address in added {
+            let outbound_tx_state = Arc::new(RwLock::new(None));
             let handle = spawn_control_stream(
                 address.clone(),
                 self.executor_id.clone(),
                 self.client_tls_config.clone(),
                 self.metrics_reader.clone(),
                 Arc::clone(&self.poll_now_notify),
+                Arc::clone(&outbound_tx_state),
             );
             self.streams.insert(address, handle);
         }
@@ -471,6 +535,7 @@ mod tests {
     fn test_control_stream_manager_new() {
         let manager = ControlStreamManager::new(
             "executor-1".to_string(),
+            "executor-1".to_string(),
             None, // no TLS
             None, // no metrics reader
         );
@@ -482,13 +547,23 @@ mod tests {
     #[test]
     fn test_control_stream_manager_new_with_metrics_reader() {
         let reader = MetricsReader::new();
-        let manager = ControlStreamManager::new("executor-2".to_string(), None, Some(reader));
+        let manager = ControlStreamManager::new(
+            "executor-2".to_string(),
+            "executor-2".to_string(),
+            None,
+            Some(reader),
+        );
         assert!(manager.metrics_reader.is_some());
     }
 
     #[test]
     fn test_control_stream_manager_update_schedulers_empty() {
-        let mut manager = ControlStreamManager::new("executor-1".to_string(), None, None);
+        let mut manager = ControlStreamManager::new(
+            "executor-1".to_string(),
+            "executor-1".to_string(),
+            None,
+            None,
+        );
         manager.update_schedulers(vec![]);
         assert!(manager.known_schedulers.is_empty());
         assert!(manager.streams.is_empty());
@@ -496,7 +571,12 @@ mod tests {
 
     #[test]
     fn test_control_stream_manager_shutdown_empty() {
-        let mut manager = ControlStreamManager::new("executor-1".to_string(), None, None);
+        let mut manager = ControlStreamManager::new(
+            "executor-1".to_string(),
+            "executor-1".to_string(),
+            None,
+            None,
+        );
         // Should not panic on empty manager
         manager.shutdown();
         assert!(manager.known_schedulers.is_empty());

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -67,7 +67,6 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use url::Url;
 use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
-use uuid::Uuid;
 use x509_certificate::CapturedX509Certificate;
 
 const SCHEDULER_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
@@ -708,6 +707,7 @@ pub async fn initialize_cluster_scheduler(rt: &Arc<Runtime>) -> crate::Result<()
 /// work loop as a future
 pub async fn initialize_cluster_executor(
     rt: Arc<Runtime>,
+    shutdown_token: CancellationToken,
 ) -> crate::Result<impl Future<Output = crate::Result<()>>> {
     let runtime_handle = Arc::clone(&rt);
 
@@ -726,8 +726,47 @@ pub async fn initialize_cluster_executor(
     let client_tls_config = rt.df.cluster_config.client_tls_config().cloned();
     let tls_enabled = client_tls_config.is_some();
 
-    // Generate executor_id early so we can use it for both the app definition request and executor registration
-    let executor_id = Uuid::new_v4().to_string();
+    // Use the configured node_bind_address for the executor flight server.
+    // Fall back to dynamic port assignment if binding fails (e.g., port already in use).
+    let cluster_bind_addr = rt.df.cluster_config.node_bind_address();
+    let bind_addr = if let Ok(bound_addr) = TcpListener::bind(cluster_bind_addr)
+        .await
+        .and_then(|l| l.local_addr())
+    {
+        bound_addr
+    } else if let Ok(dynamic_addr) = TcpListener::bind((cluster_bind_addr.ip(), 0))
+        .await
+        .and_then(|l| l.local_addr())
+    {
+        tracing::warn!(
+            "Unable to bind executor flight server to {cluster_bind_addr}, using dynamic port {dynamic_addr}"
+        );
+        dynamic_addr
+    } else {
+        return Err(FailedToStartClusterExecutor {
+            source: format!(
+                "Unable to bind executor Flight service to configured address ({cluster_bind_addr}) or fallback"
+            )
+            .into(),
+        });
+    };
+
+    // Determine the advertise host and port for executor registration
+    // node_advertise_address() returns host-only (port already stripped during config resolution)
+    let (advertise_host, advertise_port) =
+        if let Some(advertise_host) = rt.df.cluster_config.node_advertise_address() {
+            (advertise_host.to_string(), bind_addr.port())
+        } else {
+            // Fall back to hostname and bind_addr port
+            let hostname = gethostname::gethostname().into_string().map_err(|_| {
+                FailedToStartClusterExecutor {
+                    source: "Unable to determine executor hostname".to_string().into(),
+                }
+            })?;
+            (hostname, bind_addr.port())
+        };
+
+    let executor_id = format!("{advertise_host}:{advertise_port}");
 
     // Fetch the app definition from the scheduler to get temp_directory for the work_dir.
     // This ensures shuffle files are written to the configured directory.
@@ -854,31 +893,6 @@ pub async fn initialize_cluster_executor(
 
     let app_def = Arc::new(app_def);
 
-    // Use the configured node_bind_address for the executor flight server.
-    // Fall back to dynamic port assignment if binding fails (e.g., port already in use).
-    let cluster_bind_addr = rt.df.cluster_config.node_bind_address();
-    let bind_addr = if let Ok(bound_addr) = TcpListener::bind(cluster_bind_addr)
-        .await
-        .and_then(|l| l.local_addr())
-    {
-        bound_addr
-    } else if let Ok(dynamic_addr) = TcpListener::bind((cluster_bind_addr.ip(), 0))
-        .await
-        .and_then(|l| l.local_addr())
-    {
-        tracing::warn!(
-            "Unable to bind executor flight server to {cluster_bind_addr}, using dynamic port {dynamic_addr}"
-        );
-        dynamic_addr
-    } else {
-        return Err(FailedToStartClusterExecutor {
-            source: format!(
-                "Unable to bind executor Flight service to configured address ({cluster_bind_addr}) or fallback"
-            )
-            .into(),
-        });
-    };
-
     let Some(concurrent_tasks) = std::thread::available_parallelism()
         .ok()
         .and_then(|nz| u32::try_from(nz.get()).ok())
@@ -889,21 +903,6 @@ pub async fn initialize_cluster_executor(
                 .into(),
         });
     };
-
-    // Determine the advertise host and port for executor registration
-    // node_advertise_address() returns host-only (port already stripped during config resolution)
-    let (advertise_host, advertise_port) =
-        if let Some(advertise_host) = rt.df.cluster_config.node_advertise_address() {
-            (advertise_host.to_string(), bind_addr.port())
-        } else {
-            // Fall back to hostname and bind_addr port
-            let hostname = gethostname::gethostname().into_string().map_err(|_| {
-                FailedToStartClusterExecutor {
-                    source: "Unable to determine executor hostname".to_string().into(),
-                }
-            })?;
-            (hostname, bind_addr.port())
-        };
 
     let executor_meta = ExecutorRegistration {
         id: executor_id.clone(),
@@ -993,18 +992,12 @@ pub async fn initialize_cluster_executor(
     let initial_scheduler_addresses_for_manager = initial_scheduler_addresses.clone();
     let available_task_slots_for_manager = Arc::clone(&available_task_slots);
 
-    // Compute the executor's advertise address for control stream identification.
-    let executor_advertise_id =
-        if let Some(advertise_host) = rt.df.cluster_config.node_advertise_address() {
-            let bind_port = rt.df.cluster_config.node_bind_address().port();
-            format!("{advertise_host}:{bind_port}")
-        } else {
-            rt.df.cluster_config.node_bind_address().to_string()
-        };
-    let control_stream_executor_id = executor_advertise_id;
+    let control_stream_executor_id = executor_id.clone();
+    let control_stream_ballista_id = executor_id.clone();
     let control_stream_tls_config = client_tls_config.clone();
     let control_stream_initial_schedulers = initial_scheduler_addresses.clone();
     let control_stream_metrics_reader = rt.metrics_reader().cloned();
+    let shutdown_token_for_manager = shutdown_token.clone();
 
     let poll_manager = tokio::spawn(async move {
         let mut pollers: HashMap<String, SchedulerPollHandle> = HashMap::new();
@@ -1013,6 +1006,7 @@ pub async fn initialize_cluster_executor(
         // Initialize control stream manager for metrics collection
         let mut control_stream_manager = ControlStreamManager::new(
             control_stream_executor_id,
+            control_stream_ballista_id,
             control_stream_tls_config,
             control_stream_metrics_reader,
         );
@@ -1047,33 +1041,47 @@ pub async fn initialize_cluster_executor(
 
         let mut refresh = tokio::time::interval(SCHEDULER_REFRESH_INTERVAL);
         loop {
-            refresh.tick().await;
-            if let Some(addresses) = fetch_scheduler_membership(
-                &scheduler_url_for_manager,
-                client_tls_config_for_manager.clone(),
-            )
-            .await
-            {
-                if addresses.is_empty() {
-                    tracing::warn!(
-                        "Scheduler membership refresh returned empty list; keeping existing schedulers"
-                    );
-                    continue;
+            tokio::select! {
+                () = shutdown_token_for_manager.cancelled() => {
+                    control_stream_manager
+                        .notify_shutdown("runtime shutdown")
+                        .await;
+                    control_stream_manager.shutdown();
+                    for (_, handle) in pollers.drain() {
+                        handle.cancel.cancel();
+                        let _ = handle.task.await;
+                    }
+                    break;
                 }
-                // Update control streams with new scheduler membership
-                control_stream_manager.update_schedulers(addresses.clone());
+                _ = refresh.tick() => {
+                    if let Some(addresses) = fetch_scheduler_membership(
+                        &scheduler_url_for_manager,
+                        client_tls_config_for_manager.clone(),
+                    )
+                    .await
+                    {
+                        if addresses.is_empty() {
+                            tracing::warn!(
+                                "Scheduler membership refresh returned empty list; keeping existing schedulers"
+                            );
+                            continue;
+                        }
+                        // Update control streams with new scheduler membership
+                        control_stream_manager.update_schedulers(addresses.clone());
 
-                update_scheduler_pollers(
-                    &mut pollers,
-                    &mut known_schedulers,
-                    addresses,
-                    client_tls_config_for_manager.as_ref(),
-                    &executor_for_manager,
-                    &codec_for_manager,
-                    &readiness_sender,
-                    Some(&poll_now_notify),
-                    &available_task_slots_for_manager,
-                );
+                        update_scheduler_pollers(
+                            &mut pollers,
+                            &mut known_schedulers,
+                            addresses,
+                            client_tls_config_for_manager.as_ref(),
+                            &executor_for_manager,
+                            &codec_for_manager,
+                            &readiness_sender,
+                            Some(&poll_now_notify),
+                            &available_task_slots_for_manager,
+                        );
+                    }
+                }
             }
         }
     });
@@ -1094,7 +1102,9 @@ pub async fn initialize_cluster_executor(
         poll_manager
             .await
             .boxed()
-            .context(FailedToStartClusterExecutorSnafu)?
+            .context(FailedToStartClusterExecutorSnafu)?;
+
+        Ok(())
     })
 }
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use app::App;
 use arrow::array::RecordBatch;
 use arrow_ipc::writer::StreamWriter;
+use ballista_core::serde::protobuf::ExecutorStoppedParams;
+use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpc;
 use datafusion::sql::sqlparser::ast::{Ident, ObjectNamePart, visit_relations_mut};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::parser::Parser;
@@ -429,6 +431,7 @@ impl ClusterService for ClusterServiceImpl {
         // We need to identify the executor from its first message.
         // Spawn a task to handle the bidirectional stream.
         let executor_registry = Arc::clone(&self.executor_registry);
+        let datafusion = Arc::clone(&self.datafusion);
         let outbound_tx_for_registry = outbound_tx.clone();
         let inbound_task = tokio::spawn(async move {
             let executor_id = match inbound.next().await {
@@ -442,7 +445,7 @@ impl ClusterService for ClusterServiceImpl {
 
                     // Handle the first message if it contains data.
                     if let Some(message) = msg.message {
-                        handle_executor_message(&executor_id, &message, &executor_registry);
+                        handle_executor_message(&executor_id, &message, &datafusion).await;
                     }
                     executor_id
                 }
@@ -489,8 +492,9 @@ impl ClusterService for ClusterServiceImpl {
                                         handle_executor_message(
                                             &executor_id,
                                             &message,
-                                            &executor_registry,
-                                        );
+                                            &datafusion,
+                                        )
+                                        .await;
                                     }
                                 }
                             }
@@ -527,11 +531,11 @@ impl ClusterService for ClusterServiceImpl {
     }
 }
 
-/// Handles an executor control message (heartbeat, etc.)
-fn handle_executor_message(
+/// Handles an executor control message (heartbeat, shutdown, etc.)
+async fn handle_executor_message(
     executor_id: &str,
     message: &ExecutorMessage,
-    _registry: &ExecutorRegistry,
+    datafusion: &DataFusion,
 ) {
     match message {
         ExecutorMessage::Heartbeat(heartbeat) => {
@@ -547,7 +551,55 @@ fn handle_executor_message(
                 "Unexpected metrics response in handle_executor_message for {executor_id}"
             );
         }
+        ExecutorMessage::Shutdown(shutdown) => {
+            let reason = if shutdown.reason.is_empty() {
+                "executor shutdown".to_string()
+            } else {
+                shutdown.reason.clone()
+            };
+            let ballista_executor_id = if shutdown.ballista_executor_id.is_empty() {
+                executor_id
+            } else {
+                shutdown.ballista_executor_id.as_str()
+            };
+            tracing::info!(
+                executor_id = %executor_id,
+                ballista_executor_id = %ballista_executor_id,
+                reason = %reason,
+                "Executor shutdown requested"
+            );
+            if let Err(err) =
+                notify_scheduler_executor_shutdown(datafusion, ballista_executor_id, &reason).await
+            {
+                tracing::warn!(
+                    "Failed to notify scheduler about executor shutdown for {ballista_executor_id}: {err}"
+                );
+            }
+        }
     }
+}
+
+async fn notify_scheduler_executor_shutdown(
+    datafusion: &DataFusion,
+    executor_id: &str,
+    reason: &str,
+) -> Result<(), String> {
+    let scheduler = datafusion
+        .scheduler_server
+        .read()
+        .map_err(|_| "Failed to lock scheduler server".to_string())?
+        .clone()
+        .ok_or_else(|| "Scheduler server not initialized".to_string())?;
+
+    scheduler
+        .executor_stopped(Request::new(ExecutorStoppedParams {
+            executor_id: executor_id.to_string(),
+            reason: reason.to_string(),
+        }))
+        .await
+        .map_err(|e| format!("Failed to notify scheduler about executor shutdown: {e}"))?;
+
+    Ok(())
 }
 /// Encodes a slice of `RecordBatch` into Arrow IPC streaming format.
 ///

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -726,95 +726,102 @@ impl Runtime {
             None
         };
 
-        let maybe_cluster_future: Option<BoxedClusterFuture> =
-            match self.df.cluster_config.effective_role() {
-                Some(ClusterRole::Scheduler) => {
-                    cluster::initialize_cluster_scheduler(&self).await?;
-                    // Start internal cluster server for scheduler on separate port
-                    let internal_server_shutdown = CancellationToken::new();
-                    let self_ref = Arc::clone(&self);
-                    let cloned_shutdown = internal_server_shutdown.clone();
-                    let executor_registry = Arc::clone(
-                        scheduler_executor_registry
-                            .as_ref()
-                            .context(MissingSchedulerExecutorRegistrySnafu)?,
-                    );
-                    let internal_server_fut = async move {
-                        cluster::start_internal_cluster_server(
-                            Arc::clone(&self_ref),
-                            Some(cloned_shutdown),
-                            executor_registry,
-                        )
-                        .await
-                        .context(UnableToStartClusterServerSnafu)
-                    };
-                    let self_for_task = Arc::clone(&self);
-                    let internal_server_future = self_for_task
-                        .start_runtime_task(
-                            CLUSTER_INTERNAL_SERVER,
-                            Some(internal_server_shutdown),
-                            internal_server_fut,
-                        )
-                        .await;
+        let maybe_cluster_future: Option<BoxedClusterFuture> = match self
+            .df
+            .cluster_config
+            .effective_role()
+        {
+            Some(ClusterRole::Scheduler) => {
+                cluster::initialize_cluster_scheduler(&self).await?;
+                // Start internal cluster server for scheduler on separate port
+                let internal_server_shutdown = CancellationToken::new();
+                let self_ref = Arc::clone(&self);
+                let cloned_shutdown = internal_server_shutdown.clone();
+                let executor_registry = Arc::clone(
+                    scheduler_executor_registry
+                        .as_ref()
+                        .context(MissingSchedulerExecutorRegistrySnafu)?,
+                );
+                let internal_server_fut = async move {
+                    cluster::start_internal_cluster_server(
+                        Arc::clone(&self_ref),
+                        Some(cloned_shutdown),
+                        executor_registry,
+                    )
+                    .await
+                    .context(UnableToStartClusterServerSnafu)
+                };
+                let self_for_task = Arc::clone(&self);
+                let internal_server_future = self_for_task
+                    .start_runtime_task(
+                        CLUSTER_INTERNAL_SERVER,
+                        Some(internal_server_shutdown),
+                        internal_server_fut,
+                    )
+                    .await;
 
-                    let scheduler_registry_future = {
-                        let app = self.app.read().await;
-                        let config = app.as_ref().and_then(|app| app.runtime.scheduler.clone());
-                        if let Some(config) = config {
-                            let registry_shutdown = CancellationToken::new();
-                            let registry_shutdown_for_task = registry_shutdown.clone();
-                            let peers = self.scheduler_peers();
-                            let self_ref = Arc::clone(&self);
-                            let registry_task = async move {
-                                cluster::start_scheduler_registry(
-                                    self_ref,
-                                    &config,
-                                    registry_shutdown.clone(),
-                                    peers,
-                                )
-                                .await
-                                .map_err(|err| {
-                                    Error::FailedToRegisterScheduler {
-                                        source: Box::new(err),
-                                    }
-                                })
-                            };
-                            Some(
-                                self_for_task
-                                    .start_runtime_task(
-                                        CLUSTER_SCHEDULER_REGISTRY,
-                                        Some(registry_shutdown_for_task),
-                                        registry_task,
-                                    )
-                                    .await,
+                let scheduler_registry_future = {
+                    let app = self.app.read().await;
+                    let config = app.as_ref().and_then(|app| app.runtime.scheduler.clone());
+                    if let Some(config) = config {
+                        let registry_shutdown = CancellationToken::new();
+                        let registry_shutdown_for_task = registry_shutdown.clone();
+                        let peers = self.scheduler_peers();
+                        let self_ref = Arc::clone(&self);
+                        let registry_task = async move {
+                            cluster::start_scheduler_registry(
+                                self_ref,
+                                &config,
+                                registry_shutdown.clone(),
+                                peers,
                             )
-                        } else {
-                            None
-                        }
-                    };
+                            .await
+                            .map_err(|err| {
+                                Error::FailedToRegisterScheduler {
+                                    source: Box::new(err),
+                                }
+                            })
+                        };
+                        Some(
+                            self_for_task
+                                .start_runtime_task(
+                                    CLUSTER_SCHEDULER_REGISTRY,
+                                    Some(registry_shutdown_for_task),
+                                    registry_task,
+                                )
+                                .await,
+                        )
+                    } else {
+                        None
+                    }
+                };
 
-                    let cluster_future = async move {
-                        if let Some(registry_future) = scheduler_registry_future {
-                            tokio::try_join!(internal_server_future, registry_future).map(|_| ())
-                        } else {
-                            internal_server_future.await
-                        }
-                    };
+                let cluster_future = async move {
+                    if let Some(registry_future) = scheduler_registry_future {
+                        tokio::try_join!(internal_server_future, registry_future).map(|_| ())
+                    } else {
+                        internal_server_future.await
+                    }
+                };
 
-                    Some(Box::pin(cluster_future))
-                }
-                Some(ClusterRole::Executor) => {
-                    let executor_fut =
-                        cluster::initialize_cluster_executor(Arc::clone(&self)).await?;
-                    let self_ref = Arc::clone(&self);
-                    Some(Box::pin(
-                        self_ref
-                            .start_runtime_task(CLUSTER_EXECUTOR, None, executor_fut)
-                            .await,
-                    ))
-                }
-                _ => None,
-            };
+                Some(Box::pin(cluster_future))
+            }
+            Some(ClusterRole::Executor) => {
+                let executor_shutdown = CancellationToken::new();
+                let executor_fut = cluster::initialize_cluster_executor(
+                    Arc::clone(&self),
+                    executor_shutdown.clone(),
+                )
+                .await?;
+                let self_ref = Arc::clone(&self);
+                Some(Box::pin(
+                    self_ref
+                        .start_runtime_task(CLUSTER_EXECUTOR, Some(executor_shutdown), executor_fut)
+                        .await,
+                ))
+            }
+            _ => None,
+        };
 
         if self.df.cluster_config.effective_role().is_some() {
             tracing::warn!(

--- a/crates/runtime/tests/cluster/simple.rs
+++ b/crates/runtime/tests/cluster/simple.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use app::AppBuilder;
 
 use arrow::array::RecordBatch;
+use ballista_scheduler::state::executor_manager::ExecutorManager;
 use futures::TryStreamExt;
 use runtime::Runtime;
 use runtime::cluster::ResolvedClusterConfig;
@@ -29,7 +30,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 use test_framework::pki::init_pki;
-use tokio::time::{Instant, sleep_until};
+use tokio::time::{Instant, sleep, sleep_until};
 
 use crate::{
     configure_test_datafusion, init_tracing,
@@ -101,6 +102,30 @@ async fn snapshot_names_from_runtime(
         .map_err(|e| anyhow::Error::msg(e.to_string()))
         .expect("Should format batches");
     insta::assert_snapshot!(name, pretty);
+}
+
+async fn wait_for_executor_count(
+    executor_manager: &ExecutorManager,
+    expected: usize,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    let start = Instant::now();
+    loop {
+        let count = executor_manager
+            .get_executor_state()
+            .await
+            .map_err(|err| anyhow::Error::msg(err.to_string()))?
+            .len();
+        if count == expected {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow::Error::msg(format!(
+                "Timed out waiting for {expected} executors; found {count}"
+            )));
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -261,7 +286,17 @@ async fn test_simple_cluster_mode() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&scheduler_rt).await;
 
+            let scheduler_server = scheduler_rt
+                .datafusion()
+                .scheduler_server
+                .read()
+                .expect("scheduler server lock")
+                .clone()
+                .expect("scheduler server should be available");
+            let executor_manager = scheduler_server.state.executor_manager.clone();
+
             sleep_until(Instant::now() + Duration::from_secs(1)).await; // let executor connect
+            wait_for_executor_count(&executor_manager, 1, Duration::from_secs(10)).await?;
 
             // Datafusion query will run directly on the scheduler node without any clustering
             snapshot_names_from_runtime(
@@ -332,6 +367,8 @@ async fn test_simple_cluster_mode() -> Result<(), anyhow::Error> {
             executor_rt.shutdown().await;
             drop(executor_rt);
             executor_server_thread.abort();
+
+            wait_for_executor_count(&executor_manager, 0, Duration::from_secs(5)).await?;
 
             scheduler_rt.shutdown().await;
             drop(scheduler_rt);


### PR DESCRIPTION
## Summary
- send executor shutdown notifications over the scheduler control stream
- use advertise host:port as the Ballista executor ID
- add a regression check for immediate executor removal

## Changes
- extend control stream protocol with executor shutdown message
- notify Ballista scheduler on shutdown using in-process scheduler
- update cluster executor initialization to use advertise address IDs
- add cluster test coverage for shutdown deregistration

Fixes #9289