### PR TITLE
feat(cayenne): File-based retention deletes for PK tables

### DIFF
--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -55,7 +55,7 @@ pub(crate) struct FileBasedDeletionResult {
 }
 
 /// Result of scanning a single listing table for retention-eligible files.
-struct DeletionScanResult {
+struct DeletionCheckScanResult {
     /// Files whose `max(retention_col) < threshold`.
     files: Vec<(ObjectMeta, Option<usize>)>,
     /// `true` when every file in the table matched — the table is fully expired.
@@ -82,8 +82,8 @@ pub struct FileBasedDeletionSink {
     /// Main listing table to enumerate files and collect per-file statistics.
     listing_table: Arc<RwLock<Arc<ListingTable>>>,
     /// Protected snapshot listing tables keyed by snapshot ID (PK-based strategies only).
-    /// Empty for position-based tables.
-    protected_snapshot_tables: Vec<(String, Arc<ListingTable>)>,
+    /// `None` for position-based tables.
+    protected_snapshot_tables: Option<Vec<(String, Arc<ListingTable>)>>,
     /// The retention filter expression (e.g., `event_time < literal`).
     filter: Expr,
     /// Table name for logging.
@@ -106,7 +106,7 @@ impl FileBasedDeletionSink {
     ///
     /// * `listing_table` - Main listing table for the current snapshot.
     /// * `protected_snapshot_tables` - Protected snapshot listing tables keyed
-    ///   by snapshot ID. Pass empty vec for position-based tables.
+    ///   by snapshot ID. `None` for position-based tables.
     /// * `filter` - Retention filter expression.
     /// * `table_name` - Table name for logging.
     /// * `catalog` - Metadata catalog for clearing snapshot sequence records.
@@ -116,7 +116,7 @@ impl FileBasedDeletionSink {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         listing_table: Arc<RwLock<Arc<ListingTable>>>,
-        protected_snapshot_tables: Vec<(String, Arc<ListingTable>)>,
+        protected_snapshot_tables: Option<Vec<(String, Arc<ListingTable>)>>,
         filter: Expr,
         table_name: String,
         catalog: Arc<dyn MetadataCatalog>,
@@ -157,7 +157,7 @@ impl FileBasedDeletionSink {
         listing_table: &ListingTable,
         retention_col: &str,
         retention_threshold: &ScalarValue,
-    ) -> CatalogResult<DeletionScanResult> {
+    ) -> CatalogResult<DeletionCheckScanResult> {
         // Call list_files_for_scan — lists all files + collects per-file stats.
         // collect_stat is true by default via SessionConfig::default().
         let (file_groups, _aggregate_stats) = listing_table
@@ -197,7 +197,7 @@ impl FileBasedDeletionSink {
             }
         }
 
-        Ok(DeletionScanResult {
+        Ok(DeletionCheckScanResult {
             all_matched: !eligible.is_empty() && eligible.len() == total_files,
             files: eligible,
         })
@@ -329,7 +329,7 @@ impl FileBasedDeletionSink {
         let mut emptied_snapshot_ids = Vec::new();
 
         for (idx, (snapshot_id, snapshot_table)) in
-            self.protected_snapshot_tables.iter().enumerate()
+            self.protected_snapshot_tables.iter().flatten().enumerate()
         {
             let scan_result = self
                 .retention_eligible_files(&ctx, snapshot_table, &col_name, &threshold)

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -429,8 +429,10 @@ impl FileBasedDeletionSink {
             let snapshot_dir = std::path::PathBuf::from(&self.table_path)
                 .join(self.table_id.to_string())
                 .join(snapshot_id);
-            if snapshot_dir.exists() {
-                if let Err(e) = tokio::fs::remove_dir_all(&snapshot_dir).await {
+            match tokio::fs::remove_dir_all(&snapshot_dir).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
                     tracing::warn!(
                         "Failed to remove empty snapshot directory {}: {e}",
                         snapshot_dir.display()

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -23,8 +23,15 @@ limitations under the License.
 //! Unlike [`CayenneDeletionSink`](super::CayenneDeletionSink), which marks
 //! individual rows as deleted via deletion vectors, this sink physically
 //! removes data files from the filesystem or object store.
+//!
+//! For PK-based tables with protected snapshots, the sink also scans protected
+//! snapshot directories and removes eligible files from them. When a protected
+//! snapshot directory is fully emptied, the sink performs additional cleanup:
+//! it clears the snapshot sequence from the catalog, removes the entry
+//! from the in-memory protected snapshots map, and deletes the empty snapshot
+//! data directory from disk.
 
-use crate::catalog::{CatalogError, CatalogResult};
+use crate::catalog::{CatalogError, CatalogResult, MetadataCatalog};
 use crate::provider::retention::extract_retention_column_and_threshold;
 use async_trait::async_trait;
 use data_components::delete::DeletionSink;
@@ -34,49 +41,98 @@ use datafusion_catalog::TableProvider;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use object_store::{ObjectMeta, ObjectStore};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+
+/// Result from file-based deletion, including metadata for post-delete cleanup.
+#[derive(Debug)]
+pub(crate) struct FileBasedDeletionResult {
+    /// Total number of rows deleted across all files.
+    pub total_deleted_rows: u64,
+    /// IDs of protected snapshots that were fully emptied
+    /// (all files expired and deleted).
+    pub emptied_snapshot_ids: Vec<String>,
+}
+
+/// Result of scanning a single listing table for retention-eligible files.
+struct DeletionScanResult {
+    /// Files whose `max(retention_col) < threshold`.
+    files: Vec<(ObjectMeta, Option<usize>)>,
+    /// `true` when every file in the table matched — the table is fully expired.
+    all_matched: bool,
+}
 
 /// File-based deletion sink for time-based retention.
 ///
 /// Discovers files eligible for deletion based on per-file column statistics
-/// and deletes them from the filesystem. This is used for position-based tables
-/// with `retention_period` configured.
+/// and deletes them from the filesystem. Used for tables with `retention_period`
+/// configured, for both position-based and PK-based deletion strategies.
 ///
 /// # Workflow
 ///
 /// 1. Parse the filter expression to extract column name and threshold scalar.
-/// 2. Call [`list_files_for_scan`] to enumerate files with per-file statistics.
+/// 2. Call [`list_files_for_scan`] to enumerate files with per-file statistics
+///    for the main listing table and all protected snapshot tables.
 /// 3. For each file, check if `max(retention_col) < threshold` — if so, the
 ///    file is eligible for deletion (all rows are expired).
 /// 4. Delete eligible files from the filesystem.
-/// 5. Return the total number of deleted rows (from per-file stats).
-///
-/// # Notes
-///
-/// Unlike [`CayenneDeletionSink`](super::CayenneDeletionSink), this sink does
-/// not currently scan protected snapshots. File-based deletes are only enabled for the
-/// position-based strategy (no primary key), which does not use protected
-/// snapshots
+/// 5. Identify protected snapshots that are fully emptied.
+/// 6. Return the total number of deleted rows and cleanup metadata.
 pub struct FileBasedDeletionSink {
-    /// Listing table to enumerate files and collect per-file statistics.
+    /// Main listing table to enumerate files and collect per-file statistics.
     listing_table: Arc<RwLock<Arc<ListingTable>>>,
+    /// Protected snapshot listing tables keyed by snapshot ID (PK-based strategies only).
+    /// Empty for position-based tables.
+    protected_snapshot_tables: Vec<(String, Arc<ListingTable>)>,
     /// The retention filter expression (e.g., `event_time < literal`).
     filter: Expr,
     /// Table name for logging.
     table_name: String,
+
+    /// Metadata catalog for clearing snapshot sequence records.
+    catalog: Arc<dyn MetadataCatalog>,
+    /// In-memory protected snapshots map (shared with `CayenneTableProvider`).
+    protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
+    /// Table ID for catalog operations.
+    table_id: i64,
+    /// Table base path for constructing snapshot directory paths.
+    table_path: String,
 }
 
 impl FileBasedDeletionSink {
     /// Create a new file-based deletion sink.
+    ///
+    /// # Arguments
+    ///
+    /// * `listing_table` - Main listing table for the current snapshot.
+    /// * `protected_snapshot_tables` - Protected snapshot listing tables keyed
+    ///   by snapshot ID. Pass empty vec for position-based tables.
+    /// * `filter` - Retention filter expression.
+    /// * `table_name` - Table name for logging.
+    /// * `catalog` - Metadata catalog for clearing snapshot sequence records.
+    /// * `protected_snapshots` - In-memory protected snapshots map.
+    /// * `table_id` - Table ID for catalog operations.
+    /// * `table_path` - Table base path for snapshot directory construction.
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         listing_table: Arc<RwLock<Arc<ListingTable>>>,
+        protected_snapshot_tables: Vec<(String, Arc<ListingTable>)>,
         filter: Expr,
         table_name: String,
+        catalog: Arc<dyn MetadataCatalog>,
+        protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
+        table_id: i64,
+        table_path: String,
     ) -> Self {
         Self {
             listing_table,
+            protected_snapshot_tables,
             filter,
             table_name,
+            catalog,
+            protected_snapshots,
+            table_id,
+            table_path,
         }
     }
 
@@ -86,6 +142,10 @@ impl FileBasedDeletionSink {
     /// per-file column statistics. A file is eligible when its
     /// `max(retention_col) < threshold` — meaning all rows in the file are
     /// older than the retention threshold.
+    ///
+    /// Returns a [`DeletionScanResult`] containing the eligible files and
+    /// whether *all* files in the table matched (i.e. the table is fully
+    /// expired and can be cleaned up).
     ///
     /// # Errors
     ///
@@ -97,7 +157,7 @@ impl FileBasedDeletionSink {
         listing_table: &ListingTable,
         retention_col: &str,
         retention_threshold: &ScalarValue,
-    ) -> CatalogResult<Vec<(ObjectMeta, Option<usize>)>> {
+    ) -> CatalogResult<DeletionScanResult> {
         // Call list_files_for_scan — lists all files + collects per-file stats.
         // collect_stat is true by default via SessionConfig::default().
         let (file_groups, _aggregate_stats) = listing_table
@@ -117,9 +177,11 @@ impl FileBasedDeletionSink {
             })?;
 
         // Filter: file is eligible when max(retention_col) < threshold
+        let mut total_files: usize = 0;
         let mut eligible = Vec::new();
         for file_group in &file_groups {
             for file in file_group.iter() {
+                total_files += 1;
                 let stats = file.statistics.as_ref();
 
                 let dominated = stats
@@ -135,70 +197,25 @@ impl FileBasedDeletionSink {
             }
         }
 
-        Ok(eligible)
+        Ok(DeletionScanResult {
+            all_matched: !eligible.is_empty() && eligible.len() == total_files,
+            files: eligible,
+        })
     }
-}
 
-#[async_trait]
-impl DeletionSink for FileBasedDeletionSink {
-    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-        // 1. Parse the filter expression to extract column name and threshold
-        let (col_name, _op, threshold) = extract_retention_column_and_threshold(&self.filter)
-            .map_err(|e| format!("Failed to extract retention column and threshold: {e}"))?;
-
-        tracing::debug!(
-            table = %self.table_name,
-            column = %col_name,
-            threshold = %threshold,
-            "File-based retention: discovering eligible files"
-        );
-
-        // Clone listing table once to avoid holding locks across await points
-        let listing_table = {
-            self.listing_table
-                .read()
-                .map_err(|_| "Listing table lock poisoned".to_string())?
-                .clone()
-        };
-
-        // A single throwaway SessionContext for the entire operation. It only
-        // provides the object-store registry.
-        // Vortex footer/segment caches live inside the VortexFormat embedded in the
-        // shared ListingTable and are unaffected by this SessionContext.
-        let ctx = SessionContext::new();
-
-        // 2. Discover eligible files
-        let eligible_files = self
-            .retention_eligible_files(&ctx, &listing_table, &col_name, &threshold)
-            .await
-            .map_err(|e| format!("Failed to discover retention-eligible files: {e}"))?;
-
-        if eligible_files.is_empty() {
-            tracing::debug!(
-                table = %self.table_name,
-                "File-based retention: no eligible files found"
-            );
-            return Ok(0);
-        }
-
-        // 3. Get the object store for file deletion
-        let object_store_url = listing_table
-            .table_paths()
-            .first()
-            .map(datafusion_datasource::ListingTableUrl::object_store)
-            .ok_or("Table has no paths")?;
-
-        let object_store: Arc<dyn ObjectStore> = ctx
-            .runtime_env()
-            .object_store_registry
-            .get_store(object_store_url.as_ref())
-            .map_err(|e| format!("Failed to get object store: {e}"))?;
-
-        // 4. Delete eligible files and count rows
+    /// Delete eligible files from an object store.
+    ///
+    /// Returns the total number of deleted rows.
+    async fn delete_eligible_files(
+        &self,
+        eligible_files: &[(ObjectMeta, Option<usize>)],
+        object_store: &dyn ObjectStore,
+        source: &str,
+    ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         let mut total_rows: u64 = 0;
-        let mut deleted_files: u64 = 0;
+        let mut deleted_count: u64 = 0;
 
-        for (meta, num_rows) in &eligible_files {
+        for (meta, num_rows) in eligible_files {
             match object_store.delete(&meta.location).await {
                 Ok(()) => {
                     let row_count = num_rows.unwrap_or(0);
@@ -211,7 +228,7 @@ impl DeletionSink for FileBasedDeletionSink {
                     };
 
                     total_rows = total_rows.saturating_add(rows);
-                    deleted_files += 1;
+                    deleted_count += 1;
 
                     tracing::debug!(
                         table = %self.table_name,
@@ -241,8 +258,190 @@ impl DeletionSink for FileBasedDeletionSink {
             }
         }
 
-        tracing::debug!("Evicted {deleted_files} files for {}", self.table_name);
+        tracing::debug!(
+            table = %self.table_name,
+            source,
+            "Evicted {deleted_count} file(s), {total_rows} row(s)"
+        );
 
         Ok(total_rows)
+    }
+
+    /// Internal implementation that returns structured deletion results
+    /// including cleanup metadata for post-delete operations.
+    pub(crate) async fn delete_from_internal(
+        &self,
+    ) -> Result<FileBasedDeletionResult, Box<dyn std::error::Error + Send + Sync>> {
+        // Parse the filter expression to extract column name and threshold
+        let (col_name, _op, threshold) = extract_retention_column_and_threshold(&self.filter)
+            .map_err(|e| format!("Failed to extract retention column and threshold: {e}"))?;
+
+        tracing::debug!(
+            table = %self.table_name,
+            column = %col_name,
+            threshold = %threshold,
+            "File-based retention: discovering eligible files"
+        );
+
+        // Clone main listing table once to avoid holding locks across await points
+        let listing_table = {
+            self.listing_table
+                .read()
+                .map_err(|_| "Listing table lock poisoned".to_string())?
+                .clone()
+        };
+
+        // A single throwaway SessionContext for the entire operation. It only
+        // provides the object-store registry.
+        // Vortex footer/segment caches live inside the VortexFormat embedded in the
+        // shared ListingTable and are unaffected by this SessionContext.
+        let ctx = SessionContext::new();
+
+        // Get the object store for file deletion
+        let object_store_url = listing_table
+            .table_paths()
+            .first()
+            .map(datafusion_datasource::ListingTableUrl::object_store)
+            .ok_or("Table has no paths")?;
+
+        let object_store: Arc<dyn ObjectStore> = ctx
+            .runtime_env()
+            .object_store_registry
+            .get_store(object_store_url.as_ref())
+            .map_err(|e| format!("Failed to get object store: {e}"))?;
+
+        let mut total_deleted_rows: u64 = 0;
+
+        // 1. Discover and delete eligible files from the main listing table
+        let main_scan = self
+            .retention_eligible_files(&ctx, &listing_table, &col_name, &threshold)
+            .await
+            .map_err(|e| format!("Failed to discover retention-eligible files: {e}"))?;
+
+        if !main_scan.files.is_empty() {
+            let rows = self
+                .delete_eligible_files(&main_scan.files, object_store.as_ref(), "main")
+                .await?;
+            total_deleted_rows = total_deleted_rows.saturating_add(rows);
+        }
+
+        // 2. Discover and delete eligible files from protected snapshot tables
+        let mut emptied_snapshot_ids = Vec::new();
+
+        for (idx, (snapshot_id, snapshot_table)) in
+            self.protected_snapshot_tables.iter().enumerate()
+        {
+            let scan_result = self
+                .retention_eligible_files(&ctx, snapshot_table, &col_name, &threshold)
+                .await
+                .map_err(|e| {
+                    format!(
+                        "Failed to discover retention-eligible files in protected snapshot {snapshot_id}: {e}"
+                    )
+                })?;
+
+            if scan_result.files.is_empty() {
+                continue;
+            }
+
+            let source = format!("snapshot[{idx}]");
+            let rows = self
+                .delete_eligible_files(&scan_result.files, object_store.as_ref(), &source)
+                .await?;
+            total_deleted_rows = total_deleted_rows.saturating_add(rows);
+
+            if scan_result.all_matched {
+                tracing::debug!(
+                    table = %self.table_name,
+                    snapshot_id,
+                    "Protected snapshot fully emptied by file-based retention"
+                );
+                emptied_snapshot_ids.push(snapshot_id.clone());
+            }
+        }
+
+        if total_deleted_rows == 0 {
+            tracing::debug!(
+                table = %self.table_name,
+                "File-based retention: no eligible files found"
+            );
+        }
+
+        Ok(FileBasedDeletionResult {
+            total_deleted_rows,
+            emptied_snapshot_ids,
+        })
+    }
+}
+
+#[async_trait]
+impl DeletionSink for FileBasedDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let result = self.delete_from_internal().await?;
+
+        // Clean up emptied protected snapshots: catalog, in-memory map, and directory.
+        if !result.emptied_snapshot_ids.is_empty() {
+            self.cleanup_emptied_snapshots(&result.emptied_snapshot_ids)
+                .await;
+        }
+
+        Ok(result.total_deleted_rows)
+    }
+}
+
+impl FileBasedDeletionSink {
+    /// Clean up protected snapshots that were fully emptied by file-based retention.
+    ///
+    /// For each emptied snapshot:
+    /// 1. Remove the snapshot sequence from the catalog.
+    /// 2. Remove the entry from the in-memory `protected_snapshots` map.
+    /// 3. Delete the now-empty snapshot directory from disk.
+    ///
+    /// Errors are logged as warnings but do not fail the overall delete operation
+    /// — the data files are already removed, so cleanup is best-effort.
+    async fn cleanup_emptied_snapshots(&self, emptied_ids: &[String]) {
+        for snapshot_id in emptied_ids {
+            // 1. Remove snapshot sequence from catalog
+            if let Err(e) = self
+                .catalog
+                .clear_snapshot_sequence(self.table_id, snapshot_id)
+                .await
+            {
+                tracing::warn!(
+                    "Failed to clear snapshot sequence for snapshot {snapshot_id} in table {}: {e}",
+                    self.table_name
+                );
+                continue;
+            }
+
+            // 2. Remove from in-memory map
+            if let Ok(mut guard) = self.protected_snapshots.write() {
+                guard.remove(snapshot_id);
+            } else {
+                tracing::warn!(
+                    "Protected snapshots lock poisoned while cleaning up snapshot {snapshot_id} in table {}",
+                    self.table_name
+                );
+                continue;
+            }
+
+            // 3. Delete the empty snapshot directory
+            let snapshot_dir = std::path::PathBuf::from(&self.table_path)
+                .join(self.table_id.to_string())
+                .join(snapshot_id);
+            if snapshot_dir.exists() {
+                if let Err(e) = tokio::fs::remove_dir_all(&snapshot_dir).await {
+                    tracing::warn!(
+                        "Failed to remove empty snapshot directory {}: {e}",
+                        snapshot_dir.display()
+                    );
+                }
+            }
+
+            tracing::debug!(
+                "Cleaned up emptied protected snapshot {snapshot_id} for table {}",
+                self.table_name
+            );
+        }
     }
 }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4694,7 +4694,8 @@ impl CayenneTableProvider {
     /// File-level delete path.
     ///
     /// Creates a [`FileBasedDeletionSink`] that discovers eligible files
-    /// (where `max(col) < threshold_value`) and deletes them.
+    /// (where `max(col) < threshold_value`) and deletes them from the main
+    /// snapshot and all protected snapshot directories.
     fn delete_using_files(
         &self,
         filters: &[Expr],
@@ -4707,11 +4708,19 @@ impl CayenneTableProvider {
         }
         let filter = &filters[0];
 
+        // Build protected snapshot listing tables for file-based scanning
+        let protected_snapshot_tables = self.build_protected_snapshot_listing_tables()?;
+
         Ok(Arc::new(DeletionExec::new(
             Arc::new(FileBasedDeletionSink::new(
                 Arc::clone(&self.listing_table),
+                protected_snapshot_tables,
                 filter.clone(),
                 self.table_metadata.table_name.clone(),
+                Arc::clone(&self.catalog),
+                Arc::clone(&self.protected_snapshots),
+                self.table_metadata.table_id,
+                self.table_metadata.path.clone(),
             )),
             &self.table_metadata.schema,
         )))
@@ -4722,40 +4731,11 @@ impl CayenneTableProvider {
         &self,
         filters: &[Expr],
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        // Collect protected snapshot listing tables for deletion scanning
-        let protected_snapshot_tables = {
-            let protected_snapshots = {
-                let guard = self.protected_snapshots.read().map_err(|_| {
-                    datafusion_common::DataFusionError::Execution(
-                        "Protected snapshots lock poisoned".to_string(),
-                    )
-                })?;
-                guard.clone()
-            };
-
-            let mut tables = Vec::with_capacity(protected_snapshots.len());
-            for (snapshot_id, _) in protected_snapshots {
-                let snapshot_url = Self::snapshot_dir_url(
-                    &self.table_metadata.path,
-                    self.table_metadata.table_id,
-                    &snapshot_id,
-                );
-
-                let listing_table = Self::create_listing_table(
-                    &snapshot_url,
-                    Arc::clone(&self.table_metadata.schema),
-                    self.context.file_format(),
-                    &self.pk_deletion_strategy,
-                )
-                .map_err(|e| {
-                    datafusion_common::DataFusionError::Execution(format!(
-                        "Failed to create listing table for protected snapshot {snapshot_id}: {e}"
-                    ))
-                })?;
-                tables.push(listing_table);
-            }
-            tables
-        };
+        let snapshot_tables: Vec<Arc<ListingTable>> = self
+            .build_protected_snapshot_listing_tables()?
+            .into_iter()
+            .map(|(_, table)| table)
+            .collect();
 
         Ok(Arc::new(DeletionExec::new(
             Arc::new(CayenneDeletionSink::new(
@@ -4767,17 +4747,55 @@ impl CayenneTableProvider {
                 self.pk_deletion_strategy.clone(),
                 self.pk_row_converter.as_ref().map(Arc::clone),
                 self.pk_column_indices.clone(),
-                protected_snapshot_tables,
+                snapshot_tables,
             )),
             &self.table_metadata.schema,
         )))
+    }
+
+    /// Build listing tables for all protected snapshots.
+    ///
+    /// Returns a vec of `(snapshot_id, listing_table)` pairs.
+    fn build_protected_snapshot_listing_tables(
+        &self,
+    ) -> datafusion_common::Result<Vec<(String, Arc<ListingTable>)>> {
+        let protected_snapshots = {
+            let guard = self.protected_snapshots.read().map_err(|_| {
+                datafusion_common::DataFusionError::Execution(
+                    "Protected snapshots lock poisoned".to_string(),
+                )
+            })?;
+            guard.clone()
+        };
+
+        let mut result = Vec::with_capacity(protected_snapshots.len());
+        for (snapshot_id, _) in protected_snapshots {
+            let snapshot_url = Self::snapshot_dir_url(
+                &self.table_metadata.path,
+                self.table_metadata.table_id,
+                &snapshot_id,
+            );
+
+            let listing_table = Self::create_listing_table(
+                &snapshot_url,
+                Arc::clone(&self.table_metadata.schema),
+                self.context.file_format(),
+                &self.pk_deletion_strategy,
+            )
+            .map_err(|e| {
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to create listing table for protected snapshot {snapshot_id}: {e}"
+                ))
+            })?;
+            result.push((snapshot_id, listing_table));
+        }
+        Ok(result)
     }
 
     /// Returns `true` if deletes can use whole-file deletion instead of per-row deletion vectors.
     ///
     /// Requirements:
     /// - Time-based retention is configured (`time_retention_filter_builder`).
-    /// - The table uses a position-based deletion strategy.
     /// - The table is **not** backed by S3 storage.
     /// - The filter is a single `retention_col < threshold` expression matching
     ///   the configured retention column. Non-retention deletes (e.g. CDC
@@ -4788,9 +4806,7 @@ impl CayenneTableProvider {
             return false;
         };
 
-        if !self.pk_deletion_strategy.is_position_based()
-            || self.table_metadata.path.starts_with("s3://")
-        {
+        if self.table_metadata.path.starts_with("s3://") {
             return false;
         }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4708,8 +4708,13 @@ impl CayenneTableProvider {
         }
         let filter = &filters[0];
 
-        // Build protected snapshot listing tables for file-based scanning
-        let protected_snapshot_tables = self.build_protected_snapshot_listing_tables()?;
+        // Build protected snapshot listing tables for PK-based strategies only.
+        // Position-based tables have no protected snapshots.
+        let protected_snapshot_tables = if self.pk_deletion_strategy.is_position_based() {
+            None
+        } else {
+            Some(self.build_protected_snapshot_listing_tables()?)
+        };
 
         Ok(Arc::new(DeletionExec::new(
             Arc::new(FileBasedDeletionSink::new(

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -41,6 +41,9 @@ use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::prelude::*;
 use datafusion_common::ScalarValue;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
 use std::sync::Arc;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -49,6 +52,14 @@ test_with_backends!(test_file_based_retention_deletes_expired_files_impl);
 test_with_backends!(test_file_based_retention_no_eligible_files_impl);
 test_with_backends!(test_file_based_retention_deletes_all_files_impl);
 test_with_backends!(test_file_based_retention_mixed_file_not_deleted_impl);
+
+// PK-based file retention tests
+test_with_backends!(test_pk_file_based_retention_main_table_only_impl);
+test_with_backends!(test_pk_file_based_retention_with_protected_snapshots_impl);
+test_with_backends!(test_pk_file_based_retention_empties_main_snapshot_impl);
+test_with_backends!(test_pk_file_based_retention_fresh_snapshot_preserved_impl);
+test_with_backends!(test_pk_file_based_retention_upsert_after_delete_impl);
+test_with_backends!(test_pk_file_based_retention_multiple_protected_snapshots_impl);
 
 /// Test: File-based retention physically deletes files that are fully expired.
 ///
@@ -229,6 +240,361 @@ async fn test_file_based_retention_mixed_file_not_deleted_impl(fixture: TestFixt
 }
 
 // =============================================================================
+// PK-Based File Retention Tests
+// =============================================================================
+
+/// Test: File-based retention works for Int64 PK tables without upserts.
+///
+/// This is the simplest PK scenario — identical to position-based behavior
+/// but using the `Int64Pk` deletion strategy. No protected snapshots exist
+/// because no upserts have been performed.
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: None):
+///   - file 1: `event_time` = now           → fresh (kept)
+///   - file 2: `event_time` = now - 2s      → within retention (kept)
+///   - file 3: `event_time` = now - 10s     → expired (deleted)
+///
+/// After deletion: 2 files remain, count(*) = 2, ids = [1, 2].
+async fn test_pk_file_based_retention_main_table_only_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_main";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, false).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?; // fresh
+    insert_row(&table, 2, now_us - 2_000_000).await?; // 2s ago — within retention
+    insert_row(&table, 3, now_us - 10_000_000).await?; // 10s ago — expired
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(
+        count_vortex_files(&dir),
+        3,
+        "Expected 3 Vortex files after 3 inserts"
+    );
+
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 1, "Should delete 1 row (the expired file)");
+
+    assert_eq!(
+        count_vortex_files(&dir),
+        2,
+        "Expected 2 Vortex files after deletion"
+    );
+
+    assert_table_contents(&table, table_name, &[1, 2], "After deleting expired file").await?;
+
+    Ok(())
+}
+
+/// Test: File-based retention deletes expired files from both main and protected snapshots.
+///
+/// In incremental append, upserts always carry a timestamp >= the original row.
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: Upsert):
+/// 1. Insert 3 rows: id=1 (fresh), id=2 (2s ago), id=3 (10s ago, expired).
+/// 2. Upsert id=3 with 5s-ago timestamp (newer than original 10s ago, but still expired
+///    with 3s retention) → new snapshot (upserted id=3, expired) added to `protected_snapshots`,
+///    main listing table stays as-is (original snapshot).
+///    Now: main listing table has 3 files (id=1 fresh, id=2 within retention, id=3 10s-ago expired),
+///    protected snapshot has 1 file (upserted id=3, 5s-ago expired).
+/// 3. Execute retention delete.
+///
+/// Expected:
+/// - Expired file (id=3, 10s ago) deleted from main listing table.
+/// - Expired file (id=3, 5s ago) deleted from protected snapshot.
+/// - 2 files remain in main (id=1 fresh, id=2 within retention).
+/// - count(*) = 2, ids = [1, 2].
+async fn test_pk_file_based_retention_with_protected_snapshots_impl(
+    fixture: TestFixture,
+) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_snap";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, true).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?; // fresh
+    insert_row(&table, 2, now_us - 2_000_000).await?; // 2s ago — within retention
+    insert_row(&table, 3, now_us - 10_000_000).await?; // 10s ago — expired
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(count_vortex_files(&dir), 3, "3 files before upsert");
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        1,
+        "1 snapshot before upsert"
+    );
+
+    // Upsert id=3 with 5s-ago timestamp — newer than original (10s ago) per incremental
+    // append invariant, but still expired with 3s retention.
+    upsert_row(&table, 3, now_us - 5_000_000).await?;
+
+    // After upsert: 2 snapshot dirs. Main listing table (original) has 3 files,
+    // protected snapshot (new) has 1 file (upserted id=3, 5s ago, expired).
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "2 snapshots after upsert"
+    );
+    assert_eq!(count_vortex_files(&dir), 4, "4 total files after upsert");
+
+    // Execute retention delete — should remove expired files from BOTH:
+    //   id=3 (10s ago) from main listing table + id=3 (5s ago) from protected snapshot.
+    // The protected snapshot is fully emptied and its directory is cleaned up.
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(
+        deleted, 2,
+        "Should delete 2 expired files (1 from main + 1 from protected)"
+    );
+
+    assert_eq!(
+        count_vortex_files(&dir),
+        2,
+        "2 files remain: 2 in main snapshot (id=1 fresh, id=2 within retention)"
+    );
+
+    // The emptied protected snapshot directory should be removed by cleanup.
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        1,
+        "Emptied protected snapshot directory should be removed"
+    );
+
+    assert_table_contents(
+        &table,
+        table_name,
+        &[1, 2],
+        "After deleting expired files from both main and protected snapshots",
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Test: All files in the main listing table's snapshot are expired → its directory emptied.
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: Upsert):
+/// 1. Insert 1 row: id=1 (10s ago expired).
+/// 2. Upsert id=1 with fresh value → new snapshot (fresh id=1) added to `protected_snapshots`,
+///    main listing table stays as-is (original snapshot with 1 expired file).
+/// 3. Execute retention delete.
+///
+/// Expected:
+/// - The expired file in the main listing table is deleted (directory emptied but kept).
+/// - Protected snapshot's fresh file preserved.
+/// - count(*) = 1, ids = [1].
+async fn test_pk_file_based_retention_empties_main_snapshot_impl(
+    fixture: TestFixture,
+) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_empty_snap";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, true).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    // Insert one expired row
+    insert_row(&table, 1, now_us - 10_000_000).await?; // 10s ago — expired
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(count_vortex_files(&dir), 1, "1 file before upsert");
+
+    // Upsert id=1 with fresh timestamp → new snapshot (fresh id=1) becomes protected,
+    // main listing table stays pointing to original snapshot with 1 expired file.
+    upsert_row(&table, 1, now_us).await?;
+
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "2 snapshots after upsert"
+    );
+    assert_eq!(count_vortex_files(&dir), 2, "2 total files after upsert");
+
+    // Execute retention delete — should remove the expired file from main listing table.
+    // The main snapshot directory stays (it's the active snapshot) but is now empty.
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(
+        deleted, 1,
+        "Should delete 1 row (expired file in main listing table)"
+    );
+
+    // Main snapshot dir is empty (0 vortex files), protected snapshot still has 1 file.
+    assert_eq!(
+        count_vortex_files(&dir),
+        1,
+        "1 file remains in protected snapshot"
+    );
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "Both snapshot dirs still exist"
+    );
+
+    let snapshots = list_snapshot_dirs(&dir);
+    let empty_snapshot_count = snapshots
+        .iter()
+        .filter(|s| count_vortex_files_in_dir(s) == 0)
+        .count();
+    assert_eq!(
+        empty_snapshot_count, 1,
+        "Main snapshot directory should be empty (no vortex files)"
+    );
+
+    assert_table_contents(&table, table_name, &[1], "Only fresh upserted row visible").await?;
+
+    Ok(())
+}
+
+/// Test: Protected snapshot with only fresh data is not touched by retention.
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: Upsert):
+/// 1. Insert id=1 (fresh).
+/// 2. Upsert id=1 (fresh) → new snapshot added to `protected_snapshots`,
+///    main listing table stays as-is. Both snapshots have fresh data.
+/// 3. Execute retention delete.
+///
+/// Expected: 0 files deleted, both snapshots intact, count(*) = 1.
+async fn test_pk_file_based_retention_fresh_snapshot_preserved_impl(
+    fixture: TestFixture,
+) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_fresh_snap";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, true).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?; // fresh
+
+    // Upsert id=1 → new (protected) snapshot has 1 fresh file, main listing table has 1 fresh file
+    upsert_row(&table, 1, now_us).await?;
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "2 snapshots after upsert"
+    );
+    assert_eq!(count_vortex_files(&dir), 2, "2 total files");
+
+    // Retention delete — nothing should be deleted
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 0, "No files should be deleted (all fresh)");
+
+    assert_eq!(count_vortex_files(&dir), 2, "Both files still exist");
+    assert_table_contents(&table, table_name, &[1], "Only id=1 visible").await?;
+
+    Ok(())
+}
+
+/// Test: Upsert after retention delete produces correct results (no ghost rows).
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: Upsert):
+/// 1. Insert id=1 (fresh), id=2 (expired).
+/// 2. Execute retention delete → deletes expired file (id=2).
+/// 3. Upsert id=1 with updated timestamp.
+///
+/// Expected: No ghost row for id=2, upsert for id=1 correct, count(*) = 1.
+async fn test_pk_file_based_retention_upsert_after_delete_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_upsert_after";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, true).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?; // fresh
+    insert_row(&table, 2, now_us - 10_000_000).await?; // 10s ago — expired
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(count_vortex_files(&dir), 2, "2 files before delete");
+
+    // Delete expired file
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 1, "Should delete 1 expired file");
+    assert_eq!(count_vortex_files(&dir), 1, "1 file after delete");
+    assert_table_contents(&table, table_name, &[1], "Only id=1 after delete").await?;
+
+    // Upsert id=1 → new snapshot (updated row) added to protected_snapshots,
+    // main listing table stays as-is.
+    upsert_row(&table, 1, now_us + 1_000_000).await?;
+
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "2 snapshots after upsert"
+    );
+    assert_table_contents(&table, table_name, &[1], "Still only id=1, no ghost id=2").await?;
+
+    Ok(())
+}
+
+/// Test: Multiple protected snapshots — expired files deleted across all directories.
+///
+/// Setup (3-second retention, Int64 PK, `on_conflict`: Upsert):
+/// 1. Insert id=1 (expired), id=2 (expired), id=3 (fresh).
+/// 2. Upsert id=1 (fresh) → new snapshot S2 added to `protected_snapshots`.
+/// 3. Upsert id=1 (fresh) again → new snapshot S3 added to `protected_snapshots`.
+///    Now: 3 snapshots. S1 (main listing table): 3 files (id=1 expired, id=2 expired, id=3 fresh).
+///    S2 (protected): 1 file (id=1 fresh). S3 (protected): 1 file (id=1 fresh).
+/// 4. Execute retention delete.
+///
+/// Expected: Expired files (id=1, id=2 in S1) deleted from main listing table. Fresh files preserved.
+/// count(*) = 2, ids = [1, 3].
+async fn test_pk_file_based_retention_multiple_protected_snapshots_impl(
+    fixture: TestFixture,
+) -> TestResult {
+    let retention_seconds = 3;
+    let table_name = "pk_file_ret_multi_snap";
+    let table = create_pk_retention_table(&fixture, table_name, retention_seconds, true).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us - 10_000_000).await?; // expired
+    insert_row(&table, 2, now_us - 10_000_000).await?; // expired
+    insert_row(&table, 3, now_us).await?; // fresh
+
+    let dir = table_id_dir(&fixture, &table, table_name);
+    assert_eq!(count_vortex_files(&dir), 3, "3 files in initial snapshot");
+
+    // First upsert: id=1 fresh → S2 (new) added to protected_snapshots, S1 stays as main
+    upsert_row(&table, 1, now_us).await?;
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        2,
+        "2 snapshots after 1st upsert"
+    );
+
+    // Second upsert: id=1 fresh → S3 (new) added to protected_snapshots, S1 stays as main
+    upsert_row(&table, 1, now_us).await?;
+    assert_eq!(
+        list_snapshot_dirs(&dir).len(),
+        3,
+        "3 snapshots after 2nd upsert"
+    );
+    assert_eq!(
+        count_vortex_files(&dir),
+        5,
+        "5 total files across 3 snapshots"
+    );
+
+    // Execute retention delete — should remove 2 expired files from S1 (main listing table)
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(
+        deleted, 2,
+        "Should delete 2 expired files from main listing table"
+    );
+
+    assert_eq!(
+        count_vortex_files(&dir),
+        3,
+        "3 files remain: 1 in S1 (id=3 fresh) + 1 in S2 (id=1) + 1 in S3 (id=1)"
+    );
+
+    assert_table_contents(
+        &table,
+        table_name,
+        &[1, 3],
+        "Expired rows removed, fresh rows preserved across snapshots",
+    )
+    .await?;
+
+    Ok(())
+}
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 
@@ -260,6 +626,52 @@ async fn create_retention_table(
         schema: Arc::clone(&schema),
         primary_key: vec![], // No PK → position-based → file-based deletes preferred
         on_conflict: None,
+        base_path: table_dir.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let retention_builder =
+        TimeRetentionFilterBuilder::try_new("event_time", retention_seconds, &schema)
+            .expect("to create retention builder");
+
+    let catalog_arc = Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    Ok(Arc::new(
+        CayenneTableProviderBuilder::new(catalog_arc)
+            .with_time_retention_filter_builder(retention_builder)
+            .create(table_options)
+            .await?,
+    ))
+}
+
+/// Create an Int64 PK table with time-based retention.
+///
+/// When `with_upsert` is true, configures `on_conflict: Upsert` so that
+/// subsequent inserts create protected snapshots.
+async fn create_pk_retention_table(
+    fixture: &TestFixture,
+    table_name: &str,
+    retention_seconds: u64,
+    with_upsert: bool,
+) -> Result<Arc<CayenneTableProvider>, Box<dyn std::error::Error>> {
+    let table_dir = fixture.data_path.join(table_name);
+    std::fs::create_dir_all(&table_dir)?;
+
+    let schema = retention_schema();
+
+    let on_conflict = if with_upsert {
+        Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string()
+        ])))
+    } else {
+        None
+    };
+
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict,
         base_path: table_dir.to_string_lossy().to_string(),
         partition_column: None,
         vortex_config: cayenne::metadata::VortexConfig::default(),
