### PR TITLE
feat(http): Return all HTTP responses as data, skip caching 5xx

### DIFF
--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -680,18 +680,17 @@ impl HttpTableProvider {
         // If retries exhausted due to transient errors (5xx), make one final attempt
         // and return whatever response we get - 5xx is still valid data.
         // Don't retry on permanent errors (e.g., failed to read response body).
-        match result {
-            Ok(fetch_result) => Ok(fetch_result),
-            Err(_) => {
-                tracing::debug!(
-                    "Retries exhausted for {url}, making final attempt accepting any status"
-                );
-                self.perform_single_request(&url, body, path_label, true)
-                    .await
-                    .map_err(|e| match e {
-                        RetryError::Permanent(err) | RetryError::Transient { err, .. } => err,
-                    })
-            }
+        if let Ok(fetch_result) = result {
+            Ok(fetch_result)
+        } else {
+            tracing::debug!(
+                "Retries exhausted for {url}, making final attempt accepting any status"
+            );
+            self.perform_single_request(&url, body, path_label, true)
+                .await
+                .map_err(|e| match e {
+                    RetryError::Permanent(err) | RetryError::Transient { err, .. } => err,
+                })
         }
     }
 
@@ -729,12 +728,12 @@ impl HttpTableProvider {
         // 5xx: retry with backoff (might be transient server issue)
         // After retries exhausted, we'll accept 5xx as valid response
         if !accept_5xx && (500..600).contains(&status_code) {
-            tracing::debug!("HTTP server error ({}), will retry", status_code);
-            return Err(RetryError::transient(Error::HttpRequest {
-                source: response
-                    .error_for_status()
-                    .expect_err("5xx should be error"),
-            }));
+            tracing::debug!("HTTP server error ({status_code}), will retry");
+            // We already verified status_code is 5xx, so error_for_status will return Err
+            if let Err(e) = response.error_for_status() {
+                return Err(RetryError::transient(Error::HttpRequest { source: e }));
+            }
+            unreachable!("5xx status code should produce error from error_for_status");
         }
 
         // 2xx, 3xx, 4xx (and 5xx when accept_5xx=true): valid response

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -19,6 +19,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
     error::ArrowError,
 };
+use arrow_array::UInt16Array;
 use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
@@ -125,6 +126,7 @@ struct CachedResponse {
     max_age: Duration,
     detected_format: Option<String>,
     response_date: Option<SystemTime>,
+    response_status: u16,
 }
 
 impl CachedResponse {
@@ -196,6 +198,7 @@ struct HttpFetchResult {
     max_age: Duration,
     detected_format: String,
     response_date: Option<SystemTime>,
+    response_status: u16,
 }
 
 impl HttpFetchResult {
@@ -420,6 +423,7 @@ impl HttpTableProvider {
             Field::new("request_query", DataType::Utf8, true),
             Field::new("request_body", DataType::Utf8, true),
             Field::new("content", DataType::Utf8, false),
+            Field::new("response_status", DataType::UInt16, false),
             Field::new(
                 "fetched_at",
                 DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),
@@ -629,22 +633,20 @@ impl HttpTableProvider {
         path: &str,
         query: Option<&str>,
         body: Option<&str>,
-        result: HttpFetchResult,
-    ) -> String {
+        result: &HttpFetchResult,
+    ) {
         let cache_key = Self::get_cache_key(path, query, body);
-        let content_arc = Arc::new(result.content);
         let cached_response = CachedResponse {
-            content: Arc::clone(&content_arc),
+            content: Arc::new(result.content.clone()),
             cached_at: SystemTime::now(),
             max_age: result.max_age,
-            detected_format: Some(result.detected_format),
+            detected_format: Some(result.detected_format.clone()),
             response_date: result.response_date,
+            response_status: result.response_status,
         };
 
         let mut cache_write = self.cache.write().await;
         cache_write.insert(cache_key, cached_response);
-
-        Arc::unwrap_or_clone(content_arc)
     }
 
     async fn perform_request_with_retry(
@@ -687,19 +689,21 @@ impl HttpTableProvider {
                     RetryError::transient(Error::HttpRequest { source: e })
                 })?;
 
+                let status_code = response.status().as_u16();
+
                 if let Err(err) = response.error_for_status_ref() {
-                    if let Some(status) = err.status() {
-                        let status_code = status.as_u16();
-                        if (400..500).contains(&status_code) {
-                            return Err(RetryError::permanent(Error::HttpClientError {
-                                status: status_code,
-                                message: format!(
-                                    "{} for url ({})",
-                                    status.canonical_reason().unwrap_or("Client Error"),
-                                    url
-                                ),
-                            }));
-                        }
+                    if (400..500).contains(&status_code) {
+                        return Err(RetryError::permanent(Error::HttpClientError {
+                            status: status_code,
+                            message: format!(
+                                "{} for url ({})",
+                                response
+                                    .status()
+                                    .canonical_reason()
+                                    .unwrap_or("Client Error"),
+                                url
+                            ),
+                        }));
                     }
                     tracing::debug!("HTTP request returned server error, will retry: {}", err);
                     return Err(RetryError::transient(Error::HttpRequest { source: err }));
@@ -745,6 +749,7 @@ impl HttpTableProvider {
                     max_age,
                     detected_format,
                     response_date,
+                    response_status: status_code,
                 })
             }
         })
@@ -756,7 +761,7 @@ impl HttpTableProvider {
         path: &str,
         query: Option<&str>,
         body: Option<&str>,
-    ) -> Result<String> {
+    ) -> Result<HttpFetchResult> {
         let url = self.build_request_url(path, query)?;
         let path_owned = path.to_string();
         let query_owned = query.map(ToOwned::to_owned);
@@ -767,25 +772,24 @@ impl HttpTableProvider {
             .await?;
 
         if fetch_result.should_cache() {
-            return Ok(self
-                .cache_response(
-                    &path_owned,
-                    query_owned.as_deref(),
-                    body_owned.as_deref(),
-                    fetch_result,
-                )
-                .await);
+            self.cache_response(
+                &path_owned,
+                query_owned.as_deref(),
+                body_owned.as_deref(),
+                &fetch_result,
+            )
+            .await;
         }
 
-        Ok(fetch_result.content)
+        Ok(fetch_result)
     }
 
-    async fn get_content(
+    async fn get_response(
         &self,
         path: &str,
         query: Option<&str>,
         body: Option<&str>,
-    ) -> Result<String> {
+    ) -> Result<HttpFetchResult> {
         // When acceleration is enabled, skip HTTP-level caching - the acceleration layer handles it
         if self.acceleration_enabled {
             return self.fetch_and_cache(path, query, body).await;
@@ -811,7 +815,13 @@ impl HttpTableProvider {
             } else {
                 tracing::debug!("Returning fresh cached content for {}", cache_key);
             }
-            return Ok((*cached_response.content).clone());
+            return Ok(HttpFetchResult {
+                content: (*cached_response.content).clone(),
+                max_age: cached_response.max_age,
+                detected_format: cached_response.detected_format.clone().unwrap_or_default(),
+                response_date: cached_response.response_date,
+                response_status: cached_response.response_status,
+            });
         }
 
         // Fetch fresh content
@@ -960,19 +970,17 @@ impl HttpExec {
         );
 
         // Fetch content with path, query, and body
-        let content = provider
-            .get_content(path_val, query_val, body_val)
+        let result = provider
+            .get_response(path_val, query_val, body_val)
             .await
             .map_err(DataFusionError::from)?;
 
-        // Get the response date from cache (if available)
-        let cache_key = HttpTableProvider::get_cache_key(path_val, query_val, body_val);
-        let response_date = {
-            let cache = provider.cache.read().await;
-            cache
-                .get(&cache_key)
-                .and_then(|cached| cached.response_date)
-        };
+        let HttpFetchResult {
+            content,
+            response_date,
+            response_status,
+            ..
+        } = result;
 
         // Store the actual values from the partition for the primary key
         let path_for_batch = path.as_deref().unwrap_or("");
@@ -1030,6 +1038,9 @@ impl HttpExec {
                     Ok(Arc::new(StringArray::from(vec![body_for_batch; num_rows])) as ArrayRef)
                 }
                 "content" => Ok(Arc::new(StringArray::from(content_rows.clone())) as ArrayRef),
+                "response_status" => {
+                    Ok(Arc::new(UInt16Array::from(vec![response_status; num_rows])) as ArrayRef)
+                }
                 "fetched_at" => {
                     use arrow::array::TimestampNanosecondArray;
                     Ok(Arc::new(TimestampNanosecondArray::from(vec![
@@ -1959,25 +1970,28 @@ mod tests {
     fn test_base_table_schema() {
         let schema = HttpTableProvider::base_table_schema();
 
-        assert_eq!(schema.fields().len(), 5);
+        assert_eq!(schema.fields().len(), 6);
         assert_eq!(schema.field(0).name(), "request_path");
         assert_eq!(schema.field(1).name(), "request_query");
         assert_eq!(schema.field(2).name(), "request_body");
         assert_eq!(schema.field(3).name(), "content");
-        assert_eq!(schema.field(4).name(), "fetched_at");
+        assert_eq!(schema.field(4).name(), "response_status");
+        assert_eq!(schema.field(5).name(), "fetched_at");
         assert_eq!(*schema.field(0).data_type(), DataType::Utf8);
         assert_eq!(*schema.field(1).data_type(), DataType::Utf8);
         assert_eq!(*schema.field(2).data_type(), DataType::Utf8);
         assert_eq!(*schema.field(3).data_type(), DataType::Utf8);
+        assert_eq!(*schema.field(4).data_type(), DataType::UInt16);
         assert_eq!(
-            *schema.field(4).data_type(),
+            *schema.field(5).data_type(),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None)
         );
         assert!(!schema.field(0).is_nullable()); // request_path is not nullable
         assert!(schema.field(1).is_nullable()); // request_query is nullable
         assert!(schema.field(2).is_nullable()); // request_body is nullable
         assert!(!schema.field(3).is_nullable()); // content is not nullable
-        assert!(schema.field(4).is_nullable()); // fetched_at is nullable
+        assert!(!schema.field(4).is_nullable()); // response_status is not nullable
+        assert!(schema.field(5).is_nullable()); // fetched_at is nullable
     }
 
     #[test]

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1106,6 +1106,12 @@ impl HttpExec {
     fn parse_content(content: &str, limit: Option<usize>) -> Vec<String> {
         let trimmed = content.trim();
 
+        // Handle empty content - return a single row with empty content
+        // This is important for HTTP responses that return empty bodies (e.g., 5xx errors)
+        if trimmed.is_empty() {
+            return vec![content.to_string()];
+        }
+
         // Try to parse as JSON
         if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(trimmed) {
             match json_value {
@@ -2003,6 +2009,53 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_content_empty_body() {
+        // Empty body should return single row with empty content
+        let rows = HttpExec::parse_content("", None);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], "");
+
+        // Whitespace-only should also return single row
+        let rows = HttpExec::parse_content("   ", None);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], "   ");
+    }
+
+    #[test]
+    fn test_parse_content_json_object() {
+        let content = r#"{"id": 1, "name": "test"}"#;
+        let rows = HttpExec::parse_content(content, None);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].contains("\"id\""));
+    }
+
+    #[test]
+    fn test_parse_content_json_array() {
+        let content = r#"[{"id": 1}, {"id": 2}, {"id": 3}]"#;
+        let rows = HttpExec::parse_content(content, None);
+        assert_eq!(rows.len(), 3);
+
+        // With limit
+        let rows = HttpExec::parse_content(content, Some(2));
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_content_ndjson() {
+        let content = "{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3}";
+        let rows = HttpExec::parse_content(content, None);
+        assert_eq!(rows.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_content_plain_text() {
+        let content = "This is plain text content";
+        let rows = HttpExec::parse_content(content, None);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], content);
+    }
+
+    #[test]
     fn test_base_table_schema() {
         let schema = HttpTableProvider::base_table_schema();
 
@@ -2497,7 +2550,7 @@ mod tests {
 
         // Test basic query
         let df = ctx
-            .sql("SELECT request_path, content FROM posts WHERE request_path = '/posts/1'")
+            .sql("SELECT request_path, content, response_status FROM posts WHERE request_path = '/posts/1'")
             .await
             .expect("query should succeed");
 
@@ -2506,7 +2559,19 @@ mod tests {
 
         let batch = &results[0];
         assert!(batch.num_rows() > 0, "Should have rows");
-        assert_eq!(batch.num_columns(), 2);
+        assert_eq!(batch.num_columns(), 3);
+
+        // Validate response_status is 200 for successful request
+        let status_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt16Array>()
+            .expect("response_status should be UInt16Array");
+        assert_eq!(
+            status_col.value(0),
+            200,
+            "Successful request should have response_status 200"
+        );
 
         // Validate content contains expected post fields
         let content_col = batch
@@ -2554,7 +2619,7 @@ mod tests {
 
         // Test IN list filter for multiple paths
         let df = ctx
-            .sql("SELECT request_path, content FROM posts WHERE request_path IN ('/posts/1', '/posts/2', '/posts/3')")
+            .sql("SELECT request_path, content, response_status FROM posts WHERE request_path IN ('/posts/1', '/posts/2', '/posts/3')")
             .await
             .expect("query should succeed");
 
@@ -2564,7 +2629,7 @@ mod tests {
         let total_rows: usize = results.iter().map(arrow_array::RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "Should have exactly 3 rows for 3 posts");
 
-        // Verify content contains expected post IDs
+        // Verify response_status is 200 for all successful requests and content contains expected post IDs
         let mut found_posts = [false, false, false]; // Track posts 1, 2, 3
         for batch in &results {
             let content_col = batch
@@ -2573,7 +2638,20 @@ mod tests {
                 .downcast_ref::<arrow::array::StringArray>()
                 .expect("content should be string array");
 
+            let status_col = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt16Array>()
+                .expect("response_status should be UInt16Array");
+
             for i in 0..batch.num_rows() {
+                // Validate response_status is 200
+                assert_eq!(
+                    status_col.value(i),
+                    200,
+                    "All successful requests should have response_status 200"
+                );
+
                 let content = content_col.value(i);
                 assert!(content.contains("userId"), "Should contain userId field");
                 assert!(content.contains("id"), "Should contain id field");
@@ -2722,6 +2800,110 @@ mod tests {
         assert!(
             content.contains("sealed off from the rest of the world"),
             "Should contain expected summary text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_integration_tvmaze_404_not_found() {
+        use datafusion::prelude::SessionContext;
+
+        // Use an invalid route that returns 404 with JSON error body
+        let url = Url::parse("https://api.tvmaze.com").expect("valid URL");
+        let provider = HttpTableProvider::new(url, Client::new(), "json".to_string(), false)
+            .with_allowed_paths(vec!["/search/invalid_404".to_string()])
+            .expect("allowed paths");
+
+        let ctx = SessionContext::new();
+        ctx.register_table("tvmaze", Arc::new(provider))
+            .expect("register table");
+
+        // Query for an invalid route - should return a row with 404 status and error JSON
+        let df = ctx
+            .sql("SELECT request_path, content, response_status FROM tvmaze WHERE request_path = '/search/invalid_404'")
+            .await
+            .expect("query should succeed");
+
+        let results = df.collect().await.expect("collect should succeed");
+        assert!(!results.is_empty(), "Should have results even for 404");
+
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 1, "Should have exactly 1 row");
+
+        // Validate response_status is 404
+        let status_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt16Array>()
+            .expect("response_status should be UInt16Array");
+        assert_eq!(
+            status_col.value(0),
+            404,
+            "Invalid route should have response_status 404"
+        );
+
+        // Validate content contains the 404 JSON error response body
+        let content_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("content should be string array");
+
+        let content = content_col.value(0);
+        // TVMaze returns JSON error: {"name":"Not Found","message":"Page not found.","code":0,"status":404,...}
+        assert!(
+            content.contains("Not Found"),
+            "404 response should contain 'Not Found' in body"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_integration_httpbin_500_server_error() {
+        use datafusion::prelude::SessionContext;
+
+        // httpbin.org provides endpoints that return specific HTTP status codes
+        let url = Url::parse("https://httpbin.org").expect("valid URL");
+        let provider = HttpTableProvider::new(url, Client::new(), "json".to_string(), false)
+            .with_allowed_paths(vec!["/status/500".to_string()])
+            .expect("allowed paths");
+
+        let ctx = SessionContext::new();
+        ctx.register_table("httpbin", Arc::new(provider))
+            .expect("register table");
+
+        // Query for a 500 status endpoint - should return a row with 500 status
+        let df = ctx
+            .sql("SELECT request_path, content, response_status FROM httpbin WHERE request_path = '/status/500'")
+            .await
+            .expect("query should succeed");
+
+        let results = df.collect().await.expect("collect should succeed");
+        assert!(!results.is_empty(), "Should have results even for 5xx");
+
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 1, "Should have exactly 1 row");
+
+        // Validate response_status is 500
+        let status_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt16Array>()
+            .expect("response_status should be UInt16Array");
+        assert_eq!(
+            status_col.value(0),
+            500,
+            "Server error should have response_status 500"
+        );
+
+        // Validate content is empty (httpbin /status/500 returns empty body)
+        let content_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("content should be string array");
+        let content = content_col.value(0);
+        assert!(
+            content.is_empty(),
+            "httpbin 500 response should have empty content body"
         );
     }
 

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -63,6 +63,9 @@ pub enum Error {
     #[snafu(display("HTTP request failed: {source}"))]
     HttpRequest { source: reqwest::Error },
 
+    #[snafu(display("HTTP request failed with status code {status}"))]
+    HttpServerError { status: u16 },
+
     #[snafu(display("HTTP client error ({status}): {message}"))]
     HttpClientError { status: u16, message: String },
 
@@ -96,6 +99,10 @@ impl From<Error> for DataFusionError {
             Error::HttpClientError { status, message } => {
                 DataFusionError::Plan(format!("HTTP client error ({status}): {message}"))
             }
+            // Server errors (5xx) are external errors
+            Error::HttpServerError { status } => DataFusionError::External(Box::new(
+                std::io::Error::other(format!("HTTP request failed with status code {status}")),
+            )),
             // Retry exhaustion is an external error
             Error::AllRetriesFailed { max_retries, url } => {
                 DataFusionError::External(Box::new(std::io::Error::other(format!(
@@ -733,7 +740,10 @@ impl HttpTableProvider {
             if let Err(e) = response.error_for_status() {
                 return Err(RetryError::transient(Error::HttpRequest { source: e }));
             }
-            unreachable!("5xx status code should produce error from error_for_status");
+            // Defensive: should never reach here since 5xx always produces error_for_status Err
+            return Err(RetryError::transient(Error::HttpServerError {
+                status: status_code,
+            }));
         }
 
         // 2xx, 3xx, 4xx (and 5xx when accept_5xx=true): valid response

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -203,6 +203,9 @@ struct HttpFetchResult {
 
 impl HttpFetchResult {
     fn should_cache(&self) -> bool {
+        // We don't explicitly disable caching for 5xx responses because well-behaved servers
+        // should return Cache-Control: no-cache or max-age=0 for transient error responses.
+        // This keeps the caching logic simple and respects server-specified cache directives.
         self.max_age.as_secs() > 0
     }
 }
@@ -656,104 +659,137 @@ impl HttpTableProvider {
         path_label: &str,
     ) -> Result<HttpFetchResult> {
         let retry_strategy = self.retry_strategy.clone();
-        let client = self.client.clone();
-        let content_type = self.content_type.clone();
-        let custom_headers = self.custom_headers.clone();
-        let path_owned = path_label.to_string();
+        let this = self.clone();
+        let url_clone = url.clone();
         let body_owned = body.map(ToOwned::to_owned);
+        let path_owned = path_label.to_string();
 
-        retry(retry_strategy, || {
-            let client = client.clone();
-            let url = url.clone();
-            let headers = custom_headers.clone();
-            let content_type = content_type.clone();
-            let path_for_detection = path_owned.clone();
-            let body_for_request = body_owned.clone();
+        let result = retry(retry_strategy, || {
+            let this = this.clone();
+            let url = url_clone.clone();
+            let body = body_owned.clone();
+            let path = path_owned.clone();
 
             async move {
-                let mut request_builder = if let Some(ref body_content) = body_for_request {
-                    let mut req = client.post(url.clone());
-                    let ct = content_type.as_deref().unwrap_or("application/json");
-                    req = req.header("Content-Type", ct);
-                    req.body(body_content.clone())
-                } else {
-                    client.get(url.clone())
-                };
-
-                for (name, value) in &headers {
-                    request_builder = request_builder.header(name, value);
-                }
-
-                let response = request_builder.send().await.map_err(|e| {
-                    tracing::debug!("HTTP request failed: {}", e);
-                    RetryError::transient(Error::HttpRequest { source: e })
-                })?;
-
-                let status_code = response.status().as_u16();
-
-                if let Err(err) = response.error_for_status_ref() {
-                    if (400..500).contains(&status_code) {
-                        return Err(RetryError::permanent(Error::HttpClientError {
-                            status: status_code,
-                            message: format!(
-                                "{} for url ({})",
-                                response
-                                    .status()
-                                    .canonical_reason()
-                                    .unwrap_or("Client Error"),
-                                url
-                            ),
-                        }));
-                    }
-                    tracing::debug!("HTTP request returned server error, will retry: {}", err);
-                    return Err(RetryError::transient(Error::HttpRequest { source: err }));
-                }
-
-                let detected_format = Self::detect_file_format(&response, &path_for_detection);
-                tracing::debug!(
-                    "Detected file format from Content-Type header: {}",
-                    detected_format
-                );
-
-                let cache_control_header = response
-                    .headers()
-                    .get(CACHE_CONTROL)
-                    .and_then(|v| v.to_str().ok());
-                let max_age = Self::parse_cache_control(cache_control_header);
-
-                // Extract Date header from response
-                let response_date = response
-                    .headers()
-                    .get(reqwest::header::DATE)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|date_str| {
-                        // Parse HTTP date format (RFC 2822/RFC 1123)
-                        httpdate::parse_http_date(date_str).ok()
-                    });
-
-                let content = response
-                    .text()
+                this.perform_single_request(&url, body.as_deref(), &path, false)
                     .await
-                    .map_err(|e| RetryError::permanent(Error::HttpRequest { source: e }))?;
-
-                let detected_format = if detected_format.is_empty() {
-                    let inferred = Self::infer_format_from_content(&content);
-                    tracing::debug!("Inferred file format from content: {}", inferred);
-                    inferred
-                } else {
-                    detected_format
-                };
-
-                Ok(HttpFetchResult {
-                    content,
-                    max_age,
-                    detected_format,
-                    response_date,
-                    response_status: status_code,
-                })
             }
         })
-        .await
+        .await;
+
+        // If retries exhausted due to transient errors (5xx), make one final attempt
+        // and return whatever response we get - 5xx is still valid data.
+        // Don't retry on permanent errors (e.g., failed to read response body).
+        match result {
+            Ok(fetch_result) => Ok(fetch_result),
+            Err(_) => {
+                tracing::debug!(
+                    "Retries exhausted for {url}, making final attempt accepting any status"
+                );
+                self.perform_single_request(&url, body, path_label, true)
+                    .await
+                    .map_err(|e| match e {
+                        RetryError::Permanent(err) | RetryError::Transient { err, .. } => err,
+                    })
+            }
+        }
+    }
+
+    /// Perform a single HTTP request without retry logic.
+    ///
+    /// If `accept_5xx` is false, returns a transient error on 5xx to trigger retry.
+    /// If `accept_5xx` is true, accepts any status code and returns the response.
+    async fn perform_single_request(
+        &self,
+        url: &Url,
+        body: Option<&str>,
+        path_label: &str,
+        accept_5xx: bool,
+    ) -> std::result::Result<HttpFetchResult, RetryError<Error>> {
+        let mut request_builder = if let Some(body_content) = body {
+            let mut req = self.client.post(url.clone());
+            let ct = self.content_type.as_deref().unwrap_or("application/json");
+            req = req.header("Content-Type", ct);
+            req.body(body_content.to_owned())
+        } else {
+            self.client.get(url.clone())
+        };
+
+        for (name, value) in &self.custom_headers {
+            request_builder = request_builder.header(name, value);
+        }
+
+        let response = request_builder.send().await.map_err(|e| {
+            tracing::debug!("HTTP request failed: {e}");
+            RetryError::transient(Error::HttpRequest { source: e })
+        })?;
+
+        let status_code = response.status().as_u16();
+
+        // 5xx: retry with backoff (might be transient server issue)
+        // After retries exhausted, we'll accept 5xx as valid response
+        if !accept_5xx && (500..600).contains(&status_code) {
+            tracing::debug!("HTTP server error ({}), will retry", status_code);
+            return Err(RetryError::transient(Error::HttpRequest {
+                source: response
+                    .error_for_status()
+                    .expect_err("5xx should be error"),
+            }));
+        }
+
+        // 2xx, 3xx, 4xx (and 5xx when accept_5xx=true): valid response
+        // 4xx like 404 "not found" is a valid business response, not an error
+        Self::extract_response(response, status_code, path_label).await
+    }
+
+    /// Extract content and metadata from an HTTP response.
+    async fn extract_response(
+        response: reqwest::Response,
+        status_code: u16,
+        path_label: &str,
+    ) -> std::result::Result<HttpFetchResult, RetryError<Error>> {
+        let detected_format = Self::detect_file_format(&response, path_label);
+        tracing::debug!(
+            "Detected file format from Content-Type header: {}",
+            detected_format
+        );
+
+        let cache_control_header = response
+            .headers()
+            .get(CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok());
+        let max_age = Self::parse_cache_control(cache_control_header);
+
+        // Extract Date header from response
+        let response_date = response
+            .headers()
+            .get(reqwest::header::DATE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|date_str| {
+                // Parse HTTP date format (RFC 2822/RFC 1123)
+                httpdate::parse_http_date(date_str).ok()
+            });
+
+        let content = response
+            .text()
+            .await
+            .map_err(|e| RetryError::permanent(Error::HttpRequest { source: e }))?;
+
+        let detected_format = if detected_format.is_empty() {
+            let inferred = Self::infer_format_from_content(&content);
+            tracing::debug!("Inferred file format from content: {}", inferred);
+            inferred
+        } else {
+            detected_format
+        };
+
+        Ok(HttpFetchResult {
+            content,
+            max_age,
+            detected_format,
+            response_date,
+            response_status: status_code,
+        })
     }
 
     async fn fetch_and_cache(

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1955,7 +1955,7 @@ mod tests {
     #[derive(Debug)]
     struct MockHttpTableProvider {
         schema: SchemaRef,
-        /// Data to return from scan (should include response_status column)
+        /// Data to return from scan (should include `response_status` column)
         data: Vec<RecordBatch>,
     }
 
@@ -3106,7 +3106,7 @@ mod tests {
         );
     }
 
-    /// Helper to create a schema with response_status column for filter_5xx tests
+    /// Helper to create a schema with `response_status` column for `filter_5xx` tests
     fn create_http_response_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new("content", DataType::Utf8, false),

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1211,7 +1211,11 @@ impl CacheRefreshHelper {
                 let cache_key = compute_cache_key_from_filters(filters);
 
                 // Only cache if we have non-5xx data to cache
-                if !batches_for_cache.is_empty() {
+                if batches_for_cache.is_empty() {
+                    tracing::debug!(
+                        "Fetch returned 5xx response, skipping cache write for dataset={dataset_name}"
+                    );
+                } else {
                     let cache_rows: usize =
                         batches_for_cache.iter().map(RecordBatch::num_rows).sum();
 
@@ -1248,10 +1252,6 @@ impl CacheRefreshHelper {
 
                     tracing::debug!(
                         "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
-                    );
-                } else {
-                    tracing::debug!(
-                        "Fetch returned 5xx response, skipping cache write for dataset={dataset_name}"
                     );
                 }
 
@@ -1946,6 +1946,86 @@ mod tests {
             // Return an empty exec as we don't need output
             Ok(Arc::new(DataSourceExec::new(Arc::new(
                 MemorySourceConfig::try_new(&[vec![]], Arc::clone(&self.schema), None)?,
+            ))))
+        }
+    }
+
+    /// Mock HTTP source table provider that returns data with configurable response status codes.
+    /// Used to test that 5xx responses are returned to users but NOT cached.
+    #[derive(Debug)]
+    struct MockHttpTableProvider {
+        schema: SchemaRef,
+        /// Data to return from scan (should include response_status column)
+        data: Vec<RecordBatch>,
+    }
+
+    impl MockHttpTableProvider {
+        /// Create a mock HTTP provider that returns data with the specified response status code.
+        fn with_status(status_code: u16, content: &str) -> Self {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("request_path", DataType::Utf8, true),
+                Field::new("request_query", DataType::Utf8, true),
+                Field::new("content", DataType::Utf8, true),
+                Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
+                Field::new(
+                    CACHE_REFRESHED_AT_COLUMN,
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    true,
+                ),
+            ]));
+
+            #[expect(clippy::cast_possible_truncation)]
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_nanos() as i64;
+
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(StringArray::from(vec!["/api/test"])),
+                    Arc::new(StringArray::from(vec!["q=test"])),
+                    Arc::new(StringArray::from(vec![content])),
+                    Arc::new(UInt16Array::from(vec![status_code])),
+                    Arc::new(TimestampNanosecondArray::from(vec![Some(now)])),
+                ],
+            )
+            .expect("to create batch");
+
+            Self {
+                schema,
+                data: vec![batch],
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TableProvider for MockHttpTableProvider {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(DataSourceExec::new(Arc::new(
+                MemorySourceConfig::try_new(
+                    std::slice::from_ref(&self.data),
+                    Arc::clone(&self.schema),
+                    None,
+                )?,
             ))))
         }
     }
@@ -2855,6 +2935,175 @@ mod tests {
 
         let total_rows: usize = data.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "Should have 3 rows from 3 requests");
+    }
+
+    /// Test that 5xx responses are returned to users but NOT written to the cache.
+    ///
+    /// Simulates cache miss flow:
+    /// 1. Create mock HTTP source (federated) and empty accelerator
+    /// 2. Call `handle_cache_miss` (called when accelerator has no data for query)
+    /// 3. Verify user receives 5xx response data (can see the error)
+    /// 4. Verify accelerator remains empty (transient errors not persisted)
+    #[tokio::test]
+    async fn test_5xx_responses_returned_to_user_but_not_cached() {
+        use futures::StreamExt;
+
+        // 1. Create mock HTTP source (returns 500) and empty accelerator
+        let http_source = Arc::new(MockHttpTableProvider::with_status(
+            500,
+            "Internal Server Error",
+        ));
+        let schema = http_source.schema();
+
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+
+        let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        // 2. Call handle_cache_miss - this is what happens when user queries and cache is empty
+        let mut stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))], // filters
+            None,                              // limit
+            Arc::clone(&schema),
+            false, // is_expired
+            false, // stale_if_error
+            None,  // expired_batches
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()), // synchronized_children
+            batch_write_tx,
+        )
+        .await;
+
+        // Collect user-visible results
+        let mut user_batches = Vec::new();
+        while let Some(result) = stream.next().await {
+            user_batches.push(result.expect("stream should not error"));
+        }
+
+        // 3. Verify user receives the 500 response data
+        assert_eq!(user_batches.len(), 1, "User should receive 1 batch");
+        assert_eq!(user_batches[0].num_rows(), 1, "User should receive 1 row");
+
+        let status_col = user_batches[0]
+            .column(
+                user_batches[0]
+                    .schema()
+                    .index_of(RESPONSE_STATUS_COLUMN)
+                    .expect("column exists"),
+            )
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("status column");
+        assert_eq!(status_col.value(0), 500, "User should see status 500");
+
+        // Wait for cache write flush
+        tokio::time::sleep(Duration::from_millis(CACHE_WRITE_FLUSH_INTERVAL_MS + 100)).await;
+
+        // 4. Verify accelerator is empty (5xx was not cached)
+        let cached_data = accelerator.get_data();
+        assert!(
+            cached_data.is_empty(),
+            "5xx responses should NOT be in accelerator"
+        );
+    }
+
+    /// Test that 404 responses are cached.
+    ///
+    /// Simulates cache miss flow:
+    /// 1. Create mock HTTP source (federated) and empty accelerator
+    /// 2. Call `handle_cache_miss` (called when accelerator has no data for query)
+    /// 3. Verify user receives 404 response data
+    /// 4. Verify accelerator contains the 404 response
+    #[tokio::test]
+    async fn test_4xx_responses_are_cached() {
+        use futures::StreamExt;
+
+        // 1. Create mock HTTP source (returns 404) and empty accelerator
+        let http_source = Arc::new(MockHttpTableProvider::with_status(404, "Not Found"));
+        let schema = http_source.schema();
+
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+
+        let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        // 2. Call handle_cache_miss - this is what happens when user queries and cache is empty
+        let mut stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))], // filters
+            None,                              // limit
+            Arc::clone(&schema),
+            false, // is_expired
+            false, // stale_if_error
+            None,  // expired_batches
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()), // synchronized_children
+            batch_write_tx,
+        )
+        .await;
+
+        // Collect user-visible results
+        let mut user_batches = Vec::new();
+        while let Some(result) = stream.next().await {
+            user_batches.push(result.expect("stream should not error"));
+        }
+
+        // 3. Verify user receives the 404 response data
+        assert_eq!(user_batches.len(), 1, "User should receive 1 batch");
+        assert_eq!(user_batches[0].num_rows(), 1, "User should receive 1 row");
+
+        let status_col = user_batches[0]
+            .column(
+                user_batches[0]
+                    .schema()
+                    .index_of(RESPONSE_STATUS_COLUMN)
+                    .expect("column exists"),
+            )
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("status column");
+        assert_eq!(status_col.value(0), 404, "User should see status 404");
+
+        // Wait for cache write flush
+        tokio::time::sleep(Duration::from_millis(CACHE_WRITE_FLUSH_INTERVAL_MS + 100)).await;
+
+        // 4. Verify accelerator has the 404 response cached
+        let cached_data = accelerator.get_data();
+        assert!(
+            !cached_data.is_empty(),
+            "4xx responses SHOULD be in accelerator"
+        );
+
+        let cached_rows: usize = cached_data.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(cached_rows, 1, "Should have 1 cached row");
+
+        // Verify cached data has status 404
+        let cached_status = cached_data[0]
+            .column(
+                cached_data[0]
+                    .schema()
+                    .index_of(RESPONSE_STATUS_COLUMN)
+                    .expect("column exists"),
+            )
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("status column");
+        assert_eq!(
+            cached_status.value(0),
+            404,
+            "Cached response should have status 404"
+        );
     }
 
     /// Helper to create a schema with response_status column for filter_5xx tests

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -2690,10 +2690,12 @@ mod tests {
     #[tokio::test]
     async fn test_swr_handle_cache_hit_refreshes_only_accessed_entry() {
         // Create schema with request columns (HTTP connector cache pattern)
+        // Includes response_status column required by filter_5xx_responses
         let schema = Arc::new(Schema::new(vec![
             Field::new("request_path", DataType::Utf8, true),
             Field::new("request_query", DataType::Utf8, true),
             Field::new("data", DataType::Utf8, true),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
             Field::new(
                 CACHE_REFRESHED_AT_COLUMN,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -2706,6 +2708,7 @@ mod tests {
             let path = StringArray::from(vec!["/api/users"]);
             let query = StringArray::from(vec!["id=1"]);
             let data = StringArray::from(vec!["fresh_user_data"]);
+            let status = UInt16Array::from(vec![200]); // 200 OK - will pass filter_5xx_responses
 
             #[expect(clippy::cast_possible_truncation)]
             let now = SystemTime::now()
@@ -2720,6 +2723,7 @@ mod tests {
                     Arc::new(path),
                     Arc::new(query),
                     Arc::new(data),
+                    Arc::new(status),
                     Arc::new(timestamp),
                 ],
             )
@@ -2744,6 +2748,7 @@ mod tests {
                 "stale_post_data",
                 "stale_comment_data",
             ]);
+            let status = UInt16Array::from(vec![200, 200, 200]); // All 200 OK
 
             #[expect(clippy::cast_possible_truncation)]
             let two_min_ago = (SystemTime::now()
@@ -2764,6 +2769,7 @@ mod tests {
                     Arc::new(path),
                     Arc::new(query),
                     Arc::new(data),
+                    Arc::new(status),
                     Arc::new(timestamp),
                 ],
             )

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -1975,6 +1975,7 @@ mod tests {
             Field::new("request_path", DataType::Utf8, true),
             Field::new("request_query", DataType::Utf8, true),
             Field::new("request_body", DataType::Utf8, true),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
             Field::new(
                 CACHE_REFRESHED_AT_COLUMN,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -1990,6 +1991,7 @@ mod tests {
         let path_array = StringArray::from(vec![Some("/api/users"), Some("/api/posts")]);
         let query_array = StringArray::from(vec![Some("page=1"), Some("limit=10")]);
         let body_array = StringArray::from(vec![Some("{\"id\":1}"), Some("{\"id\":2}")]);
+        let status_array = UInt16Array::from(vec![200, 200]);
 
         #[expect(clippy::cast_possible_truncation)]
         let now = SystemTime::now()
@@ -2006,6 +2008,7 @@ mod tests {
                 Arc::new(path_array),
                 Arc::new(query_array),
                 Arc::new(body_array),
+                Arc::new(status_array),
                 Arc::new(refresh_timestamps),
             ],
         )
@@ -2023,6 +2026,7 @@ mod tests {
         let path_array = StringArray::from(vec![Some("/api/users")]);
         let query_array = StringArray::from(vec![None::<&str>]); // Null query
         let body_array = StringArray::from(vec![Some("{\"id\":1}")]);
+        let status_array = UInt16Array::from(vec![200]);
 
         #[expect(clippy::cast_possible_truncation)]
         let now = SystemTime::now()
@@ -2039,6 +2043,7 @@ mod tests {
                 Arc::new(path_array),
                 Arc::new(query_array),
                 Arc::new(body_array),
+                Arc::new(status_array),
                 Arc::new(refresh_timestamps),
             ],
         )
@@ -2057,6 +2062,7 @@ mod tests {
         let path_array = StringArray::from(vec![Some("")]); // Empty string
         let query_array = StringArray::from(vec![Some("page=1")]);
         let body_array = StringArray::from(vec![Some("")]); // Empty string
+        let status_array = UInt16Array::from(vec![200]);
 
         #[expect(clippy::cast_possible_truncation)]
         let now = SystemTime::now()
@@ -2073,6 +2079,7 @@ mod tests {
                 Arc::new(path_array),
                 Arc::new(query_array),
                 Arc::new(body_array),
+                Arc::new(status_array),
                 Arc::new(refresh_timestamps),
             ],
         )
@@ -2882,7 +2889,11 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![
-                Arc::new(StringArray::from(vec!["not found", "bad request", "forbidden"])),
+                Arc::new(StringArray::from(vec![
+                    "not found",
+                    "bad request",
+                    "forbidden",
+                ])),
                 Arc::new(UInt16Array::from(vec![404, 400, 403])),
             ],
         )
@@ -2917,7 +2928,12 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![
-                Arc::new(StringArray::from(vec!["ok", "not found", "server error", "created"])),
+                Arc::new(StringArray::from(vec![
+                    "ok",
+                    "not found",
+                    "server error",
+                    "created",
+                ])),
                 Arc::new(UInt16Array::from(vec![200, 404, 500, 201])),
             ],
         )
@@ -2979,55 +2995,16 @@ mod tests {
         let result =
             filter_5xx_responses(vec![batch1, batch2, batch3]).expect("filter should succeed");
 
-        assert_eq!(result.len(), 2, "Should have 2 batches (batch2 filtered out entirely)");
-        assert_eq!(result[0].num_rows(), 1, "First batch should have 1 row");
-        assert_eq!(result[1].num_rows(), 1, "Second kept batch should have 1 row");
-    }
-
-    #[test]
-    fn test_filter_5xx_responses_missing_column_returns_error() {
-        let schema = Arc::new(Schema::new(vec![Field::new("content", DataType::Utf8, false)]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(StringArray::from(vec!["data"]))],
-        )
-        .expect("to create batch");
-
-        let result = filter_5xx_responses(vec![batch]);
-        assert!(result.is_err(), "Should error on missing response_status column");
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Missing required 'response_status'"),
-            "Error should mention missing column"
+        assert_eq!(
+            result.len(),
+            2,
+            "Should have 2 batches (batch2 filtered out entirely)"
         );
-    }
-
-    #[test]
-    fn test_filter_5xx_responses_wrong_column_type_returns_error() {
-        // Create schema with response_status as wrong type (Int32 instead of UInt16)
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("content", DataType::Utf8, false),
-            Field::new(RESPONSE_STATUS_COLUMN, DataType::Int32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(StringArray::from(vec!["data"])),
-                Arc::new(Int32Array::from(vec![200])),
-            ],
-        )
-        .expect("to create batch");
-
-        let result = filter_5xx_responses(vec![batch]);
-        assert!(result.is_err(), "Should error on wrong column type");
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("must be UInt16Array"),
-            "Error should mention wrong type"
+        assert_eq!(result[0].num_rows(), 1, "First batch should have 1 row");
+        assert_eq!(
+            result[1].num_rows(),
+            1,
+            "Second kept batch should have 1 row"
         );
     }
 

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -21,7 +21,8 @@ use std::sync::atomic::AtomicI64;
 use std::time::{Duration, SystemTime};
 
 use arrow::array::StringArray;
-use arrow::array::{Array, RecordBatch, TimestampNanosecondArray};
+use arrow::array::{Array, RecordBatch, TimestampNanosecondArray, UInt16Array};
+use arrow::compute::filter_record_batch;
 use arrow::datatypes::SchemaRef;
 use arrow_tools::format::SchemaDisplay;
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
@@ -403,6 +404,8 @@ fn compute_cache_key_from_filters(filters: &[Expr]) -> String {
     parts.join("|")
 }
 
+const RESPONSE_STATUS_COLUMN: &str = "response_status";
+
 /// Helper functions for cache refresh operations
 pub struct CacheRefreshHelper;
 
@@ -545,8 +548,13 @@ impl CacheRefreshHelper {
         // Fetch fresh data for this specific entry
         let batches = Self::fetch_from_source(&federated, dataset_name, filters, None).await?;
 
+        // Filter out 5xx responses - they are transient errors that should not be cached
+        let batches = filter_5xx_responses(batches)?;
+
         if batches.is_empty() {
-            tracing::debug!("No data returned from source for dataset={dataset_name}");
+            tracing::debug!(
+                "No cacheable data for dataset={dataset_name} (source returned empty or 5xx)"
+            );
             // Remove from in-flight since no data to write
             let mut in_flight = in_flight_revalidations.lock().await;
             in_flight.remove(&cache_key);
@@ -1184,48 +1192,70 @@ impl CacheRefreshHelper {
                 let batch_schema = batches[0].schema();
                 tracing::trace!("Fetched batch schema:\n{}", SchemaDisplay(&batch_schema));
 
+                // Filter out 5xx responses for caching - they are transient errors
+                // that should not be persisted. User still receives all data.
+                let batches_for_cache = match filter_5xx_responses(batches.clone()) {
+                    Ok(filtered) => filtered,
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to filter 5xx responses for caching for dataset={dataset_name}: {e}"
+                        );
+                        Vec::new() // Skip caching on error, but still return data to user
+                    }
+                };
+
                 // Clone batches for propagation to children.
                 // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
-                let batches_for_propagate = batches.clone();
+                let batches_for_propagate = batches_for_cache.clone();
                 let filters_clone: Vec<Expr> = filters.to_vec();
                 let cache_key = compute_cache_key_from_filters(filters);
 
-                // Send write request to batched consumer (takes ownership of batches clone)
-                let write_request = CacheWriteRequest {
-                    batches: batches.clone(),
-                    filters: filters.to_vec(),
-                    is_upsert: is_expired,
-                    cache_key,
-                };
-                if let Err(e) = batch_write_tx.send(write_request).await {
-                    tracing::warn!(
-                        "Failed to enqueue cache write for dataset {dataset_name}: {e} (channel closed)"
+                // Only cache if we have non-5xx data to cache
+                if !batches_for_cache.is_empty() {
+                    let cache_rows: usize =
+                        batches_for_cache.iter().map(RecordBatch::num_rows).sum();
+
+                    // Send write request to batched consumer
+                    let write_request = CacheWriteRequest {
+                        batches: batches_for_cache,
+                        filters: filters.to_vec(),
+                        is_upsert: is_expired,
+                        cache_key,
+                    };
+                    if let Err(e) = batch_write_tx.send(write_request).await {
+                        tracing::warn!(
+                            "Failed to enqueue cache write for dataset {dataset_name}: {e} (channel closed)"
+                        );
+                    } else {
+                        tracing::trace!(
+                            "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows, is_upsert={is_expired}",
+                        );
+                    }
+
+                    // Propagate filtered data to children (same as parent - excludes 5xx for consistency)
+                    let synchronized_children_clone = Arc::clone(&synchronized_children);
+                    let dataset_name_clone = dataset_name.to_string();
+                    io_runtime.spawn(async move {
+                        Self::propagate_to_synchronized_children(
+                            &synchronized_children_clone,
+                            &dataset_name_clone,
+                            &filters_clone,
+                            &batches_for_propagate,
+                            is_expired,
+                        )
+                        .await;
+                    });
+
+                    tracing::debug!(
+                        "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
                     );
                 } else {
-                    tracing::trace!(
-                        "Enqueued cache write for dataset={dataset_name}, {total_rows} rows, is_upsert={is_expired}",
+                    tracing::debug!(
+                        "Fetch returned 5xx response, skipping cache write for dataset={dataset_name}"
                     );
                 }
 
-                // Propagate to synchronized children immediately (don't wait for flush interval)
-                let synchronized_children_clone = Arc::clone(&synchronized_children);
-                let dataset_name_clone = dataset_name.to_string();
-                io_runtime.spawn(async move {
-                    Self::propagate_to_synchronized_children(
-                        &synchronized_children_clone,
-                        &dataset_name_clone,
-                        &filters_clone,
-                        &batches_for_propagate,
-                        is_expired,
-                    )
-                    .await;
-                });
-
-                tracing::debug!(
-                    "Background cache update performed for dataset={dataset_name}, {total_rows} rows"
-                );
-
-                // Return data to user immediately (don't wait for background write)
+                // Return ALL data to user (including 5xx responses)
                 let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
                 let adapter = RecordBatchStreamAdapter::new(batch_schema, batch_stream);
                 Box::pin(adapter)
@@ -1693,6 +1723,58 @@ impl ExecutionPlan for CachingAccelerationScanExec {
         let adapter = RecordBatchStreamAdapter::new(schema, cache_miss_or_stale_stream);
         Ok(Box::pin(adapter))
     }
+}
+
+/// Filter out 5xx server error responses from batches before caching.
+///
+/// 5xx errors are typically transient (e.g., server overload, temporary outage)
+/// and should not be persisted in the cache. This ensures that temporary
+/// failures don't pollute the cache with error responses that would be
+/// served to subsequent requests.
+///
+/// Returns an error if the `response_status` column is missing or has the wrong type,
+/// as this indicates a schema bug in the HTTP connector code path.
+fn filter_5xx_responses(batches: Vec<RecordBatch>) -> DataFusionResult<Vec<RecordBatch>> {
+    let mut result = Vec::with_capacity(batches.len());
+
+    for batch in batches {
+        // Get the response_status column index - must exist for HTTP connector batches
+        let col_idx = batch
+            .schema()
+            .index_of(RESPONSE_STATUS_COLUMN)
+            .map_err(|_| {
+                DataFusionError::Internal(format!(
+                    "Missing required '{RESPONSE_STATUS_COLUMN}' column in HTTP response batch"
+                ))
+            })?;
+
+        // Get the response_status column as UInt16Array
+        let status_array = batch
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "'{RESPONSE_STATUS_COLUMN}' column must be UInt16Array"
+                ))
+            })?;
+
+        // Create boolean mask: true for non-5xx status codes
+        let mask: arrow::array::BooleanArray = status_array
+            .iter()
+            .map(|status| status.map(|s| !(500..600).contains(&s)))
+            .collect();
+
+        // Apply filter
+        let filtered = filter_record_batch(&batch, &mask)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        if filtered.num_rows() > 0 {
+            result.push(filtered);
+        }
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -2766,5 +2848,213 @@ mod tests {
 
         let total_rows: usize = data.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "Should have 3 rows from 3 requests");
+    }
+
+    /// Helper to create a schema with response_status column for filter_5xx tests
+    fn create_http_response_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("content", DataType::Utf8, false),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
+        ]))
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_keeps_2xx() {
+        let schema = create_http_response_schema();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["ok1", "ok2", "ok3"])),
+                Arc::new(UInt16Array::from(vec![200, 201, 204])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]).expect("filter should succeed");
+
+        assert_eq!(result.len(), 1, "Should have 1 batch");
+        assert_eq!(result[0].num_rows(), 3, "All 2xx rows should be kept");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_keeps_4xx() {
+        let schema = create_http_response_schema();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["not found", "bad request", "forbidden"])),
+                Arc::new(UInt16Array::from(vec![404, 400, 403])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]).expect("filter should succeed");
+
+        assert_eq!(result.len(), 1, "Should have 1 batch");
+        assert_eq!(result[0].num_rows(), 3, "All 4xx rows should be kept");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_removes_5xx() {
+        let schema = create_http_response_schema();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["error1", "error2", "error3"])),
+                Arc::new(UInt16Array::from(vec![500, 502, 503])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]).expect("filter should succeed");
+
+        assert!(result.is_empty(), "All 5xx rows should be filtered out");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_mixed_status_codes() {
+        let schema = create_http_response_schema();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["ok", "not found", "server error", "created"])),
+                Arc::new(UInt16Array::from(vec![200, 404, 500, 201])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]).expect("filter should succeed");
+
+        assert_eq!(result.len(), 1, "Should have 1 batch");
+        assert_eq!(result[0].num_rows(), 3, "Should keep 3 non-5xx rows");
+
+        // Verify the content column has the expected values
+        let content = result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("content column");
+        assert_eq!(content.value(0), "ok");
+        assert_eq!(content.value(1), "not found");
+        assert_eq!(content.value(2), "created");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_empty_batches() {
+        let result = filter_5xx_responses(vec![]).expect("filter should succeed");
+        assert!(result.is_empty(), "Empty input should return empty output");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_multiple_batches() {
+        let schema = create_http_response_schema();
+
+        let batch1 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["ok"])),
+                Arc::new(UInt16Array::from(vec![200])),
+            ],
+        )
+        .expect("to create batch1");
+
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["error"])),
+                Arc::new(UInt16Array::from(vec![500])),
+            ],
+        )
+        .expect("to create batch2");
+
+        let batch3 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["not found"])),
+                Arc::new(UInt16Array::from(vec![404])),
+            ],
+        )
+        .expect("to create batch3");
+
+        let result =
+            filter_5xx_responses(vec![batch1, batch2, batch3]).expect("filter should succeed");
+
+        assert_eq!(result.len(), 2, "Should have 2 batches (batch2 filtered out entirely)");
+        assert_eq!(result[0].num_rows(), 1, "First batch should have 1 row");
+        assert_eq!(result[1].num_rows(), 1, "Second kept batch should have 1 row");
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_missing_column_returns_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("content", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec!["data"]))],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]);
+        assert!(result.is_err(), "Should error on missing response_status column");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing required 'response_status'"),
+            "Error should mention missing column"
+        );
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_wrong_column_type_returns_error() {
+        // Create schema with response_status as wrong type (Int32 instead of UInt16)
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("content", DataType::Utf8, false),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["data"])),
+                Arc::new(Int32Array::from(vec![200])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]);
+        assert!(result.is_err(), "Should error on wrong column type");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must be UInt16Array"),
+            "Error should mention wrong type"
+        );
+    }
+
+    #[test]
+    fn test_filter_5xx_responses_boundary_status_codes() {
+        let schema = create_http_response_schema();
+        // Test boundary: 499 (kept), 500 (filtered), 599 (filtered), 600 (kept - not 5xx)
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["499", "500", "599", "600"])),
+                Arc::new(UInt16Array::from(vec![499, 500, 599, 600])),
+            ],
+        )
+        .expect("to create batch");
+
+        let result = filter_5xx_responses(vec![batch]).expect("filter should succeed");
+
+        assert_eq!(result.len(), 1, "Should have 1 batch");
+        assert_eq!(result[0].num_rows(), 2, "Should keep 499 and 600");
+
+        let status = result[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("status column");
+        assert_eq!(status.value(0), 499);
+        assert_eq!(status.value(1), 600);
     }
 }

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -47,7 +47,7 @@ limitations under the License.
 //! - `test_caching_mode_background_refresh_on_stale`: Background refresh triggered when data becomes stale (TTL expiration)
 
 use app::AppBuilder;
