### PR TITLE
Add refresh processed records/bytes metric

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -45,6 +45,20 @@ pub(crate) static REFRESH_DATA_FETCHES_SKIPPED: LazyLock<Counter<u64>> = LazyLoc
         .build()
 });
 
+pub(crate) static REFRESH_PROCESSED_ROWS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("dataset_acceleration_refresh_processed_rows")
+        .with_description("Number of rows processed during dataset refresh.")
+        .build()
+});
+
+pub(crate) static REFRESH_PROCESSED_BYTES: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("dataset_acceleration_refresh_updated_rows")
+        .with_description("Number of bytes processed during dataset refresh.")
+        .build()
+});
+
 pub(crate) static LAST_REFRESH_TIME_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     METER
         .f64_gauge("dataset_acceleration_last_refresh_unix_time_ms")

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -54,7 +54,7 @@ pub(crate) static REFRESH_PROCESSED_ROWS: LazyLock<Counter<u64>> = LazyLock::new
 
 pub(crate) static REFRESH_PROCESSED_BYTES: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("dataset_acceleration_refresh_updated_rows")
+        .u64_counter("dataset_acceleration_refresh_processed_bytes")
         .with_description("Number of bytes processed during dataset refresh.")
         .build()
 });

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -746,6 +746,14 @@ impl RefreshTask {
                 .await;
         }
 
+        if let Some(stat) = &refresh_stat {
+            for dataset_name in self.get_dataset_names().await {
+                let labels = [KeyValue::new("dataset", dataset_name.to_string())];
+                metrics::REFRESH_PROCESSED_ROWS.add(stat.num_rows as u64, &labels);
+                metrics::REFRESH_PROCESSED_BYTES.add(stat.memory_size as u64, &labels);
+            }
+        }
+
         self.set_refresh_status(sql, status::ComponentStatus::Ready)
             .await;
 


### PR DESCRIPTION
## 📝 Summary

Add two metrics:
* `dataset_acceleration_refresh_processed_rows`
* `dataset_acceleration_refresh_processed_bytes`