### PR TITLE
Proper support for `constraints`/`on_conflict` in Cayenne Acceleration

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -47,7 +47,10 @@ use tokio::{
     sync::RwLock,
 };
 use url::Url;
-use util::{RetryError, fibonacci_backoff::FibonacciBackoff, retry};
+use util::{
+    RetryError, retry,
+    retry_strategy::{RetryBackoff, RetryBackoffBuilder},
+};
 
 use crate::dataset_checkpoint::DatasetCheckpointerFactory;
 
@@ -105,6 +108,18 @@ const SNAPSHOT_MULTIPART_CHUNK_SIZE: usize = 8 * 1024 * 1024;
 const SNAPSHOT_METADATA_FORMAT_VERSION: u32 = 1;
 const METADATA_FILE_NAME: &str = "metadata.json";
 const SNAPSHOT_CHECKSUM_ALGORITHM: &str = "SHA256";
+const NETWORK_RETRY_MAX: usize = 3;
+
+/// Returns `true` if the given object store error is likely transient and worth retrying.
+fn is_retriable_object_store_error(err: &object_store::Error) -> bool {
+    !matches!(
+        err,
+        object_store::Error::NotFound { .. }
+            | object_store::Error::NotSupported { .. }
+            | object_store::Error::AlreadyExists { .. }
+            | object_store::Error::Precondition { .. }
+    )
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -555,6 +570,7 @@ pub struct SnapshotManager {
     bootstrap_failure_behavior: BootstrapOnFailureBehavior,
     checkpointer_factory: Option<DatasetCheckpointerFactory>,
     snapshots_creation_policy: SnapshotsCreationPolicy,
+    network_retry_strategy: RetryBackoff,
 }
 
 impl std::fmt::Debug for SnapshotManager {
@@ -570,6 +586,7 @@ impl std::fmt::Debug for SnapshotManager {
                 &self.bootstrap_failure_behavior,
             )
             .field("object_store", &self.object_store)
+            .field("network_retry_strategy", &self.network_retry_strategy)
             .finish_non_exhaustive()
     }
 }
@@ -625,49 +642,61 @@ impl SnapshotManager {
         let metadata_path = self.metadata_path();
         let metadata_path_display = metadata_path.to_string();
 
-        let get_result = match self.object_store.get(&metadata_path).await {
-            Ok(result) => result,
-            Err(object_store::Error::NotFound { .. }) => return Ok(None),
-            Err(source) => {
-                return Err(MetadataLoadError::Read {
-                    path: metadata_path_display,
+        retry(self.network_retry_strategy.clone(), || async {
+            let get_result = match self.object_store.get(&metadata_path).await {
+                Ok(result) => result,
+                Err(object_store::Error::NotFound { .. }) => return Ok(None),
+                Err(source) => {
+                    tracing::warn!(
+                        "Transient error reading snapshot metadata, retrying. path={metadata_path_display} error={source}"
+                    );
+                    return Err(RetryError::transient(MetadataLoadError::Read {
+                        path: metadata_path_display.clone(),
+                        source,
+                    }));
+                }
+            };
+
+            let meta = get_result.meta.clone();
+            let bytes = get_result.bytes().await.map_err(|source| {
+                tracing::warn!(
+                    "Transient error reading snapshot metadata bytes, retrying. path={metadata_path_display} error={source}"
+                );
+                RetryError::transient(MetadataLoadError::Read {
+                    path: metadata_path_display.clone(),
                     source,
-                });
+                })
+            })?;
+
+            let metadata: SnapshotMetadata =
+                serde_json::from_slice(&bytes).map_err(|source| {
+                    RetryError::permanent(MetadataLoadError::Parse {
+                        path: metadata_path_display.clone(),
+                        source,
+                    })
+                })?;
+
+            if metadata.format_version != SNAPSHOT_METADATA_FORMAT_VERSION {
+                return Err(RetryError::permanent(
+                    MetadataLoadError::UnsupportedVersion {
+                        path: metadata_path_display.clone(),
+                        version: metadata.format_version,
+                    },
+                ));
             }
-        };
 
-        let meta = get_result.meta.clone();
-        let bytes = get_result
-            .bytes()
-            .await
-            .map_err(|source| MetadataLoadError::Read {
-                path: metadata_path_display.clone(),
-                source,
-            })?;
+            let version = if meta.e_tag.is_some() || meta.version.is_some() {
+                Some(UpdateVersion {
+                    e_tag: meta.e_tag.clone(),
+                    version: meta.version.clone(),
+                })
+            } else {
+                None
+            };
 
-        let metadata: SnapshotMetadata =
-            serde_json::from_slice(&bytes).map_err(|source| MetadataLoadError::Parse {
-                path: metadata_path_display.clone(),
-                source,
-            })?;
-
-        if metadata.format_version != SNAPSHOT_METADATA_FORMAT_VERSION {
-            return Err(MetadataLoadError::UnsupportedVersion {
-                path: metadata_path_display,
-                version: metadata.format_version,
-            });
-        }
-
-        let version = if meta.e_tag.is_some() || meta.version.is_some() {
-            Some(UpdateVersion {
-                e_tag: meta.e_tag.clone(),
-                version: meta.version.clone(),
-            })
-        } else {
-            None
-        };
-
-        Ok(Some(MetadataHandle { metadata, version }))
+            Ok(Some(MetadataHandle { metadata, version }))
+        })
+        .await
     }
 
     /// Checks if there are any existing snapshots for this dataset.
@@ -792,6 +821,10 @@ impl SnapshotManager {
             }
         }
 
