### PR TITLE
Improve cayenne to handle upserts more robust during runtime restarts

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -845,7 +845,9 @@ impl MetadataCatalog for CayenneCatalog {
         // Order matters for crash safety:
         // 1. Clear delete files first - they reference the old snapshot's data
         // 2. Clear insert records - they correspond to the cleared delete files
-        // 3. Update snapshot pointer - commits the new snapshot as active
+        // 3. Clear snapshot sequences - protected snapshots are no longer needed
+        //    after compaction since all data is merged into the new snapshot
+        // 4. Update snapshot pointer - commits the new snapshot as active
         //
         // If interrupted between these, the old snapshot remains active with
         // no delete files, which is safe (just loses the pending deletions,
@@ -854,6 +856,7 @@ impl MetadataCatalog for CayenneCatalog {
             "BEGIN TRANSACTION; \
              DELETE FROM cayenne_delete_file WHERE table_id = {table_id}; \
              DELETE FROM cayenne_insert_record WHERE table_id = {table_id}; \
+             DELETE FROM cayenne_snapshot_sequence WHERE table_id = {table_id}; \
              UPDATE cayenne_table SET current_snapshot_id = '{new_snapshot_id}' WHERE table_id = {table_id}; \
              COMMIT;"
         );

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -679,8 +679,8 @@ mod tests {
     ///
     /// Scenario:
     ///   Round 1: insert alice(100), bob(200), clint(300)
-    ///   Round 2: upsert alice(101), bob(201)  — creates delete (seq=1), snapshot A (seq=2)
-    ///   Round 3: upsert clint(301)            — creates delete (seq=3), snapshot B (seq=4)
+    ///   Round 2: upsert alice(101), bob(201)  — creates a delete and new snapshot A
+    ///   Round 3: upsert clint(301)            — creates a delete and new snapshot B
     ///   Restart → should still have exactly 3 rows: alice(101), bob(201), clint(301)
     #[tokio::test]
     async fn test_multi_upsert_rounds_survive_restart() {

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -782,7 +782,7 @@ mod tests {
             "{}",
             pretty_format_batches(&pre_batches).expect("format pre-restart results")
         );
-        insta::assert_snapshot!("pre_restart", pre_results);
+        insta::assert_snapshot!("restart_after_upserts_before_restart", pre_results);
 
         // ---- Restart: drop provider, re-open from fresh catalog ----
         drop(provider);
@@ -818,7 +818,7 @@ mod tests {
             "{}",
             pretty_format_batches(&post_batches).expect("format post-restart results")
         );
-        insta::assert_snapshot!("post_restart", post_results);
+        insta::assert_snapshot!("restart_after_upserts_after_restart", post_results);
 
         tracing::info!("✓ Multi-round upsert data survives restart correctly");
     }

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -80,19 +80,36 @@ mod tests {
     use crate::catalog::MetadataCatalog;
     use crate::cayenne_catalog::CayenneCatalog;
     use crate::metadata::CreateTableOptions;
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::{Int32Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
+    use arrow::util::pretty::pretty_format_batches;
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::datasource::source::DataSourceExec;
     use datafusion::execution::context::SessionContext;
     use datafusion_catalog::TableProvider;
     use datafusion_expr::dml::InsertOp;
     use datafusion_physical_plan::collect;
+    use datafusion_table_providers::util::column_reference::ColumnReference;
     use datafusion_table_providers::util::on_conflict::OnConflict;
     use futures::future::join_all;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    /// Insert a single batch via `insert_into()` (append mode).
+    async fn insert_batch(provider: &CayenneTableProvider, batch: RecordBatch) {
+        let ctx = SessionContext::new();
+        let schema = Arc::clone(batch.schema_ref());
+        let input_exec = MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None)
+            .expect("Failed to create MemorySourceConfig");
+        let plan = provider
+            .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+            .await
+            .expect("Failed to create insert plan");
+        collect(plan, ctx.task_ctx())
+            .await
+            .expect("Failed to execute insert");
+    }
 
     /// Helper to create a test catalog with a table containing sample data
     async fn setup_test_table(
@@ -647,5 +664,162 @@ mod tests {
         }
 
         tracing::info!("✓ Data sorted correctly by sort_columns");
+    }
+
+    /// Test that multiple upsert rounds with different PKs survive restart correctly.
+    ///
+    /// Previously: `load_protected_snapshots` computed a single global `max_delete_seq`
+    /// from ALL deletion vectors and only kept snapshots where `seq > max_delete_seq`.
+    /// With multiple upsert rounds, later rounds raised the global max, causing earlier
+    /// protected snapshots to be dropped and their data lost on restart.
+    ///
+    /// The test verifies that after a restart, all upserted rows are preserved correctly.
+    ///
+    /// Scenario:
+    ///   Round 1: insert alice(100), bob(200), clint(300)
+    ///   Round 2: upsert alice(101), bob(201)  — creates delete (seq=1), snapshot A (seq=2)
+    ///   Round 3: upsert clint(301)            — creates delete (seq=3), snapshot B (seq=4)
+    ///   Restart → should still have exactly 3 rows: alice(101), bob(201), clint(301)
+    #[tokio::test]
+    async fn test_multi_upsert_rounds_survive_restart() {
+        let temp_dir =
+            TempDir::new().expect("Failed to create temp directory for multi-upsert restart test");
+        let db_path = temp_dir.path().join("cayenne_multi_upsert.db");
+        let connection_string = format!("sqlite://{}", db_path.to_string_lossy());
+        let data_dir = temp_dir.path().join("data");
+        std::fs::create_dir_all(&data_dir)
+            .expect("Failed to create data directory for multi-upsert restart test");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("email", DataType::Utf8, false),
+            Field::new("username", DataType::Utf8, false),
+            Field::new("items_bought", DataType::Int64, false),
+        ]));
+
+        // Create catalog
+        let catalog = Arc::new(
+            CayenneCatalog::new(connection_string.clone())
+                .expect("Failed to create CayenneCatalog for multi-upsert restart test"),
+        );
+        catalog
+            .init()
+            .await
+            .expect("Failed to initialize catalog for multi-upsert restart test");
+        let catalog_trait: Arc<dyn MetadataCatalog> =
+            Arc::clone(&catalog) as Arc<dyn MetadataCatalog>;
+
+        let table_options = CreateTableOptions {
+            table_name: "users".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["email".to_string()],
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "email".to_string()
+            ]))),
+            base_path: data_dir.to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: crate::metadata::VortexConfig::default(),
+        };
+
+        let provider =
+            CayenneTableProvider::create_table(Arc::clone(&catalog_trait), table_options)
+                .await
+                .expect("Failed to create table for multi-upsert restart test");
+        let provider = Arc::new(provider);
+
+        // ---- Round 1: Initial insert of all 3 users ----
+        let batch1 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "alice@sample.com",
+                    "bob@umbrellacorp.com",
+                    "clint@bobsumbrellas.com",
+                ])),
+                Arc::new(StringArray::from(vec!["alice", "bob", "clint"])),
+                Arc::new(Int64Array::from(vec![100, 200, 300])),
+            ],
+        )
+        .expect("to create batch");
+        insert_batch(&provider, batch1).await;
+
+        // ---- Round 2: Upsert alice and bob only (clint unchanged) ----
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "alice@sample.com",
+                    "bob@umbrellacorp.com",
+                ])),
+                Arc::new(StringArray::from(vec!["alice", "bob"])),
+                Arc::new(Int64Array::from(vec![101, 201])),
+            ],
+        )
+        .expect("to create batch");
+        insert_batch(&provider, batch2).await;
+
+        // ---- Round 3: Upsert clint only (alice and bob unchanged) ----
+        let batch3 = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["clint@bobsumbrellas.com"])),
+                Arc::new(StringArray::from(vec!["clint"])),
+                Arc::new(Int64Array::from(vec![301])),
+            ],
+        )
+        .expect("to create batch");
+        insert_batch(&provider, batch3).await;
+
+        // Verify pre-restart: should have exactly 3 rows with latest values
+        let ctx = SessionContext::new();
+        ctx.register_table("users", Arc::clone(&provider) as Arc<dyn TableProvider>)
+            .expect("Failed to register table for pre-restart check");
+        let df = ctx
+            .sql("SELECT email, items_bought FROM users ORDER BY email")
+            .await
+            .expect("Failed to query pre-restart");
+        let pre_batches = df.collect().await.expect("Failed to collect pre-restart");
+        let pre_results = format!(
+            "{}",
+            pretty_format_batches(&pre_batches).expect("format pre-restart results")
+        );
+        insta::assert_snapshot!("pre_restart", pre_results);
+
+        // ---- Restart: drop provider, re-open from fresh catalog ----
+        drop(provider);
+        drop(ctx);
+
+        let catalog2 = Arc::new(
+            CayenneCatalog::new(connection_string)
+                .expect("Failed to re-create CayenneCatalog after restart"),
+        );
+        catalog2
+            .init()
+            .await
+            .expect("Failed to re-initialize catalog after restart");
+        let catalog_trait2: Arc<dyn MetadataCatalog> =
+            Arc::clone(&catalog2) as Arc<dyn MetadataCatalog>;
+
+        let provider2 = CayenneTableProviderBuilder::new(catalog_trait2)
+            .open("users")
+            .await
+            .expect("Failed to reopen table after restart");
+        let provider2 = Arc::new(provider2);
+
+        let ctx2 = SessionContext::new();
+        ctx2.register_table("users", Arc::clone(&provider2) as Arc<dyn TableProvider>)
+            .expect("Failed to register table post-restart");
+
+        let df2 = ctx2
+            .sql("SELECT email, items_bought FROM users ORDER BY email")
+            .await
+            .expect("Failed to query post-restart");
+        let post_batches = df2.collect().await.expect("Failed to collect post-restart");
+        let post_results = format!(
+            "{}",
+            pretty_format_batches(&post_batches).expect("format post-restart results")
+        );
+        insta::assert_snapshot!("post_restart", post_results);
+
+        tracing::info!("✓ Multi-round upsert data survives restart correctly");
     }
 }

