### PR TITLE
feat: Add scheduler task for async job cleanup

### DIFF
--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -143,12 +143,13 @@ pub async fn start_scheduler_registry(
     );
 
     // Initialize job executor for async SQL queries
-    let job_store = crate::jobs::JobStore::new(
+    let job_store = Arc::new(crate::jobs::JobStore::new(
         Arc::clone(&store),
         base_prefix.clone(),
         scheduler_id.clone(),
-    );
-    let job_executor = crate::jobs::JobExecutor::new(Arc::new(job_store), rt.datafusion());
+    ));
+
+    let job_executor = crate::jobs::JobExecutor::new(Arc::clone(&job_store), rt.datafusion());
     rt.set_job_executor(Arc::new(job_executor)).await;
     tracing::info!(
         "Initialized async SQL jobs API with state location: {}",

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -154,7 +154,8 @@ pub async fn start_scheduler_registry(
 
     let job_executor = crate::jobs::JobExecutor::new(Arc::clone(&job_store), rt.datafusion());
     rt.set_job_executor(Arc::new(job_executor)).await;
-    rt.create_job_store_cleanup_schedule(&job_store)
+    Arc::clone(&rt)
+        .create_job_store_cleanup_schedule(&job_store)
         .await
         .context(FailedToStartJobStoreCleanupTaskSnafu)?;
     tracing::info!(

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -83,6 +83,9 @@ pub enum Error {
 
     #[snafu(display("Failed to serialize scheduler state: {source}"))]
     SerializeState { source: serde_json::Error },
+
+    #[snafu(display("{source}"))]
+    FailedToStartJobStoreCleanupTask { source: crate::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -151,7 +154,9 @@ pub async fn start_scheduler_registry(
 
     let job_executor = crate::jobs::JobExecutor::new(Arc::clone(&job_store), rt.datafusion());
     rt.set_job_executor(Arc::new(job_executor)).await;
-    rt.create_job_store_cleanup_schedule(&job_store).await?;
+    rt.create_job_store_cleanup_schedule(&job_store)
+        .await
+        .context(FailedToStartJobStoreCleanupTaskSnafu)?;
     tracing::info!(
         "Initialized async SQL jobs API with state location: {}",
         config.state_location

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -151,6 +151,7 @@ pub async fn start_scheduler_registry(
 
     let job_executor = crate::jobs::JobExecutor::new(Arc::clone(&job_store), rt.datafusion());
     rt.set_job_executor(Arc::new(job_executor)).await;
+    rt.create_job_store_cleanup_schedule(&job_store).await?;
     tracing::info!(
         "Initialized async SQL jobs API with state location: {}",
         config.state_location

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -323,6 +323,15 @@ impl Runtime {
         self: Arc<Self>,
         job_store: &Arc<JobStore>,
     ) -> Result<()> {
+        let schedulers_lock = Arc::clone(&self.schedulers);
+        let mut schedulers = schedulers_lock.write().await;
+        if let Some(existing_scheduler) = schedulers.get(JOB_CLEANUP_SCHEDULER_NAME) {
+            tracing::debug!(
+                "Job cleanup scheduler already exists, skipping creation of job cleanup schedule"
+            );
+            return Ok(());
+        }
+
         let cleanup_task: Arc<dyn ScheduledTask> =
             Arc::new(JobCleanupTask::new(Arc::clone(job_store)));
 
@@ -344,15 +353,6 @@ impl Runtime {
                 .await
                 .context(crate::FailedToStartSchedulerSnafu)?,
         );
-
-        let schedulers_lock = Arc::clone(&self.schedulers);
-        let mut schedulers = schedulers_lock.write().await;
-        if let Some(existing_scheduler) = schedulers.get(JOB_CLEANUP_SCHEDULER_NAME) {
-            tracing::debug!(
-                "Job cleanup scheduler already exists, skipping creation of job cleanup schedule"
-            );
-            return Ok(());
-        }
 
         schedulers.insert(JOB_CLEANUP_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
 

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -325,7 +325,7 @@ impl Runtime {
     ) -> Result<()> {
         let schedulers_lock = Arc::clone(&self.schedulers);
         let mut schedulers = schedulers_lock.write().await;
-        if let Some(existing_scheduler) = schedulers.get(JOB_CLEANUP_SCHEDULER_NAME) {
+        if schedulers.get(JOB_CLEANUP_SCHEDULER_NAME).is_some() {
             tracing::debug!(
                 "Job cleanup scheduler already exists, skipping creation of job cleanup schedule"
             );

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use datafusion::sql::TableReference;
 use scheduler::{
-    channel::cron::CronRequestChannel,
+    channel::{cron::CronRequestChannel, interval::IntervalRequestChannel},
     schedule::Schedule,
     scheduler::{Running, Scheduler, SchedulerBuilder},
     task::ScheduledTask,
@@ -36,8 +36,12 @@ use crate::{
         view::View,
     },
     dataaccelerator::AccelerationSource,
+    jobs::{
+        CLEANUP_INTERVAL_SECONDS, JOB_CLEANUP_SCHEDULE_NAME, JOB_CLEANUP_SCHEDULER_NAME, JobStore,
+    },
     scheduling::{
         dataset::DatasetRefreshTask,
+        jobs::JobCleanupTask,
         view::ViewRefreshTask,
         worker::{WorkerPromptTask, WorkerSqlTask},
     },
@@ -311,6 +315,51 @@ impl Runtime {
         );
 
         schedulers.insert(REFRESH_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
+
+        Ok(())
+    }
+
+    pub async fn create_job_store_cleanup_schedule(
+        self: Arc<Self>,
+        job_store: &Arc<JobStore>,
+    ) -> Result<()> {
+        let cleanup_task: Arc<dyn ScheduledTask> =
+            Arc::new(JobCleanupTask::new(Arc::clone(job_store)));
+
+        let interval_channel = Arc::new(RwLock::new(IntervalRequestChannel::new(
+            CLEANUP_INTERVAL_SECONDS,
+        )));
+
+        let schedule = Arc::new(
+            Schedule::new(JOB_CLEANUP_SCHEDULE_NAME.into(), cleanup_task)
+                .add_trigger(interval_channel),
+        );
+
+        let scheduler = Arc::new(
+            SchedulerBuilder::new(JOB_CLEANUP_SCHEDULER_NAME.into())
+                .add_schedule(schedule)
+                .build()
+                .context(crate::FailedToBuildSchedulerSnafu)?
+                .start()
+                .await
+                .context(crate::FailedToStartSchedulerSnafu)?,
+        );
+
+        let schedulers_lock = Arc::clone(&self.schedulers);
+        let mut schedulers = schedulers_lock.write().await;
+        if let Some(existing_scheduler) = schedulers.get(JOB_CLEANUP_SCHEDULER_NAME) {
+            tracing::debug!(
+                "Job cleanup scheduler already exists, skipping creation of job cleanup schedule"
+            );
+            return Ok(());
+        }
+
+        schedulers.insert(JOB_CLEANUP_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
+
+        tracing::debug!(
+            interval_seconds = CLEANUP_INTERVAL_SECONDS,
+            "Started distributed job cleanup scheduler"
+        );
 
         Ok(())
     }

--- a/crates/runtime/src/jobs/mod.rs
+++ b/crates/runtime/src/jobs/mod.rs
@@ -32,3 +32,4 @@ pub use executor::JobExecutor;
 pub use state::JobErrorCode;
 pub use state::{DEFAULT_CHUNK_SIZE, JobResult, JobResultManifest, JobSchema, JobState, JobStatus};
 pub use store::JobStore;
+pub use store::{CLEANUP_INTERVAL_SECONDS, JOB_CLEANUP_SCHEDULE_NAME, JOB_CLEANUP_SCHEDULER_NAME};

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -458,6 +458,16 @@ impl JobStore {
             total_chunks = total_chunks.saturating_add(1);
 
             if let Err(err) = self.store.delete(&meta.location).await {
+                if let ObjectStoreError::NotFound { .. } = err {
+                    // Chunk was already deleted - deletion occurred concurrently
+                    tracing::debug!(
+                        job_id,
+                        path = %meta.location,
+                        "Chunk already deleted during job deletion (likely deleted during list operation), skipping"
+                    );
+                    continue;
+                }
+
                 tracing::warn!(
                     job_id,
                     path = %meta.location,
@@ -479,10 +489,19 @@ impl JobStore {
 
         // Delete job state
         let path = self.job_state_path(job_id);
-        self.store
-            .delete(&path)
-            .await
-            .context(ObjectStoreDeleteSnafu)?;
+        let job_state_delete_result = self.store.delete(&path).await;
+
+        if let Err(ObjectStoreError::NotFound { .. }) = job_state_delete_result {
+            // Job state was already deleted - deletion occurred concurrently
+            tracing::debug!(
+                job_id,
+                path = %path,
+                "Job state already deleted during job deletion (likely deleted during list operation), skipping"
+            );
+            return Ok(());
+        }
+
+        job_state_delete_result.context(ObjectStoreDeleteSnafu)?;
 
         Ok(())
     }

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -40,6 +40,15 @@ use super::state::{
     JobState, JobStatus,
 };
 
+/// Interval in seconds between expired job cleanup runs.
+pub const CLEANUP_INTERVAL_SECONDS: u64 = 5 * 60; // 5 minutes
+
+/// Name of the scheduler used for job cleanup.
+pub const JOB_CLEANUP_SCHEDULER_NAME: &str = "job_cleanup_scheduler";
+
+/// Name of the schedule used for job cleanup.
+pub const JOB_CLEANUP_SCHEDULE_NAME: &str = "job_cleanup";
+
 /// Stores job state and results in the shared object store.
 ///
 /// Layout:

--- a/crates/runtime/src/scheduling/jobs/mod.rs
+++ b/crates/runtime/src/scheduling/jobs/mod.rs
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Scheduled task for cleaning up expired distributed query jobs.
+
+use std::sync::Arc;
+
+use scheduler::Result;
+use scheduler::task::ScheduledTask;
+use tonic::async_trait;
+
+use crate::jobs::JobStore;
+
+/// A scheduled task that cleans up expired jobs from the job store.
+///
+/// This task is designed to run periodically (e.g., every 5 minutes) to remove
+/// jobs whose results have exceeded their TTL. It logs errors but does not
+/// propagate them, allowing the scheduler to continue running subsequent
+/// cleanup cycles.
+pub struct JobCleanupTask {
+    job_store: Arc<JobStore>,
+}
+
+impl JobCleanupTask {
+    /// Creates a new `JobCleanupTask` with the given job store.
+    #[must_use]
+    pub fn new(job_store: Arc<JobStore>) -> Self {
+        Self { job_store }
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for JobCleanupTask {
+    async fn execute(&self) -> Result<()> {
+        tracing::debug!("Starting cleanup of expired distributed query jobs");
+        match self.job_store.cleanup_expired_jobs().await {
+            Ok(deleted_count) => {
+                if deleted_count > 0 {
+                    tracing::debug!(deleted_count, "Cleaned up expired distributed query jobs");
+                } else {
+                    tracing::debug!("No expired distributed query jobs to clean up");
+                }
+            }
+            Err(e) => {
+                // Log the error but do not propagate - allow the schedule to continue
+                // for the next cleanup cycle
+                tracing::error!("Failed to clean up expired distributed query jobs. {e}");
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/runtime/src/scheduling/mod.rs
+++ b/crates/runtime/src/scheduling/mod.rs
@@ -15,5 +15,6 @@ limitations under the License.
 */
 
 pub mod dataset;
+pub mod jobs;
 pub mod view;
 pub mod worker;


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a `JobCleanupTask` which calls the `JobStore::cleanup_expired_jobs`
* Adds a `create_job_store_cleanup_schedule` to `Runtime`
* Updates `start_scheduler_registry` to call `Runtime::create_job_store_cleanup_schedule()` so that the job cleanup task is started whenever the scheduler starts
* Updates the `JobStore::delete_job` to debug log when job state (and data chunks) are not found during deletion (due to deletion concurrency)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #9134 
