### PR TITLE
testoperator dispatch: dry run & don't exit on failure

### DIFF
--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -49,6 +49,10 @@ pub struct DispatchArgs {
     /// Maximum number of concurrent workflow runs allowed
     #[arg(long)]
     pub(crate) max_concurrent: Option<usize>,
+
+    /// Dry run mode - print the workflow dispatch request without sending it
+    #[arg(long, default_value = "false")]
+    pub(crate) dry_run: bool,
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -31,8 +31,8 @@ pub struct DispatchArgs {
     #[arg(long)]
     pub(crate) workflow: Workflow,
 
-    #[arg(long, env = "GH_TOKEN")]
-    pub(crate) github_token: String,
+    #[arg(long, env = "GH_TOKEN", required_if_eq("dry_run", "false"))]
+    pub(crate) github_token: Option<String>,
 
     #[arg(long, env = "SPICED_COMMIT", default_value = "")]
     pub(crate) spiced_commit: String,
@@ -42,9 +42,6 @@ pub struct DispatchArgs {
 
     #[arg(long, default_value = "false", action = ArgAction::Set)]
     pub(crate) update_snapshots: bool,
-
-    #[arg(long, action = ArgAction::Set, default_value_t = false, default_missing_value = "true", num_args = 0..=1, require_equals = false)]
-    pub(crate) validate: bool,
 
     /// Maximum number of concurrent workflow runs allowed
     #[arg(long)]

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -27,16 +27,25 @@ use test_framework::{
 use crate::args::dispatch::{DispatchArgs, DispatchTestFile, WorkflowArgs};
 
 pub async fn dispatch(args: DispatchArgs) -> Result<()> {
-    if !args.path.is_dir() && !args.path.is_file() {
+    let DispatchArgs {
+        path,
+        workflow,
+        workflow_commit,
+        github_token,
+        spiced_commit,
+        update_snapshots,
+        max_concurrent,
+        ..
+    } = args;
+    if !path.is_dir() && !path.is_file() {
         return Err(anyhow::anyhow!("Path must be a directory or a file"));
     }
 
-    let octo_client = octocrab::instance().user_access_token(args.github_token)?;
-    let test_type: TestType = args.workflow.into();
-    let yaml_files = if args.path.is_dir() {
-        scan_directory_for_yamls(&args.path)?
+    let test_type: TestType = workflow.into();
+    let yaml_files = if path.is_dir() {
+        scan_directory_for_yamls(&path)?
     } else {
-        vec![args.path]
+        vec![path]
     };
 
     println!("Found {} YAML files to load", yaml_files.len());
@@ -64,8 +73,8 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                         serde_json::json!(WorkflowArgs {
                             specific_args: bench
                                 .clone()
-                                .with_update_snapshots(args.update_snapshots.into()),
-                            spiced_commit: args.spiced_commit.clone(),
+                                .with_update_snapshots(update_snapshots.into()),
+                            spiced_commit: spiced_commit.clone(),
                         }),
                     ));
                 }
@@ -76,7 +85,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                         path,
                         serde_json::json!(WorkflowArgs {
                             specific_args: load.clone(),
-                            spiced_commit: args.spiced_commit.clone(),
+                            spiced_commit: spiced_commit.clone(),
                         }),
                     ));
                 }
@@ -87,7 +96,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                         path,
                         serde_json::json!(WorkflowArgs {
                             specific_args: throughput.clone(),
-                            spiced_commit: args.spiced_commit.clone(),
+                            spiced_commit: spiced_commit.clone(),
                         }),
                     ));
                 }
@@ -98,7 +107,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                         path,
                         serde_json::json!(WorkflowArgs {
                             specific_args: append.clone(),
-                            spiced_commit: args.spiced_commit.clone(),
+                            spiced_commit: spiced_commit.clone(),
                         }),
                     ));
                 }
@@ -109,7 +118,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                         path,
                         serde_json::json!(WorkflowArgs {
                             specific_args: text_to_sql.clone(),
-                            spiced_commit: args.spiced_commit.clone(),
+                            spiced_commit: spiced_commit.clone(),
                         }),
                     ));
                 }
@@ -137,14 +146,15 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
             path.display(),
         );
 
-        if args.dry_run {
+        // If github token is none, `--dry-run true` is forced by `clap`'s `required_if_eq` constraint.
+        let Some(gh_token) = github_token.as_deref() else {
             let url = format!(
                 "https://api.github.com/repos/spiceai/spiceai/actions/workflows/{}/dispatches",
                 test_type.workflow()
             );
 
             let body = serde_json::json!({
-                "ref": &args.workflow_commit,
+                "ref": &workflow_commit,
                 "inputs": payload
             });
 
@@ -152,22 +162,19 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                 "curl -L \\
   -X POST \\
   -H \"Accept: application/vnd.github+json\" \\
-  -H \"Authorization: Bearer <GITHUB_TOKEN>\" \\
+  -H \"Authorization: Bearer $GH_TOKEN\" \\
   -H \"X-GitHub-Api-Version: 2022-11-28\" \\
   {url} \\
   -d '{body}'"
             );
             continue;
-        }
+        };
 