--- a/crates/cayenne/src/provider/snapshots/cayenne__provider__tests__restart_after_upserts_after_restart.snap
+++ b/crates/cayenne/src/provider/snapshots/cayenne__provider__tests__restart_after_upserts_after_restart.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cayenne/src/provider/mod.rs
+expression: post_results
+---
++-------------------------+--------------+
+| email                   | items_bought |
++-------------------------+--------------+
+| alice@sample.com        | 101          |
+| bob@umbrellacorp.com    | 201          |
+| clint@bobsumbrellas.com | 301          |
++-------------------------+--------------+

--- a/crates/cayenne/src/provider/snapshots/cayenne__provider__tests__restart_after_upserts_before_restart.snap
+++ b/crates/cayenne/src/provider/snapshots/cayenne__provider__tests__restart_after_upserts_before_restart.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cayenne/src/provider/mod.rs
+expression: pre_results
+---
++-------------------------+--------------+
+| email                   | items_bought |
++-------------------------+--------------+
+| alice@sample.com        | 101          |
+| bob@umbrellacorp.com    | 201          |
+| clint@bobsumbrellas.com | 301          |
++-------------------------+--------------+

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2550,25 +2550,12 @@ impl CayenneTableProvider {
         // isn't filtered out. We use delete_sequence + 1 for the re-insertion.
         let insert_sequence = delete_sequence + 1;
 
-        // Capture existing delete files so we can replace them atomically.
-        let existing_delete_files = self
-            .catalog
-            .get_table_delete_files(self.table_metadata.table_id)
-            .await
-            .map_err(|err| CatalogError::InvalidOperationNoSource {
-                message: format!("Failed to load existing delete files: {err}"),
-            })?;
-
-        let existing_ids: Vec<i64> = existing_delete_files
-            .iter()
-            .map(|f| f.delete_file_id)
-            .collect();
-        let existing_paths: Vec<std::path::PathBuf> = existing_delete_files
-            .iter()
-            .map(|f| f.path.clone().into())
-            .collect();
-
-        let writer = DeletionVectorWriter::new(&self.table_metadata);
+        // Create a temporary metadata with the fresh delete sequence number.
+        // The table_metadata's current_sequence_number is stale (set at table open time),
+        // so we must use the actual delete_sequence from increment_sequence_number().
+        let mut temp_metadata = self.table_metadata.clone();
+        temp_metadata.current_sequence_number = delete_sequence;
+        let writer = DeletionVectorWriter::new(&temp_metadata);
 
         // For on-conflict (upsert) handling, use key-based deletion vectors.
         // Position-based tables don't support upserts, so we always use row keys here.
@@ -2620,25 +2607,9 @@ impl CayenneTableProvider {
             }
         }
 
