### PR TITLE
fix(spidapter): use Flight handshake auth instead of x-api-key header

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -101,7 +101,11 @@ impl Handler for SpidapterHandler {
                     serde_json::Value::String(state.flight_url.clone()),
                 ),
                 (
-                    "adbc.flight.sql.rpc.call_header.x-api-key".to_string(),
+                    "username".to_string(),
+                    serde_json::Value::String(String::new()),
+                ),
+                (
+                    "password".to_string(),
                     serde_json::Value::String(state.api_key.clone()),
                 ),
             ]),


### PR DESCRIPTION
## Problem

The ADBC FlightSQL driver in spicebench was failing with:

```
Unauthenticated: [FlightSQL] invalid API key (Unauthenticated; ExecuteQuery)
```

## Root Cause

spidapter's `query_method` was returning the API key as a custom gRPC metadata header:

```
adbc.flight.sql.rpc.call_header.x-api-key -> api_key
```

The Spice Cloud Flight endpoint does not authenticate via the `x-api-key` gRPC header. It uses the standard **Arrow Flight handshake protocol** — the same way the `spice-rs` SDK authenticates: `username=""` and `password=<api_key>`, which triggers a `Handshake` RPC with Basic auth that returns a Bearer token for subsequent calls.

## Fix

Return `username`/`password` in `db_kwargs` instead of the custom header, so the ADBC FlightSQL driver performs the standard Flight handshake.

## Verification

Tested with a real API key against `us-east-1-dev-aws-flight.spiceai.io`:
- ❌ `adbc.flight.sql.rpc.call_header.x-api-key` → `Unauthenticated: invalid API key`
- ✅ `username=""` + `password=<api_key>` → `SELECT 1` returns successfully