### PR TITLE
Append: add hourly partitioned append+retention test for Cayenne file-based deletes

### DIFF
--- a/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml
@@ -1,0 +1,137 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-cayenne[file]-append_partitioning_retention_period
+
+refresh_check_interval: &refresh_check_interval 30s
+retention_check_interval: &retention_check_interval 30s
+retention_period: &retention_period 1d
+
+datasets:
+  - from: file:customer.parquet
+    name: customer
+    time_format: timestamptz
+    time_column: c_created_at
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', c_created_at)"
+
+  - from: file:lineitem.parquet
+    name: lineitem
+    time_column: l_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', l_created_at)"
+
+  - from: file:nation.parquet
+    name: nation
+    time_column: n_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', n_created_at)"
+
+  - from: file:orders.parquet
+    name: orders
+    time_column: o_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', o_created_at)"
+
+  - from: file:part.parquet
+    name: part
+    time_column: p_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', p_created_at)"
+
+  - from: file:partsupp.parquet
+    name: partsupp
+    time_column: ps_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', ps_created_at)"
+
+  - from: file:region.parquet
+    name: region
+    time_column: r_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', r_created_at)"
+
+  - from: file:supplier.parquet
+    name: supplier
+    time_column: s_created_at
+    time_format: timestamptz
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      refresh_check_interval: *refresh_check_interval
+      retention_check_enabled: true
+      retention_check_interval: *retention_check_interval
+      retention_period: *retention_period
+      partition_by:
+        - "date_trunc('hour', s_created_at)"
+

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml
@@ -1,0 +1,5 @@
+tests:
+  append:
+    spicepod_path: accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml
+    query_set: tpch
+    with_retention_data: true


### PR DESCRIPTION
## 📝 Summary

Adds a new append benchmark spicepod and dispatch config for testing Cayenne's file-based retention deletes with partitioned tables.

Cayenne's file-based delete can only remove **entire Vortex files** where `max(time_column) < retention_threshold`. Without partitioning, retention data (old timestamps) and regular data (current timestamps) arrive in a single batch during the initial load, landing in the same Vortex files. Since those files contain both old and new timestamps, `max(time_column)` is always current — making them ineligible for file-based deletion.

## Solution

Partition each table by `date_trunc('hour', <time_column>)` routes retention test data (~24h old) and regular data (current) into separate partition directories:

```
expression=1770732000000000/ ← retention data (yesterday's hour)
└── *.vortex ← all files have max(time_col) < threshold → deletable
expression=1770818400000000/ ← regular data (current hour)
└── *.vortex ← kept
```

When retention runs, the old partition's files all satisfy `max(time_col) < now() - 1d`, so they are fully deleted

```bash
⚡ ./target/debug/testoperator run append --ready-wait 300 --query-set tpch --load-steps 10 --load-interval 20 --duration 240 --with-retention-data -p "./test/spicepods/tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_partitioning_retention_period.yaml"

...

2026-02-11T14:48:06.019145Z  INFO runtime::accelerated_table::retention: [retention] Evicting data for lineitem where l_created_at < 2026-02-10T14:48:06+00:00
2026-02-11T14:48:06.019194Z  INFO runtime::accelerated_table::retention: [retention] Evicting data for nation where n_created_at < 2026-02-10T14:48:06+00:00
2026-02-11T14:48:06.019116Z  INFO runtime::accelerated_table::retention: [retention] Evicting data for customer where c_created_at < 2026-02-10T14:48:06+00:00
2026-02-11T14:48:06.019275Z  INFO runtime::accelerated_table::retention: [retention] Evicting data for part where p_created_at < 2026-02-10T14:48:06+00:00
2026-02-11T14:48:06.020412Z  INFO runtime::accelerated_table::retention: [retention] Evicting data for orders where o_created_at < 2026-02-10T14:48:06+00:00
2026-02-11T14:48:06.023258Z  INFO runtime::accelerated_table::retention: [retention] Evicted 3 records for nation
2026-02-11T14:48:06.023569Z  INFO runtime::accelerated_table::retention: [retention] Evicted 15000 records for customer
2026-02-11T14:48:06.023658Z  INFO runtime::accelerated_table::retention: [retention] Evicted 20000 records for part
2026-02-11T14:48:06.023753Z  INFO runtime::accelerated_table::retention: [retention] Evicted 1000 records for supplier
2026-02-11T14:48:06.024692Z  INFO runtime::accelerated_table::retention: [retention] Evicted 600572 records for lineitem
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