-        // Remove old delete files after new ones are registered.
-        if !existing_ids.is_empty() {
-            self.catalog
-                .remove_delete_files(self.table_metadata.table_id, &existing_ids)
-                .await
-                .map_err(|err| CatalogError::InvalidOperationNoSource {
-                    message: format!("Failed to remove old delete files: {err}"),
-                })?;
-
-            // Best-effort cleanup of old files on disk.
-            for path in existing_paths {
-                if let Err(err) = tokio::fs::remove_file(&path).await {
-                    tracing::debug!(
-                        "Failed to delete obsolete deletion vector file {:?}: {err}",
-                        path
-                    );
-                }
-            }
-        }
+        // For PK-based strategies, keep old delete files to preserve deletion history.
+        // Each upsert round may affect a different subset of PKs, so removing old files
+        // would lose deletion records for PKs not in the current round.
 
         // Update the appropriate cache based on deletion strategy.
         // This follows Iceberg's pattern where deletes are tracked by PK + sequence number.
@@ -3850,35 +3821,37 @@ impl CayenneTableProvider {
             return Ok(HashMap::new());
         }
 
-        // Get the maximum delete sequence from the current deletions
-        let max_delete_seq = match strategy {
-            PkDeletionStrategy::Int64Pk => deleted_pk_i64.values().max().copied().unwrap_or(0),
-            PkDeletionStrategy::RowConverterBased => {
-                deleted_row_keys.values().max().copied().unwrap_or(0)
-            }
-            PkDeletionStrategy::PositionBased => 0,
-        };
-
         // Get all snapshot sequences from catalog
         let snapshot_sequences = catalog.get_all_snapshot_sequences(table_id).await?;
 
