### PR TITLE
feat(spidapter): add cayenne acceleration to CREATE TABLE DDL

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -316,7 +316,11 @@ fn sql_url_from_cname(cname: &str) -> String {
     format!("https://{cname}.spiceai.io/v1/sql")
 }
 
-/// Generate a `CREATE TABLE IF NOT EXISTS` DDL statement from a dataset's Arrow schema.
+/// Generate a `CREATE TABLE IF NOT EXISTS` DDL statement from a dataset's Arrow schema,
+/// with acceleration configured for the cayenne engine with append refresh every 10 seconds.
+///
+/// If the schema contains a timestamp column, it is used as the acceleration time column
+/// with `timestamptz` format.
 fn create_table_ddl(table_name: &str, config: &DatasetConfig) -> String {
     let columns: Vec<String> = config
         .schema
@@ -329,10 +333,18 @@ fn create_table_ddl(table_name: &str, config: &DatasetConfig) -> String {
         })
         .collect();
 
+    let with_opts = vec![
+        "\"acceleration.engine\" = 'cayenne'".to_string(),
+        "\"acceleration.mode\" = 'file'".to_string(),
+        "\"acceleration.refresh_mode\" = 'full'".to_string(),
+        "\"acceleration.refresh_check_interval\" = '1s'".to_string(),
+    ];
+
     format!(
-        "CREATE TABLE IF NOT EXISTS {} ({})",
+        "CREATE TABLE IF NOT EXISTS {} ({}) WITH ({})",
         quote_ident(table_name),
-        columns.join(", ")
+        columns.join(", "),
+        with_opts.join(", ")
     )
 }
 


### PR DESCRIPTION
## Summary

Tables created by spidapter now include `WITH` clause options for per-table acceleration using the cayenne engine with append refresh every 10 seconds.

### Generated DDL example

```sql
CREATE TABLE IF NOT EXISTS "orders" ("id" BIGINT NOT NULL, "amount" DOUBLE) WITH (
    "acceleration.engine" = 'cayenne',
    "acceleration.refresh_mode" = 'append',
    "acceleration.refresh_check_interval" = '1s',
    "acceleration.time_column" = '__created_at',
    "acceleration.time_format" = 'timestamptz'
)
```

### Acceleration options
- **engine**: `cayenne`
- **refresh_mode**: `append`
- **refresh_check_interval**: `10s`
- **time_column**: `__created_at`
- **time_format**: `timestamptz`