### PR TITLE
fix: Return better error for Cayenne metadata schema mismatch

### DIFF
--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -107,6 +107,9 @@ pub enum CatalogError {
     #[snafu(display("The function '{function}' is not implemented"))]
     NotImplemented { function: String },
 
+    #[snafu(display("Cayenne metadata schema mismatch for table '{table}'. The metadata database format has changed and is incompatible with this version. To continue, clear your acceleration data (delete the Cayenne metadata directory) so it can be recreated. Existing accelerated data will be re-synced from the source."))]
+    SchemaMismatch { table: String },
+
     #[snafu(display(
         "Deletion vectors require non-negative row IDs, found negative values: {row_ids}"
     ))]

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -30,6 +30,133 @@ use std::fmt::Display;
 use super::catalog::CatalogResult;
 use async_trait::async_trait;
 
+/// Expected column definitions for a metadata table.
+///
+/// Used by [`validate_existing_schema`] to compare the actual schema of an existing
+/// metadata table against the expected schema. Only column names are checked — types
+/// and constraints are not compared because `SQLite`/`libSQL` type affinity makes
+/// exact type matching unreliable and columns may be added with `ALTER TABLE`.
+#[derive(Debug, Clone)]
+pub struct ExpectedTable {
+    /// The table name (e.g., `"cayenne_table"`).
+    pub name: &'static str,
+    /// The ordered list of expected column names.
+    pub columns: &'static [&'static str],
+}
+
+/// Expected schema definitions for all Cayenne metadata tables.
+///
+/// These must be kept in sync with the DDL constants in `sqlite.rs` and `turso.rs`.
+/// When the schema changes, update both the DDL constants **and** these definitions.
+pub const EXPECTED_TABLES: &[ExpectedTable] = &[
+    ExpectedTable {
+        name: "cayenne_table",
+        columns: &[
+            "table_id",
+            "table_uuid",
+            "table_name",
+            "path",
+            "path_is_relative",
+            "schema_json",
+            "primary_key_json",
+            "on_conflict_json",
+            "current_snapshot_id",
+            "partition_column",
+            "vortex_config_json",
+            "current_sequence_number",
+        ],
+    },
+    ExpectedTable {
+        name: "cayenne_delete_file",
+        columns: &[
+            "delete_file_id",
+            "table_id",
+            "path",
+            "path_is_relative",
+            "format",
+            "delete_count",
+            "file_size_bytes",
+            "source_data_file_path",
+            "sequence_number",
+        ],
+    },
+    ExpectedTable {
+        name: "cayenne_partition",
+        columns: &[
+            "partition_id",
+            "table_id",
+            "partition_columns_json",
+            "partition_values_json",
+            "partition_key",
+            "path",
+            "path_is_relative",
+            "record_count",
+            "file_size_bytes",
+        ],
+    },
+    ExpectedTable {
+        name: "cayenne_insert_record",
+        columns: &[
+            "insert_record_id",
+            "table_id",
+            "pk_bytes",
+            "sequence_number",
+        ],
+    },
+    ExpectedTable {
+        name: "cayenne_snapshot_sequence",
+        columns: &["table_id", "snapshot_id", "sequence_number"],
+    },
+];
+
+/// Validate the existing metadata table schemas against the expected definitions.
+///
+/// Compares the actual column names of each metadata table against
+/// [`EXPECTED_TABLES`]. If any table has a different set of columns (missing,
+/// extra, or reordered), returns a [`CatalogError::SchemaMismatch`] that tells
+/// the user to clear their acceleration data.
+///
+/// `actual_columns_fn` is an async callback that returns the ordered list of
+/// column names for a given table. It should return an empty `Vec` if the table
+/// does not yet exist (the table will be created by the DDL that runs before
+/// validation).
+///
+/// # Errors
+///
+/// Returns [`CatalogError::SchemaMismatch`] when the existing schema does not
+/// match the expected schema.
+pub async fn validate_existing_schema<F, Fut>(actual_columns_fn: F) -> CatalogResult<()>
+where
+    F: Fn(&'static str) -> Fut,
+    Fut: std::future::Future<Output = CatalogResult<Vec<String>>>,
+{
+    for expected in EXPECTED_TABLES {
+        let actual_columns = actual_columns_fn(expected.name).await?;
+
+        // If the table has no columns it was freshly created — nothing to validate.
+        if actual_columns.is_empty() {
+            continue;
+        }
+
+        let expected_columns: Vec<&str> = expected.columns.to_vec();
+        let actual_refs: Vec<&str> = actual_columns.iter().map(String::as_str).collect();
+
+        if expected_columns != actual_refs {
+            tracing::debug!(
+                "Cayenne schema mismatch for '{}': expected columns [{}], found [{}]",
+                expected.name,
+                expected_columns.join(", "),
+                actual_refs.join(", ")
+            );
+            return Err(super::catalog::CatalogError::SchemaMismatch {
+                table: expected.name.to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// Parameters for querying a single row from the database.
 #[derive(Debug)]
 pub struct QueryRowParams<'a> {
@@ -344,4 +471,128 @@ pub trait MetastoreBackend: Send + Sync {
     ///
     /// Returns an error if cleanup fails.
     async fn shutdown(&self) -> CatalogResult<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::CatalogError;
+
+    #[tokio::test]
+    async fn test_validate_existing_schema_matching_columns() {
+        // When actual columns exactly match expected columns, validation passes.
+        let result = validate_existing_schema(|table_name| async move {
+            let expected = EXPECTED_TABLES
+                .iter()
+                .find(|t| t.name == table_name)
+                .expect("table should exist in EXPECTED_TABLES");
+            Ok(expected.columns.iter().map(|c| (*c).to_string()).collect())
+        })
+        .await;
+
+        assert!(result.is_ok(), "Matching schema should pass validation");
+    }
+
+    #[tokio::test]
+    async fn test_validate_existing_schema_empty_table_skipped() {
+        // When a table returns no columns (freshly created), it should be skipped.
+        let result = validate_existing_schema(|_table_name| async move {
+            Ok(Vec::new()) // Simulate a table that doesn't exist yet
+        })
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "Empty (new) tables should be skipped during validation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_existing_schema_extra_column_fails() {
+        // When a table has an extra column not in the expected schema, validation fails.
+        let result = validate_existing_schema(|table_name| async move {
+            let expected = EXPECTED_TABLES
+                .iter()
+                .find(|t| t.name == table_name)
+                .expect("table should exist in EXPECTED_TABLES");
+            let mut cols: Vec<String> = expected.columns.iter().map(|c| (*c).to_string()).collect();
+            cols.push("unexpected_new_column".to_string());
+            Ok(cols)
+        })
+        .await;
+
+        assert!(result.is_err(), "Extra column should fail validation");
+        let err = result.expect_err("should be SchemaMismatch");
+        assert!(
+            matches!(err, CatalogError::SchemaMismatch { .. }),
+            "Error should be SchemaMismatch, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_existing_schema_missing_column_fails() {
+        // When a table is missing a column from the expected schema, validation fails.
+        let result = validate_existing_schema(|table_name| async move {
+            let expected = EXPECTED_TABLES
+                .iter()
+                .find(|t| t.name == table_name)
+                .expect("table should exist in EXPECTED_TABLES");
+            // Return all columns except the last one
+            let cols: Vec<String> = expected.columns[..expected.columns.len() - 1]
+                .iter()
+                .map(|c| (*c).to_string())
+                .collect();
+            Ok(cols)
+        })
+        .await;
+
+        assert!(result.is_err(), "Missing column should fail validation");
+        let err = result.expect_err("should be SchemaMismatch");
+        assert!(
+            matches!(err, CatalogError::SchemaMismatch { .. }),
+            "Error should be SchemaMismatch, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_existing_schema_reordered_columns_fails() {
+        // When columns are in a different order, validation fails.
+        let result = validate_existing_schema(|table_name| async move {
+            let expected = EXPECTED_TABLES
+                .iter()
+                .find(|t| t.name == table_name)
+                .expect("table should exist in EXPECTED_TABLES");
+            let mut cols: Vec<String> = expected.columns.iter().map(|c| (*c).to_string()).collect();
+            // Swap first two columns if there are at least 2
+            if cols.len() >= 2 {
+                cols.swap(0, 1);
+            }
+            Ok(cols)
+        })
+        .await;
+
+        assert!(result.is_err(), "Reordered columns should fail validation");
+        let err = result.expect_err("should be SchemaMismatch");
+        assert!(
+            matches!(err, CatalogError::SchemaMismatch { .. }),
+            "Error should be SchemaMismatch, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_schema_mismatch_error_message_is_actionable() {
+        // The error message should tell users what to do.
+        let err = CatalogError::SchemaMismatch {
+            table: "cayenne_table".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("clear your acceleration data"),
+            "Error message should tell the user to clear data: {msg}"
+        );
+        assert!(
+            msg.contains("cayenne_table"),
+            "Error message should name the mismatched table: {msg}"
+        );
+    }
 }

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -369,6 +369,29 @@ impl MetastoreBackend for SqliteMetastore {
             },
         )?;
 
+        // Validate that existing tables match the expected schema.
+        // This catches incompatible metadata databases from previous versions.
+        let validate_conn = self.get_conn().await?;
+        super::validate_existing_schema(|table_name| {
+            let conn = validate_conn.clone();
+            async move {
+                conn.call(move |conn| {
+                    let mut stmt = conn.prepare(&format!("PRAGMA table_info('{table_name}')"))?;
+                    let columns: Vec<String> = stmt
+                        .query_map([], |row| row.get::<_, String>(1))?
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok::<Vec<String>, rusqlite::Error>(columns)
+                })
+                .await
+                .map_err(
+                    |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                        message: format!("Failed to read table schema for validation: {e}"),
+                    },
+                )
+            }
+        })
+        .await?;
+
         Ok(())
     }
 

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -348,6 +348,59 @@ impl MetastoreBackend for TursoMetastore {
             )
             .await;
 
+        // Validate that existing tables match the expected schema.
+        // This catches incompatible metadata databases from previous versions.
+        // We query table_info for each expected table using a fresh connection per table
+        // since turso::Connection is not Clone.
+        for expected in super::EXPECTED_TABLES {
+            let table_conn = self.get_conn().await?;
+            let mut rows = table_conn
+                .query(&format!("PRAGMA table_info('{}')", expected.name), ())
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to read table schema for validation: {e}"),
+                })?;
+
+            let mut actual_columns = Vec::new();
+            loop {
+                match rows.next().await {
+                    Ok(Some(row)) => {
+                        // PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+                        // Column name is at index 1.
+                        if let Ok(turso::Value::Text(name)) = row.get_value(1) {
+                            actual_columns.push(name);
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        return Err(CatalogError::Database {
+                            message: format!("Failed to read table schema for validation: {e}"),
+                        });
+                    }
+                }
+            }
+
+            // Skip validation for freshly created tables (no columns = table didn't exist before).
+            if actual_columns.is_empty() {
+                continue;
+            }
+
+            let expected_columns: Vec<&str> = expected.columns.to_vec();
+            let actual_refs: Vec<&str> = actual_columns.iter().map(String::as_str).collect();
+
+            if expected_columns != actual_refs {
+                tracing::debug!(
+                    "Cayenne schema mismatch for '{}': expected columns [{}], found [{}]",
+                    expected.name,
+                    expected_columns.join(", "),
+                    actual_refs.join(", ")
+                );
+                return Err(CatalogError::SchemaMismatch {
+                    table: expected.name.to_string(),
+                });
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Returns a more user friendly error when a Cayenne metadata schema is different from the expected schema, instead of an undetermined SQL error for invalid column selection

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #8777