### PR TITLE
feat: Add Iceberg DELETE FROM support via equality delete files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,6 +5233,7 @@ dependencies = [
  "object_store",
  "opendal",
  "oracle",
+ "parquet",
  "rand 0.9.2",
  "rdkafka",
  "regex",
@@ -9327,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc822e6e9e7a1d9a04b6cd5bae0339f46558616e#cc822e6e9e7a1d9a04b6cd5bae0339f46558616e"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d9dd7af67f65380695a66b11ff8f073a020ca493#d9dd7af67f65380695a66b11ff8f073a020ca493"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -9383,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc822e6e9e7a1d9a04b6cd5bae0339f46558616e#cc822e6e9e7a1d9a04b6cd5bae0339f46558616e"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d9dd7af67f65380695a66b11ff8f073a020ca493#d9dd7af67f65380695a66b11ff8f073a020ca493"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9398,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc822e6e9e7a1d9a04b6cd5bae0339f46558616e#cc822e6e9e7a1d9a04b6cd5bae0339f46558616e"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d9dd7af67f65380695a66b11ff8f073a020ca493#d9dd7af67f65380695a66b11ff8f073a020ca493"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9424,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc822e6e9e7a1d9a04b6cd5bae0339f46558616e#cc822e6e9e7a1d9a04b6cd5bae0339f46558616e"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d9dd7af67f65380695a66b11ff8f073a020ca493#d9dd7af67f65380695a66b11ff8f073a020ca493"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9439,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc822e6e9e7a1d9a04b6cd5bae0339f46558616e#cc822e6e9e7a1d9a04b6cd5bae0339f46558616e"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d9dd7af67f65380695a66b11ff8f073a020ca493#d9dd7af67f65380695a66b11ff8f073a020ca493"
 dependencies = [
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,11 +381,11 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc822e6e9e7a1d9a04b6cd5bae0339f46558616e" }              # spiceai-0.8.0
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc822e6e9e7a1d9a04b6cd5bae0339f46558616e" } # spiceai-0.8.0
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc822e6e9e7a1d9a04b6cd5bae0339f46558616e" } # spiceai-0.8.0
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc822e6e9e7a1d9a04b6cd5bae0339f46558616e" }   # spiceai-0.8.0
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc822e6e9e7a1d9a04b6cd5bae0339f46558616e" }   # spiceai-0.8.0
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d9dd7af67f65380695a66b11ff8f073a020ca493" }              # spiceai-51
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d9dd7af67f65380695a66b11ff8f073a020ca493" } # spiceai-51
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d9dd7af67f65380695a66b11ff8f073a020ca493" } # spiceai-51
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d9dd7af67f65380695a66b11ff8f073a020ca493" }   # spiceai-51
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d9dd7af67f65380695a66b11ff8f073a020ca493" }   # spiceai-51
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }
 

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -59,6 +59,7 @@ hash-index = { path = "../hash-index", features = ["metrics"] }
 http.workspace = true
 httpdate.workspace = true
 iceberg = { workspace = true, features = ["storage-gcs", "storage-s3"] }
+parquet = { workspace = true }
 iceberg-catalog-rest.workspace = true
 iceberg-datafusion.workspace = true
 imap = { workspace = true, optional = true }

--- a/crates/data_components/src/iceberg/delete.rs
+++ b/crates/data_components/src/iceberg/delete.rs
@@ -1,0 +1,576 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Iceberg delete support via equality delete files.
+//!
+//! This module implements `DELETE FROM` for Iceberg tables by writing equality
+//! delete files and committing them via the `RowDeltaAction` transaction.
+//!
+//! The approach:
+//! 1. Compute equality-eligible columns (primitive, non-float types)
+//! 2. Scan the table with WHERE filters, projected to only equality columns
+//! 3. Write the matching rows as equality delete Parquet files
+//! 4. Commit the delete files via `RowDeltaAction`
+//!
+//! This uses Iceberg's merge-on-read strategy: the delete files are separate
+//! from data files, and the Iceberg reader filters them out at read time.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use async_trait::async_trait;
+use datafusion::catalog::{ScanArgs, ScanResult, Session};
+use datafusion::common::{
+    Constraints, DataFusionError, Result as DFResult, Statistics, ToDFSchema, tree_node::TreeNode,
+};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+};
+use futures::StreamExt;
+use iceberg::arrow::schema_to_arrow_schema;
+use iceberg::spec::{DataFileFormat, TableProperties};
+use iceberg::table::Table;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
+use iceberg::writer::base_writer::equality_delete_writer::{
+    EqualityDeleteFileWriterBuilder, EqualityDeleteWriterConfig,
+};
+use iceberg::writer::file_writer::ParquetWriterBuilder;
+use iceberg::writer::file_writer::location_generator::{
+    DefaultFileNameGenerator, DefaultLocationGenerator,
+};
+use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
+use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use iceberg::{Catalog, Error as IcebergError};
+use parquet::file::properties::WriterProperties;
+use uuid::Uuid;
+
+use iceberg::arrow::FieldMatchMode;
+fn to_df_error(e: IcebergError) -> DataFusionError {
+    DataFusionError::External(Box::new(e))
+}
+
+/// Execution plan that scans matching rows, writes equality delete files,
+/// and commits them via `RowDeltaAction`.
+///
+/// Output schema: single column `count` (`UInt64`) with the number of deleted rows.
+pub(crate) struct IcebergDeleteExec {
+    table: Table,
+    catalog: Arc<dyn Catalog>,
+    /// The child plan that produces the rows to delete (a scan with filters applied).
+    /// The scan is projected to only include columns eligible for equality deletes.
+    input: Arc<dyn ExecutionPlan>,
+    /// Pre-computed equality delete field IDs (primitive, non-float columns).
+    equality_ids: Vec<i32>,
+    /// Schema of the count output.
+    count_schema: ArrowSchemaRef,
+    plan_properties: PlanProperties,
+}
+
+impl IcebergDeleteExec {
+    pub fn new(
+        table: Table,
+        catalog: Arc<dyn Catalog>,
+        input: Arc<dyn ExecutionPlan>,
+        equality_ids: Vec<i32>,
+    ) -> Self {
+        let count_schema = Self::make_count_schema();
+        let plan_properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&count_schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+
+        Self {
+            table,
+            catalog,
+            input,
+            equality_ids,
+            count_schema,
+            plan_properties,
+        }
+    }
+
+    fn make_count_schema() -> ArrowSchemaRef {
+        Arc::new(ArrowSchema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]))
+    }
+
+    fn make_count_batch(count: u64) -> DFResult<RecordBatch> {
+        let count_array = Arc::new(UInt64Array::from(vec![count])) as ArrayRef;
+        RecordBatch::try_from_iter_with_nullable(vec![("count", count_array, false)])
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+impl Debug for IcebergDeleteExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergDeleteExec")
+            .field("table", &self.table.identifier().to_string())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for IcebergDeleteExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(f, "IcebergDeleteExec: table={}", self.table.identifier())
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for IcebergDeleteExec {
+    fn name(&self) -> &'static str {
+        "IcebergDeleteExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn required_input_distribution(&self) -> Vec<datafusion::physical_plan::Distribution> {
+        vec![datafusion::physical_plan::Distribution::SinglePartition]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "IcebergDeleteExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(IcebergDeleteExec::new(
+            self.table.clone(),
+            Arc::clone(&self.catalog),
+            Arc::clone(&children[0]),
+            self.equality_ids.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "IcebergDeleteExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let table = self.table.clone();
+        let catalog = Arc::clone(&self.catalog);
+        let input_plan = Arc::clone(&self.input);
+        let count_schema = Arc::clone(&self.count_schema);
+        let equality_ids = self.equality_ids.clone();
+
+        let stream = futures::stream::once(async move {
+            // Collect all input partitions into a single stream
+            let partition_count = input_plan.output_partitioning().partition_count();
+            let mut total_delete_count: u64 = 0;
+
+            // Get the iceberg schema for the equality delete writer
+            let iceberg_schema = Arc::clone(table.metadata().current_schema());
+
+            tracing::debug!(
+                table = %table.identifier(),
+                equality_id_count = equality_ids.len(),
+                ?equality_ids,
+                "Writing equality delete files"
+            );
+
+            // Set up the equality delete writer
+            let file_io = table.file_io().clone();
+            let location_generator =
+                DefaultLocationGenerator::new(table.metadata().clone()).map_err(to_df_error)?;
+            let file_name_generator = DefaultFileNameGenerator::new(
+                Uuid::now_v7().to_string(),
+                Some("eq-del".to_string()),
+                DataFileFormat::Parquet,
+            );
+
+            let target_file_size = table
+                .metadata()
+                .properties()
+                .get(TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES)
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
+
+            // Build a sub-schema containing only the equality-eligible
+            // fields. The input scan is already projected to these columns,
+            // so the `EqualityDeleteWriterConfig` projector must map from
+            // this sub-schema (not the full table schema) to avoid index
+            // out-of-bounds when re-projecting the already-projected batches.
+            let equality_id_set: std::collections::HashSet<i32> =
+                equality_ids.iter().copied().collect();
+            let equality_fields: Vec<_> = iceberg_schema
+                .as_struct()
+                .fields()
+                .iter()
+                .filter(|f| equality_id_set.contains(&f.id))
+                .cloned()
+                .collect();
+            let equality_schema = Arc::new(
+                iceberg::spec::Schema::builder()
+                    .with_schema_id(iceberg_schema.schema_id())
+                    .with_fields(equality_fields)
+                    .build()
+                    .map_err(to_df_error)?,
+            );
+
+            let parquet_writer_builder = ParquetWriterBuilder::new_with_match_mode(
+                WriterProperties::default(),
+                Arc::clone(&equality_schema),
+                FieldMatchMode::Name,
+            );
+            let rolling_writer_builder = RollingFileWriterBuilder::new(
+                parquet_writer_builder,
+                target_file_size,
+                file_io,
+                location_generator,
+                file_name_generator,
+            );
+
+            let config = EqualityDeleteWriterConfig::new(equality_ids.clone(), equality_schema)
+                .map_err(to_df_error)?;
+
+            let writer_builder =
+                EqualityDeleteFileWriterBuilder::new(rolling_writer_builder, config);
+
+            let mut writer = writer_builder.build(None).await.map_err(to_df_error)?;
+
+            // Read from all partitions and write equality delete files.
+            // The input scan is already projected to only include the equality
+            // columns, so no additional projection is needed.
+            for p in 0..partition_count {
+                let mut batch_stream = input_plan.execute(p, Arc::clone(&context))?;
+                while let Some(batch_result) = batch_stream.next().await {
+                    let batch = batch_result?;
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+
+                    let batch_rows = u64::try_from(batch.num_rows()).map_err(|_| {
+                        DataFusionError::Internal(format!(
+                            "Batch row count {} exceeds u64 range",
+                            batch.num_rows()
+                        ))
+                    })?;
+                    total_delete_count =
+                        total_delete_count.checked_add(batch_rows).ok_or_else(|| {
+                            DataFusionError::Internal(
+                                "Total delete row count overflowed u64".to_string(),
+                            )
+                        })?;
+                    writer.write(batch).await.map_err(to_df_error)?;
+                }
+            }
+
+            // If no rows matched, return count=0
+            if total_delete_count == 0 {
+                return Self::make_count_batch(0);
+            }
+
+            // Close the writer to get the delete files
+            let delete_files = writer.close().await.map_err(to_df_error)?;
+
+            if delete_files.is_empty() {
+                return Self::make_count_batch(0);
+            }
+
+            // Commit via RowDeltaAction
+            let tx = Transaction::new(&table);
+            let action = tx.row_delta().add_delete_files(delete_files);
+
+            action
+                .apply(tx)
+                .map_err(to_df_error)?
+                .commit(catalog.as_ref())
+                .await
+                .map_err(to_df_error)?;
+
+            Self::make_count_batch(total_delete_count)
+        })
+        .boxed();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            count_schema,
+            stream,
+        )))
+    }
+}
+
+/// Wrapper that makes an `IcebergTableProvider` support `DeletionTableProvider`.
+///
+/// This is registered as the table provider when the Iceberg data connector
+/// supports writes, enabling `DELETE FROM` SQL statements.
+pub struct IcebergDeletionProvider {
+    catalog: Arc<dyn Catalog>,
+    table_ident: iceberg::TableIdent,
+    inner: Arc<dyn datafusion::datasource::TableProvider>,
+}
+
+impl IcebergDeletionProvider {
+    /// Create a new deletion-capable wrapper around an `IcebergTableProvider`.
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        namespace: iceberg::NamespaceIdent,
+        table_name: String,
+        inner: Arc<dyn datafusion::datasource::TableProvider>,
+    ) -> Self {
+        let table_ident = iceberg::TableIdent::new(namespace, table_name);
+        Self {
+            catalog,
+            table_ident,
+            inner,
+        }
+    }
+}
+
+impl Debug for IcebergDeletionProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergDeletionProvider")
+            .field("table_ident", &self.table_ident.to_string())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl datafusion::datasource::TableProvider for IcebergDeletionProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.inner.schema()
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        self.inner.constraints()
+    }
+
+    fn table_type(&self) -> datafusion::datasource::TableType {
+        self.inner.table_type()
+    }
+
+    fn get_table_definition(&self) -> Option<&str> {
+        self.inner.get_table_definition()
+    }
+
+    fn get_logical_plan(&'_ self) -> Option<Cow<'_, LogicalPlan>> {
+        self.inner.get_logical_plan()
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&datafusion::logical_expr::Expr> {
+        self.inner.get_column_default(column)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&datafusion::logical_expr::Expr],
+    ) -> DFResult<Vec<datafusion::logical_expr::TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[datafusion::logical_expr::Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.scan(state, projection, filters, limit).await
+    }
+
+    async fn scan_with_args<'a>(
+        &self,
+        state: &dyn Session,
+        args: ScanArgs<'a>,
+    ) -> DFResult<ScanResult> {
+        self.inner.scan_with_args(state, args).await
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        overwrite: datafusion::logical_expr::dml::InsertOp,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.insert_into(state, input, overwrite).await
+    }
+}
+
+#[async_trait]
+impl crate::delete::DeletionTableProvider for IcebergDeletionProvider {
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: &[datafusion::logical_expr::Expr],
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Load fresh table metadata
+        let table = self
+            .catalog
+            .load_table(&self.table_ident)
+            .await
+            .map_err(to_df_error)?;
+
+        // Verify format version supports deletes
+        if table.metadata().format_version() == iceberg::spec::FormatVersion::V1 {
+            return Err(DataFusionError::Plan(
+                "DELETE is not supported on Iceberg v1 tables. Upgrade to v2 format.".to_string(),
+            ));
+        }
+
+        // Derive the equality_ids and scan projection up front. Only primitive
+        // non-floating-point columns are eligible for equality deletes per the
+        // Iceberg spec. We compute them here so the scan can be projected to
+        // only those columns, avoiding reads of float/nested columns that the
+        // Iceberg reader cannot resolve by field-id.
+        let iceberg_schema = table.metadata().current_schema();
+        let arrow_schema = Arc::new(schema_to_arrow_schema(iceberg_schema).map_err(to_df_error)?);
+
+        // Compute (column_index, field_id) pairs for eligible equality columns
+        let mut equality_ids: Vec<i32> = Vec::new();
+        let mut projection_indices: Vec<usize> = Vec::new();
+        for (idx, field) in arrow_schema.fields().iter().enumerate() {
+            if field.data_type().is_nested()
+                || matches!(
+                    field.data_type(),
+                    arrow::datatypes::DataType::Float16
+                        | arrow::datatypes::DataType::Float32
+                        | arrow::datatypes::DataType::Float64
+                )
+            {
+                continue;
+            }
+            if let Some(field_id) = field
+                .metadata()
+                .get(parquet::arrow::PARQUET_FIELD_ID_META_KEY)
+                .and_then(|v| v.parse::<i32>().ok())
+            {
+                equality_ids.push(field_id);
+                projection_indices.push(idx);
+            }
+        }
+
+        tracing::debug!(
+            table = %table.identifier(),
+            schema_field_count = arrow_schema.fields().len(),
+            equality_id_count = equality_ids.len(),
+            ?equality_ids,
+            "Computed equality delete IDs for scan projection"
+        );
+
+        // Scan only the equality-eligible columns. This avoids reading
+        // float/nested columns that cause field-id resolution errors.
+        let scan_plan = self
+            .inner
+            .scan(state, Some(&projection_indices), filters, None)
+            .await?;
+
+        // The Iceberg provider may not push down filters, so add a FilterExec
+        // on top of the scan to ensure only matching rows are processed.
+        // Filter column references must be unqualified to match the scan
+        // output schema (which uses bare column names, not table-qualified).
+        let filtered_plan = if filters.is_empty() {
+            scan_plan
+        } else {
+            let scan_schema = scan_plan.schema();
+            let df_schema = scan_schema.to_dfschema_ref()?;
+            let unqualified_filters: Vec<datafusion::logical_expr::Expr> = filters
+                .iter()
+                .map(|expr| {
+                    expr.clone()
+                        .transform(|e| {
+                            if let datafusion::logical_expr::Expr::Column(mut col) = e {
+                                col.relation = None;
+                                Ok(datafusion::common::tree_node::Transformed::yes(
+                                    datafusion::logical_expr::Expr::Column(col),
+                                ))
+                            } else {
+                                Ok(datafusion::common::tree_node::Transformed::no(e))
+                            }
+                        })
+                        .map(|t| t.data)
+                })
+                .collect::<DFResult<Vec<_>>>()?;
+            let combined_filter = unqualified_filters
+                .into_iter()
+                .reduce(datafusion::prelude::Expr::and)
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Filter list unexpectedly empty".to_string())
+                })?;
+            let physical_filter = datafusion::physical_expr::create_physical_expr(
+                &combined_filter,
+                &df_schema,
+                state.execution_props(),
+            )?;
+            Arc::new(datafusion::physical_plan::filter::FilterExec::try_new(
+                physical_filter,
+                scan_plan,
+            )?) as Arc<dyn ExecutionPlan>
+        };
+
+        // Coalesce into a single partition for the delete writer
+        let coalesced = Arc::new(
+            datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(
+                filtered_plan,
+            ),
+        );
+
+        Ok(Arc::new(IcebergDeleteExec::new(
+            table,
+            Arc::clone(&self.catalog),
+            coalesced,
+            equality_ids,
+        )))
+    }
+}

