### PR TITLE
Fix Flight SQL schema consistency: expand view types and verify field names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5285,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5364,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5388,7 +5388,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5411,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "futures",
  "log",
@@ -5421,7 +5421,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5457,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5480,7 +5480,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5502,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5552,12 +5552,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 
 [[package]]
 name = "datafusion-execution"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "chrono",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5834,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
+source = "git+https://github.com/spiceai/datafusion.git?rev=f73f01ed75ea1b0e713975b481df992306c20096#f73f01ed75ea1b0e713975b481df992306c20096"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5285,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5364,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5388,7 +5388,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5411,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "futures",
  "log",
@@ -5421,7 +5421,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5457,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5480,7 +5480,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5502,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5552,12 +5552,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 
 [[package]]
 name = "datafusion-execution"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "chrono",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5834,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "51.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=50944286d02f23d77fd3bf311ddd101566e2300b#50944286d02f23d77fd3bf311ddd101566e2300b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b0c46fa277775e0634943d1ebea4d5e8d258d97c#b0c46fa277775e0634943d1ebea4d5e8d258d97c"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,25 +346,25 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }                       # spiceai-51
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }               # spiceai-51
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }                # spiceai-51
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }        # spiceai-51
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }            # spiceai-51
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }    # spiceai-51
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }             # spiceai-51
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }                  # spiceai-51
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }           # spiceai-51
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }             # spiceai-51
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }         # spiceai-51
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" } # spiceai-51
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }  # spiceai-51
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }         # spiceai-51
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }                 # spiceai-51
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }          # spiceai-51
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }               # spiceai-51
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }               # spiceai-51
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "50944286d02f23d77fd3bf311ddd101566e2300b" }                   # spiceai-51
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                       # spiceai-51
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                # spiceai-51
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }        # spiceai-51
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }            # spiceai-51
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }    # spiceai-51
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }             # spiceai-51
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                  # spiceai-51
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }           # spiceai-51
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }             # spiceai-51
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }         # spiceai-51
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" } # spiceai-51
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }  # spiceai-51
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }         # spiceai-51
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                 # spiceai-51
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }          # spiceai-51
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                   # spiceai-51
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "330a4d790b892dd6be23b71589ec60b620bf29f5" } # spiceai-51
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,25 +346,25 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                       # spiceai-51
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                # spiceai-51
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }        # spiceai-51
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }            # spiceai-51
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }    # spiceai-51
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }             # spiceai-51
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                  # spiceai-51
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }           # spiceai-51
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }             # spiceai-51
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }         # spiceai-51
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" } # spiceai-51
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }  # spiceai-51
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }         # spiceai-51
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                 # spiceai-51
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }          # spiceai-51
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }               # spiceai-51
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b0c46fa277775e0634943d1ebea4d5e8d258d97c" }                   # spiceai-51
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }                       # spiceai-51
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }               # spiceai-51
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }                # spiceai-51
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }        # spiceai-51
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }            # spiceai-51
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }    # spiceai-51
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }             # spiceai-51
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }                  # spiceai-51
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }           # spiceai-51
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }             # spiceai-51
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }         # spiceai-51
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" } # spiceai-51
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }  # spiceai-51
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }         # spiceai-51
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }                 # spiceai-51
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }          # spiceai-51
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }               # spiceai-51
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }               # spiceai-51
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "f73f01ed75ea1b0e713975b481df992306c20096" }                   # spiceai-51
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "330a4d790b892dd6be23b71589ec60b620bf29f5" } # spiceai-51
 

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -36,6 +36,15 @@ pub enum Error {
         actual: String,
     },
 
+    #[snafu(display(
+        "Query returned an unexpected field name at position {position}: expected '{expected}', received '{actual}'"
+    ))]
+    SchemaMismatchFieldName {
+        position: usize,
+        expected: String,
+        actual: String,
+    },
+
     #[snafu(display("Failed to get field data type"))]
     UnableToGetFieldDataType {},
 }
@@ -63,6 +72,16 @@ pub fn verify_schema(
     for idx in 0..expected.len() {
         let a = expected.get(idx).context(UnableToGetFieldDataTypeSnafu)?;
         let b = actual.get(idx).context(UnableToGetFieldDataTypeSnafu)?;
+
+        // Verify field names match
+        if a.name() != b.name() {
+            return SchemaMismatchFieldNameSnafu {
+                position: idx,
+                expected: a.name(),
+                actual: b.name(),
+            }
+            .fail();
+        }
 
         let a_data_type = a.data_type();
         let b_data_type = b.data_type();

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -210,7 +210,16 @@ impl Service {
     ) -> Result<(Schema, Option<Schema>), Status> {
         let query = QueryBuilder::new(sql, datafusion).build();
 
-        query.get_schema().await.map_err(handle_datafusion_error)
+        let (dataset_schema, parameter_schema) =
+            query.get_schema().await.map_err(handle_datafusion_error)?;
+
+        // The logical plan may report Utf8View/BinaryView, but the physical
+        // execution (with `expand_views_at_output = true`) will produce
+        // LargeUtf8/LargeBinary.  Align the advertised schema so that
+        // `get_flight_info` and `do_get` are consistent.
+        let dataset_schema = arrow_tools::schema::expand_views_schema(&dataset_schema);
+
+        Ok((dataset_schema, parameter_schema))
     }
 
     fn serialize_schema(schema: &Schema) -> Result<Bytes, Status> {


### PR DESCRIPTION
## 📝 Summary

1. Apply `expand_views_schema` in `get_arrow_schema` so `get_flight_info` advertises `LargeUtf8`/`LargeBinary` matching physical execution (`expand_views_at_output = true`) instead of `Utf8View`/`BinaryView`.

2. Add field name verification to `verify_schema` to detect when DataFusion's physical plan qualifies column names with subquery aliases (e.g. `custsale.cntrycode` instead of `cntrycode`), surfacing the mismatch as a clear error rather than letting it propagate silently to Flight SQL clients.

3. Include the following DF fix to fix column names mismatch (e.g. custsale.cntrycode instead of cntrycode)
- https://github.com/spiceai/datafusion/pull/127

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
