### PR TITLE
Snapshots Improvements

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/directory_archive.rs
+++ b/crates/runtime-acceleration/src/snapshot/directory_archive.rs
@@ -193,6 +193,15 @@ pub struct ExtractOptions {
     /// If provided and `verify_existing_checksums` is true, existing files are verified
     /// against these checksums.
     pub expected_checksums: Option<HashMap<String, String>>,
+
+    /// Mapping from archive prefixes to target directories.
+    /// When set, archive entries starting with a prefix will be extracted to the
+    /// corresponding target directory instead of `target_dir`.
+    ///
+    /// For example, if the mapping contains `("data/", "/spice/data/my_table")`,
+    /// an archive entry `data/file.parquet` will be extracted to
+    /// `/spice/data/my_table/file.parquet` instead of `{target_dir}/data/file.parquet`.
+    pub prefix_mappings: Option<Vec<(String, PathBuf)>>,
 }
 
 impl ExtractOptions {
@@ -205,6 +214,7 @@ impl ExtractOptions {
             skip_if_exists: true,
             verify_existing_checksums: true,
             expected_checksums: None, // Checksums will be computed from archive contents
+            prefix_mappings: None,
         }
     }
 
@@ -216,6 +226,7 @@ impl ExtractOptions {
             skip_if_exists: true,
             verify_existing_checksums: false,
             expected_checksums: None,
+            prefix_mappings: None,
         }
     }
 }
@@ -369,6 +380,34 @@ fn hex_encode(bytes: &[u8]) -> String {
     output
 }
 
+/// Remap an archive entry path to its destination path using prefix mappings.
+///
+/// If `prefix_mappings` is provided and the entry path starts with one of the prefixes,
+/// the prefix is replaced with the corresponding target directory. Otherwise, the entry
+/// is extracted to `default_target_dir`.
+fn remap_entry_path(
+    entry_path: &Path,
+    default_target_dir: &Path,
+    prefix_mappings: Option<&Vec<(String, PathBuf)>>,
+) -> PathBuf {
+    let entry_path_str = entry_path.to_string_lossy();
+
+    if let Some(mappings) = prefix_mappings {
+        for (prefix, target_dir) in mappings {
+            if entry_path_str.starts_with(prefix) {
+                // Strip the prefix and join with the target directory
+                let relative = entry_path_str
+                    .strip_prefix(prefix)
+                    .unwrap_or(&entry_path_str);
+                return target_dir.join(relative);
+            }
+        }
+    }
+
+    // No matching prefix, use default target directory
+    default_target_dir.join(entry_path)
+}
+
 /// Extract archive entries, skipping files that already exist with optional checksum verification.
 ///
 /// When `options.verify_existing_checksums` is enabled, this function computes the checksum
