### PR TITLE
fix: derive table location from namespace for Iceberg DDL CREATE TABLE

### DIFF
--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -221,9 +221,36 @@ impl ExecutionPlan for IcebergCreateTableExec {
                 )));
             }
 
+            // Try to derive a table location from the namespace properties.
+            // Some catalogs (e.g. AWS Glue) require an explicit `location` when
+            // creating tables.  We look up the namespace's `location` property
+            // and, if present, derive `{namespace_location}/{table_name}`.
+            let table_location: Option<String> = match catalog
+                .get_namespace(&namespace)
+                .await
+            {
+                Ok(ns) => {
+                    ns.properties()
+                        .get("location")
+                        .map(|loc| {
+                            let base = loc.trim_end_matches('/');
+                            format!("{base}/{table_name}")
+                        })
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Could not fetch namespace properties for '{}' \
+                         (table location will not be set): {e}",
+                        namespace.join(".")
+                    );
+                    None
+                }
+            };
+
             // Create the table in the Iceberg catalog
             let table_creation = TableCreation::builder()
                 .name(table_name.clone())
+                .location_opt(table_location)
                 .schema(iceberg_schema)
                 .build();
 
@@ -362,11 +389,7 @@ async fn create_accelerated_iceberg_table(
         ))
     })?;
 
-    let dataset_name = TableReference::full(
-        catalog_name.to_string(),
-        schema_name.to_string(),
-        table_name.to_string(),
-    );
+    let dataset_name = TableReference::bare(table_name.to_string());
     let source_string = format!("{catalog_name}.{schema_name}.{table_name}");
 
     let source_schema = source_provider.schema();


### PR DESCRIPTION
## Problem
AWS Glue catalogs require an explicit `location` when creating Iceberg tables. Previously, `TableCreation` was built without a location, causing Glue to reject the request with:
```
Cannot parse missing string: location
```

## Solution
- Fetch namespace properties via `catalog.get_namespace()` and look for a `location` property
- Derive the table location as `{namespace_location}/{table_name}`
- Pass the derived location using `.location_opt()` on the `TableCreation` builder
- Gracefully fall back to `None` when the namespace has no location property (e.g. local REST catalogs that auto-generate locations)
- Use `TableReference::bare` for accelerated table dataset names, matching the convention used by the normal dataset acceleration path (fixes `failed to resolve catalog` error during refresh)

## Testing
Verified against AWS Glue catalog in us-west-1:
- ✅ `CREATE TABLE` succeeds (table created with correct S3 location)
- ✅ `INSERT INTO` non-accelerated table writes data to S3
- ✅ `SELECT` returns correct data
- ✅ `DROP TABLE` works
- ✅ `CREATE TABLE ... WITH (acceleration.engine = 'arrow')` creates table and starts refresh loop without errors