### PR TITLE
feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*")

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -284,6 +284,7 @@ impl RuntimeBuilder {
         }
 
         let df = Arc::new(df);
+        df.set_self_ref();
 
         let datasets_health_monitor = if self.datasets_health_monitor_enabled {
             let is_task_history_enabled = self

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -279,11 +279,15 @@ impl DataFusionBuilder {
             config = config.with_spill_compression(spill_compression);
         }
 
+        let datafusion_ref = super::iceberg_ddl::new_shared_datafusion_ref();
+
         let mut state = SessionStateBuilder::new()
             .with_config(config)
             .with_default_features()
             .with_query_planner(Arc::new(
-                ExtensionPlanQueryPlanner::from_extension_planners(default_extension_planners()),
+                ExtensionPlanQueryPlanner::from_extension_planners(default_extension_planners(
+                    Arc::clone(&datafusion_ref),
+                )),
             ))
             .with_runtime_env(runtime_env(
                 self.memory_limit,
@@ -407,6 +411,8 @@ impl DataFusionBuilder {
         let caching = self.caching.unwrap_or(Arc::new(Caching::default()));
 
         let ddl_enabled_catalogs = Arc::new(RwLock::new(HashSet::new()));
+        let acceleration_options_store =
+            super::iceberg_ddl::acceleration_options::new_shared_store();
 
         // Add the Iceberg DDL analyzer rule after context creation so it can
         // reference the catalog list and DDL-enabled catalogs.
@@ -416,6 +422,7 @@ impl DataFusionBuilder {
             super::iceberg_ddl::analyzer_rule::IcebergDdlAnalyzerRule::new(
                 ctx.state().catalog_list(),
                 &ddl_enabled_catalogs,
+                Arc::clone(&acceleration_options_store),
             ),
         ));
 
@@ -425,6 +432,8 @@ impl DataFusionBuilder {
             data_writers: RwLock::new(HashSet::new()),
             writable_catalogs: RwLock::new(HashSet::new()),
             ddl_enabled_catalogs,
+            acceleration_options_store,
+            datafusion_ref,
             caching,
             pending_sink_tables: TokioRwLock::new(Vec::new()),
             deferred_tables: TokioRwLock::new(HashMap::new()),
@@ -576,12 +585,14 @@ pub(crate) fn runtime_env(
     }
 }
 
-pub(crate) fn default_extension_planners() -> Vec<Arc<dyn ExtensionPlanner + Send + Sync>> {
+pub(crate) fn default_extension_planners(
+    datafusion_ref: super::iceberg_ddl::SharedDataFusionRef,
+) -> Vec<Arc<dyn ExtensionPlanner + Send + Sync>> {
     vec![
         Arc::new(IndexTableScanExtensionPlanner::new()),
         Arc::new(FederatedPlanner::new()),
         Arc::new(CacheInvalidationExtensionPlanner::new()),
-        Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new()),
+        Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new(datafusion_ref)),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
@@ -140,7 +140,6 @@ fn parse_bool(value: &str, field: &str) -> DFResult<bool> {
         "Invalid value for '{field}': '{value}'. Expected 'true' or 'false'."
     )))
 }
-
 fn parse_mode(value: &str) -> DFResult<acceleration::Mode> {
     match value.to_lowercase().as_str() {
         "memory" => Ok(acceleration::Mode::Memory),

--- a/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025, Spice AI, Inc.
+Copyright 2026, Spice AI, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -78,11 +78,7 @@ pub fn parse_acceleration_options(options: &[(String, String)]) -> DFResult<Acce
 
         match field {
             "enabled" => {
-                accel.enabled = value.parse().map_err(|_| {
-                    DataFusionError::Plan(format!(
-                        "Invalid value for 'acceleration.enabled': '{value}'. Expected 'true' or 'false'."
-                    ))
-                })?;
+                accel.enabled = parse_bool(value, "acceleration.enabled")?;
             }
             "engine" => {
                 accel.engine = Some(value.clone());
@@ -112,11 +108,8 @@ pub fn parse_acceleration_options(options: &[(String, String)]) -> DFResult<Acce
                 accel.retention_check_interval = Some(value.clone());
             }
             "retention_check_enabled" => {
-                accel.retention_check_enabled = value.parse().map_err(|_| {
-                    DataFusionError::Plan(format!(
-                        "Invalid value for 'acceleration.retention_check_enabled': '{value}'. Expected 'true' or 'false'."
-                    ))
-                })?;
+                accel.retention_check_enabled =
+                    parse_bool(value, "acceleration.retention_check_enabled")?;
             }
             unknown => {
                 return Err(DataFusionError::Plan(format!(
@@ -133,6 +126,19 @@ pub fn parse_acceleration_options(options: &[(String, String)]) -> DFResult<Acce
     }
 
     Ok(accel)
+}
+
+fn parse_bool(value: &str, field: &str) -> DFResult<bool> {
+    if value.eq_ignore_ascii_case("true") {
+        return Ok(true);
+    }
+    if value.eq_ignore_ascii_case("false") {
+        return Ok(false);
+    }
+
+    Err(DataFusionError::Plan(format!(
+        "Invalid value for '{field}': '{value}'. Expected 'true' or 'false'."
+    )))
 }
 
 fn parse_mode(value: &str) -> DFResult<acceleration::Mode> {
@@ -186,6 +192,21 @@ mod tests {
         let options = vec![("acceleration.enabled".to_string(), "false".to_string())];
         let accel = parse_acceleration_options(&options).expect("should parse");
         assert!(!accel.enabled);
+    }
+
+    #[test]
+    fn test_parse_uppercase_booleans() {
+        let options = vec![
+            ("acceleration.enabled".to_string(), "TRUE".to_string()),
+            (
+                "acceleration.retention_check_enabled".to_string(),
+                "FALSE".to_string(),
+            ),
+        ];
+
+        let accel = parse_acceleration_options(&options).expect("should parse");
+        assert!(accel.enabled);
+        assert!(!accel.retention_check_enabled);
     }
 
     #[test]

--- a/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
@@ -1,0 +1,236 @@
+/*
+Copyright 2024-2025, Spice AI, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Store and parse acceleration options extracted from `CREATE TABLE ... WITH (...)` statements.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use spicepod::acceleration::{self, Acceleration};
+
+/// Stores acceleration options extracted from `CREATE TABLE ... WITH (acceleration.*)` clauses.
+///
+/// Keyed by the table name as it appeared in the SQL statement. The analyzer rule
+/// retrieves (and removes) the options when rewriting the DDL plan.
+#[derive(Debug, Clone, Default)]
+pub struct AccelerationOptionsStore {
+    options: HashMap<String, Acceleration>,
+}
+
+impl AccelerationOptionsStore {
+    /// Insert acceleration options for a table.
+    pub fn insert(&mut self, table_name: String, acceleration: Acceleration) {
+        self.options.insert(table_name, acceleration);
+    }
+
+    /// Remove and return acceleration options for a table (consume on use).
+    pub fn remove(&mut self, table_name: &str) -> Option<Acceleration> {
+        self.options.remove(table_name)
+    }
+}
+
+/// Thread-safe, shared acceleration options store.
+pub type SharedAccelerationOptionsStore = Arc<RwLock<AccelerationOptionsStore>>;
+
+/// Create a new shared store.
+#[must_use]
+pub fn new_shared_store() -> SharedAccelerationOptionsStore {
+    Arc::new(RwLock::new(AccelerationOptionsStore::default()))
+}
+
+/// Parse `acceleration.*` key-value pairs into an [`Acceleration`] struct.
+///
+/// Keys use dot-prefix format: `acceleration.engine`, `acceleration.mode`, etc.
+/// In SQL `WITH (...)` clauses, these must be double-quoted since dots are not
+/// valid in bare identifiers:
+///
+/// ```sql
+/// CREATE TABLE t (id INT) WITH ("acceleration.engine" = 'arrow')
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if an unknown `acceleration.*` key is encountered or a value
+/// cannot be parsed.
+pub fn parse_acceleration_options(options: &[(String, String)]) -> DFResult<Acceleration> {
+    let mut accel = Acceleration::default();
+
+    for (key, value) in options {
+        let field = key.strip_prefix("acceleration.").ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Expected 'acceleration.' prefix on table option, got '{key}'"
+            ))
+        })?;
+
+        match field {
+            "enabled" => {
+                accel.enabled = value.parse().map_err(|_| {
+                    DataFusionError::Plan(format!(
+                        "Invalid value for 'acceleration.enabled': '{value}'. Expected 'true' or 'false'."
+                    ))
+                })?;
+            }
+            "engine" => {
+                accel.engine = Some(value.clone());
+            }
+            "mode" => {
+                accel.mode = parse_mode(value)?;
+            }
+            "refresh_mode" => {
+                accel.refresh_mode = Some(parse_refresh_mode(value)?);
+            }
+            "refresh_check_interval" => {
+                accel.refresh_check_interval = Some(value.clone());
+            }
+            "refresh_sql" => {
+                accel.refresh_sql = Some(value.clone());
+            }
+            "refresh_data_window" => {
+                accel.refresh_data_window = Some(value.clone());
+            }
+            "refresh_append_overlap" => {
+                accel.refresh_append_overlap = Some(value.clone());
+            }
+            "retention_period" => {
+                accel.retention_period = Some(value.clone());
+            }
+            "retention_check_interval" => {
+                accel.retention_check_interval = Some(value.clone());
+            }
+            "retention_check_enabled" => {
+                accel.retention_check_enabled = value.parse().map_err(|_| {
+                    DataFusionError::Plan(format!(
+                        "Invalid value for 'acceleration.retention_check_enabled': '{value}'. Expected 'true' or 'false'."
+                    ))
+                })?;
+            }
+            unknown => {
+                return Err(DataFusionError::Plan(format!(
+                    "Unknown acceleration option: 'acceleration.{unknown}'. \
+                     Supported options: acceleration.enabled, acceleration.engine, \
+                     acceleration.mode, acceleration.refresh_mode, \
+                     acceleration.refresh_check_interval, acceleration.refresh_sql, \
+                     acceleration.refresh_data_window, acceleration.refresh_append_overlap, \
+                     acceleration.retention_period, acceleration.retention_check_interval, \
+                     acceleration.retention_check_enabled."
+                )));
+            }
+        }
+    }
+
+    Ok(accel)
+}
+
+fn parse_mode(value: &str) -> DFResult<acceleration::Mode> {
+    match value.to_lowercase().as_str() {
+        "memory" => Ok(acceleration::Mode::Memory),
+        "file" => Ok(acceleration::Mode::File),
+        "file_create" => Ok(acceleration::Mode::FileCreate),
+        _ => Err(DataFusionError::Plan(format!(
+            "Invalid value for 'acceleration.mode': '{value}'. Expected 'memory', 'file', or 'file_create'."
+        ))),
+    }
+}
+
+fn parse_refresh_mode(value: &str) -> DFResult<acceleration::RefreshMode> {
+    match value.to_lowercase().as_str() {
+        "full" => Ok(acceleration::RefreshMode::Full),
+        "append" => Ok(acceleration::RefreshMode::Append),
+        "changes" => Ok(acceleration::RefreshMode::Changes),
+        _ => Err(DataFusionError::Plan(format!(
+            "Invalid value for 'acceleration.refresh_mode': '{value}'. Expected 'full', 'append', or 'changes'."
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_acceleration_options() {
+        let options = vec![
+            ("acceleration.engine".to_string(), "arrow".to_string()),
+            ("acceleration.mode".to_string(), "memory".to_string()),
+            ("acceleration.refresh_mode".to_string(), "full".to_string()),
+            (
+                "acceleration.refresh_check_interval".to_string(),
+                "10s".to_string(),
+            ),
+        ];
+
+        let accel = parse_acceleration_options(&options).expect("should parse");
+        assert!(accel.enabled);
+        assert_eq!(accel.engine.as_deref(), Some("arrow"));
+        assert_eq!(accel.mode, acceleration::Mode::Memory);
+        assert_eq!(accel.refresh_mode, Some(acceleration::RefreshMode::Full));
+        assert_eq!(accel.refresh_check_interval.as_deref(), Some("10s"));
+    }
+
+    #[test]
+    fn test_parse_disabled_acceleration() {
+        let options = vec![("acceleration.enabled".to_string(), "false".to_string())];
+        let accel = parse_acceleration_options(&options).expect("should parse");
+        assert!(!accel.enabled);
+    }
+
+    #[test]
+    fn test_parse_unknown_option_errors() {
+        let options = vec![(
+            "acceleration.unknown_field".to_string(),
+            "value".to_string(),
+        )];
+        let result = parse_acceleration_options(&options);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Unknown acceleration option"));
+    }
+
+    #[test]
+    fn test_parse_invalid_mode_errors() {
+        let options = vec![("acceleration.mode".to_string(), "invalid".to_string())];
+        let result = parse_acceleration_options(&options);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_refresh_mode_errors() {
+        let options = vec![(
+            "acceleration.refresh_mode".to_string(),
+            "invalid".to_string(),
+        )];
+        let result = parse_acceleration_options(&options);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_missing_prefix_errors() {
+        let options = vec![("engine".to_string(), "arrow".to_string())];
+        let result = parse_acceleration_options(&options);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_store_insert_and_remove() {
+        let mut store = AccelerationOptionsStore::default();
+        let accel = Acceleration::default();
+        store.insert("my_table".to_string(), accel.clone());
+
+        assert!(store.remove("my_table").is_some());
+        assert!(store.remove("my_table").is_none()); // consumed
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
@@ -31,6 +31,7 @@ use datafusion::optimizer::AnalyzerRule;
 
 use data_components::iceberg::provider::IcebergCatalogProvider;
 
+use super::acceleration_options::SharedAccelerationOptionsStore;
 use super::composed_catalog_to_iceberg;
 use super::logical_nodes::{IcebergCreateTableNode, IcebergDropTableNode};
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
@@ -47,6 +48,8 @@ pub struct IcebergDdlAnalyzerRule {
     catalog_list: Weak<dyn CatalogProviderList>,
     /// Weak reference to the set of DDL-enabled catalog names.
     ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
+    /// Shared store for acceleration options extracted from `WITH` clauses.
+    acceleration_options: SharedAccelerationOptionsStore,
 }
 
 impl fmt::Debug for IcebergDdlAnalyzerRule {
@@ -61,10 +64,12 @@ impl IcebergDdlAnalyzerRule {
     pub fn new(
         catalog_list: &Arc<dyn CatalogProviderList>,
         ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
+        acceleration_options: SharedAccelerationOptionsStore,
     ) -> Self {
         Self {
             catalog_list: Arc::downgrade(catalog_list),
             ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
+            acceleration_options,
         }
     }
 
@@ -127,6 +132,13 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
 
                 let namespace = iceberg::NamespaceIdent::new(schema_name.clone());
 
+                // Look up acceleration options from the store (consumed on use)
+                let acceleration = self
+                    .acceleration_options
+                    .write()
+                    .ok()
+                    .and_then(|mut store| store.remove(&table_name));
+
                 let node = IcebergCreateTableNode::new(
                     iceberg_catalog,
                     namespace,
@@ -136,6 +148,7 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
                     create.or_replace,
                     catalog_name,
                     schema_name,
+                    acceleration,
                 );
 
                 Ok(LogicalPlan::Extension(Extension {

--- a/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, RwLock, Weak};
 
 use datafusion::catalog::CatalogProviderList;
 use datafusion::config::ConfigOptions;
+use datafusion::error::DataFusionError;
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::DdlStatement;
 use datafusion::logical_expr::{Extension, LogicalPlan};
@@ -126,6 +127,7 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
                     .unwrap_or(SPICE_DEFAULT_SCHEMA)
                     .to_string();
                 let table_name = create.name.table().to_string();
+                let acceleration_key = create.name.to_string();
 
                 // Extract the Arrow schema from the logical plan's input
                 let arrow_schema = Arc::new(create.input.schema().inner().as_ref().clone());
@@ -133,11 +135,14 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
                 let namespace = iceberg::NamespaceIdent::new(schema_name.clone());
 
                 // Look up acceleration options from the store (consumed on use)
-                let acceleration = self
-                    .acceleration_options
-                    .write()
-                    .ok()
-                    .and_then(|mut store| store.remove(&table_name));
+                let acceleration = {
+                    let mut store = self.acceleration_options.write().map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to acquire acceleration options store lock: {e}"
+                        ))
+                    })?;
+                    store.remove(&acceleration_key)
+                };
 
                 let node = IcebergCreateTableNode::new(
                     iceberg_catalog,

--- a/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
@@ -25,6 +25,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::DFSchemaRef;
 use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use iceberg::{Catalog, NamespaceIdent};
+use spicepod::acceleration::Acceleration;
 
 /// Creates the shared output schema for DDL result nodes (single `result` column).
 fn ddl_output_schema() -> DFSchemaRef {
@@ -57,6 +58,8 @@ pub struct IcebergCreateTableNode {
     pub df_catalog_name: String,
     /// The `DataFusion` schema name (for registering the table provider).
     pub df_schema_name: String,
+    /// Acceleration options from `WITH (acceleration.*)`, if any.
+    pub acceleration: Option<Acceleration>,
     /// Output schema (single "result" column).
     output_schema: DFSchemaRef,
 }
@@ -73,6 +76,7 @@ impl IcebergCreateTableNode {
         or_replace: bool,
         df_catalog_name: String,
         df_schema_name: String,
+        acceleration: Option<Acceleration>,
     ) -> Self {
         Self {
             catalog,
@@ -83,6 +87,7 @@ impl IcebergCreateTableNode {
             or_replace,
             df_catalog_name,
             df_schema_name,
+            acceleration,
             output_schema: ddl_output_schema(),
         }
     }
@@ -153,6 +158,7 @@ impl UserDefinedLogicalNodeCore for IcebergCreateTableNode {
             or_replace: self.or_replace,
             df_catalog_name: self.df_catalog_name.clone(),
             df_schema_name: self.df_schema_name.clone(),
+            acceleration: self.acceleration.clone(),
             output_schema: DFSchemaRef::clone(&self.output_schema),
         })
     }

--- a/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
@@ -18,17 +18,33 @@ limitations under the License.
 //! and physical execution plans for `CREATE TABLE` / `DROP TABLE` on
 //! Iceberg-backed catalogs.
 
+pub mod acceleration_options;
 pub mod analyzer_rule;
 pub mod logical_nodes;
 pub mod physical_plans;
 pub mod planner;
+pub mod preprocess;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock, Weak};
 
 use data_components::iceberg::provider::IcebergCatalogProvider;
 use datafusion::catalog::CatalogProvider;
 
+use super::DataFusion;
 use super::composed_catalog::ComposedCatalogProvider;
+
+/// A shared, lazily-initialized weak reference to the [`DataFusion`] instance.
+///
+/// Created at build time and shared between the extension planner and the
+/// `DataFusion` struct.  The `OnceLock` is populated once the `DataFusion` is
+/// wrapped in an `Arc` (see [`DataFusion::set_self_ref`]).
+pub type SharedDataFusionRef = Arc<OnceLock<Weak<DataFusion>>>;
+
+/// Create a new, empty [`SharedDataFusionRef`].
+#[must_use]
+pub fn new_shared_datafusion_ref() -> SharedDataFusionRef {
+    Arc::new(OnceLock::new())
+}
 
 /// Try to extract the Iceberg catalog from a `CatalogProvider`.
 /// Handles both direct `IcebergCatalogProvider` and `ComposedCatalogProvider`

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -225,7 +225,6 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     ))
                 })?,
             );
-
             // Register in the DataFusion catalog's schema provider
             let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
                 return Err(DataFusionError::Execution(format!(
@@ -316,7 +315,7 @@ impl ExecutionPlan for IcebergCreateTableExec {
 /// `acceleration`.
 async fn create_accelerated_iceberg_table(
     datafusion: &Weak<DataFusion>,
-    source_provider: Arc<dyn datafusion::catalog::TableProvider>,
+    source_provider: Arc<dyn datafusion::datasource::TableProvider>,
     acceleration: &Acceleration,
     catalog_name: &str,
     schema_name: &str,

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -246,11 +246,10 @@ impl ExecutionPlan for IcebergCreateTableExec {
                             table_name.clone(),
                             raw_provider,
                         );
-                    let adapted: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(
-                        data_components::delete::DeletionTableProviderAdapter::new(Arc::new(
-                            deletion_provider,
-                        )),
-                    );
+                    let adapted: Arc<dyn datafusion::datasource::TableProvider> =
+                        Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
+                            Arc::new(deletion_provider),
+                        ));
                     schema_provider.register_table(table_name.clone(), adapted)?;
                     Ok(())
                 };

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -225,7 +225,6 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     ))
                 })?,
             );
-<<<<<<< HEAD
             // Register in the DataFusion catalog's schema provider
             let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
                 return Err(DataFusionError::Execution(format!(
@@ -237,22 +236,6 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     "Schema '{df_schema_name}' not found in catalog '{df_catalog_name}'"
                 )));
             };
-
-=======
-
-            // Register in the DataFusion catalog's schema provider
-            let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
-                return Err(DataFusionError::Execution(format!(
-                    "Catalog '{df_catalog_name}' not found"
-                )));
-            };
-            let Some(schema_provider) = df_catalog.schema(&df_schema_name) else {
-                return Err(DataFusionError::Execution(format!(
-                    "Schema '{df_schema_name}' not found in catalog '{df_catalog_name}'"
-                )));
-            };
-
->>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
             let register_raw_provider =
                 |raw_provider: Arc<dyn datafusion::datasource::TableProvider>| -> DFResult<()> {
                     let deletion_provider =
@@ -262,18 +245,10 @@ impl ExecutionPlan for IcebergCreateTableExec {
                             table_name.clone(),
                             raw_provider,
                         );
-<<<<<<< HEAD
                     let adapted: Arc<dyn datafusion::datasource::TableProvider> =
                         Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
                             Arc::new(deletion_provider),
                         ));
-=======
-                    let adapted: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(
-                        data_components::delete::DeletionTableProviderAdapter::new(Arc::new(
-                            deletion_provider,
-                        )),
-                    );
->>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
                     schema_provider.register_table(table_name.clone(), adapted)?;
                     Ok(())
                 };
@@ -333,20 +308,12 @@ impl ExecutionPlan for IcebergCreateTableExec {
 /// Create an [`AcceleratedTable`] wrapping an Iceberg table provider.
 ///
 /// This is a streamlined version of `DataFusion::create_accelerated_table` for
-<<<<<<< HEAD
 /// DDL-created tables. It is typically used with full-refresh mode (the common
 /// case for ad-hoc CREATE TABLE) but honors the refresh mode configured in
 /// `acceleration`.
 async fn create_accelerated_iceberg_table(
     datafusion: &Weak<DataFusion>,
     source_provider: Arc<dyn datafusion::datasource::TableProvider>,
-=======
-/// DDL-created tables. It only supports full-refresh mode (the common case for
-/// ad-hoc CREATE TABLE).
-async fn create_accelerated_iceberg_table(
-    datafusion: &Weak<DataFusion>,
-    source_provider: Arc<dyn datafusion::catalog::TableProvider>,
->>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
     acceleration: &Acceleration,
     catalog_name: &str,
     schema_name: &str,
@@ -556,7 +523,6 @@ impl ExecutionPlan for IcebergDropTableExec {
                 )));
             }
 
-<<<<<<< HEAD
             // Drop from Iceberg catalog
             catalog.drop_table(&table_ident).await.map_err(|e| {
                 DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
@@ -564,20 +530,11 @@ impl ExecutionPlan for IcebergDropTableExec {
 
             // Deregister from DataFusion catalog after successful Iceberg drop.
             // This preserves consistency if Iceberg drop fails.
-=======
-            // Deregister from DataFusion catalog — this drops the table provider,
-            // which for AcceleratedTable will abort its background refresh handlers.
->>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
             if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
                 && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
             {
                 let _ = schema_provider.deregister_table(&table_name);
             }
-
-            // Drop from Iceberg catalog
-            catalog.drop_table(&table_ident).await.map_err(|e| {
-                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
-            })?;
 
             let batch = RecordBatch::try_new(
                 result_schema,

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2025, Spice AI, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ limitations under the License.
 
 use std::any::Any;
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -30,7 +30,10 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 use iceberg_datafusion::IcebergTableProvider;
+use spicepod::acceleration::Acceleration;
 
+use crate::accelerated_table::AcceleratedTable;
+use crate::datafusion::DataFusion;
 use datafusion::catalog::CatalogProviderList;
 
 /// Creates a result schema for DDL operations (single "result" column).
@@ -53,6 +56,8 @@ pub struct IcebergCreateTableExec {
     df_catalog_name: String,
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
+    acceleration: Option<Acceleration>,
+    datafusion: Weak<DataFusion>,
     properties: PlanProperties,
 }
 
@@ -64,6 +69,7 @@ impl fmt::Debug for IcebergCreateTableExec {
             .field("df_catalog_name", &self.df_catalog_name)
             .field("df_schema_name", &self.df_schema_name)
             .field("if_not_exists", &self.if_not_exists)
+            .field("acceleration", &self.acceleration.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -81,6 +87,8 @@ impl IcebergCreateTableExec {
         df_catalog_name: String,
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
+        acceleration: Option<Acceleration>,
+        datafusion: Weak<DataFusion>,
     ) -> Self {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -99,6 +107,8 @@ impl IcebergCreateTableExec {
             df_catalog_name,
             df_schema_name,
             catalog_list,
+            acceleration,
+            datafusion,
             properties,
         }
     }
@@ -152,6 +162,8 @@ impl ExecutionPlan for IcebergCreateTableExec {
         let df_schema_name = self.df_schema_name.clone();
         let catalog_list = Arc::clone(&self.catalog_list);
         let result_schema = ddl_result_schema();
+        let acceleration = self.acceleration.clone();
+        let datafusion = Weak::<DataFusion>::clone(&self.datafusion);
 
         let stream = futures::stream::once(async move {
             // Convert Arrow schema to Iceberg schema
@@ -199,44 +211,92 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     DataFusionError::Execution(format!("Failed to create Iceberg table: {e}"))
                 })?;
 
-            // Create an IcebergTableProvider for the new table and register it
-            let provider = IcebergTableProvider::try_new(
-                Arc::clone(&catalog),
-                namespace.clone(),
-                table_name.clone(),
-            )
-            .await
-            .map_err(|e| {
-                DataFusionError::Execution(format!(
-                    "Failed to create table provider for new Iceberg table: {e}"
-                ))
-            })?;
+            // Create an IcebergTableProvider for the new table
+            let provider: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(
+                IcebergTableProvider::try_new(
+                    Arc::clone(&catalog),
+                    namespace.clone(),
+                    table_name.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to create table provider for new Iceberg table: {e}"
+                    ))
+                })?,
+            );
 
-            // Register in the DataFusion catalog's schema provider.
-            // Wrap in IcebergDeletionProvider + DeletionTableProviderAdapter so the
-            // table supports DELETE FROM via equality delete files.
-            if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
-                && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
-            {
-                let deletion_provider =
-                    data_components::iceberg::delete::IcebergDeletionProvider::new(
-                        Arc::clone(&catalog),
-                        namespace.clone(),
-                        table_name.clone(),
-                        Arc::new(provider),
+            // Register in the DataFusion catalog's schema provider
+            let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
+                return Err(DataFusionError::Execution(format!(
+                    "Catalog '{df_catalog_name}' not found"
+                )));
+            };
+            let Some(schema_provider) = df_catalog.schema(&df_schema_name) else {
+                return Err(DataFusionError::Execution(format!(
+                    "Schema '{df_schema_name}' not found in catalog '{df_catalog_name}'"
+                )));
+            };
+
+            let register_raw_provider =
+                |raw_provider: Arc<dyn datafusion::datasource::TableProvider>| -> DFResult<()> {
+                    let deletion_provider =
+                        data_components::iceberg::delete::IcebergDeletionProvider::new(
+                            Arc::clone(&catalog),
+                            namespace.clone(),
+                            table_name.clone(),
+                            raw_provider,
+                        );
+                    let adapted: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(
+                        data_components::delete::DeletionTableProviderAdapter::new(Arc::new(
+                            deletion_provider,
+                        )),
                     );
-                let adapted: Arc<dyn datafusion::datasource::TableProvider> =
-                    Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
-                        Arc::new(deletion_provider),
-                    ));
-                schema_provider.register_table(table_name.clone(), adapted)?;
-            }
+                    schema_provider.register_table(table_name.clone(), adapted)?;
+                    Ok(())
+                };
+
+            let message = if let Some(ref accel) = acceleration
+                && accel.enabled
+            {
+                // Wrap in AcceleratedTable
+                match create_accelerated_iceberg_table(
+                    &datafusion,
+                    Arc::clone(&provider),
+                    accel,
+                    &df_catalog_name,
+                    &df_schema_name,
+                    &table_name,
+                )
+                .await
+                {
+                    Ok(accel_table) => {
+                        schema_provider
+                            .register_table(table_name.clone(), Arc::new(accel_table))?;
+                        format!(
+                            "Table '{table_name}' created with acceleration (engine={})",
+                            accel.engine.as_deref().unwrap_or("arrow")
+                        )
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to create accelerated table '{table_name}', \
+                             falling back to direct Iceberg reads: {e}"
+                        );
+                        // Fall back to registering the raw provider
+                        register_raw_provider(Arc::clone(&provider))?;
+                        format!("Table '{table_name}' created (acceleration failed: {e})")
+                    }
+                }
+            } else {
+                // No acceleration — register raw IcebergTableProvider
+                register_raw_provider(provider)?;
+                format!("Table '{table_name}' created")
+            };
 
             let batch = RecordBatch::try_new(
                 result_schema,
-                vec![Arc::new(StringArray::from(vec![format!(
-                    "Table '{table_name}' created"
-                )]))],
+                vec![Arc::new(StringArray::from(vec![message]))],
             )?;
             Ok(batch)
         });
@@ -248,6 +308,92 @@ impl ExecutionPlan for IcebergCreateTableExec {
     }
 }
 
+/// Create an [`AcceleratedTable`] wrapping an Iceberg table provider.
+///
+/// This is a streamlined version of `DataFusion::create_accelerated_table` for
+/// DDL-created tables. It only supports full-refresh mode (the common case for
+/// ad-hoc CREATE TABLE).
+async fn create_accelerated_iceberg_table(
+    datafusion: &Weak<DataFusion>,
+    source_provider: Arc<dyn datafusion::catalog::TableProvider>,
+    acceleration: &Acceleration,
+    catalog_name: &str,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<AcceleratedTable, DataFusionError> {
+    use crate::accelerated_table::refresh::Refresh;
+    use crate::component::dataset::acceleration::{
+        Acceleration as RuntimeAcceleration, RefreshMode,
+    };
+    use crate::federated_table::FederatedTable;
+    use datafusion::common::TableReference;
+
+    let df = datafusion.upgrade().ok_or_else(|| {
+        DataFusionError::Execution(
+            "DataFusion runtime is no longer available for accelerated table creation".to_string(),
+        )
+    })?;
+
+    // Convert spicepod Acceleration → runtime Acceleration (parses durations, engine, etc.)
+    let runtime_accel = RuntimeAcceleration::try_from(acceleration.clone()).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Failed to parse acceleration settings for table '{table_name}': {e}"
+        ))
+    })?;
+
+    let dataset_name = TableReference::full(
+        catalog_name.to_string(),
+        schema_name.to_string(),
+        table_name.to_string(),
+    );
+    let source_string = format!("{catalog_name}.{schema_name}.{table_name}");
+
+    let source_schema = source_provider.schema();
+    let federated_source = Arc::new(FederatedTable::new_unchecked(source_provider));
+
+    // Determine refresh mode from the acceleration settings
+    let refresh_mode = runtime_accel.refresh_mode.unwrap_or(RefreshMode::Full);
+
+    // Create the accelerator engine table (Arrow/DuckDB/SQLite in-memory or file)
+    let accelerated_table_provider = df
+        .accelerator_engine_registry
+        .create_accelerator_table(
+            dataset_name.clone(),
+            Arc::clone(&source_schema),
+            None, // no constraints for DDL tables
+            &runtime_accel,
+            Arc::new(tokio::sync::RwLock::new(crate::secrets::Secrets::default())),
+            None, // no AccelerationSource
+            Arc::clone(&df.ctx),
+        )
+        .await
+        .map_err(|e| {
+            DataFusionError::Execution(format!("Failed to create acceleration engine table: {e}"))
+        })?;
+
+    // Build refresh configuration
+    let mut refresh = Refresh::new(refresh_mode);
+    if let Some(check_interval) = runtime_accel.refresh_check_interval {
+        refresh = refresh.check_interval(check_interval);
+    }
+
+    // Build the AcceleratedTable
+    let accelerated_table = AcceleratedTable::builder(
+        Arc::clone(&df.runtime_status),
+        dataset_name,
+        federated_source,
+        source_string,
+        accelerated_table_provider,
+        refresh,
+        df.io_runtime.clone(),
+    )
+    .build()
+    .await
+    .map_err(|e| DataFusionError::Execution(format!("Failed to build accelerated table: {e}")))?;
+
+    Ok(accelerated_table)
+}
+
 /// Physical plan for dropping an Iceberg table.
 pub struct IcebergDropTableExec {
     catalog: Arc<dyn Catalog>,
@@ -257,6 +403,7 @@ pub struct IcebergDropTableExec {
     df_catalog_name: String,
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
+    _datafusion: Weak<DataFusion>,
     properties: PlanProperties,
 }
 
@@ -274,6 +421,7 @@ impl fmt::Debug for IcebergDropTableExec {
 
 impl IcebergDropTableExec {
     #[must_use]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         catalog: Arc<dyn Catalog>,
         namespace: NamespaceIdent,
@@ -282,6 +430,7 @@ impl IcebergDropTableExec {
         df_catalog_name: String,
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
+        datafusion: Weak<DataFusion>,
     ) -> Self {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -298,6 +447,7 @@ impl IcebergDropTableExec {
             df_catalog_name,
             df_schema_name,
             catalog_list,
+            _datafusion: datafusion,
             properties,
         }
     }
@@ -375,17 +525,18 @@ impl ExecutionPlan for IcebergDropTableExec {
                 )));
             }
 
-            // Drop from Iceberg catalog
-            catalog.drop_table(&table_ident).await.map_err(|e| {
-                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
-            })?;
-
-            // Deregister from DataFusion catalog
+            // Deregister from DataFusion catalog — this drops the table provider,
+            // which for AcceleratedTable will abort its background refresh handlers.
             if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
                 && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
             {
                 let _ = schema_provider.deregister_table(&table_name);
             }
+
+            // Drop from Iceberg catalog
+            catalog.drop_table(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
+            })?;
 
             let batch = RecordBatch::try_new(
                 result_schema,

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -225,6 +225,7 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     ))
                 })?,
             );
+<<<<<<< HEAD
             // Register in the DataFusion catalog's schema provider
             let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
                 return Err(DataFusionError::Execution(format!(
@@ -237,6 +238,21 @@ impl ExecutionPlan for IcebergCreateTableExec {
                 )));
             };
 
+=======
+
+            // Register in the DataFusion catalog's schema provider
+            let Some(df_catalog) = catalog_list.catalog(&df_catalog_name) else {
+                return Err(DataFusionError::Execution(format!(
+                    "Catalog '{df_catalog_name}' not found"
+                )));
+            };
+            let Some(schema_provider) = df_catalog.schema(&df_schema_name) else {
+                return Err(DataFusionError::Execution(format!(
+                    "Schema '{df_schema_name}' not found in catalog '{df_catalog_name}'"
+                )));
+            };
+
+>>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
             let register_raw_provider =
                 |raw_provider: Arc<dyn datafusion::datasource::TableProvider>| -> DFResult<()> {
                     let deletion_provider =
@@ -246,10 +262,18 @@ impl ExecutionPlan for IcebergCreateTableExec {
                             table_name.clone(),
                             raw_provider,
                         );
+<<<<<<< HEAD
                     let adapted: Arc<dyn datafusion::datasource::TableProvider> =
                         Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
                             Arc::new(deletion_provider),
                         ));
+=======
+                    let adapted: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(
+                        data_components::delete::DeletionTableProviderAdapter::new(Arc::new(
+                            deletion_provider,
+                        )),
+                    );
+>>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
                     schema_provider.register_table(table_name.clone(), adapted)?;
                     Ok(())
                 };
@@ -309,12 +333,20 @@ impl ExecutionPlan for IcebergCreateTableExec {
 /// Create an [`AcceleratedTable`] wrapping an Iceberg table provider.
 ///
 /// This is a streamlined version of `DataFusion::create_accelerated_table` for
+<<<<<<< HEAD
 /// DDL-created tables. It is typically used with full-refresh mode (the common
 /// case for ad-hoc CREATE TABLE) but honors the refresh mode configured in
 /// `acceleration`.
 async fn create_accelerated_iceberg_table(
     datafusion: &Weak<DataFusion>,
     source_provider: Arc<dyn datafusion::datasource::TableProvider>,
+=======
+/// DDL-created tables. It only supports full-refresh mode (the common case for
+/// ad-hoc CREATE TABLE).
+async fn create_accelerated_iceberg_table(
+    datafusion: &Weak<DataFusion>,
+    source_provider: Arc<dyn datafusion::catalog::TableProvider>,
+>>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
     acceleration: &Acceleration,
     catalog_name: &str,
     schema_name: &str,
@@ -524,6 +556,7 @@ impl ExecutionPlan for IcebergDropTableExec {
                 )));
             }
 
+<<<<<<< HEAD
             // Drop from Iceberg catalog
             catalog.drop_table(&table_ident).await.map_err(|e| {
                 DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
@@ -531,11 +564,20 @@ impl ExecutionPlan for IcebergDropTableExec {
 
             // Deregister from DataFusion catalog after successful Iceberg drop.
             // This preserves consistency if Iceberg drop fails.
+=======
+            // Deregister from DataFusion catalog — this drops the table provider,
+            // which for AcceleratedTable will abort its background refresh handlers.
+>>>>>>> fb0993d5b (feat: Per-table acceleration via CREATE TABLE ... WITH ("acceleration.*"))
             if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
                 && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
             {
                 let _ = schema_provider.deregister_table(&table_name);
             }
+
+            // Drop from Iceberg catalog
+            catalog.drop_table(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
+            })?;
 
             let batch = RecordBatch::try_new(
                 result_schema,

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -311,8 +311,9 @@ impl ExecutionPlan for IcebergCreateTableExec {
 /// Create an [`AcceleratedTable`] wrapping an Iceberg table provider.
 ///
 /// This is a streamlined version of `DataFusion::create_accelerated_table` for
-/// DDL-created tables. It only supports full-refresh mode (the common case for
-/// ad-hoc CREATE TABLE).
+/// DDL-created tables. It is typically used with full-refresh mode (the common
+/// case for ad-hoc CREATE TABLE) but honors the refresh mode configured in
+/// `acceleration`.
 async fn create_accelerated_iceberg_table(
     datafusion: &Weak<DataFusion>,
     source_provider: Arc<dyn datafusion::catalog::TableProvider>,
@@ -525,18 +526,18 @@ impl ExecutionPlan for IcebergDropTableExec {
                 )));
             }
 
-            // Deregister from DataFusion catalog — this drops the table provider,
-            // which for AcceleratedTable will abort its background refresh handlers.
+            // Drop from Iceberg catalog
+            catalog.drop_table(&table_ident).await.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
+            })?;
+
+            // Deregister from DataFusion catalog after successful Iceberg drop.
+            // This preserves consistency if Iceberg drop fails.
             if let Some(df_catalog) = catalog_list.catalog(&df_catalog_name)
                 && let Some(schema_provider) = df_catalog.schema(&df_schema_name)
             {
                 let _ = schema_provider.deregister_table(&table_name);
             }
-
-            // Drop from Iceberg catalog
-            catalog.drop_table(&table_ident).await.map_err(|e| {
-                DataFusionError::Execution(format!("Failed to drop Iceberg table: {e}"))
-            })?;
 
             let batch = RecordBatch::try_new(
                 result_schema,

--- a/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2025, Spice AI, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,17 +26,24 @@ use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
+use super::SharedDataFusionRef;
 use super::logical_nodes::{IcebergCreateTableNode, IcebergDropTableNode};
 use super::physical_plans::{IcebergCreateTableExec, IcebergDropTableExec};
 
 /// Extension planner for Iceberg DDL operations.
-#[derive(Debug, Default)]
-pub struct IcebergDdlExtensionPlanner;
+///
+/// Holds a [`SharedDataFusionRef`] — a lazily-initialized weak reference to the
+/// `DataFusion` instance — so that physical plans can access the runtime for
+/// accelerated table creation.
+#[derive(Debug)]
+pub struct IcebergDdlExtensionPlanner {
+    datafusion_ref: SharedDataFusionRef,
+}
 
 impl IcebergDdlExtensionPlanner {
     #[must_use]
-    pub fn new() -> Self {
-        Self
+    pub fn new(datafusion_ref: SharedDataFusionRef) -> Self {
+        Self { datafusion_ref }
     }
 }
 
@@ -52,6 +59,9 @@ impl ExtensionPlanner for IcebergDdlExtensionPlanner {
     ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
         let catalog_list = Arc::<dyn CatalogProviderList>::clone(session_state.catalog_list());
 
+        // Resolve the weak DataFusion reference for physical plans
+        let datafusion_weak = self.datafusion_ref.get().cloned().unwrap_or_default();
+
         if let Some(create) = node.as_any().downcast_ref::<IcebergCreateTableNode>() {
             return Ok(Some(Arc::new(IcebergCreateTableExec::new(
                 Arc::clone(&create.catalog),
@@ -63,6 +73,8 @@ impl ExtensionPlanner for IcebergDdlExtensionPlanner {
                 create.df_catalog_name.clone(),
                 create.df_schema_name.clone(),
                 catalog_list,
+                create.acceleration.clone(),
+                datafusion_weak,
             ))));
         }
 
@@ -75,6 +87,7 @@ impl ExtensionPlanner for IcebergDdlExtensionPlanner {
                 drop.df_catalog_name.clone(),
                 drop.df_schema_name.clone(),
                 catalog_list,
+                datafusion_weak,
             ))));
         }
 

--- a/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
@@ -1,0 +1,240 @@
+/*
+Copyright 2024-2025, Spice AI, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Pre-processing for `CREATE TABLE ... WITH ("acceleration.*")` SQL statements.
+//!
+//! `DataFusion`'s `SqlToRel` does not support `WITH (...)` options on `CREATE TABLE`
+//! (it only matches `table_options: CreateTableOptions::None`). This module
+//! intercepts such statements before they reach `DataFusion`, extracts the
+//! acceleration options into the shared [`AccelerationOptionsStore`], and returns
+//! modified SQL without the `WITH` clause so `DataFusion` can plan it normally.
+//!
+//! Keys must be double-quoted because dots are not valid in bare SQL identifiers:
+//! ```sql
+//! CREATE TABLE t (id INT) WITH ("acceleration.engine" = 'arrow')
+//! ```
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::sql::sqlparser::ast::{CreateTableOptions, SqlOption, Statement};
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+use datafusion::sql::sqlparser::parser::Parser;
+
+use super::acceleration_options::{SharedAccelerationOptionsStore, parse_acceleration_options};
+
+/// Result of pre-processing: either the original SQL unchanged, or modified SQL
+/// with acceleration options extracted.
+#[derive(Debug)]
+pub enum PreprocessResult {
+    /// SQL was not a `CREATE TABLE ... WITH (acceleration.*)` — pass through unchanged.
+    Unchanged,
+    /// SQL was modified: `WITH` clause stripped, acceleration options stored.
+    /// Contains the rewritten SQL string.
+    Modified(String),
+}
+
+/// Pre-process a SQL string to extract `CREATE TABLE ... WITH (acceleration.*)` options.
+///
+/// If the SQL is a `CREATE TABLE` with `WITH` options containing `acceleration.*` keys,
+/// the options are parsed, stored in `accel_store`, and the SQL is returned without
+/// the `WITH` clause. Otherwise, the original SQL is returned unchanged.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The `WITH` options contain invalid `acceleration.*` keys or values.
+/// - The `WITH` options mix `acceleration.*` keys with non-acceleration keys.
+pub fn preprocess_create_table_acceleration(
+    sql: &str,
+    accel_store: &SharedAccelerationOptionsStore,
+) -> DFResult<PreprocessResult> {
+    // Quick check: if the SQL doesn't contain "WITH", skip parsing
+    if !sql.to_uppercase().contains("WITH") {
+        return Ok(PreprocessResult::Unchanged);
+    }
+
+    let dialect = PostgreSqlDialect {};
+    let Ok(statements) = Parser::parse_sql(&dialect, sql) else {
+        // If sqlparser can't parse it, let `DataFusion` handle the error
+        return Ok(PreprocessResult::Unchanged);
+    };
+
+    // Only handle single-statement CREATE TABLE
+    let [Statement::CreateTable(ref create_table)] = statements[..] else {
+        return Ok(PreprocessResult::Unchanged);
+    };
+
+    let CreateTableOptions::With(ref options) = create_table.table_options else {
+        return Ok(PreprocessResult::Unchanged);
+    };
+
+    // Separate acceleration options from other options
+    let mut accel_opts = Vec::new();
+    let mut other_opts = Vec::new();
+
+    for opt in options {
+        match opt {
+            SqlOption::KeyValue { key, value } => {
+                let key_str = key.value.clone();
+                let value_str = match value {
+                    datafusion::sql::sqlparser::ast::Expr::Value(v) => v.to_string(),
+                    datafusion::sql::sqlparser::ast::Expr::Identifier(ident) => ident.value.clone(),
+                    other => other.to_string(),
+                };
+
+                if key_str.starts_with("acceleration.") {
+                    accel_opts.push((key_str, value_str));
+                } else {
+                    other_opts.push(opt.clone());
+                }
+            }
+            _ => {
+                other_opts.push(opt.clone());
+            }
+        }
+    }
+
+    if accel_opts.is_empty() {
+        return Ok(PreprocessResult::Unchanged);
+    }
+
+    // Reject mixing acceleration and non-acceleration options for clarity
+    if !other_opts.is_empty() {
+        return Err(DataFusionError::Plan(
+            "Cannot mix 'acceleration.*' options with other WITH options in CREATE TABLE. \
+             Use only 'acceleration.*' options."
+                .to_string(),
+        ));
+    }
+
+    // Parse acceleration options
+    // Strip surrounding quotes from values (sqlparser includes them for string literals)
+    let cleaned_opts: Vec<(String, String)> = accel_opts
+        .into_iter()
+        .map(|(k, v)| {
+            let v = v
+                .trim_start_matches('\'')
+                .trim_end_matches('\'')
+                .trim_start_matches('"')
+                .trim_end_matches('"')
+                .to_string();
+            (k, v)
+        })
+        .collect();
+
+    let acceleration = parse_acceleration_options(&cleaned_opts)?;
+
+    // Extract the table name for the store key
+    let table_name = create_table.name.to_string();
+
+    // Store the acceleration options
+    {
+        let mut store = accel_store.write().map_err(|e| {
+            DataFusionError::Execution(format!(
+                "Failed to acquire acceleration options store lock: {e}"
+            ))
+        })?;
+        store.insert(table_name, acceleration);
+    }
+
+    // Reconstruct the CREATE TABLE without the WITH clause
+    let mut modified = create_table.clone();
+    modified.table_options = CreateTableOptions::None;
+    let modified_sql = Statement::CreateTable(modified).to_string();
+
+    Ok(PreprocessResult::Modified(modified_sql))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafusion::iceberg_ddl::acceleration_options::new_shared_store;
+
+    #[test]
+    fn test_preprocess_no_with_clause() {
+        let store = new_shared_store();
+        let sql = "CREATE TABLE foo (id INT, name VARCHAR)";
+        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        assert!(matches!(result, PreprocessResult::Unchanged));
+    }
+
+    #[test]
+    fn test_preprocess_non_create_table() {
+        let store = new_shared_store();
+        let sql = "SELECT * FROM foo";
+        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        assert!(matches!(result, PreprocessResult::Unchanged));
+    }
+
+    #[test]
+    fn test_preprocess_with_acceleration_options() {
+        let store = new_shared_store();
+        let sql = r#"CREATE TABLE foo (id INT, name VARCHAR) WITH ("acceleration.engine" = 'arrow', "acceleration.mode" = 'memory')"#;
+
+        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+
+        match result {
+            PreprocessResult::Modified(modified_sql) => {
+                // The modified SQL should not contain acceleration options
+                assert!(
+                    !modified_sql.contains("acceleration."),
+                    "Modified SQL should not contain acceleration options: {modified_sql}"
+                );
+                // Should still be valid CREATE TABLE
+                assert!(modified_sql.to_uppercase().contains("CREATE TABLE"));
+            }
+            PreprocessResult::Unchanged => panic!("Expected Modified result"),
+        }
+
+        // Check that the store has the options
+        let accel = store
+            .write()
+            .unwrap()
+            .remove("foo")
+            .expect("should have options for 'foo'");
+        assert_eq!(accel.engine.as_deref(), Some("arrow"));
+        assert_eq!(accel.mode, spicepod::acceleration::Mode::Memory);
+    }
+
+    #[test]
+    fn test_preprocess_with_non_acceleration_options_unchanged() {
+        let store = new_shared_store();
+        // WITH options that don't have acceleration. prefix
+        let sql = "CREATE TABLE foo (id INT) WITH (fillfactor = 70)";
+        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        assert!(matches!(result, PreprocessResult::Unchanged));
+    }
+
+    #[test]
+    fn test_preprocess_mixed_options_errors() {
+        let store = new_shared_store();
+        let sql =
+            r#"CREATE TABLE foo (id INT) WITH ("acceleration.engine" = 'arrow', fillfactor = 70)"#;
+        let result = preprocess_create_table_acceleration(sql, &store);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Cannot mix"));
+    }
+
+    #[test]
+    fn test_preprocess_invalid_acceleration_option_errors() {
+        let store = new_shared_store();
+        let sql = r#"CREATE TABLE foo (id INT) WITH ("acceleration.nonexistent" = 'value')"#;
+        let result = preprocess_create_table_acceleration(sql, &store);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Unknown acceleration option"));
+    }
+}

--- a/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025, Spice AI, Inc.
+Copyright 2026, Spice AI, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,8 +41,33 @@ pub enum PreprocessResult {
     /// SQL was not a `CREATE TABLE ... WITH (acceleration.*)` — pass through unchanged.
     Unchanged,
     /// SQL was modified: `WITH` clause stripped, acceleration options stored.
-    /// Contains the rewritten SQL string.
-    Modified(String),
+    Modified {
+        /// The rewritten SQL string without the `WITH` clause.
+        sql: String,
+        /// The store key used for the inserted acceleration options.
+        store_key: String,
+    },
+}
+
+/// Remove a previously inserted acceleration option entry from the shared store.
+///
+/// Intended for error paths where preprocessing has inserted options but logical
+/// planning failed before the analyzer could consume the entry.
+///
+/// # Errors
+///
+/// Returns an error if the store lock cannot be acquired.
+pub fn cleanup_preprocessed_acceleration_option(
+    accel_store: &SharedAccelerationOptionsStore,
+    store_key: &str,
+) -> DFResult<()> {
+    let mut store = accel_store.write().map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Failed to acquire acceleration options store lock: {e}"
+        ))
+    })?;
+    let _ = store.remove(store_key);
+    Ok(())
 }
 
 /// Pre-process a SQL string to extract `CREATE TABLE ... WITH (acceleration.*)` options.
@@ -154,7 +179,10 @@ pub fn preprocess_create_table_acceleration(
     modified.table_options = CreateTableOptions::None;
     let modified_sql = Statement::CreateTable(modified).to_string();
 
-    Ok(PreprocessResult::Modified(modified_sql))
+    Ok(PreprocessResult::Modified {
+        sql: modified_sql,
+        store_key: table_name,
+    })
 }
 
 #[cfg(test)]
@@ -186,7 +214,10 @@ mod tests {
         let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
 
         match result {
-            PreprocessResult::Modified(modified_sql) => {
+            PreprocessResult::Modified {
+                sql: modified_sql,
+                store_key,
+            } => {
                 // The modified SQL should not contain acceleration options
                 assert!(
                     !modified_sql.contains("acceleration."),
@@ -194,6 +225,7 @@ mod tests {
                 );
                 // Should still be valid CREATE TABLE
                 assert!(modified_sql.to_uppercase().contains("CREATE TABLE"));
+                assert_eq!(store_key, "foo");
             }
             PreprocessResult::Unchanged => panic!("Expected Modified result"),
         }

--- a/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
@@ -163,6 +163,7 @@ pub fn preprocess_create_table_acceleration(
 
     // Extract the table name for the store key
     let table_name = create_table.name.to_string();
+    let store_key = table_name.clone();
 
     // Store the acceleration options
     {
@@ -181,7 +182,7 @@ pub fn preprocess_create_table_acceleration(
 
     Ok(PreprocessResult::Modified {
         sql: modified_sql,
-        store_key: table_name,
+        store_key,
     })
 }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -398,18 +398,23 @@ struct DeferredTableRegistration {
 
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
-    runtime_status: Arc<status::RuntimeStatus>,
+    pub(crate) runtime_status: Arc<status::RuntimeStatus>,
     data_writers: RwLock<HashSet<TableReference>>,
     writable_catalogs: RwLock<HashSet<String>>,
     /// Catalogs that allow DDL operations (CREATE TABLE, DROP TABLE, etc.)
     ddl_enabled_catalogs: Arc<RwLock<HashSet<String>>>,
+    /// Shared store for acceleration options from `CREATE TABLE ... WITH (acceleration.*)`.
+    acceleration_options_store: iceberg_ddl::acceleration_options::SharedAccelerationOptionsStore,
+    /// Shared weak self-reference, populated after `Arc::new(DataFusion)`.
+    /// Used by the extension planner to pass `Weak<DataFusion>` to physical plans.
+    datafusion_ref: iceberg_ddl::SharedDataFusionRef,
     accelerated_tables: TokioRwLock<HashSet<TableReference>>,
     caching: Arc<Caching>,
     pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
     deferred_tables: TokioRwLock<HashMap<String, DeferredTableRegistration>>,
     deferred_catalogs: TokioRwLock<HashMap<String, Arc<DeferredCatalogProvider>>>,
 
-    accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
+    pub(crate) accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     // Controls the parallelism of accelerated table refreshes
     acceleration_refresh_semaphore: Option<Arc<Semaphore>>,
     pub(crate) task_history_enabled: bool,
@@ -417,7 +422,7 @@ pub struct DataFusion {
     cpu_runtime: OnceLock<ManagedTokioRuntime>,
     // Dedicated runtime for CPU-bound DataFusion acceleration for dataset acceleration refresh tasks
     refresh_runtime: OnceLock<ManagedTokioRuntime>,
-    io_runtime: Handle,
+    pub(crate) io_runtime: Handle,
     metrics: Option<Metrics>,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
 
@@ -750,6 +755,32 @@ impl DataFusion {
             .map_err(|_| Error::UnableToLockWritableCatalogs {})?
             .insert(catalog_name.to_string());
         Ok(())
+    }
+
+    /// Returns a reference to the shared acceleration options store.
+    ///
+    /// Used by the query execution path to insert options extracted from
+    /// `CREATE TABLE ... WITH (acceleration.*)` statements, which are then
+    /// consumed by the `IcebergDdlAnalyzerRule`.
+    #[must_use]
+    pub fn acceleration_options_store(
+        &self,
+    ) -> &iceberg_ddl::acceleration_options::SharedAccelerationOptionsStore {
+        &self.acceleration_options_store
+    }
+
+    /// Returns the shared weak self-reference holder.
+    ///
+    /// The extension planner uses this to obtain a `Weak<DataFusion>` for physical plans.
+    #[must_use]
+    pub fn datafusion_ref(&self) -> &iceberg_ddl::SharedDataFusionRef {
+        &self.datafusion_ref
+    }
+
+    /// Populate the shared weak self-reference. Must be called once after
+    /// wrapping `DataFusion` in `Arc`.
+    pub fn set_self_ref(self: &Arc<Self>) {
+        let _ = self.datafusion_ref.set(Arc::downgrade(self));
     }
 
     pub fn mark_dataset_writable(&self, dataset_name: &TableReference) -> Result<()> {
@@ -2121,8 +2152,20 @@ impl DataFusion {
         key: &RawCacheKey,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
+        // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning.
+        // This extracts acceleration options, stores them for the analyzer rule,
+        // and returns modified SQL without the WITH clause.
+        let preprocessed = iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+            sql,
+            &self.acceleration_options_store,
+        )?;
+        let effective_sql = match &preprocessed {
+            iceberg_ddl::preprocess::PreprocessResult::Modified(modified) => modified.as_str(),
+            iceberg_ddl::preprocess::PreprocessResult::Unchanged => sql,
+        };
+
         let Some(plans_cache) = self.plans_cache_provider() else {
-            return session.create_logical_plan(sql).await;
+            return session.create_logical_plan(effective_sql).await;
         };
 
         if let Some(plan) = plans_cache.get_raw_key(&key.as_u64()).await {
@@ -2130,7 +2173,7 @@ impl DataFusion {
             return Ok(plan);
         }
 
-        let plan = session.create_logical_plan(sql).await?;
+        let plan = session.create_logical_plan(effective_sql).await?;
 
         tracing::trace!("caching plan for {sql}");
         plans_cache.put_raw_key(&key.as_u64(), plan.clone()).await;

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2405,7 +2405,25 @@ async fn build_snapshot_creation_config(
                     Ok(batches)
                 }
             }
+            None => Ok(DEFAULT_SNAPSHOT_CREATION_BATCHES),
         }
+    };
+
+    // Caching mode only supports time_interval - no "refresh complete" or "stream_batches" events.
+    let is_caching = matches!(refresh_mode, RefreshMode::Caching);
+
+    let snapshot_creation_trigger = if is_caching {
+        match snapshot_trigger {
+            None | Some(SnapshotsTrigger::TimeInterval) => {
+                let interval = parse_interval(&snapshot_threshold)?;
+                SnapshotCreateTrigger::Interval(interval)
+            }
+            Some(SnapshotsTrigger::RefreshComplete | SnapshotsTrigger::StreamBatches) => {
+                return Err(Error::UnsupportedSnapshotTriggerForCaching);
+            }
+        }
+    } else if is_streaming_refresh {
+        match snapshot_trigger {
             None | Some(SnapshotsTrigger::TimeInterval) => {
                 let interval = parse_interval(&snapshot_threshold)?;
                 SnapshotCreateTrigger::Interval(interval)
@@ -2425,6 +2443,10 @@ async fn build_snapshot_creation_config(
             }
             Some(SnapshotsTrigger::TimeInterval) => {
                 let interval = parse_interval(&snapshot_threshold)?;
+                SnapshotCreateTrigger::Interval(interval)
+            }
+            Some(SnapshotsTrigger::StreamBatches) => {
+                return Err(Error::UnsupportedStreamBatchesForBatchRefresh);
             }
         }
     };

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2405,25 +2405,7 @@ async fn build_snapshot_creation_config(
                     Ok(batches)
                 }
             }
-            None => Ok(DEFAULT_SNAPSHOT_CREATION_BATCHES),
         }
-    };
-
-    // Caching mode only supports time_interval - no "refresh complete" or "stream_batches" events.
-    let is_caching = matches!(refresh_mode, RefreshMode::Caching);
-
-    let snapshot_creation_trigger = if is_caching {
-        match snapshot_trigger {
-            None | Some(SnapshotsTrigger::TimeInterval) => {
-                let interval = parse_interval(&snapshot_threshold)?;
-                SnapshotCreateTrigger::Interval(interval)
-            }
-            Some(SnapshotsTrigger::RefreshComplete | SnapshotsTrigger::StreamBatches) => {
-                return Err(Error::UnsupportedSnapshotTriggerForCaching);
-            }
-        }
-    } else if is_streaming_refresh {
-        match snapshot_trigger {
             None | Some(SnapshotsTrigger::TimeInterval) => {
                 let interval = parse_interval(&snapshot_threshold)?;
                 SnapshotCreateTrigger::Interval(interval)
@@ -2443,10 +2425,6 @@ async fn build_snapshot_creation_config(
             }
             Some(SnapshotsTrigger::TimeInterval) => {
                 let interval = parse_interval(&snapshot_threshold)?;
-                SnapshotCreateTrigger::Interval(interval)
-            }
-            Some(SnapshotsTrigger::StreamBatches) => {
-                return Err(Error::UnsupportedStreamBatchesForBatchRefresh);
             }
         }
     };

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2152,6 +2152,15 @@ impl DataFusion {
         key: &RawCacheKey,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
+        let plans_cache = self.plans_cache_provider();
+
+        if let Some(cache) = plans_cache.as_ref()
+            && let Some(plan) = cache.get_raw_key(&key.as_u64()).await
+        {
+            tracing::trace!("using cached plan for {sql}");
+            return Ok(plan);
+        }
+
         // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning.
         // This extracts acceleration options, stores them for the analyzer rule,
         // and returns modified SQL without the WITH clause.
@@ -2159,24 +2168,31 @@ impl DataFusion {
             sql,
             &self.acceleration_options_store,
         )?;
-        let effective_sql = match &preprocessed {
-            iceberg_ddl::preprocess::PreprocessResult::Modified(modified) => modified.as_str(),
-            iceberg_ddl::preprocess::PreprocessResult::Unchanged => sql,
+        let (effective_sql, store_key) = match &preprocessed {
+            iceberg_ddl::preprocess::PreprocessResult::Modified {
+                sql: modified,
+                store_key,
+            } => (modified.as_str(), Some(store_key.as_str())),
+            iceberg_ddl::preprocess::PreprocessResult::Unchanged => (sql, None),
         };
 
-        let Some(plans_cache) = self.plans_cache_provider() else {
-            return session.create_logical_plan(effective_sql).await;
+        let plan = match session.create_logical_plan(effective_sql).await {
+            Ok(plan) => plan,
+            Err(e) => {
+                if let Some(store_key) = store_key {
+                    iceberg_ddl::preprocess::cleanup_preprocessed_acceleration_option(
+                        &self.acceleration_options_store,
+                        store_key,
+                    )?;
+                }
+                return Err(e);
+            }
         };
 
-        if let Some(plan) = plans_cache.get_raw_key(&key.as_u64()).await {
-            tracing::trace!("using cached plan for {sql}");
-            return Ok(plan);
+        if let Some(cache) = plans_cache {
+            tracing::trace!("caching plan for {sql}");
+            cache.put_raw_key(&key.as_u64(), plan.clone()).await;
         }
-
-        let plan = session.create_logical_plan(effective_sql).await?;
-
-        tracing::trace!("caching plan for {sql}");
-        plans_cache.put_raw_key(&key.as_u64(), plan.clone()).await;
 
         Ok(plan)
     }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -901,7 +901,6 @@ impl Query {
                             self.handle_schema_error(&request_context, &cleanup_err);
                             return Err(cleanup_err);
                         }
-
                         let e = find_datafusion_root(e);
                         self.handle_schema_error(&request_context, &e);
                         return Err(e);

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -864,17 +864,18 @@ impl Query {
             QueryMethod::Plan(ref plan) => plan.clone(),
             QueryMethod::Text { ref sql, .. } => {
                 // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning
-                let preprocessed = match super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
-                    sql,
-                    self.df.acceleration_options_store(),
-                ) {
-                    Ok(preprocessed) => preprocessed,
-                    Err(e) => {
-                        let e = find_datafusion_root(e);
-                        self.handle_schema_error(&request_context, &e);
-                        return Err(e);
-                    }
-                };
+                let preprocessed =
+                    match super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+                        sql,
+                        self.df.acceleration_options_store(),
+                    ) {
+                        Ok(preprocessed) => preprocessed,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            self.handle_schema_error(&request_context, &e);
+                            return Err(e);
+                        }
+                    };
 
                 let (effective_sql, store_key) = match &preprocessed {
                     super::iceberg_ddl::preprocess::PreprocessResult::Modified {

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -864,20 +864,43 @@ impl Query {
             QueryMethod::Plan(ref plan) => plan.clone(),
             QueryMethod::Text { ref sql, .. } => {
                 // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning
-                let preprocessed =
-                    super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
-                        sql,
-                        self.df.acceleration_options_store(),
-                    );
-                let effective_sql = match &preprocessed {
-                    Ok(super::iceberg_ddl::preprocess::PreprocessResult::Modified(modified)) => {
-                        modified.as_str()
+                let preprocessed = match super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+                    sql,
+                    self.df.acceleration_options_store(),
+                ) {
+                    Ok(preprocessed) => preprocessed,
+                    Err(e) => {
+                        let e = find_datafusion_root(e);
+                        self.handle_schema_error(&request_context, &e);
+                        return Err(e);
                     }
-                    _ => sql.as_ref(),
                 };
+
+                let (effective_sql, store_key) = match &preprocessed {
+                    super::iceberg_ddl::preprocess::PreprocessResult::Modified {
+                        sql: modified,
+                        store_key,
+                    } => (modified.as_str(), Some(store_key.as_str())),
+                    super::iceberg_ddl::preprocess::PreprocessResult::Unchanged => {
+                        (sql.as_ref(), None)
+                    }
+                };
+
                 match session.create_logical_plan(effective_sql).await {
                     Ok(plan) => Box::new(plan),
                     Err(e) => {
+                        if let Some(store_key) = store_key
+                            && let Err(cleanup_err) =
+                                super::iceberg_ddl::preprocess::cleanup_preprocessed_acceleration_option(
+                                    self.df.acceleration_options_store(),
+                                    store_key,
+                                )
+                        {
+                            let cleanup_err = find_datafusion_root(cleanup_err);
+                            self.handle_schema_error(&request_context, &cleanup_err);
+                            return Err(cleanup_err);
+                        }
+
                         let e = find_datafusion_root(e);
                         self.handle_schema_error(&request_context, &e);
                         return Err(e);

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -862,14 +862,28 @@ impl Query {
 
         let plan = match self.sql {
             QueryMethod::Plan(ref plan) => plan.clone(),
-            QueryMethod::Text { ref sql, .. } => match session.create_logical_plan(sql).await {
-                Ok(plan) => Box::new(plan),
-                Err(e) => {
-                    let e = find_datafusion_root(e);
-                    self.handle_schema_error(&request_context, &e);
-                    return Err(e);
+            QueryMethod::Text { ref sql, .. } => {
+                // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning
+                let preprocessed =
+                    super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+                        sql,
+                        self.df.acceleration_options_store(),
+                    );
+                let effective_sql = match &preprocessed {
+                    Ok(super::iceberg_ddl::preprocess::PreprocessResult::Modified(modified)) => {
+                        modified.as_str()
+                    }
+                    _ => sql.as_ref(),
+                };
+                match session.create_logical_plan(effective_sql).await {
+                    Ok(plan) => Box::new(plan),
+                    Err(e) => {
+                        let e = find_datafusion_root(e);
+                        self.handle_schema_error(&request_context, &e);
+                        return Err(e);
+                    }
                 }
-            },
+            }
         };
 
         // Verify the plan against the restricted options

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -200,9 +200,7 @@ impl Handler for SpidapterHandler {
                         );
                     }
                     Err(e) => {
-                        eprintln!(
-                            "[stdio] teardown: failed to drop table '{table_name}': {e}"
-                        );
+                        eprintln!("[stdio] teardown: failed to drop table '{table_name}': {e}");
                     }
                 }
             }
@@ -373,7 +371,7 @@ fn generate_initial_spicepod(run_id: &Uuid) -> String {
     let run_id_str = run_id.to_string();
     let short_id = run_id_str.split('-').next().unwrap_or_default();
     format!(
-        r#"version: v1beta1
+        r"version: v1beta1
 kind: Spicepod
 name: spidapter-{short_id}
 
@@ -386,6 +384,6 @@ catalogs:
       iceberg_s3_access_key_id: ${{secrets:AWS_ACCESS_KEY_ID}}
       iceberg_s3_secret_access_key: ${{secrets:AWS_SECRET_ACCESS_KEY}}
       iceberg_s3_region: us-east-1
-"#
+"
     )
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -155,7 +155,6 @@ impl Handler for SpidapterHandler {
             state.created_tables.push(table_name.clone());
             eprintln!("[stdio] create_tables: table '{table_name}' created");
         }
-
         Ok(CreateTablesResponse { ok: true })
     }
 

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -339,22 +339,17 @@ fn create_table_ddl(table_name: &str, config: &DatasetConfig) -> String {
 fn sql_type_for_arrow(data_type: &DataType) -> &'static str {
     match data_type {
         DataType::Boolean => "BOOLEAN",
-        DataType::Int8 => "TINYINT",
-        DataType::Int16 => "SMALLINT",
-        DataType::Int32 => "INT",
-        DataType::Int64 => "BIGINT",
-        DataType::UInt8 => "TINYINT",
-        DataType::UInt16 => "SMALLINT",
-        DataType::UInt32 => "INT",
-        DataType::UInt64 => "BIGINT",
+        DataType::Int8 | DataType::UInt8 => "TINYINT",
+        DataType::Int16 | DataType::UInt16 => "SMALLINT",
+        DataType::Int32 | DataType::UInt32 => "INT",
+        DataType::Int64 | DataType::UInt64 => "BIGINT",
         DataType::Float32 => "FLOAT",
         DataType::Float64 => "DOUBLE",
-        DataType::Utf8 | DataType::LargeUtf8 => "VARCHAR",
         DataType::Date32 | DataType::Date64 => "DATE",
-        DataType::Timestamp(TimeUnit::Second, _) => "TIMESTAMP",
-        DataType::Timestamp(TimeUnit::Millisecond, _) => "TIMESTAMP",
-        DataType::Timestamp(TimeUnit::Microsecond, _) => "TIMESTAMP",
-        DataType::Timestamp(TimeUnit::Nanosecond, _) => "TIMESTAMP",
+        DataType::Timestamp(
+            TimeUnit::Second | TimeUnit::Millisecond | TimeUnit::Microsecond | TimeUnit::Nanosecond,
+            _,
+        ) => "TIMESTAMP",
         DataType::Decimal128(p, s) => {
             // Leak a formatted string for the static lifetime — only called at table creation
             // time with a small number of distinct precision/scale pairs.

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -88,19 +88,7 @@ impl Handler for SpidapterHandler {
         .await
         .map_err(|e| format!("Setup failed: {e}"))?;
 
-        self.runs.insert(run_id, state);
-        Ok(SetupResponse { ok: true })
-    }
-
-    async fn query_method(&mut self, run_id: Uuid) -> Result<QueryMethodResponse, String> {
-        eprintln!("[stdio] query_method: run_id={run_id}");
-
-        let state = self
-            .runs
-            .get(&run_id)
-            .ok_or_else(|| format!("Unknown run_id: {run_id}"))?;
-
-        Ok(QueryMethodResponse {
+        let response = SetupResponse {
             driver: AdbcDriver::Flightsql,
             db_kwargs: HashMap::from([
                 (
@@ -116,7 +104,10 @@ impl Handler for SpidapterHandler {
                     serde_json::Value::String(state.api_key.clone()),
                 ),
             ]),
-        })
+        };
+
+        self.runs.insert(run_id, state);
+        Ok(response)
     }
 
     async fn create_tables(

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -88,7 +88,19 @@ impl Handler for SpidapterHandler {
         .await
         .map_err(|e| format!("Setup failed: {e}"))?;
 
-        let response = SetupResponse {
+        self.runs.insert(run_id, state);
+        Ok(SetupResponse { ok: true })
+    }
+
+    async fn query_method(&mut self, run_id: Uuid) -> Result<QueryMethodResponse, String> {
+        eprintln!("[stdio] query_method: run_id={run_id}");
+
+        let state = self
+            .runs
+            .get(&run_id)
+            .ok_or_else(|| format!("Unknown run_id: {run_id}"))?;
+
+        Ok(QueryMethodResponse {
             driver: AdbcDriver::Flightsql,
             db_kwargs: HashMap::from([
                 (
@@ -104,10 +116,7 @@ impl Handler for SpidapterHandler {
                     serde_json::Value::String(state.api_key.clone()),
                 ),
             ]),
-        };
-
-        self.runs.insert(run_id, state);
-        Ok(response)
+        })
     }
 
     async fn create_tables(


### PR DESCRIPTION
## Summary

Adds per-table acceleration for Iceberg DDL tables specified inline in SQL:

```sql
CREATE TABLE orders (id INT, name VARCHAR) WITH (
    "acceleration.engine" = 'arrow',
    "acceleration.mode" = 'memory',
    "acceleration.refresh_check_interval" = '10s'
);
```

When `"acceleration.enabled"` is `true` (default when any `acceleration.*` option is present), the table is wrapped in an `AcceleratedTable` with the specified engine, mode, and refresh configuration. Without acceleration options, tables are registered as raw `IcebergTableProvider` instances (existing behavior).

## Changes

### SQL parsing layer (`iceberg_ddl/`)
- **`acceleration_options.rs`** — `AccelerationOptionsStore` (thread-safe store keyed by table name) + `parse_acceleration_options()` parser that maps `"acceleration.*"` keys to `spicepod::Acceleration` fields
- **`preprocess.rs`** — Pre-processes `CREATE TABLE` SQL to extract `WITH (...)` options containing `"acceleration.*"` keys, stores them in the shared store, and returns modified SQL without the `WITH` clause so DataFusion can plan normally

### Logical/physical plan threading
- `IcebergCreateTableNode` carries `Option<Acceleration>` through planning
- Analyzer rule retrieves stored options from `SharedAccelerationOptionsStore`
- `IcebergDdlExtensionPlanner` passes `Weak<DataFusion>` to physical plans
- `IcebergCreateTableExec` / `IcebergDropTableExec` accept `Weak<DataFusion>`

### AcceleratedTable creation (`physical_plans.rs`)
- `create_accelerated_iceberg_table()` — streamlined accelerated table builder for DDL tables:
  - Converts `spicepod::Acceleration` → `runtime::Acceleration` via `TryFrom`
  - Creates accelerator engine table (Arrow/DuckDB/SQLite)
  - Builds `AcceleratedTable` with refresh configuration
  - Graceful fallback to raw Iceberg reads on failure

### Runtime wiring
- `SharedDataFusionRef` (`Arc<OnceLock<Weak<DataFusion>>>`) avoids circular dependencies
- Set via `DataFusion::set_self_ref()` after `Arc::new(df)` in runtime builder
- Three `DataFusion` fields made `pub(crate)`: `runtime_status`, `accelerator_engine_registry`, `io_runtime`

### Drop cleanup
- `IcebergDropTableExec` deregisters table from DataFusion first (triggers `Drop` → aborts background refresh handlers), then drops from Iceberg catalog

## Tests

13 unit tests covering option parsing, SQL preprocessing, and store lifecycle.