### PR TITLE
Log health check issues as warnings instead of failing append benchmarks

### DIFF
--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -125,9 +125,8 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
 
     let health_report = health_monitor.stop().await;
 
-    // Test passes only if: (1) table row counts match expected values, (2) all queries succeeded, and (3) health checks passed
-    let test_status: TestStatus =
-        (table_count_result.is_ok() && test_succeeded && health_report.is_ok()).into();
+    // Test passes only if: (1) table row counts match expected values and (2) all queries succeeded
+    let test_status: TestStatus = (table_count_result.is_ok() && test_succeeded).into();
     test_metrics.emit(test_status).await?;
 
     spiced_instance.stop()?;
@@ -135,7 +134,8 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
 
     table_count_result?;
     if let Some(message) = health_report.failure_message() {
-        return Err(anyhow::anyhow!(message));
+        // Health check failures are logged as warnings but don't fail the test
+        eprintln!("Warning: {message}");
     }
     Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

PR applies the same change to Append tests for consistency:
- https://github.com/spiceai/spiceai/pull/9301

During intensive benchmark runs, health check latency can spike due to CPU utilization, causing false positive failures. This change logs the health check issues as warnings instead of failing the entire test run.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
