### PR TITLE
`pr-builds` tool to use binaries from CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6435,6 +6435,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console 0.16.2",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7414,9 +7426,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -14064,6 +14076,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pr-builds"
+version = "2.0.0-unstable"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dialoguer 0.12.0",
+ "dirs",
+ "flate2",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15252,7 +15280,7 @@ dependencies = [
  "arrow-flight",
  "arrow-json",
  "clap",
- "dialoguer",
+ "dialoguer 0.11.0",
  "dirs",
  "flight_client",
  "futures",
@@ -17882,7 +17910,7 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "dialoguer",
+ "dialoguer 0.11.0",
  "dirs",
  "dotenvy",
  "flate2",
@@ -23264,9 +23292,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6435,18 +6435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console 0.16.2",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14081,7 +14069,7 @@ version = "2.0.0-unstable"
 dependencies = [
  "anyhow",
  "clap",
- "dialoguer 0.12.0",
+ "dialoguer",
  "dirs",
  "flate2",
  "serde",
@@ -15280,7 +15268,7 @@ dependencies = [
  "arrow-flight",
  "arrow-json",
  "clap",
- "dialoguer 0.11.0",
+ "dialoguer",
  "dirs",
  "flight_client",
  "futures",
@@ -17910,7 +17898,7 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "dialoguer 0.11.0",
+ "dialoguer",
  "dirs",
  "dotenvy",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "tools/spicepod-validator",
     "tools/testoperator",
     "tools/parsley",
+    "tools/pr-builds"
 ]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/tools/pr-builds/Cargo.toml
+++ b/tools/pr-builds/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pr-builds"
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+dialoguer = "0.12.0"
+dirs = "6.0.0"
+flate2 = "1.1.9"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tar = "0.4.44"
+tempfile.workspace = true
+walkdir = "2.5.0"

--- a/tools/pr-builds/Cargo.toml
+++ b/tools/pr-builds/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-dialoguer = "0.12.0"
+dialoguer = "0.11.0"
 dirs = "6.0.0"
 flate2 = "1.1.9"
 serde = { workspace = true, features = ["derive"] }

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -55,6 +55,7 @@ struct Cli {
 enum Commands {
     /// Trigger a build for the current (or specified) branch.
     ///
+    /// Triggers the 'build_and_release' workflow in GitHub Actions.
     /// If an active build exists for the latest commit (SHA-based), it will be reused.
     /// If a successful build exists (for this commit), no action is taken.
     Trigger {
@@ -72,7 +73,10 @@ enum Commands {
         #[arg(short, long)]
         wait: bool,
     },
-    /// Install the latest binary for the current (or specified) branch
+    /// Install the latest binary for the current (or specified) branch.
+    ///
+    /// Downloads and installs the 'spiced' binary from the latest successful
+    /// GitHub Actions run for the branch.
     Install {
         /// Branch to install binary for. Defaults to current branch.
         #[arg(short, long)]
@@ -82,7 +86,10 @@ enum Commands {
         #[arg(short, long)]
         pr: Option<u64>,
     },
-    /// Run the binary for the current (or specified) branch
+    /// Run the binary for the current (or specified) branch.
+    ///
+    /// If the binary is not installed locally, it will be automatically downloaded
+    /// and installed from the latest successful build.
     Run {
         /// Branch to run binary for. Defaults to current branch.
         #[arg(short, long)]

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -22,6 +22,8 @@ use std::env;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tar::Archive;
@@ -39,7 +41,7 @@ struct Cli {
 enum Commands {
     /// Trigger a build for the current (or specified) branch.
     ///
-    /// Triggers the 'build_and_release' workflow in GitHub Actions.
+    /// Triggers the '`build_and_release`' workflow in GitHub Actions.
     /// If an active build exists for the latest commit (SHA-based), it will be reused.
     /// If a successful build exists (for this commit), no action is taken.
     Trigger {
@@ -105,14 +107,18 @@ struct GhPr {
     head_ref_name: String,
 }
 
+#[derive(Deserialize)]
+struct GhRepo {
+    #[serde(rename = "nameWithOwner")]
+    name_with_owner: String,
+}
+
 #[cfg(unix)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Trigger { branch, pr, wait } => {
-            trigger_build(branch.as_deref(), *pr, *wait)
-        }
+        Commands::Trigger { branch, pr, wait } => trigger_build(branch.as_deref(), *pr, *wait),
         Commands::Install { branch, pr } => install_build(branch.as_deref(), *pr),
         Commands::Run {
             branch,
@@ -135,24 +141,25 @@ fn resolve_branch_or_pr(branch: Option<&str>, pr: Option<u64>) -> Result<String>
     }
 
     if let Some(pr_num) = pr {
-        println!("Resolving PR #{} to branch...", pr_num);
+        println!("Resolving PR #{pr_num} to branch...");
         let output = Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr_num.to_string(),
-                "--json",
-                "headRefName",
-            ])
+            .args(["pr", "view", &pr_num.to_string(), "--json", "headRefName"])
             .output()
             .context("Failed to execute gh pr view")?;
 
         if !output.status.success() {
-            anyhow::bail!("Failed to resolve PR #{}: {}", pr_num, String::from_utf8_lossy(&output.stderr));
+            anyhow::bail!(
+                "Failed to resolve PR #{}: {}",
+                pr_num,
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         let pr_data: GhPr = serde_json::from_slice(&output.stdout)?;
-        println!("Resolved PR #{} to branch '{}'", pr_num, pr_data.head_ref_name);
+        println!(
+            "Resolved PR #{} to branch '{}'",
+            pr_num, pr_data.head_ref_name
+        );
         return Ok(pr_data.head_ref_name);
     }
 
@@ -188,7 +195,7 @@ fn validate_branch_name(branch: &str) -> Result<()> {
     if branch.contains("..") {
         anyhow::bail!("Branch name cannot contain '..'");
     }
-    if branch.starts_with('/') || branch.contains(":") {
+    if branch.starts_with('/') || branch.contains(':') {
         anyhow::bail!("Branch name contains invalid characters");
     }
     Ok(())
@@ -208,12 +215,6 @@ fn get_repo_owner_name() -> Result<String> {
         );
     }
 
-    #[derive(Deserialize)]
-    struct GhRepo {
-        #[serde(rename = "nameWithOwner")]
-        name_with_owner: String,
-    }
-
     let gh_repo: GhRepo =
         serde_json::from_slice(&output.stdout).context("Failed to parse gh repo view output")?;
     Ok(gh_repo.name_with_owner)
@@ -226,11 +227,11 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
     let repo_owner_name = get_repo_owner_name()?;
 
     // Get the latest commit SHA for the branch
-    println!("Fetching latest commit SHA for branch '{}'...", branch);
+    println!("Fetching latest commit SHA for branch '{branch}'...");
     let output = Command::new("gh")
         .args([
             "api",
-            &format!("repos/{}/branches/{}", repo_owner_name, branch),
+            &format!("repos/{repo_owner_name}/branches/{branch}"),
             "--jq",
             ".commit.sha",
         ])
@@ -238,11 +239,14 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         .context("Failed to fetch branch SHA")?;
 
     if !output.status.success() {
-        anyhow::bail!("Failed to get branch SHA: {}", String::from_utf8_lossy(&output.stderr));
+        anyhow::bail!(
+            "Failed to get branch SHA: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     let latest_sha = String::from_utf8(output.stdout)?.trim().to_string();
-    println!("Latest SHA: {}", latest_sha);
+    println!("Latest SHA: {latest_sha}");
 
     // Check for existing runs for this SHA
     println!("Checking for existing builds for this SHA...");
@@ -268,33 +272,37 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
     if output.status.success() {
         let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
         for run in runs {
-            if let Some(id) = run["databaseId"].as_u64() {
-                if id > max_seen_id {
-                    max_seen_id = id;
-                }
+            if let Some(id) = run["databaseId"].as_u64()
+                && id > max_seen_id
+            {
+                max_seen_id = id;
             }
 
-            if let Some(run_sha) = run["headSha"].as_str() {
-                if run_sha == latest_sha {
-                    // Found a run for the same SHA
-                    let status = run["status"].as_str().unwrap_or("");
-                    let conclusion = run["conclusion"].as_str().unwrap_or("");
-                    let id = run["databaseId"].as_u64();
+            if let Some(run_sha) = run["headSha"].as_str()
+                && run_sha == latest_sha
+            {
+                // Found a run for the same SHA
+                let status = run["status"].as_str().unwrap_or("");
+                let conclusion = run["conclusion"].as_str().unwrap_or("");
+                let id = run["databaseId"].as_u64();
 
-                    if let Some(id) = id {
-                        if status == "completed" && conclusion == "success" {
-                            println!("Found successful build for this SHA (Run ID: {}). No need to trigger.", id);
-                            return Ok(());
-                        } else if status != "completed" {
-                             println!("Found active build for this SHA (Run ID: {}). Reusing it.", id);
-                             existing_run_id = Some(id);
-                             break;
-                        } else {
-                            println!("Found failed/cancelled build for this SHA (Run ID: {}). Retrying...", id);
-                            // If failed, we probably want to trigger a new one, so continue loop or stop?
-                            // Default behavior: trigger new if latest is failed.
-                        }
+                if let Some(id) = id {
+                    if status == "completed" && conclusion == "success" {
+                        println!(
+                            "Found successful build for this SHA (Run ID: {id}). No need to trigger.",
+                        );
+                        return Ok(());
+                    } else if status != "completed" {
+                        println!("Found active build for this SHA (Run ID: {id}). Reusing it.",);
+                        existing_run_id = Some(id);
+                        break;
                     }
+
+                    println!(
+                        "Found failed/cancelled build for this SHA (Run ID: {id}). Retrying...",
+                    );
+                    // If failed, we probably want to trigger a new one, so continue loop or stop?
+                    // Default behavior: trigger new if latest is failed.
                 }
             }
         }
@@ -319,15 +327,13 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
                 }
                 (other_os, other_arch) => {
                     anyhow::bail!(
-                        "Failed to determine build platform for OS {} and architecture {}: Unsupported combination for build_and_release workflow. Supported combinations are: linux/aarch64, linux/x86_64, macos/aarch64.",
-                        other_os,
-                        other_arch
+                        "Failed to determine build platform for OS {other_os} and architecture {other_arch}: Unsupported combination for build_and_release workflow. Supported combinations are: linux/aarch64, linux/x86_64, macos/aarch64.",
                     );
                 }
             }
         };
 
-        println!("Requesting platform: {}", platform_option);
+        println!("Requesting platform: {platform_option}");
 
         let status = Command::new("gh")
             .args([
@@ -337,7 +343,7 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
                 "--ref",
                 &branch,
                 "-f",
-                &format!("platform_option={}", platform_option),
+                &format!("platform_option={platform_option}"),
             ])
             .status()
             .context("Failed to execute gh workflow run")?;
@@ -349,12 +355,9 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         println!("Build triggered successfully.");
 
         if !wait {
-             println!("You can check the status with:");
-             println!(
-                 "  gh run list --workflow build_and_release.yml --branch \"{}\"",
-                 branch
-             );
-             return Ok(());
+            println!("You can check the status with:");
+            println!("  gh run list --workflow build_and_release.yml --branch \"{branch}\"",);
+            return Ok(());
         }
 
         println!("Waiting for build to start...");
@@ -384,26 +387,32 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
             if output.status.success() {
                 let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
                 if let Some(run) = runs.first() {
-                     let status = run["status"].as_str().unwrap_or("");
-                     let run_sha = run["headSha"].as_str().unwrap_or("");
-                     let id = run["databaseId"].as_u64();
+                    let status = run["status"].as_str().unwrap_or("");
+                    let run_sha = run["headSha"].as_str().unwrap_or("");
+                    let id = run["databaseId"].as_u64();
 
-                     // Ensure we picked up a run for the correct SHA that is active and NEW (id > max_seen_id)
-                     if let Some(id) = id {
-                         if id > max_seen_id && (status == "queued" || status == "in_progress" || status == "requested" || status == "waiting") && run_sha == latest_sha {
-                             found_new_run_id = Some(id);
-                             break;
-                         }
-                     }
+                    // Ensure we picked up a run for the correct SHA that is active and NEW (id > max_seen_id)
+                    if let Some(id) = id
+                        && id > max_seen_id
+                        && (status == "queued"
+                            || status == "in_progress"
+                            || status == "requested"
+                            || status == "waiting")
+                        && run_sha == latest_sha
+                    {
+                        found_new_run_id = Some(id);
+                        break;
+                    }
                 }
             }
         }
 
-        found_new_run_id.context("Could not find the newly triggered run (or it completed instantly).")?
+        found_new_run_id
+            .context("Could not find the newly triggered run (or it completed instantly).")?
     };
 
     if wait {
-        println!("Waiting for Run ID: {}...", run_id_to_watch);
+        println!("Waiting for Run ID: {run_id_to_watch}...");
         let status = Command::new("gh")
             .args(["run", "watch", &run_id_to_watch.to_string()])
             .status()
@@ -428,8 +437,7 @@ fn get_artifact_names() -> Result<Vec<String>> {
         // Fallback/Default
         other => {
             anyhow::bail!(
-                "Unsupported OS '{}' for PR build artifacts; only 'macos' and 'linux' are supported",
-                other
+                "Unsupported OS '{other}' for PR build artifacts; only 'macos' and 'linux' are supported",
             );
         }
     };
@@ -437,9 +445,9 @@ fn get_artifact_names() -> Result<Vec<String>> {
     // Prioritize metal for darwin
     let mut names = Vec::new();
     if os == "darwin" {
-        names.push(format!("spiced_metal_{}_{}", os, arch));
+        names.push(format!("spiced_metal_{os}_{arch}"));
     }
-    names.push(format!("spiced_{}_{}", os, arch));
+    names.push(format!("spiced_{os}_{arch}"));
 
     Ok(names)
 }
@@ -465,7 +473,7 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
         .join(".spice/bin")
         .join(&branch);
 
-    println!("Looking for latest successful build for branch: {}...", branch);
+    println!("Looking for latest successful build for branch: {branch}...",);
 
     let output = Command::new("gh")
         .args([
@@ -493,20 +501,19 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
     }
 
     let runs: Vec<GhRun> = serde_json::from_slice(&output.stdout)?;
-    let run = runs.first().context(format!(
-        "No successful build found for branch '{}'",
-        branch
-    ))?;
+    let run = runs
+        .first()
+        .context(format!("No successful build found for branch '{branch}'"))?;
     let run_id = run.database_id;
 
-    println!("Found Run ID: {}", run_id);
+    println!("Found Run ID: {run_id}");
 
     // List artifacts for the run to check which one exists
     println!("Checking available artifacts...");
     let output = Command::new("gh")
         .args([
             "api",
-            &format!("repos/{}/actions/runs/{}/artifacts", repo_owner_name, run_id),
+            &format!("repos/{repo_owner_name}/actions/runs/{run_id}/artifacts",),
         ])
         .output()
         .context("Failed to fetch artifacts list")?;
@@ -567,11 +574,11 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
     for entry in fs::read_dir(temp_path)? {
         let entry = entry?;
         let path = entry.path();
-        if let Some(ext) = path.extension() {
-            if ext == "gz" {
-                tar_file = Some(path);
-                break;
-            }
+        if let Some(ext) = path.extension()
+            && ext == "gz"
+        {
+            tar_file = Some(path);
+            break;
         }
     }
 
@@ -611,10 +618,10 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
     // Rename might fail if cross-device link (EXDEV), so we try copy+remove as fallback
     if let Err(e) = fs::rename(&temp_target, &target_binary) {
         if e.kind() == std::io::ErrorKind::CrossesDevices {
-             fs::copy(&temp_target, &target_binary)?;
-             let _ = fs::remove_file(&temp_target);
+            fs::copy(&temp_target, &target_binary)?;
+            let _ = fs::remove_file(&temp_target);
         } else {
-             return Err(e.into());
+            return Err(e.into());
         }
     }
 
@@ -637,13 +644,21 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
         symlink_path.display(),
         target_binary.display()
     );
-    println!("You can now run it comfortably via: {}", symlink_path.display());
+    println!(
+        "You can now run it comfortably via: {}",
+        symlink_path.display()
+    );
 
     Ok(())
 }
 
 #[cfg(unix)]
-fn run_build(branch: Option<&str>, pr: Option<u64>, interactive: bool, args: &[String]) -> Result<()> {
+fn run_build(
+    branch: Option<&str>,
+    pr: Option<u64>,
+    interactive: bool,
+    args: &[String],
+) -> Result<()> {
     let branch = if interactive {
         select_branch()?
     } else {
@@ -665,15 +680,14 @@ fn run_build(branch: Option<&str>, pr: Option<u64>, interactive: bool, args: &[S
         install_build(Some(&branch), None)?;
     }
 
-    println!("Running spiced from branch '{}'...", branch);
+    println!("Running spiced from branch '{branch}'...");
     println!("Exec: {} {}", binary_path.display(), args.join(" "));
 
     // Replace the current process with spiced (Unix only)
-    use std::os::unix::process::CommandExt;
     let error = Command::new(&binary_path).args(args).exec();
 
     // If we're here, exec failed
-    anyhow::bail!("Failed to execute spiced: {}", error);
+    anyhow::bail!("Failed to execute spiced: {error}");
 }
 
 #[cfg(unix)]
@@ -691,18 +705,18 @@ fn select_branch() -> Result<String> {
     // Walk directory to find all 'spiced' binaries
     for entry in WalkDir::new(&base_dir).min_depth(1) {
         let entry = entry.ok();
-        if let Some(entry) = entry {
-            if entry.file_type().is_file() && entry.file_name() == "spiced" {
-                // Found a spiced binary, the parent dir is the branch path
-                if let Some(branch_dir) = entry.path().parent() {
-                    // Get relative path from base_dir to get the branch name
-                    if let Ok(rel_path) = branch_dir.strip_prefix(&base_dir) {
-                        if let Some(branch_name) = rel_path.to_str() {
-                            if !branch_name.is_empty() {
-                                branches.push(branch_name.to_string());
-                            }
-                        }
-                    }
+        if let Some(entry) = entry
+            && entry.file_type().is_file()
+            && entry.file_name() == "spiced"
+        {
+            // Found a spiced binary, the parent dir is the branch path
+            if let Some(branch_dir) = entry.path().parent() {
+                // Get relative path from base_dir to get the branch name
+                if let Ok(rel_path) = branch_dir.strip_prefix(&base_dir)
+                    && let Some(branch_name) = rel_path.to_str()
+                    && !branch_name.is_empty()
+                {
+                    branches.push(branch_name.to_string());
                 }
             }
         }

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -53,7 +53,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Trigger a build for the current (or specified) branch
+    /// Trigger a build for the current (or specified) branch.
+    ///
+    /// If an active build exists for the latest commit, it will be reused.
+    /// If a successful build exists, no action is taken.
     Trigger {
         /// Branch to trigger build for. Defaults to current branch.
         #[arg(short, long)]
@@ -63,7 +66,9 @@ enum Commands {
         #[arg(short, long)]
         pr: Option<u64>,
 
-        /// Wait for the build to complete
+        /// Wait for the build to complete.
+        ///
+        /// If an existing build is reused, this will wait for that build.
         #[arg(short, long)]
         wait: bool,
     },

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -55,8 +55,8 @@ struct Cli {
 enum Commands {
     /// Trigger a build for the current (or specified) branch.
     ///
-    /// If an active build exists for the latest commit, it will be reused.
-    /// If a successful build exists, no action is taken.
+    /// If an active build exists for the latest commit (SHA-based), it will be reused.
+    /// If a successful build exists (for this commit), no action is taken.
     Trigger {
         /// Branch to trigger build for. Defaults to current branch.
         #[arg(short, long)]
@@ -266,7 +266,7 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         id
     } else {
         println!("No active build found for latest SHA. Triggering new build...");
-        
+
         let platform_option = match env::consts::OS {
             "linux" => match env::consts::ARCH {
                 "aarch64" => "Linux aarch64",
@@ -294,9 +294,9 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         if !status.success() {
             anyhow::bail!("Failed to trigger build");
         }
-        
+
         println!("Build triggered successfully.");
-        
+
         if !wait {
              println!("You can check the status with:");
              println!(
@@ -307,13 +307,13 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         }
 
         println!("Waiting for build to start...");
-        
+
         let mut found_new_run_id: Option<u64> = None;
-        
+
         // Poll for up to 30 seconds to find the new run
         for _ in 0..10 {
             std::thread::sleep(std::time::Duration::from_secs(3));
-            
+
             let output = Command::new("gh")
                 .args([
                     "run",
@@ -335,7 +335,7 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
                 if let Some(run) = runs.first() {
                      let status = run["status"].as_str().unwrap_or("");
                      let run_sha = run["headSha"].as_str().unwrap_or("");
-                     
+
                      // Ensure we picked up a run for the correct SHA that is active
                      if (status == "queued" || status == "in_progress" || status == "requested" || status == "waiting") && run_sha == latest_sha {
                          found_new_run_id = run["databaseId"].as_u64();
@@ -344,7 +344,7 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
                 }
             }
         }
-        
+
         found_new_run_id.context("Could not find the newly triggered run (or it completed instantly).")?
     };
 
@@ -354,7 +354,7 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
             .args(["run", "watch", &run_id_to_watch.to_string()])
             .status()
             .context("Failed to watch run")?;
-        
+
         if status.success() {
             println!("Build completed successfully!");
         } else {

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -1,9 +1,42 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 use std::env;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -54,6 +87,7 @@ struct GhRun {
     database_id: u64,
 }
 
+#[cfg(unix)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -68,6 +102,12 @@ fn main() -> Result<()> {
     }
 }
 
+#[cfg(not(unix))]
+fn main() -> Result<()> {
+    anyhow::bail!("This tool is currently only supported on Unix-like systems.");
+}
+
+#[cfg(unix)]
 fn get_current_branch() -> Result<String> {
     let output = Command::new("git")
         .args(["branch", "--show-current"])
@@ -158,6 +198,17 @@ fn get_artifact_names() -> Vec<String> {
     names
 }
 
+#[derive(Deserialize, Debug)]
+struct Artifact {
+    name: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ArtifactList {
+    artifacts: Vec<Artifact>,
+}
+
+#[cfg(unix)]
 fn install_build(branch: Option<&str>) -> Result<()> {
     let branch = match branch {
         Some(b) => b.to_string(),
@@ -205,47 +256,59 @@ fn install_build(branch: Option<&str>) -> Result<()> {
 
     println!("Found Run ID: {}", run_id);
 
+    // List artifacts for the run to check which one exists
+    println!("Checking available artifacts...");
+    let output = Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/spiceai/spiceai/actions/runs/{}/artifacts", run_id),
+        ])
+        .output()
+        .context("Failed to fetch artifacts list")?;
+
+    if !output.status.success() {
+        anyhow::bail!("Failed to list artifacts");
+    }
+
+    let artifact_list: ArtifactList = serde_json::from_slice(&output.stdout)?;
+    let available_artifacts: Vec<String> = artifact_list
+        .artifacts
+        .into_iter()
+        .map(|a| a.name)
+        .collect();
+
+    let wanted_artifacts = get_artifact_names();
+    let artifact_to_download = wanted_artifacts
+        .iter()
+        .find(|name| available_artifacts.contains(name))
+        .context("No compatible artifact found in this build")?;
+
     let temp_dir = tempfile::tempdir()?;
     let temp_path = temp_dir.path();
 
-    println!("Downloading artifact to {}...", temp_path.display());
+    println!(
+        "Downloading artifact '{}' to {}...",
+        artifact_to_download,
+        temp_path.display()
+    );
 
-    let artifacts = get_artifact_names();
-    let mut downloaded = false;
+    let status = Command::new("gh")
+        .args([
+            "run",
+            "download",
+            &run_id.to_string(),
+            "-n",
+            artifact_to_download,
+            "-D",
+        ])
+        .arg(temp_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("Failed to execute gh run download")?;
 
-    for artifact_name in &artifacts {
-        println!("Attempting to download artifact: {}", artifact_name);
-        // Using temp_path to convert to string safely
-        let temp_path_str = temp_path
-            .to_str()
-            .context("Temp path contains invalid UTF-8")?;
-
-        let status = Command::new("gh")
-            .args([
-                "run",
-                "download",
-                &run_id.to_string(),
-                "-n",
-                artifact_name,
-                "-D",
-                temp_path_str,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::inherit())
-            .status()
-            .context("Failed to execute gh run download")?;
-
-        if status.success() {
-            downloaded = true;
-            break;
-        }
-    }
-
-    if !downloaded {
-        anyhow::bail!(
-            "Failed to download any compatible artifacts. Tried: {:?}",
-            artifacts
-        );
+    if !status.success() {
+        anyhow::bail!("Failed to download artifact");
     }
 
     println!("Installing to {}...", target_dir.display());
@@ -256,7 +319,6 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     for entry in fs::read_dir(temp_path)? {
         let entry = entry?;
         let path = entry.path();
-        // Check for extension safely
         if let Some(ext) = path.extension() {
             if ext == "gz" {
                 tar_file = Some(path);
@@ -267,34 +329,46 @@ fn install_build(branch: Option<&str>) -> Result<()> {
 
     let tar_file = tar_file.context("No tar.gz file found in downloaded artifact")?;
 
-    // Extract
+    // Extract directly to target location
     let tar_gz = fs::File::open(&tar_file)?;
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);
-    archive.unpack(temp_path)?;
 
-    // Find binary
-    let spiced_path = temp_path.join("spiced");
-    if !spiced_path.exists() {
-        anyhow::bail!(
-            "Could not find 'spiced' binary in extracted archive at {}",
-            spiced_path.display()
-        );
+    // Use a temp file in the target directory for extraction
+    let temp_target = target_dir.join("spiced.tmp");
+    let mut found_binary = false;
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        if path.ends_with("spiced") {
+            println!("Extracting binary to {}...", temp_target.display());
+            entry.unpack(&temp_target)?;
+            found_binary = true;
+            break;
+        }
+    }
+
+    if !found_binary {
+        anyhow::bail!("Could not find 'spiced' binary in archive");
     }
 
     let target_binary = target_dir.join("spiced");
-    // Rename might fail if cross-device link, but unlikely for temp to home usually on same mount or different.
-    // fs::rename is atomic but platform specific. If it fails, we might need copy+delete.
-    // For now, assuming fs::rename works or fails loudly.
-    if target_binary.exists() {
-        fs::remove_file(&target_binary)?;
-    }
-    fs::rename(&spiced_path, &target_binary)?;
 
-    // Make executable
-    let mut perms = fs::metadata(&target_binary)?.permissions();
+    // Make executable before rename
+    let mut perms = fs::metadata(&temp_target)?.permissions();
     perms.set_mode(0o755);
-    fs::set_permissions(&target_binary, perms)?;
+    fs::set_permissions(&temp_target, perms)?;
+
+    // Rename might fail if cross-device link (EXDEV), so we try copy+remove as fallback
+    if let Err(e) = fs::rename(&temp_target, &target_binary) {
+        if e.kind() == std::io::ErrorKind::CrossesDevices {
+             fs::copy(&temp_target, &target_binary)?;
+             let _ = fs::remove_file(&temp_target);
+        } else {
+             return Err(e.into());
+        }
+    }
 
     println!("Installed spiced to {}", target_binary.display());
 
@@ -320,6 +394,7 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result<()> {
     let branch = if interactive {
         select_branch()?
@@ -355,6 +430,7 @@ fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result
     anyhow::bail!("Failed to execute spiced: {}", error);
 }
 
+#[cfg(unix)]
 fn select_branch() -> Result<String> {
     let base_dir = dirs::home_dir()
         .context("Could not find home directory")?

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -58,18 +58,34 @@ enum Commands {
         /// Branch to trigger build for. Defaults to current branch.
         #[arg(short, long)]
         branch: Option<String>,
+
+        /// PR number to resolve to a branch.
+        #[arg(short, long)]
+        pr: Option<u64>,
+
+        /// Wait for the build to complete
+        #[arg(short, long)]
+        wait: bool,
     },
     /// Install the latest binary for the current (or specified) branch
     Install {
         /// Branch to install binary for. Defaults to current branch.
         #[arg(short, long)]
         branch: Option<String>,
+
+        /// PR number to resolve to a branch.
+        #[arg(short, long)]
+        pr: Option<u64>,
     },
     /// Run the binary for the current (or specified) branch
     Run {
         /// Branch to run binary for. Defaults to current branch.
         #[arg(short, long)]
         branch: Option<String>,
+
+        /// PR number to resolve to a branch.
+        #[arg(short, long)]
+        pr: Option<u64>,
 
         /// Interactive mode: select a branch from installed binaries
         #[arg(short, long)]
@@ -87,24 +103,64 @@ struct GhRun {
     database_id: u64,
 }
 
+#[derive(Deserialize, Debug)]
+struct GhPr {
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+}
+
 #[cfg(unix)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Trigger { branch } => trigger_build(branch.as_deref()),
-        Commands::Install { branch } => install_build(branch.as_deref()),
+        Commands::Trigger { branch, pr, wait } => {
+            trigger_build(branch.as_deref(), *pr, *wait)
+        }
+        Commands::Install { branch, pr } => install_build(branch.as_deref(), *pr),
         Commands::Run {
             branch,
+            pr,
             interactive,
             args,
-        } => run_build(branch.as_deref(), *interactive, args),
+        } => run_build(branch.as_deref(), *pr, *interactive, args),
     }
 }
 
 #[cfg(not(unix))]
 fn main() -> Result<()> {
     anyhow::bail!("This tool is currently only supported on Unix-like systems.");
+}
+
+#[cfg(unix)]
+fn resolve_branch_or_pr(branch: Option<&str>, pr: Option<u64>) -> Result<String> {
+    if let Some(b) = branch {
+        return Ok(b.to_string());
+    }
+
+    if let Some(pr_num) = pr {
+        println!("Resolving PR #{} to branch...", pr_num);
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_num.to_string(),
+                "--json",
+                "headRefName",
+            ])
+            .output()
+            .context("Failed to execute gh pr view")?;
+
+        if !output.status.success() {
+            anyhow::bail!("Failed to resolve PR #{}: {}", pr_num, String::from_utf8_lossy(&output.stderr));
+        }
+
+        let pr_data: GhPr = serde_json::from_slice(&output.stdout)?;
+        println!("Resolved PR #{} to branch '{}'", pr_num, pr_data.head_ref_name);
+        return Ok(pr_data.head_ref_name);
+    }
+
+    get_current_branch()
 }
 
 #[cfg(unix)]
@@ -129,11 +185,9 @@ fn get_current_branch() -> Result<String> {
     Ok(branch)
 }
 
-fn trigger_build(branch: Option<&str>) -> Result<()> {
-    let branch = match branch {
-        Some(b) => b.to_string(),
-        None => get_current_branch()?,
-    };
+#[cfg(unix)]
+fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()> {
+    let branch = resolve_branch_or_pr(branch, pr)?;
 
     println!("Triggering build for branch: {}...", branch);
 
@@ -166,11 +220,84 @@ fn trigger_build(branch: Option<&str>) -> Result<()> {
 
     if status.success() {
         println!("Build triggered successfully.");
-        println!("You can check the status with:");
-        println!(
-            "  gh run list --workflow build_and_release.yml --branch \"{}\"",
-            branch
-        );
+        
+        if wait {
+            println!("Waiting for build to start...");
+            
+            // We need to find the run that was just created.
+            // Since we just triggered it, it should be the newest one (created very recently).
+            // We'll poll for a short period to find a run created *after* we started.
+            // But 'gh run list' doesn't let us filter by exact time easily, just order.
+            // The previous code failed because it picked up an OLD run (already completed).
+            
+            let mut found_run_id: Option<u64> = None;
+            
+            // Poll for up to 30 seconds to find the new run
+            for _ in 0..10 {
+                std::thread::sleep(std::time::Duration::from_secs(3));
+                
+                let output = Command::new("gh")
+                    .args([
+                        "run",
+                        "list",
+                        "--workflow",
+                        "build_and_release.yml",
+                        "--branch",
+                        &branch,
+                        "--limit",
+                        "1",
+                        "--json",
+                        "databaseId,status,createdAt",
+                    ])
+                    .output()
+                    .context("Failed to fetch latest run ID")?;
+
+                if output.status.success() {
+                    let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
+                    if let Some(run) = runs.first() {
+                         // Check if this run is actually new (e.g. in_progress or queued, or created just now)
+                         // A simple heuristic: if it's "completed" and we just triggered it, it's probably the OLD one.
+                         // unless our build is instant (unlikely).
+                         // Better: check status != completed, OR check createdAt is recent.
+                         // For now, let's rely on status. If we just triggered it, it shouldn't be completed yet.
+                         
+                         let status = run["status"].as_str().unwrap_or("");
+                         // let created_at = run["createdAt"].as_str().unwrap_or("");
+                         
+                         if status == "queued" || status == "in_progress" || status == "requested" || status == "waiting" {
+                             found_run_id = run["databaseId"].as_u64();
+                             break;
+                         }
+                    }
+                }
+            }
+
+            if let Some(run_id) = found_run_id {
+                println!("Waiting for Run ID: {}...", run_id);
+                let status = Command::new("gh")
+                    .args(["run", "watch", &run_id.to_string()])
+                    .status()
+                    .context("Failed to watch run")?;
+                
+                if status.success() {
+                    println!("Build completed successfully!");
+                } else {
+                    anyhow::bail!("Build failed or was cancelled.");
+                }
+            } else {
+                 println!("Warning: Could not find the new run ID (or it completed instantly). You'll need to check manually.");
+                 println!(
+                     "  gh run list --workflow build_and_release.yml --branch \"{}\"",
+                     branch
+                 );
+            }
+        } else {
+             println!("You can check the status with:");
+             println!(
+                 "  gh run list --workflow build_and_release.yml --branch \"{}\"",
+                 branch
+             );
+        }
     } else {
         anyhow::bail!("Failed to trigger build");
     }
@@ -209,11 +336,8 @@ struct ArtifactList {
 }
 
 #[cfg(unix)]
-fn install_build(branch: Option<&str>) -> Result<()> {
-    let branch = match branch {
-        Some(b) => b.to_string(),
-        None => get_current_branch()?,
-    };
+fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
+    let branch = resolve_branch_or_pr(branch, pr)?;
 
     let target_dir = dirs::home_dir()
         .context("Could not find home directory")?
@@ -395,14 +519,11 @@ fn install_build(branch: Option<&str>) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result<()> {
+fn run_build(branch: Option<&str>, pr: Option<u64>, interactive: bool, args: &[String]) -> Result<()> {
     let branch = if interactive {
         select_branch()?
     } else {
-        match branch {
-            Some(b) => b.to_string(),
-            None => get_current_branch()?,
-        }
+        resolve_branch_or_pr(branch, pr)?
     };
 
     let binary_path = dirs::home_dir()
@@ -416,7 +537,7 @@ fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result
             "Binary not found at {}. Installing...",
             binary_path.display()
         );
-        install_build(Some(&branch))?;
+        install_build(Some(&branch), None)?;
     }
 
     println!("Running spiced from branch '{}'...", branch);

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -189,117 +189,172 @@ fn get_current_branch() -> Result<String> {
 fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()> {
     let branch = resolve_branch_or_pr(branch, pr)?;
 
-    println!("Triggering build for branch: {}...", branch);
-
-    // Determine platform option based on current OS and Arch
-    let platform_option = match env::consts::OS {
-        "linux" => match env::consts::ARCH {
-            "aarch64" => "Linux aarch64",
-            _ => "Linux x64",
-        },
-        // Only Apple Silicon is supported for macOS in the CI matrix
-        "macos" => "macOS aarch64 (Apple Silicon)",
-        // Fallback for others
-        _ => "Linux x64",
-    };
-
-    println!("Requesting platform: {}", platform_option);
-
-    let status = Command::new("gh")
+    // Get the latest commit SHA for the branch
+    println!("Fetching latest commit SHA for branch '{}'...", branch);
+    let output = Command::new("gh")
         .args([
-            "workflow",
-            "run",
-            "build_and_release.yml",
-            "--ref",
-            &branch,
-            "-f",
-            &format!("platform_option={}", platform_option),
+            "api",
+            &format!("repos/spiceai/spiceai/branches/{}", branch),
+            "--jq",
+            ".commit.sha",
         ])
-        .status()
-        .context("Failed to execute gh workflow run")?;
+        .output()
+        .context("Failed to fetch branch SHA")?;
 
-    if status.success() {
-        println!("Build triggered successfully.");
-        
-        if wait {
-            println!("Waiting for build to start...");
-            
-            // We need to find the run that was just created.
-            // Since we just triggered it, it should be the newest one (created very recently).
-            // We'll poll for a short period to find a run created *after* we started.
-            // But 'gh run list' doesn't let us filter by exact time easily, just order.
-            // The previous code failed because it picked up an OLD run (already completed).
-            
-            let mut found_run_id: Option<u64> = None;
-            
-            // Poll for up to 30 seconds to find the new run
-            for _ in 0..10 {
-                std::thread::sleep(std::time::Duration::from_secs(3));
-                
-                let output = Command::new("gh")
-                    .args([
-                        "run",
-                        "list",
-                        "--workflow",
-                        "build_and_release.yml",
-                        "--branch",
-                        &branch,
-                        "--limit",
-                        "1",
-                        "--json",
-                        "databaseId,status,createdAt",
-                    ])
-                    .output()
-                    .context("Failed to fetch latest run ID")?;
+    if !output.status.success() {
+        anyhow::bail!("Failed to get branch SHA: {}", String::from_utf8_lossy(&output.stderr));
+    }
 
-                if output.status.success() {
-                    let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
-                    if let Some(run) = runs.first() {
-                         // Check if this run is actually new (e.g. in_progress or queued, or created just now)
-                         // A simple heuristic: if it's "completed" and we just triggered it, it's probably the OLD one.
-                         // unless our build is instant (unlikely).
-                         // Better: check status != completed, OR check createdAt is recent.
-                         // For now, let's rely on status. If we just triggered it, it shouldn't be completed yet.
-                         
-                         let status = run["status"].as_str().unwrap_or("");
-                         // let created_at = run["createdAt"].as_str().unwrap_or("");
-                         
-                         if status == "queued" || status == "in_progress" || status == "requested" || status == "waiting" {
-                             found_run_id = run["databaseId"].as_u64();
+    let latest_sha = String::from_utf8(output.stdout)?.trim().to_string();
+    println!("Latest SHA: {}", latest_sha);
+
+    // Check for existing runs for this SHA
+    println!("Checking for existing builds for this SHA...");
+    let output = Command::new("gh")
+        .args([
+            "run",
+            "list",
+            "--workflow",
+            "build_and_release.yml",
+            "--branch",
+            &branch,
+            "--limit",
+            "5", // Check a few recent runs
+            "--json",
+            "databaseId,headSha,status,conclusion",
+        ])
+        .output()
+        .context("Failed to list recent runs")?;
+
+    let mut existing_run_id: Option<u64> = None;
+
+    if output.status.success() {
+        let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
+        for run in runs {
+            if let Some(run_sha) = run["headSha"].as_str() {
+                if run_sha == latest_sha {
+                    // Found a run for the same SHA
+                    let status = run["status"].as_str().unwrap_or("");
+                    let conclusion = run["conclusion"].as_str().unwrap_or("");
+                    let id = run["databaseId"].as_u64();
+
+                    if let Some(id) = id {
+                        if status == "completed" && conclusion == "success" {
+                            println!("Found successful build for this SHA (Run ID: {}). No need to trigger.", id);
+                            return Ok(());
+                        } else if status != "completed" {
+                             println!("Found active build for this SHA (Run ID: {}). Reusing it.", id);
+                             existing_run_id = Some(id);
                              break;
-                         }
+                        } else {
+                            println!("Found failed/cancelled build for this SHA (Run ID: {}). Retrying...", id);
+                            // If failed, we probably want to trigger a new one, so continue loop or stop?
+                            // Default behavior: trigger new if latest is failed.
+                        }
                     }
                 }
             }
+        }
+    }
 
-            if let Some(run_id) = found_run_id {
-                println!("Waiting for Run ID: {}...", run_id);
-                let status = Command::new("gh")
-                    .args(["run", "watch", &run_id.to_string()])
-                    .status()
-                    .context("Failed to watch run")?;
-                
-                if status.success() {
-                    println!("Build completed successfully!");
-                } else {
-                    anyhow::bail!("Build failed or was cancelled.");
-                }
-            } else {
-                 println!("Warning: Could not find the new run ID (or it completed instantly). You'll need to check manually.");
-                 println!(
-                     "  gh run list --workflow build_and_release.yml --branch \"{}\"",
-                     branch
-                 );
-            }
-        } else {
+    let run_id_to_watch = if let Some(id) = existing_run_id {
+        id
+    } else {
+        println!("No active build found for latest SHA. Triggering new build...");
+        
+        let platform_option = match env::consts::OS {
+            "linux" => match env::consts::ARCH {
+                "aarch64" => "Linux aarch64",
+                _ => "Linux x64",
+            },
+            "macos" => "macOS aarch64 (Apple Silicon)",
+            _ => "Linux x64",
+        };
+
+        println!("Requesting platform: {}", platform_option);
+
+        let status = Command::new("gh")
+            .args([
+                "workflow",
+                "run",
+                "build_and_release.yml",
+                "--ref",
+                &branch,
+                "-f",
+                &format!("platform_option={}", platform_option),
+            ])
+            .status()
+            .context("Failed to execute gh workflow run")?;
+
+        if !status.success() {
+            anyhow::bail!("Failed to trigger build");
+        }
+        
+        println!("Build triggered successfully.");
+        
+        if !wait {
              println!("You can check the status with:");
              println!(
                  "  gh run list --workflow build_and_release.yml --branch \"{}\"",
                  branch
              );
+             return Ok(());
         }
-    } else {
-        anyhow::bail!("Failed to trigger build");
+
+        println!("Waiting for build to start...");
+        
+        let mut found_new_run_id: Option<u64> = None;
+        
+        // Poll for up to 30 seconds to find the new run
+        for _ in 0..10 {
+            std::thread::sleep(std::time::Duration::from_secs(3));
+            
+            let output = Command::new("gh")
+                .args([
+                    "run",
+                    "list",
+                    "--workflow",
+                    "build_and_release.yml",
+                    "--branch",
+                    &branch,
+                    "--limit",
+                    "1",
+                    "--json",
+                    "databaseId,status,createdAt,headSha",
+                ])
+                .output()
+                .context("Failed to fetch latest run ID")?;
+
+            if output.status.success() {
+                let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
+                if let Some(run) = runs.first() {
+                     let status = run["status"].as_str().unwrap_or("");
+                     let run_sha = run["headSha"].as_str().unwrap_or("");
+                     
+                     // Ensure we picked up a run for the correct SHA that is active
+                     if (status == "queued" || status == "in_progress" || status == "requested" || status == "waiting") && run_sha == latest_sha {
+                         found_new_run_id = run["databaseId"].as_u64();
+                         break;
+                     }
+                }
+            }
+        }
+        
+        found_new_run_id.context("Could not find the newly triggered run (or it completed instantly).")?
+    };
+
+    if wait {
+        println!("Waiting for Run ID: {}...", run_id_to_watch);
+        let status = Command::new("gh")
+            .args(["run", "watch", &run_id_to_watch.to_string()])
+            .status()
+            .context("Failed to watch run")?;
+        
+        if status.success() {
+            println!("Build completed successfully!");
+        } else {
+            anyhow::bail!("Build failed or was cancelled.");
+        }
     }
 
     Ok(())

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -1,0 +1,334 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tar::Archive;
+use walkdir::WalkDir;
+
+#[derive(Parser)]
+#[command(name = "pr-builds")]
+#[command(about = "Manage PR builds for Spice.ai", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Trigger a build for the current (or specified) branch
+    Trigger {
+        /// Branch to trigger build for. Defaults to current branch.
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Install the latest binary for the current (or specified) branch
+    Install {
+        /// Branch to install binary for. Defaults to current branch.
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Run the binary for the current (or specified) branch
+    Run {
+        /// Branch to run binary for. Defaults to current branch.
+        #[arg(short, long)]
+        branch: Option<String>,
+
+        /// Interactive mode: select a branch from installed binaries
+        #[arg(short, long)]
+        interactive: bool,
+
+        /// Arguments to pass to spiced
+        #[arg(last = true)]
+        args: Vec<String>,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+struct GhRun {
+    #[serde(rename = "databaseId")]
+    database_id: u64,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Trigger { branch } => trigger_build(branch.as_deref()),
+        Commands::Install { branch } => install_build(branch.as_deref()),
+        Commands::Run {
+            branch,
+            interactive,
+            args,
+        } => run_build(branch.as_deref(), *interactive, args),
+    }
+}
+
+fn get_current_branch() -> Result<String> {
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .output()
+        .context("Failed to execute git command")?;
+
+    if !output.status.success() {
+        anyhow::bail!("git branch --show-current failed");
+    }
+
+    let branch = String::from_utf8(output.stdout)?.trim().to_string();
+    if branch.is_empty() {
+        anyhow::bail!("Could not determine current branch");
+    }
+    Ok(branch)
+}
+
+fn trigger_build(branch: Option<&str>) -> Result<()> {
+    let branch = match branch {
+        Some(b) => b.to_string(),
+        None => get_current_branch()?,
+    };
+
+    println!("Triggering build for branch: {} on macOS aarch64...", branch);
+
+    let status = Command::new("gh")
+        .args([
+            "workflow",
+            "run",
+            "build_and_release.yml",
+            "--ref",
+            &branch,
+            "-f",
+            "platform_option=macOS aarch64 (Apple Silicon)",
+        ])
+        .status()
+        .context("Failed to execute gh workflow run")?;
+
+    if status.success() {
+        println!("Build triggered successfully.");
+        println!("You can check the status with:");
+        println!(
+            "  gh run list --workflow build_and_release.yml --branch \"{}\"",
+            branch
+        );
+    } else {
+        anyhow::bail!("Failed to trigger build");
+    }
+
+    Ok(())
+}
+
+fn install_build(branch: Option<&str>) -> Result<()> {
+    let branch = match branch {
+        Some(b) => b.to_string(),
+        None => get_current_branch()?,
+    };
+
+    let target_dir = dirs::home_dir()
+        .context("Could not find home directory")?
+        .join(".spice/bin")
+        .join(&branch);
+
+    println!("Looking for latest successful build for branch: {}...", branch);
+
+    let output = Command::new("gh")
+        .args([
+            "run",
+            "list",
+            "--workflow",
+            "build_and_release.yml",
+            "--branch",
+            &branch,
+            "--status",
+            "success",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId",
+        ])
+        .output()
+        .context("Failed to execute gh run list")?;
+
+    if !output.status.success() {
+        anyhow::bail!("gh run list failed: {}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    let runs: Vec<GhRun> = serde_json::from_slice(&output.stdout)?;
+    let run = runs.first().context(format!(
+        "No successful build found for branch '{}'",
+        branch
+    ))?;
+    let run_id = run.database_id;
+
+    println!("Found Run ID: {}", run_id);
+
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = temp_dir.path();
+
+    println!("Downloading artifact to {}...", temp_path.display());
+
+    // Try metal first, then default
+    let artifacts = ["spiced_metal_darwin_aarch64", "spiced_darwin_aarch64"];
+    let mut downloaded = false;
+
+    for artifact_name in artifacts {
+        println!("Attempting to download artifact: {}", artifact_name);
+        let status = Command::new("gh")
+            .args([
+                "run",
+                "download",
+                &run_id.to_string(),
+                "-n",
+                artifact_name,
+                "-D",
+                temp_path.to_str().unwrap(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .status()?;
+
+        if status.success() {
+            downloaded = true;
+            break;
+        }
+    }
+
+    if !downloaded {
+        anyhow::bail!("Failed to download any compatible artifacts.");
+    }
+
+    println!("Installing to {}...", target_dir.display());
+    fs::create_dir_all(&target_dir)?;
+
+    // Find tar.gz
+    let mut tar_file: Option<PathBuf> = None;
+    for entry in fs::read_dir(temp_path)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("gz") {
+            tar_file = Some(path);
+            break;
+        }
+    }
+
+    let tar_file = tar_file.context("No tar.gz file found in downloaded artifact")?;
+    
+    // Extract
+    let tar_gz = fs::File::open(&tar_file)?;
+    let tar = GzDecoder::new(tar_gz);
+    let mut archive = Archive::new(tar);
+    archive.unpack(temp_path)?;
+
+    // Find binary
+    let spiced_path = temp_path.join("spiced");
+    if !spiced_path.exists() {
+        anyhow::bail!("Could not find 'spiced' binary in extracted archive at {}", spiced_path.display());
+    }
+
+    let target_binary = target_dir.join("spiced");
+    fs::rename(&spiced_path, &target_binary)?;
+
+    // Make executable
+    let mut perms = fs::metadata(&target_binary)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&target_binary, perms)?;
+
+    println!("Installed spiced to {}", target_binary.display());
+
+    // Symlink
+    let symlink_path = dirs::home_dir()
+        .context("Could not find home directory")?
+        .join(".spice/bin/spiced-dev");
+    
+    // Remove existing symlink if it exists
+    if symlink_path.exists() || fs::symlink_metadata(&symlink_path).is_ok() {
+        fs::remove_file(&symlink_path).ok();
+    }
+
+    std::os::unix::fs::symlink(&target_binary, &symlink_path)?;
+
+    println!("Updated symlink: {} -> {}", symlink_path.display(), target_binary.display());
+    println!("You can now run it comfortably via: {}", symlink_path.display());
+
+    Ok(())
+}
+
+fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result<()> {
+    let branch = if interactive {
+        select_branch()?
+    } else {
+        match branch {
+            Some(b) => b.to_string(),
+            None => get_current_branch()?,
+        }
+    };
+
+    let binary_path = dirs::home_dir()
+        .context("Could not find home directory")?
+        .join(".spice/bin")
+        .join(&branch)
+        .join("spiced");
+
+    if !binary_path.exists() {
+        println!("Binary not found at {}. Installing...", binary_path.display());
+        install_build(Some(&branch))?;
+    }
+
+    println!("Running spiced from branch '{}'...", branch);
+    println!("Exec: {} {}", binary_path.display(), args.join(" "));
+
+    // Replace the current process with spiced (Unix only)
+    use std::os::unix::process::CommandExt;
+    let error = Command::new(&binary_path).args(args).exec();
+
+    // If we're here, exec failed
+    anyhow::bail!("Failed to execute spiced: {}", error);
+}
+
+fn select_branch() -> Result<String> {
+    let base_dir = dirs::home_dir()
+        .context("Could not find home directory")?
+        .join(".spice/bin");
+
+    if !base_dir.exists() {
+        anyhow::bail!("No binaries found in {}", base_dir.display());
+    }
+
+    let mut branches = Vec::new();
+    
+    // Walk directory to find all 'spiced' binaries
+    for entry in WalkDir::new(&base_dir).min_depth(1).max_depth(5) {
+        let entry = entry.ok();
+        if let Some(entry) = entry {
+            if entry.file_type().is_file() && entry.file_name() == "spiced" {
+                //Found a spiced binary, the parent dir is the branch path
+                let branch_dir = entry.path().parent().unwrap();
+                
+                // Get relative path from base_dir to get the branch name
+                if let Ok(rel_path) = branch_dir.strip_prefix(&base_dir) {
+                    if let Some(branch_name) = rel_path.to_str() {
+                        if !branch_name.is_empty() {
+                            branches.push(branch_name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if branches.is_empty() {
+        anyhow::bail!("No installed branches found in {}", base_dir.display());
+    }
+
+    branches.sort();
+
+    let selection = dialoguer::Select::new()
+        .with_prompt("Select a branch to run")
+        .items(&branches)
+        .default(0)
+        .interact()
+        .context("Failed to select branch")?;
+
+    Ok(branches[selection].clone())
+}

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -2,9 +2,10 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
+use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tar::Archive;
 use walkdir::WalkDir;
@@ -77,7 +78,11 @@ fn get_current_branch() -> Result<String> {
         anyhow::bail!("git branch --show-current failed");
     }
 
-    let branch = String::from_utf8(output.stdout)?.trim().to_string();
+    let branch = String::from_utf8(output.stdout)
+        .context("Branch name is not valid UTF-8")?
+        .trim()
+        .to_string();
+
     if branch.is_empty() {
         anyhow::bail!("Could not determine current branch");
     }
@@ -90,7 +95,21 @@ fn trigger_build(branch: Option<&str>) -> Result<()> {
         None => get_current_branch()?,
     };
 
-    println!("Triggering build for branch: {} on macOS aarch64...", branch);
+    println!("Triggering build for branch: {}...", branch);
+
+    // Determine platform option based on current OS and Arch
+    let platform_option = match env::consts::OS {
+        "linux" => match env::consts::ARCH {
+            "aarch64" => "Linux aarch64",
+            _ => "Linux x64",
+        },
+        // Only Apple Silicon is supported for macOS in the CI matrix
+        "macos" => "macOS aarch64 (Apple Silicon)",
+        // Fallback for others
+        _ => "Linux x64",
+    };
+
+    println!("Requesting platform: {}", platform_option);
 
     let status = Command::new("gh")
         .args([
@@ -100,7 +119,7 @@ fn trigger_build(branch: Option<&str>) -> Result<()> {
             "--ref",
             &branch,
             "-f",
-            "platform_option=macOS aarch64 (Apple Silicon)",
+            &format!("platform_option={}", platform_option),
         ])
         .status()
         .context("Failed to execute gh workflow run")?;
@@ -117,6 +136,26 @@ fn trigger_build(branch: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn get_artifact_names() -> Vec<String> {
+    let (os, arch) = match env::consts::OS {
+        // CI only builds aarch64 for macOS (Apple Silicon)
+        "macos" => ("darwin", "aarch64"),
+        // For Linux, the CI uses standard architecture names (x86_64, aarch64)
+        "linux" => ("linux", env::consts::ARCH),
+        // Fallback/Default
+        _ => ("linux", "x86_64"),
+    };
+
+    // Prioritize metal for darwin
+    let mut names = Vec::new();
+    if os == "darwin" {
+        names.push(format!("spiced_metal_{}_{}", os, arch));
+    }
+    names.push(format!("spiced_{}_{}", os, arch));
+
+    names
 }
 
 fn install_build(branch: Option<&str>) -> Result<()> {
@@ -151,7 +190,10 @@ fn install_build(branch: Option<&str>) -> Result<()> {
         .context("Failed to execute gh run list")?;
 
     if !output.status.success() {
-        anyhow::bail!("gh run list failed: {}", String::from_utf8_lossy(&output.stderr));
+        anyhow::bail!(
+            "gh run list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     let runs: Vec<GhRun> = serde_json::from_slice(&output.stdout)?;
@@ -168,12 +210,16 @@ fn install_build(branch: Option<&str>) -> Result<()> {
 
     println!("Downloading artifact to {}...", temp_path.display());
 
-    // Try metal first, then default
-    let artifacts = ["spiced_metal_darwin_aarch64", "spiced_darwin_aarch64"];
+    let artifacts = get_artifact_names();
     let mut downloaded = false;
 
-    for artifact_name in artifacts {
+    for artifact_name in &artifacts {
         println!("Attempting to download artifact: {}", artifact_name);
+        // Using temp_path to convert to string safely
+        let temp_path_str = temp_path
+            .to_str()
+            .context("Temp path contains invalid UTF-8")?;
+
         let status = Command::new("gh")
             .args([
                 "run",
@@ -182,11 +228,12 @@ fn install_build(branch: Option<&str>) -> Result<()> {
                 "-n",
                 artifact_name,
                 "-D",
-                temp_path.to_str().unwrap(),
+                temp_path_str,
             ])
             .stdout(Stdio::null())
             .stderr(Stdio::inherit())
-            .status()?;
+            .status()
+            .context("Failed to execute gh run download")?;
 
         if status.success() {
             downloaded = true;
@@ -195,7 +242,10 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     }
 
     if !downloaded {
-        anyhow::bail!("Failed to download any compatible artifacts.");
+        anyhow::bail!(
+            "Failed to download any compatible artifacts. Tried: {:?}",
+            artifacts
+        );
     }
 
     println!("Installing to {}...", target_dir.display());
@@ -206,14 +256,17 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     for entry in fs::read_dir(temp_path)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) == Some("gz") {
-            tar_file = Some(path);
-            break;
+        // Check for extension safely
+        if let Some(ext) = path.extension() {
+            if ext == "gz" {
+                tar_file = Some(path);
+                break;
+            }
         }
     }
 
     let tar_file = tar_file.context("No tar.gz file found in downloaded artifact")?;
-    
+
     // Extract
     let tar_gz = fs::File::open(&tar_file)?;
     let tar = GzDecoder::new(tar_gz);
@@ -223,10 +276,19 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     // Find binary
     let spiced_path = temp_path.join("spiced");
     if !spiced_path.exists() {
-        anyhow::bail!("Could not find 'spiced' binary in extracted archive at {}", spiced_path.display());
+        anyhow::bail!(
+            "Could not find 'spiced' binary in extracted archive at {}",
+            spiced_path.display()
+        );
     }
 
     let target_binary = target_dir.join("spiced");
+    // Rename might fail if cross-device link, but unlikely for temp to home usually on same mount or different.
+    // fs::rename is atomic but platform specific. If it fails, we might need copy+delete.
+    // For now, assuming fs::rename works or fails loudly.
+    if target_binary.exists() {
+        fs::remove_file(&target_binary)?;
+    }
     fs::rename(&spiced_path, &target_binary)?;
 
     // Make executable
@@ -240,7 +302,7 @@ fn install_build(branch: Option<&str>) -> Result<()> {
     let symlink_path = dirs::home_dir()
         .context("Could not find home directory")?
         .join(".spice/bin/spiced-dev");
-    
+
     // Remove existing symlink if it exists
     if symlink_path.exists() || fs::symlink_metadata(&symlink_path).is_ok() {
         fs::remove_file(&symlink_path).ok();
@@ -248,7 +310,11 @@ fn install_build(branch: Option<&str>) -> Result<()> {
 
     std::os::unix::fs::symlink(&target_binary, &symlink_path)?;
 
-    println!("Updated symlink: {} -> {}", symlink_path.display(), target_binary.display());
+    println!(
+        "Updated symlink: {} -> {}",
+        symlink_path.display(),
+        target_binary.display()
+    );
     println!("You can now run it comfortably via: {}", symlink_path.display());
 
     Ok(())
@@ -271,7 +337,10 @@ fn run_build(branch: Option<&str>, interactive: bool, args: &[String]) -> Result
         .join("spiced");
 
     if !binary_path.exists() {
-        println!("Binary not found at {}. Installing...", binary_path.display());
+        println!(
+            "Binary not found at {}. Installing...",
+            binary_path.display()
+        );
         install_build(Some(&branch))?;
     }
 
@@ -296,20 +365,20 @@ fn select_branch() -> Result<String> {
     }
 
     let mut branches = Vec::new();
-    
+
     // Walk directory to find all 'spiced' binaries
     for entry in WalkDir::new(&base_dir).min_depth(1).max_depth(5) {
         let entry = entry.ok();
         if let Some(entry) = entry {
             if entry.file_type().is_file() && entry.file_name() == "spiced" {
-                //Found a spiced binary, the parent dir is the branch path
-                let branch_dir = entry.path().parent().unwrap();
-                
-                // Get relative path from base_dir to get the branch name
-                if let Ok(rel_path) = branch_dir.strip_prefix(&base_dir) {
-                    if let Some(branch_name) = rel_path.to_str() {
-                        if !branch_name.is_empty() {
-                            branches.push(branch_name.to_string());
+                // Found a spiced binary, the parent dir is the branch path
+                if let Some(branch_dir) = entry.path().parent() {
+                    // Get relative path from base_dir to get the branch name
+                    if let Ok(rel_path) = branch_dir.strip_prefix(&base_dir) {
+                        if let Some(branch_name) = rel_path.to_str() {
+                            if !branch_name.is_empty() {
+                                branches.push(branch_name.to_string());
+                            }
                         }
                     }
                 }

--- a/tools/pr-builds/src/main.rs
+++ b/tools/pr-builds/src/main.rs
@@ -14,22 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Copyright 2024-2026 The Spice.ai OSS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use flate2::read::GzDecoder;
@@ -197,16 +181,56 @@ fn get_current_branch() -> Result<String> {
     Ok(branch)
 }
 
+fn validate_branch_name(branch: &str) -> Result<()> {
+    if branch.is_empty() {
+        anyhow::bail!("Branch name cannot be empty");
+    }
+    if branch.contains("..") {
+        anyhow::bail!("Branch name cannot contain '..'");
+    }
+    if branch.starts_with('/') || branch.contains(":") {
+        anyhow::bail!("Branch name contains invalid characters");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn get_repo_owner_name() -> Result<String> {
+    let output = Command::new("gh")
+        .args(["repo", "view", "--json", "nameWithOwner"])
+        .output()
+        .context("Failed to determine current repository via gh repo view")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "gh repo view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[derive(Deserialize)]
+    struct GhRepo {
+        #[serde(rename = "nameWithOwner")]
+        name_with_owner: String,
+    }
+
+    let gh_repo: GhRepo =
+        serde_json::from_slice(&output.stdout).context("Failed to parse gh repo view output")?;
+    Ok(gh_repo.name_with_owner)
+}
+
 #[cfg(unix)]
 fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()> {
     let branch = resolve_branch_or_pr(branch, pr)?;
+    validate_branch_name(&branch)?;
+    let repo_owner_name = get_repo_owner_name()?;
 
     // Get the latest commit SHA for the branch
     println!("Fetching latest commit SHA for branch '{}'...", branch);
     let output = Command::new("gh")
         .args([
             "api",
-            &format!("repos/spiceai/spiceai/branches/{}", branch),
+            &format!("repos/{}/branches/{}", repo_owner_name, branch),
             "--jq",
             ".commit.sha",
         ])
@@ -239,10 +263,17 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
         .context("Failed to list recent runs")?;
 
     let mut existing_run_id: Option<u64> = None;
+    let mut max_seen_id: u64 = 0;
 
     if output.status.success() {
         let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
         for run in runs {
+            if let Some(id) = run["databaseId"].as_u64() {
+                if id > max_seen_id {
+                    max_seen_id = id;
+                }
+            }
+
             if let Some(run_sha) = run["headSha"].as_str() {
                 if run_sha == latest_sha {
                     // Found a run for the same SHA
@@ -274,13 +305,26 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
     } else {
         println!("No active build found for latest SHA. Triggering new build...");
 
-        let platform_option = match env::consts::OS {
-            "linux" => match env::consts::ARCH {
-                "aarch64" => "Linux aarch64",
-                _ => "Linux x64",
-            },
-            "macos" => "macOS aarch64 (Apple Silicon)",
-            _ => "Linux x64",
+        let platform_option = {
+            let os = env::consts::OS;
+            let arch = env::consts::ARCH;
+            match (os, arch) {
+                ("linux", "aarch64") => "Linux aarch64".to_string(),
+                ("linux", "x86_64") => "Linux x64".to_string(),
+                ("macos", "aarch64") => "macOS aarch64 (Apple Silicon)".to_string(),
+                ("macos", "x86_64") => {
+                    anyhow::bail!(
+                        "Failed to determine build platform for OS macOS and architecture x86_64: Intel macOS is not supported by the build_and_release workflow. Use an Apple Silicon macOS or supported Linux machine to trigger this build."
+                    );
+                }
+                (other_os, other_arch) => {
+                    anyhow::bail!(
+                        "Failed to determine build platform for OS {} and architecture {}: Unsupported combination for build_and_release workflow. Supported combinations are: linux/aarch64, linux/x86_64, macos/aarch64.",
+                        other_os,
+                        other_arch
+                    );
+                }
+            }
         };
 
         println!("Requesting platform: {}", platform_option);
@@ -342,11 +386,14 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
                 if let Some(run) = runs.first() {
                      let status = run["status"].as_str().unwrap_or("");
                      let run_sha = run["headSha"].as_str().unwrap_or("");
+                     let id = run["databaseId"].as_u64();
 
-                     // Ensure we picked up a run for the correct SHA that is active
-                     if (status == "queued" || status == "in_progress" || status == "requested" || status == "waiting") && run_sha == latest_sha {
-                         found_new_run_id = run["databaseId"].as_u64();
-                         break;
+                     // Ensure we picked up a run for the correct SHA that is active and NEW (id > max_seen_id)
+                     if let Some(id) = id {
+                         if id > max_seen_id && (status == "queued" || status == "in_progress" || status == "requested" || status == "waiting") && run_sha == latest_sha {
+                             found_new_run_id = Some(id);
+                             break;
+                         }
                      }
                 }
             }
@@ -372,14 +419,19 @@ fn trigger_build(branch: Option<&str>, pr: Option<u64>, wait: bool) -> Result<()
     Ok(())
 }
 
-fn get_artifact_names() -> Vec<String> {
+fn get_artifact_names() -> Result<Vec<String>> {
     let (os, arch) = match env::consts::OS {
         // CI only builds aarch64 for macOS (Apple Silicon)
         "macos" => ("darwin", "aarch64"),
         // For Linux, the CI uses standard architecture names (x86_64, aarch64)
         "linux" => ("linux", env::consts::ARCH),
         // Fallback/Default
-        _ => ("linux", "x86_64"),
+        other => {
+            anyhow::bail!(
+                "Unsupported OS '{}' for PR build artifacts; only 'macos' and 'linux' are supported",
+                other
+            );
+        }
     };
 
     // Prioritize metal for darwin
@@ -389,7 +441,7 @@ fn get_artifact_names() -> Vec<String> {
     }
     names.push(format!("spiced_{}_{}", os, arch));
 
-    names
+    Ok(names)
 }
 
 #[derive(Deserialize, Debug)]
@@ -405,6 +457,8 @@ struct ArtifactList {
 #[cfg(unix)]
 fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
     let branch = resolve_branch_or_pr(branch, pr)?;
+    validate_branch_name(&branch)?;
+    let repo_owner_name = get_repo_owner_name()?;
 
     let target_dir = dirs::home_dir()
         .context("Could not find home directory")?
@@ -452,13 +506,16 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
     let output = Command::new("gh")
         .args([
             "api",
-            &format!("repos/spiceai/spiceai/actions/runs/{}/artifacts", run_id),
+            &format!("repos/{}/actions/runs/{}/artifacts", repo_owner_name, run_id),
         ])
         .output()
         .context("Failed to fetch artifacts list")?;
 
     if !output.status.success() {
-        anyhow::bail!("Failed to list artifacts");
+        anyhow::bail!(
+            "Failed to list artifacts: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     let artifact_list: ArtifactList = serde_json::from_slice(&output.stdout)?;
@@ -468,7 +525,7 @@ fn install_build(branch: Option<&str>, pr: Option<u64>) -> Result<()> {
         .map(|a| a.name)
         .collect();
 
-    let wanted_artifacts = get_artifact_names();
+    let wanted_artifacts = get_artifact_names()?;
     let artifact_to_download = wanted_artifacts
         .iter()
         .find(|name| available_artifacts.contains(name))
@@ -592,6 +649,7 @@ fn run_build(branch: Option<&str>, pr: Option<u64>, interactive: bool, args: &[S
     } else {
         resolve_branch_or_pr(branch, pr)?
     };
+    validate_branch_name(&branch)?;
 
     let binary_path = dirs::home_dir()
         .context("Could not find home directory")?
@@ -631,7 +689,7 @@ fn select_branch() -> Result<String> {
     let mut branches = Vec::new();
 
     // Walk directory to find all 'spiced' binaries
-    for entry in WalkDir::new(&base_dir).min_depth(1).max_depth(5) {
+    for entry in WalkDir::new(&base_dir).min_depth(1) {
         let entry = entry.ok();
         if let Some(entry) = entry {
             if entry.file_type().is_file() && entry.file_name() == "spiced" {


### PR DESCRIPTION
## 📝 Summary

Trigger, install and run spiced binary CI builds from the CLI. 

```bash
# Trigger a build for PR #9390 and wait for it to finish
>>> pr-builds trigger -p 9390 --wait

# Install the binary from the last successful `build_and_release` on branch `jeadie/26-02-12/pr-builds`. 
>>> pr-builds install -b jeadie/26-02-12/pr-builds

# Run the spiced binary. No flags, will use local branch. Will install if not found locally.
>>> pr-builds run
```

For ` pr-builds trigger --wait`: 
**Build Progress Monitoring:**
<img width="1268" height="1186" alt="image" src="https://github.com/user-attachments/assets/85cf152a-d594-4f1c-ab34-d3a521fecb35" />

### Interactive Mode
Run spiced instances across many branches easily.
```
>>> pr-builds run -i
Select a branch to run:
> jeadie/26-02-10/SessionContext
  jeadie/26-02-10/cron
```

### Standard Usage
```bash
## Current branch
### Trigger a `build_and_release` in GH.
>>> pr-builds trigger

### Install a completed `build_and_release` locally.
>>> pr-builds install

### Run spiced binary for branch
>>> pr-builds run # This will install if not found locally.

## Specify a branch manually
>>> pr-builds trigger -b jeadie/26-02-12/pr-builds
```