--- a/crates/data_components/src/iceberg/mod.rs
+++ b/crates/data_components/src/iceberg/mod.rs
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 pub mod catalog;
+pub mod delete;
 pub mod provider;

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -323,7 +323,21 @@ impl IcebergSchemaProvider {
         )
         .await
         {
-            Ok(provider) => Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>)),
+            Ok(provider) => {
+                // Wrap in IcebergDeletionProvider + DeletionTableProviderAdapter so that
+                // catalog tables support DELETE FROM via equality delete files.
+                // Access control is handled by the SQL validator, not here.
+                let deletion_provider = crate::iceberg::delete::IcebergDeletionProvider::new(
+                    Arc::clone(&catalog),
+                    table_name.namespace().clone(),
+                    table_name.name().to_string(),
+                    Arc::new(provider),
+                );
+                let adapted: Arc<dyn TableProvider> = Arc::new(
+                    crate::delete::DeletionTableProviderAdapter::new(Arc::new(deletion_provider)),
+                );
+                Ok(Some(adapted))
+            }
             Err(e) => {
                 let err_msg = e.to_string();
                 if err_msg.contains("NoSuchIcebergTableException") || err_msg.contains("code: 404")

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use aws_sdk_credential_bridge::S3CredentialProvider;
 use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
-use iceberg::{Catalog, TableIdent, io::CustomAwsCredentialLoader};
+use iceberg::{Catalog, NamespaceIdent, TableIdent, io::CustomAwsCredentialLoader};
 use iceberg_datafusion::IcebergTableProvider;
 use secrecy::ExposeSecret;
 use util::concat_arrays;
@@ -101,6 +101,14 @@ impl DataConnectorFactory for IcebergDataConnectorFactory {
     }
 }
 
