### PR TITLE
Add `actions: write` permission to streaming dispatch workflow

### DIFF
--- a/.github/workflows/testoperator_run_streaming_dynamodb.yml
+++ b/.github/workflows/testoperator_run_streaming_dynamodb.yml
@@ -1,4 +1,4 @@
-name: streaming dynamodb benchmark
+name: testoperator streaming dynamodb benchmark
 run-name: streaming - ${{ github.event.inputs.queryset }} - ${{ github.event.inputs.config_name }} - ${{ github.event.inputs.run_id }}
 
 on:

--- a/.github/workflows/testoperator_run_streaming_dynamodb_dispatch.yml
+++ b/.github/workflows/testoperator_run_streaming_dynamodb_dispatch.yml
@@ -1,4 +1,4 @@
-name: streaming dynamodb dispatch
+name: testoperator streaming dynamodb dispatch
 run-name: streaming-dispatch - ${{ github.event.inputs.queryset }} - sf${{ github.event.inputs.scale_factor }}
 
 on:
@@ -57,6 +57,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 


### PR DESCRIPTION
## 📝 Summary

Add `actions: write` permission to streaming dispatch workflow + rename workflows for consistency