### PR TITLE
Add acceleration refresh ingestion metrics (rows_written, bytes_written)

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -111,3 +111,23 @@ pub(crate) static SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .with_unit("By")
         .build()
 });
+
+pub(crate) static REFRESH_ROWS_WRITTEN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("dataset_acceleration_refresh_rows_written")
+        .with_description(
+            "Cumulative number of rows read from the federated source and written into the accelerated table.",
+        )
+        .with_unit("rows")
+        .build()
+});
+
+pub(crate) static REFRESH_BYTES_WRITTEN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("dataset_acceleration_refresh_bytes_written")
+        .with_description(
+            "Cumulative number of bytes (Arrow in-memory size) read from the federated source and written into the accelerated table.",
+        )
+        .with_unit("By")
+        .build()
+});

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -687,6 +687,12 @@ impl RefreshTask {
                                 stat.num_rows += batch.num_rows();
                                 stat.memory_size += batch.get_array_memory_size();
 
+                                // Record incremental ingestion counters per batch.
+                                let labels = [KeyValue::new("dataset", ds_name.clone())];
+                                metrics::REFRESH_ROWS_WRITTEN.add(batch.num_rows() as u64, &labels);
+                                metrics::REFRESH_BYTES_WRITTEN
+                                    .add(batch.get_array_memory_size() as u64, &labels);
+
                                 // Check memory usage after processing each batch
                                 if let Some(ref monitor) = resource_monitor {
                                     monitor.check_memory_usage(&ds_name);


### PR DESCRIPTION
## Summary

Add two new OpenTelemetry counters to the `dataset_acceleration` meter that track cumulative rows and bytes written into accelerated tables during refresh operations. These metrics capture the federated-to-accelerated ingestion path.

## New Metrics

| Metric | Type | Unit | Description |
|--------|------|------|-------------|
| `dataset_acceleration_refresh_rows_written` | Counter\<u64\> | rows | Cumulative rows read from federated source and written into the accelerated table |
| `dataset_acceleration_refresh_bytes_written` | Counter\<u64\> | By | Cumulative bytes (Arrow in-memory size) read from federated source and written into the accelerated table |

Both are labeled with `dataset` (the table reference name) and exposed via the existing Prometheus `/metrics` endpoint.

## Changes

- **`crates/runtime/src/accelerated_table/metrics.rs`**: Define two new `LazyLock<Counter<u64>>` statics
- **`crates/runtime/src/accelerated_table/refresh_task.rs`**: Record the counters in `write_streaming_data_update()` after each successful refresh, using the `RefreshStat` that already tracks `num_rows` and `memory_size`

## Motivation

These metrics enable downstream consumers (e.g. spicebench's spidapter system adapter) to scrape ingestion throughput from the Prometheus endpoint and report `rows_ingested` / `bytes_ingested` back to the benchmark harness.