### PR TITLE
feat: Add Iceberg DDL support (CREATE TABLE / DROP TABLE) for default catalog override

### DIFF
--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -1,24 +1,25 @@
-/*
-Copyright 2024-2025 The Spice.ai OSS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 //! Implementation of the `DataFusion` Catalog/Schema providers for Iceberg.
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
@@ -41,10 +42,16 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// multiple [`SchemaProvider`], each associated with distinct namespaces.
 #[derive(Debug)]
 pub struct IcebergCatalogProvider {
-    /// A `HashMap` where keys are namespace names
+    /// The underlying Iceberg catalog client.
+    catalog: Arc<dyn Catalog>,
+    /// Optional root namespace to scope namespace discovery.
+    root_namespace: Option<NamespaceIdent>,
+    /// Optional glob patterns for filtering tables.
+    include: Option<GlobSet>,
+    /// A `RwLock`-protected `HashMap` where keys are namespace names
     /// and values are dynamic references to objects implementing the
     /// [`SchemaProvider`] trait.
-    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+    schemas: RwLock<HashMap<String, Arc<dyn SchemaProvider>>>,
 }
 
 impl IcebergCatalogProvider {
@@ -65,10 +72,43 @@ impl IcebergCatalogProvider {
         root_namespace: Option<NamespaceIdent>,
         includes: Option<&GlobSet>,
     ) -> Result<Self> {
+        let schemas = Self::load_schemas(
+            Arc::clone(&client),
+            root_namespace.as_ref(),
+            includes,
+        )
+        .await?;
+
+        Ok(IcebergCatalogProvider {
+            catalog: client,
+            root_namespace,
+            include: includes.cloned(),
+            schemas: RwLock::new(schemas),
+        })
+    }
+
+    /// Returns a reference to the underlying Iceberg catalog client.
+    #[must_use]
+    pub fn catalog(&self) -> &Arc<dyn Catalog> {
+        &self.catalog
+    }
+
+    /// Returns the root namespace, if any.
+    #[must_use]
+    pub fn root_namespace(&self) -> Option<&NamespaceIdent> {
+        self.root_namespace.as_ref()
+    }
+
+    /// Load all schemas (namespaces) from the Iceberg catalog.
+    async fn load_schemas(
+        client: Arc<dyn Catalog>,
+        root_namespace: Option<&NamespaceIdent>,
+        includes: Option<&GlobSet>,
+    ) -> Result<HashMap<String, Arc<dyn SchemaProvider>>> {
         // Create the semaphore first, so we can use it in the closures below
         let load_semaphore = Arc::new(Semaphore::new(10));
 
-        let schema_names: Vec<_> = match client.list_namespaces(root_namespace.as_ref()).await {
+        let schema_names: Vec<_> = match client.list_namespaces(root_namespace).await {
             Ok(namespaces) => namespaces
                 .iter()
                 .flat_map(|ns| ns.as_ref().clone())
@@ -113,7 +153,7 @@ impl IcebergCatalogProvider {
             })
             .collect();
 
-        Ok(IcebergCatalogProvider { schemas })
+        Ok(schemas)
     }
 }
 
@@ -123,18 +163,39 @@ impl CatalogProvider for IcebergCatalogProvider {
     }
 
     fn schema_names(&self) -> Vec<String> {
-        self.schemas.keys().cloned().collect()
+        self.schemas
+            .read()
+            .map(|schemas| schemas.keys().cloned().collect())
+            .unwrap_or_default()
     }
 
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        self.schemas.get(name).cloned()
+        self.schemas
+            .read()
+            .ok()
+            .and_then(|schemas| schemas.get(name).cloned())
     }
 }
 
 #[async_trait]
 impl RefreshableCatalogProvider for IcebergCatalogProvider {
     async fn refresh(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Will be implemented in a future enhancement.
+        let new_schemas = Self::load_schemas(
+            Arc::clone(&self.catalog),
+            self.root_namespace.as_ref(),
+            self.include.as_ref(),
+        )
+        .await?;
+
+        match self.schemas.write() {
+            Ok(mut schemas) => {
+                *schemas = new_schemas;
+            }
+            Err(poisoned) => {
+                *poisoned.into_inner() = new_schemas;
+            }
+        }
+
         Ok(())
     }
 }
@@ -142,11 +203,15 @@ impl RefreshableCatalogProvider for IcebergCatalogProvider {
 /// Represents a [`SchemaProvider`] for the Iceberg [`Catalog`], managing
 /// access to table providers within a specific namespace.
 #[derive(Debug)]
-pub(crate) struct IcebergSchemaProvider {
-    /// A `HashMap` where keys are table names
+pub struct IcebergSchemaProvider {
+    /// The underlying Iceberg catalog client.
+    catalog: Arc<dyn Catalog>,
+    /// The namespace this schema provider manages.
+    namespace: NamespaceIdent,
+    /// A `RwLock`-protected `HashMap` where keys are table names
     /// and values are dynamic references to objects implementing the
     /// [`TableProvider`] trait.
-    tables: HashMap<String, Arc<dyn TableProvider>>,
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
 }
 
 impl IcebergSchemaProvider {
@@ -169,8 +234,42 @@ impl IcebergSchemaProvider {
         load_semaphore: Arc<Semaphore>,
         include: Option<&GlobSet>,
     ) -> Result<Self> {
+        let tables = Self::load_tables(
+            Arc::clone(&client),
+            &namespace,
+            load_semaphore,
+            include,
+        )
+        .await?;
+
+        Ok(IcebergSchemaProvider {
+            catalog: client,
+            namespace,
+            tables: RwLock::new(tables),
+        })
+    }
+
+    /// Returns a reference to the underlying Iceberg catalog client.
+    #[must_use]
+    pub fn catalog(&self) -> &Arc<dyn Catalog> {
+        &self.catalog
+    }
+
+    /// Returns the namespace this schema provider manages.
+    #[must_use]
+    pub fn namespace(&self) -> &NamespaceIdent {
+        &self.namespace
+    }
+
+    /// Load all tables from the Iceberg catalog for this namespace.
+    async fn load_tables(
+        client: Arc<dyn Catalog>,
+        namespace: &NamespaceIdent,
+        load_semaphore: Arc<Semaphore>,
+        include: Option<&GlobSet>,
+    ) -> Result<HashMap<String, Arc<dyn TableProvider>>> {
         let table_names: Vec<_> = client
-            .list_tables(&namespace)
+            .list_tables(namespace)
             .await
             .map_err(handle_iceberg_error)?
             .into_iter()
@@ -212,7 +311,7 @@ impl IcebergSchemaProvider {
             }
         }
 
-        Ok(IcebergSchemaProvider { tables })
+        Ok(tables)
     }
 
     async fn load_table(
@@ -260,15 +359,47 @@ impl SchemaProvider for IcebergSchemaProvider {
     }
 
     fn table_names(&self) -> Vec<String> {
-        self.tables.keys().cloned().collect()
+        self.tables
+            .read()
+            .map(|tables| tables.keys().cloned().collect())
+            .unwrap_or_default()
     }
 
     fn table_exist(&self, name: &str) -> bool {
-        self.tables.contains_key(name)
+        self.tables
+            .read()
+            .map(|tables| tables.contains_key(name))
+            .unwrap_or(false)
     }
 
     async fn table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
-        Ok(self.tables.get(name).cloned())
+        Ok(self
+            .tables
+            .read()
+            .ok()
+            .and_then(|tables| tables.get(name).cloned()))
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        match self.tables.write() {
+            Ok(mut tables) => Ok(tables.insert(name, table)),
+            Err(_) => Err(datafusion::error::DataFusionError::Internal(
+                "Failed to acquire write lock on tables".to_string(),
+            )),
+        }
+    }
+
+    fn deregister_table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        match self.tables.write() {
+            Ok(mut tables) => Ok(tables.remove(name)),
+            Err(_) => Err(datafusion::error::DataFusionError::Internal(
+                "Failed to acquire write lock on tables".to_string(),
+            )),
+        }
     }
 }
 

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -1,19 +1,18 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 //! Implementation of the `DataFusion` Catalog/Schema providers for Iceberg.
 
@@ -72,12 +71,8 @@ impl IcebergCatalogProvider {
         root_namespace: Option<NamespaceIdent>,
         includes: Option<&GlobSet>,
     ) -> Result<Self> {
-        let schemas = Self::load_schemas(
-            Arc::clone(&client),
-            root_namespace.as_ref(),
-            includes,
-        )
-        .await?;
+        let schemas =
+            Self::load_schemas(Arc::clone(&client), root_namespace.as_ref(), includes).await?;
 
         Ok(IcebergCatalogProvider {
             catalog: client,
@@ -234,13 +229,8 @@ impl IcebergSchemaProvider {
         load_semaphore: Arc<Semaphore>,
         include: Option<&GlobSet>,
     ) -> Result<Self> {
-        let tables = Self::load_tables(
-            Arc::clone(&client),
-            &namespace,
-            load_semaphore,
-            include,
-        )
-        .await?;
+        let tables =
+            Self::load_tables(Arc::clone(&client), &namespace, load_semaphore, include).await?;
 
         Ok(IcebergSchemaProvider {
             catalog: client,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -406,12 +406,25 @@ impl DataFusionBuilder {
 
         let caching = self.caching.unwrap_or(Arc::new(Caching::default()));
 
+        let ddl_enabled_catalogs = Arc::new(RwLock::new(HashSet::new()));
+
+        // Add the Iceberg DDL analyzer rule after context creation so it can
+        // reference the catalog list and DDL-enabled catalogs.
+        // Uses Weak references to avoid reference cycles (SessionContext owns
+        // the analyzer rules, so Arc refs back would create a cycle).
+        ctx.add_analyzer_rule(Arc::new(
+            super::iceberg_ddl::analyzer_rule::IcebergDdlAnalyzerRule::new(
+                ctx.state().catalog_list(),
+                &ddl_enabled_catalogs,
+            ),
+        ));
+
         DataFusion {
             runtime_status: self.status,
             ctx: Arc::new(ctx),
             data_writers: RwLock::new(HashSet::new()),
             writable_catalogs: RwLock::new(HashSet::new()),
-            ddl_enabled_catalogs: RwLock::new(HashSet::new()),
+            ddl_enabled_catalogs,
             caching,
             pending_sink_tables: TokioRwLock::new(Vec::new()),
             deferred_tables: TokioRwLock::new(HashMap::new()),
@@ -568,6 +581,7 @@ pub(crate) fn default_extension_planners() -> Vec<Arc<dyn ExtensionPlanner + Sen
         Arc::new(IndexTableScanExtensionPlanner::new()),
         Arc::new(FederatedPlanner::new()),
         Arc::new(CacheInvalidationExtensionPlanner::new()),
+        Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new()),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/composed_catalog.rs
+++ b/crates/runtime/src/datafusion/composed_catalog.rs
@@ -1,19 +1,18 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 //! A [`CatalogProvider`] that composes an external catalog (e.g., Iceberg)
 //! with internal Spice schemas (`runtime`, `metadata`, `eval`, `scp`).
@@ -122,10 +121,10 @@ mod tests {
         let external = Arc::new(MemoryCatalogProvider::new());
         external
             .register_schema("public", Arc::new(MemorySchemaProvider::new()))
-            .unwrap();
+            .expect("register public schema");
         external
             .register_schema("user_schema", Arc::new(MemorySchemaProvider::new()))
-            .unwrap();
+            .expect("register user_schema");
 
         let mut internal = HashMap::new();
         internal.insert(
@@ -164,19 +163,19 @@ mod tests {
     #[test]
     fn test_register_internal_schema_rejected() {
         let provider = make_test_provider();
-        let result =
-            provider.register_schema("runtime", Arc::new(MemorySchemaProvider::new()));
+        let result = provider.register_schema("runtime", Arc::new(MemorySchemaProvider::new()));
         assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
+        let err = result
+            .expect_err("should reject internal schema")
+            .to_string();
         assert!(err.contains("reserved Spice internal schema"));
     }
 
     #[test]
     fn test_register_user_schema() {
         let provider = make_test_provider();
-        let result =
-            provider.register_schema("new_schema", Arc::new(MemorySchemaProvider::new()));
-        assert!(result.is_ok());
+        let result = provider.register_schema("new_schema", Arc::new(MemorySchemaProvider::new()));
+        result.expect("register user schema should succeed");
         assert!(provider.schema("new_schema").is_some());
     }
 }

--- a/crates/runtime/src/datafusion/composed_catalog.rs
+++ b/crates/runtime/src/datafusion/composed_catalog.rs
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! A [`CatalogProvider`] that composes an external catalog (e.g., Iceberg)
+//! with internal Spice schemas (`runtime`, `metadata`, `eval`, `scp`).
+//!
+//! When a user-defined catalog overrides the default `spice` catalog,
+//! internal schemas must be preserved alongside the external catalog's schemas.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::catalog::{CatalogProvider, SchemaProvider};
+use datafusion::error::Result as DFResult;
+
+/// Internal schema names that are managed by Spice and must not be
+/// overridden by external catalogs.
+const INTERNAL_SCHEMA_NAMES: &[&str] = &["runtime", "metadata", "eval", "scp"];
+
+/// A [`CatalogProvider`] that composes an external catalog with
+/// Spice's internal schemas.
+///
+/// Internal schemas (e.g., `runtime`, `metadata`, `eval`, `scp`) take
+/// priority over external schemas with the same name, preventing user
+/// schemas from shadowing system schemas.
+///
+/// Schema registration for non-internal names is delegated to the
+/// external catalog (enabling `CREATE SCHEMA` support).
+#[derive(Debug)]
+pub struct ComposedCatalogProvider {
+    /// The external catalog (e.g., Iceberg) — provides user schemas.
+    external: Arc<dyn CatalogProvider>,
+    /// Internal schemas that must always be present.
+    internal_schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl ComposedCatalogProvider {
+    /// Create a new `ComposedCatalogProvider` that wraps `external` with
+    /// the given `internal_schemas`.
+    #[must_use]
+    pub fn new(
+        external: Arc<dyn CatalogProvider>,
+        internal_schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+    ) -> Self {
+        Self {
+            external,
+            internal_schemas,
+        }
+    }
+
+    /// Returns a reference to the external catalog provider.
+    #[must_use]
+    pub fn external(&self) -> &Arc<dyn CatalogProvider> {
+        &self.external
+    }
+
+    /// Returns `true` if `name` is an internal schema name.
+    fn is_internal_schema(name: &str) -> bool {
+        INTERNAL_SCHEMA_NAMES.contains(&name)
+    }
+}
+
+impl CatalogProvider for ComposedCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.internal_schemas.keys().cloned().collect();
+        for name in self.external.schema_names() {
+            if !self.internal_schemas.contains_key(&name) {
+                names.push(name);
+            }
+        }
+        names
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        // Internal schemas take priority
+        if let Some(schema) = self.internal_schemas.get(name) {
+            return Some(Arc::clone(schema));
+        }
+        self.external.schema(name)
+    }
+
+    fn register_schema(
+        &self,
+        name: &str,
+        schema: Arc<dyn SchemaProvider>,
+    ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
+        if Self::is_internal_schema(name) {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "Cannot register schema '{name}': it is a reserved Spice internal schema"
+            )));
+        }
+        self.external.register_schema(name, schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::catalog::MemoryCatalogProvider;
+    use datafusion::catalog::MemorySchemaProvider;
+
+    fn make_test_provider() -> ComposedCatalogProvider {
+        let external = Arc::new(MemoryCatalogProvider::new());
+        external
+            .register_schema("public", Arc::new(MemorySchemaProvider::new()))
+            .unwrap();
+        external
+            .register_schema("user_schema", Arc::new(MemorySchemaProvider::new()))
+            .unwrap();
+
+        let mut internal = HashMap::new();
+        internal.insert(
+            "runtime".to_string(),
+            Arc::new(MemorySchemaProvider::new()) as Arc<dyn SchemaProvider>,
+        );
+        internal.insert(
+            "metadata".to_string(),
+            Arc::new(MemorySchemaProvider::new()) as Arc<dyn SchemaProvider>,
+        );
+
+        ComposedCatalogProvider::new(external, internal)
+    }
+
+    #[test]
+    fn test_schema_names_union() {
+        let provider = make_test_provider();
+        let mut names = provider.schema_names();
+        names.sort();
+        assert_eq!(names, vec!["metadata", "public", "runtime", "user_schema"]);
+    }
+
+    #[test]
+    fn test_internal_schema_priority() {
+        let provider = make_test_provider();
+        // Internal schemas should be retrievable
+        assert!(provider.schema("runtime").is_some());
+        assert!(provider.schema("metadata").is_some());
+        // External schemas should also be retrievable
+        assert!(provider.schema("public").is_some());
+        assert!(provider.schema("user_schema").is_some());
+        // Non-existent schema
+        assert!(provider.schema("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_register_internal_schema_rejected() {
+        let provider = make_test_provider();
+        let result =
+            provider.register_schema("runtime", Arc::new(MemorySchemaProvider::new()));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("reserved Spice internal schema"));
+    }
+
+    #[test]
+    fn test_register_user_schema() {
+        let provider = make_test_provider();
+        let result =
+            provider.register_schema("new_schema", Arc::new(MemorySchemaProvider::new()));
+        assert!(result.is_ok());
+        assert!(provider.schema("new_schema").is_some());
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
@@ -1,0 +1,185 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Analyzer rule that intercepts DDL plans (`CREATE TABLE` / `DROP TABLE`)
+//! targeting Iceberg-backed DDL-enabled catalogs and rewrites them into
+//! custom [`LogicalPlan::Extension`] nodes.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::{Arc, RwLock, Weak};
+
+use datafusion::catalog::CatalogProviderList;
+use datafusion::config::ConfigOptions;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::DdlStatement;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion::optimizer::AnalyzerRule;
+
+use data_components::iceberg::provider::IcebergCatalogProvider;
+
+use super::composed_catalog_to_iceberg;
+use super::logical_nodes::{IcebergCreateTableNode, IcebergDropTableNode};
+use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+
+/// Analyzer rule that rewrites DDL targeting Iceberg catalogs into
+/// custom extension nodes that perform async Iceberg catalog operations.
+///
+/// Uses `Weak` references to avoid reference cycles: the `SessionContext`
+/// owns the analyzer rules, so holding `Arc` refs back to the session's
+/// catalog list or to `DataFusion`'s `ddl_enabled_catalogs` would create
+/// a cycle that prevents cleanup.
+pub struct IcebergDdlAnalyzerRule {
+    /// Weak reference to the catalog list for catalog resolution.
+    catalog_list: Weak<dyn CatalogProviderList>,
+    /// Weak reference to the set of DDL-enabled catalog names.
+    ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
+}
+
+impl fmt::Debug for IcebergDdlAnalyzerRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IcebergDdlAnalyzerRule")
+            .finish_non_exhaustive()
+    }
+}
+
+impl IcebergDdlAnalyzerRule {
+    #[must_use]
+    pub fn new(
+        catalog_list: &Arc<dyn CatalogProviderList>,
+        ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
+    ) -> Self {
+        Self {
+            catalog_list: Arc::downgrade(catalog_list),
+            ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
+        }
+    }
+
+    fn is_ddl_enabled(&self, catalog_name: &str) -> bool {
+        self.ddl_enabled_catalogs
+            .upgrade()
+            .and_then(|catalogs| catalogs.read().ok().map(|set| set.contains(catalog_name)))
+            .unwrap_or(false)
+    }
+
+    /// Try to get the Iceberg catalog from a `DataFusion` catalog name.
+    /// Handles both direct `IcebergCatalogProvider` and `ComposedCatalogProvider`
+    /// wrapping an `IcebergCatalogProvider`.
+    fn get_iceberg_catalog(&self, catalog_name: &str) -> Option<Arc<dyn iceberg::Catalog>> {
+        let catalog_list = self.catalog_list.upgrade()?;
+        let df_catalog = catalog_list.catalog(catalog_name)?;
+
+        // Try direct downcast first
+        if let Some(iceberg_provider) = df_catalog.as_any().downcast_ref::<IcebergCatalogProvider>()
+        {
+            return Some(Arc::clone(iceberg_provider.catalog()));
+        }
+
+        // Try via ComposedCatalogProvider
+        composed_catalog_to_iceberg(df_catalog.as_ref())
+    }
+}
+
+impl AnalyzerRule for IcebergDdlAnalyzerRule {
+    fn name(&self) -> &'static str {
+        "iceberg_ddl_rewrite"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> DFResult<LogicalPlan> {
+        match &plan {
+            LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(create)) => {
+                let catalog_name = create
+                    .name
+                    .catalog()
+                    .unwrap_or(SPICE_DEFAULT_CATALOG)
+                    .to_string();
+
+                if !self.is_ddl_enabled(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                let Some(iceberg_catalog) = self.get_iceberg_catalog(&catalog_name) else {
+                    return Ok(plan);
+                };
+
+                let schema_name = create
+                    .name
+                    .schema()
+                    .unwrap_or(SPICE_DEFAULT_SCHEMA)
+                    .to_string();
+                let table_name = create.name.table().to_string();
+
+                // Extract the Arrow schema from the logical plan's input
+                let arrow_schema = Arc::new(create.input.schema().inner().as_ref().clone());
+
+                let namespace = iceberg::NamespaceIdent::new(schema_name.clone());
+
+                let node = IcebergCreateTableNode::new(
+                    iceberg_catalog,
+                    namespace,
+                    table_name,
+                    arrow_schema,
+                    create.if_not_exists,
+                    create.or_replace,
+                    catalog_name,
+                    schema_name,
+                );
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(node),
+                }))
+            }
+            LogicalPlan::Ddl(DdlStatement::DropTable(drop)) => {
+                let catalog_name = drop
+                    .name
+                    .catalog()
+                    .unwrap_or(SPICE_DEFAULT_CATALOG)
+                    .to_string();
+
+                if !self.is_ddl_enabled(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                let Some(iceberg_catalog) = self.get_iceberg_catalog(&catalog_name) else {
+                    return Ok(plan);
+                };
+
+                let schema_name = drop
+                    .name
+                    .schema()
+                    .unwrap_or(SPICE_DEFAULT_SCHEMA)
+                    .to_string();
+                let table_name = drop.name.table().to_string();
+
+                let namespace = iceberg::NamespaceIdent::new(schema_name.clone());
+
+                let node = IcebergDropTableNode::new(
+                    iceberg_catalog,
+                    namespace,
+                    table_name,
+                    drop.if_exists,
+                    catalog_name,
+                    schema_name,
+                );
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(node),
+                }))
+            }
+            _ => Ok(plan),
+        }
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
@@ -1,0 +1,267 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Custom logical plan nodes for Iceberg DDL operations.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::common::DFSchemaRef;
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use iceberg::{Catalog, NamespaceIdent};
+
+/// Creates the shared output schema for DDL result nodes (single `result` column).
+fn ddl_output_schema() -> DFSchemaRef {
+    DFSchemaRef::new(
+        datafusion::common::DFSchema::try_from(Schema::new(vec![Field::new(
+            "result",
+            DataType::Utf8,
+            false,
+        )]))
+        .unwrap_or_else(|e| unreachable!("fixed DDL output schema must be valid: {e}")),
+    )
+}
+
+/// Logical plan node for `CREATE TABLE` on an Iceberg catalog.
+#[derive(Debug)]
+pub struct IcebergCreateTableNode {
+    /// The Iceberg catalog to create the table in.
+    pub catalog: Arc<dyn Catalog>,
+    /// The namespace (schema) to create the table in.
+    pub namespace: NamespaceIdent,
+    /// The table name.
+    pub table_name: String,
+    /// The Arrow schema for the new table.
+    pub arrow_schema: Arc<Schema>,
+    /// If true, do not error if the table already exists.
+    pub if_not_exists: bool,
+    /// If true, replace the table if it already exists.
+    pub or_replace: bool,
+    /// The `DataFusion` catalog name (for registering the table provider).
+    pub df_catalog_name: String,
+    /// The `DataFusion` schema name (for registering the table provider).
+    pub df_schema_name: String,
+    /// Output schema (single "result" column).
+    output_schema: DFSchemaRef,
+}
+
+impl IcebergCreateTableNode {
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        namespace: NamespaceIdent,
+        table_name: String,
+        arrow_schema: Arc<Schema>,
+        if_not_exists: bool,
+        or_replace: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+    ) -> Self {
+        Self {
+            catalog,
+            namespace,
+            table_name,
+            arrow_schema,
+            if_not_exists,
+            or_replace,
+            df_catalog_name,
+            df_schema_name,
+            output_schema: ddl_output_schema(),
+        }
+    }
+}
+
+impl Hash for IcebergCreateTableNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_name.hash(state);
+        self.namespace.to_string().hash(state);
+        self.df_catalog_name.hash(state);
+        self.df_schema_name.hash(state);
+    }
+}
+
+impl PartialEq for IcebergCreateTableNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.table_name == other.table_name
+            && self.namespace == other.namespace
+            && self.df_catalog_name == other.df_catalog_name
+            && self.df_schema_name == other.df_schema_name
+    }
+}
+
+impl Eq for IcebergCreateTableNode {}
+
+impl PartialOrd for IcebergCreateTableNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.table_name.partial_cmp(&other.table_name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for IcebergCreateTableNode {
+    fn name(&self) -> &'static str {
+        "IcebergCreateTable"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "IcebergCreateTable: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(Self {
+            catalog: Arc::clone(&self.catalog),
+            namespace: self.namespace.clone(),
+            table_name: self.table_name.clone(),
+            arrow_schema: Arc::clone(&self.arrow_schema),
+            if_not_exists: self.if_not_exists,
+            or_replace: self.or_replace,
+            df_catalog_name: self.df_catalog_name.clone(),
+            df_schema_name: self.df_schema_name.clone(),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}
+
+/// Logical plan node for `DROP TABLE` on an Iceberg catalog.
+#[derive(Debug)]
+pub struct IcebergDropTableNode {
+    /// The Iceberg catalog to drop the table from.
+    pub catalog: Arc<dyn Catalog>,
+    /// The namespace (schema) the table is in.
+    pub namespace: NamespaceIdent,
+    /// The table name.
+    pub table_name: String,
+    /// If true, do not error if the table does not exist.
+    pub if_exists: bool,
+    /// The `DataFusion` catalog name.
+    pub df_catalog_name: String,
+    /// The `DataFusion` schema name.
+    pub df_schema_name: String,
+    /// Output schema (single "result" column).
+    output_schema: DFSchemaRef,
+}
+
+impl IcebergDropTableNode {
+    #[must_use]
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        namespace: NamespaceIdent,
+        table_name: String,
+        if_exists: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+    ) -> Self {
+        Self {
+            catalog,
+            namespace,
+            table_name,
+            if_exists,
+            df_catalog_name,
+            df_schema_name,
+            output_schema: ddl_output_schema(),
+        }
+    }
+}
+
+impl Hash for IcebergDropTableNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_name.hash(state);
+        self.namespace.to_string().hash(state);
+        self.df_catalog_name.hash(state);
+    }
+}
+
+impl PartialEq for IcebergDropTableNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.table_name == other.table_name
+            && self.namespace == other.namespace
+            && self.df_catalog_name == other.df_catalog_name
+            && self.df_schema_name == other.df_schema_name
+    }
+}
+
+impl Eq for IcebergDropTableNode {}
+
+impl PartialOrd for IcebergDropTableNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.table_name.partial_cmp(&other.table_name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for IcebergDropTableNode {
+    fn name(&self) -> &'static str {
+        "IcebergDropTable"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "IcebergDropTable: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(Self {
+            catalog: Arc::clone(&self.catalog),
+            namespace: self.namespace.clone(),
+            table_name: self.table_name.clone(),
+            if_exists: self.if_exists,
+            df_catalog_name: self.df_catalog_name.clone(),
+            df_schema_name: self.df_schema_name.clone(),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
@@ -1,0 +1,53 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Iceberg DDL support: analyzer rule, logical nodes, extension planner,
+//! and physical execution plans for `CREATE TABLE` / `DROP TABLE` on
+//! Iceberg-backed catalogs.
+
+pub mod analyzer_rule;
+pub mod logical_nodes;
+pub mod physical_plans;
+pub mod planner;
+
+use std::sync::Arc;
+
+use data_components::iceberg::provider::IcebergCatalogProvider;
+use datafusion::catalog::CatalogProvider;
+
+use super::composed_catalog::ComposedCatalogProvider;
+
+/// Try to extract the Iceberg catalog from a `CatalogProvider`.
+/// Handles both direct `IcebergCatalogProvider` and `ComposedCatalogProvider`
+/// wrapping an `IcebergCatalogProvider`.
+pub fn composed_catalog_to_iceberg(
+    provider: &dyn CatalogProvider,
+) -> Option<Arc<dyn iceberg::Catalog>> {
+    // Try direct downcast
+    if let Some(iceberg) = provider.as_any().downcast_ref::<IcebergCatalogProvider>() {
+        return Some(Arc::clone(iceberg.catalog()));
+    }
+    // Try via ComposedCatalogProvider
+    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>()
+        && let Some(iceberg) = composed
+            .external()
+            .as_any()
+            .downcast_ref::<IcebergCatalogProvider>()
+    {
+        return Some(Arc::clone(iceberg.catalog()));
+    }
+    None
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -1,0 +1,391 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Physical execution plans for Iceberg DDL operations.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
+use iceberg_datafusion::IcebergTableProvider;
+
+use datafusion::catalog::CatalogProviderList;
+
+/// Creates a result schema for DDL operations (single "result" column).
+fn ddl_result_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "result",
+        DataType::Utf8,
+        false,
+    )]))
+}
+
+/// Physical plan for creating an Iceberg table.
+pub struct IcebergCreateTableExec {
+    catalog: Arc<dyn Catalog>,
+    namespace: NamespaceIdent,
+    table_name: String,
+    arrow_schema: Arc<Schema>,
+    if_not_exists: bool,
+    _or_replace: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for IcebergCreateTableExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IcebergCreateTableExec")
+            .field("namespace", &self.namespace)
+            .field("table_name", &self.table_name)
+            .field("df_catalog_name", &self.df_catalog_name)
+            .field("df_schema_name", &self.df_schema_name)
+            .field("if_not_exists", &self.if_not_exists)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IcebergCreateTableExec {
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        namespace: NamespaceIdent,
+        table_name: String,
+        arrow_schema: Arc<Schema>,
+        if_not_exists: bool,
+        or_replace: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+        catalog_list: Arc<dyn CatalogProviderList>,
+    ) -> Self {
+        let schema = ddl_result_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            catalog,
+            namespace,
+            table_name,
+            arrow_schema,
+            if_not_exists,
+            _or_replace: or_replace,
+            df_catalog_name,
+            df_schema_name,
+            catalog_list,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for IcebergCreateTableExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "IcebergCreateTableExec: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+}
+
+impl ExecutionPlan for IcebergCreateTableExec {
+    fn name(&self) -> &'static str {
+        "IcebergCreateTableExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let catalog = Arc::clone(&self.catalog);
+        let namespace = self.namespace.clone();
+        let table_name = self.table_name.clone();
+        let arrow_schema = Arc::clone(&self.arrow_schema);
+        let if_not_exists = self.if_not_exists;
+        let df_catalog_name = self.df_catalog_name.clone();
+        let df_schema_name = self.df_schema_name.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
+        let result_schema = ddl_result_schema();
+
+        let stream = futures::stream::once(async move {
+            // Convert Arrow schema to Iceberg schema
+            let iceberg_schema =
+                iceberg::arrow::arrow_schema_to_schema_auto_assign_ids(arrow_schema.as_ref())
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to convert Arrow schema to Iceberg schema: {e}"
+                        ))
+                    })?;
+
+            let table_ident = TableIdent::new(namespace.clone(), table_name.clone());
+
+            // Check if table already exists
+            let exists = catalog.table_exists(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to check table existence: {e}"))
+            })?;
+
+            if exists {
+                if if_not_exists {
+                    let batch = RecordBatch::try_new(
+                        result_schema,
+                        vec![Arc::new(StringArray::from(vec![format!(
+                            "Table '{table_name}' already exists"
+                        )]))],
+                    )?;
+                    return Ok(batch);
+                }
+                return Err(DataFusionError::Execution(format!(
+                    "Table '{table_name}' already exists in namespace '{}'",
+                    namespace.join(".")
+                )));
+            }
+
+            // Create the table in the Iceberg catalog
+            let table_creation = TableCreation::builder()
+                .name(table_name.clone())
+                .schema(iceberg_schema)
+                .build();
+
+            catalog
+                .create_table(&namespace, table_creation)
+                .await
+                .map_err(|e| {
+                    DataFusionError::Execution(format!("Failed to create Iceberg table: {e}"))
+                })?;
+
+            // Create an IcebergTableProvider for the new table and register it
+            let provider = IcebergTableProvider::try_new(
+                Arc::clone(&catalog),
+                namespace.clone(),
+                table_name.clone(),
+            )
+            .await
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Failed to create table provider for new Iceberg table: {e}"
+                ))
+            })?;
+
+            // Register in the DataFusion catalog's schema provider
+            if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
+                && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
+            {
+                schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+            }
+
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(StringArray::from(vec![format!(
+                    "Table '{table_name}' created"
+                )]))],
+            )?;
+            Ok(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            ddl_result_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Physical plan for dropping an Iceberg table.
+pub struct IcebergDropTableExec {
+    catalog: Arc<dyn Catalog>,
+    namespace: NamespaceIdent,
+    table_name: String,
+    if_exists: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for IcebergDropTableExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IcebergDropTableExec")
+            .field("namespace", &self.namespace)
+            .field("table_name", &self.table_name)
+            .field("df_catalog_name", &self.df_catalog_name)
+            .field("df_schema_name", &self.df_schema_name)
+            .field("if_exists", &self.if_exists)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IcebergDropTableExec {
+    #[must_use]
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        namespace: NamespaceIdent,
+        table_name: String,
+        if_exists: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+        catalog_list: Arc<dyn CatalogProviderList>,
+    ) -> Self {
+        let schema = ddl_result_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            catalog,
+            namespace,
+            table_name,
+            if_exists,
+            df_catalog_name,
+            df_schema_name,
+            catalog_list,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for IcebergDropTableExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "IcebergDropTableExec: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+}
+
+impl ExecutionPlan for IcebergDropTableExec {
+    fn name(&self) -> &'static str {
+        "IcebergDropTableExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let catalog = Arc::clone(&self.catalog);
+        let namespace = self.namespace.clone();
+        let table_name = self.table_name.clone();
+        let if_exists = self.if_exists;
+        let df_catalog_name = self.df_catalog_name.clone();
+        let df_schema_name = self.df_schema_name.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
+        let result_schema = ddl_result_schema();
+
+        let stream = futures::stream::once(async move {
+            let table_ident = TableIdent::new(namespace.clone(), table_name.clone());
+
+            // Check existence
+            let exists = catalog.table_exists(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to check table existence: {e}"))
+            })?;
+
+            if !exists {
+                if if_exists {
+                    let batch = RecordBatch::try_new(
+                        result_schema,
+                        vec![Arc::new(StringArray::from(vec![format!(
+                            "Table '{table_name}' does not exist"
+                        )]))],
+                    )?;
+                    return Ok(batch);
+                }
+                return Err(DataFusionError::Execution(format!(
+                    "Table '{table_name}' does not exist in namespace '{}'",
+                    namespace.join(".")
+                )));
+            }
+
+            // Drop from Iceberg catalog
+            catalog.drop_table(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
+            })?;
+
+            // Deregister from DataFusion catalog
+            if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
+                && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
+            {
+                let _ = schema_provider.deregister_table(&table_name);
+            }
+
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(StringArray::from(vec![format!(
+                    "Table '{table_name}' dropped"
+                )]))],
+            )?;
+            Ok(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            ddl_result_schema(),
+            stream,
+        )))
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
@@ -1,0 +1,83 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Extension planner that converts Iceberg DDL logical nodes into
+//! physical execution plans.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+
+use super::logical_nodes::{IcebergCreateTableNode, IcebergDropTableNode};
+use super::physical_plans::{IcebergCreateTableExec, IcebergDropTableExec};
+
+/// Extension planner for Iceberg DDL operations.
+#[derive(Debug, Default)]
+pub struct IcebergDdlExtensionPlanner;
+
+impl IcebergDdlExtensionPlanner {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ExtensionPlanner for IcebergDdlExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        _physical_inputs: &[Arc<dyn ExecutionPlan>],
+        session_state: &datafusion::execution::SessionState,
+    ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+        let catalog_list = Arc::<dyn CatalogProviderList>::clone(session_state.catalog_list());
+
+        if let Some(create) = node.as_any().downcast_ref::<IcebergCreateTableNode>() {
+            return Ok(Some(Arc::new(IcebergCreateTableExec::new(
+                Arc::clone(&create.catalog),
+                create.namespace.clone(),
+                create.table_name.clone(),
+                Arc::clone(&create.arrow_schema),
+                create.if_not_exists,
+                create.or_replace,
+                create.df_catalog_name.clone(),
+                create.df_schema_name.clone(),
+                catalog_list,
+            ))));
+        }
+
+        if let Some(drop) = node.as_any().downcast_ref::<IcebergDropTableNode>() {
+            return Ok(Some(Arc::new(IcebergDropTableExec::new(
+                Arc::clone(&drop.catalog),
+                drop.namespace.clone(),
+                drop.table_name.clone(),
+                drop.if_exists,
+                drop.df_catalog_name.clone(),
+                drop.df_schema_name.clone(),
+                catalog_list,
+            ))));
+        }
+
+        Ok(None)
+    }
+}

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -129,6 +129,7 @@ pub mod secrets_context_extension;
 pub mod sort_columns;
 pub(crate) mod sql_validator;
 pub mod udf;
+pub mod composed_catalog;
 
 pub const SPICE_DEFAULT_CATALOG: &str = "spice";
 pub const SPICE_RUNTIME_SCHEMA: &str = "runtime";

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -548,7 +548,14 @@ impl DataFusion {
                 .await
                 .insert(name.to_string(), Arc::new(deferred_catalog.clone()));
         } else {
-            self.ctx.register_catalog(name, catalog);
+            let catalog_to_register = if name == SPICE_DEFAULT_CATALOG {
+                // When overriding the default catalog, preserve internal schemas
+                self.compose_with_internal_schemas(catalog)?
+            } else {
+                catalog
+            };
+
+            self.ctx.register_catalog(name, catalog_to_register);
 
             if access.allows_ddl() {
                 self.mark_catalog_ddl_enabled(name)?;
@@ -558,6 +565,42 @@ impl DataFusion {
         }
 
         Ok(())
+    }
+
+    /// When an external catalog replaces the default `spice` catalog, extract the
+    /// internal schemas (`runtime`, `metadata`, `eval`, `scp`) from the current
+    /// default catalog and wrap the external catalog in a [`ComposedCatalogProvider`]
+    /// that preserves those internal schemas.
+    fn compose_with_internal_schemas(
+        &self,
+        external: Arc<dyn CatalogProvider>,
+    ) -> Result<Arc<dyn CatalogProvider>> {
+        use composed_catalog::ComposedCatalogProvider;
+        use std::collections::HashMap;
+
+        let internal_schema_names = [
+            SPICE_RUNTIME_SCHEMA,
+            SPICE_METADATA_SCHEMA,
+            SPICE_SCP_SCHEMA,
+            #[cfg(feature = "models")]
+            SPICE_EVAL_SCHEMA,
+        ];
+
+        let mut internal_schemas: HashMap<String, Arc<dyn datafusion::catalog::SchemaProvider>> =
+            HashMap::new();
+
+        if let Some(current_catalog) = self.ctx.catalog(SPICE_DEFAULT_CATALOG) {
+            for schema_name in &internal_schema_names {
+                if let Some(schema) = current_catalog.schema(schema_name) {
+                    internal_schemas.insert((*schema_name).to_string(), schema);
+                }
+            }
+        }
+
+        Ok(Arc::new(ComposedCatalogProvider::new(
+            external,
+            internal_schemas,
+        )))
     }
 
     // Returns a Notify if the table supports notifying the runtime when the table is ready.

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -114,10 +114,12 @@ pub mod query;
 
 pub mod app_context_extension;
 pub mod builder;
+pub mod composed_catalog;
 pub mod dialect;
 pub mod error;
 pub mod filter_converter;
 pub mod flight_session_extension;
+pub mod iceberg_ddl;
 pub mod job_executor_context_extension;
 pub mod managed_runtime;
 pub mod param_utils;
@@ -129,7 +131,6 @@ pub mod secrets_context_extension;
 pub mod sort_columns;
 pub(crate) mod sql_validator;
 pub mod udf;
-pub mod composed_catalog;
 
 pub const SPICE_DEFAULT_CATALOG: &str = "spice";
 pub const SPICE_RUNTIME_SCHEMA: &str = "runtime";
@@ -401,7 +402,7 @@ pub struct DataFusion {
     data_writers: RwLock<HashSet<TableReference>>,
     writable_catalogs: RwLock<HashSet<String>>,
     /// Catalogs that allow DDL operations (CREATE TABLE, DROP TABLE, etc.)
-    ddl_enabled_catalogs: RwLock<HashSet<String>>,
+    ddl_enabled_catalogs: Arc<RwLock<HashSet<String>>>,
     accelerated_tables: TokioRwLock<HashSet<TableReference>>,
     caching: Arc<Caching>,
     pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
@@ -550,7 +551,7 @@ impl DataFusion {
         } else {
             let catalog_to_register = if name == SPICE_DEFAULT_CATALOG {
                 // When overriding the default catalog, preserve internal schemas
-                self.compose_with_internal_schemas(catalog)?
+                self.compose_with_internal_schemas(catalog)
             } else {
                 catalog
             };
@@ -574,7 +575,7 @@ impl DataFusion {
     fn compose_with_internal_schemas(
         &self,
         external: Arc<dyn CatalogProvider>,
-    ) -> Result<Arc<dyn CatalogProvider>> {
+    ) -> Arc<dyn CatalogProvider> {
         use composed_catalog::ComposedCatalogProvider;
         use std::collections::HashMap;
 
@@ -597,10 +598,7 @@ impl DataFusion {
             }
         }
 
-        Ok(Arc::new(ComposedCatalogProvider::new(
-            external,
-            internal_schemas,
-        )))
+        Arc::new(ComposedCatalogProvider::new(external, internal_schemas))
     }
 
     // Returns a Notify if the table supports notifying the runtime when the table is ready.
@@ -707,6 +705,14 @@ impl DataFusion {
         } else {
             false
         }
+    }
+
+    /// Check if a table reference belongs to a writable catalog.
+    /// Handles both explicit catalog names and bare names (defaults to `SPICE_DEFAULT_CATALOG`).
+    #[must_use]
+    pub fn is_path_catalog_writable(&self, table_reference: &TableReference) -> bool {
+        let catalog = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+        self.is_catalog_writable(catalog)
     }
 
     pub fn mark_catalog_writable(&self, catalog_name: &str) -> Result<()> {
@@ -947,7 +953,7 @@ impl DataFusion {
         table_reference: &TableReference,
         data_update: DataUpdate,
     ) -> Result<()> {
-        if !self.is_writable(table_reference) {
+        if !self.is_writable(table_reference) && !self.is_path_catalog_writable(table_reference) {
             TableNotWritableSnafu {
                 table_name: table_reference.to_string(),
             }
@@ -1005,7 +1011,7 @@ impl DataFusion {
         table_reference: &TableReference,
         streaming_update: StreamingDataUpdate,
     ) -> Result<()> {
-        if !self.is_writable(table_reference) {
+        if !self.is_writable(table_reference) && !self.is_path_catalog_writable(table_reference) {
             TableNotWritableSnafu {
                 table_name: table_reference.to_string(),
             }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -719,8 +719,10 @@ impl Query {
                 };
 
             // Skip schema verification for Statement plans (PREPARE/EXECUTE/DEALLOCATE)
-            // as their logical plan schema may differ from the actual execution result
-            if !matches!(&*plan, LogicalPlan::Statement(_)) {
+            // and DDL plans (CREATE TABLE/DROP TABLE) as their logical plan schema may
+            // differ from the actual execution result (DDL plans may be rewritten by
+            // analyzer rules into extension nodes with different output schemas)
+            if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_)) {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -59,18 +59,18 @@ pub fn validate_sql_query_operations(
                     );
                 }
 
-                // Check if attempting to write into a catalog. The default catalog name indicates writing to a table registered as a dataset, not via a catalog.
-                if let Some(catalog) = dml.table_name.catalog() && catalog != super::SPICE_DEFAULT_CATALOG {
-                    if !df.is_catalog_writable(catalog) {
-                        return plan_err!(
-                            "INSERT operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
-                            dml.table_name
-                        );
+                // Check if attempting to write into a catalog.
+                if let Some(catalog) = dml.table_name.catalog() {
+                    if df.is_catalog_writable(catalog) {
+                        return Ok(TreeNodeRecursion::Continue);
                     }
-                    return Ok(TreeNodeRecursion::Continue);
                 }
 
+                // Fall back to per-table writable check
                 if df.is_writable(&dml.table_name) {
+                    Ok(TreeNodeRecursion::Continue)
+                } else if df.is_catalog_writable(super::SPICE_DEFAULT_CATALOG) {
+                    // No catalog specified but default catalog is writable
                     Ok(TreeNodeRecursion::Continue)
                 } else {
                     plan_err!(
@@ -137,7 +137,7 @@ fn validate_ddl_operation(
 
     // Check if the operation is targeting a DDL-enabled catalog
     if let Some(catalog) = catalog_name {
-        if catalog != super::SPICE_DEFAULT_CATALOG && df.is_catalog_ddl_enabled(&catalog) {
+        if df.is_catalog_ddl_enabled(&catalog) {
             return Ok(TreeNodeRecursion::Continue);
         }
         return plan_err!(
@@ -145,6 +145,11 @@ fn validate_ddl_operation(
             ddl.name(),
             catalog
         );
+    }
+
+    // No catalog specified — check if the default catalog is DDL-enabled
+    if df.is_catalog_ddl_enabled(super::SPICE_DEFAULT_CATALOG) {
+        return Ok(TreeNodeRecursion::Continue);
     }
 
     // DDL on the default catalog or without a catalog is not allowed
@@ -645,6 +650,94 @@ mod tests {
         assert!(
             result.is_err(),
             "INSERT should fail on read-only dataset in default catalog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_ddl_on_default_catalog_when_ddl_enabled() {
+        let df = create_test_datafusion();
+
+        // Mark the default catalog as DDL-enabled (simulates Iceberg catalog override)
+        df.mark_catalog_ddl_enabled("spice")
+            .expect("should mark default catalog as DDL-enabled");
+
+        // CREATE TABLE on default catalog (bare name) should be allowed
+        let sql = "CREATE TABLE new_table (id INT, name VARCHAR(50))";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "CREATE TABLE should be allowed on DDL-enabled default catalog (bare name)"
+        );
+
+        // CREATE TABLE with explicit spice catalog should also work
+        let sql = "CREATE TABLE spice.public.another_table (id INT, name VARCHAR(50))";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "CREATE TABLE should be allowed on DDL-enabled default catalog (explicit name)"
+        );
+
+        // DROP TABLE should also work
+        let sql = "DROP TABLE IF EXISTS new_table";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "DROP TABLE should be allowed on DDL-enabled default catalog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_dml_on_default_catalog_when_writable() {
+        let df = create_test_datafusion();
+
+        // Mark the default catalog as DDL-enabled (which also marks it writable)
+        df.mark_catalog_ddl_enabled("spice")
+            .expect("should mark default catalog as DDL-enabled");
+
+        // Register a test table to INSERT into
+        let mem_table = Arc::new(
+            MemTable::try_new(create_test_schema(), vec![])
+                .expect("mem table should be created"),
+        );
+        df.ctx
+            .register_table("catalog_table", mem_table)
+            .expect("table should be registered");
+
+        // INSERT on a catalog-managed table (not individually marked writable) should work
+        // because the default catalog is writable
+        let sql = "INSERT INTO catalog_table VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "INSERT should be allowed on table in writable default catalog"
         );
     }
 }

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -60,10 +60,10 @@ pub fn validate_sql_query_operations(
                 }
 
                 // Check if attempting to write into a catalog.
-                if let Some(catalog) = dml.table_name.catalog() {
-                    if df.is_catalog_writable(catalog) {
-                        return Ok(TreeNodeRecursion::Continue);
-                    }
+                if let Some(catalog) = dml.table_name.catalog()
+                    && df.is_catalog_writable(catalog)
+                {
+                    return Ok(TreeNodeRecursion::Continue);
                 }
 
                 // Fall back to per-table writable check
@@ -717,8 +717,7 @@ mod tests {
 
         // Register a test table to INSERT into
         let mem_table = Arc::new(
-            MemTable::try_new(create_test_schema(), vec![])
-                .expect("mem table should be created"),
+            MemTable::try_new(create_test_schema(), vec![]).expect("mem table should be created"),
         );
         df.ctx
             .register_table("catalog_table", mem_table)

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -67,11 +67,11 @@ pub(crate) async fn handle(
             Box::pin(flightsql::get_xdbc_type_info::do_get(command)).await
         }
         // Additional Commands not yet supported
-        Command::CommandStatementUpdate(cmd) => {
+        Command::CommandStatementUpdate(_cmd) => {
             let _start = metrics::track_flight_request("do_get", Some("statement_update")).await;
-            tracing::debug!("CommandStatementUpdate not yet implemented: {cmd:?}");
-            Err(Status::unimplemented(
-                "CommandStatementUpdate is not yet implemented",
+            // CommandStatementUpdate should be sent via DoPut, not DoGet
+            Err(Status::invalid_argument(
+                "CommandStatementUpdate should be sent via DoPut, not DoGet. See the FlightSQL specification.",
             ))
         }
         Command::CommandStatementSubstraitPlan(cmd) => {

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -86,6 +86,9 @@ pub(crate) async fn handle(
                 )
                 .await;
             }
+            Command::CommandStatementUpdate(cmd) => {
+                return flightsql::statement_update::do_put(cmd).await;
+            }
             Command::CommandStatementIngest(ingest_cmd) => {
                 // Handle FlightSQL bulk ingestion command
                 // Extract the table reference from the command
@@ -162,7 +165,7 @@ pub(crate) async fn handle(
     let context = RequestContext::current(AsyncMarker::new().await);
     let datafusion = get_current_datafusion(&context);
 
-    if !datafusion.is_writable(&path) {
+    if !datafusion.is_writable(&path) && !datafusion.is_path_catalog_writable(&path) {
         return Err(Status::invalid_argument(format!(
             "Path doesn't exist or is not writable: {path}",
         )));

--- a/crates/runtime/src/flight/flightsql.rs
+++ b/crates/runtime/src/flight/flightsql.rs
@@ -24,3 +24,4 @@ pub(crate) mod get_xdbc_type_info;
 pub(crate) mod prepared_statement_query;
 pub(crate) mod prepared_statement_update;
 pub(crate) mod statement_query;
+pub(crate) mod statement_update;

--- a/crates/runtime/src/flight/flightsql/statement_update.rs
+++ b/crates/runtime/src/flight/flightsql/statement_update.rs
@@ -1,0 +1,136 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Handler for `FlightSQL` `CommandStatementUpdate` — executes SQL DML
+//! statements (`INSERT INTO`, `CREATE TABLE`, `DROP TABLE`, etc.)
+//! and returns the number of affected rows.
+
+use arrow::array::{Int64Array, RecordBatch};
+use arrow_flight::{
+    PutResult,
+    flight_service_server::FlightService,
+    sql::{CommandStatementUpdate, DoPutUpdateResult, ProstMessageExt},
+};
+use prost::Message;
+use tonic::{Response, Status};
+
+use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
+    flight::{Service, metrics},
+};
+use runtime_request_context::{AsyncMarker, RequestContext};
+
+use crate::datafusion::sql_validator::validate_sql_query_operations;
+use runtime_auth::AuthRequestContext;
+
+/// Execute a SQL DML statement received via `DoPut` with `CommandStatementUpdate`.
+///
+/// Per the `FlightSQL` spec, this executes the SQL and returns a `DoPutUpdateResult`
+/// with the count of affected rows.
+pub(crate) async fn do_put(
+    cmd: CommandStatementUpdate,
+) -> Result<Response<<Service as FlightService>::DoPutStream>, Status> {
+    let _start = metrics::track_flight_request("do_put", Some("statement_update")).await;
+
+    // Authenticate — this handler is dispatched before the generic DoPut auth
+    // check, so we must verify credentials here.
+    let context = RequestContext::current(AsyncMarker::new().await);
+    match context.auth_principal() {
+        Some(principal) => {
+            if !principal
+                .groups()
+                .iter()
+                .any(|group| *group == "write" || *group == "read_write")
+            {
+                return Err(Status::permission_denied(
+                    "Write access denied. Verify that authentication key used has write access and try again.",
+                ));
+            }
+        }
+        None => {
+            return Err(Status::unauthenticated(
+                "Flight DoPut requires authentication.\nFor auth details, visit https://spiceai.org/docs/api/auth",
+            ));
+        }
+    }
+
+    let datafusion = get_current_datafusion(&context);
+
+    let sql = &cmd.query;
+    tracing::trace!("do_put_statement_update: {sql}");
+
+    // Parse and validate
+    let session = datafusion.ctx.state();
+    let plan = session
+        .create_logical_plan(sql)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to create logical plan: {e}")))?;
+
+    if let Err(e) = validate_sql_query_operations(&plan, &datafusion) {
+        return Err(Status::permission_denied(format!(
+            "Operation not allowed: {e}"
+        )));
+    }
+
+    // Execute
+    let physical_plan = session
+        .create_physical_plan(&plan)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to create physical plan: {e}")))?;
+
+    let results = datafusion::physical_plan::collect(physical_plan, datafusion.ctx.task_ctx())
+        .await
+        .map_err(|e| Status::internal(format!("Failed to execute statement: {e}")))?;
+
+    // Extract affected rows count
+    let affected_rows = extract_affected_rows(&results);
+
+    let result = DoPutUpdateResult {
+        record_count: affected_rows,
+    };
+
+    let output = futures::stream::iter(vec![Ok(PutResult {
+        app_metadata: result.as_any().encode_to_vec().into(),
+    })]);
+
+    Ok(Response::new(Box::pin(output)))
+}
+
+/// Extract affected row count from execution results.
+fn extract_affected_rows(results: &[RecordBatch]) -> i64 {
+    if results.is_empty() || results[0].num_rows() == 0 {
+        return 0;
+    }
+
+    let batch = &results[0];
+    if batch.num_columns() == 0 {
+        return 0;
+    }
+
+    let count_array = batch.column(0);
+    if let Some(int64_array) = count_array.as_any().downcast_ref::<Int64Array>() {
+        int64_array.value(0)
+    } else if let Some(uint64_array) = count_array
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+    {
+        // Row counts exceeding i64::MAX are physically impossible, but
+        // saturate rather than silently returning a wrong value.
+        i64::try_from(uint64_array.value(0)).unwrap_or(i64::MAX)
+    } else {
+        0
+    }
+}

--- a/crates/runtime/src/flight/get_flight_info.rs
+++ b/crates/runtime/src/flight/get_flight_info.rs
@@ -77,13 +77,14 @@ pub(crate) async fn handle(
             ))
         }
         // Additional Commands not yet supported
-        Command::CommandStatementUpdate(cmd) => {
+        Command::CommandStatementUpdate(_cmd) => {
             let _start =
                 metrics::track_flight_request("get_flight_info", Some("statement_update")).await;
-            tracing::debug!("CommandStatementUpdate not yet implemented: {cmd:?}");
-            Err(Status::unimplemented(
-                "CommandStatementUpdate is not yet implemented",
-            ))
+            // Per FlightSQL spec, CommandStatementUpdate is primarily handled via DoPut.
+            // Return minimal FlightInfo indicating this is a write operation.
+            let fd = request.into_inner();
+            let info = FlightInfo::new().with_descriptor(fd);
+            Ok(Response::new(info))
         }
         Command::CommandStatementSubstraitPlan(cmd) => {
             let _start =


### PR DESCRIPTION
## Overview

Enable DDL support (`CREATE TABLE` / `DROP TABLE`) in Spice runtime for Iceberg format. Users can define an Iceberg catalog named `spice` to override the default catalog, managing tables entirely through SQL and ADBC/FlightSQL.

### Example Spicepod

```yaml
version: v1beta1
kind: Spicepod
name: my_app

catalogs:
  - from: iceberg:http://localhost:8181/v1/namespaces/warehouse
    name: spice
    access: read_write_create
    params:
      s3_endpoint: http://localhost:9000
      s3_access_key_id: admin
      s3_secret_access_key: password
      s3_region: us-east-1
```

Then DDL is available immediately:

```sql
CREATE TABLE my_table (id INT, name VARCHAR, ts TIMESTAMP);
INSERT INTO my_table VALUES (1, 'hello', '2025-01-01T00:00:00');
SELECT * FROM my_table;
DROP TABLE my_table;
```

## Changes

### Iceberg Provider Refactor
- Refactored `IcebergCatalogProvider` and `IcebergSchemaProvider` to hold `Arc<dyn Catalog>`, use `RwLock<HashMap>` for schemas/tables
- Implemented real `refresh()` that re-fetches namespaces and tables from the Iceberg catalog
- Added `register_table()`/`deregister_table()` support
- Made `IcebergSchemaProvider` public for use by DDL module

### Default Catalog Override
- New `ComposedCatalogProvider` wraps external catalogs while preserving Spice's internal schemas (`runtime`, `metadata`, `eval`, `scp`)
- `register_catalog()` wraps in `ComposedCatalogProvider` when overriding the default `spice` catalog
- Validation blocks datasets/views in Spicepod when a catalog named `spice` is configured

### DDL Analyzer Rule & Extension Planner
- `IcebergDdlAnalyzerRule` intercepts `CREATE TABLE`/`DROP TABLE` plans for DDL-enabled Iceberg catalogs, rewrites to custom extension nodes
- Uses `Weak` references to avoid reference cycles with `SessionContext`
- `IcebergCreateTableExec`/`IcebergDropTableExec` physical plans call Iceberg catalog APIs and register/deregister table providers
- `IcebergDdlExtensionPlanner` converts logical nodes to physical plans

### SQL Validator Updates
- Allow DDL and DML on the default catalog when it's marked DDL-enabled/writable
- Removed the `catalog != SPICE_DEFAULT_CATALOG` exclusion that previously blocked all operations on the default catalog

### FlightSQL DML Support
- New `CommandStatementUpdate` handler for SQL DML via `DoPut`
- Catalog-level writable fallback in `write_data()`/`write_streaming_data()` and `do_put` for catalog-managed tables
- `is_path_catalog_writable()` helper for table references
