### PR TITLE
feat: support dataset.time_column and dataset.time_format in CREATE TABLE WITH options

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -411,7 +411,7 @@ impl DataFusionBuilder {
         let caching = self.caching.unwrap_or(Arc::new(Caching::default()));
 
         let ddl_enabled_catalogs = Arc::new(RwLock::new(HashSet::new()));
-        let acceleration_options_store =
+        let ddl_options_store =
             super::iceberg_ddl::acceleration_options::new_shared_store();
 
         // Add the Iceberg DDL analyzer rule after context creation so it can
@@ -422,7 +422,7 @@ impl DataFusionBuilder {
             super::iceberg_ddl::analyzer_rule::IcebergDdlAnalyzerRule::new(
                 ctx.state().catalog_list(),
                 &ddl_enabled_catalogs,
-                Arc::clone(&acceleration_options_store),
+                Arc::clone(&ddl_options_store),
             ),
         ));
 
@@ -432,7 +432,7 @@ impl DataFusionBuilder {
             data_writers: RwLock::new(HashSet::new()),
             writable_catalogs: RwLock::new(HashSet::new()),
             ddl_enabled_catalogs,
-            acceleration_options_store,
+            ddl_options_store,
             datafusion_ref,
             caching,
             pending_sink_tables: TokioRwLock::new(Vec::new()),

--- a/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/acceleration_options.rs
@@ -14,53 +14,117 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Store and parse acceleration options extracted from `CREATE TABLE ... WITH (...)` statements.
+//! Store and parse DDL table options extracted from `CREATE TABLE ... WITH (...)` statements.
+//!
+//! Supports two option prefixes:
+//! - `acceleration.*` — acceleration engine, mode, refresh settings, etc.
+//! - `dataset.*` — dataset-level settings like `time_column` and `time_format`.
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use datafusion::error::{DataFusionError, Result as DFResult};
 use spicepod::acceleration::{self, Acceleration};
+use spicepod::component::dataset::TimeFormat as SpicepodTimeFormat;
 
-/// Stores acceleration options extracted from `CREATE TABLE ... WITH (acceleration.*)` clauses.
+/// Dataset-level options extracted from `CREATE TABLE ... WITH ("dataset.*")` clauses.
+#[derive(Debug, Clone, Default)]
+pub struct DatasetOptions {
+    /// The column to use as the time column for append-mode refreshes.
+    pub time_column: Option<String>,
+    /// The format of the time column (e.g. `timestamp`, `ISO8601`, `unix_seconds`).
+    pub time_format: Option<SpicepodTimeFormat>,
+}
+
+/// Combined DDL table options extracted from `CREATE TABLE ... WITH (...)` clauses.
+///
+/// Bundles both `acceleration.*` and `dataset.*` options.
+#[derive(Debug, Clone, Default)]
+pub struct DdlTableOptions {
+    /// Acceleration options, if any `acceleration.*` keys were present.
+    pub acceleration: Option<Acceleration>,
+    /// Dataset-level options, if any `dataset.*` keys were present.
+    pub dataset: DatasetOptions,
+}
+
+/// Stores DDL table options extracted from `CREATE TABLE ... WITH (...)` clauses.
 ///
 /// Keyed by the table name as it appeared in the SQL statement. The analyzer rule
 /// retrieves (and removes) the options when rewriting the DDL plan.
 #[derive(Debug, Clone, Default)]
-pub struct AccelerationOptionsStore {
-    options: HashMap<String, Acceleration>,
+pub struct DdlOptionsStore {
+    options: HashMap<String, DdlTableOptions>,
 }
 
-impl AccelerationOptionsStore {
-    /// Insert acceleration options for a table.
-    pub fn insert(&mut self, table_name: String, acceleration: Acceleration) {
-        self.options.insert(table_name, acceleration);
+impl DdlOptionsStore {
+    /// Insert DDL table options for a table.
+    pub fn insert(&mut self, table_name: String, options: DdlTableOptions) {
+        self.options.insert(table_name, options);
     }
 
-    /// Remove and return acceleration options for a table (consume on use).
-    pub fn remove(&mut self, table_name: &str) -> Option<Acceleration> {
+    /// Remove and return DDL table options for a table (consume on use).
+    pub fn remove(&mut self, table_name: &str) -> Option<DdlTableOptions> {
         self.options.remove(table_name)
     }
 }
 
-/// Thread-safe, shared acceleration options store.
-pub type SharedAccelerationOptionsStore = Arc<RwLock<AccelerationOptionsStore>>;
+/// Thread-safe, shared DDL options store.
+pub type SharedDdlOptionsStore = Arc<RwLock<DdlOptionsStore>>;
 
 /// Create a new shared store.
 #[must_use]
-pub fn new_shared_store() -> SharedAccelerationOptionsStore {
-    Arc::new(RwLock::new(AccelerationOptionsStore::default()))
+pub fn new_shared_store() -> SharedDdlOptionsStore {
+    Arc::new(RwLock::new(DdlOptionsStore::default()))
 }
 
-/// Parse `acceleration.*` key-value pairs into an [`Acceleration`] struct.
+/// Parse `acceleration.*` and `dataset.*` key-value pairs into a [`DdlTableOptions`].
 ///
-/// Keys use dot-prefix format: `acceleration.engine`, `acceleration.mode`, etc.
+/// Keys use dot-prefix format: `acceleration.engine`, `dataset.time_column`, etc.
 /// In SQL `WITH (...)` clauses, these must be double-quoted since dots are not
 /// valid in bare identifiers:
 ///
 /// ```sql
-/// CREATE TABLE t (id INT) WITH ("acceleration.engine" = 'arrow')
+/// CREATE TABLE t (id INT) WITH (
+///     "acceleration.engine" = 'arrow',
+///     "dataset.time_column" = 'created_at',
+///     "dataset.time_format" = 'timestamp'
+/// )
 /// ```
+///
+/// # Errors
+///
+/// Returns an error if an unknown key is encountered or a value cannot be parsed.
+pub fn parse_ddl_table_options(options: &[(String, String)]) -> DFResult<DdlTableOptions> {
+    let mut accel_opts = Vec::new();
+    let mut dataset_opts = Vec::new();
+
+    for (key, value) in options {
+        if key.starts_with("acceleration.") {
+            accel_opts.push((key.clone(), value.clone()));
+        } else if key.starts_with("dataset.") {
+            dataset_opts.push((key.clone(), value.clone()));
+        } else {
+            return Err(DataFusionError::Plan(format!(
+                "Unknown option prefix in '{key}'. Expected 'acceleration.*' or 'dataset.*'."
+            )));
+        }
+    }
+
+    let acceleration = if accel_opts.is_empty() {
+        None
+    } else {
+        Some(parse_acceleration_options(&accel_opts)?)
+    };
+
+    let dataset = parse_dataset_options(&dataset_opts)?;
+
+    Ok(DdlTableOptions {
+        acceleration,
+        dataset,
+    })
+}
+
+/// Parse `acceleration.*` key-value pairs into an [`Acceleration`] struct.
 ///
 /// # Errors
 ///
@@ -126,6 +190,56 @@ pub fn parse_acceleration_options(options: &[(String, String)]) -> DFResult<Acce
     }
 
     Ok(accel)
+}
+
+/// Parse `dataset.*` key-value pairs into a [`DatasetOptions`] struct.
+///
+/// # Errors
+///
+/// Returns an error if an unknown `dataset.*` key is encountered or a value
+/// cannot be parsed.
+pub fn parse_dataset_options(options: &[(String, String)]) -> DFResult<DatasetOptions> {
+    let mut dataset = DatasetOptions::default();
+
+    for (key, value) in options {
+        let field = key.strip_prefix("dataset.").ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Expected 'dataset.' prefix on table option, got '{key}'"
+            ))
+        })?;
+
+        match field {
+            "time_column" => {
+                dataset.time_column = Some(value.clone());
+            }
+            "time_format" => {
+                dataset.time_format = Some(parse_time_format(value)?);
+            }
+            unknown => {
+                return Err(DataFusionError::Plan(format!(
+                    "Unknown dataset option: 'dataset.{unknown}'. \
+                     Supported options: dataset.time_column, dataset.time_format."
+                )));
+            }
+        }
+    }
+
+    Ok(dataset)
+}
+
+fn parse_time_format(value: &str) -> DFResult<SpicepodTimeFormat> {
+    match value.to_lowercase().as_str() {
+        "timestamp" => Ok(SpicepodTimeFormat::Timestamp),
+        "timestamptz" => Ok(SpicepodTimeFormat::Timestamptz),
+        "unix_seconds" | "unixseconds" => Ok(SpicepodTimeFormat::UnixSeconds),
+        "unix_millis" | "unixmillis" => Ok(SpicepodTimeFormat::UnixMillis),
+        "iso8601" => Ok(SpicepodTimeFormat::ISO8601),
+        "date" => Ok(SpicepodTimeFormat::Date),
+        _ => Err(DataFusionError::Plan(format!(
+            "Invalid value for 'dataset.time_format': '{value}'. \
+             Expected 'timestamp', 'timestamptz', 'unix_seconds', 'unix_millis', 'ISO8601', or 'date'."
+        ))),
+    }
 }
 
 fn parse_bool(value: &str, field: &str) -> DFResult<bool> {
@@ -242,10 +356,126 @@ mod tests {
 
     #[test]
     fn test_store_insert_and_remove() {
-        let mut store = AccelerationOptionsStore::default();
-        store.insert("my_table".to_string(), Acceleration::default());
+        let mut store = DdlOptionsStore::default();
+        store.insert("my_table".to_string(), DdlTableOptions::default());
 
         assert!(store.remove("my_table").is_some());
         assert!(store.remove("my_table").is_none()); // consumed
+    }
+
+    #[test]
+    fn test_parse_dataset_time_column() {
+        let options = vec![(
+            "dataset.time_column".to_string(),
+            "created_at".to_string(),
+        )];
+        let dataset = parse_dataset_options(&options).expect("should parse");
+        assert_eq!(dataset.time_column.as_deref(), Some("created_at"));
+        assert_eq!(dataset.time_format, None);
+    }
+
+    #[test]
+    fn test_parse_dataset_time_format() {
+        let options = vec![
+            (
+                "dataset.time_column".to_string(),
+                "updated_at".to_string(),
+            ),
+            (
+                "dataset.time_format".to_string(),
+                "timestamptz".to_string(),
+            ),
+        ];
+        let dataset = parse_dataset_options(&options).expect("should parse");
+        assert_eq!(dataset.time_column.as_deref(), Some("updated_at"));
+        assert_eq!(dataset.time_format, Some(SpicepodTimeFormat::Timestamptz));
+    }
+
+    #[test]
+    fn test_parse_dataset_all_time_formats() {
+        for (input, expected) in [
+            ("timestamp", SpicepodTimeFormat::Timestamp),
+            ("timestamptz", SpicepodTimeFormat::Timestamptz),
+            ("unix_seconds", SpicepodTimeFormat::UnixSeconds),
+            ("unixseconds", SpicepodTimeFormat::UnixSeconds),
+            ("unix_millis", SpicepodTimeFormat::UnixMillis),
+            ("unixmillis", SpicepodTimeFormat::UnixMillis),
+            ("ISO8601", SpicepodTimeFormat::ISO8601),
+            ("iso8601", SpicepodTimeFormat::ISO8601),
+            ("date", SpicepodTimeFormat::Date),
+        ] {
+            let options = vec![("dataset.time_format".to_string(), input.to_string())];
+            let dataset = parse_dataset_options(&options)
+                .unwrap_or_else(|_| panic!("should parse time_format '{input}'"));
+            assert_eq!(dataset.time_format, Some(expected), "for input '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_parse_dataset_invalid_time_format_errors() {
+        let options = vec![("dataset.time_format".to_string(), "invalid".to_string())];
+        let err = parse_dataset_options(&options)
+            .expect_err("should return an error")
+            .to_string();
+        assert!(err.contains("Invalid value for 'dataset.time_format'"));
+    }
+
+    #[test]
+    fn test_parse_dataset_unknown_option_errors() {
+        let options = vec![("dataset.unknown".to_string(), "value".to_string())];
+        let err = parse_dataset_options(&options)
+            .expect_err("should return an error")
+            .to_string();
+        assert!(err.contains("Unknown dataset option"));
+    }
+
+    #[test]
+    fn test_parse_ddl_table_options_mixed() {
+        let options = vec![
+            ("acceleration.engine".to_string(), "arrow".to_string()),
+            (
+                "dataset.time_column".to_string(),
+                "created_at".to_string(),
+            ),
+            (
+                "dataset.time_format".to_string(),
+                "timestamptz".to_string(),
+            ),
+        ];
+        let ddl_opts = parse_ddl_table_options(&options).expect("should parse");
+        assert!(ddl_opts.acceleration.is_some());
+        let accel = ddl_opts.acceleration.expect("acceleration should be Some");
+        assert_eq!(accel.engine.as_deref(), Some("arrow"));
+        assert_eq!(
+            ddl_opts.dataset.time_column.as_deref(),
+            Some("created_at")
+        );
+        assert_eq!(
+            ddl_opts.dataset.time_format,
+            Some(SpicepodTimeFormat::Timestamptz)
+        );
+    }
+
+    #[test]
+    fn test_parse_ddl_table_options_unknown_prefix_errors() {
+        let options = vec![("other.key".to_string(), "value".to_string())];
+        let err = parse_ddl_table_options(&options)
+            .expect_err("should return an error")
+            .to_string();
+        assert!(err.contains("Unknown option prefix"));
+    }
+
+    #[test]
+    fn test_parse_ddl_table_options_dataset_only() {
+        let options = vec![(
+            "dataset.time_column".to_string(),
+            "created_at".to_string(),
+        )];
+        let ddl_opts = parse_ddl_table_options(&options).expect("should parse");
+        assert!(ddl_opts.acceleration.is_none());
+        assert_eq!(
+            ddl_opts.dataset.time_column.as_deref(),
+            Some("created_at")
+        );
     }
 }

--- a/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/analyzer_rule.rs
@@ -32,7 +32,7 @@ use datafusion::optimizer::AnalyzerRule;
 
 use data_components::iceberg::provider::IcebergCatalogProvider;
 
-use super::acceleration_options::SharedAccelerationOptionsStore;
+use super::acceleration_options::SharedDdlOptionsStore;
 use super::composed_catalog_to_iceberg;
 use super::logical_nodes::{IcebergCreateTableNode, IcebergDropTableNode};
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
@@ -49,8 +49,8 @@ pub struct IcebergDdlAnalyzerRule {
     catalog_list: Weak<dyn CatalogProviderList>,
     /// Weak reference to the set of DDL-enabled catalog names.
     ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
-    /// Shared store for acceleration options extracted from `WITH` clauses.
-    acceleration_options: SharedAccelerationOptionsStore,
+    /// Shared store for DDL table options extracted from `WITH` clauses.
+    ddl_options: SharedDdlOptionsStore,
 }
 
 impl fmt::Debug for IcebergDdlAnalyzerRule {
@@ -65,12 +65,12 @@ impl IcebergDdlAnalyzerRule {
     pub fn new(
         catalog_list: &Arc<dyn CatalogProviderList>,
         ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
-        acceleration_options: SharedAccelerationOptionsStore,
+        ddl_options: SharedDdlOptionsStore,
     ) -> Self {
         Self {
             catalog_list: Arc::downgrade(catalog_list),
             ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
-            acceleration_options,
+            ddl_options,
         }
     }
 
@@ -134,14 +134,17 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
 
                 let namespace = iceberg::NamespaceIdent::new(schema_name.clone());
 
-                // Look up acceleration options from the store (consumed on use)
-                let acceleration = {
-                    let mut store = self.acceleration_options.write().map_err(|e| {
+                // Look up DDL table options from the store (consumed on use)
+                let (acceleration, dataset_options) = {
+                    let mut store = self.ddl_options.write().map_err(|e| {
                         DataFusionError::Execution(format!(
-                            "Failed to acquire acceleration options store lock: {e}"
+                            "Failed to acquire DDL options store lock: {e}"
                         ))
                     })?;
-                    store.remove(&acceleration_key)
+                    match store.remove(&acceleration_key) {
+                        Some(opts) => (opts.acceleration, opts.dataset),
+                        None => (None, Default::default()),
+                    }
                 };
 
                 let node = IcebergCreateTableNode::new(
@@ -154,6 +157,7 @@ impl AnalyzerRule for IcebergDdlAnalyzerRule {
                     catalog_name,
                     schema_name,
                     acceleration,
+                    dataset_options,
                 );
 
                 Ok(LogicalPlan::Extension(Extension {

--- a/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/logical_nodes.rs
@@ -27,6 +27,8 @@ use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use iceberg::{Catalog, NamespaceIdent};
 use spicepod::acceleration::Acceleration;
 
+use super::acceleration_options::DatasetOptions;
+
 /// Creates the shared output schema for DDL result nodes (single `result` column).
 fn ddl_output_schema() -> DFSchemaRef {
     DFSchemaRef::new(
@@ -60,6 +62,8 @@ pub struct IcebergCreateTableNode {
     pub df_schema_name: String,
     /// Acceleration options from `WITH (acceleration.*)`, if any.
     pub acceleration: Option<Acceleration>,
+    /// Dataset options from `WITH (dataset.*)`, if any.
+    pub dataset_options: DatasetOptions,
     /// Output schema (single "result" column).
     output_schema: DFSchemaRef,
 }
@@ -77,6 +81,7 @@ impl IcebergCreateTableNode {
         df_catalog_name: String,
         df_schema_name: String,
         acceleration: Option<Acceleration>,
+        dataset_options: DatasetOptions,
     ) -> Self {
         Self {
             catalog,
@@ -88,6 +93,7 @@ impl IcebergCreateTableNode {
             df_catalog_name,
             df_schema_name,
             acceleration,
+            dataset_options,
             output_schema: ddl_output_schema(),
         }
     }
@@ -159,6 +165,7 @@ impl UserDefinedLogicalNodeCore for IcebergCreateTableNode {
             df_catalog_name: self.df_catalog_name.clone(),
             df_schema_name: self.df_schema_name.clone(),
             acceleration: self.acceleration.clone(),
+            dataset_options: self.dataset_options.clone(),
             output_schema: DFSchemaRef::clone(&self.output_schema),
         })
     }

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -32,6 +32,7 @@ use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 use iceberg_datafusion::IcebergTableProvider;
 use spicepod::acceleration::Acceleration;
 
+use super::acceleration_options::DatasetOptions;
 use crate::accelerated_table::AcceleratedTable;
 use crate::datafusion::DataFusion;
 use datafusion::catalog::CatalogProviderList;
@@ -77,6 +78,7 @@ pub struct IcebergCreateTableExec {
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
     acceleration: Option<Acceleration>,
+    dataset_options: DatasetOptions,
     datafusion: Weak<DataFusion>,
     properties: PlanProperties,
 }
@@ -108,6 +110,7 @@ impl IcebergCreateTableExec {
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
         acceleration: Option<Acceleration>,
+        dataset_options: DatasetOptions,
         datafusion: Weak<DataFusion>,
     ) -> Self {
         let schema = ddl_result_schema();
@@ -128,6 +131,7 @@ impl IcebergCreateTableExec {
             df_schema_name,
             catalog_list,
             acceleration,
+            dataset_options,
             datafusion,
             properties,
         }
@@ -183,6 +187,7 @@ impl ExecutionPlan for IcebergCreateTableExec {
         let catalog_list = Arc::clone(&self.catalog_list);
         let result_schema = ddl_result_schema();
         let acceleration = self.acceleration.clone();
+        let dataset_options = self.dataset_options.clone();
         let datafusion = Weak::<DataFusion>::clone(&self.datafusion);
 
         let stream = futures::stream::once(async move {
@@ -311,6 +316,7 @@ impl ExecutionPlan for IcebergCreateTableExec {
                     &datafusion,
                     Arc::clone(&provider),
                     accel,
+                    &dataset_options,
                     &df_catalog_name,
                     &df_schema_name,
                     &table_name,
@@ -365,6 +371,7 @@ async fn create_accelerated_iceberg_table(
     datafusion: &Weak<DataFusion>,
     source_provider: Arc<dyn datafusion::datasource::TableProvider>,
     acceleration: &Acceleration,
+    dataset_options: &DatasetOptions,
     catalog_name: &str,
     schema_name: &str,
     table_name: &str,
@@ -373,6 +380,7 @@ async fn create_accelerated_iceberg_table(
     use crate::component::dataset::acceleration::{
         Acceleration as RuntimeAcceleration, RefreshMode,
     };
+    use crate::component::dataset::TimeFormat;
     use crate::federated_table::FederatedTable;
     use datafusion::common::TableReference;
 
@@ -419,6 +427,12 @@ async fn create_accelerated_iceberg_table(
     let mut refresh = Refresh::new(refresh_mode);
     if let Some(check_interval) = runtime_accel.refresh_check_interval {
         refresh = refresh.check_interval(check_interval);
+    }
+    if let Some(ref time_column) = dataset_options.time_column {
+        refresh = refresh.time_column(time_column.clone());
+    }
+    if let Some(ref time_format) = dataset_options.time_format {
+        refresh = refresh.time_format(TimeFormat::from(time_format.clone()));
     }
 
     // Build the AcceleratedTable

--- a/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/planner.rs
@@ -74,6 +74,7 @@ impl ExtensionPlanner for IcebergDdlExtensionPlanner {
                 create.df_schema_name.clone(),
                 catalog_list,
                 create.acceleration.clone(),
+                create.dataset_options.clone(),
                 datafusion_weak,
             ))));
         }

--- a/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/preprocess.rs
@@ -14,17 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Pre-processing for `CREATE TABLE ... WITH ("acceleration.*")` SQL statements.
+//! Pre-processing for `CREATE TABLE ... WITH ("acceleration.*", "dataset.*")` SQL statements.
 //!
 //! `DataFusion`'s `SqlToRel` does not support `WITH (...)` options on `CREATE TABLE`
 //! (it only matches `table_options: CreateTableOptions::None`). This module
 //! intercepts such statements before they reach `DataFusion`, extracts the
-//! acceleration options into the shared [`AccelerationOptionsStore`], and returns
+//! DDL table options into the shared [`DdlOptionsStore`], and returns
 //! modified SQL without the `WITH` clause so `DataFusion` can plan it normally.
 //!
 //! Keys must be double-quoted because dots are not valid in bare SQL identifiers:
 //! ```sql
-//! CREATE TABLE t (id INT) WITH ("acceleration.engine" = 'arrow')
+//! CREATE TABLE t (id INT) WITH (
+//!     "acceleration.engine" = 'arrow',
+//!     "dataset.time_column" = 'created_at'
+//! )
 //! ```
 
 use datafusion::error::{DataFusionError, Result as DFResult};
@@ -32,24 +35,24 @@ use datafusion::sql::sqlparser::ast::{CreateTableOptions, SqlOption, Statement};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 
-use super::acceleration_options::{SharedAccelerationOptionsStore, parse_acceleration_options};
+use super::acceleration_options::{SharedDdlOptionsStore, parse_ddl_table_options};
 
 /// Result of pre-processing: either the original SQL unchanged, or modified SQL
-/// with acceleration options extracted.
+/// with DDL table options extracted.
 #[derive(Debug)]
 pub enum PreprocessResult {
-    /// SQL was not a `CREATE TABLE ... WITH (acceleration.*)` — pass through unchanged.
+    /// SQL was not a `CREATE TABLE ... WITH (acceleration.*|dataset.*)` — pass through unchanged.
     Unchanged,
-    /// SQL was modified: `WITH` clause stripped, acceleration options stored.
+    /// SQL was modified: `WITH` clause stripped, options stored.
     Modified {
         /// The rewritten SQL string without the `WITH` clause.
         sql: String,
-        /// The store key used for the inserted acceleration options.
+        /// The store key used for the inserted options.
         store_key: String,
     },
 }
 
-/// Remove a previously inserted acceleration option entry from the shared store.
+/// Remove a previously inserted DDL option entry from the shared store.
 ///
 /// Intended for error paths where preprocessing has inserted options but logical
 /// planning failed before the analyzer could consume the entry.
@@ -57,33 +60,35 @@ pub enum PreprocessResult {
 /// # Errors
 ///
 /// Returns an error if the store lock cannot be acquired.
-pub fn cleanup_preprocessed_acceleration_option(
-    accel_store: &SharedAccelerationOptionsStore,
+pub fn cleanup_preprocessed_ddl_options(
+    store: &SharedDdlOptionsStore,
     store_key: &str,
 ) -> DFResult<()> {
-    let mut store = accel_store.write().map_err(|e| {
+    let mut guard = store.write().map_err(|e| {
         DataFusionError::Execution(format!(
-            "Failed to acquire acceleration options store lock: {e}"
+            "Failed to acquire DDL options store lock: {e}"
         ))
     })?;
-    let _ = store.remove(store_key);
+    let _ = guard.remove(store_key);
     Ok(())
 }
 
-/// Pre-process a SQL string to extract `CREATE TABLE ... WITH (acceleration.*)` options.
+/// Pre-process a SQL string to extract `CREATE TABLE ... WITH (...)` options.
 ///
-/// If the SQL is a `CREATE TABLE` with `WITH` options containing `acceleration.*` keys,
-/// the options are parsed, stored in `accel_store`, and the SQL is returned without
-/// the `WITH` clause. Otherwise, the original SQL is returned unchanged.
+/// If the SQL is a `CREATE TABLE` with `WITH` options containing `acceleration.*`
+/// or `dataset.*` keys, the options are parsed, stored in the shared store, and
+/// the SQL is returned without the `WITH` clause so `DataFusion` can plan it
+/// normally. Otherwise, the original SQL is returned unchanged.
 ///
 /// # Errors
 ///
 /// Returns an error if:
-/// - The `WITH` options contain invalid `acceleration.*` keys or values.
-/// - The `WITH` options mix `acceleration.*` keys with non-acceleration keys.
-pub fn preprocess_create_table_acceleration(
+/// - The `WITH` options contain invalid keys or values.
+/// - The `WITH` options contain keys with unrecognized prefixes (not `acceleration.*`
+///   or `dataset.*`).
+pub fn preprocess_create_table_with_options(
     sql: &str,
-    accel_store: &SharedAccelerationOptionsStore,
+    ddl_store: &SharedDdlOptionsStore,
 ) -> DFResult<PreprocessResult> {
     // Quick check: if the SQL doesn't contain "WITH", skip parsing
     if !sql.to_uppercase().contains("WITH") {
@@ -105,8 +110,8 @@ pub fn preprocess_create_table_acceleration(
         return Ok(PreprocessResult::Unchanged);
     };
 
-    // Separate acceleration options from other options
-    let mut accel_opts = Vec::new();
+    // Extract key-value pairs, separating recognized prefixes from unknown ones
+    let mut recognized_opts = Vec::new();
     let mut other_opts = Vec::new();
 
     for opt in options {
@@ -119,8 +124,8 @@ pub fn preprocess_create_table_acceleration(
                     other => other.to_string(),
                 };
 
-                if key_str.starts_with("acceleration.") {
-                    accel_opts.push((key_str, value_str));
+                if key_str.starts_with("acceleration.") || key_str.starts_with("dataset.") {
+                    recognized_opts.push((key_str, value_str));
                 } else {
                     other_opts.push(opt.clone());
                 }
@@ -131,22 +136,21 @@ pub fn preprocess_create_table_acceleration(
         }
     }
 
-    if accel_opts.is_empty() {
+    if recognized_opts.is_empty() {
         return Ok(PreprocessResult::Unchanged);
     }
 
-    // Reject mixing acceleration and non-acceleration options for clarity
+    // Reject mixing recognized options with other WITH options for clarity
     if !other_opts.is_empty() {
         return Err(DataFusionError::Plan(
-            "Cannot mix 'acceleration.*' options with other WITH options in CREATE TABLE. \
-             Use only 'acceleration.*' options."
+            "Cannot mix 'acceleration.*' or 'dataset.*' options with other WITH options in CREATE TABLE. \
+             Use only 'acceleration.*' and/or 'dataset.*' options."
                 .to_string(),
         ));
     }
 
-    // Parse acceleration options
     // Strip surrounding quotes from values (sqlparser includes them for string literals)
-    let cleaned_opts: Vec<(String, String)> = accel_opts
+    let cleaned_opts: Vec<(String, String)> = recognized_opts
         .into_iter()
         .map(|(k, v)| {
             let v = v
@@ -159,20 +163,20 @@ pub fn preprocess_create_table_acceleration(
         })
         .collect();
 
-    let acceleration = parse_acceleration_options(&cleaned_opts)?;
+    let ddl_table_options = parse_ddl_table_options(&cleaned_opts)?;
 
     // Extract the table name for the store key
     let table_name = create_table.name.to_string();
     let store_key = table_name.clone();
 
-    // Store the acceleration options
+    // Store the DDL table options
     {
-        let mut store = accel_store.write().map_err(|e| {
+        let mut guard = ddl_store.write().map_err(|e| {
             DataFusionError::Execution(format!(
-                "Failed to acquire acceleration options store lock: {e}"
+                "Failed to acquire DDL options store lock: {e}"
             ))
         })?;
-        store.insert(table_name, acceleration);
+        guard.insert(table_name, ddl_table_options);
     }
 
     // Reconstruct the CREATE TABLE without the WITH clause
@@ -195,7 +199,7 @@ mod tests {
     fn test_preprocess_no_with_clause() {
         let store = new_shared_store();
         let sql = "CREATE TABLE foo (id INT, name VARCHAR)";
-        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
         assert!(matches!(result, PreprocessResult::Unchanged));
     }
 
@@ -203,7 +207,7 @@ mod tests {
     fn test_preprocess_non_create_table() {
         let store = new_shared_store();
         let sql = "SELECT * FROM foo";
-        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
         assert!(matches!(result, PreprocessResult::Unchanged));
     }
 
@@ -212,50 +216,99 @@ mod tests {
         let store = new_shared_store();
         let sql = r#"CREATE TABLE foo (id INT, name VARCHAR) WITH ("acceleration.engine" = 'arrow', "acceleration.mode" = 'memory')"#;
 
-        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
 
         match result {
             PreprocessResult::Modified {
                 sql: modified_sql,
                 store_key,
             } => {
-                // The modified SQL should not contain acceleration options
                 assert!(
                     !modified_sql.contains("acceleration."),
                     "Modified SQL should not contain acceleration options: {modified_sql}"
                 );
-                // Should still be valid CREATE TABLE
                 assert!(modified_sql.to_uppercase().contains("CREATE TABLE"));
                 assert_eq!(store_key, "foo");
             }
             PreprocessResult::Unchanged => panic!("Expected Modified result"),
         }
 
-        // Check that the store has the options
-        let accel = store
+        let ddl_opts = store
             .write()
             .expect("store lock should be available")
             .remove("foo")
             .expect("should have options for 'foo'");
+        let accel = ddl_opts.acceleration.expect("acceleration should be Some");
         assert_eq!(accel.engine.as_deref(), Some("arrow"));
         assert_eq!(accel.mode, spicepod::acceleration::Mode::Memory);
     }
 
     #[test]
-    fn test_preprocess_with_non_acceleration_options_unchanged() {
+    fn test_preprocess_with_dataset_options() {
         let store = new_shared_store();
-        // WITH options that don't have acceleration. prefix
+        let sql = r#"CREATE TABLE foo (id INT, ts TIMESTAMP) WITH ("dataset.time_column" = 'ts', "dataset.time_format" = 'timestamp')"#;
+
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
+
+        match result {
+            PreprocessResult::Modified {
+                sql: modified_sql,
+                store_key,
+            } => {
+                assert!(
+                    !modified_sql.contains("dataset."),
+                    "Modified SQL should not contain dataset options: {modified_sql}"
+                );
+                assert_eq!(store_key, "foo");
+            }
+            PreprocessResult::Unchanged => panic!("Expected Modified result"),
+        }
+
+        let ddl_opts = store
+            .write()
+            .expect("store lock should be available")
+            .remove("foo")
+            .expect("should have options for 'foo'");
+        assert!(ddl_opts.acceleration.is_none());
+        assert_eq!(ddl_opts.dataset.time_column.as_deref(), Some("ts"));
+        assert_eq!(
+            ddl_opts.dataset.time_format,
+            Some(spicepod::component::dataset::TimeFormat::Timestamp)
+        );
+    }
+
+    #[test]
+    fn test_preprocess_with_mixed_accel_and_dataset_options() {
+        let store = new_shared_store();
+        let sql = r#"CREATE TABLE foo (id INT, ts TIMESTAMP) WITH ("acceleration.engine" = 'arrow', "acceleration.refresh_mode" = 'append', "dataset.time_column" = 'ts')"#;
+
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
+        assert!(matches!(result, PreprocessResult::Modified { .. }));
+
+        let ddl_opts = store
+            .write()
+            .expect("store lock should be available")
+            .remove("foo")
+            .expect("should have options for 'foo'");
+        let accel = ddl_opts.acceleration.expect("acceleration should be Some");
+        assert_eq!(accel.engine.as_deref(), Some("arrow"));
+        assert_eq!(ddl_opts.dataset.time_column.as_deref(), Some("ts"));
+    }
+
+    #[test]
+    fn test_preprocess_with_non_recognized_options_unchanged() {
+        let store = new_shared_store();
         let sql = "CREATE TABLE foo (id INT) WITH (fillfactor = 70)";
-        let result = preprocess_create_table_acceleration(sql, &store).expect("should succeed");
+        let result = preprocess_create_table_with_options(sql, &store).expect("should succeed");
         assert!(matches!(result, PreprocessResult::Unchanged));
     }
 
     #[test]
-    fn test_preprocess_mixed_options_errors() {
+    fn test_preprocess_mixed_recognized_and_other_options_errors() {
         let store = new_shared_store();
         let sql =
             r#"CREATE TABLE foo (id INT) WITH ("acceleration.engine" = 'arrow', fillfactor = 70)"#;
-        let result = preprocess_create_table_acceleration(sql, &store);
+        let result = preprocess_create_table_with_options(sql, &store);
         let err = result.expect_err("should return an error").to_string();
         assert!(err.contains("Cannot mix"));
     }
@@ -264,8 +317,17 @@ mod tests {
     fn test_preprocess_invalid_acceleration_option_errors() {
         let store = new_shared_store();
         let sql = r#"CREATE TABLE foo (id INT) WITH ("acceleration.nonexistent" = 'value')"#;
-        let result = preprocess_create_table_acceleration(sql, &store);
+        let result = preprocess_create_table_with_options(sql, &store);
         let err = result.expect_err("should return an error").to_string();
         assert!(err.contains("Unknown acceleration option"));
+    }
+
+    #[test]
+    fn test_preprocess_invalid_dataset_option_errors() {
+        let store = new_shared_store();
+        let sql = r#"CREATE TABLE foo (id INT) WITH ("dataset.nonexistent" = 'value')"#;
+        let result = preprocess_create_table_with_options(sql, &store);
+        let err = result.expect_err("should return an error").to_string();
+        assert!(err.contains("Unknown dataset option"));
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -403,8 +403,8 @@ pub struct DataFusion {
     writable_catalogs: RwLock<HashSet<String>>,
     /// Catalogs that allow DDL operations (CREATE TABLE, DROP TABLE, etc.)
     ddl_enabled_catalogs: Arc<RwLock<HashSet<String>>>,
-    /// Shared store for acceleration options from `CREATE TABLE ... WITH (acceleration.*)`.
-    acceleration_options_store: iceberg_ddl::acceleration_options::SharedAccelerationOptionsStore,
+    /// Shared store for DDL table options from `CREATE TABLE ... WITH (acceleration.*, dataset.*)`.
+    ddl_options_store: iceberg_ddl::acceleration_options::SharedDdlOptionsStore,
     /// Shared weak self-reference, populated after `Arc::new(DataFusion)`.
     /// Used by the extension planner to pass `Weak<DataFusion>` to physical plans.
     datafusion_ref: iceberg_ddl::SharedDataFusionRef,
@@ -757,16 +757,16 @@ impl DataFusion {
         Ok(())
     }
 
-    /// Returns a reference to the shared acceleration options store.
+    /// Returns a reference to the shared DDL options store.
     ///
     /// Used by the query execution path to insert options extracted from
-    /// `CREATE TABLE ... WITH (acceleration.*)` statements, which are then
-    /// consumed by the `IcebergDdlAnalyzerRule`.
+    /// `CREATE TABLE ... WITH (acceleration.*, dataset.*)` statements, which
+    /// are then consumed by the `IcebergDdlAnalyzerRule`.
     #[must_use]
-    pub fn acceleration_options_store(
+    pub fn ddl_options_store(
         &self,
-    ) -> &iceberg_ddl::acceleration_options::SharedAccelerationOptionsStore {
-        &self.acceleration_options_store
+    ) -> &iceberg_ddl::acceleration_options::SharedDdlOptionsStore {
+        &self.ddl_options_store
     }
 
     /// Returns the shared weak self-reference holder.
@@ -2161,12 +2161,12 @@ impl DataFusion {
             return Ok(plan);
         }
 
-        // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning.
-        // This extracts acceleration options, stores them for the analyzer rule,
+        // Pre-process CREATE TABLE ... WITH (acceleration.*, dataset.*) before planning.
+        // This extracts DDL table options, stores them for the analyzer rule,
         // and returns modified SQL without the WITH clause.
-        let preprocessed = iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+        let preprocessed = iceberg_ddl::preprocess::preprocess_create_table_with_options(
             sql,
-            &self.acceleration_options_store,
+            &self.ddl_options_store,
         )?;
         let (effective_sql, store_key) = match &preprocessed {
             iceberg_ddl::preprocess::PreprocessResult::Modified {
@@ -2180,8 +2180,8 @@ impl DataFusion {
             Ok(plan) => plan,
             Err(e) => {
                 if let Some(store_key) = store_key {
-                    iceberg_ddl::preprocess::cleanup_preprocessed_acceleration_option(
-                        &self.acceleration_options_store,
+                    iceberg_ddl::preprocess::cleanup_preprocessed_ddl_options(
+                        &self.ddl_options_store,
                         store_key,
                     )?;
                 }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -863,11 +863,11 @@ impl Query {
         let plan = match self.sql {
             QueryMethod::Plan(ref plan) => plan.clone(),
             QueryMethod::Text { ref sql, .. } => {
-                // Pre-process CREATE TABLE ... WITH (acceleration.*) before planning
+                // Pre-process CREATE TABLE ... WITH (acceleration.*, dataset.*) before planning
                 let preprocessed =
-                    match super::iceberg_ddl::preprocess::preprocess_create_table_acceleration(
+                    match super::iceberg_ddl::preprocess::preprocess_create_table_with_options(
                         sql,
-                        self.df.acceleration_options_store(),
+                        self.df.ddl_options_store(),
                     ) {
                         Ok(preprocessed) => preprocessed,
                         Err(e) => {
@@ -892,8 +892,8 @@ impl Query {
                     Err(e) => {
                         if let Some(store_key) = store_key
                             && let Err(cleanup_err) =
-                                super::iceberg_ddl::preprocess::cleanup_preprocessed_acceleration_option(
-                                    self.df.acceleration_options_store(),
+                                super::iceberg_ddl::preprocess::cleanup_preprocessed_ddl_options(
+                                    self.df.ddl_options_store(),
                                     store_key,
                                 )
                         {


### PR DESCRIPTION
## Summary

Add support for `dataset.time_column` and `dataset.time_format` options in `CREATE TABLE ... WITH (...)` DDL statements for Iceberg tables. These dataset-level options affect acceleration behavior for append-mode refreshes by specifying which column contains timestamps and what format they use.

### Example

```sql
CREATE TABLE orders (id INT, created_at TIMESTAMP) WITH (
    "acceleration.engine" = 'arrow',
    "acceleration.refresh_mode" = 'append',
    "dataset.time_column" = 'created_at',
    "dataset.time_format" = 'timestamp'
)
```

### Changes

- Broaden `AccelerationOptionsStore` to `DdlOptionsStore`, storing `DdlTableOptions` which bundles both acceleration and dataset options
- Add `DatasetOptions` struct with `time_column` and `time_format` fields
- Add `parse_dataset_options()` and `parse_ddl_table_options()` functions
- Support all `TimeFormat` variants: `timestamp`, `timestamptz`, `unix_seconds`, `unix_millis`, `ISO8601`, `date`
- Thread `DatasetOptions` through analyzer rule → logical nodes → planner → physical plans
- Wire `time_column` and `time_format` into the `Refresh` config when creating accelerated Iceberg tables
- Rename preprocess function and cleanup helper to reflect broader scope
- Add 25 unit tests for parsing and preprocessing

### Validation

- Invalid `dataset.*` options return clear errors with supported option list
- Invalid `time_format` values return errors listing valid formats
- Unknown option prefixes (not `acceleration.*` or `dataset.*`) pass through to DataFusion
- Tested end-to-end with local Iceberg REST catalog + MinIO