### PR TITLE
docs: fix typos and syntax errors in style guide and error handling docs

### DIFF
--- a/docs/dev/error_handling.md
+++ b/docs/dev/error_handling.md
@@ -140,8 +140,6 @@ Related reading:
         Is your `file_format` parameter correct? Spice found the following file extensions: '.parquet'.
     ```
 
-    ```
-
 6. **Do not use internal concepts in error messages**
 
     Users generally do not care about the fact that the logical plan builder failed to construct - they care about the fact that their query failed.

--- a/docs/dev/style_guide.md
+++ b/docs/dev/style_guide.md
@@ -13,7 +13,7 @@ The principles guiding this work are as follows:
 
 ### Style
 
-**Error handling**: Error handling in Rust is a nuanced topic with many different approaches. The [Snafu design philosophy](https://docs.rs/snafu/latest/snafu/guide/philosophy/index.html#snafus-design-philosophy) is followed, utilizing the the [Snafu crate](https://docs.rs/snafu/latest/snafu/index.html) for defining and using error types.
+**Error handling**: Error handling in Rust is a nuanced topic with many different approaches. The [Snafu design philosophy](https://docs.rs/snafu/latest/snafu/guide/philosophy/index.html#snafus-design-philosophy) is followed, utilizing the [Snafu crate](https://docs.rs/snafu/latest/snafu/index.html) for defining and using error types.
 
 ### All errors use SNAFU functionality
 
@@ -239,7 +239,7 @@ Accessing the newtype value directly through a `Copy`:
 #[derive(Clone, Copy)]
 struct MyStruct(u64);
 
-fn consumes_value(v: MyStruct) -> {
+fn consumes_value(v: MyStruct) {
     v.0;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes three documentation bugs found in the developer docs:

### 1. Double word typo in `style_guide.md`
- **File**: `docs/dev/style_guide.md`
- **Issue**: Duplicate word "the the" in the Error handling section
- **Fix**: Removed the extra "the"

### 2. Invalid Rust syntax in `style_guide.md`
- **File**: `docs/dev/style_guide.md`  
- **Issue**: The "Bad" example in the "Avoid using Clone or Copy on Newtypes" section contained invalid Rust syntax: `fn consumes_value(v: MyStruct) -> {` — the `->` token requires a return type that was missing
- **Fix**: Corrected to `fn consumes_value(v: MyStruct) {`

### 3. Stray code fence in `error_handling.md`
- **File**: `docs/dev/error_handling.md`
- **Issue**: An extra `````` code fence after the "Bad" example in guideline #5 ("Reference documentation in errors") caused guideline #6 ("Do not use internal concepts in error messages") and all subsequent content to render inside a code block, breaking the document structure
- **Fix**: Removed the stray code fence

## Changes
- `docs/dev/style_guide.md`: 2 fixes (duplicate word + invalid Rust syntax)
- `docs/dev/error_handling.md`: 1 fix (stray code fence)