### PR TITLE
x.ai models now exclusively use /v1/responses endpoint

### DIFF
--- a/crates/llms/src/xai/mod.rs
+++ b/crates/llms/src/xai/mod.rs
@@ -19,6 +19,7 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 
 mod list_models;
+mod responses;
 
 pub use list_models::XaiModelLister;
 

--- a/crates/llms/src/xai/mod.rs
+++ b/crates/llms/src/xai/mod.rs
@@ -23,6 +23,8 @@ mod responses;
 
 pub use list_models::XaiModelLister;
 
+use std::sync::Arc;
+
 use async_openai::{
     Client,
     config::OpenAIConfig,
@@ -35,12 +37,14 @@ use async_openai::{
     },
 };
 use async_trait::async_trait;
+use runtime_rate_control::RateController;
 use serde_json::json;
 
 use crate::chat::{
     Chat, Error,
     nsql::{SqlGeneration, json::JsonSchemaSqlGeneration},
 };
+use crate::openai::default_rate_controller;
 
 static DEFAULT_ENDPOINT: &str = "https://api.x.ai/v1";
 static DEFAULT_MODEL: &str = "grok-3";
@@ -49,6 +53,7 @@ static DEFAULT_MODEL: &str = "grok-3";
 pub struct Xai {
     pub model: String, // Xai model
     pub client: Client<OpenAIConfig>,
+    pub rate_controller: Arc<RateController>,
 }
 
 impl Xai {
@@ -61,6 +66,7 @@ impl Xai {
         Self {
             model: model.unwrap_or(DEFAULT_MODEL).to_string(),
             client: Client::with_config(cfg),
+            rate_controller: default_rate_controller(),
         }
     }
 
@@ -144,12 +150,19 @@ impl Chat for Xai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
         let stream = self
             .client
             .chat()
             .create_stream(self.alter_request(req))
             .await?;
 
+        drop(permit);
         Ok(Box::pin(stream))
     }
 
@@ -157,6 +170,15 @@ impl Chat for Xai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
-        self.client.chat().create(self.alter_request(req)).await
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
+        let resp = self.client.chat().create(self.alter_request(req)).await?;
+
+        drop(permit);
+        Ok(resp)
     }
 }

--- a/crates/llms/src/xai/responses.rs
+++ b/crates/llms/src/xai/responses.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/llms/src/xai/responses.rs
+++ b/crates/llms/src/xai/responses.rs
@@ -58,8 +58,15 @@ impl Responses for Xai {
         let mut inner_req = req.clone();
         inner_req.model = Some(self.model.clone());
 
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
         let stream = self.client.responses().create_stream(inner_req).await?;
 
+        drop(permit);
         Ok(Box::pin(stream))
     }
 
@@ -67,8 +74,15 @@ impl Responses for Xai {
         let mut inner_req = req.clone();
         inner_req.model = Some(self.model.clone());
 
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
         let resp = self.client.responses().create(inner_req).await?;
 
+        drop(permit);
         Ok(resp)
     }
 }

