### PR TITLE
fix: Provide a more informative 404 on async API when result has no chunks

### DIFF
--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -327,7 +327,10 @@ pub async fn handle_get_async_query_result(body: &[u8]) -> Result<Vec<u8>, Statu
     let batches = executor
         .get_chunk(request.query_id.as_str(), request.chunk_index)
         .await
-        .map_err(|e| Status::internal(format!("Failed to get result chunk: {e}")))?;
+        .map_err(|e| match &e {
+            crate::jobs::Error::NoRowsReturned { .. } => Status::not_found(e.to_string()),
+            _ => Status::internal(format!("Failed to get result chunk: {e}")),
+        })?;
 
     // Serialize to Arrow IPC
     serialize_batches_to_ipc(&batches)

--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -328,7 +328,13 @@ pub async fn handle_get_async_query_result(body: &[u8]) -> Result<Vec<u8>, Statu
         .get_chunk(request.query_id.as_str(), request.chunk_index)
         .await
         .map_err(|e| match &e {
-            crate::jobs::Error::NoRowsReturned { .. } => Status::not_found(e.to_string()),
+            crate::jobs::Error::NoRowsReturned { .. }
+            | crate::jobs::Error::ChunkNotFound { .. }
+            | crate::jobs::Error::JobNotFound { .. }
+            | crate::jobs::Error::JobResultsExpired { .. } => Status::not_found(e.to_string()),
+            crate::jobs::Error::JobNotComplete { .. } => {
+                Status::failed_precondition(e.to_string())
+            }
             _ => Status::internal(format!("Failed to get result chunk: {e}")),
         })?;
 

--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -332,9 +332,7 @@ pub async fn handle_get_async_query_result(body: &[u8]) -> Result<Vec<u8>, Statu
             | crate::jobs::Error::ChunkNotFound { .. }
             | crate::jobs::Error::JobNotFound { .. }
             | crate::jobs::Error::JobResultsExpired { .. } => Status::not_found(e.to_string()),
-            crate::jobs::Error::JobNotComplete { .. } => {
-                Status::failed_precondition(e.to_string())
-            }
+            crate::jobs::Error::JobNotComplete { .. } => Status::failed_precondition(e.to_string()),
             _ => Status::internal(format!("Failed to get result chunk: {e}")),
         })?;
 

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -805,12 +805,7 @@ fn error_to_response(error: &crate::jobs::Error) -> Response {
     use crate::jobs::Error;
 
     match error {
-        Error::JobNotFound { .. } | Error::ChunkNotFound { .. } => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": error.to_string()})),
-        )
-            .into_response(),
-        Error::NoRowsReturned { .. } => (
+        Error::JobNotFound { .. } | Error::ChunkNotFound { .. } | Error::NoRowsReturned { .. } => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": error.to_string()})),
         )

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -810,6 +810,14 @@ fn error_to_response(error: &crate::jobs::Error) -> Response {
             Json(serde_json::json!({"error": error.to_string()})),
         )
             .into_response(),
+        Error::NoRowsReturned { .. } => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": error.to_string(),
+                "error_code": "NO_ROWS_RETURNED"
+            })),
+        )
+            .into_response(),
         Error::JobResultsExpired { .. } => (
             StatusCode::GONE,
             Json(serde_json::json!({"error": error.to_string()})),

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -812,10 +812,7 @@ fn error_to_response(error: &crate::jobs::Error) -> Response {
             .into_response(),
         Error::NoRowsReturned { .. } => (
             StatusCode::NOT_FOUND,
-            Json(serde_json::json!({
-                "error": error.to_string(),
-                "error_code": "NO_ROWS_RETURNED"
-            })),
+            Json(serde_json::json!({"error": error.to_string()})),
         )
             .into_response(),
         Error::JobResultsExpired { .. } => (

--- a/crates/runtime/src/jobs/error.rs
+++ b/crates/runtime/src/jobs/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[snafu(display("Result chunk {chunk_index} not found for job {job_id}"))]
     ChunkNotFound { job_id: String, chunk_index: usize },
 
+    #[snafu(display("Job {job_id} completed with no rows returned"))]
+    NoRowsReturned { job_id: String },
+
     #[snafu(display("Job {job_id} is not yet complete (status: {status})"))]
     JobNotComplete { job_id: String, status: String },
 

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -150,12 +150,12 @@ impl JobExecutor {
         }
 
         // If the job completed with no rows, there are no chunks to read.
-        if let Some(result) = &state.result {
-            if result.manifest.total_chunk_count == 0 {
-                return Err(super::error::Error::NoRowsReturned {
-                    job_id: job_id.to_string(),
-                });
-            }
+        if let Some(result) = &state.result
+            && result.manifest.total_chunk_count == 0
+        {
+            return Err(super::error::Error::NoRowsReturned {
+                job_id: job_id.to_string(),
+            });
         }
 
         self.job_store.read_chunk(job_id, chunk_index).await

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -149,6 +149,15 @@ impl JobExecutor {
             });
         }
 
+        // If the job completed with no rows, there are no chunks to read.
+        if let Some(result) = &state.result {
+            if result.manifest.total_chunk_count == 0 {
+                return Err(super::error::Error::NoRowsReturned {
+                    job_id: job_id.to_string(),
+                });
+            }
+        }
+
         self.job_store.read_chunk(job_id, chunk_index).await
     }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* When a query has no rows, it has no chunks. Previously, retrieving the chunk would just return an uninformative error about a missing chunk - now, it returns a better error that no chunks are available because there were no rows from the query.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #8938