### PR TITLE
Update `search_01.exp`

### DIFF
--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -30,10 +30,10 @@ proc perform_search {search_term expected_term} {
     }
 }
 expect "search>"
-perform_search "Spice runtime error" {\| 1 .*\| .* \| [0-9]+\.[0-9]+ \| spice\.public\.issues +\|}
+perform_search "Spice runtime error" {1 +[0-9]+ +.* +[0-9]+\.[0-9]+ +spice\.public\.issues}
 
 expect "search>"
-perform_search "friends" {\| 1 .*\| .* \| [0-9]+\.[0-9]+ \| spice\.public\.catalog_page +\|}
+perform_search "friends" {1 +[0-9]+ +.* +[0-9]+\.[0-9]+ +spice\.public\.catalog_page}
 
 # Signal to exit (Ctrl+C)
 send \x03


### PR DESCRIPTION
`spice search` changed its output format when moved to Rust. Update the expected format (not the data etc).

- See Github [action](https://github.com/spiceai/spiceai/actions/runs/21831231178/job/62989897623).