-        let workflow = GitHubWorkflow::new(
-            "spiceai",
-            "spiceai",
-            test_type.workflow(),
-            &args.workflow_commit,
-        );
+        let octo_client = octocrab::instance().user_access_token(gh_token)?;
+        let workflow =
+            GitHubWorkflow::new("spiceai", "spiceai", test_type.workflow(), &workflow_commit);
 
-        let result = match args.max_concurrent {
+        let result = match max_concurrent {
             Some(max_concurrent) => {
                 // Dispatch workflow while waiting for an available slot, limiting to max_concurrent parallel runs
                 dispatch_workflow_with_concurrency(
@@ -185,7 +192,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
         };
 
         if let Err(e) = result {
-            eprintln!("Failed to dispatch {path}. Error: {e}");
+            eprintln!("Failed to dispatch {}. Error: {e}", path.display());
             failed_dispatches.push((path.display().to_string(), e));
             continue;
         }
@@ -196,9 +203,9 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
     }
 
     if !failed_dispatches.is_empty() {
-        println!("\nFailed to dispatch {} tests:", failed_dispatches.len());
+        eprintln!("\nFailed to dispatch {} tests:", failed_dispatches.len());
         for (path, error) in &failed_dispatches {
-            println!("  - {path}: {error}");
+            eprintln!("  - {path}: {error}");
         }
         return Err(anyhow::anyhow!("Some workflow requests failed"));
     }

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -185,6 +185,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
         };
 
         if let Err(e) = result {
+            eprintln!("Failed to dispatch {path}. Error: {e}");
             failed_dispatches.push((path.display().to_string(), e));
             continue;
         }

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -125,6 +125,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
         return Ok(());
     }
 
+    let mut failed_dispatches = Vec::new();
     let total_tests = tests_to_dispatch.len();
     for (index, (path, mut payload)) in tests_to_dispatch.into_iter().enumerate() {
         payload = map_numbers_to_strings(payload);
@@ -136,6 +137,29 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
             path.display(),
         );
 
+        if args.dry_run {
+            let url = format!(
+                "https://api.github.com/repos/spiceai/spiceai/actions/workflows/{}/dispatches",
+                test_type.workflow()
+            );
+
+            let body = serde_json::json!({
+                "ref": &args.workflow_commit,
+                "inputs": payload
+            });
+
+            println!(
+                "curl -L \\
+  -X POST \\
+  -H \"Accept: application/vnd.github+json\" \\
+  -H \"Authorization: Bearer <GITHUB_TOKEN>\" \\
+  -H \"X-GitHub-Api-Version: 2022-11-28\" \\
+  {url} \\
+  -d '{body}'"
+            );
+            continue;
+        }
+
         let workflow = GitHubWorkflow::new(
             "spiceai",
             "spiceai",
@@ -143,7 +167,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
             &args.workflow_commit,
         );
 
-        match args.max_concurrent {
+        let result = match args.max_concurrent {
             Some(max_concurrent) => {
                 // Dispatch workflow while waiting for an available slot, limiting to max_concurrent parallel runs
                 dispatch_workflow_with_concurrency(
@@ -152,17 +176,30 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                     Some(payload),
                     max_concurrent,
                 )
-                .await?;
+                .await
             }
             None => {
                 // Dispatch workflow without concurrency limit
-                workflow.send(octo_client.actions(), Some(payload)).await?;
+                workflow.send(octo_client.actions(), Some(payload)).await
             }
+        };
+
+        if let Err(e) = result {
+            failed_dispatches.push((path.display().to_string(), e));
+            continue;
         }
 
         // sleep to space out runs
         println!("Waiting for next run...");
         tokio::time::sleep(std::time::Duration::from_secs(80)).await;
+    }
+
+    if !failed_dispatches.is_empty() {
+        println!("\nFailed to dispatch {} tests:", failed_dispatches.len());
+        for (path, error) in &failed_dispatches {
+            println!("  - {path}: {error}");
+        }
+        return Err(anyhow::anyhow!("Some workflow requests failed"));
     }
 
     Ok(())


### PR DESCRIPTION
## 📝 Summary
 - `--dry-run` command to give debug information on `testoperator dispatch ...`. 
 - Do not exit early on first failure to dispatch. Aggregate errors. 