+/// Holds the components needed for both read and read-write Iceberg providers.
+struct IcebergTableParts {
+    provider: Arc<dyn TableProvider>,
+    catalog: Arc<dyn Catalog>,
+    namespace: NamespaceIdent,
+    table_name: String,
+}
+
 #[derive(Clone, Debug)]
 pub struct IcebergDataConnector {
     params: Parameters,
@@ -118,6 +126,16 @@ impl IcebergDataConnector {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        let parts = self.create_iceberg_table_parts(dataset).await?;
+        Ok(parts.provider)
+    }
+
+    /// Creates the Iceberg table provider along with the catalog, namespace, and table name.
+    /// This is used by `read_write_provider` to create a deletion-capable wrapper.
+    async fn create_iceberg_table_parts(
+        &self,
+        dataset: &Dataset,
+    ) -> super::DataConnectorResult<IcebergTableParts> {
         let source = dataset.path();
 
         let mut props = HashMap::new();
@@ -227,15 +245,15 @@ impl IcebergDataConnector {
             catalog_client = catalog_client.with_file_io_extension(custom_loader);
         }
 
-        let catalog_client = Arc::new(catalog_client);
+        let catalog_client: Arc<dyn Catalog> = Arc::new(catalog_client);
 
         // Load the specific table
         let namespace_ident = namespace.name().clone();
-        let table_identifier = TableIdent::new(namespace_ident, table_name);
+        let table_identifier = TableIdent::new(namespace_ident, table_name.clone());
 
         // Create IcebergTableProvider with catalog reference for read/write support
         let table_provider = IcebergTableProvider::try_new(
-            catalog_client,
+            Arc::clone(&catalog_client),
             table_identifier.namespace().clone(),
             table_identifier.name().to_string(),
         )
@@ -246,7 +264,12 @@ impl IcebergDataConnector {
             source: Box::new(e),
         })?;
 
-        Ok(Arc::new(table_provider))
+        Ok(IcebergTableParts {
+            provider: Arc::new(table_provider),
+            catalog: catalog_client,
+            namespace: table_identifier.namespace().clone(),
+            table_name,
+        })
     }
 
     async fn load_hadoop_catalog(
@@ -255,7 +278,7 @@ impl IcebergDataConnector {
         dataset: &Dataset,
         source: &str,
         metadata_mode: MetadataMode,
-    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+    ) -> super::DataConnectorResult<IcebergTableParts> {
         let (base_uri, namespace, table_name) = parse_hadoop_table_url(source, None).map_err(|e| {
                 Error::InvalidConfiguration {
                     dataconnector: "iceberg".into(),
@@ -266,6 +289,7 @@ impl IcebergDataConnector {
             })?;
 
         // Load the specific table
+        let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 
         let mut catalog_builder = HadoopCatalogBuilder::default()
@@ -288,7 +312,7 @@ impl IcebergDataConnector {
 
         // Create IcebergTableProvider with catalog reference for read/write support
         let table_provider = IcebergTableProvider::try_new(
-            catalog_client,
+            Arc::clone(&catalog_client),
             table_identifier.namespace().clone(),
             table_identifier.name().to_string(),
         )
@@ -299,7 +323,12 @@ impl IcebergDataConnector {
             source: Box::new(e),
         })?;
 
-        Ok(Arc::new(table_provider))
+        Ok(IcebergTableParts {
+            provider: Arc::new(table_provider),
+            catalog: catalog_client,
+            namespace: table_identifier.namespace().clone(),
+            table_name: table_name_str,
+        })
     }
 }
 
@@ -321,8 +350,24 @@ impl DataConnector for IcebergDataConnector {
         &self,
         dataset: &Dataset,
     ) -> Option<super::DataConnectorResult<Arc<dyn TableProvider>>> {
-        // IcebergTableProvider supports both read and write operations
-        Some(self.create_iceberg_table_provider(dataset).await)
+        // Create the table parts which include catalog + identity for delete support
+        let parts = match self.create_iceberg_table_parts(dataset).await {
+            Ok(parts) => parts,
+            Err(e) => return Some(Err(e)),
+        };
+
+        // Wrap in IcebergDeletionProvider for DELETE FROM support, then in
+        // DeletionTableProviderAdapter so get_deletion_provider can find it.
+        let deletion_provider = data_components::iceberg::delete::IcebergDeletionProvider::new(
+            parts.catalog,
+            parts.namespace,
+            parts.table_name,
+            parts.provider,
+        );
+        let adapted: Arc<dyn TableProvider> = Arc::new(
+            data_components::delete::DeletionTableProviderAdapter::new(Arc::new(deletion_provider)),
+        );
+        Some(Ok(adapted))
     }
 }
 

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -212,11 +212,24 @@ impl ExecutionPlan for IcebergCreateTableExec {
                 ))
             })?;
 
