### PR TITLE
Fix Show sccache stats in build-test to check SCCACHE_SETUP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -227,7 +227,7 @@ jobs:
         run: cargo build -p testoperator --all-features --locked
 
       - name: Show sccache stats
-        if: needs.check_changes.outputs.relevant_changes == 'true'
+        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
 
       - name: Check if Cargo.lock is updated


### PR DESCRIPTION
## 📝 Summary

The `Show sccache stats` step in the `build-test` job ran unconditionally, failing with `sccache: command not found (exit code 127)` when sccache wasn't set up (e.g. when `TEST_MINIO_ENDPOINT` secret is unavailable).

Gate the step on `env.SCCACHE_SETUP == 'true'`, matching the pattern already used in lint-rust.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
