### PR TITLE
Validate lag_exceeds_shard_retention_behavior param in DynamoDB

### DIFF
--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -421,12 +421,12 @@ impl DataConnector for DynamoDB {
                 match LagExceedsShardRetentionBehavior::from_str(value_str) {
                     Ok(behavior) => behavior,
                     Err(e) => {
-                        tracing::error!(
+                        tracing::warn!(
                             dataset = %dataset.name,
                             error = %e,
-                            "Failed to parse 'lag_exceeds_shard_retention_behavior' parameter"
+                            "Failed to parse 'lag_exceeds_shard_retention_behavior' parameter. Defaulting to 'error'"
                         );
-                        return None;
+                        LagExceedsShardRetentionBehavior::default()
                     }
                 }
             }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -423,7 +423,8 @@ impl DataConnector for DynamoDB {
                     Err(e) => {
                         tracing::error!(
                             dataset = %dataset.name,
-                            "Invalid lag_exceeds_shard_retention_behavior: {value_str}. Valid values: error, ready_before_load, ready_after_load. {e}"
+                            error = %e,
+                            "Failed to parse 'lag_exceeds_shard_retention_behavior' parameter"
                         );
                         return None;
                     }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -418,13 +418,16 @@ impl DataConnector for DynamoDB {
             .expose()
         {
             ExposedParamLookup::Present(value_str) => {
-                LagExceedsShardRetentionBehavior::from_str(value_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
-                    dataconnector: "dynamodb".to_string(),
-                    message: format!(
-                        "Invalid lag_exceeds_shard_retention_behavior: {value_str}. Valid values: error, ready_before_load, ready_after_load"
-                    ),
-                    connector_component: ConnectorComponent::from(&dataset),
-                })?
+                match LagExceedsShardRetentionBehavior::from_str(value_str) {
+                    Ok(behavior) => behavior,
+                    Err(e) => {
+                        tracing::error!(
+                            dataset = %dataset.name,
+                            "Invalid lag_exceeds_shard_retention_behavior: {value_str}. Valid values: error, ready_before_load, ready_after_load. {e}"
+                        );
+                        return None;
+                    }
+                }
             }
             ExposedParamLookup::Absent(_) => LagExceedsShardRetentionBehavior::default(),
         };

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -412,13 +412,22 @@ impl DataConnector for DynamoDB {
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
 
-        let lag_exceeds_behavior = self
+        let lag_exceeds_behavior = match self
             .params
             .get("lag_exceeds_shard_retention_behavior")
             .expose()
-            .ok()
-            .and_then(|v| LagExceedsShardRetentionBehavior::from_str(v).ok())
-            .unwrap_or_default();
+        {
+            ExposedParamLookup::Present(value_str) => {
+                LagExceedsShardRetentionBehavior::from_str(value_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+                    dataconnector: "dynamodb".to_string(),
+                    message: format!(
+                        "Invalid lag_exceeds_shard_retention_behavior: {value_str}. Valid values: error, ready_before_load, ready_after_load"
+                    ),
+                    connector_component: ConnectorComponent::from(&dataset),
+                })?
+            }
+            ExposedParamLookup::Absent(_) => LagExceedsShardRetentionBehavior::default(),
+        };
 
         let metrics_collector = Arc::clone(&self.metrics_collector);
 


### PR DESCRIPTION
## 📝 Summary

closes #9356 

Return an error if the parameter value is invalid, instead of silently falling back to the default. Error message includes valid values and dataset context.

This pull request refines how the `lag_exceeds_shard_retention_behavior` parameter is handled in the `DynamoDB` data connector. The new implementation improves error handling and validation by explicitly matching on the parameter's presence and providing clear error messages for invalid values.

**Parameter handling and error reporting improvements:**

* Updated the extraction of `lag_exceeds_shard_retention_behavior` to use a `match` statement, providing explicit error messages if the value is invalid and defaulting gracefully when absent. This enhances configuration validation and debugging for users.