-        // Filter to only protected snapshots (those with seq > max_delete_seq)
-        let protected: HashMap<String, i64> = snapshot_sequences
-            .into_iter()
-            .filter(|(_snapshot_id, seq)| *seq > max_delete_seq)
-            .map(|(snapshot_id, _seq)| (snapshot_id, max_delete_seq)) // Store max_delete_seq for reference
-            .collect();
-
-        if !protected.is_empty() {
-            tracing::debug!(
-                "Loaded {} protected snapshot(s) for table_id {} with max_delete_seq={}",
-                protected.len(),
-                table_id,
-                max_delete_seq
-            );
+        if snapshot_sequences.is_empty() {
+            return Ok(HashMap::new());
         }
 
-        Ok(protected)
+        // Treat ALL snapshots as protected, using each snapshot's own persisted
+        // `sequence_number` as its deletion threshold.
+        //
+        // Each snapshot's `sequence_number` was allocated (via `increment_sequence_number`)
+        // BEFORE the same round's deletions were created. Therefore:
+        // - All deletions from PRIOR rounds have `delete_seq < sequence_number`
+        // - All deletions from the SAME or LATER rounds have `delete_seq > sequence_number`
+        //
+        // The partial deletion filter uses `delete_seq > threshold`, so setting the
+        // threshold to `sequence_number` correctly:
+        // - Skips deletions from prior rounds (already accounted for at snapshot creation)
+        // - Applies deletions from the same or later rounds
+        //
+        // Previously, this function computed a single global `max_delete_seq` from ALL
+        // deletions and filtered out snapshots where `seq <= max_delete_seq`. This was
+        // incorrect because later rounds' deletions raised the global max, causing earlier
+        // snapshots to be incorrectly dropped and their data lost on restart.
+
+        tracing::debug!(
+            "Loaded {} protected snapshot(s) for table_id {table_id}",
+            snapshot_sequences.len(),
+        );
+
+        Ok(snapshot_sequences)
     }
 
     /// Creates a projection that strips additional columns added for deletion filtering.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3684,19 +3684,12 @@ impl CayenneTableProvider {
         table_id: i64,
         strategy: &PkDeletionStrategyWithCache,
     ) -> CatalogResult<HashMap<String, i64>> {
-        // Check if there are any pending deletions
-        let has_deletions = match strategy {
-            PkDeletionStrategy::Int64Pk => !deleted_pk_i64.is_empty(),
-            PkDeletionStrategy::RowConverterBased => !deleted_row_keys.is_empty(),
-            PkDeletionStrategy::PositionBased => false, // Per-file deletion vectors don't need protected snapshots
-        };
-
-        if !has_deletions {
-            // No deletions, no protected snapshots needed
+        // Only PK-based strategies support sequence-ordered snapshot protection.
+        // Position-based deletion vectors are per-file and don't need protected snapshots.
+        if strategy.is_position_based() {
             return Ok(HashMap::new());
         }
 
-        // Get all snapshot sequences from catalog
         let snapshot_sequences = catalog.get_all_snapshot_sequences(table_id).await?;
 
         if snapshot_sequences.is_empty() {

--- a/crates/cayenne/tests/retention_test.rs
+++ b/crates/cayenne/tests/retention_test.rs
@@ -20,7 +20,7 @@ limitations under the License.
 
 mod common;
 
-use arrow::array::{Int64Array, RecordBatch};
+use arrow::array::{Int64Array, RecordBatch, UInt64Array};
 
 use arrow::datatypes::{DataType, Field, Schema};
 
@@ -108,7 +108,7 @@ async fn test_retention_filters_apply_on_insert_impl(
         let row_id_array = batch
             .column(0)
             .as_any()
-            .downcast_ref::<Int64Array>()
+            .downcast_ref::<UInt64Array>()
             .expect("row_id column");
         for idx in 0..row_id_array.len() {
             deleted_row_ids.push(row_id_array.value(idx));
@@ -116,7 +116,7 @@ async fn test_retention_filters_apply_on_insert_impl(
     }
     assert_eq!(
         deleted_row_ids,
-        vec![0, 1],
+        vec![0u64, 1],
         "Retention should delete the first two logical rows"
     );
 


### PR DESCRIPTION
## 📝 Summary

After a runtime restart, Cayenne lost data from earlier upsert rounds. `load_protected_snapshots` computed a single global `max_delete_seq` from ALL deletion vectors and filtered out snapshots with `seq <= max_delete_seq`. With multiple upsert rounds, each round's deletions raised the global max, causing earlier snapshots to be incorrectly dropped — their rows became invisible after restart.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
