### PR TITLE
cluster: route Ballista task cancellation via control stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=56225b2a66868462d4f75a7881490118c43db9b6#56225b2a66868462d4f75a7881490118c43db9b6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=9298d4410b3cfde5639aa3d7bea8777942741573#9298d4410b3cfde5639aa3d7bea8777942741573"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=56225b2a66868462d4f75a7881490118c43db9b6#56225b2a66868462d4f75a7881490118c43db9b6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=9298d4410b3cfde5639aa3d7bea8777942741573#9298d4410b3cfde5639aa3d7bea8777942741573"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=56225b2a66868462d4f75a7881490118c43db9b6#56225b2a66868462d4f75a7881490118c43db9b6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=9298d4410b3cfde5639aa3d7bea8777942741573#9298d4410b3cfde5639aa3d7bea8777942741573"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,9 +361,9 @@ datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "509
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "330a4d790b892dd6be23b71589ec60b620bf29f5" } # spiceai-51
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "56225b2a66868462d4f75a7881490118c43db9b6" }      # spiceai-51
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "56225b2a66868462d4f75a7881490118c43db9b6" } # spiceai-51
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "56225b2a66868462d4f75a7881490118c43db9b6" } # spiceai-51
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "9298d4410b3cfde5639aa3d7bea8777942741573" } # spiceai-51
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "9298d4410b3cfde5639aa3d7bea8777942741573" } # spiceai-51
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "9298d4410b3cfde5639aa3d7bea8777942741573" } # spiceai-51
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "4ce55c37be6f394675457545e806c503c813b34e" } # spiceai-0.17.0
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -112,6 +112,7 @@ message SchedulerControlMessage {
     oneof message {
         MetricsRequest request_metrics = 1;
         PollNowCommand poll_now = 2;
+        CancelTasksCommand cancel_tasks = 3;
     }
 }
 
