### PR TITLE
Minor improvements for streaming benchmarks

### DIFF
--- a/.github/workflows/testoperator_run_streaming_dynamodb.yml
+++ b/.github/workflows/testoperator_run_streaming_dynamodb.yml
@@ -147,14 +147,14 @@ jobs:
             ${QUERY_LIVENESS_FLAG}
         env:
           # DynamoDB credentials
-          DYNAMODB_AWS_REGION: ${{ secrets.DYNAMODB_AWS_REGION }}
+          DYNAMODB_AWS_REGION: us-east-1
           DYNAMODB_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DYNAMODB_ACCESS_KEY_ID }}
           DYNAMODB_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DYNAMODB_SECRET_ACCESS_KEY }}
           # Snapshot storage
-          SNAPSHOT_S3_LOCATION: ${{ secrets.STREAMING_SNAPSHOT_S3_LOCATION }}
+          SNAPSHOT_S3_LOCATION: s3://streaming-benchmark-snapshots
           SNAPSHOT_S3_ACCESS_KEY_ID: ${{ secrets.STREAMING_SNAPSHOT_S3_ACCESS_KEY_ID }}
           SNAPSHOT_S3_SECRET_ACCESS_KEY: ${{ secrets.STREAMING_SNAPSHOT_S3_SECRET_ACCESS_KEY }}
-          SNAPSHOT_S3_REGION: ${{ secrets.STREAMING_SNAPSHOT_S3_REGION }}
+          SNAPSHOT_S3_REGION: us-east-1
           # Metrics
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_streaming_dynamodb_dispatch.yml
+++ b/.github/workflows/testoperator_run_streaming_dynamodb_dispatch.yml
@@ -122,14 +122,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # DynamoDB credentials
-          DYNAMODB_AWS_REGION: ${{ secrets.DYNAMODB_AWS_REGION }}
+          DYNAMODB_AWS_REGION: us-east-1
           DYNAMODB_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DYNAMODB_ACCESS_KEY_ID }}
           DYNAMODB_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DYNAMODB_SECRET_ACCESS_KEY }}
           # Snapshot storage
-          SNAPSHOT_S3_LOCATION: ${{ secrets.STREAMING_SNAPSHOT_S3_LOCATION }}
+          SNAPSHOT_S3_LOCATION: s3://streaming-benchmark-snapshots
           SNAPSHOT_S3_ACCESS_KEY_ID: ${{ secrets.STREAMING_SNAPSHOT_S3_ACCESS_KEY_ID }}
           SNAPSHOT_S3_SECRET_ACCESS_KEY: ${{ secrets.STREAMING_SNAPSHOT_S3_SECRET_ACCESS_KEY }}
-          SNAPSHOT_S3_REGION: ${{ secrets.STREAMING_SNAPSHOT_S3_REGION }}
+          SNAPSHOT_S3_REGION: us-east-1
           # Metrics
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
+++ b/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
@@ -1250,6 +1250,7 @@ fn transform_spicepod(
                 // engine: "cayenne" -> set cayenne_file_path
                 let engine = accel.engine.as_deref();
 
+                #[expect(clippy::expect_used)]
                 std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}"))
                     .expect("Failed to create benchmark directory");
 

--- a/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
+++ b/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
@@ -1203,6 +1203,10 @@ fn transform_spicepod(
         _ => "unknown",
     };
 
+    #[expect(clippy::expect_used)]
+    std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}"))
+        .expect("Failed to create benchmark directory");
+
     // 1. Update dataset `from` field with prefixed table name, keep `name` unchanged
     for dataset in &mut spicepod.datasets {
         if let ComponentOrReference::Component(d) = dataset {
@@ -1249,10 +1253,6 @@ fn transform_spicepod(
                 // engine: None or "duckdb" -> set duckdb_file
                 // engine: "cayenne" -> set cayenne_file_path
                 let engine = accel.engine.as_deref();
-
-                #[expect(clippy::expect_used)]
-                std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}"))
-                    .expect("Failed to create benchmark directory");
 
                 match engine {
                     None | Some("duckdb") => {

--- a/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
+++ b/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
@@ -1250,19 +1250,22 @@ fn transform_spicepod(
                 // engine: "cayenne" -> set cayenne_file_path
                 let engine = accel.engine.as_deref();
 
-                std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}")).expect("Failed to create benchmark directory");
+                std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}"))
+                    .expect("Failed to create benchmark directory");
 
                 match engine {
                     None | Some("duckdb") => {
-                        let duckdb_file =
-                            format!("/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}.db");
+                        let duckdb_file = format!(
+                            "/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}.db"
+                        );
                         params
                             .data
                             .insert("duckdb_file".to_string(), ParamValue::String(duckdb_file));
                     }
                     Some("cayenne") => {
-                        let cayenne_dir =
-                            format!("/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}_cayenne/");
+                        let cayenne_dir = format!(
+                            "/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}_cayenne/"
+                        );
                         params.data.insert(
                             "cayenne_file_path".to_string(),
                             ParamValue::String(cayenne_dir),

--- a/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
+++ b/tools/testoperator/src/commands/streaming/sources/dynamodb.rs
@@ -1250,17 +1250,19 @@ fn transform_spicepod(
                 // engine: "cayenne" -> set cayenne_file_path
                 let engine = accel.engine.as_deref();
 
+                std::fs::create_dir_all(format!("/tmp/benchmarks/{run_id}")).expect("Failed to create benchmark directory");
+
                 match engine {
                     None | Some("duckdb") => {
                         let duckdb_file =
-                            format!("/tmp/{config_name}_{dataset_name}_{phase_suffix}.db");
+                            format!("/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}.db");
                         params
                             .data
                             .insert("duckdb_file".to_string(), ParamValue::String(duckdb_file));
                     }
                     Some("cayenne") => {
                         let cayenne_dir =
-                            format!("/tmp/{config_name}_{dataset_name}_{phase_suffix}_cayenne/");
+                            format!("/tmp/benchmarks/{run_id}/{config_name}_{dataset_name}_{phase_suffix}_cayenne/");
                         params.data.insert(
                             "cayenne_file_path".to_string(),
                             ParamValue::String(cayenne_dir),


### PR DESCRIPTION
## 📝 Summary

1. Hardcode regions in workflow files to avoid adding new secrets
2. Add `{run_id}/` section to the acceleration file path