-use arrow::array::{Array, StringArray, TimestampNanosecondArray};
+use arrow::array::{Array, StringArray, TimestampNanosecondArray, UInt16Array};
 use datafusion::prelude::*;
 use runtime::Runtime;
 use spicepod::{
@@ -2429,6 +2429,160 @@ async fn test_caching_mode_query_param_order() -> Result<(), anyhow::Error> {
 
             let batches2 = df2.collect().await?;
             assert_column_has_data(&batches2, "content");
+
+            Ok(())
+        })
+        .await
+}
+
+/// 4xx responses (like 404 "Not Found") represent valid business responses (e.g., "user not found",
+/// "resource doesn't exist") and should be returned to user and cached.
+///
+/// This test:
+/// 1. Queries an invalid path that returns 404
+/// 2. Verifies user receives the 404 response with status code
+/// 3. Queries same path again (should be cache hit)
+/// 4. Verifies cached data is returned
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_caching_mode_http_404_responses_cached() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=trace,runtime::accelerated_table::caching=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            // Create HTTP dataset with caching mode
+            let mut dataset = Dataset::new("https://api.tvmaze.com", "tvmaze");
+            dataset.params = Some(Params::from_string_map(
+                vec![
+                    (
+                        "allowed_request_paths".to_string(),
+                        "/search/invalid_404_test".to_string(), // Invalid path that returns 404
+                    ),
+                    ("request_query_filters".to_string(), "enabled".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                mode: Mode::Memory,
+                refresh_mode: Some(RefreshMode::Caching),
+                refresh_check_interval: Some("30s".to_string()),
+                ..Acceleration::default()
+            });
+
+            let mut app = AppBuilder::new("test_caching_404")
+                .with_dataset(dataset)
+                .build();
+
+            // Disable SQL results caching to test acceleration caching specifically
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let status = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&status).load_components() => {}
+            }
+
+            runtime_ready_check(&status).await;
+
+            // STEP 1: Query invalid path (cache miss) - should fetch from HTTP and return 404
+            eprintln!("TEST: Step 1 - Cache miss: querying invalid path that returns 404...");
+            let df1 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/invalid_404_test")))?
+                .select(vec![
+                    col("request_path"),
+                    col("response_status"),
+                    col("content"),
+                ])?;
+
+            let batches1 = df1.collect().await?;
+            assert!(!batches1.is_empty(), "Should have results even for 404");
+            assert_eq!(batches1[0].num_rows(), 1, "Should have exactly 1 row");
+
+            // Verify response_status is 404
+            let status_col = batches1[0]
+                .column(1)
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("response_status should be UInt16Array");
+            assert_eq!(
+                status_col.value(0),
+                404,
+                "Invalid path should return 404 status"
+            );
+
+            // Verify content contains 404 error message
+            let content_col = batches1[0]
+                .column(2)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("content should be StringArray");
+            let content = content_col.value(0);
+            assert!(
+                content.contains("Not Found"),
+                "404 response body should contain 'Not Found'"
+            );
+
+            // Small delay to allow cache write to complete
+            tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+
+            // STEP 2: Same query again (cache hit) - should return cached 404 response
+            eprintln!("TEST: Step 2 - Cache hit: same query should return cached 404 response...");
+            let df2 = status
+                .datafusion()
+                .ctx
+                .table("tvmaze")
+                .await?
+                .filter(col("request_path").eq(lit("/search/invalid_404_test")))?
+                .select(vec![
+                    col("request_path"),
+                    col("response_status"),
+                    col("content"),
+                ])?;
+
+            let batches2 = df2.collect().await?;
+            assert!(!batches2.is_empty(), "Should have cached results");
+            assert_eq!(batches2[0].num_rows(), 1, "Cached result should have 1 row");
+
+            // Verify cached response still has 404 status
+            let status_col2 = batches2[0]
+                .column(1)
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("response_status should be UInt16Array");
+            assert_eq!(
+                status_col2.value(0),
+                404,
+                "Cached response should still have 404 status"
+            );
+
+            // Verify cached content still contains error message
+            let content_col2 = batches2[0]
+                .column(2)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("content should be StringArray");
+            let cached_content = content_col2.value(0);
+            assert!(
+                cached_content.contains("Not Found"),
+                "Cached 404 response should contain 'Not Found'"
+            );
 
             Ok(())
         })


### PR DESCRIPTION
## 📝 Summary


Changes HTTP connector to treat 4xx and 5xx responses as valid data rather than errors, while preventing transient 5xx errors from being cached.

HTTP Provider:
1. Add `response_status` column (UInt16) to schema for tracking HTTP status codes
1. Return 4xx responses immediately as valid data (previously treated as permanent errors)
1. Retry 5xx responses 3x with backoff, then return response body as data
1. Handle empty response bodies

Caching Layer:
1. Add `filter_5xx_responses()` to exclude 5xx status codes from cache writes
1. User receives all data including 5xx; only cache storage is filtered
1. Existing cached data is preserved when upstream returns 5xx 

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