@@ -138,6 +139,19 @@ message AllocateInitialPartitionsResponse {
 message PollNowCommand {
     // Optional reason for the immediate poll (for debugging/logging).
     string reason = 1;
+}
+
+// Command sent from scheduler to executor to cancel running tasks.
+message CancelTasksCommand {
+    repeated TaskCancelInfo tasks = 1;
+}
+
+// Identifies a single running task that should be cancelled.
+message TaskCancelInfo {
+    uint32 task_id = 1;
+    string job_id = 2;
+    uint32 stage_id = 3;
+    uint32 partition_id = 4;
 }
 
 // Heartbeat message sent by executor to scheduler.

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -18,14 +18,15 @@ limitations under the License.
 //!
 //! This module provides functionality for executors to establish and maintain
 //! bidirectional control streams with schedulers. These streams allow schedulers
-//! to request metrics from executors on-demand and receive `PollNow` commands
-//! to trigger immediate work polling.
+//! to request metrics from executors on-demand, issue task cancellations, and
+//! send `PollNow` commands to trigger immediate work polling.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
 use ballista_core::utils::create_grpc_client_endpoint;
+use ballista_executor::executor::Executor;
 use futures::StreamExt;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
 use runtime_proto::scheduler_control_message::Message as SchedulerMessage;
@@ -64,6 +65,7 @@ fn spawn_control_stream(
     executor_id: String,
     client_tls_config: Option<ClientTlsConfig>,
     metrics_reader: Option<Arc<MetricsReader>>,
+    executor: Option<Arc<Executor>>,
     poll_now_notify: Arc<Notify>,
     outbound_tx_state: Arc<RwLock<Option<mpsc::Sender<ExecutorControlMessage>>>>,
 ) -> ControlStreamHandle {
@@ -244,6 +246,7 @@ fn spawn_control_stream(
                                         message,
                                         &outbound_tx,
                                         metrics_reader.as_deref(),
+                                        executor.as_deref(),
                                         &poll_now_notify,
                                     )
                                     .await;
@@ -296,6 +299,7 @@ async fn handle_scheduler_message(
     message: SchedulerMessage,
     outbound_tx: &mpsc::Sender<ExecutorControlMessage>,
     metrics_reader: Option<&MetricsReader>,
+    executor: Option<&Executor>,
     poll_now_notify: &Notify,
 ) {
     match message {
@@ -332,6 +336,48 @@ async fn handle_scheduler_message(
             );
             poll_now_notify.notify_one();
         }
+        SchedulerMessage::CancelTasks(cmd) => {
+            let Some(executor) = executor else {
+                tracing::warn!(
+                    "Received CancelTasks from {scheduler_address} but no executor is available"
+                );
+                return;
+            };
+
+            for task in cmd.tasks {
+                match executor
+                    .cancel_task(
+                        task.task_id as usize,
+                        task.job_id.clone(),
+                        task.stage_id as usize,
+                        task.partition_id as usize,
+                    )
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::debug!(
+                            task_id = task.task_id,
+                            job_id = %task.job_id,
+                            "Cancelled task from scheduler {scheduler_address}"
+                        );
+                    }
+                    Ok(false) => {
+                        tracing::debug!(
+                            task_id = task.task_id,
+                            job_id = %task.job_id,
+                            "Task not found for cancellation (may have already completed)"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            task_id = task.task_id,
+                            job_id = %task.job_id,
+                            "Failed to cancel task: {e}"
+                        );
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -355,6 +401,7 @@ pub struct ControlStreamManager {
     ballista_executor_id: String,
     client_tls_config: Option<ClientTlsConfig>,
     metrics_reader: Option<Arc<MetricsReader>>,
+    executor: Option<Arc<Executor>>,
     streams: HashMap<String, ControlStreamHandle>,
     known_schedulers: HashSet<String>,
     /// Shared notify handle signaled when any scheduler sends `PollNow`.
@@ -369,12 +416,14 @@ impl ControlStreamManager {
         ballista_executor_id: String,
         client_tls_config: Option<ClientTlsConfig>,
         metrics_reader: Option<MetricsReader>,
+        executor: Option<Arc<Executor>>,
     ) -> Self {
         Self {
             executor_id,
             ballista_executor_id,
             client_tls_config,
             metrics_reader: metrics_reader.map(Arc::new),
+            executor,
             streams: HashMap::new(),
             known_schedulers: HashSet::new(),
             poll_now_notify: Arc::new(Notify::new()),
@@ -456,6 +505,7 @@ impl ControlStreamManager {
                 self.executor_id.clone(),
                 self.client_tls_config.clone(),
                 self.metrics_reader.clone(),
+                self.executor.clone(),
                 Arc::clone(&self.poll_now_notify),
                 Arc::clone(&outbound_tx_state),
             );
@@ -538,6 +588,7 @@ mod tests {
             "executor-1".to_string(),
             None, // no TLS
             None, // no metrics reader
+            None,
         );
         assert!(manager.known_schedulers.is_empty());
         assert!(manager.streams.is_empty());
@@ -552,6 +603,7 @@ mod tests {
             "executor-2".to_string(),
             None,
             Some(reader),
+            None,
         );
         assert!(manager.metrics_reader.is_some());
     }
@@ -561,6 +613,7 @@ mod tests {
         let mut manager = ControlStreamManager::new(
             "executor-1".to_string(),
             "executor-1".to_string(),
+            None,
             None,
             None,
         );
@@ -574,6 +627,7 @@ mod tests {
         let mut manager = ControlStreamManager::new(
             "executor-1".to_string(),
             "executor-1".to_string(),
+            None,
             None,
             None,
         );

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -45,9 +45,10 @@ use ballista_executor::execution_loop;
 use ballista_executor::executor::Executor;
 use ballista_scheduler::cluster::memory::{InMemoryClusterState, InMemoryJobState};
 use ballista_scheduler::cluster::{BallistaCluster, ClusterState};
-use ballista_scheduler::config::SchedulerConfig;
+use ballista_scheduler::config::{OnCancelTasksFn, SchedulerConfig};
 use ballista_scheduler::scheduler_process;
 use ballista_scheduler::scheduler_server::SchedulerServer;
+use ballista_scheduler::state::execution_graph::RunningTaskInfo;
 use datafusion::codec::spice_logical_codec::SpiceLogicalCodec;
 use datafusion::codec::spice_physical_codec::SpicePhysicalCodec;
 use datafusion_datasource::ListingTableUrl;
@@ -56,7 +57,7 @@ use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 use runtime_object_store::registry::default_runtime_env;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
-use runtime_proto::{GetAppDefinitionRequest, GetSchedulersRequest};
+use runtime_proto::{GetAppDefinitionRequest, GetSchedulersRequest, TaskCancelInfo};
 use runtime_secrets::Secrets;
 use snafu::ResultExt;
 use std::collections::{HashMap, HashSet};
@@ -1166,6 +1167,7 @@ pub async fn initialize_cluster_executor(
             control_stream_ballista_id,
             control_stream_tls_config,
             control_stream_metrics_reader,
+            Some(Arc::clone(&executor_for_manager)),
         );
 
         // Get the shared poll_now notify handle from the control stream manager.
@@ -1378,6 +1380,55 @@ async fn create_scheduler_server(
     let on_work_available: Arc<dyn Fn(&str) + Send + Sync> =
         Arc::new(move |reason: &str| registry_for_callback.broadcast_poll_now(reason));
 
+    let registry_for_cancel = executor_stream_registry.clone();
+    let on_cancel_tasks: OnCancelTasksFn =
+        Arc::new(move |executor_id: &str, tasks: Vec<RunningTaskInfo>| {
+            let tasks_to_cancel = tasks
+                .into_iter()
+                .filter_map(|task| {
+                    let Ok(task_id) = u32::try_from(task.task_id) else {
+                        tracing::warn!(
+                            executor_id,
+                            task_id = task.task_id,
+                            "Skipping cancel task with out-of-range task_id"
+                        );
+                        return None;
+                    };
+
+                    let Ok(stage_id) = u32::try_from(task.stage_id) else {
+                        tracing::warn!(
+                            executor_id,
+                            stage_id = task.stage_id,
+                            "Skipping cancel task with out-of-range stage_id"
+                        );
+                        return None;
+                    };
+
+                    let Ok(partition_id) = u32::try_from(task.partition_id) else {
+                        tracing::warn!(
+                            executor_id,
+                            partition_id = task.partition_id,
+                            "Skipping cancel task with out-of-range partition_id"
+                        );
+                        return None;
+                    };
+
+                    Some(TaskCancelInfo {
+                        task_id,
+                        job_id: task.job_id,
+                        stage_id,
+                        partition_id,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            if !registry_for_cancel.send_cancel_tasks(executor_id, tasks_to_cancel) {
+                tracing::warn!(
+                    "Failed to send cancel tasks to executor {executor_id}: no control stream"
+                );
+            }
+        });
+
     // Create InMemoryClusterState first so we can reference it in the config_producer
     let cluster_state: Arc<dyn ClusterState> = Arc::new(InMemoryClusterState::default());
 
@@ -1494,6 +1545,7 @@ async fn create_scheduler_server(
         override_create_grpc_client_endpoint,
         override_metrics_collector: Some(scheduler_metrics_collector),
         on_work_available: Some(on_work_available),
+        on_cancel_tasks: Some(on_cancel_tasks),
 
         // Faster failure detection: 30s timeout with 10s heartbeat interval
         executor_timeout_seconds: 30,

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -52,11 +52,11 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use parking_lot::RwLock;
 use runtime_proto::{
     AllocateInitialPartitionsRequest, AllocateInitialPartitionsResponse, BytesArray,
-    ExecutorControlMessage, ExpandSecretRequest, ExpandSecretResponse, GetAppDefinitionRequest,
-    GetAppDefinitionResponse, GetMetricsRequest, GetMetricsResponse, GetSchedulersRequest,
-    GetSchedulersResponse, GetTaskHistoryRequest, GetTaskHistoryResponse, PollNowCommand,
-    SchedulerControlMessage, SchedulerInstance, cluster_service_server::ClusterService,
-    executor_control_message::Message as ExecutorMessage,
+    CancelTasksCommand, ExecutorControlMessage, ExpandSecretRequest, ExpandSecretResponse,
+    GetAppDefinitionRequest, GetAppDefinitionResponse, GetMetricsRequest, GetMetricsResponse,
+    GetSchedulersRequest, GetSchedulersResponse, GetTaskHistoryRequest, GetTaskHistoryResponse,
+    PollNowCommand, SchedulerControlMessage, SchedulerInstance, TaskCancelInfo,
+    cluster_service_server::ClusterService, executor_control_message::Message as ExecutorMessage,
     scheduler_control_message::Message as SchedulerMessage,
 };
 use runtime_secrets::Secrets;
@@ -129,6 +129,23 @@ impl ExecutorControlStreamRegistry {
         }
 
         tracing::debug!("Broadcast PollNow to {count} executors: {reason}");
+    }
+
+    /// Sends a `CancelTasks` command to a specific connected executor.
+    ///
+    /// Returns `true` when the message is accepted into the outbound channel.
+    #[must_use]
+    pub fn send_cancel_tasks(&self, executor_id: &str, tasks: Vec<TaskCancelInfo>) -> bool {
+        let streams = self.streams.read();
+        let Some(handle) = streams.get(executor_id) else {
+            return false;
+        };
+
+        let message = SchedulerControlMessage {
+            message: Some(SchedulerMessage::CancelTasks(CancelTasksCommand { tasks })),
+        };
+
+        handle.tx.try_send(message).is_ok()
     }
 
     /// Registers an executor stream for receiving control messages.

--- a/crates/runtime/tests/cluster/cancel_tasks.rs
+++ b/crates/runtime/tests/cluster/cancel_tasks.rs
@@ -1,0 +1,350 @@
+use app::AppBuilder;
+use ballista_executor::executor::Executor;
+use ballista_scheduler::state::executor_manager::ExecutorManager;
+use runtime::Runtime;
+use runtime::cluster::ResolvedClusterConfig;
+use runtime::config::ClusterConfig;
+use runtime::datafusion::query::QueryBuilder;
+use runtime::{auth::EndpointAuth, config::Config};
+use rustls::crypto::{CryptoProvider, aws_lc_rs};
+use spicepod::component::dataset::Dataset;
+use std::fmt::Write;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::Arc;
+use std::time::Duration;
+use test_framework::pki::init_pki;
+use tokio::time::{Instant, sleep, sleep_until, timeout};
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{runtime_ready_check, test_request_context},
+};
+
+fn build_large_csv(rows: usize) -> String {
+    let mut csv = String::from("id,name,age,city,score\n");
+    for i in 1..=rows {
+        let city = match i % 5 {
+            0 => "New York",
+            1 => "Los Angeles",
+            2 => "Chicago",
+            3 => "Houston",
+            _ => "Phoenix",
+        };
+        writeln!(
+            &mut csv,
+            "{i},name-{i},{},{},{}",
+            20 + (i % 50),
+            city,
+            50 + (i % 50)
+        )
+        .expect("writing csv row to String should not fail");
+    }
+    csv
+}
+
+async fn wait_for_executor_count(
+    executor_manager: &ExecutorManager,
+    expected: usize,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    let start = Instant::now();
+    loop {
+        let count = executor_manager
+            .get_executor_state()
+            .await
+            .map_err(|err| anyhow::Error::msg(err.to_string()))?
+            .len();
+        if count == expected {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow::Error::msg(format!(
+                "Timed out waiting for {expected} executors; found {count}"
+            )));
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn wait_for_executor_instance(
+    runtime: &Arc<Runtime>,
+    timeout: Duration,
+) -> Result<Arc<Executor>, anyhow::Error> {
+    let start = Instant::now();
+    loop {
+        if let Some(executor) = runtime
+            .datafusion()
+            .executor
+            .read()
+            .expect("executor lock")
+            .clone()
+        {
+            return Ok(executor);
+        }
+
+        if start.elapsed() > timeout {
+            return Err(anyhow::Error::msg(
+                "Timed out waiting for executor instance to be bound",
+            ));
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_active_tasks_at_least(
+    executor: &Executor,
+    minimum: usize,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    let start = Instant::now();
+    loop {
+        let count = executor.active_task_count();
+        if count >= minimum {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow::Error::msg(format!(
+                "Timed out waiting for active task count >= {minimum}; found {count}"
+            )));
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_active_tasks_eq(
+    executor: &Executor,
+    expected: usize,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    let start = Instant::now();
+    loop {
+        let count = executor.active_task_count();
+        if count == expected {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow::Error::msg(format!(
+                "Timed out waiting for active task count == {expected}; found {count}"
+            )));
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cancel_tasks_via_control_stream() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let tempdir = tempfile::tempdir().expect("should create temp dir");
+            let _ = CryptoProvider::install_default(aws_lc_rs::default_provider());
+
+            let pki = init_pki(tempdir.path()).expect("should create PKI");
+            let scheduler_cert = pki
+                .create_client_cert("scheduler")
+                .expect("should create scheduler cert");
+            let executor_cert = pki
+                .create_client_cert("executor")
+                .expect("should create executor cert");
+
+            let csv_data = build_large_csv(200);
+            std::fs::write(
+                tempdir.path().join("./cancel_tasks_via_control_stream.csv"),
+                csv_data,
+            )
+            .expect("write file");
+
+            let scheduler_app = AppBuilder::new("cancel_tasks_via_control_stream")
+                .with_dataset(Dataset::new(
+                    format!(
+                        "file:{}",
+                        tempdir
+                            .path()
+                            .join("cancel_tasks_via_control_stream.csv")
+                            .to_str()
+                            .expect("should have str")
+                    )
+                    .as_str(),
+                    "names",
+                ))
+                .build();
+
+            let executor_app = AppBuilder::new("cancel_tasks_via_control_stream_executor").build();
+
+            configure_test_datafusion();
+
+            let scheduler_config = Config {
+                http_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8390,
+                )),
+                flight_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    52151,
+                )),
+                cluster: ClusterConfig {
+                    role: Some(runtime::config::ClusterRole::Scheduler),
+                    node_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                        Ipv4Addr::LOCALHOST,
+                        52152,
+                    )),
+                    node_advertise_address: Some("127.0.0.1".to_string()),
+                    node_mtls_ca_certificate_file: Some(
+                        pki.ca_cert_path.to_string_lossy().to_string(),
+                    ),
+                    node_mtls_certificate_file: Some(
+                        scheduler_cert.cert_path.to_string_lossy().to_string(),
+                    ),
+                    node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            };
+
+            let scheduler_rt = Arc::new(
+                Runtime::builder()
+                    .with_runtime_config(scheduler_config.clone())
+                    .with_resolved_cluster_config(
+                        ResolvedClusterConfig::try_new(scheduler_config.cluster.clone())
+                            .expect("should resolve cluster config"),
+                    )
+                    .with_app(scheduler_app)
+                    .build()
+                    .await,
+            );
+
+            let cloned_scheduler_rt = Arc::clone(&scheduler_rt);
+            let scheduler_server_thread = tokio::spawn(async move {
+                Box::pin(cloned_scheduler_rt.start_servers(
+                    scheduler_config,
+                    None,
+                    EndpointAuth::no_auth(),
+                ))
+                .await
+            });
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for scheduler components"));
+                }
+                () = Arc::clone(&scheduler_rt).load_components() => {}
+            }
+
+            let executor_config = Config {
+                http_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8391,
+                )),
+                flight_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    52153,
+                )),
+                cluster: ClusterConfig {
+                    role: Some(runtime::config::ClusterRole::Executor),
+                    node_bind_address: std::net::SocketAddr::V4(SocketAddrV4::new(
+                        Ipv4Addr::LOCALHOST,
+                        52154,
+                    )),
+                    scheduler_address: Some("127.0.0.1:52152".to_string()),
+                    node_advertise_address: Some("127.0.0.1".to_string()),
+                    node_mtls_ca_certificate_file: Some(
+                        pki.ca_cert_path.to_string_lossy().to_string(),
+                    ),
+                    node_mtls_certificate_file: Some(
+                        executor_cert.cert_path.to_string_lossy().to_string(),
+                    ),
+                    node_mtls_key_file: Some(executor_cert.key_path.to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            };
+
+            let executor_rt = Arc::new(
+                Runtime::builder()
+                    .with_runtime_config(executor_config.clone())
+                    .with_resolved_cluster_config(
+                        ResolvedClusterConfig::try_new(executor_config.cluster.clone())
+                            .expect("should resolve cluster config"),
+                    )
+                    .with_app(executor_app)
+                    .build()
+                    .await,
+            );
+
+            let cloned_executor_rt = Arc::clone(&executor_rt);
+            let executor_server_thread = tokio::spawn(async move {
+                Box::pin(cloned_executor_rt.start_servers(
+                    executor_config,
+                    None,
+                    EndpointAuth::no_auth(),
+                ))
+                .await
+            });
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for executor components"));
+                }
+                () = Arc::clone(&executor_rt).load_components() => {}
+            }
+
+            runtime_ready_check(&scheduler_rt).await;
+            runtime_ready_check(&executor_rt).await;
+
+            let scheduler_server = scheduler_rt
+                .datafusion()
+                .scheduler_server
+                .read()
+                .expect("scheduler server lock")
+                .clone()
+                .expect("scheduler server should be available");
+            let executor_manager = scheduler_server.state.executor_manager.clone();
+
+            let executor =
+                wait_for_executor_instance(&executor_rt, Duration::from_secs(10)).await?;
+
+            sleep_until(Instant::now() + Duration::from_secs(1)).await; // let executor connect
+            wait_for_executor_count(&executor_manager, 1, Duration::from_secs(10)).await?;
+
+            let query = QueryBuilder::new(
+                "SELECT COUNT(*) FROM names a, names b, names c, names d, names e, names f",
+                scheduler_rt.datafusion(),
+            );
+
+            let query_handle = query
+                .build()
+                .submit_distributed("testing_cancel_via_control_stream")
+                .await
+                .expect("should submit distributed query");
+
+            wait_for_active_tasks_at_least(executor.as_ref(), 1, Duration::from_secs(20)).await?;
+
+            query_handle
+                .cancel()
+                .await
+                .expect("cancellation request should succeed");
+
+            wait_for_active_tasks_eq(executor.as_ref(), 0, Duration::from_secs(20)).await?;
+
+            let completion = timeout(Duration::from_secs(20), query_handle.wait_for_completion())
+                .await
+                .map_err(|_| anyhow::Error::msg("Timed out waiting for query cancellation"))?;
+            assert!(
+                completion.is_err(),
+                "Cancelled query should not complete successfully"
+            );
+
+            executor_rt.shutdown().await;
+            drop(executor_rt);
+            executor_server_thread.abort();
+
+            wait_for_executor_count(&executor_manager, 0, Duration::from_secs(5)).await?;
+
+            scheduler_rt.shutdown().await;
+            drop(scheduler_rt);
+            scheduler_server_thread.abort();
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/cluster/in_memory_shuffle.rs
+++ b/crates/runtime/tests/cluster/in_memory_shuffle.rs
@@ -94,6 +94,74 @@ async fn wait_for_executor_count(
     }
 }
 
+async fn run_distributed_query_with_retries(
+    runtime: &Arc<Runtime>,
+    sql: &str,
+    job_name: &str,
+    max_attempts: usize,
+) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    for attempt in 1..=max_attempts {
+        let query = QueryBuilder::new(sql, runtime.datafusion());
+        let attempt_job_name = format!("{job_name}_{attempt}");
+        let query_handle = query
+            .build()
+            .submit_distributed(&attempt_job_name)
+            .await
+            .map_err(|err| {
+                anyhow::Error::msg(format!(
+                    "Failed to submit distributed query {attempt_job_name}: {err}"
+                ))
+            })?;
+
+        let stream_result = query_handle.into_stream().await;
+        match stream_result {
+            Ok(stream) => match stream.try_collect::<Vec<RecordBatch>>().await {
+                Ok(results) => return Ok(results),
+                Err(err) => {
+                    let message = err.to_string();
+                    let is_retryable =
+                        message.contains("reported as completed but status is not successful");
+                    if attempt < max_attempts && is_retryable {
+                        tracing::warn!(
+                            attempt,
+                            max_attempts,
+                            %message,
+                            "Distributed query failed with retryable status; retrying"
+                        );
+                        sleep(Duration::from_secs(1)).await;
+                        continue;
+                    }
+                    return Err(anyhow::Error::msg(format!(
+                        "Distributed query failed (attempt {attempt}/{max_attempts}): {message}"
+                    )));
+                }
+            },
+            Err(err) => {
+                let message = err.to_string();
+                let is_retryable =
+                    message.contains("reported as completed but status is not successful");
+                if attempt < max_attempts && is_retryable {
+                    tracing::warn!(
+                        attempt,
+                        max_attempts,
+                        %message,
+                        "Distributed query stream creation failed with retryable status; retrying"
+                    );
+                    sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+                return Err(anyhow::Error::msg(format!(
+                    "Failed to get distributed query stream (attempt {attempt}/{max_attempts}): {message}"
+                )));
+            }
+        }
+    }
+
+    Err(anyhow::Error::msg(
+        "Distributed query failed after retry attempts",
+    ))
+}
+
 /// Test that in-memory shuffle works correctly with multiple executors.
 ///
 /// This test creates a cluster with:
@@ -335,6 +403,8 @@ async fn test_in_memory_shuffle_multiple_executors() -> Result<(), anyhow::Error
             }
 
             runtime_ready_check(&scheduler_rt).await;
+            runtime_ready_check(&executor1_rt).await;
+            runtime_ready_check(&executor2_rt).await;
 
             let scheduler_server = scheduler_rt
                 .datafusion()
@@ -348,51 +418,38 @@ async fn test_in_memory_shuffle_multiple_executors() -> Result<(), anyhow::Error
             // Wait for both executors to connect
             wait_for_executor_count(&executor_manager, 2, Duration::from_secs(15)).await?;
 
-            // Run a distributed GROUP BY query that requires shuffle
+            // Give the scheduler a moment to observe executor capacity before planning.
+            // Without this, the first query can race with cluster-capacity propagation and
+            // fail with a transient non-successful completed job status.
+            sleep(Duration::from_secs(2)).await;
+
+            // Run a distributed GROUP BY query that requires shuffle.
             // This query aggregates by city, which will cause hash repartitioning
             // and require shuffle data exchange between executors.
-            let query = QueryBuilder::new(
+            let results = run_distributed_query_with_retries(
+                &scheduler_rt,
                 "SELECT city, COUNT(*) as count, AVG(score) as avg_score \
                  FROM test_data \
                  GROUP BY city \
                  ORDER BY city",
-                scheduler_rt.datafusion(),
-            );
-
-            let query_handle = query
-                .build()
-                .submit_distributed("test_in_memory_shuffle_group_by")
-                .await
-                .expect("should submit distributed query");
-
-            let query_result = query_handle.into_stream().await.expect("should get stream");
-            let results = query_result
-                .try_collect::<Vec<RecordBatch>>()
-                .await
-                .expect("should collect results");
+                "test_in_memory_shuffle_group_by",
+                6,
+            )
+            .await?;
 
             let pretty = arrow::util::pretty::pretty_format_batches(&results)
                 .map_err(|e| anyhow::Error::msg(e.to_string()))
                 .expect("Should format batches");
             insta::assert_snapshot!("in_memory_shuffle_group_by_results", pretty);
 
-            // Run an ORDER BY query that also requires shuffle (sort merge)
-            let query = QueryBuilder::new(
+            // Run an ORDER BY query that also requires shuffle (sort merge).
+            let results = run_distributed_query_with_retries(
+                &scheduler_rt,
                 "SELECT name, score FROM test_data ORDER BY score DESC LIMIT 5",
-                scheduler_rt.datafusion(),
-            );
-
-            let query_handle = query
-                .build()
-                .submit_distributed("test_in_memory_shuffle_order_by")
-                .await
-                .expect("should submit distributed query");
-
-            let query_result = query_handle.into_stream().await.expect("should get stream");
-            let results = query_result
-                .try_collect::<Vec<RecordBatch>>()
-                .await
-                .expect("should collect results");
+                "test_in_memory_shuffle_order_by",
+                6,
+            )
+            .await?;
 
             let pretty = arrow::util::pretty::pretty_format_batches(&results)
                 .map_err(|e| anyhow::Error::msg(e.to_string()))

--- a/crates/runtime/tests/cluster/mod.rs
+++ b/crates/runtime/tests/cluster/mod.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+mod cancel_tasks;
 mod in_memory_shuffle;
 mod job_store;
 mod simple;


### PR DESCRIPTION
## Summary
- route scheduler task cancellation through the Spice control stream instead of direct executor gRPC cancellation
- add cancel_tasks control-stream message plumbing in runtime proto, scheduler dispatch, and executor handling
- add integration coverage asserting cancellation stops executor tasks early

Closes #8943