+        let network_retry_strategy = RetryBackoffBuilder::new()
+            .max_retries(Some(NETWORK_RETRY_MAX))
+            .build();
+
         Some(Self {
             dataset_name,
             snapshots_location: path,
@@ -803,6 +836,7 @@ impl SnapshotManager {
             checkpointer_factory: None,
             bootstrap_failure_behavior: snapshot_config.bootstrap_on_failure_behavior,
             snapshots_creation_policy: SnapshotsCreationPolicy::default(),
+            network_retry_strategy,
         })
     }
 
@@ -876,6 +910,10 @@ impl SnapshotManager {
         // Use a no-op layout and engine for metadata-only queries
         let snapshot_engine = create_snapshot_engine(&AccelerationEngine::Cayenne, false);
 
+        let network_retry_strategy = RetryBackoffBuilder::new()
+            .max_retries(Some(NETWORK_RETRY_MAX))
+            .build();
+
         Some(Self {
             dataset_name,
             snapshots_location: path,
@@ -887,6 +925,7 @@ impl SnapshotManager {
             checkpointer_factory: None,
             bootstrap_failure_behavior: snapshot_config.bootstrap_on_failure_behavior,
             snapshots_creation_policy: SnapshotsCreationPolicy::default(),
+            network_retry_strategy,
         })
     }
 
@@ -1066,10 +1105,25 @@ impl SnapshotManager {
             .await
             .context(PrepareUploadSnafu)?;
 
-        // Step 4: Upload the file
-        let upload_result = self
-            .upload_snapshot_file(&final_source_local_path, destination_location)
-            .await;
+        // Step 4: Upload the file (with retry for transient network errors)
+        let upload_result = retry(self.network_retry_strategy.clone(), || async {
+            self.upload_snapshot_file(&final_source_local_path, destination_location)
+                .await
+                .map_err(|err| match &err {
+                    SnapshotUploadError::StartUpload { .. }
+                    | SnapshotUploadError::UploadPart { .. }
+                    | SnapshotUploadError::CompleteUpload { .. }
+                    | SnapshotUploadError::AbortUpload { .. } => {
+                        tracing::warn!(
+                            "Transient error uploading snapshot, retrying. dataset={} error={err}",
+                            self.dataset_name,
+                        );
+                        RetryError::transient(err)
+                    }
+                    _ => RetryError::permanent(err),
+                })
+        })
+        .await;
 
         // Step 5: Cleanup temp files
         let _ = fs::remove_file(&temp_copy_path).await;
@@ -1126,10 +1180,25 @@ impl SnapshotManager {
             self.dataset_name
         );
 
-        // Step 3: Upload the tar archive
-        let upload_result = self
-            .upload_snapshot_file(&temp_archive_path, destination_location)
-            .await;
+        // Step 3: Upload the tar archive (with retry for transient network errors)
+        let upload_result = retry(self.network_retry_strategy.clone(), || async {
+            self.upload_snapshot_file(&temp_archive_path, destination_location)
+                .await
+                .map_err(|err| match &err {
+                    SnapshotUploadError::StartUpload { .. }
+                    | SnapshotUploadError::UploadPart { .. }
+                    | SnapshotUploadError::CompleteUpload { .. }
+                    | SnapshotUploadError::AbortUpload { .. } => {
+                        tracing::warn!(
+                            "Transient error uploading snapshot, retrying. dataset={} error={err}",
+                            self.dataset_name,
+                        );
+                        RetryError::transient(err)
+                    }
+                    _ => RetryError::permanent(err),
+                })
+        })
+        .await;
 
         // Step 4: Cleanup temp archive
         let _ = fs::remove_file(&temp_archive_path).await;
@@ -1291,7 +1360,7 @@ impl SnapshotManager {
                 }
             }
             BootstrapOnFailureBehavior::Retry => {
-                let retry_strategy = FibonacciBackoff::default();
+                let retry_strategy = RetryBackoffBuilder::new().build();
                 let dataset_name = self.dataset_name.clone();
                 let location = self.snapshots_location.to_string();
 
@@ -1991,8 +2060,7 @@ impl SnapshotManager {
             let payload = PutPayload::from(serialized);
 
             match self
-                .object_store
-                .put_opts(&metadata_path, payload.clone(), put_mode.clone().into())
+                .put_opts_with_retry(&metadata_path, payload.clone(), put_mode.clone())
                 .await
             {
                 Ok(_) => return Ok(()),
@@ -2003,8 +2071,7 @@ impl SnapshotManager {
                     if matches!(put_mode, PutMode::Update(_)) =>
                 {
                     match self
-                        .object_store
-                        .put_opts(&metadata_path, payload, PutMode::Overwrite.into())
+                        .put_opts_with_retry(&metadata_path, payload, PutMode::Overwrite)
                         .await
                     {
                         Ok(_) => return Ok(()),
@@ -2139,14 +2206,62 @@ impl SnapshotManager {
         })
     }
 
-    /// Checks if a snapshot exists in the object store.
+    /// Wraps `object_store.put_opts()` with retry for transient network errors.
+    ///
+    /// Non-retriable errors (`NotFound`, `AlreadyExists`, `Precondition`, `NotSupported`)
+    /// are returned immediately so callers can handle them (e.g., OCC retry loops).
+    async fn put_opts_with_retry(
+        &self,
+        path: &ObjectPath,
+        payload: PutPayload,
+        put_mode: PutMode,
+    ) -> Result<object_store::PutResult, object_store::Error> {
+        retry(self.network_retry_strategy.clone(), || async {
+            self.object_store
+                .put_opts(path, payload.clone(), put_mode.clone().into())
+                .await
+                .map_err(|err| {
+                    if is_retriable_object_store_error(&err) {
+                        tracing::warn!(
+                            "Transient error writing to object store, retrying. dataset={} path={path} error={err}",
+                            self.dataset_name,
+                        );
+                        RetryError::transient(err)
+                    } else {
+                        RetryError::permanent(err)
+                    }
+                })
+        })
+        .await
+    }
+
+    /// Checks if a snapshot exists in the object store, with retry for transient errors.
     async fn snapshot_exists(&self, snapshot_uri: &str) -> bool {
         let Ok(object_path) = self.snapshot_uri_to_object_path(snapshot_uri) else {
             return false;
         };
 
-        // Use head() for a lightweight existence check without downloading content
-        self.object_store.head(&object_path).await.is_ok()
+        retry(self.network_retry_strategy.clone(), || async {
+            match self.object_store.head(&object_path).await {
+                Ok(_) => Ok(true),
+                Err(object_store::Error::NotFound { .. }) => Ok(false),
+                Err(err) => {
+                    tracing::warn!(
+                        "Transient error checking snapshot existence, retrying. dataset={} path={object_path} error={err}",
+                        self.dataset_name,
+                    );
+                    Err(RetryError::transient(err))
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!(
+                "Failed to check snapshot existence after retries. dataset={} path={object_path} error={err}",
+                self.dataset_name,
+            );
+            false
+        })
     }
 
     /// Compacts dataset metadata by removing entries whose snapshot files no longer
@@ -2333,8 +2448,7 @@ impl SnapshotManager {
             let payload = PutPayload::from(serialized);
 
             match self
-                .object_store
-                .put_opts(&metadata_path, payload.clone(), put_mode.clone().into())
+                .put_opts_with_retry(&metadata_path, payload.clone(), put_mode.clone())
                 .await
             {
                 Ok(_) => return Ok(()),
@@ -2346,8 +2460,7 @@ impl SnapshotManager {
                 {
                     // Object store doesn't support conditional updates, fall back to overwrite
                     match self
-                        .object_store
-                        .put_opts(&metadata_path, payload, PutMode::Overwrite.into())
+                        .put_opts_with_retry(&metadata_path, payload, PutMode::Overwrite)
                         .await
                     {
                         Ok(_) => return Ok(()),
@@ -2551,6 +2664,9 @@ mod tests {
             bootstrap_failure_behavior: behavior,
             checkpointer_factory: Some(factory),
             snapshots_creation_policy: SnapshotsCreationPolicy::Always,
+            network_retry_strategy: RetryBackoffBuilder::new()
+                .max_retries(Some(NETWORK_RETRY_MAX))
+                .build(),
         }
     }
 
@@ -4173,6 +4289,9 @@ mod tests {
             bootstrap_failure_behavior: BootstrapOnFailureBehavior::Warn,
             checkpointer_factory: None,
             snapshots_creation_policy: SnapshotsCreationPolicy::default(),
+            network_retry_strategy: RetryBackoffBuilder::new()
+                .max_retries(Some(NETWORK_RETRY_MAX))
+                .build(),
         }
     }
 
@@ -4601,6 +4720,9 @@ mod tests {
             bootstrap_failure_behavior: BootstrapOnFailureBehavior::Warn,
             checkpointer_factory: None,
             snapshots_creation_policy: SnapshotsCreationPolicy::default(),
+            network_retry_strategy: RetryBackoffBuilder::new()
+                .max_retries(Some(NETWORK_RETRY_MAX))
+                .build(),
         }
     }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -47,7 +47,10 @@ use snafu::prelude::*;
 use tokio::sync::OnceCell;
 use util::concat_arrays;
 
-use super::{AccelerationSource, BootstrapStatus, DataAccelerator, upsert_dedup};
+use super::{
+    AccelerationSource, BootstrapStatus, DataAccelerator, get_primary_keys_from_constraints,
+    upsert_dedup,
+};
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode};
 use crate::dataaccelerator::cayenne::s3::{S3_PARAMETERS, S3_PARAMS_LEN};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
@@ -584,6 +587,8 @@ impl CayenneAccelerator {
         schema: Arc<Schema>,
         source: &dyn AccelerationSource,
         retention_filters: Vec<Expr>,
+        primary_keys: Vec<String>,
+        on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
     ) -> Result<Arc<cayenne::CayenneTableProvider>> {
         use cayenne::{CayenneTableProviderBuilder, metadata::CreateTableOptions};
 
@@ -625,44 +630,6 @@ impl CayenneAccelerator {
                 vortex_config.target_vortex_file_size_mb
             );
         }
-
-        let (primary_keys, on_conflict) = if let Some(acceleration) = source.acceleration() {
-            // Use configured primary key if provided.
-            let pk_vec = acceleration
-                .primary_key
-                .as_ref()
-                .map(|pk| pk.iter().map(std::string::ToString::to_string).collect())
-                .unwrap_or_default();
-
-            // Derive on_conflict from acceleration settings.
-            let on_conflict = acceleration
-                .on_conflict
-                .iter()
-                .map(|(col_ref, behavior)| {
-                    let col =
-                        datafusion_table_providers::util::column_reference::ColumnReference::new(
-                            col_ref
-                                .iter()
-                                .map(std::string::ToString::to_string)
-                                .collect(),
-                        );
-                    match behavior {
-                        crate::component::dataset::acceleration::OnConflictBehavior::Drop => {
-                            datafusion_table_providers::util::on_conflict::OnConflict::DoNothing(
-                                col,
-                            )
-                        }
-                        crate::component::dataset::acceleration::OnConflictBehavior::Upsert(
-                            _options,
-                        ) => datafusion_table_providers::util::on_conflict::OnConflict::Upsert(col),
-                    }
-                })
-                .next();
-
-            (pk_vec, on_conflict)
-        } else {
-            (Vec::new(), None)
-        };
 
         let table_options = CreateTableOptions {
             table_name: table_name.to_string(),
@@ -1005,6 +972,31 @@ impl DataAccelerator for CayenneAccelerator {
             Vec::new()
         };
 
+        // Extract primary keys and on_conflict once, used by both partitioned and non-partitioned paths.
+        // Uses explicit user config if provided, otherwise falls back to federated table constraints
+        // (e.g. DynamoDB partition key) and on_conflict from options populated by create_accelerator_table.
+        let primary_keys = source
+            .acceleration()
+            .and_then(|a| a.primary_key.as_ref())
+            .map(|pk| {
+                pk.iter()
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|pk| !pk.is_empty())
+            .unwrap_or_else(|| get_primary_keys_from_constraints(&cmd.constraints, &arrow_schema));
+
+        let on_conflict = cmd
+            .options
+            .get("on_conflict")
+            .map(|s| {
+                datafusion_table_providers::util::on_conflict::OnConflict::try_from(s.as_str())
+            })
+            .transpose()
+            .map_err(|e| Error::InvalidConfiguration {
+                detail: Arc::from(format!("on_conflict invalid: {e}")),
+            })?;
+
         // Always create the base Cayenne table provider
         let cayenne_table = self
             .create_cayenne_table_provider(
@@ -1013,6 +1005,8 @@ impl DataAccelerator for CayenneAccelerator {
                 Arc::clone(&arrow_schema),
                 source,
                 retention_filters.clone(),
+                primary_keys.clone(),
+                on_conflict.clone(),
             )
             .await
             .boxed()?;
@@ -1091,43 +1085,6 @@ impl DataAccelerator for CayenneAccelerator {
                     vortex_config.target_vortex_file_size_mb
                 );
             }
-
-            // Extract primary_key and on_conflict from acceleration settings for partitioned tables
-            let (primary_keys, on_conflict) = if let Some(acceleration) = source.acceleration() {
-                let pk_vec = acceleration
-                    .primary_key
-                    .as_ref()
-                    .map(|pk| pk.iter().map(std::string::ToString::to_string).collect())
-                    .unwrap_or_default();
-
-                let on_conflict = acceleration
-                    .on_conflict
-                    .iter()
-                    .map(|(col_ref, behavior)| {
-                        let col =
-                            datafusion_table_providers::util::column_reference::ColumnReference::new(
-                                col_ref
-                                    .iter()
-                                    .map(std::string::ToString::to_string)
-                                    .collect(),
-                            );
-                        match behavior {
-                            crate::component::dataset::acceleration::OnConflictBehavior::Drop => {
-                                datafusion_table_providers::util::on_conflict::OnConflict::DoNothing(
-                                    col,
-                                )
-                            }
-                            crate::component::dataset::acceleration::OnConflictBehavior::Upsert(
-                                _options,
-                            ) => datafusion_table_providers::util::on_conflict::OnConflict::Upsert(col),
-                        }
-                    })
-                    .next();
-
-                (pk_vec, on_conflict)
-            } else {
-                (Vec::new(), None)
-            };
 
             let creator = Arc::new(CayennePartitionCreator::new(
                 table_name,

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -580,6 +580,7 @@ impl CayenneAccelerator {
             .map(Arc::clone)
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn create_cayenne_table_provider(
         &self,
         table_name: &str,

--- a/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__dynamodb_streams_cayenne_file_acceleration.snap
+++ b/crates/runtime/tests/dynamodb/snapshots/integration__dynamodb__streams__dynamodb_streams_cayenne_file_acceleration.snap
@@ -1,0 +1,9 @@
+---
+source: crates/runtime/tests/dynamodb/streams.rs
+expression: formatted
+---
++--------------------------+----+
+| created_at               | id |
++--------------------------+----+
+| 2025-10-12T23:37:16.345Z | 1  |
++--------------------------+----+

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -427,49 +427,6 @@ pub fn make_dynamodb_dataset_with_file_accel(
     dataset
 }
 
-pub fn make_dynamodb_dataset_with_cayenne_accel(
-    table_name: &str,
-    port: u16,
-    access_key: &str,
-    secret_key: &str,
-    cayenne_file_path: &str,
-    cayenne_metadata_dir: &str,
-) -> Dataset {
-    let mut dataset = Dataset::new(format!("dynamodb:{table_name}"), table_name.to_string());
-    let params = HashMap::from([
-        (
-            "dynamodb_aws_access_key_id".to_string(),
-            access_key.to_string(),
-        ),
-        (
-            "dynamodb_aws_secret_access_key".to_string(),
-            secret_key.to_string(),
-        ),
-        ("dynamodb_aws_region".to_string(), "us-east-1".to_string()),
-        ("dynamodb_aws_auth".to_string(), "key".to_string()),
-        (
-            "endpoint_url".to_string(),
-            format!("http://localhost:{port}"),
-        ),
-    ]);
-    println!("params: {:#?}", params);
-    dataset.params = Some(DatasetParams::from_string_map(params));
-    dataset.acceleration = Some(Acceleration {
-        enabled: true,
-        mode: Mode::File,
-        refresh_mode: Some(RefreshMode::Changes),
-        engine: Some("cayenne".to_string()),
-        params: Some(DatasetParams::from_string_map(HashMap::from([
-            (
-                "duckdb_file".to_string(),
-                cayenne_file_path.to_string(),
-            ),
-        ]))),
-        ..Acceleration::default()
-    });
-    dataset
-}
-
 /// Creates a mock checkpoint with fake shard IDs from scratch.
 /// Used when no real checkpoint exists yet (e.g., testing fresh checkpoint error propagation).
 fn create_mock_checkpoint(duckdb_path: &str, dataset_name: &str, hours_ago: u64) {
@@ -962,105 +919,57 @@ async fn dynamodb_shard_not_found_expired_checkpoint_ready_before_load() -> anyh
         .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn dynamodb_streams_duckdb_file_acceleration() -> anyhow::Result<()> {
-    let _tracing = init_tracing(Some(
-        "integration=debug,runtime=debug,data_components=debug,dynamodb_streams=debug,info",
-    ));
-
-    let table_name = "test_table_duckdb";
-    let access_key = "foo";
-    let secret_key = "bar";
-
-    test_request_context()
-        .scope(async {
-            let running_container = start_dynamodb_docker_container(PORT7).await?;
-
-            let client = get_client(PORT7, access_key, secret_key);
-
-            create_table(&client, table_name).await;
-
-            // Insert a single record with created_at timestamp
-            client
-                .put_item()
-                .table_name(table_name)
-                .item("id", AttributeValue::S("1".to_string()))
-                .item(
-                    "created_at",
-                    AttributeValue::S("2025-10-12T23:37:16.345Z".to_string()),
-                )
-                .send()
-                .await
-                .expect("Failed to insert item");
-
-            sleep(Duration::from_secs(2)).await;
-
-            let temp_dir = tempfile::tempdir()?;
-            let duckdb_path = temp_dir.path().join("test.duckdb");
-            let duckdb_path_str = duckdb_path.to_str().expect("path should be valid UTF-8");
-
-            let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
-                .with_dataset(make_dynamodb_dataset_with_file_accel(
-                    table_name,
-                    PORT7,
-                    access_key,
-                    secret_key,
-                    duckdb_path_str,
-                    None,
-                ))
-                .with_results_cache(ResultsCache {
-                    enabled: false,
-                    ..Default::default()
-                })
-                .build();
-
-            configure_test_datafusion();
-            let rt = Runtime::builder().with_app(app).build().await;
-
-            let cloned_rt = Arc::new(rt.clone());
-
-            tokio::select! {
-                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
-                }
-                () = cloned_rt.load_components() => {}
-            }
-
-            runtime_ready_check(&rt).await;
-            sleep(Duration::from_secs(2)).await;
-            run_and_snapshot_query(
-                &rt,
-                &format!("SELECT * FROM {table_name} ORDER BY id"),
-                "duckdb_file_accel_test1",
+pub fn make_dynamodb_dataset_with_accele(
+    table_name: &str,
+    port: u16,
+    access_key: &str,
+    secret_key: &str,
+    engine: &str,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("dynamodb:{table_name}"), table_name.to_string());
+    let params = HashMap::from([
+        (
+            "dynamodb_aws_access_key_id".to_string(),
+            access_key.to_string(),
+        ),
+        (
+            "dynamodb_aws_secret_access_key".to_string(),
+            secret_key.to_string(),
+        ),
+        ("dynamodb_aws_region".to_string(), "us-east-1".to_string()),
+        ("dynamodb_aws_auth".to_string(), "key".to_string()),
+        (
+            "endpoint_url".to_string(),
+            format!("http://localhost:{port}"),
+        ),
+    ]);
+    let temp_dir = tempfile::tempdir().unwrap().keep();
+    let cayenne_path = temp_dir.join("cayenne_data");
+    let metadata_dir = temp_dir.join("cayenne_metadata");
+    let duckdb_path = temp_dir.join("test.duckdb");
+    dataset.params = Some(DatasetParams::from_string_map(params));
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        mode: Mode::File,
+        refresh_mode: Some(RefreshMode::Changes),
+        engine: Some(engine.to_string()),
+        params: Some(DatasetParams::from_string_map(HashMap::from([
+            (
+                "cayenne_file_path".to_string(),
+                cayenne_path.to_str().unwrap().to_string(),
+            ),
+            (
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.to_str().unwrap().to_string(),
+            ),
+            (
+                "duckdb_file".to_string(),
+                duckdb_path.to_str().unwrap().to_string(),
             )
-            .await?;
-
-            insert_rows(&client, table_name, 5..7).await;
-            sleep(Duration::from_secs(2)).await;
-            run_and_snapshot_query(
-                &rt,
-                &format!("SELECT * FROM {table_name} ORDER BY id"),
-                "duckdb_file_accel_test2",
-            )
-            .await?;
-
-            insert_rows(&client, table_name, 7..10).await;
-            sleep(Duration::from_secs(2)).await;
-            run_and_snapshot_query(
-                &rt,
-                &format!("SELECT * FROM {table_name} ORDER BY id"),
-                "duckdb_file_accel_test3",
-            )
-            .await?;
-
-            running_container.remove().await.map_err(|e| {
-                tracing::error!("running_container.remove: {e}");
-                anyhow::Error::msg(e.to_string())
-            })?;
-
-            Ok(())
-        })
-        .await
+        ]))),
+        ..Acceleration::default()
+    });
+    dataset
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1100,14 +1009,16 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
             let cayenne_path = temp_dir.path().join("cayenne_data");
             let metadata_dir = temp_dir.path().join("cayenne_metadata");
 
-            let app = AppBuilder::new("dynamodb_cayenne_file_accel_test")
-                .with_dataset(make_dynamodb_dataset_with_cayenne_accel(
+            let duckdb_path = temp_dir.path().join("test.duckdb");
+            let duckdb_path_str = duckdb_path.to_str().expect("path should be valid UTF-8");
+
+            let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
+                .with_dataset(make_dynamodb_dataset_with_accele(
                     table_name,
                     PORT6,
                     access_key,
                     secret_key,
-                    cayenne_path.to_str().expect("path should be valid UTF-8"),
-                    metadata_dir.to_str().expect("path should be valid UTF-8"),
+                    "cayenne",
                 ))
                 .with_results_cache(ResultsCache {
                     enabled: false,
@@ -1125,21 +1036,19 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
                 }
                 () = cloned_rt.load_components() => {}
             }
-            println!("!!!!!!!!");
             runtime_ready_check(&rt).await;
             sleep(Duration::from_secs(2)).await;
 
             run_and_snapshot_query(
                 &rt,
-                &format!("SELECT created_at FROM {table_name}"),
-                "cayenne_file_accel_created_at",
-            )
-            .await?;
+                &format!("SELECT * FROM {table_name}"),
+                "dynamodb_streams_cayenne_file_acceleration",
+            ).await?;
 
-            // running_container.remove().await.map_err(|e| {
-            //     tracing::error!("running_container.remove: {e}");
-            //     anyhow::Error::msg(e.to_string())
-            // })?;
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
 
             Ok(())
         })

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -51,7 +51,6 @@ const PORT3: u16 = 8003;
 const PORT4: u16 = 8004;
 const PORT5: u16 = 8005;
 const PORT6: u16 = 8006;
-const PORT7: u16 = 8007;
 
 #[instrument]
 pub async fn start_dynamodb_docker_container(
@@ -919,12 +918,11 @@ async fn dynamodb_shard_not_found_expired_checkpoint_ready_before_load() -> anyh
         .await
 }
 
-pub fn make_dynamodb_dataset_with_accele(
+pub fn make_dynamodb_dataset_with_cayenne_acceleration(
     table_name: &str,
     port: u16,
     access_key: &str,
     secret_key: &str,
-    engine: &str,
 ) -> Dataset {
     let mut dataset = Dataset::new(format!("dynamodb:{table_name}"), table_name.to_string());
     let params = HashMap::from([
@@ -946,13 +944,12 @@ pub fn make_dynamodb_dataset_with_accele(
     let temp_dir = tempfile::tempdir().unwrap().keep();
     let cayenne_path = temp_dir.join("cayenne_data");
     let metadata_dir = temp_dir.join("cayenne_metadata");
-    let duckdb_path = temp_dir.join("test.duckdb");
     dataset.params = Some(DatasetParams::from_string_map(params));
     dataset.acceleration = Some(Acceleration {
         enabled: true,
         mode: Mode::File,
         refresh_mode: Some(RefreshMode::Changes),
-        engine: Some(engine.to_string()),
+        engine: Some("cayenne".to_string()),
         params: Some(DatasetParams::from_string_map(HashMap::from([
             (
                 "cayenne_file_path".to_string(),
@@ -962,10 +959,6 @@ pub fn make_dynamodb_dataset_with_accele(
                 "cayenne_metadata_dir".to_string(),
                 metadata_dir.to_str().unwrap().to_string(),
             ),
-            (
-                "duckdb_file".to_string(),
-                duckdb_path.to_str().unwrap().to_string(),
-            )
         ]))),
         ..Acceleration::default()
     });
@@ -1013,12 +1006,8 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
             let duckdb_path_str = duckdb_path.to_str().expect("path should be valid UTF-8");
 
             let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
-                .with_dataset(make_dynamodb_dataset_with_accele(
-                    table_name,
-                    PORT6,
-                    access_key,
-                    secret_key,
-                    "cayenne",
+                .with_dataset(make_dynamodb_dataset_with_cayenne_acceleration(
+                    table_name, PORT6, access_key, secret_key,
                 ))
                 .with_results_cache(ResultsCache {
                     enabled: false,
@@ -1043,7 +1032,8 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
                 &rt,
                 &format!("SELECT * FROM {table_name}"),
                 "dynamodb_streams_cayenne_file_acceleration",
-            ).await?;
+            )
+            .await?;
 
             running_container.remove().await.map_err(|e| {
                 tracing::error!("running_container.remove: {e}");

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -941,7 +941,7 @@ pub fn make_dynamodb_dataset_with_cayenne_acceleration(
             format!("http://localhost:{port}"),
         ),
     ]);
-    let temp_dir = tempfile::tempdir().unwrap().keep();
+    let temp_dir = tempfile::tempdir().expect("failed to create temp directory").keep();
     let cayenne_path = temp_dir.join("cayenne_data");
     let metadata_dir = temp_dir.join("cayenne_metadata");
     dataset.params = Some(DatasetParams::from_string_map(params));
@@ -953,11 +953,11 @@ pub fn make_dynamodb_dataset_with_cayenne_acceleration(
         params: Some(DatasetParams::from_string_map(HashMap::from([
             (
                 "cayenne_file_path".to_string(),
-                cayenne_path.to_str().unwrap().to_string(),
+                cayenne_path.to_str().expect("cayenne_path should be valid UTF-8").to_string(),
             ),
             (
                 "cayenne_metadata_dir".to_string(),
-                metadata_dir.to_str().unwrap().to_string(),
+                metadata_dir.to_str().expect("metadata_dir should be valid UTF-8").to_string(),
             ),
         ]))),
         ..Acceleration::default()
@@ -998,12 +998,7 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
 
             sleep(Duration::from_secs(2)).await;
 
-            let temp_dir = tempfile::tempdir()?;
-            let cayenne_path = temp_dir.path().join("cayenne_data");
-            let metadata_dir = temp_dir.path().join("cayenne_metadata");
-
-            let duckdb_path = temp_dir.path().join("test.duckdb");
-            let duckdb_path_str = duckdb_path.to_str().expect("path should be valid UTF-8");
+            let _temp_dir = tempfile::tempdir()?;
 
             let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
                 .with_dataset(make_dynamodb_dataset_with_cayenne_acceleration(

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -50,6 +50,8 @@ const PORT2: u16 = 8002;
 const PORT3: u16 = 8003;
 const PORT4: u16 = 8004;
 const PORT5: u16 = 8005;
+const PORT6: u16 = 8006;
+const PORT7: u16 = 8007;
 
 #[instrument]
 pub async fn start_dynamodb_docker_container(
@@ -420,6 +422,49 @@ pub fn make_dynamodb_dataset_with_file_accel(
             "duckdb_file".to_string(),
             duckdb_path.to_string(),
         )]))),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+pub fn make_dynamodb_dataset_with_cayenne_accel(
+    table_name: &str,
+    port: u16,
+    access_key: &str,
+    secret_key: &str,
+    cayenne_file_path: &str,
+    cayenne_metadata_dir: &str,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("dynamodb:{table_name}"), table_name.to_string());
+    let params = HashMap::from([
+        (
+            "dynamodb_aws_access_key_id".to_string(),
+            access_key.to_string(),
+        ),
+        (
+            "dynamodb_aws_secret_access_key".to_string(),
+            secret_key.to_string(),
+        ),
+        ("dynamodb_aws_region".to_string(), "us-east-1".to_string()),
+        ("dynamodb_aws_auth".to_string(), "key".to_string()),
+        (
+            "endpoint_url".to_string(),
+            format!("http://localhost:{port}"),
+        ),
+    ]);
+    println!("params: {:#?}", params);
+    dataset.params = Some(DatasetParams::from_string_map(params));
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        mode: Mode::File,
+        refresh_mode: Some(RefreshMode::Changes),
+        engine: Some("cayenne".to_string()),
+        params: Some(DatasetParams::from_string_map(HashMap::from([
+            (
+                "duckdb_file".to_string(),
+                cayenne_file_path.to_string(),
+            ),
+        ]))),
         ..Acceleration::default()
     });
     dataset
@@ -911,6 +956,190 @@ async fn dynamodb_shard_not_found_expired_checkpoint_ready_before_load() -> anyh
                 tracing::error!("running_container.remove: {e}");
                 anyhow::Error::msg(e.to_string())
             })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_streams_duckdb_file_acceleration() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,dynamodb_streams=debug,info",
+    ));
+
+    let table_name = "test_table_duckdb";
+    let access_key = "foo";
+    let secret_key = "bar";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT7).await?;
+
+            let client = get_client(PORT7, access_key, secret_key);
+
+            create_table(&client, table_name).await;
+
+            // Insert a single record with created_at timestamp
+            client
+                .put_item()
+                .table_name(table_name)
+                .item("id", AttributeValue::S("1".to_string()))
+                .item(
+                    "created_at",
+                    AttributeValue::S("2025-10-12T23:37:16.345Z".to_string()),
+                )
+                .send()
+                .await
+                .expect("Failed to insert item");
+
+            sleep(Duration::from_secs(2)).await;
+
+            let temp_dir = tempfile::tempdir()?;
+            let duckdb_path = temp_dir.path().join("test.duckdb");
+            let duckdb_path_str = duckdb_path.to_str().expect("path should be valid UTF-8");
+
+            let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
+                .with_dataset(make_dynamodb_dataset_with_file_accel(
+                    table_name,
+                    PORT7,
+                    access_key,
+                    secret_key,
+                    duckdb_path_str,
+                    None,
+                ))
+                .with_results_cache(ResultsCache {
+                    enabled: false,
+                    ..Default::default()
+                })
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+            sleep(Duration::from_secs(2)).await;
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "duckdb_file_accel_test1",
+            )
+            .await?;
+
+            insert_rows(&client, table_name, 5..7).await;
+            sleep(Duration::from_secs(2)).await;
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "duckdb_file_accel_test2",
+            )
+            .await?;
+
+            insert_rows(&client, table_name, 7..10).await;
+            sleep(Duration::from_secs(2)).await;
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT * FROM {table_name} ORDER BY id"),
+                "duckdb_file_accel_test3",
+            )
+            .await?;
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,dynamodb_streams=debug,info",
+    ));
+
+    let table_name = "cayenne_created_at_test";
+    let access_key = "foo";
+    let secret_key = "bar";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT6).await?;
+            let client = get_client(PORT6, access_key, secret_key);
+
+            // Create table with just `id` as hash key (created_at is a non-key attribute)
+            create_table(&client, table_name).await;
+
+            // Insert a single record with created_at timestamp
+            client
+                .put_item()
+                .table_name(table_name)
+                .item("id", AttributeValue::S("1".to_string()))
+                .item(
+                    "created_at",
+                    AttributeValue::S("2025-10-12T23:37:16.345Z".to_string()),
+                )
+                .send()
+                .await
+                .expect("Failed to insert item");
+
+            sleep(Duration::from_secs(2)).await;
+
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_path = temp_dir.path().join("cayenne_data");
+            let metadata_dir = temp_dir.path().join("cayenne_metadata");
+
+            let app = AppBuilder::new("dynamodb_cayenne_file_accel_test")
+                .with_dataset(make_dynamodb_dataset_with_cayenne_accel(
+                    table_name,
+                    PORT6,
+                    access_key,
+                    secret_key,
+                    cayenne_path.to_str().expect("path should be valid UTF-8"),
+                    metadata_dir.to_str().expect("path should be valid UTF-8"),
+                ))
+                .with_results_cache(ResultsCache {
+                    enabled: false,
+                    ..Default::default()
+                })
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            println!("!!!!!!!!");
+            runtime_ready_check(&rt).await;
+            sleep(Duration::from_secs(2)).await;
+
+            run_and_snapshot_query(
+                &rt,
+                &format!("SELECT created_at FROM {table_name}"),
+                "cayenne_file_accel_created_at",
+            )
+            .await?;
+
+            // running_container.remove().await.map_err(|e| {
+            //     tracing::error!("running_container.remove: {e}");
+            //     anyhow::Error::msg(e.to_string())
+            // })?;
 
             Ok(())
         })

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -941,7 +941,9 @@ pub fn make_dynamodb_dataset_with_cayenne_acceleration(
             format!("http://localhost:{port}"),
         ),
     ]);
-    let temp_dir = tempfile::tempdir().expect("failed to create temp directory").keep();
+    let temp_dir = tempfile::tempdir()
+        .expect("failed to create temp directory")
+        .keep();
     let cayenne_path = temp_dir.join("cayenne_data");
     let metadata_dir = temp_dir.join("cayenne_metadata");
     dataset.params = Some(DatasetParams::from_string_map(params));
@@ -953,11 +955,17 @@ pub fn make_dynamodb_dataset_with_cayenne_acceleration(
         params: Some(DatasetParams::from_string_map(HashMap::from([
             (
                 "cayenne_file_path".to_string(),
-                cayenne_path.to_str().expect("cayenne_path should be valid UTF-8").to_string(),
+                cayenne_path
+                    .to_str()
+                    .expect("cayenne_path should be valid UTF-8")
+                    .to_string(),
             ),
             (
                 "cayenne_metadata_dir".to_string(),
-                metadata_dir.to_str().expect("metadata_dir should be valid UTF-8").to_string(),
+                metadata_dir
+                    .to_str()
+                    .expect("metadata_dir should be valid UTF-8")
+                    .to_string(),
             ),
         ]))),
         ..Acceleration::default()

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -1006,8 +1006,6 @@ async fn dynamodb_streams_cayenne_file_acceleration() -> anyhow::Result<()> {
 
             sleep(Duration::from_secs(2)).await;
 
-            let _temp_dir = tempfile::tempdir()?;
-
             let app = AppBuilder::new("dynamodb_duckdb_file_accel_test")
                 .with_dataset(make_dynamodb_dataset_with_cayenne_acceleration(
                     table_name, PORT6, access_key, secret_key,


### PR DESCRIPTION
## 📝 Summary

Read `primary_key` and `on_conflict` from `cmd.constraints`/`cmd.options` (already populated by `create_accelerator_table`) instead of only from explicit user config.

This will make code consistent with other accelrations, and will make following spicepod work without explicitly defining `primary_key`:

```yaml
datasets:
  - from: dynamodb:ddb
    name: ddb
    acceleration:
      refresh_mode: changes
      engine: cayenne
      mode: file
```

Test for this logic and https://github.com/spiceai/spiceai/pull/9297
