### PR TITLE
Spidapter: fix iceberg catalog configuration

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -379,7 +379,7 @@ kind: Spicepod
 name: spidapter-{short_id}
 
 catalogs:
-  - from: iceberg:https://glue.us-east-1.amazonaws.com/iceberg/v1/catalogs/211125479522
+  - from: iceberg:https://glue.us-east-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
     name: spice
     access: read_write_create
     params:


### PR DESCRIPTION
## 📝 Summary

Cannot setup the catalog spice (iceberg) with an invalid configuration. A Catalog Path is required for Iceberg in the format of: http://<host_and_port>/v1/namespaces/<namespace>. For details, visit: https://spiceai.org/docs/components/catalogs/iceberg#from Path must contain 'namespaces' segment

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