@@ -390,7 +429,7 @@ fn extract_with_skip_existing_and_verify<R: std::io::Read>(
         let entry_path = entry
             .path()
             .map_err(|source| ArchiveError::ReadArchive { source })?;
-        let dest_path = target_dir.join(&entry_path);
+        let dest_path = remap_entry_path(&entry_path, target_dir, options.prefix_mappings.as_ref());
 
         let entry_type = entry.header().entry_type();
 
@@ -1129,6 +1168,81 @@ mod tests {
         assert_eq!(
             content, "new_content",
             "File should be overwritten without skip_if_exists"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_with_prefix_mapping() -> Result<()> {
+        // Test that prefix_mappings correctly remaps archive paths to different target directories.
+        // This is critical for Cayenne snapshot restore where the archive has "data/" prefix
+        // but the actual data directory might be named after the dataset (e.g., "my_table").
+        let test_dir = TempDir::new().expect("Failed to create temp dir");
+        let metadata_dir = test_dir.path().join("metadata");
+        let data_dir = test_dir.path().join("my_table"); // Different from archive prefix "data/"
+        std::fs::create_dir_all(&metadata_dir).expect("Failed to create metadata dir");
+        std::fs::create_dir_all(&data_dir).expect("Failed to create data dir");
+
+        // Create test files
+        std::fs::write(metadata_dir.join("catalog.db"), b"metadata content")
+            .expect("Failed to write catalog");
+        std::fs::write(data_dir.join("table.parquet"), b"table data")
+            .expect("Failed to write table");
+
+        // Archive with standard prefixes (metadata/ and data/)
+        let mut archive_buffer = Vec::new();
+        let dirs = vec![
+            (metadata_dir.clone(), "metadata/".to_string()),
+            (data_dir.clone(), "data/".to_string()), // Archive prefix is "data/" but dir is "my_table"
+        ];
+        archive_directories(&dirs, Cursor::new(&mut archive_buffer)).await?;
+
+        // Extract to a new location with prefix mappings
+        let extract_base = TempDir::new().expect("Failed to create extract dir");
+        let extract_metadata = extract_base.path().join("metadata");
+        let extract_data = extract_base.path().join("restored_table"); // Different name again
+
+        // Create prefix mappings: archive "data/" -> extract to "restored_table/"
+        let prefix_mappings = vec![
+            ("metadata/".to_string(), extract_metadata.clone()),
+            ("data/".to_string(), extract_data.clone()),
+        ];
+
+        let mut options = ExtractOptions::skip_existing();
+        options.prefix_mappings = Some(prefix_mappings);
+
+        extract_archive_with_options(
+            Cursor::new(archive_buffer),
+            extract_base.path(), // This is the fallback, but prefix mappings should override
+            options,
+        )
+        .await?;
+
+        // Verify files are extracted to the mapped directories, not the archive prefix paths
+        assert!(
+            extract_metadata.join("catalog.db").exists(),
+            "metadata/catalog.db should be extracted to mapped metadata dir"
+        );
+        assert!(
+            extract_data.join("table.parquet").exists(),
+            "data/table.parquet should be extracted to mapped data dir (restored_table), not literal 'data/'"
+        );
+
+        // Verify the content is correct
+        let catalog_content =
+            std::fs::read_to_string(extract_metadata.join("catalog.db")).expect("read catalog");
+        assert_eq!(catalog_content, "metadata content");
+
+        let table_content =
+            std::fs::read_to_string(extract_data.join("table.parquet")).expect("read table");
+        assert_eq!(table_content, "table data");
+
+        // Verify that without prefix mapping, files would go to wrong location
+        // (This is what was broken before the fix)
+        assert!(
+            !extract_base.path().join("data/table.parquet").exists(),
+            "data/table.parquet should NOT exist at literal archive path"
         );
 
         Ok(())

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -2076,16 +2076,23 @@ impl SnapshotManager {
         let current_snapshot_id = dataset_metadata.current_snapshot_id;
         let dataset_engine = dataset_metadata.engine.clone();
 
-        // Check which snapshots actually exist in the object store (with bounded concurrency)
-        let existence_results: HashMap<u64, bool> =
-            futures::stream::iter(dataset_metadata.snapshots.iter().map(|entry| {
+        // Check which snapshots actually exist in the object store (with bounded concurrency).
+        // Eagerly collect futures into a Vec so the closure doesn't capture `&self` lazily,
+        // which would cause higher-ranked lifetime issues with axum handlers.
+        let existence_futures: Vec<_> = dataset_metadata
+            .snapshots
+            .iter()
+            .map(|entry| {
                 let snapshot_uri = entry.snapshot.clone();
                 let snapshot_id = entry.snapshot_id;
                 async move {
                     let exists = self.snapshot_exists(&snapshot_uri).await;
                     (snapshot_id, exists)
                 }
-            }))
+            })
+            .collect();
+
+        let existence_results: HashMap<u64, bool> = futures::stream::iter(existence_futures)
             .buffer_unordered(10)
             .collect()
             .await;
@@ -2158,11 +2165,15 @@ impl SnapshotManager {
             return;
         }
 
-        let existence_results: HashMap<u64, bool> = futures::stream::iter(entries_to_check)
+        let existence_futures: Vec<_> = entries_to_check
+            .into_iter()
             .map(|(id, uri)| async move {
                 let exists = self.snapshot_exists(&uri).await;
                 (id, exists)
             })
+            .collect();
+
+        let existence_results: HashMap<u64, bool> = futures::stream::iter(existence_futures)
             .buffer_unordered(10)
             .collect()
             .await;

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -2109,7 +2109,7 @@ impl SnapshotManager {
                         checksum_algorithm: entry.snapshot_checksum_algorithm.clone(),
                         size_bytes: entry.snapshot_size,
                         engine: entry.snapshot_engine.clone(),
-                row_count: entry.snapshot_row_count,
+                        row_count: entry.snapshot_row_count,
                         is_current: Some(entry.snapshot_id) == current_snapshot_id,
                     })
                 } else {

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -515,7 +515,7 @@ impl AccelerationEngine {
     #[must_use]
     pub fn snapshot_extension(&self) -> &'static str {
         match self {
-            Self::Cayenne => ".cayenne.tar",
+            Self::Cayenne => ".cayenne",
             #[cfg(feature = "duckdb")]
             Self::DuckDB => ".duckdb",
             #[cfg(feature = "sqlite")]

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -461,21 +461,26 @@ pub enum SnapshotUploadError {
     },
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct SnapshotPathLayout<'a> {
     dataset_name: &'a str,
+    engine: &'a AccelerationEngine,
 }
 
 impl<'a> SnapshotPathLayout<'a> {
-    fn new(dataset_name: &'a str) -> Self {
-        Self { dataset_name }
+    fn new(dataset_name: &'a str, engine: &'a AccelerationEngine) -> Self {
+        Self {
+            dataset_name,
+            engine,
+        }
     }
 
     fn snapshot_filename(&self, instant: DateTime<Utc>) -> String {
         format!(
-            "{}_{}.db",
+            "{}_{}{}",
             self.dataset_name,
-            instant.format(SNAPSHOT_TIMESTAMP_FORMAT)
+            instant.format(SNAPSHOT_TIMESTAMP_FORMAT),
+            self.engine.snapshot_extension()
         )
     }
 
@@ -503,6 +508,22 @@ pub enum AccelerationEngine {
     Sqlite,
     #[cfg(feature = "turso")]
     Turso,
+}
+
+impl AccelerationEngine {
+    /// Returns the file extension for snapshot files of this engine type.
+    #[must_use]
+    pub fn snapshot_extension(&self) -> &'static str {
+        match self {
+            Self::Cayenne => ".cayenne.tar",
+            #[cfg(feature = "duckdb")]
+            Self::DuckDB => ".duckdb",
+            #[cfg(feature = "sqlite")]
+            Self::Sqlite => ".sqlite",
+            #[cfg(feature = "turso")]
+            Self::Turso => ".turso",
+        }
+    }
 }
 
 impl std::fmt::Display for AccelerationEngine {
@@ -543,6 +564,7 @@ impl std::fmt::Debug for SnapshotManager {
             .field("snapshots_location", &self.snapshots_location)
             .field("snapshot_location_uri", &self.snapshot_location_uri)
             .field("layout", &self.layout)
+            .field("engine", &self.engine)
             .field(
                 "bootstrap_failure_behavior",
                 &self.bootstrap_failure_behavior,
@@ -671,7 +693,7 @@ impl SnapshotManager {
         }
 
         // Check if actual snapshot files exist in object store
-        let layout = SnapshotPathLayout::new(&self.dataset_name);
+        let layout = SnapshotPathLayout::new(&self.dataset_name, &self.engine);
         let dataset_partition = layout.dataset_partition_raw();
 
         let mut list_stream = self.object_store.list(Some(&self.snapshots_location));
@@ -956,7 +978,7 @@ impl SnapshotManager {
 
         let start_time = Instant::now();
         let now = Utc::now();
-        let layout = SnapshotPathLayout::new(&self.dataset_name);
+        let layout = SnapshotPathLayout::new(&self.dataset_name, &self.engine);
         let destination_location = layout.build_location(&self.snapshots_location, now);
         let timestamp_ms = now.timestamp_millis();
 
@@ -1773,16 +1795,23 @@ impl SnapshotManager {
             }
         })?;
 
-        extract_archive_with_options(
-            archive_file,
-            extract_target,
-            ExtractOptions::skip_existing(),
-        )
-        .await
-        .map_err(|source| SnapshotDownloadError::ArchiveExtract {
-            path: temp_archive_path.clone(),
-            source: std::io::Error::other(source.to_string()),
-        })?;
+        // Build prefix mappings from dirs: map archive prefixes to target directories.
+        // This ensures files archived with prefix "data/" are extracted to the actual
+        // data directory (e.g., /spice/data/my_table/) rather than a literal "data/" subdirectory.
+        let prefix_mappings: Vec<(String, PathBuf)> = dirs
+            .iter()
+            .map(|(target_dir, prefix)| (prefix.clone(), target_dir.clone()))
+            .collect();
+
+        let mut extract_options = ExtractOptions::skip_existing();
+        extract_options.prefix_mappings = Some(prefix_mappings);
+
+        extract_archive_with_options(archive_file, extract_target, extract_options)
+            .await
+            .map_err(|source| SnapshotDownloadError::ArchiveExtract {
+                path: temp_archive_path.clone(),
+                source: std::io::Error::other(source.to_string()),
+            })?;
 
         // Cleanup temp archive
         let _ = fs::remove_file(&temp_archive_path).await;
@@ -2008,6 +2037,8 @@ impl SnapshotManager {
 
     /// Retrieves the snapshot summary for this dataset, including all available snapshots.
     ///
+    /// Only snapshots that actually exist in the object store are returned.
+    ///
     /// # Errors
     ///
     /// Returns an error if reading or parsing the metadata fails.
@@ -2041,19 +2072,55 @@ impl SnapshotManager {
 
         let current_snapshot_id = dataset_metadata.current_snapshot_id;
         let dataset_engine = dataset_metadata.engine.clone();
+
+        // Check which snapshots actually exist in the object store (in parallel)
+        let existence_futures: Vec<_> = dataset_metadata
+            .snapshots
+            .iter()
+            .map(|entry| {
+                let snapshot_uri = entry.snapshot.clone();
+                let snapshot_id = entry.snapshot_id;
+                async move {
+                    let exists = self.snapshot_exists(&snapshot_uri).await;
+                    (snapshot_id, exists)
+                }
+            })
+            .collect();
+
+        let existence_results: HashMap<u64, bool> = futures::future::join_all(existence_futures)
+            .await
+            .into_iter()
+            .collect();
+
         let snapshots: Vec<api::SnapshotInfo> = dataset_metadata
             .snapshots
             .iter()
-            .map(|entry| api::SnapshotInfo {
-                snapshot_id: entry.snapshot_id,
-                timestamp_ms: entry.timestamp_ms,
-                location: entry.snapshot.clone(),
-                checksum: entry.snapshot_checksum.clone(),
-                checksum_algorithm: entry.snapshot_checksum_algorithm.clone(),
-                size_bytes: entry.snapshot_size,
-                engine: entry.snapshot_engine.clone(),
+            .filter_map(|entry| {
+                let exists = existence_results
+                    .get(&entry.snapshot_id)
+                    .copied()
+                    .unwrap_or(false);
+                if exists {
+                    Some(api::SnapshotInfo {
+                        snapshot_id: entry.snapshot_id,
+                        timestamp_ms: entry.timestamp_ms,
+                        location: entry.snapshot.clone(),
+                        checksum: entry.snapshot_checksum.clone(),
+                        checksum_algorithm: entry.snapshot_checksum_algorithm.clone(),
+                        size_bytes: entry.snapshot_size,
+                        engine: entry.snapshot_engine.clone(),
                 row_count: entry.snapshot_row_count,
-                is_current: Some(entry.snapshot_id) == current_snapshot_id,
+                        is_current: Some(entry.snapshot_id) == current_snapshot_id,
+                    })
+                } else {
+                    tracing::debug!(
+                        dataset = %self.dataset_name,
+                        snapshot_id = entry.snapshot_id,
+                        location = %entry.snapshot,
+                        "Snapshot referenced in metadata does not exist in object store"
+                    );
+                    None
+                }
             })
             .collect();
 
@@ -2065,6 +2132,16 @@ impl SnapshotManager {
             current_snapshot_id,
             snapshots,
         })
+    }
+
+    /// Checks if a snapshot exists in the object store.
+    async fn snapshot_exists(&self, snapshot_uri: &str) -> bool {
+        let Ok(object_path) = self.snapshot_uri_to_object_path(snapshot_uri) else {
+            return false;
+        };
+
+        // Use head() for a lightweight existence check without downloading content
+        self.object_store.head(&object_path).await.is_ok()
     }
 
     /// Retrieves information about a specific snapshot by ID.
@@ -2508,7 +2585,7 @@ mod tests {
     async fn download_latest_snapshot_downloads_current_snapshot() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 1, 2, 3, 4, 5)
             .single()
@@ -2578,7 +2655,7 @@ mod tests {
     async fn download_with_fallback_uses_next_snapshot_on_integrity_failure() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
 
         let first_instant = Utc
             .with_ymd_and_hms(2025, 2, 1, 0, 0, 0)
@@ -2856,7 +2933,7 @@ mod tests {
     async fn download_snapshot_entry_rejects_checksum_mismatch() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 3, 1, 12, 0, 0)
             .single()
@@ -2924,7 +3001,7 @@ mod tests {
     async fn download_snapshot_entry_rejects_size_mismatch() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 4, 1, 12, 0, 0)
             .single()
@@ -2992,7 +3069,7 @@ mod tests {
     async fn download_snapshot_entry_rejects_unsupported_checksum_algorithm() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 5, 1, 12, 0, 0)
             .single()
@@ -3060,7 +3137,7 @@ mod tests {
     async fn download_snapshot_entry_rejects_schema_mismatch() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 6, 1, 12, 0, 0)
             .single()
@@ -3135,7 +3212,7 @@ mod tests {
     async fn download_snapshot_entry_rejects_engine_mismatch() {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::Cayenne);
         let instant = Utc
             .with_ymd_and_hms(2025, 6, 1, 12, 0, 0)
             .single()
@@ -3452,7 +3529,7 @@ mod tests {
     async fn generic_download_snapshot_with_valid_metadata(engine: &AccelerationEngine) {
         let store = Arc::new(InMemory::new());
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let layout = SnapshotPathLayout::new(DATASET_NAME);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
         let instant = Utc
             .with_ymd_and_hms(2025, 3, 15, 10, 30, 0)
             .single()

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -4181,6 +4181,13 @@ mod tests {
 
         write_metadata(&store, &metadata_path, &metadata).await;
 
+        // Create the actual snapshot file so it passes the existence check
+        let snapshot_path = Path::from("snapshots/test_snapshot.db");
+        store
+            .put(&snapshot_path, Bytes::from_static(b"snapshot data").into())
+            .await
+            .expect("write snapshot file");
+
         let manager = build_manager_for_api_tests(Arc::clone(&store));
         let summary = manager
             .get_snapshot_summary()
@@ -4354,6 +4361,22 @@ mod tests {
         };
 
         write_metadata(&store, &metadata_path, &metadata).await;
+
+        // Create the actual snapshot files so they pass the existence check
+        store
+            .put(
+                &Path::from("snapshots/snapshot1.db"),
+                Bytes::from_static(b"snapshot data 1").into(),
+            )
+            .await
+            .expect("write snapshot file 1");
+        store
+            .put(
+                &Path::from("snapshots/snapshot2.db"),
+                Bytes::from_static(b"snapshot data 2").into(),
+            )
+            .await
+            .expect("write snapshot file 2");
 
         let manager = build_manager_for_api_tests(Arc::clone(&store));
 

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -1971,6 +1971,9 @@ impl SnapshotManager {
             dataset_entry.snapshots.push(snapshot_entry);
             dataset_entry.current_snapshot_id = Some(next_snapshot_id);
 
+            // Remove metadata entries whose snapshot files no longer exist.
+            self.compact_metadata(dataset_entry).await;
+
             let serialized = serde_json::to_vec_pretty(&metadata).map_err(|source| {
                 SnapshotUploadError::UploadSerializeMetadata {
                     path: metadata_path_display.clone(),
@@ -2073,24 +2076,19 @@ impl SnapshotManager {
         let current_snapshot_id = dataset_metadata.current_snapshot_id;
         let dataset_engine = dataset_metadata.engine.clone();
 
-        // Check which snapshots actually exist in the object store (in parallel)
-        let existence_futures: Vec<_> = dataset_metadata
-            .snapshots
-            .iter()
-            .map(|entry| {
+        // Check which snapshots actually exist in the object store (with bounded concurrency)
+        let existence_results: HashMap<u64, bool> =
+            futures::stream::iter(dataset_metadata.snapshots.iter().map(|entry| {
                 let snapshot_uri = entry.snapshot.clone();
                 let snapshot_id = entry.snapshot_id;
                 async move {
                     let exists = self.snapshot_exists(&snapshot_uri).await;
                     (snapshot_id, exists)
                 }
-            })
-            .collect();
-
-        let existence_results: HashMap<u64, bool> = futures::future::join_all(existence_futures)
-            .await
-            .into_iter()
-            .collect();
+            }))
+            .buffer_unordered(10)
+            .collect()
+            .await;
 
         let snapshots: Vec<api::SnapshotInfo> = dataset_metadata
             .snapshots
@@ -2142,6 +2140,50 @@ impl SnapshotManager {
 
         // Use head() for a lightweight existence check without downloading content
         self.object_store.head(&object_path).await.is_ok()
+    }
+
+    /// Compacts dataset metadata by removing entries whose snapshot files no longer
+    /// exist in the object store. The current snapshot entry is always preserved.
+    async fn compact_metadata(&self, dataset_entry: &mut DatasetMetadata) {
+        let current_id = dataset_entry.current_snapshot_id;
+
+        let entries_to_check: Vec<_> = dataset_entry
+            .snapshots
+            .iter()
+            .filter(|e| Some(e.snapshot_id) != current_id)
+            .map(|e| (e.snapshot_id, e.snapshot.clone()))
+            .collect();
+
+        if entries_to_check.is_empty() {
+            return;
+        }
+
+        let existence_results: HashMap<u64, bool> = futures::stream::iter(entries_to_check)
+            .map(|(id, uri)| async move {
+                let exists = self.snapshot_exists(&uri).await;
+                (id, exists)
+            })
+            .buffer_unordered(10)
+            .collect()
+            .await;
+
+        let before = dataset_entry.snapshots.len();
+        dataset_entry.snapshots.retain(|e| {
+            Some(e.snapshot_id) == current_id
+                || existence_results
+                    .get(&e.snapshot_id)
+                    .copied()
+                    .unwrap_or(true)
+        });
+        let removed = before - dataset_entry.snapshots.len();
+
+        if removed > 0 {
+            tracing::info!(
+                dataset = %dataset_entry.name,
+                removed_count = removed,
+                "Compacted snapshot metadata: removed entries for non-existent snapshots"
+            );
+        }
     }
 
     /// Retrieves information about a specific snapshot by ID.
@@ -4974,5 +5016,112 @@ mod tests {
             serde_json::json!(100),
             "snapshot-row-count should be serialized"
         );
+    }
+
+    #[tokio::test]
+    async fn compact_metadata_removes_stale_entries() {
+        let store = Arc::new(InMemory::new());
+
+        // Create a snapshot file for only one of the two entries
+        let existing_path = Path::from("snapshots/existing_snapshot.db");
+        store
+            .put(&existing_path, Bytes::from_static(b"snapshot data").into())
+            .await
+            .expect("write snapshot file");
+
+        let manager = build_manager_for_api_tests(Arc::clone(&store));
+
+        let existing_entry = SnapshotEntry {
+            snapshot_id: 1,
+            timestamp_ms: 1_000_000,
+            snapshot: format!("{SNAPSHOT_URI_PREFIX}/existing_snapshot.db"),
+            snapshot_checksum: "aaa".to_string(),
+            snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
+            snapshot_size: 100,
+            snapshot_engine: None,
+            snapshot_row_count: None,
+            snapshot_last_updated_at_ms: None,
+        };
+
+        let stale_entry = SnapshotEntry {
+            snapshot_id: 0,
+            timestamp_ms: 900_000,
+            snapshot: format!("{SNAPSHOT_URI_PREFIX}/deleted_snapshot.db"),
+            snapshot_checksum: "bbb".to_string(),
+            snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
+            snapshot_size: 200,
+            snapshot_engine: None,
+            snapshot_row_count: None,
+            snapshot_last_updated_at_ms: None,
+        };
+
+        let mut dataset_entry = DatasetMetadata {
+            name: DATASET_NAME.to_string(),
+            engine: None,
+            schemas: vec![],
+            current_schema_id: 0,
+            snapshots: vec![stale_entry, existing_entry],
+            current_snapshot_id: Some(1),
+            properties: HashMap::new(),
+        };
+
+        manager.compact_metadata(&mut dataset_entry).await;
+
+        assert_eq!(
+            dataset_entry.snapshots.len(),
+            1,
+            "Stale entry should be removed"
+        );
+        assert_eq!(dataset_entry.snapshots[0].snapshot_id, 1);
+    }
+
+    #[tokio::test]
+    async fn compact_metadata_preserves_current_snapshot_even_if_missing() {
+        let store = Arc::new(InMemory::new());
+        let manager = build_manager_for_api_tests(Arc::clone(&store));
+
+        // Both entries point to non-existent files, but the current one should be preserved
+        let current_entry = SnapshotEntry {
+            snapshot_id: 5,
+            timestamp_ms: 1_000_000,
+            snapshot: format!("{SNAPSHOT_URI_PREFIX}/missing_current.db"),
+            snapshot_checksum: "aaa".to_string(),
+            snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
+            snapshot_size: 100,
+            snapshot_engine: None,
+            snapshot_row_count: None,
+            snapshot_last_updated_at_ms: None,
+        };
+
+        let old_entry = SnapshotEntry {
+            snapshot_id: 3,
+            timestamp_ms: 900_000,
+            snapshot: format!("{SNAPSHOT_URI_PREFIX}/missing_old.db"),
+            snapshot_checksum: "bbb".to_string(),
+            snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
+            snapshot_size: 200,
+            snapshot_engine: None,
+            snapshot_row_count: None,
+            snapshot_last_updated_at_ms: None,
+        };
+
+        let mut dataset_entry = DatasetMetadata {
+            name: DATASET_NAME.to_string(),
+            engine: None,
+            schemas: vec![],
+            current_schema_id: 0,
+            snapshots: vec![old_entry, current_entry],
+            current_snapshot_id: Some(5),
+            properties: HashMap::new(),
+        };
+
+        manager.compact_metadata(&mut dataset_entry).await;
+
+        assert_eq!(
+            dataset_entry.snapshots.len(),
+            1,
+            "Only the current snapshot should remain"
+        );
+        assert_eq!(dataset_entry.snapshots[0].snapshot_id, 5);
     }
 }

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -46,12 +46,12 @@ pub type SnapshotCallback =
 
 /// Spawns a task that periodically creates snapshots at the specified interval.
 ///
-/// If `runtime_status` is provided, the task will wait for the dataset to be ready
-/// before starting the snapshot interval loop. This prevents creating snapshots before
-/// the dataset has finished its initial load or bootstrap.
+/// The task uses the checkpointer's `last_checkpoint_time()` to determine when the next
+/// snapshot should be created:
+/// - If `snapshots_create_interval` has passed since the last checkpoint, create immediately
+/// - Otherwise, schedule the first snapshot at `last_checkpoint_time + snapshots_create_interval`
 ///
-/// If `bootstrap_status` indicates the dataset was bootstrapped, the first snapshot will be delayed
-/// by the full interval after the dataset becomes ready (to avoid creating a snapshot immediately after bootstrap).
+/// If no previous checkpoint exists, a snapshot is created immediately after the runtime is ready.
 #[expect(clippy::too_many_arguments)]
 pub fn spawn_snapshot_interval_task(
     snapshots_create_interval: Option<Duration>,
@@ -61,7 +61,7 @@ pub fn spawn_snapshot_interval_task(
     dataset_name: TableReference,
     federated_schema: Arc<Schema>,
     runtime_status: Arc<RuntimeStatus>,
-    bootstrap_status: crate::dataaccelerator::BootstrapStatus,
+    _bootstrap_status: crate::dataaccelerator::BootstrapStatus,
     last_updated_at: Arc<AtomicI64>,
     accelerator: Option<Arc<dyn TableProvider>>,
 ) -> Option<tokio::task::JoinHandle<()>> {
@@ -78,20 +78,44 @@ pub fn spawn_snapshot_interval_task(
         // Wait for the runtime to become ready
         runtime_status.wait_for_ready().await;
 
-        if !bootstrap_status.is_bootstrapped() {
-            // Force create initial snapshot immediately after runtime is ready unless it was bootstrapped
-            create_checkpoint_and_snapshot(
-                &checkpointer,
-                Some(&snapshot_manager),
-                &federated_schema,
-                &accelerator_write_mutex,
-                &dataset_name,
-                &last_updated_at,
-                ForceCreate(true),
+        // Determine the initial delay based on last checkpoint time
+        let initial_delay = match checkpointer.last_checkpoint_time().await {
+            Ok(Some(last_checkpoint)) => {
+                let elapsed = last_checkpoint.elapsed().unwrap_or(Duration::ZERO);
+                if elapsed >= interval_duration {
+                    // Enough time has passed, create snapshot immediately
+                    Duration::ZERO
+                } else {
+                    // Wait until interval_duration has passed since last checkpoint
+                    interval_duration - elapsed
+                }
+            }
+            Ok(None) | Err(_) => {
+                // No previous checkpoint or error getting it, create immediately
+                Duration::ZERO
+            }
+        };
+
+        if !initial_delay.is_zero() {
+            tokio::time::sleep(initial_delay).await;
+        }
+
+        create_checkpoint_and_snapshot(
+            &checkpointer,
+            Some(&snapshot_manager),
+            &federated_schema,
+            &accelerator_write_mutex,
+            &dataset_name,
+            &last_updated_at,
+            // Force creation when interval already elapsed.
+            // Even though this may create a snapshot identical to the last one, we do this to avoid
+            // losing snapshots due to potential object storage retention policy.
+            // Consider use case: periodic
+            ForceCreate(initial_delay.is_zero()),
                 accelerator.as_ref(),
             )
             .await;
-        }
+
 
         let mut ticker = interval(interval_duration);
         // Consume the first tick which returns immediately per tokio::time::interval behavior

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -112,10 +112,9 @@ pub fn spawn_snapshot_interval_task(
             // losing snapshots due to potential object storage retention policy.
             // Consider use case: periodic
             ForceCreate(initial_delay.is_zero()),
-                accelerator.as_ref(),
-            )
-            .await;
-
+            accelerator.as_ref(),
+        )
+        .await;
 
         let mut ticker = interval(interval_duration);
         // Consume the first tick which returns immediately per tokio::time::interval behavior

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -121,7 +121,7 @@ impl SnapshotS3Context {
                 Path::new(filename)
                     .extension()
                     .and_then(std::ffi::OsStr::to_str)
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("db"))
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("duckdb"))
                     && meta
                         .location
                         .as_ref()

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -121,7 +121,11 @@ impl SnapshotS3Context {
                 Path::new(filename)
                     .extension()
                     .and_then(std::ffi::OsStr::to_str)
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("duckdb"))
+                    .is_some_and(|ext| {
+                        ext.eq_ignore_ascii_case("duckdb")
+                            || ext.eq_ignore_ascii_case("sqlite")
+                            || ext.eq_ignore_ascii_case("cayenne")
+                    })
                     && meta
                         .location
                         .as_ref()
@@ -140,7 +144,6 @@ impl SnapshotS3Context {
         max_wait: Duration,
     ) -> Result<Vec<ObjectMeta>> {
         let deadline = Instant::now() + max_wait;
-
         loop {
             if Instant::now() >= deadline {
                 return Err(anyhow!(


### PR DESCRIPTION
## 📝 Summary

1. Fix Cayenne snapshots - properly map directories after archive extraction
2. Schedule `time_interval` based task based on last snapshot creation time 
3. When returning list of snapshots in `get_snapshot_summary` - only returns snapshots that actually exist
4. Add `compact_metadata` - remove metadata records of snapshots that no longer exist. Performed after snapshot creation in the process of updating metadata
5. Add proper extensions to snapshot files:
    a. Duckdb: `.duckdb`
    b. Cayenne - `.cayenne`
    c. Sqlite - `.sqlite`
    d. Turso - `.turso`