@@ -312,6 +724,23 @@ async fn insert_row(
     )?;
     let inserted = common::insert_batch(table, batch).await?;
     assert_eq!(inserted, 1, "Should insert 1 row for id={id}");
+    Ok(())
+}
+
+/// Upsert a single row — may replace an existing row (returned count can be 0).
+async fn upsert_row(
+    table: &CayenneTableProvider,
+    id: i64,
+    event_time_us: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let batch = RecordBatch::try_new(
+        retention_schema(),
+        vec![
+            Arc::new(Int64Array::from(vec![id])),
+            Arc::new(TimestampMicrosecondArray::from(vec![event_time_us]).with_timezone("UTC")),
+        ],
+    )?;
+    let _inserted = common::insert_batch(table, batch).await?;
     Ok(())
 }
 
@@ -420,6 +849,29 @@ fn count_vortex_files(table_dir: &std::path::Path) -> usize {
         }
     }
     count
+}
+
+/// List snapshot subdirectories under the table's data directory.
+fn list_snapshot_dirs(table_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let Ok(entries) = std::fs::read_dir(table_dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+/// Count `.vortex` files directly inside a single directory (not recursive).
+fn count_vortex_files_in_dir(dir: &std::path::Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "vortex"))
+        .count()
 }
 
 /// Resolve the on-disk directory containing snapshot data for a table.


### PR DESCRIPTION
## 📝 Summary

Extends file-based retention to support PK-based tables (Int64Pk, RowConverterBased). Previously, file-based retention only worked for PositionBased (no PK) tables — PK tables always fell through to the slower deletion vector path.

### Changes

- Remove `is_position_based()` gate in `file_based_deletes_preferred()` — PK tables now use file-level deletes when the filter matches retention pattern
- Scan protected snapshot directories during file-based retention — `FileBasedDeletionSink` iterates main table + all protected snapshot listing tables
- Clean up emptied protected snapshots after file deletion — clears catalog `cayenne_snapshot_sequence`, removes from in-memory `protected_snapshots` map, deletes empty snapshot data directory
- `build_protected_snapshot_listing_tables()` returns `Vec<(String, Arc<ListingTable>)>` shared by both file-based and DV-based delete paths

Write lock coordination is handled by the runtime's existing `accelerator_write_mutex`, which serializes refresh inserts and retention deletes.

### Tests

6 new PK-based retention tests covering main-only, protected snapshots, emptied snapshots, fresh snapshot preservation, upsert-after-delete, and multiple protected snapshots.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

There is also separate work item created as further improvement for PK with upserts (nice to have):
- https://github.com/spiceai/spiceai/issues/9388