--- a/crates/llms/src/xai/responses.rs
+++ b/crates/llms/src/xai/responses.rs
@@ -1,0 +1,74 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_openai::{
+    error::OpenAIError,
+    types::responses::{CreateResponse, CreateResponseArgs, Response, ResponseStream},
+};
+use async_trait::async_trait;
+use snafu::ResultExt;
+use tracing_futures::Instrument;
+
+use crate::{
+    responses::{Error::HealthCheckError, FailedToLoadModelSnafu, Responses, Result},
+    xai::Xai,
+};
+
+#[async_trait]
+impl Responses for Xai {
+    async fn health(&self) -> Result<()> {
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "health", input = "health");
+
+        let mut req = CreateResponseArgs::default()
+            .input("ping")
+            .model(self.model.clone())
+            .build()
+            .boxed()
+            .context(FailedToLoadModelSnafu)?;
+
+        req.max_output_tokens = Some(150);
+
+        let result = self.responses_request(req).instrument(span.clone()).await;
+        tracing::debug!(
+            "{} model responses API health check response: {:?}",
+            self.model,
+            result
+        );
+        if let Err(e) = result {
+            tracing::error!(target: "task_history", parent: &span, "{e}");
+            return Err(HealthCheckError { source: e.into() });
+        }
+        Ok(())
+    }
+
+    async fn responses_stream(&self, req: CreateResponse) -> Result<ResponseStream, OpenAIError> {
+        let mut inner_req = req.clone();
+        inner_req.model = Some(self.model.clone());
+
+        let stream = self.client.responses().create_stream(inner_req).await?;
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn responses_request(&self, req: CreateResponse) -> Result<Response, OpenAIError> {
+        let mut inner_req = req.clone();
+        inner_req.model = Some(self.model.clone());
+
+        let resp = self.client.responses().create(inner_req).await?;
+
+        Ok(resp)
+    }
+}

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -27,9 +27,14 @@ use llms::{
 };
 use secrecy::SecretString;
 use snafu::ResultExt;
-use spicepod::component::model::Model as SpicepodModel;
+use spicepod::component::model::{Model as SpicepodModel, ModelSource};
 
-fn supports_responses_api(params: &HashMap<String, SecretString>) -> bool {
+fn supports_responses_api(m: &SpicepodModel, params: &HashMap<String, SecretString>) -> bool {
+    // xAI always uses Responses API (chat/completions is legacy)
+    if let Some(ModelSource::Xai) = m.get_source() {
+        return true;
+    }
+
     params
         .get("responses_api")
         .map(secrecy::ExposeSecret::expose_secret)
@@ -58,7 +63,7 @@ impl Runtime {
             .map_err(try_map_boxed_error_to_box)
             .context(UnableToInitializeLlmSnafu)?;
 
-        let mut responses_model = if supports_responses_api(&params) {
+        let mut responses_model = if supports_responses_api(&m, &params) {
             try_to_responses_model(&m, &params, Arc::new(self.clone()))
                 .await
                 .ok()

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -31,7 +31,7 @@ use spicepod::component::model::{Model as SpicepodModel, ModelSource};
 
 fn supports_responses_api(m: &SpicepodModel, params: &HashMap<String, SecretString>) -> bool {
     // xAI always uses Responses API (chat/completions is legacy)
-    if let Some(ModelSource::Xai) = m.get_source() {
+    if m.get_source() == Some(ModelSource::Xai) {
         return true;
     }
 

--- a/crates/runtime/src/model/responses.rs
+++ b/crates/runtime/src/model/responses.rs
@@ -131,6 +131,8 @@ fn construct_model(
     let model = match prefix {
         ModelSource::OpenAi => openai(model_id, params),
         ModelSource::Azure => azure(model_id, component.name.as_str(), params),
+
+        ModelSource::Xai => xai(model_id.as_deref(), params),
         _ => Err(LlmError::ResponsesNotSupported {
             from: component.get_source().ok_or(LlmError::UnknownModelSource {
                 from: component.from.clone(),
@@ -253,4 +255,13 @@ fn azure(
         entra_token,
         api_key,
     )) as Arc<dyn Responses>)
+}
+
+fn xai(model_id: Option<&str>, params: &Parameters) -> Result<Arc<dyn Responses>, LlmError> {
+    let Some(api_key) = params.get("api_key").expose().ok() else {
+        return Err(LlmError::FailedToLoadModel {
+            source: "No `xai_api_key` provided for xAI model.".into(),
+        });
+    };
+    Ok(Arc::new(llms::xai::Xai::new(model_id, api_key)) as Arc<dyn Responses>)
 }


### PR DESCRIPTION
Aligns with x.ai's API strategy where:

/v1/messages is deprecated
/v1/chat/completions is legacy
/v1/responses is current

See https://docs.x.ai/overview