### PR TITLE
Skip sccache setup when MinIO endpoint is not available

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -11,6 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set sccache environment variables
+      if: inputs.minio_endpoint != ''
       shell: bash
       run: |
         echo "SCCACHE_CACHE_SIZE=200G" >> $GITHUB_ENV
@@ -20,7 +21,7 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
     - name: Set up sccache (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.minio_endpoint != ''
       shell: bash
       run: |
         sudo apt-get update && sudo apt-get install wget -y


### PR DESCRIPTION
## 📝 Summary

Skip sccache configuration when minio_endpoint is not defined. This avoids InvalidUri(Empty) errors when the S3 endpoint is unavailable (e.g., fork PRs where repository secrets are not exposed). Without a configured endpoint, cargo compiles directly without a cache wrapper.

The macOS and Windows steps already guarded against this — this aligns the Linux step and the environment variables step with the same inputs.minio_endpoint != '' condition. When the endpoint isn't available, sccache is skipped and cargo compiles directly.

Fixes the `pr / Rust Lint` check failing for external contributor PRs from forks.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I'll review if we should improve `pr.yaml` to use `pull_request_target ` instead of `pull_request` similar to integration tests to make secrets available.
