### PR TITLE
Testoperator: add support for api-key when connecting to external spice instance

### DIFF
--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -55,6 +55,7 @@ pub enum SpicedInstance {
     External {
         flight_url: String,
         http_base_url: String,
+        api_key: Option<String>,
     },
     Owned {
         child: Child,
@@ -142,16 +143,22 @@ impl SpicedInstance {
     #[must_use]
     pub fn external(flight_url: impl Into<String>) -> Self {
         let flight_url = flight_url.into();
-        // Derive HTTP URL from Flight URL by replacing port
-        // e.g., "http://localhost:50051" -> "http://localhost:8090"
-        let http_base_url = if let Some(last_colon) = flight_url.rfind(':') {
+
+        // Spice Cloud has a dedicated HTTP endpoint
+        let http_base_url = if flight_url.contains("flight.spiceai.io") {
+            "https://data.spiceai.io".to_string()
+        } else if let Some(last_colon) = flight_url.rfind(':') {
+            // Derive HTTP URL from Flight URL by replacing port
+            // e.g., "http://localhost:50051" -> "http://localhost:8090"
             format!("{}:8090", &flight_url[..last_colon])
         } else {
             format!("{flight_url}:8090")
         };
+
         Self::External {
             flight_url,
             http_base_url,
+            api_key: None,
         }
     }
 
@@ -164,7 +171,21 @@ impl SpicedInstance {
         Self::External {
             flight_url: flight_url.into(),
             http_base_url: http_base_url.into(),
+            api_key: None,
         }
+    }
+
+    /// Set the API key for an external instance.
+    #[must_use]
+    pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
+        if let Self::External {
+            api_key: ref mut key,
+            ..
+        } = self
+        {
+            *key = api_key;
+        }
+        self
     }
 
     /// Start a spiced instance
@@ -286,9 +307,22 @@ impl SpicedInstance {
     ///
     /// - If the http client fails to be created
     pub fn http_client(&self) -> Result<reqwest::Client> {
-        Ok(reqwest::Client::builder()
-            .user_agent("spice-test-framework/1.0")
-            .build()?)
+        let mut builder = reqwest::Client::builder().user_agent("spice-test-framework/1.0");
+
+        if let Self::External {
+            api_key: Some(key), ..
+        } = self
+        {
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                "X-API-Key",
+                reqwest::header::HeaderValue::from_str(key)
+                    .map_err(|e| anyhow!("Invalid API key header value: {e}"))?,
+            );
+            builder = builder.default_headers(headers);
+        }
+
+        Ok(builder.build()?)
     }
 
     /// Get the HTTP base URL for this instance

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -297,6 +297,11 @@ pub struct LoadTestArgs {
     /// Run until manually interrupted; disables duration-based stopping for the load phase
     #[arg(long)]
     pub(crate) run_until_stopped: bool,
+
+    /// API key for authenticating with an external spiced instance.
+    /// Only applicable when --spiced-path is a URL to an already-running instance.
+    #[arg(long)]
+    pub(crate) api_key: Option<String>,
 }
 
 /// Parse a duration string like "500ms", "2s", "1m" into a `Duration`

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -45,6 +45,11 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         ));
     }
 
+    // Warn if api_key is set but not connecting to an external instance
+    if args.api_key.is_some() && !args.test_args.common.is_external_instance() {
+        println!("--api-key is only applicable when connecting to an external instance; ignoring");
+    }
+
     // Check if connecting to an external instance or starting a new one
     let (app, mut spiced_instance) = if args.test_args.common.is_external_instance() {
         println!(
@@ -55,7 +60,8 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         let app = AppBuilder::new(spicepod.name.clone())
             .with_spicepod(spicepod)
             .build();
-        let instance = SpicedInstance::external(&args.test_args.common.spiced_path);
+        let instance = SpicedInstance::external(&args.test_args.common.spiced_path)
+            .with_api_key(args.api_key.clone());
         (app, instance)
     } else {
         let (app, start_request) = get_app_and_start_request(&args.test_args.common).await?;
@@ -63,9 +69,13 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         (app, instance)
     };
 
+    println!("Waiting for spiced instance to be ready...");
+
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.test_args.common.ready_wait))
         .await?;
+
+    println!("spiced instance is ready!");
 
     // Build resource with attributes known upfront, before creating telemetry.
     // This ensures the SdkMeterProvider is created with the correct resource,
@@ -136,6 +146,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
 
     let warm_up = SpiceTest::<NotStarted>::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
+        .with_api_key(args.api_key.clone())
         .with_progress_bars(!args.test_args.common.disable_progress_bars)
         .start()
         .await?;
@@ -164,6 +175,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
 
     let baseline_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
+        .with_api_key(args.api_key.clone())
         .with_progress_bars(!args.test_args.common.disable_progress_bars)
         .start()
         .await?;
@@ -226,6 +238,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
 
     let throughput_test = SpiceTest::<NotStarted>::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
+        .with_api_key(args.api_key.clone())
         .with_progress_bars(!args.test_args.common.disable_progress_bars)
         .start()
         .await?;


### PR DESCRIPTION
## 📝 Summary

Add support for api-key when connecting to external spice instance

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