-            // Register in the DataFusion catalog's schema provider
+            // Register in the DataFusion catalog's schema provider.
+            // Wrap in IcebergDeletionProvider + DeletionTableProviderAdapter so the
+            // table supports DELETE FROM via equality delete files.
             if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
                 && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
             {
-                schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+                let deletion_provider =
+                    data_components::iceberg::delete::IcebergDeletionProvider::new(
+                        Arc::clone(&catalog),
+                        namespace.clone(),
+                        table_name.clone(),
+                        Arc::new(provider),
+                    );
+                let adapted: Arc<dyn datafusion::datasource::TableProvider> =
+                    Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
+                        Arc::new(deletion_provider),
+                    ));
+                schema_provider.register_table(table_name.clone(), adapted)?;
             }
 
             let batch = RecordBatch::try_new(

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -682,6 +682,41 @@ impl Query {
                         }
                     };
                     (stream, df_plan)
+                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+                    // DELETE operations need special handling because DataFusion doesn't
+                    // support DELETE natively. We intercept the DML Delete plan, extract
+                    // the filter predicates, and delegate to the DeletionTableProvider.
+                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df).await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
+
+                    let task_ctx = Arc::new(TaskContext::from(&session));
+                    let stream = match execute_stream(Arc::clone(&delete_plan), task_ctx) {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
+                    (stream, delete_plan)
                 } else {
                     // For regular plans, use the standard physical plan execution
                     let physical_plan = match session.create_physical_plan(&plan).await {
@@ -718,11 +753,16 @@ impl Query {
                     (stream, physical_plan)
                 };
 
-            // Skip schema verification for Statement plans (PREPARE/EXECUTE/DEALLOCATE)
-            // and DDL plans (CREATE TABLE/DROP TABLE) as their logical plan schema may
-            // differ from the actual execution result (DDL plans may be rewritten by
-            // analyzer rules into extension nodes with different output schemas)
-            if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_)) {
+            // Skip schema verification for Statement plans (PREPARE/EXECUTE/DEALLOCATE),
+            // DDL plans (CREATE TABLE/DROP TABLE), and DML Delete plans, as their logical
+            // plan schema may differ from the actual execution result (DDL plans may be
+            // rewritten by analyzer rules into extension nodes with different output schemas)
+            if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
+                && !matches!(
+                    &*plan,
+                    LogicalPlan::Dml(dml) if matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
+                )
+            {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 
@@ -1090,6 +1130,62 @@ pub fn write_to_json_string(
     writer.finish()?;
 
     String::from_utf8(writer.into_inner()).boxed()
+}
+
+/// Creates a physical execution plan for a `DELETE FROM` DML statement.
+///
+/// `DataFusion` does not natively support `DELETE` operations, so we intercept
+/// the logical `DmlStatement` with `WriteOp::Delete`, extract the filter
+/// predicate from the source plan, look up the table's `DeletionTableProvider`,
+/// and call `delete_from` to produce the physical plan.
+///
+/// The source plan in the `DmlStatement` is either:
+/// - `Filter(predicate, TableScan)` — when `DELETE FROM t WHERE <predicate>`
+/// - `TableScan` — when `DELETE FROM t` (no WHERE clause)
+async fn create_delete_physical_plan(
+    dml: &datafusion::logical_expr::DmlStatement,
+    df: &Arc<DataFusion>,
+) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    use data_components::delete::get_deletion_provider;
+
+    // Extract filter expressions from the source plan
+    let filters = extract_delete_filters(&dml.input);
+
+    // Look up the table provider
+    let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Table '{}' not found for DELETE operation",
+            dml.table_name
+        ))
+    })?;
+
+    // Get the DeletionTableProvider
+    let deletion_provider = get_deletion_provider(table_provider).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Table '{}' does not support DELETE operations",
+            dml.table_name
+        ))
+    })?;
+
+    let session_state = df.ctx.state();
+    deletion_provider
+        .delete_from(&session_state, &filters)
+        .await
+}
+
+/// Extract filter expressions from a DELETE's source logical plan.
+///
+/// The source plan is either `Filter(predicate, scan)` or just `scan`.
+/// Returns the individual conjunctive filter expressions, or an empty
+/// vec if there is no WHERE clause.
+fn extract_delete_filters(source: &LogicalPlan) -> Vec<datafusion::logical_expr::Expr> {
+    use datafusion_expr::utils::split_conjunction_owned;
+
+    if let LogicalPlan::Filter(filter) = source {
+        split_conjunction_owned(filter.predicate.clone())
+    } else {
+        vec![]
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -27,10 +27,10 @@ use crate::datafusion::DataFusion;
 /// Validates that a logical plan only performs allowed operations on datasets.
 ///
 /// Reads (SELECT queries) are allowed on all tables.
-/// INSERT operations are only allowed on datasets that are configured as writable,
+/// INSERT and DELETE operations are only allowed on datasets that are configured as writable,
 /// and are not allowed on internal Spice tables.
 /// DDL operations are only allowed on catalogs configured with `access: read_write_create`.
-/// DML (other than allowed INSERT), COPY, and Statement operations are not permitted.
+/// DML (other than allowed INSERT/DELETE), COPY, and Statement operations are not permitted.
 ///
 /// # Returns
 /// * `Ok(())` if the plan is valid
@@ -75,6 +75,36 @@ pub fn validate_sql_query_operations(
                 } else {
                     plan_err!(
                         "INSERT operations are not allowed on read-only dataset '{}'. Verify the dataset is configured with 'access: read_write' and try again.",
+                        dml.table_name
+                    )
+                }
+            } else if matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+                if super::is_spice_internal_dataset(&dml.table_name) {
+                    return plan_err!(
+                        "DELETE operations are not allowed on Spice system dataset '{}'.",
+                        dml.table_name
+                    );
+                }
+
+                // Check if attempting to delete from a catalog table.
+                if let Some(catalog) = dml.table_name.catalog() && catalog != super::SPICE_DEFAULT_CATALOG {
+                    if !df.is_catalog_writable(catalog) {
+                        return plan_err!(
+                            "DELETE operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
+                            dml.table_name
+                        );
+                    }
+                    return Ok(TreeNodeRecursion::Continue);
+                }
+
+                if df.is_writable(&dml.table_name) {
+                    Ok(TreeNodeRecursion::Continue)
+                } else if df.is_catalog_writable(super::SPICE_DEFAULT_CATALOG) {
+                    // No catalog specified but default catalog is writable
+                    Ok(TreeNodeRecursion::Continue)
+                } else {
+                    plan_err!(
+                        "DELETE operations are not allowed on read-only dataset '{}'. Verify the dataset is configured with 'access: read_write' and try again.",
                         dml.table_name
                     )
                 }
@@ -397,7 +427,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_delete_operation_blocked() {
+    async fn test_validate_delete_on_writable_dataset_allowed() {
         let df = create_test_datafusion();
 
         let sql = "DELETE FROM tbl_writable WHERE id = 1";
@@ -408,9 +438,49 @@ mod tests {
             .await
             .expect("plan should be created");
 
-        // DELETE operations should be blocked
+        // DELETE operations should be allowed on writable datasets
         let result = validate_sql_query_operations(&plan, &df);
-        assert!(result.is_err(), "DELETE operations should be blocked");
+        assert!(
+            result.is_ok(),
+            "DELETE should be allowed on writable dataset"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_delete_on_readonly_dataset_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "DELETE FROM tbl_read_only WHERE id = 1";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // DELETE operations should be blocked on read-only datasets
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "DELETE should fail on read-only dataset");
+    }
+
+    #[tokio::test]
+    async fn test_validate_delete_on_internal_table_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "DELETE FROM runtime.spice_table WHERE id = 1";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // DELETE operations should be blocked on internal tables
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_err(),
+            "DELETE should fail on Spice internal dataset"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/tests/iceberg/delete/mod.rs
+++ b/crates/runtime/tests/iceberg/delete/mod.rs
@@ -1,0 +1,233 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{runtime_ready_check, test_request_context},
+};
+use anyhow::Context;
+use app::AppBuilder;
+use arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+
+use runtime::{Runtime, datafusion::query::QueryBuilder};
+use spicepod::component::dataset::Dataset;
+use spicepod::param::Params;
+use std::sync::Arc;
+
+/// Test that DELETE FROM works on an Iceberg table via equality delete files.
+///
+/// This test:
+/// 1. Inserts 4 rows with a unique `batch_id` into a read-write Iceberg table
+/// 2. Deletes 2 of them with a WHERE filter
+/// 3. Verifies only the non-deleted rows remain
+/// 4. Deletes the remaining rows
+/// 5. Verifies no rows remain for this batch
+#[tokio::test]
+async fn iceberg_delete_from_table() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(None);
+    test_request_context()
+        .scope(async {
+            let dataset = make_iceberg_dataset("spice_write", "test_table", "test_table")?;
+
+            let app = AppBuilder::new("iceberg-delete").with_dataset(dataset).build();
+
+            configure_test_datafusion();
+
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let batch_uuid = uuid::Uuid::new_v4().to_string();
+
+            // Step 1: Insert 4 rows with distinct int_col values (1, 2, 3, 4)
+            let insert_sql = format!(
+                "INSERT INTO test_table \
+                (batch_id, boolean_col, int_col, long_col, float_col, double_col, decimal_col, date_col, timestamp_col, binary_col) \
+                VALUES \
+                ('{batch_uuid}', TRUE,  1, 100, REAL '1.0', 1.0, DECIMAL '1.0000', DATE '2025-01-01', TIMESTAMP '2025-01-01 00:00:00', X'01'), \
+                ('{batch_uuid}', TRUE,  2, 200, REAL '2.0', 2.0, DECIMAL '2.0000', DATE '2025-01-02', TIMESTAMP '2025-01-02 00:00:00', X'02'), \
+                ('{batch_uuid}', FALSE, 3, 300, REAL '3.0', 3.0, DECIMAL '3.0000', DATE '2025-01-03', TIMESTAMP '2025-01-03 00:00:00', X'03'), \
+                ('{batch_uuid}', FALSE, 4, 400, REAL '4.0', 4.0, DECIMAL '4.0000', DATE '2025-01-04', TIMESTAMP '2025-01-04 00:00:00', X'04');"
+            );
+
+            execute_query_and_validate_result(
+                &rt,
+                &insert_sql,
+                "delete_insert_result",
+            ).await?;
+
+            // Verify all 4 rows exist
+            let select_all_sql = format!(
+                "SELECT int_col, boolean_col, long_col FROM test_table \
+                WHERE batch_id = '{batch_uuid}' ORDER BY int_col"
+            );
+            execute_query_and_validate_result(
+                &rt,
+                &select_all_sql,
+                "delete_all_rows_before_delete",
+            ).await?;
+
+            // Step 2: Delete rows where boolean_col = FALSE (rows with int_col 3 and 4)
+            let delete_sql = format!(
+                "DELETE FROM test_table WHERE batch_id = '{batch_uuid}' AND boolean_col = false"
+            );
+            execute_query_and_validate_result(
+                &rt,
+                &delete_sql,
+                "delete_partial_result",
+            ).await?;
+
+            // Step 3: Verify only rows with int_col 1 and 2 remain
+            execute_query_and_validate_result(
+                &rt,
+                &select_all_sql,
+                "delete_rows_after_partial_delete",
+            ).await?;
+
+            // Step 4: Delete remaining rows
+            let delete_all_sql = format!(
+                "DELETE FROM test_table WHERE batch_id = '{batch_uuid}'"
+            );
+            execute_query_and_validate_result(
+                &rt,
+                &delete_all_sql,
+                "delete_remaining_result",
+            ).await?;
+
+            // Step 5: Verify no rows remain for this batch
+            execute_query_and_validate_result(
+                &rt,
+                &select_all_sql,
+                "delete_rows_after_full_delete",
+            ).await?;
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that DELETE FROM with no matching rows succeeds with count=0.
+#[tokio::test]
+async fn iceberg_delete_no_matching_rows() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(None);
+    test_request_context()
+        .scope(async {
+            let dataset = make_iceberg_dataset("spice_write", "test_table", "test_table")?;
+
+            let app = AppBuilder::new("iceberg-delete-noop")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Delete with a batch_id that doesn't exist — should return count=0
+            let nonexistent_uuid = uuid::Uuid::new_v4().to_string();
+            let delete_sql =
+                format!("DELETE FROM test_table WHERE batch_id = '{nonexistent_uuid}'");
+            execute_query_and_validate_result(&rt, &delete_sql, "delete_no_match_result").await?;
+
+            Ok(())
+        })
+        .await
+}
+
+async fn execute_query_and_validate_result(
+    rt: &Runtime,
+    query: &str,
+    snapshot_name: &str,
+) -> Result<(), anyhow::Error> {
+    let query = QueryBuilder::new(query, rt.datafusion()).build();
+
+    let query_result = query
+        .run()
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("Failed to execute query: {e}")))?;
+
+    let records = query_result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("Failed to collect query results: {e}")))?;
+
+    let pretty = arrow::util::pretty::pretty_format_batches(&records)
+        .map_err(|e| anyhow::Error::msg(format!("Failed to format record batches: {e}")))?;
+
+    insta::assert_snapshot!(snapshot_name, pretty);
+
+    Ok(())
+}
+
+fn make_iceberg_dataset(
+    namespace: &str,
+    table: &str,
+    name: &str,
+) -> Result<Dataset, anyhow::Error> {
+    let account_id =
+        std::env::var("AWS_ICEBERG_ACCOUNT_ID").context("AWS_ICEBERG_ACCOUNT_ID is not set")?;
+
+    let from = format!(
+        "iceberg:https://glue.us-east-1.amazonaws.com/iceberg/v1/catalogs/{account_id}/namespaces/{namespace}/tables/{table}"
+    );
+    let mut dataset = Dataset::new(from, name);
+    dataset.params = Some(get_iceberg_params());
+    dataset.access = spicepod::component::access::AccessMode::ReadWrite;
+    Ok(dataset)
+}
+
+fn get_iceberg_params() -> Params {
+    Params::from_string_map(
+        vec![
+            ("iceberg_s3_region".to_string(), "us-east-1".to_string()),
+            (
+                "iceberg_s3_access_key_id".to_string(),
+                "${ env:AWS_ICEBERG_ACCESS_KEY_ID }".to_string(),
+            ),
+            (
+                "iceberg_s3_secret_access_key".to_string(),
+                "${ env:AWS_ICEBERG_SECRET_ACCESS_KEY }".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    )
+}

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_all_rows_before_delete.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_all_rows_before_delete.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++---------+-------------+----------+
+| int_col | boolean_col | long_col |
++---------+-------------+----------+
+| 1       | true        | 100      |
+| 2       | true        | 200      |
+| 3       | false       | 300      |
+| 4       | false       | 400      |
++---------+-------------+----------+

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_insert_result.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_insert_result.snap
@@ -1,0 +1,9 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++-------+
+| count |
++-------+
+| 4     |
++-------+

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_no_match_result.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_no_match_result.snap
@@ -1,0 +1,9 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++-------+
+| count |
++-------+
+| 0     |
++-------+

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_partial_result.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_partial_result.snap
@@ -1,0 +1,9 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++-------+
+| count |
++-------+
+| 2     |
++-------+

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_remaining_result.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_remaining_result.snap
@@ -1,0 +1,9 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++-------+
+| count |
++-------+
+| 2     |
++-------+

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_rows_after_full_delete.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_rows_after_full_delete.snap
@@ -1,0 +1,6 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
+++
+++

--- a/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_rows_after_partial_delete.snap
+++ b/crates/runtime/tests/iceberg/delete/snapshots/integration__iceberg__delete__delete_rows_after_partial_delete.snap
@@ -1,0 +1,10 @@
+---
+source: crates/runtime/tests/iceberg/delete/mod.rs
+expression: pretty
+---
++---------+-------------+----------+
+| int_col | boolean_col | long_col |
++---------+-------------+----------+
+| 1       | true        | 100      |
+| 2       | true        | 200      |
++---------+-------------+----------+

--- a/crates/runtime/tests/iceberg/mod.rs
+++ b/crates/runtime/tests/iceberg/mod.rs
@@ -1,4 +1,6 @@
 mod catalog;
 mod connector;
 #[cfg(feature = "iceberg-write")]
+mod delete;
+#[cfg(feature = "iceberg-write")]
 mod write;


### PR DESCRIPTION
## Summary

Add `DELETE FROM` support for Iceberg tables via SQL, using the merge-on-read strategy with equality delete files.

`DELETE FROM iceberg_table WHERE condition` now works through the normal SQL query path for any Iceberg table configured with `access: read_write`.

## Changes

### iceberg-rust fork (spiceai-51)
- Updated to `d9dd7af6` which includes `RowDeltaAction` for committing delete files ([spiceai/iceberg-rust#28](https://github.com/spiceai/iceberg-rust/pull/28))

### data_components (`crates/data_components/src/iceberg/delete.rs`) — new file
- **`IcebergDeleteExec`** — DataFusion `ExecutionPlan` that:
  1. Scans rows matching DELETE filters via a child plan
  2. Projects rows to the full table schema
  3. Writes equality delete files using `EqualityDeleteFileWriter`
  4. Commits via `RowDeltaAction` transaction
  5. Returns a `count` column with the number of deleted rows

- **`IcebergDeletionProvider`** — Wraps `IcebergTableProvider`, implements `DeletionTableProvider`:
  - `delete_from(state, filters)` → scans table with filters, coalesces partitions, produces `IcebergDeleteExec`
  - Validates format version ≥ 2 (V1 tables do not support delete files)
  - Delegates all `TableProvider` methods to the inner provider

### SQL Validator (`crates/runtime/src/datafusion/sql_validator.rs`)
- Allow `WriteOp::Delete` on writable datasets and writable catalog tables (mirroring INSERT validation)
- Block DELETE on read-only datasets, internal Spice system tables, and read-only catalogs
- Updated tests: replaced `test_validate_delete_operation_blocked` with 3 targeted tests:
  - `test_validate_delete_on_writable_dataset_allowed`
  - `test_validate_delete_on_readonly_dataset_blocked`
  - `test_validate_delete_on_internal_table_blocked`

### Query Execution (`crates/runtime/src/datafusion/query.rs`)
- Added DML Delete branch in `run_internal` — intercepts `LogicalPlan::Dml(WriteOp::Delete)` before DataFusion's physical planner (which doesn't support DELETE natively)
- `create_delete_physical_plan()` — looks up the table's `DeletionTableProvider` via `get_deletion_provider` and calls `delete_from`
- `extract_delete_filters()` — extracts conjunctive predicates from the DELETE's source logical plan
- Skip schema verification for DML Delete plans (output is `count`, not the table schema)

### Runtime connector (`crates/runtime/src/dataconnector/iceberg.rs`)
- Added `IcebergTableParts` struct to carry catalog + namespace + table name alongside the provider
- Refactored `create_iceberg_table_provider` → `create_iceberg_table_parts` for shared use
- Updated `read_write_provider` to wrap in `IcebergDeletionProvider` → `DeletionTableProviderAdapter`

### Integration Tests (`crates/runtime/tests/iceberg/delete/mod.rs`) — new file
- `iceberg_delete_from_table` — inserts 4 rows, deletes 2 by filter, verifies remaining, deletes rest, verifies empty
- `iceberg_delete_no_matching_rows` — verifies DELETE with non-matching WHERE returns count=0

## How it works

When a user issues `DELETE FROM iceberg_table WHERE condition`:
1. DataFusion parses the SQL into `LogicalPlan::Dml(WriteOp::Delete)`
2. SQL validator allows it for writable datasets
3. Runtime intercepts the DML Delete plan, extracts filter predicates, looks up `DeletionTableProvider`
4. `IcebergDeletionProvider::delete_from()` creates a scan plan with the filters
5. `IcebergDeleteExec` executes the scan, writes matching rows as equality delete Parquet files
6. The delete files are committed via `RowDeltaAction` (new snapshot with `Operation::Delete`)
7. Subsequent reads use Iceberg's merge-on-read to exclude the deleted rows

## Design Notes

- **Generic SQL DELETE support**: The SQL validator + query execution changes are not Iceberg-specific. Any table provider wrapped in `DeletionTableProviderAdapter` will support `DELETE FROM` via SQL.
- **Equality deletes over position deletes**: All building blocks for equality deletes exist in the iceberg-rust fork; position delete writers do not exist yet.
- **Merge-on-read**: Delete files are separate from data files. No data files are rewritten, making deletes fast. The Iceberg reader filters them out at read time.