### PR TITLE
feat: Add Cayenne Catalog with DDL

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -364,6 +364,16 @@ pub async fn run(args: Args) -> Result<()> {
     let tracing_config = runtime_config.and_then(|rt| rt.tracing.clone());
     let telemetry_config = runtime_config.map(|rt| rt.telemetry.clone());
 
+    // Configure Flight DoPut rate limits from spicepod runtime.flight settings
+    let flight_config = runtime_config.and_then(|rt| rt.flight.clone());
+    let rate_limits = {
+        let mut limits = runtime::flight::RateLimits::default();
+        if let Some(ref flight) = flight_config {
+            limits = limits.with_flight_write_enabled(flight.do_put_rate_limit_enabled);
+        }
+        limits
+    };
+
     let resolved_cluster_config =
         in_tracing_context(|| ResolvedClusterConfig::try_new(args.runtime.cluster.clone()));
 
@@ -379,6 +389,7 @@ pub async fn run(args: Args) -> Result<()> {
         .with_datasets_health_monitor()
         .with_metrics_server_opt(args.metrics, prometheus_registry.clone())
         .with_runtime_config(args.runtime.clone())
+        .with_rate_limits(rate_limits)
         .with_io_runtime(Handle::current());
 
     // Check for explicit cluster role OR implicit executor role (scheduler_address set without explicit role)

--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -199,6 +199,9 @@ pub trait MetadataCatalog: Send + Sync {
     /// Initialize the catalog, creating necessary tables if they don't exist.
     async fn init(&self) -> CatalogResult<()>;
 
+    /// List all table names in the catalog.
+    async fn list_table_names(&self) -> CatalogResult<Vec<String>>;
+
     /// Create a new table.
     async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64>;
 

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -198,6 +198,7 @@ impl MetadataCatalog for CayenneCatalog {
             tokio::fs::create_dir_all(db_dir).await?;
         }
 
+
         // Initialize schema using the appropriate metastore backend
         match &self.metastore {
             MetastoreImpl::Sqlite(metastore) => metastore.init_schema().await?,
@@ -206,6 +207,18 @@ impl MetadataCatalog for CayenneCatalog {
         }
 
         Ok(())
+    }
+
+    async fn list_table_names(&self) -> CatalogResult<Vec<String>> {
+        self.metastore
+            .query_helper(
+                QueryParams {
+                    sql: "SELECT table_name FROM cayenne_table ORDER BY table_name",
+                    params: vec![],
+                },
+                |row| row.get_string(0),
+            )
+            .await
     }
 
     async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64> {
@@ -338,9 +351,9 @@ impl MetadataCatalog for CayenneCatalog {
     async fn get_table(&self, table_name: &str) -> CatalogResult<TableMetadata> {
         let table_name_owned = table_name.to_string();
 
-        self.metastore
-            .query_row_helper(
-                QueryRowParams {
+        let results = self.metastore
+            .query_helper(
+                QueryParams {
                     sql: r"
                     SELECT table_id, table_uuid,
                            table_name, path, path_is_relative, schema_json, primary_key_json,
@@ -446,7 +459,11 @@ impl MetadataCatalog for CayenneCatalog {
             .await
             .map_err(|e| CatalogError::FailedToGetTable {
                 source: Box::new(e),
-            })
+            })?;
+
+        results.into_iter().next().ok_or(CatalogError::TableNotFound {
+            table_name: table_name_owned,
+        })
     }
 
     async fn set_current_snapshot(&self, table_id: i64, snapshot_id: &str) -> CatalogResult<()> {

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Catalog connector for Cayenne catalogs backed by S3 Express One Zone storage.
+//!
+//! Cayenne catalogs use SQLite for metadata and Vortex files for columnar data,
+//! with data stored exclusively in S3 Express One Zone directory buckets.
+
+use super::{CatalogConnector, ConnectorComponent, ParameterSpec};
+use crate::{
+    Runtime,
+    component::catalog::Catalog,
+    dataconnector::parameters::ConnectorParams,
+    parameters::Parameters,
+};
+use async_trait::async_trait;
+use data_components::RefreshableCatalogProvider as _;
+use std::any::Any;
+use std::sync::Arc;
+
+pub mod provider;
+
+use provider::CayenneCatalogProvider;
+
+/// Catalog connector prefix for Cayenne catalogs.
+pub static PREFIX: &str = "cayenne";
+
+/// Default schema name for Cayenne catalogs (flat namespace).
+pub const CAYENNE_DEFAULT_SCHEMA: &str = "default";
+
+/// The Cayenne catalog also exposes a `public` schema alias so that
+/// unqualified DDL (which DataFusion resolves to the `public` schema)
+/// works transparently.
+pub const CAYENNE_PUBLIC_SCHEMA: &str = "public";
+
+/// Parameters for configuring a Cayenne catalog.
+pub const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::component("cayenne_data_dir")
+        .description("Local directory for table data files. When set, uses local file storage instead of S3. Defaults to spice data directory if neither S3 nor data_dir is configured."),
+    ParameterSpec::component("cayenne_s3_bucket")
+        .description("Explicit S3 Express One Zone bucket name. If not specified, auto-generated from catalog_id and zone."),
+    ParameterSpec::component("cayenne_s3_zone_ids")
+        .description("Comma-separated Availability Zone IDs for S3 Express One Zone storage (e.g., 'usw2-az1'). Required when using S3 storage."),
+    ParameterSpec::component("cayenne_s3_region")
+        .description("AWS region for S3 Express One Zone storage. If not specified, derived from cayenne_s3_zone_ids."),
+    ParameterSpec::component("cayenne_s3_endpoint")
+        .description("Custom S3 endpoint URL for S3 Express One Zone."),
+    ParameterSpec::component("cayenne_s3_key")
+        .description("AWS access key ID for S3 authentication.")
+        .secret(),
+    ParameterSpec::component("cayenne_s3_secret")
+        .description("AWS secret access key for S3 authentication.")
+        .secret(),
+    ParameterSpec::component("cayenne_s3_session_token")
+        .description("AWS session token for temporary credentials (optional).")
+        .secret(),
+    ParameterSpec::component("cayenne_s3_auth")
+        .description("Authentication method: 'iam_role' (default) or 'key'.")
+        .default("iam_role"),
+    ParameterSpec::component("cayenne_s3_client_timeout")
+        .description("Timeout for S3 client operations. Default: 120s.")
+        .default("120s"),
+    ParameterSpec::component("cayenne_s3_allow_http")
+        .description("Allow HTTP (non-TLS) connections. Default: false.")
+        .default("false"),
+    ParameterSpec::component("cayenne_s3_unsigned_payload")
+        .description("Use unsigned payload for S3 Express uploads. Default: true.")
+        .default("true"),
+    ParameterSpec::component("cayenne_metadata_dir")
+        .description("Local directory for Cayenne SQLite metadata. Defaults to spice data directory."),
+    ParameterSpec::component("cayenne_footer_cache_mb")
+        .description("Vortex footer cache size in MB. Default: 128.")
+        .default("128"),
+    ParameterSpec::component("cayenne_segment_cache_mb")
+        .description("Vortex segment cache size in MB. Default: 256.")
+        .default("256"),
+    ParameterSpec::component("cayenne_target_file_size_mb")
+        .description("Target Vortex file size in MB. Default: 128.")
+        .default("128"),
+    ParameterSpec::component("cayenne_compression_strategy")
+        .description("Compression: 'btrblocks' (default) or 'zstd'.")
+        .default("btrblocks"),
+    ParameterSpec::component("cayenne_upload_concurrency")
+        .description("Parallel file upload concurrency. Default: 4.")
+        .default("4"),
+];
+
+/// A catalog connector for Cayenne lakehouse catalogs.
+///
+/// Cayenne catalogs provide a high-performance lakehouse format combining:
+/// - SQLite for transactional metadata management (stored locally)
+/// - Vortex columnar files for data (stored locally or in S3 Express One Zone)
+///
+/// **Storage modes:**
+/// - **Local**: Set `cayenne_data_dir` or omit all S3 parameters. Data is stored on local disk.
+/// - **S3 Express One Zone**: Set `cayenne_s3_zone_ids` (and optionally `cayenne_s3_bucket`).
+///   Data is stored in S3 Express One Zone directory buckets.
+#[derive(Clone)]
+pub struct CayenneCatalogConnector {
+    params: Parameters,
+}
+
+impl CayenneCatalogConnector {
+    /// Create a new Cayenne catalog connector from the given parameters.
+    #[must_use]
+    pub fn new_connector(params: ConnectorParams) -> Arc<dyn CatalogConnector> {
+        Arc::new(Self {
+            params: params.parameters,
+        })
+    }
+}
+
+#[async_trait]
+impl CatalogConnector for CayenneCatalogConnector {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn refreshable_catalog_provider(
+        self: Arc<Self>,
+        _runtime: Arc<Runtime>,
+        catalog: &Catalog,
+    ) -> super::Result<Arc<dyn data_components::RefreshableCatalogProvider>> {
+        let refreshable_provider = Arc::new(
+            CayenneCatalogProvider::try_new(self.params.clone(), catalog)
+                .await
+                .map_err(|e| super::Error::UnableToGetCatalogProvider {
+                    connector: PREFIX.to_string(),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                })?,
+        );
+
+        refreshable_provider.refresh().await.map_err(|source| {
+            super::Error::UnableToGetCatalogProvider {
+                connector: PREFIX.to_string(),
+                connector_component: ConnectorComponent::from(catalog),
+                source,
+            }
+        })?;
+
+        Ok(refreshable_provider)
+    }
+}

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Catalog connector for Cayenne catalogs backed by S3 Express One Zone storage.
+//! Catalog connector for Cayenne catalogs backed by local file storage.
 //!
 //! Cayenne catalogs use SQLite for metadata and Vortex files for columnar data,
-//! with data stored exclusively in S3 Express One Zone directory buckets.
+//! with data stored on local disk.
 
 use super::{CatalogConnector, ConnectorComponent, ParameterSpec};
 use crate::{
@@ -49,36 +49,7 @@ pub const CAYENNE_PUBLIC_SCHEMA: &str = "public";
 /// Parameters for configuring a Cayenne catalog.
 pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("cayenne_data_dir")
-        .description("Local directory for table data files. When set, uses local file storage instead of S3. Defaults to spice data directory if neither S3 nor data_dir is configured."),
-    ParameterSpec::component("cayenne_s3_bucket")
-        .description("Explicit S3 Express One Zone bucket name. If not specified, auto-generated from catalog_id and zone."),
-    ParameterSpec::component("cayenne_s3_zone_ids")
-        .description("Comma-separated Availability Zone IDs for S3 Express One Zone storage (e.g., 'usw2-az1'). Required when using S3 storage."),
-    ParameterSpec::component("cayenne_s3_region")
-        .description("AWS region for S3 Express One Zone storage. If not specified, derived from cayenne_s3_zone_ids."),
-    ParameterSpec::component("cayenne_s3_endpoint")
-        .description("Custom S3 endpoint URL for S3 Express One Zone."),
-    ParameterSpec::component("cayenne_s3_key")
-        .description("AWS access key ID for S3 authentication.")
-        .secret(),
-    ParameterSpec::component("cayenne_s3_secret")
-        .description("AWS secret access key for S3 authentication.")
-        .secret(),
-    ParameterSpec::component("cayenne_s3_session_token")
-        .description("AWS session token for temporary credentials (optional).")
-        .secret(),
-    ParameterSpec::component("cayenne_s3_auth")
-        .description("Authentication method: 'iam_role' (default) or 'key'.")
-        .default("iam_role"),
-    ParameterSpec::component("cayenne_s3_client_timeout")
-        .description("Timeout for S3 client operations. Default: 120s.")
-        .default("120s"),
-    ParameterSpec::component("cayenne_s3_allow_http")
-        .description("Allow HTTP (non-TLS) connections. Default: false.")
-        .default("false"),
-    ParameterSpec::component("cayenne_s3_unsigned_payload")
-        .description("Use unsigned payload for S3 Express uploads. Default: true.")
-        .default("true"),
+        .description("Local directory for table data files. Defaults to spice data directory."),
     ParameterSpec::component("cayenne_metadata_dir")
         .description("Local directory for Cayenne SQLite metadata. Defaults to spice data directory."),
     ParameterSpec::component("cayenne_footer_cache_mb")
@@ -93,21 +64,15 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("cayenne_compression_strategy")
         .description("Compression: 'btrblocks' (default) or 'zstd'.")
         .default("btrblocks"),
-    ParameterSpec::component("cayenne_upload_concurrency")
-        .description("Parallel file upload concurrency. Default: 4.")
-        .default("4"),
 ];
 
 /// A catalog connector for Cayenne lakehouse catalogs.
 ///
 /// Cayenne catalogs provide a high-performance lakehouse format combining:
 /// - SQLite for transactional metadata management (stored locally)
-/// - Vortex columnar files for data (stored locally or in S3 Express One Zone)
+/// - Vortex columnar files for data (stored locally)
 ///
-/// **Storage modes:**
-/// - **Local**: Set `cayenne_data_dir` or omit all S3 parameters. Data is stored on local disk.
-/// - **S3 Express One Zone**: Set `cayenne_s3_zone_ids` (and optionally `cayenne_s3_bucket`).
-///   Data is stored in S3 Express One Zone directory buckets.
+/// Used as `from: cayenne` in the spicepod. Does not support a catalog ID.
 #[derive(Clone)]
 pub struct CayenneCatalogConnector {
     params: Parameters,

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -1,0 +1,694 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Cayenne catalog and schema provider implementations for DataFusion.
+//!
+//! Provides a flat-namespace catalog backed by a Cayenne [`MetadataCatalog`]
+//! (SQLite) and S3 Express One Zone storage for data files.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use aws_sdk_credential_bridge::S3CredentialProvider;
+use cayenne::metadata::{ObjectStoreConfig, VortexConfig};
+use cayenne::{CayenneCatalog, CayenneTableProviderBuilder, MetadataCatalog};
+use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
+use datafusion::error::Result as DFResult;
+use object_store::aws::AmazonS3Builder;
+use object_store::client::SpawnedReqwestConnector;
+use object_store::{ClientOptions, RetryConfig};
+use snafu::prelude::*;
+use url::Url;
+
+use crate::component::catalog::Catalog;
+use crate::dataaccelerator::cayenne::s3::{
+    derive_region_from_zone, generate_bucket_name,
+};
+use crate::parameters::Parameters;
+use crate::spice_data_base_path;
+use data_components::RefreshableCatalogProvider;
+
+use super::CAYENNE_DEFAULT_SCHEMA;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to initialize Cayenne catalog: {source}"))]
+    CatalogInit {
+        source: cayenne::catalog::CatalogError,
+    },
+
+    #[snafu(display("Failed to build S3 object store for Cayenne catalog: {source}"))]
+    S3ObjectStore {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Invalid Cayenne catalog configuration: {message}"))]
+    InvalidConfiguration { message: String },
+
+    #[snafu(display("Failed to create Cayenne table provider: {source}"))]
+    TableProvider {
+        source: cayenne::catalog::CatalogError,
+    },
+
+    #[snafu(display("Failed to create S3 Express One Zone bucket: {source}"))]
+    BucketCreation {
+        source: crate::dataaccelerator::cayenne::s3::Error,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// DataFusion [`CatalogProvider`] backed by a Cayenne metadata catalog.
+///
+/// All tables are in a single "default" schema. Data is stored in S3 Express
+/// One Zone, metadata in local SQLite.
+pub struct CayenneCatalogProvider {
+    /// The underlying Cayenne metadata catalog (SQLite).
+    catalog: Arc<dyn MetadataCatalog>,
+    /// S3 object store configuration for data files.
+    object_store_config: Option<ObjectStoreConfig>,
+    /// Vortex configuration for table providers.
+    vortex_config: VortexConfig,
+    /// Base S3 path for table data.
+    data_base_path: String,
+    /// Local metadata directory.
+    metadata_dir: String,
+    /// Schema providers (just "default" for Cayenne).
+    schemas: RwLock<HashMap<String, Arc<dyn SchemaProvider>>>,
+}
+
+impl std::fmt::Debug for CayenneCatalogProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneCatalogProvider")
+            .field("data_base_path", &self.data_base_path)
+            .field("metadata_dir", &self.metadata_dir)
+            .finish()
+    }
+}
+
+impl CayenneCatalogProvider {
+    /// Create a new Cayenne catalog provider.
+    ///
+    /// Initializes the SQLite metadata catalog and configures storage.
+    /// If S3 parameters (`cayenne_s3_zone_ids` or `cayenne_s3_bucket`) are
+    /// provided, uses S3 Express One Zone. Otherwise, uses local file storage.
+    pub async fn try_new(params: Parameters, catalog_config: &Catalog) -> Result<Self> {
+        let catalog_id = catalog_config
+            .catalog_id
+            .as_deref()
+            .unwrap_or("cayenne_catalog");
+
+        // Resolve metadata directory
+        let metadata_dir = params
+            .get("cayenne_metadata_dir")
+            .expose()
+            .ok()
+            .map(String::from)
+            .unwrap_or_else(|| format!("{}/cayenne_catalog_{catalog_id}/metadata", spice_data_base_path()));
+
+        // Ensure metadata directory exists
+        std::fs::create_dir_all(&metadata_dir).map_err(|e| Error::InvalidConfiguration {
+            message: format!("Failed to create metadata directory '{metadata_dir}': {e}"),
+        })?;
+
+        // Initialize SQLite catalog
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(
+            CayenneCatalog::new(connection_string)
+                .map_err(|e| Error::CatalogInit { source: e })?,
+        ) as Arc<dyn MetadataCatalog>;
+
+        catalog.init().await.context(CatalogInitSnafu)?;
+
+        // Determine storage mode: S3 or local
+        let has_s3_zone = params.get("cayenne_s3_zone_ids").expose().ok().is_some();
+        let has_s3_bucket = params.get("cayenne_s3_bucket").expose().ok().is_some();
+        let use_s3 = has_s3_zone || has_s3_bucket;
+
+        let (data_base_path, object_store_config) = if use_s3 {
+            Self::init_s3_storage(&params, catalog_id).await?
+        } else {
+            Self::init_local_storage(&params, catalog_id)?
+        };
+
+        // Parse Vortex config from parameters
+        let vortex_config = Self::parse_vortex_config(&params);
+
+        let provider = Self {
+            catalog,
+            object_store_config,
+            vortex_config,
+            data_base_path,
+            metadata_dir,
+            schemas: RwLock::new(HashMap::new()),
+        };
+
+        Ok(provider)
+    }
+
+    /// Initialize S3 Express One Zone storage.
+    ///
+    /// Creates the directory bucket if needed and builds the object store config.
+    async fn init_s3_storage(
+        params: &Parameters,
+        catalog_id: &str,
+    ) -> Result<(String, Option<ObjectStoreConfig>)> {
+        let zone_ids_str = params.get("cayenne_s3_zone_ids").expose().ok()
+            .map(String::from)
+            .unwrap_or_default();
+
+        let primary_zone = zone_ids_str
+            .split(',')
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        // Use explicit bucket name if provided, otherwise auto-generate
+        let bucket_name = if let Some(explicit_bucket) = params
+            .get("cayenne_s3_bucket")
+            .expose()
+            .ok()
+        {
+            explicit_bucket.to_string()
+        } else {
+            let zone = primary_zone.ok_or_else(|| Error::InvalidConfiguration {
+                message: "S3 storage requires 'cayenne_s3_zone_ids' when 'cayenne_s3_bucket' is not specified".to_string(),
+            })?;
+            let sanitized_catalog = catalog_id.replace(['.', '/'], "_");
+            generate_bucket_name("catalog", &sanitized_catalog, zone)
+                .map_err(|e| Error::InvalidConfiguration {
+                    message: format!("Failed to generate S3 bucket name: {e}"),
+                })?
+        };
+
+        let data_base_path = format!("s3://{bucket_name}/");
+
+        // Derive region and zone for bucket creation
+        // If zone is known, use it; if only bucket is specified, try to extract zone from bucket name
+        let effective_zone = primary_zone
+            .map(String::from)
+            .or_else(|| {
+                crate::dataaccelerator::cayenne::s3::extract_zone_id_from_bucket(&bucket_name)
+                    .map(String::from)
+            });
+
+        let s3_region = params.get("cayenne_s3_region").expose().ok().map(String::from);
+        let effective_region = s3_region
+            .clone()
+            .or_else(|| {
+                effective_zone.as_deref()
+                    .and_then(|z| derive_region_from_zone(z).map(String::from))
+            })
+            .ok_or_else(|| Error::InvalidConfiguration {
+                message: "Cannot determine AWS region. Specify 'cayenne_s3_region' or 'cayenne_s3_zone_ids'.".to_string(),
+            })?;
+
+        // Extract credentials for bucket creation
+        let s3_key = params.get("cayenne_s3_key").expose().ok().map(String::from);
+        let s3_secret = params.get("cayenne_s3_secret").expose().ok().map(String::from);
+        let s3_session_token = params.get("cayenne_s3_session_token").expose().ok().map(String::from);
+
+        // Ensure the S3 Express One Zone directory bucket exists
+        if let Some(ref zone) = effective_zone {
+            crate::dataaccelerator::cayenne::s3::create_s3_express_bucket_if_needed(
+                &bucket_name,
+                zone,
+                &effective_region,
+                s3_key.clone(),
+                s3_secret.clone(),
+                s3_session_token.clone(),
+            )
+            .await
+            .context(BucketCreationSnafu)?;
+        }
+
+        // Build object store config
+        let zone_for_store = effective_zone.as_deref().unwrap_or("");
+        let object_store_config =
+            Self::build_object_store(params, &data_base_path, zone_for_store).await?;
+
+        Ok((data_base_path, Some(object_store_config)))
+    }
+
+    /// Initialize local file storage.
+    ///
+    /// Creates the data directory and returns the local path.
+    fn init_local_storage(
+        params: &Parameters,
+        catalog_id: &str,
+    ) -> Result<(String, Option<ObjectStoreConfig>)> {
+        let data_dir = params
+            .get("cayenne_data_dir")
+            .expose()
+            .ok()
+            .map(String::from)
+            .unwrap_or_else(|| format!("{}/cayenne_catalog_{catalog_id}/data", spice_data_base_path()));
+
+        std::fs::create_dir_all(&data_dir).map_err(|e| Error::InvalidConfiguration {
+            message: format!("Failed to create data directory '{data_dir}': {e}"),
+        })?;
+
+        // Ensure trailing slash for consistent path joining
+        let data_base_path = if data_dir.ends_with('/') {
+            data_dir
+        } else {
+            format!("{data_dir}/")
+        };
+
+        tracing::info!("Cayenne catalog using local file storage at '{data_base_path}'");
+
+        Ok((data_base_path, None))
+    }
+
+    /// Returns a reference to the underlying Cayenne metadata catalog.
+    #[must_use]
+    pub fn metadata_catalog(&self) -> &Arc<dyn MetadataCatalog> {
+        &self.catalog
+    }
+
+    /// Returns the S3 object store configuration, if any.
+    #[must_use]
+    pub fn object_store_config(&self) -> Option<&ObjectStoreConfig> {
+        self.object_store_config.as_ref()
+    }
+
+    /// Returns the base data path (S3 Express One Zone URL).
+    #[must_use]
+    pub fn data_base_path(&self) -> &str {
+        &self.data_base_path
+    }
+
+    /// Returns the Vortex configuration.
+    #[must_use]
+    pub fn vortex_config(&self) -> &VortexConfig {
+        &self.vortex_config
+    }
+
+    /// Returns the metadata directory path.
+    #[must_use]
+    pub fn metadata_dir(&self) -> &str {
+        &self.metadata_dir
+    }
+
+    /// Build S3 object store for the Cayenne catalog.
+    async fn build_object_store(
+        params: &Parameters,
+        data_path: &str,
+        zone_id: &str,
+    ) -> Result<ObjectStoreConfig> {
+        let url = Url::parse(data_path).map_err(|e| Error::InvalidConfiguration {
+            message: format!("Invalid S3 data path '{data_path}': {e}"),
+        })?;
+
+        let bucket_name = aws_sdk_credential_bridge::get_bucket_name(&url)
+            .map_err(|e| Error::InvalidConfiguration {
+                message: format!("Cannot extract bucket name from '{data_path}': {e}"),
+            })?
+            .to_string();
+
+        // Get credentials from params
+        let s3_region = params.get("cayenne_s3_region").expose().ok().map(String::from);
+        let s3_endpoint = params.get("cayenne_s3_endpoint").expose().ok().map(String::from);
+        let s3_key = params.get("cayenne_s3_key").expose().ok().map(String::from);
+        let s3_secret = params.get("cayenne_s3_secret").expose().ok().map(String::from);
+        let s3_session_token = params.get("cayenne_s3_session_token").expose().ok().map(String::from);
+        let s3_auth = params
+            .get("cayenne_s3_auth")
+            .expose()
+            .ok()
+            .unwrap_or("iam_role");
+        let s3_allow_http = params
+            .get("cayenne_s3_allow_http")
+            .expose()
+            .ok()
+            .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+        let s3_unsigned_payload = params
+            .get("cayenne_s3_unsigned_payload")
+            .expose()
+            .ok()
+            .is_none_or(|v| !v.eq_ignore_ascii_case("false"));
+
+        // Derive region
+        let effective_region = s3_region
+            .or_else(|| derive_region_from_zone(zone_id).map(String::from))
+            .ok_or_else(|| Error::InvalidConfiguration {
+                message: format!(
+                    "Cannot determine AWS region. Specify 'cayenne_s3_region' or use standard zone ID format. Zone: {zone_id}"
+                ),
+            })?
+            .to_string();
+
+        let io_runtime = tokio::runtime::Handle::current();
+        let mut s3_builder = AmazonS3Builder::from_env()
+            .with_bucket_name(&bucket_name)
+            .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
+            .with_allow_http(s3_allow_http)
+            .with_region(&effective_region)
+            .with_s3_express(true)
+            .with_virtual_hosted_style_request(true)
+            .with_unsigned_payload(s3_unsigned_payload);
+
+        // Set retry config
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            retry_timeout: std::time::Duration::from_secs(600),
+            ..Default::default()
+        };
+        s3_builder = s3_builder.with_retry(retry_config);
+
+        // S3 Express endpoint
+        if let Some(ref endpoint) = s3_endpoint {
+            s3_builder = s3_builder.with_endpoint(endpoint);
+        } else {
+            let express_endpoint =
+                format!("https://{bucket_name}.s3express-{zone_id}.{effective_region}.amazonaws.com");
+            s3_builder = s3_builder.with_endpoint(&express_endpoint);
+        }
+
+        // Client timeout
+        let mut client_options =
+            ClientOptions::default().with_timeout(std::time::Duration::from_secs(120));
+        if let Some(timeout_str) = params.get("cayenne_s3_client_timeout").expose().ok() {
+            if let Ok(duration) = fundu::parse_duration(timeout_str) {
+                client_options = client_options.with_timeout(duration);
+            }
+        }
+        s3_builder = s3_builder.with_client_options(client_options);
+
+        // Credentials
+        let mut load_from_env = true;
+        if s3_auth == "key" {
+            if let (Some(key), Some(secret)) = (&s3_key, &s3_secret) {
+                s3_builder = s3_builder.with_access_key_id(key);
+                s3_builder = s3_builder.with_secret_access_key(secret);
+                if let Some(ref token) = s3_session_token {
+                    s3_builder = s3_builder.with_token(token);
+                }
+                load_from_env = false;
+            }
+        }
+
+        if load_from_env {
+            if let Ok(Some(sdk_config)) =
+                aws_sdk_credential_bridge::get_or_init_sdk_config().await
+            {
+                if sdk_config.credentials_provider().is_some() {
+                    s3_builder = s3_builder.with_credentials(Arc::new(
+                        S3CredentialProvider::from_config(sdk_config.as_ref())
+                            .boxed()
+                            .context(S3ObjectStoreSnafu)?,
+                    ));
+                }
+            }
+        }
+
+        let store = s3_builder.build().boxed().context(S3ObjectStoreSnafu)?;
+
+        Ok(ObjectStoreConfig {
+            url,
+            store: Arc::new(store),
+        })
+    }
+
+    /// Parse Vortex configuration from catalog parameters.
+    fn parse_vortex_config(params: &Parameters) -> VortexConfig {
+        let mut config = VortexConfig::default();
+
+        if let Some(v) = params.get("cayenne_footer_cache_mb").expose().ok() {
+            if let Ok(val) = v.parse::<usize>() {
+                config.footer_cache_mb = val;
+            }
+        }
+        if let Some(v) = params.get("cayenne_segment_cache_mb").expose().ok() {
+            if let Ok(val) = v.parse::<usize>() {
+                config.segment_cache_mb = val;
+            }
+        }
+        if let Some(v) = params.get("cayenne_target_file_size_mb").expose().ok() {
+            if let Ok(val) = v.parse::<usize>() {
+                config.target_vortex_file_size_mb = val;
+            }
+        }
+        if let Some(v) = params.get("cayenne_compression_strategy").expose().ok() {
+            match v.to_lowercase().as_str() {
+                "zstd" => {
+                    config.compression_strategy =
+                        cayenne::metadata::CompressionStrategy::Zstd;
+                }
+                "btrblocks" => {
+                    config.compression_strategy =
+                        cayenne::metadata::CompressionStrategy::Btrblocks;
+                }
+                _ => {}
+            }
+        }
+        if let Some(v) = params.get("cayenne_upload_concurrency").expose().ok() {
+            if let Ok(val) = v.parse::<usize>() {
+                config.upload_concurrency = val.max(1);
+            }
+        }
+
+        config
+    }
+
+    /// Load all tables from the Cayenne catalog into a schema provider.
+    async fn load_schema(
+        catalog: &Arc<dyn MetadataCatalog>,
+        object_store_config: Option<&ObjectStoreConfig>,
+    ) -> Result<Arc<dyn SchemaProvider>> {
+        let schema_provider = CayenneSchemaProvider::try_new(
+            Arc::clone(catalog),
+            object_store_config.cloned(),
+        )
+        .await?;
+
+        Ok(Arc::new(schema_provider))
+    }
+}
+
+impl CatalogProvider for CayenneCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        vec![
+            CAYENNE_DEFAULT_SCHEMA.to_string(),
+            super::CAYENNE_PUBLIC_SCHEMA.to_string(),
+        ]
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        // Both "default" and "public" resolve to the same schema provider.
+        let key = if name == super::CAYENNE_PUBLIC_SCHEMA {
+            CAYENNE_DEFAULT_SCHEMA
+        } else {
+            name
+        };
+        self.schemas
+            .read()
+            .ok()
+            .and_then(|schemas| schemas.get(key).cloned())
+    }
+}
+
+#[async_trait]
+impl RefreshableCatalogProvider for CayenneCatalogProvider {
+    async fn refresh(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let schema = Self::load_schema(&self.catalog, self.object_store_config.as_ref()).await?;
+
+        match self.schemas.write() {
+            Ok(mut schemas) => {
+                schemas.insert(CAYENNE_DEFAULT_SCHEMA.to_string(), schema);
+            }
+            Err(poisoned) => {
+                poisoned
+                    .into_inner()
+                    .insert(CAYENNE_DEFAULT_SCHEMA.to_string(), schema);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Schema provider for a Cayenne catalog's "default" schema.
+///
+/// Discovers all tables in the Cayenne metadata catalog and creates
+/// [`CayenneTableProvider`] instances for each.
+pub struct CayenneSchemaProvider {
+    /// The underlying Cayenne metadata catalog.
+    catalog: Arc<dyn MetadataCatalog>,
+    /// S3 object store config for creating table providers.
+    object_store_config: Option<ObjectStoreConfig>,
+    /// Table providers keyed by table name.
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
+}
+
+impl std::fmt::Debug for CayenneSchemaProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneSchemaProvider").finish()
+    }
+}
+
+impl CayenneSchemaProvider {
+    /// Create a new schema provider, loading all existing tables from the catalog.
+    pub async fn try_new(
+        catalog: Arc<dyn MetadataCatalog>,
+        object_store_config: Option<ObjectStoreConfig>,
+    ) -> Result<Self> {
+        // Load all existing tables from the metadata catalog
+        let table_names = catalog
+            .list_table_names()
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to list existing Cayenne tables: {e}");
+                Vec::new()
+            });
+
+        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
+        for name in &table_names {
+            match Self::load_table(&catalog, name, object_store_config.as_ref()).await {
+                Ok(Some(provider)) => {
+                    tables.insert(name.clone(), provider);
+                }
+                Ok(None) => {
+                    tracing::debug!("Table '{name}' listed in catalog but could not be loaded");
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load Cayenne table '{name}': {e}");
+                }
+            }
+        }
+
+        if !tables.is_empty() {
+            tracing::info!(
+                "Loaded {} existing Cayenne table{}",
+                tables.len(),
+                if tables.len() == 1 { "" } else { "s" }
+            );
+        }
+
+        let provider = Self {
+            catalog,
+            object_store_config,
+            tables: RwLock::new(tables),
+        };
+
+        Ok(provider)
+    }
+
+    /// Returns a reference to the underlying Cayenne metadata catalog.
+    #[must_use]
+    pub fn metadata_catalog(&self) -> &Arc<dyn MetadataCatalog> {
+        &self.catalog
+    }
+
+    /// Create a [`CayenneTableProvider`] for a table by name.
+    async fn load_table(
+        catalog: &Arc<dyn MetadataCatalog>,
+        table_name: &str,
+        object_store_config: Option<&ObjectStoreConfig>,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        // Check if the table exists in the catalog
+        match catalog.get_table(table_name).await {
+            Ok(_metadata) => {
+                let mut builder = CayenneTableProviderBuilder::new(Arc::clone(catalog));
+                if let Some(config) = object_store_config {
+                    builder = builder.with_object_store(config.clone());
+                }
+
+                match builder.open(table_name).await {
+                    Ok(provider) => Ok(Some(Arc::new(provider))),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to open Cayenne table '{table_name}': {e}"
+                        );
+                        Ok(None)
+                    }
+                }
+            }
+            Err(cayenne::catalog::CatalogError::TableNotFound { .. }) => Ok(None),
+            Err(e) => Err(Error::TableProvider { source: e }),
+        }
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for CayenneSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.tables
+            .read()
+            .map(|tables| tables.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables
+            .read()
+            .map(|tables| tables.contains_key(name))
+            .unwrap_or(false)
+    }
+
+    async fn table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        // Check in-memory cache first
+        if let Ok(tables) = self.tables.read() {
+            if let Some(provider) = tables.get(name) {
+                return Ok(Some(Arc::clone(provider)));
+            }
+        }
+
+        // Try to load from catalog (lazy loading)
+        match Self::load_table(&self.catalog, name, self.object_store_config.as_ref()).await {
+            Ok(Some(provider)) => {
+                if let Ok(mut tables) = self.tables.write() {
+                    tables.insert(name.to_string(), Arc::clone(&provider));
+                }
+                Ok(Some(provider))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(datafusion::error::DataFusionError::External(Box::new(e))),
+        }
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        match self.tables.write() {
+            Ok(mut tables) => Ok(tables.insert(name, table)),
+            Err(_) => Err(datafusion::error::DataFusionError::Internal(
+                "Failed to acquire write lock on Cayenne tables".to_string(),
+            )),
+        }
+    }
+
+    fn deregister_table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        match self.tables.write() {
+            Ok(mut tables) => Ok(tables.remove(name)),
+            Err(_) => Err(datafusion::error::DataFusionError::Internal(
+                "Failed to acquire write lock on Cayenne tables".to_string(),
+            )),
+        }
+    }
+}

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -17,28 +17,20 @@ limitations under the License.
 //! Cayenne catalog and schema provider implementations for DataFusion.
 //!
 //! Provides a flat-namespace catalog backed by a Cayenne [`MetadataCatalog`]
-//! (SQLite) and S3 Express One Zone storage for data files.
+//! (SQLite) and local file storage for data files.
 
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
-use aws_sdk_credential_bridge::S3CredentialProvider;
-use cayenne::metadata::{ObjectStoreConfig, VortexConfig};
+use cayenne::metadata::VortexConfig;
 use cayenne::{CayenneCatalog, CayenneTableProviderBuilder, MetadataCatalog};
 use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
 use datafusion::error::Result as DFResult;
-use object_store::aws::AmazonS3Builder;
-use object_store::client::SpawnedReqwestConnector;
-use object_store::{ClientOptions, RetryConfig};
 use snafu::prelude::*;
-use url::Url;
 
 use crate::component::catalog::Catalog;
-use crate::dataaccelerator::cayenne::s3::{
-    derive_region_from_zone, generate_bucket_name,
-};
 use crate::parameters::Parameters;
 use crate::spice_data_base_path;
 use data_components::RefreshableCatalogProvider;
@@ -52,11 +44,6 @@ pub enum Error {
         source: cayenne::catalog::CatalogError,
     },
 
-    #[snafu(display("Failed to build S3 object store for Cayenne catalog: {source}"))]
-    S3ObjectStore {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
     #[snafu(display("Invalid Cayenne catalog configuration: {message}"))]
     InvalidConfiguration { message: String },
 
@@ -64,27 +51,23 @@ pub enum Error {
     TableProvider {
         source: cayenne::catalog::CatalogError,
     },
-
-    #[snafu(display("Failed to create S3 Express One Zone bucket: {source}"))]
-    BucketCreation {
-        source: crate::dataaccelerator::cayenne::s3::Error,
-    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Default catalog name used when no catalog ID is specified.
+const DEFAULT_CATALOG_NAME: &str = "cayenne";
+
 /// DataFusion [`CatalogProvider`] backed by a Cayenne metadata catalog.
 ///
-/// All tables are in a single "default" schema. Data is stored in S3 Express
-/// One Zone, metadata in local SQLite.
+/// All tables are in a single "default" schema. Data is stored on local disk,
+/// metadata in local SQLite.
 pub struct CayenneCatalogProvider {
     /// The underlying Cayenne metadata catalog (SQLite).
     catalog: Arc<dyn MetadataCatalog>,
-    /// S3 object store configuration for data files.
-    object_store_config: Option<ObjectStoreConfig>,
     /// Vortex configuration for table providers.
     vortex_config: VortexConfig,
-    /// Base S3 path for table data.
+    /// Base path for table data on local disk.
     data_base_path: String,
     /// Local metadata directory.
     metadata_dir: String,
@@ -104,14 +87,10 @@ impl std::fmt::Debug for CayenneCatalogProvider {
 impl CayenneCatalogProvider {
     /// Create a new Cayenne catalog provider.
     ///
-    /// Initializes the SQLite metadata catalog and configures storage.
-    /// If S3 parameters (`cayenne_s3_zone_ids` or `cayenne_s3_bucket`) are
-    /// provided, uses S3 Express One Zone. Otherwise, uses local file storage.
-    pub async fn try_new(params: Parameters, catalog_config: &Catalog) -> Result<Self> {
-        let catalog_id = catalog_config
-            .catalog_id
-            .as_deref()
-            .unwrap_or("cayenne_catalog");
+    /// Initializes the SQLite metadata catalog and local file storage.
+    /// The `catalog_id` field is ignored; Cayenne always uses a fixed default name.
+    pub async fn try_new(params: Parameters, _catalog_config: &Catalog) -> Result<Self> {
+        let catalog_name = DEFAULT_CATALOG_NAME;
 
         // Resolve metadata directory
         let metadata_dir = params
@@ -119,7 +98,7 @@ impl CayenneCatalogProvider {
             .expose()
             .ok()
             .map(String::from)
-            .unwrap_or_else(|| format!("{}/cayenne_catalog_{catalog_id}/metadata", spice_data_base_path()));
+            .unwrap_or_else(|| format!("{}/cayenne_{catalog_name}/metadata", spice_data_base_path()));
 
         // Ensure metadata directory exists
         std::fs::create_dir_all(&metadata_dir).map_err(|e| Error::InvalidConfiguration {
@@ -135,129 +114,13 @@ impl CayenneCatalogProvider {
 
         catalog.init().await.context(CatalogInitSnafu)?;
 
-        // Determine storage mode: S3 or local
-        let has_s3_zone = params.get("cayenne_s3_zone_ids").expose().ok().is_some();
-        let has_s3_bucket = params.get("cayenne_s3_bucket").expose().ok().is_some();
-        let use_s3 = has_s3_zone || has_s3_bucket;
-
-        let (data_base_path, object_store_config) = if use_s3 {
-            Self::init_s3_storage(&params, catalog_id).await?
-        } else {
-            Self::init_local_storage(&params, catalog_id)?
-        };
-
-        // Parse Vortex config from parameters
-        let vortex_config = Self::parse_vortex_config(&params);
-
-        let provider = Self {
-            catalog,
-            object_store_config,
-            vortex_config,
-            data_base_path,
-            metadata_dir,
-            schemas: RwLock::new(HashMap::new()),
-        };
-
-        Ok(provider)
-    }
-
-    /// Initialize S3 Express One Zone storage.
-    ///
-    /// Creates the directory bucket if needed and builds the object store config.
-    async fn init_s3_storage(
-        params: &Parameters,
-        catalog_id: &str,
-    ) -> Result<(String, Option<ObjectStoreConfig>)> {
-        let zone_ids_str = params.get("cayenne_s3_zone_ids").expose().ok()
-            .map(String::from)
-            .unwrap_or_default();
-
-        let primary_zone = zone_ids_str
-            .split(',')
-            .next()
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
-
-        // Use explicit bucket name if provided, otherwise auto-generate
-        let bucket_name = if let Some(explicit_bucket) = params
-            .get("cayenne_s3_bucket")
-            .expose()
-            .ok()
-        {
-            explicit_bucket.to_string()
-        } else {
-            let zone = primary_zone.ok_or_else(|| Error::InvalidConfiguration {
-                message: "S3 storage requires 'cayenne_s3_zone_ids' when 'cayenne_s3_bucket' is not specified".to_string(),
-            })?;
-            let sanitized_catalog = catalog_id.replace(['.', '/'], "_");
-            generate_bucket_name("catalog", &sanitized_catalog, zone)
-                .map_err(|e| Error::InvalidConfiguration {
-                    message: format!("Failed to generate S3 bucket name: {e}"),
-                })?
-        };
-
-        let data_base_path = format!("s3://{bucket_name}/");
-
-        // Derive region and zone for bucket creation
-        // If zone is known, use it; if only bucket is specified, try to extract zone from bucket name
-        let effective_zone = primary_zone
-            .map(String::from)
-            .or_else(|| {
-                crate::dataaccelerator::cayenne::s3::extract_zone_id_from_bucket(&bucket_name)
-                    .map(String::from)
-            });
-
-        let s3_region = params.get("cayenne_s3_region").expose().ok().map(String::from);
-        let effective_region = s3_region
-            .clone()
-            .or_else(|| {
-                effective_zone.as_deref()
-                    .and_then(|z| derive_region_from_zone(z).map(String::from))
-            })
-            .ok_or_else(|| Error::InvalidConfiguration {
-                message: "Cannot determine AWS region. Specify 'cayenne_s3_region' or 'cayenne_s3_zone_ids'.".to_string(),
-            })?;
-
-        // Extract credentials for bucket creation
-        let s3_key = params.get("cayenne_s3_key").expose().ok().map(String::from);
-        let s3_secret = params.get("cayenne_s3_secret").expose().ok().map(String::from);
-        let s3_session_token = params.get("cayenne_s3_session_token").expose().ok().map(String::from);
-
-        // Ensure the S3 Express One Zone directory bucket exists
-        if let Some(ref zone) = effective_zone {
-            crate::dataaccelerator::cayenne::s3::create_s3_express_bucket_if_needed(
-                &bucket_name,
-                zone,
-                &effective_region,
-                s3_key.clone(),
-                s3_secret.clone(),
-                s3_session_token.clone(),
-            )
-            .await
-            .context(BucketCreationSnafu)?;
-        }
-
-        // Build object store config
-        let zone_for_store = effective_zone.as_deref().unwrap_or("");
-        let object_store_config =
-            Self::build_object_store(params, &data_base_path, zone_for_store).await?;
-
-        Ok((data_base_path, Some(object_store_config)))
-    }
-
-    /// Initialize local file storage.
-    ///
-    /// Creates the data directory and returns the local path.
-    fn init_local_storage(
-        params: &Parameters,
-        catalog_id: &str,
-    ) -> Result<(String, Option<ObjectStoreConfig>)> {
+        // Initialize local file storage
         let data_dir = params
             .get("cayenne_data_dir")
             .expose()
             .ok()
             .map(String::from)
-            .unwrap_or_else(|| format!("{}/cayenne_catalog_{catalog_id}/data", spice_data_base_path()));
+            .unwrap_or_else(|| format!("{}/cayenne_{catalog_name}/data", spice_data_base_path()));
 
         std::fs::create_dir_all(&data_dir).map_err(|e| Error::InvalidConfiguration {
             message: format!("Failed to create data directory '{data_dir}': {e}"),
@@ -272,7 +135,18 @@ impl CayenneCatalogProvider {
 
         tracing::info!("Cayenne catalog using local file storage at '{data_base_path}'");
 
-        Ok((data_base_path, None))
+        // Parse Vortex config from parameters
+        let vortex_config = Self::parse_vortex_config(&params);
+
+        let provider = Self {
+            catalog,
+            vortex_config,
+            data_base_path,
+            metadata_dir,
+            schemas: RwLock::new(HashMap::new()),
+        };
+
+        Ok(provider)
     }
 
     /// Returns a reference to the underlying Cayenne metadata catalog.
@@ -281,13 +155,7 @@ impl CayenneCatalogProvider {
         &self.catalog
     }
 
-    /// Returns the S3 object store configuration, if any.
-    #[must_use]
-    pub fn object_store_config(&self) -> Option<&ObjectStoreConfig> {
-        self.object_store_config.as_ref()
-    }
-
-    /// Returns the base data path (S3 Express One Zone URL).
+    /// Returns the base data path on local disk.
     #[must_use]
     pub fn data_base_path(&self) -> &str {
         &self.data_base_path
@@ -303,126 +171,6 @@ impl CayenneCatalogProvider {
     #[must_use]
     pub fn metadata_dir(&self) -> &str {
         &self.metadata_dir
-    }
-
-    /// Build S3 object store for the Cayenne catalog.
-    async fn build_object_store(
-        params: &Parameters,
-        data_path: &str,
-        zone_id: &str,
-    ) -> Result<ObjectStoreConfig> {
-        let url = Url::parse(data_path).map_err(|e| Error::InvalidConfiguration {
-            message: format!("Invalid S3 data path '{data_path}': {e}"),
-        })?;
-
-        let bucket_name = aws_sdk_credential_bridge::get_bucket_name(&url)
-            .map_err(|e| Error::InvalidConfiguration {
-                message: format!("Cannot extract bucket name from '{data_path}': {e}"),
-            })?
-            .to_string();
-
-        // Get credentials from params
-        let s3_region = params.get("cayenne_s3_region").expose().ok().map(String::from);
-        let s3_endpoint = params.get("cayenne_s3_endpoint").expose().ok().map(String::from);
-        let s3_key = params.get("cayenne_s3_key").expose().ok().map(String::from);
-        let s3_secret = params.get("cayenne_s3_secret").expose().ok().map(String::from);
-        let s3_session_token = params.get("cayenne_s3_session_token").expose().ok().map(String::from);
-        let s3_auth = params
-            .get("cayenne_s3_auth")
-            .expose()
-            .ok()
-            .unwrap_or("iam_role");
-        let s3_allow_http = params
-            .get("cayenne_s3_allow_http")
-            .expose()
-            .ok()
-            .is_some_and(|v| v.eq_ignore_ascii_case("true"));
-        let s3_unsigned_payload = params
-            .get("cayenne_s3_unsigned_payload")
-            .expose()
-            .ok()
-            .is_none_or(|v| !v.eq_ignore_ascii_case("false"));
-
-        // Derive region
-        let effective_region = s3_region
-            .or_else(|| derive_region_from_zone(zone_id).map(String::from))
-            .ok_or_else(|| Error::InvalidConfiguration {
-                message: format!(
-                    "Cannot determine AWS region. Specify 'cayenne_s3_region' or use standard zone ID format. Zone: {zone_id}"
-                ),
-            })?
-            .to_string();
-
-        let io_runtime = tokio::runtime::Handle::current();
-        let mut s3_builder = AmazonS3Builder::from_env()
-            .with_bucket_name(&bucket_name)
-            .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
-            .with_allow_http(s3_allow_http)
-            .with_region(&effective_region)
-            .with_s3_express(true)
-            .with_virtual_hosted_style_request(true)
-            .with_unsigned_payload(s3_unsigned_payload);
-
-        // Set retry config
-        let retry_config = RetryConfig {
-            max_retries: 3,
-            retry_timeout: std::time::Duration::from_secs(600),
-            ..Default::default()
-        };
-        s3_builder = s3_builder.with_retry(retry_config);
-
-        // S3 Express endpoint
-        if let Some(ref endpoint) = s3_endpoint {
-            s3_builder = s3_builder.with_endpoint(endpoint);
-        } else {
-            let express_endpoint =
-                format!("https://{bucket_name}.s3express-{zone_id}.{effective_region}.amazonaws.com");
-            s3_builder = s3_builder.with_endpoint(&express_endpoint);
-        }
-
-        // Client timeout
-        let mut client_options =
-            ClientOptions::default().with_timeout(std::time::Duration::from_secs(120));
-        if let Some(timeout_str) = params.get("cayenne_s3_client_timeout").expose().ok() {
-            if let Ok(duration) = fundu::parse_duration(timeout_str) {
-                client_options = client_options.with_timeout(duration);
-            }
-        }
-        s3_builder = s3_builder.with_client_options(client_options);
-
-        // Credentials
-        let mut load_from_env = true;
-        if s3_auth == "key" {
-            if let (Some(key), Some(secret)) = (&s3_key, &s3_secret) {
-                s3_builder = s3_builder.with_access_key_id(key);
-                s3_builder = s3_builder.with_secret_access_key(secret);
-                if let Some(ref token) = s3_session_token {
-                    s3_builder = s3_builder.with_token(token);
-                }
-                load_from_env = false;
-            }
-        }
-
-        if load_from_env {
-            if let Ok(Some(sdk_config)) =
-                aws_sdk_credential_bridge::get_or_init_sdk_config().await
-            {
-                if sdk_config.credentials_provider().is_some() {
-                    s3_builder = s3_builder.with_credentials(Arc::new(
-                        S3CredentialProvider::from_config(sdk_config.as_ref())
-                            .boxed()
-                            .context(S3ObjectStoreSnafu)?,
-                    ));
-                }
-            }
-        }
-
-        let store = s3_builder.build().boxed().context(S3ObjectStoreSnafu)?;
-
-        Ok(ObjectStoreConfig {
-            url,
-            store: Arc::new(store),
-        })
     }
 
     /// Parse Vortex configuration from catalog parameters.
@@ -457,11 +205,6 @@ impl CayenneCatalogProvider {
                 _ => {}
             }
         }
-        if let Some(v) = params.get("cayenne_upload_concurrency").expose().ok() {
-            if let Ok(val) = v.parse::<usize>() {
-                config.upload_concurrency = val.max(1);
-            }
-        }
 
         config
     }
@@ -469,11 +212,9 @@ impl CayenneCatalogProvider {
     /// Load all tables from the Cayenne catalog into a schema provider.
     async fn load_schema(
         catalog: &Arc<dyn MetadataCatalog>,
-        object_store_config: Option<&ObjectStoreConfig>,
     ) -> Result<Arc<dyn SchemaProvider>> {
         let schema_provider = CayenneSchemaProvider::try_new(
             Arc::clone(catalog),
-            object_store_config.cloned(),
         )
         .await?;
 
@@ -510,7 +251,7 @@ impl CatalogProvider for CayenneCatalogProvider {
 #[async_trait]
 impl RefreshableCatalogProvider for CayenneCatalogProvider {
     async fn refresh(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let schema = Self::load_schema(&self.catalog, self.object_store_config.as_ref()).await?;
+        let schema = Self::load_schema(&self.catalog).await?;
 
         match self.schemas.write() {
             Ok(mut schemas) => {
@@ -534,8 +275,6 @@ impl RefreshableCatalogProvider for CayenneCatalogProvider {
 pub struct CayenneSchemaProvider {
     /// The underlying Cayenne metadata catalog.
     catalog: Arc<dyn MetadataCatalog>,
-    /// S3 object store config for creating table providers.
-    object_store_config: Option<ObjectStoreConfig>,
     /// Table providers keyed by table name.
     tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
 }
@@ -550,7 +289,6 @@ impl CayenneSchemaProvider {
     /// Create a new schema provider, loading all existing tables from the catalog.
     pub async fn try_new(
         catalog: Arc<dyn MetadataCatalog>,
-        object_store_config: Option<ObjectStoreConfig>,
     ) -> Result<Self> {
         // Load all existing tables from the metadata catalog
         let table_names = catalog
@@ -563,7 +301,7 @@ impl CayenneSchemaProvider {
 
         let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
         for name in &table_names {
-            match Self::load_table(&catalog, name, object_store_config.as_ref()).await {
+            match Self::load_table(&catalog, name).await {
                 Ok(Some(provider)) => {
                     tables.insert(name.clone(), provider);
                 }
@@ -586,7 +324,6 @@ impl CayenneSchemaProvider {
 
         let provider = Self {
             catalog,
-            object_store_config,
             tables: RwLock::new(tables),
         };
 
@@ -603,15 +340,11 @@ impl CayenneSchemaProvider {
     async fn load_table(
         catalog: &Arc<dyn MetadataCatalog>,
         table_name: &str,
-        object_store_config: Option<&ObjectStoreConfig>,
     ) -> Result<Option<Arc<dyn TableProvider>>> {
         // Check if the table exists in the catalog
         match catalog.get_table(table_name).await {
             Ok(_metadata) => {
-                let mut builder = CayenneTableProviderBuilder::new(Arc::clone(catalog));
-                if let Some(config) = object_store_config {
-                    builder = builder.with_object_store(config.clone());
-                }
+                let builder = CayenneTableProviderBuilder::new(Arc::clone(catalog));
 
                 match builder.open(table_name).await {
                     Ok(provider) => Ok(Some(Arc::new(provider))),
@@ -658,7 +391,7 @@ impl SchemaProvider for CayenneSchemaProvider {
         }
 
         // Try to load from catalog (lazy loading)
-        match Self::load_table(&self.catalog, name, self.object_store_config.as_ref()).await {
+        match Self::load_table(&self.catalog, name).await {
             Ok(Some(provider)) => {
                 if let Ok(mut tables) = self.tables.write() {
                     tables.insert(name.to_string(), Arc::clone(&provider));

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -85,6 +85,8 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[cfg(not(windows))]
+pub mod cayenne;
 #[cfg(feature = "databricks")]
 pub mod databricks;
 pub mod deferred;
@@ -175,6 +177,16 @@ pub async fn register_all() {
             ducklake::DuckLakeCatalog::new_connector,
             ducklake::PREFIX,
             ducklake::PARAMETERS,
+        ),
+    );
+
+    #[cfg(not(windows))]
+    registry.insert(
+        cayenne::PREFIX.to_string(),
+        CatalogConnectorFactory::new(
+            cayenne::CayenneCatalogConnector::new_connector,
+            cayenne::PREFIX,
+            cayenne::PARAMETERS,
         ),
     );
 }

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -214,7 +214,7 @@ pub async fn start_executor_flight_server(
         )
         .layer(WriteRateLimitLayer::new(RateLimiter::direct(
             RateLimits::default().flight_write_limit,
-        )));
+        ), true));
 
     let server = server.add_service(
         arrow_flight::flight_service_server::FlightServiceServer::new(composite_service)

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -186,6 +186,14 @@ impl TryFrom<spicepod_catalog::Catalog> for CatalogBuilder {
 
         validate_identifier(&catalog.name).context(crate::ComponentSnafu)?;
 
+        if catalog.name.eq_ignore_ascii_case(crate::datafusion::SPICE_DEFAULT_CATALOG) {
+            return Err(crate::Error::ComponentError {
+                source: super::Error::ReservedCatalogName {
+                    name: catalog.name.clone(),
+                },
+            });
+        }
+
         Ok(CatalogBuilder {
             provider: provider.to_string(),
             catalog_id,
@@ -214,6 +222,14 @@ impl CatalogBuilder {
     #[expect(clippy::result_large_err)]
     pub fn try_new(from: String, name: &str) -> std::result::Result<Self, crate::Error> {
         validate_identifier(name).context(crate::ComponentSnafu)?;
+
+        if name.eq_ignore_ascii_case(crate::datafusion::SPICE_DEFAULT_CATALOG) {
+            return Err(crate::Error::ComponentError {
+                source: super::Error::ReservedCatalogName {
+                    name: name.to_string(),
+                },
+            });
+        }
 
         let provider = Catalog::provider(from.as_str());
         let catalog_id = Catalog::catalog_id(from.as_str()).map(String::from);

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -28,6 +28,11 @@ pub enum Error {
         "Component name is not a valid SQL identifier. Use alphanumeric characters, underscores, or quoted identifiers."
     ))]
     InvalidIdentifier,
+
+    #[snafu(display(
+        "'{name}' is a reserved catalog name and cannot be used. Choose a different name for the catalog."
+    ))]
+    ReservedCatalogName { name: String },
 }
 
 pub mod access;

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -124,7 +124,7 @@ fn is_vortex_supported_type(data_type: &DataType) -> bool {
 /// Transform schema according to `unsupported_type_action` policy
 /// Always converts Float16 to Float32 and normalizes timestamps to Microsecond (these are compatible transformations)
 /// Handles truly unsupported types according to the action: String (convert to Utf8) or Error (return error)
-fn transform_schema_for_vortex(
+pub(crate) fn transform_schema_for_vortex(
     schema: &arrow::datatypes::Schema,
     unsupported_type_action: UnsupportedTypeAction,
 ) -> Result<arrow::datatypes::Schema> {

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -425,6 +425,15 @@ impl DataFusionBuilder {
             ),
         ));
 
+        // Add the Cayenne DDL analyzer rule.
+        #[cfg(not(windows))]
+        ctx.add_analyzer_rule(Arc::new(
+            super::cayenne_ddl::analyzer_rule::CayenneDdlAnalyzerRule::new(
+                ctx.state().catalog_list(),
+                &ddl_enabled_catalogs,
+            ),
+        ));
+
         DataFusion {
             runtime_status: self.status,
             ctx: Arc::new(ctx),
@@ -592,6 +601,8 @@ pub(crate) fn default_extension_planners(
         Arc::new(FederatedPlanner::new()),
         Arc::new(CacheInvalidationExtensionPlanner::new()),
         Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new(datafusion_ref)),
+        #[cfg(not(windows))]
+        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new()),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Analyzer rule that intercepts DDL plans (`CREATE TABLE` / `DROP TABLE`)
+//! targeting Cayenne-backed DDL-enabled catalogs and rewrites them into
+//! custom [`LogicalPlan::Extension`] nodes.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::{Arc, RwLock, Weak};
+
+use datafusion::catalog::CatalogProviderList;
+use datafusion::config::ConfigOptions;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::DdlStatement;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion::optimizer::AnalyzerRule;
+
+use super::is_cayenne_catalog;
+use super::logical_nodes::{CayenneCreateTableNode, CayenneDropTableNode};
+use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+
+/// Analyzer rule that rewrites DDL targeting Cayenne catalogs into
+/// custom extension nodes for Cayenne catalog operations.
+///
+/// Uses `Weak` references to avoid reference cycles.
+pub struct CayenneDdlAnalyzerRule {
+    /// Weak reference to the catalog list for catalog resolution.
+    catalog_list: Weak<dyn CatalogProviderList>,
+    /// Weak reference to the set of DDL-enabled catalog names.
+    ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
+}
+
+impl fmt::Debug for CayenneDdlAnalyzerRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CayenneDdlAnalyzerRule")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneDdlAnalyzerRule {
+    #[must_use]
+    pub fn new(
+        catalog_list: &Arc<dyn CatalogProviderList>,
+        ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
+    ) -> Self {
+        Self {
+            catalog_list: Arc::downgrade(catalog_list),
+            ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
+        }
+    }
+
+    fn is_ddl_enabled(&self, catalog_name: &str) -> bool {
+        self.ddl_enabled_catalogs
+            .upgrade()
+            .and_then(|catalogs| catalogs.read().ok().map(|set| set.contains(catalog_name)))
+            .unwrap_or(false)
+    }
+
+    /// Check if the given catalog is backed by a Cayenne catalog provider.
+    fn is_cayenne_backed(&self, catalog_name: &str) -> bool {
+        let Some(catalog_list) = self.catalog_list.upgrade() else {
+            return false;
+        };
+        let Some(df_catalog) = catalog_list.catalog(catalog_name) else {
+            return false;
+        };
+        is_cayenne_catalog(df_catalog.as_ref())
+    }
+}
+
+impl AnalyzerRule for CayenneDdlAnalyzerRule {
+    fn name(&self) -> &'static str {
+        "cayenne_ddl_rewrite"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> DFResult<LogicalPlan> {
+        match &plan {
+            LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(create)) => {
+                let catalog_name = create
+                    .name
+                    .catalog()
+                    .unwrap_or(SPICE_DEFAULT_CATALOG)
+                    .to_string();
+
+                if !self.is_ddl_enabled(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                let schema_name = create
+                    .name
+                    .schema()
+                    .unwrap_or(SPICE_DEFAULT_SCHEMA)
+                    .to_string();
+                let table_name = create.name.table().to_string();
+
+                // Extract the Arrow schema from the logical plan's input
+                let arrow_schema = Arc::new(create.input.schema().inner().as_ref().clone());
+
+                let node = CayenneCreateTableNode::new(
+                    table_name,
+                    arrow_schema,
+                    create.if_not_exists,
+                    create.or_replace,
+                    catalog_name,
+                    schema_name,
+                );
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(node),
+                }))
+            }
+            LogicalPlan::Ddl(DdlStatement::DropTable(drop)) => {
+                let catalog_name = drop
+                    .name
+                    .catalog()
+                    .unwrap_or(SPICE_DEFAULT_CATALOG)
+                    .to_string();
+
+                if !self.is_ddl_enabled(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                let schema_name = drop
+                    .name
+                    .schema()
+                    .unwrap_or(SPICE_DEFAULT_SCHEMA)
+                    .to_string();
+                let table_name = drop.name.table().to_string();
+
+                let node = CayenneDropTableNode::new(
+                    table_name,
+                    drop.if_exists,
+                    catalog_name,
+                    schema_name,
+                );
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(node),
+                }))
+            }
+            _ => Ok(plan),
+        }
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Custom logical plan nodes for Cayenne DDL operations.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::common::DFSchemaRef;
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+
+/// Creates the shared output schema for DDL result nodes (single `result` column).
+fn ddl_output_schema() -> DFSchemaRef {
+    DFSchemaRef::new(
+        datafusion::common::DFSchema::try_from(Schema::new(vec![Field::new(
+            "result",
+            DataType::Utf8,
+            false,
+        )]))
+        .unwrap_or_else(|e| unreachable!("fixed DDL output schema must be valid: {e}")),
+    )
+}
+
+/// Logical plan node for `CREATE TABLE` on a Cayenne catalog.
+#[derive(Debug)]
+pub struct CayenneCreateTableNode {
+    /// The table name to create.
+    pub table_name: String,
+    /// The Arrow schema for the new table.
+    pub arrow_schema: Arc<Schema>,
+    /// If true, do not error if the table already exists.
+    pub if_not_exists: bool,
+    /// If true, replace the table if it already exists.
+    pub or_replace: bool,
+    /// The `DataFusion` catalog name (for registering the table provider).
+    pub df_catalog_name: String,
+    /// The `DataFusion` schema name (for registering the table provider).
+    pub df_schema_name: String,
+    /// Output schema (single "result" column).
+    output_schema: DFSchemaRef,
+}
+
+impl CayenneCreateTableNode {
+    #[must_use]
+    pub fn new(
+        table_name: String,
+        arrow_schema: Arc<Schema>,
+        if_not_exists: bool,
+        or_replace: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+    ) -> Self {
+        Self {
+            table_name,
+            arrow_schema,
+            if_not_exists,
+            or_replace,
+            df_catalog_name,
+            df_schema_name,
+            output_schema: ddl_output_schema(),
+        }
+    }
+}
+
+impl Hash for CayenneCreateTableNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_name.hash(state);
+        self.df_catalog_name.hash(state);
+        self.df_schema_name.hash(state);
+    }
+}
+
+impl PartialEq for CayenneCreateTableNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.table_name == other.table_name
+            && self.df_catalog_name == other.df_catalog_name
+            && self.df_schema_name == other.df_schema_name
+    }
+}
+
+impl Eq for CayenneCreateTableNode {}
+
+impl PartialOrd for CayenneCreateTableNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.table_name.partial_cmp(&other.table_name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
+    fn name(&self) -> &'static str {
+        "CayenneCreateTable"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneCreateTable: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(Self {
+            table_name: self.table_name.clone(),
+            arrow_schema: Arc::clone(&self.arrow_schema),
+            if_not_exists: self.if_not_exists,
+            or_replace: self.or_replace,
+            df_catalog_name: self.df_catalog_name.clone(),
+            df_schema_name: self.df_schema_name.clone(),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}
+
+/// Logical plan node for `DROP TABLE` on a Cayenne catalog.
+#[derive(Debug)]
+pub struct CayenneDropTableNode {
+    /// The table name to drop.
+    pub table_name: String,
+    /// If true, do not error if the table does not exist.
+    pub if_exists: bool,
+    /// The `DataFusion` catalog name.
+    pub df_catalog_name: String,
+    /// The `DataFusion` schema name.
+    pub df_schema_name: String,
+    /// Output schema (single "result" column).
+    output_schema: DFSchemaRef,
+}
+
+impl CayenneDropTableNode {
+    #[must_use]
+    pub fn new(
+        table_name: String,
+        if_exists: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+    ) -> Self {
+        Self {
+            table_name,
+            if_exists,
+            df_catalog_name,
+            df_schema_name,
+            output_schema: ddl_output_schema(),
+        }
+    }
+}
+
+impl Hash for CayenneDropTableNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_name.hash(state);
+        self.df_catalog_name.hash(state);
+    }
+}
+
+impl PartialEq for CayenneDropTableNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.table_name == other.table_name
+            && self.df_catalog_name == other.df_catalog_name
+            && self.df_schema_name == other.df_schema_name
+    }
+}
+
+impl Eq for CayenneDropTableNode {}
+
+impl PartialOrd for CayenneDropTableNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.table_name.partial_cmp(&other.table_name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for CayenneDropTableNode {
+    fn name(&self) -> &'static str {
+        "CayenneDropTable"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneDropTable: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(Self {
+            table_name: self.table_name.clone(),
+            if_exists: self.if_exists,
+            df_catalog_name: self.df_catalog_name.clone(),
+            df_schema_name: self.df_schema_name.clone(),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Cayenne DDL support: analyzer rule, logical nodes, extension planner,
+//! and physical execution plans for `CREATE TABLE` / `DROP TABLE` on
+//! Cayenne-backed DDL-enabled catalogs.
+//!
+//! Reuses the shared DDL options infrastructure from [`super::iceberg_ddl::acceleration_options`]
+//! and [`super::iceberg_ddl::preprocess`].
+
+pub mod analyzer_rule;
+pub mod logical_nodes;
+pub mod physical_plans;
+pub mod planner;
+
+use datafusion::catalog::CatalogProvider;
+
+use super::composed_catalog::ComposedCatalogProvider;
+use crate::catalogconnector::cayenne::provider::CayenneCatalogProvider;
+
+/// Check whether the given catalog provider is a Cayenne-backed catalog.
+pub fn is_cayenne_catalog(provider: &dyn CatalogProvider) -> bool {
+    if provider
+        .as_any()
+        .downcast_ref::<CayenneCatalogProvider>()
+        .is_some()
+    {
+        return true;
+    }
+    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>() {
+        return composed
+            .external()
+            .as_any()
+            .downcast_ref::<CayenneCatalogProvider>()
+            .is_some();
+    }
+    false
+}
+
+/// Extract the [`CayenneCatalogProvider`] reference from a `CatalogProvider`.
+///
+/// Handles both direct `CayenneCatalogProvider` and `ComposedCatalogProvider`
+/// wrapping a `CayenneCatalogProvider`.
+pub fn get_cayenne_provider(provider: &dyn CatalogProvider) -> Option<&CayenneCatalogProvider> {
+    if let Some(cayenne) = provider.as_any().downcast_ref::<CayenneCatalogProvider>() {
+        return Some(cayenne);
+    }
+    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>() {
+        return composed
+            .external()
+            .as_any()
+            .downcast_ref::<CayenneCatalogProvider>();
+    }
+    None
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -182,7 +182,6 @@ impl ExecutionPlan for CayenneCreateTableExec {
 
             // Get catalog references before the async boundary
             let metadata_catalog = Arc::clone(cayenne_provider.metadata_catalog());
-            let object_store_config = cayenne_provider.object_store_config().cloned();
             let data_base_path = cayenne_provider.data_base_path().to_string();
             let vortex_config = cayenne_provider.vortex_config().clone();
 
@@ -235,10 +234,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
             };
 
             // Create the table via Cayenne
-            let mut builder = CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
-            if let Some(config) = object_store_config {
-                builder = builder.with_object_store(config);
-            }
+            let builder = CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
 
             let provider = builder.create(create_options).await.map_err(|e| {
                 DataFusionError::Execution(format!(

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1,0 +1,435 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Physical execution plans for Cayenne DDL operations.
+//!
+//! `CayenneCreateTableExec` creates a new table in the Cayenne metadata catalog
+//! with data stored in S3 Express One Zone via Vortex columnar format.
+//!
+//! `CayenneDropTableExec` removes a table from both the Cayenne metadata catalog
+//! and the DataFusion catalog.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use cayenne::metadata::CreateTableOptions;
+use cayenne::CayenneTableProviderBuilder;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_table_providers::UnsupportedTypeAction;
+
+use super::get_cayenne_provider;
+use crate::dataaccelerator::cayenne::transform_schema_for_vortex;
+
+/// Creates a result schema for DDL operations (single "result" column).
+fn ddl_result_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "result",
+        DataType::Utf8,
+        false,
+    )]))
+}
+
+/// Physical plan for creating a Cayenne table.
+///
+/// Executes the following steps:
+/// 1. Retrieves the [`CayenneCatalogProvider`] from the DataFusion catalog.
+/// 2. Transforms the Arrow schema for Vortex compatibility.
+/// 3. Creates the table via [`CayenneTableProviderBuilder::create`].
+/// 4. Registers the resulting [`CayenneTableProvider`] in the schema provider.
+///
+/// Write-through inserts are handled natively by the `CayenneTableProvider`'s
+/// `insert_into()` implementation; no additional wrapping is needed.
+pub struct CayenneCreateTableExec {
+    table_name: String,
+    arrow_schema: Arc<Schema>,
+    if_not_exists: bool,
+    _or_replace: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for CayenneCreateTableExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CayenneCreateTableExec")
+            .field("table_name", &self.table_name)
+            .field("df_catalog_name", &self.df_catalog_name)
+            .field("df_schema_name", &self.df_schema_name)
+            .field("if_not_exists", &self.if_not_exists)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneCreateTableExec {
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        table_name: String,
+        arrow_schema: Arc<Schema>,
+        if_not_exists: bool,
+        or_replace: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+        catalog_list: Arc<dyn CatalogProviderList>,
+    ) -> Self {
+        let schema = ddl_result_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            table_name,
+            arrow_schema,
+            if_not_exists,
+            _or_replace: or_replace,
+            df_catalog_name,
+            df_schema_name,
+            catalog_list,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for CayenneCreateTableExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneCreateTableExec: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+}
+
+impl ExecutionPlan for CayenneCreateTableExec {
+    fn name(&self) -> &'static str {
+        "CayenneCreateTableExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let table_name = self.table_name.clone();
+        let arrow_schema = Arc::clone(&self.arrow_schema);
+        let if_not_exists = self.if_not_exists;
+        let df_catalog_name = self.df_catalog_name.clone();
+        let df_schema_name = self.df_schema_name.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
+        let result_schema = ddl_result_schema();
+
+        let stream = futures::stream::once(async move {
+            // Get the Cayenne catalog provider
+            let df_catalog =
+                catalog_list
+                    .catalog(&df_catalog_name)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "Catalog '{df_catalog_name}' not found"
+                        ))
+                    })?;
+
+            let cayenne_provider =
+                get_cayenne_provider(df_catalog.as_ref()).ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "Catalog '{df_catalog_name}' is not a Cayenne catalog"
+                    ))
+                })?;
+
+            // Get catalog references before the async boundary
+            let metadata_catalog = Arc::clone(cayenne_provider.metadata_catalog());
+            let object_store_config = cayenne_provider.object_store_config().cloned();
+            let data_base_path = cayenne_provider.data_base_path().to_string();
+            let vortex_config = cayenne_provider.vortex_config().clone();
+
+            // Check if table already exists via the metadata catalog
+            let exists = metadata_catalog
+                .get_table(&table_name)
+                .await
+                .is_ok();
+
+            if exists {
+                if if_not_exists {
+                    let batch = RecordBatch::try_new(
+                        result_schema,
+                        vec![Arc::new(StringArray::from(vec![format!(
+                            "Table '{table_name}' already exists"
+                        )]))],
+                    )?;
+                    return Ok(batch);
+                }
+                return Err(DataFusionError::Execution(format!(
+                    "Table '{table_name}' already exists in catalog '{df_catalog_name}'"
+                )));
+            }
+
+            // Transform schema for Vortex compatibility
+            let vortex_schema =
+                transform_schema_for_vortex(&arrow_schema, UnsupportedTypeAction::Error)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to transform schema for Vortex: {e}"
+                        ))
+                    })?;
+
+            let table_data_path = format!(
+                "{}{table_name}/",
+                data_base_path.trim_end_matches('/')
+                    .to_string()
+                    + "/"
+            );
+
+            // Create table options
+            let create_options = CreateTableOptions {
+                table_name: table_name.clone(),
+                schema: Arc::new(vortex_schema),
+                primary_key: Vec::new(),
+                on_conflict: None,
+                base_path: table_data_path,
+                partition_column: None,
+                vortex_config,
+            };
+
+            // Create the table via Cayenne
+            let mut builder = CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
+            if let Some(config) = object_store_config {
+                builder = builder.with_object_store(config);
+            }
+
+            let provider = builder.create(create_options).await.map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Failed to create Cayenne table '{table_name}': {e}"
+                ))
+            })?;
+
+            // Register in the DataFusion schema provider
+            let schema_provider =
+                df_catalog
+                    .schema(&df_schema_name)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "Schema '{df_schema_name}' not found in catalog '{df_catalog_name}'"
+                        ))
+                    })?;
+
+            schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(StringArray::from(vec![format!(
+                    "Table '{table_name}' created"
+                )]))],
+            )?;
+            Ok(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            ddl_result_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Physical plan for dropping a Cayenne table.
+pub struct CayenneDropTableExec {
+    table_name: String,
+    if_exists: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for CayenneDropTableExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CayenneDropTableExec")
+            .field("table_name", &self.table_name)
+            .field("df_catalog_name", &self.df_catalog_name)
+            .field("df_schema_name", &self.df_schema_name)
+            .field("if_exists", &self.if_exists)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneDropTableExec {
+    #[must_use]
+    pub fn new(
+        table_name: String,
+        if_exists: bool,
+        df_catalog_name: String,
+        df_schema_name: String,
+        catalog_list: Arc<dyn CatalogProviderList>,
+    ) -> Self {
+        let schema = ddl_result_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            table_name,
+            if_exists,
+            df_catalog_name,
+            df_schema_name,
+            catalog_list,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for CayenneDropTableExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneDropTableExec: {}.{}.{}",
+            self.df_catalog_name, self.df_schema_name, self.table_name
+        )
+    }
+}
+
+impl ExecutionPlan for CayenneDropTableExec {
+    fn name(&self) -> &'static str {
+        "CayenneDropTableExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let table_name = self.table_name.clone();
+        let if_exists = self.if_exists;
+        let df_catalog_name = self.df_catalog_name.clone();
+        let df_schema_name = self.df_schema_name.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
+        let result_schema = ddl_result_schema();
+
+        let stream = futures::stream::once(async move {
+            // Get the Cayenne catalog provider
+            let df_catalog =
+                catalog_list
+                    .catalog(&df_catalog_name)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "Catalog '{df_catalog_name}' not found"
+                        ))
+                    })?;
+
+            let cayenne_provider =
+                get_cayenne_provider(df_catalog.as_ref()).ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "Catalog '{df_catalog_name}' is not a Cayenne catalog"
+                    ))
+                })?;
+
+            let metadata_catalog = Arc::clone(cayenne_provider.metadata_catalog());
+
+            // Drop from the Cayenne metadata catalog
+            let was_dropped = metadata_catalog
+                .drop_table(&table_name)
+                .await
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to drop Cayenne table '{table_name}': {e}"
+                    ))
+                })?;
+
+            if !was_dropped {
+                if if_exists {
+                    let batch = RecordBatch::try_new(
+                        result_schema,
+                        vec![Arc::new(StringArray::from(vec![format!(
+                            "Table '{table_name}' does not exist"
+                        )]))],
+                    )?;
+                    return Ok(batch);
+                }
+                return Err(DataFusionError::Execution(format!(
+                    "Table '{table_name}' does not exist in catalog '{df_catalog_name}'"
+                )));
+            }
+
+            // Deregister from the DataFusion catalog
+            if let Some(schema_provider) = df_catalog.schema(&df_schema_name) {
+                let _ = schema_provider.deregister_table(&table_name);
+            }
+
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(StringArray::from(vec![format!(
+                    "Table '{table_name}' dropped"
+                )]))],
+            )?;
+            Ok(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            ddl_result_schema(),
+            stream,
+        )))
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Extension planner that converts Cayenne DDL logical nodes into
+//! physical execution plans.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+
+use super::logical_nodes::{CayenneCreateTableNode, CayenneDropTableNode};
+use super::physical_plans::{CayenneCreateTableExec, CayenneDropTableExec};
+
+/// Extension planner for Cayenne DDL operations.
+#[derive(Debug)]
+pub struct CayenneDdlExtensionPlanner;
+
+impl CayenneDdlExtensionPlanner {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ExtensionPlanner for CayenneDdlExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        _physical_inputs: &[Arc<dyn ExecutionPlan>],
+        session_state: &datafusion::execution::SessionState,
+    ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+        let catalog_list = Arc::<dyn CatalogProviderList>::clone(session_state.catalog_list());
+
+        if let Some(create) = node.as_any().downcast_ref::<CayenneCreateTableNode>() {
+            return Ok(Some(Arc::new(CayenneCreateTableExec::new(
+                create.table_name.clone(),
+                Arc::clone(&create.arrow_schema),
+                create.if_not_exists,
+                create.or_replace,
+                create.df_catalog_name.clone(),
+                create.df_schema_name.clone(),
+                catalog_list,
+            ))));
+        }
+
+        if let Some(drop) = node.as_any().downcast_ref::<CayenneDropTableNode>() {
+            return Ok(Some(Arc::new(CayenneDropTableExec::new(
+                drop.table_name.clone(),
+                drop.if_exists,
+                drop.df_catalog_name.clone(),
+                drop.df_schema_name.clone(),
+                catalog_list,
+            ))));
+        }
+
+        Ok(None)
+    }
+}

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -114,6 +114,8 @@ pub mod query;
 
 pub mod app_context_extension;
 pub mod builder;
+#[cfg(not(windows))]
+pub mod cayenne_ddl;
 pub mod composed_catalog;
 pub mod dialect;
 pub mod error;

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -313,36 +313,11 @@ fn create_response_stream(
     }
 }
 
-/// Maximum number of rows per batch sent to the write channel.
-/// 32,768 is four times the default batch size in DataFusion
-/// (`datafusion.execution.batch_size`), which defaults to 8,192.
-const MAX_BATCH_ROWS: usize = 32_768;
-
 async fn handle_record_batch(
     batch: RecordBatch,
     batch_tx: &Sender<Result<RecordBatch, DataFusionError>>,
 ) -> Result<PutResult, Status> {
     tracing::trace!("Received batch with {} rows", batch.num_rows());
-
-    // Slice oversized batches into chunks rather than rejecting them outright.
-    // This avoids forcing clients to pre-chunk during bulk ingest, reducing
-    // round-trip overhead and improving throughput.
-    if batch.num_rows() > MAX_BATCH_ROWS {
-        let mut offset = 0;
-        let total = batch.num_rows();
-        while offset < total {
-            let length = (total - offset).min(MAX_BATCH_ROWS);
-            let chunk = batch.slice(offset, length);
-            if let Err(e) = batch_tx.send(Ok(chunk)).await {
-                tracing::error!("Error sending record batch chunk to write channel: {e}");
-                return Err(Status::internal(format!(
-                    "Error sending record batch to write channel: {e}"
-                )));
-            }
-            offset += length;
-        }
-        return Ok(PutResult::default());
-    }
 
     if let Err(e) = batch_tx.send(Ok(batch)).await {
         tracing::error!("Error sending record batch to write channel: {e}");

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -32,10 +32,7 @@ use datafusion::{
 };
 use prost::Message as _;
 use runtime_auth::AuthRequestContext;
-use tokio::{
-    sync::mpsc::{self, Sender},
-    time::sleep,
-};
+use tokio::sync::mpsc::{self, Sender};
 use tokio_stream::{StreamExt as _, adapters::Peekable, wrappers::ReceiverStream};
 use tonic::{Request, Response, Status, Streaming};
 
@@ -214,7 +211,7 @@ fn create_response_stream(
     .ok();
 
     stream! {
-        // channel to propogate new record batches to the data writing stream
+        // channel to propagate new record batches to the data writing stream
         let (batch_tx, batch_rx)= mpsc::channel::<Result<RecordBatch, DataFusionError>>(100);
 
         let write_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(Arc::clone(&schema), Box::new(ReceiverStream::new(batch_rx))));
@@ -226,9 +223,15 @@ fn create_response_stream(
             yield handle_record_batch(first_batch, &batch_tx).await;
         }
 
+        // Use a single pinned Sleep future that is reset on each received message,
+        // rather than creating a new timer allocation on every loop iteration.
+        let idle_timeout = Duration::from_secs(120);
+        let deadline = tokio::time::sleep(idle_timeout);
+        tokio::pin!(deadline);
+
         loop {
             tokio::select! {
-                () = sleep(Duration::from_secs(120)) => {
+                () = &mut deadline => {
                     tracing::error!("Timeout: no record batch received within 120 seconds");
                     yield Err(Status::deadline_exceeded("Timeout: no record batch received within 120 seconds"));
                     break;
@@ -260,6 +263,9 @@ fn create_response_stream(
                 message = streaming_flight.next() => {
                     match message {
                         Some(Ok(message)) => {
+                            // Reset the idle timeout on each received message
+                            deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
+
                             let new_batch = match flight_data_to_arrow_batch(
                                 &message,
                                 Arc::clone(&schema),
@@ -307,19 +313,35 @@ fn create_response_stream(
     }
 }
 
+/// Maximum number of rows per batch sent to the write channel.
+/// 32,768 is four times the default batch size in DataFusion
+/// (`datafusion.execution.batch_size`), which defaults to 8,192.
+const MAX_BATCH_ROWS: usize = 32_768;
+
 async fn handle_record_batch(
     batch: RecordBatch,
     batch_tx: &Sender<Result<RecordBatch, DataFusionError>>,
 ) -> Result<PutResult, Status> {
     tracing::trace!("Received batch with {} rows", batch.num_rows());
 
-    // 32,768 is four times the default batch size in DataFusion (`datafusion.execution.batch_size`), which defaults to 8,192.
-    if batch.num_rows() > 32_768 {
-        return Err(Status::invalid_argument(format!(
-            "The provided batch contains too many rows. Maximum allowed: {allowed}, received: {received}.",
-            allowed = 32_768,
-            received = batch.num_rows()
-        )));
+    // Slice oversized batches into chunks rather than rejecting them outright.
+    // This avoids forcing clients to pre-chunk during bulk ingest, reducing
+    // round-trip overhead and improving throughput.
+    if batch.num_rows() > MAX_BATCH_ROWS {
+        let mut offset = 0;
+        let total = batch.num_rows();
+        while offset < total {
+            let length = (total - offset).min(MAX_BATCH_ROWS);
+            let chunk = batch.slice(offset, length);
+            if let Err(e) = batch_tx.send(Ok(chunk)).await {
+                tracing::error!("Error sending record batch chunk to write channel: {e}");
+                return Err(Status::internal(format!(
+                    "Error sending record batch to write channel: {e}"
+                )));
+            }
+            offset += length;
+        }
+        return Ok(PutResult::default());
     }
 
     if let Err(e) = batch_tx.send(Ok(batch)).await {

--- a/crates/runtime/src/flight/middleware/rate_limit.rs
+++ b/crates/runtime/src/flight/middleware/rate_limit.rs
@@ -32,16 +32,22 @@ type DirectRateLimiter = RateLimiter<
 >;
 
 /// Enforces a rate limit on the number of Flight `DoPut` requests the underlying service can handle over a period of time.
+///
+/// When `enabled` is `false`, the layer is a no-op: it does not insert a
+/// [`RateLimiterExtension`] into the request, so downstream handlers skip
+/// the rate-limit check entirely.
 #[derive(Clone)]
 pub struct WriteRateLimitLayer {
     rate_limiter: Arc<DirectRateLimiter>,
+    enabled: bool,
 }
 
 impl WriteRateLimitLayer {
     #[must_use]
-    pub fn new(rate_limiter: DirectRateLimiter) -> Self {
+    pub fn new(rate_limiter: DirectRateLimiter, enabled: bool) -> Self {
         Self {
             rate_limiter: Arc::new(rate_limiter),
+            enabled,
         }
     }
 }
@@ -50,7 +56,7 @@ impl<S> Layer<S> for WriteRateLimitLayer {
     type Service = WriteRateLimitMiddleware<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        WriteRateLimitMiddleware::new(inner, Arc::clone(&self.rate_limiter))
+        WriteRateLimitMiddleware::new(inner, Arc::clone(&self.rate_limiter), self.enabled)
     }
 }
 
@@ -58,13 +64,15 @@ impl<S> Layer<S> for WriteRateLimitLayer {
 pub struct WriteRateLimitMiddleware<S> {
     inner: S,
     rate_limiter: Arc<DirectRateLimiter>,
+    enabled: bool,
 }
 
 impl<S> WriteRateLimitMiddleware<S> {
-    fn new(inner: S, rate_limiter: Arc<DirectRateLimiter>) -> Self {
+    fn new(inner: S, rate_limiter: Arc<DirectRateLimiter>, enabled: bool) -> Self {
         WriteRateLimitMiddleware {
             inner,
             rate_limiter,
+            enabled,
         }
     }
 }
@@ -108,7 +116,9 @@ where
 
     fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
         // Apply rate limiting to the Flight DoPut only
-        if req.uri().path() != "/arrow.flight.protocol.FlightService/DoPut" {
+        if !self.enabled
+            || req.uri().path() != "/arrow.flight.protocol.FlightService/DoPut"
+        {
             return Box::pin(self.inner.call(req));
         }
 

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -542,10 +542,11 @@ pub async fn start(
             RequestContextLayer::new(app, rt.datafusion(), session_store, rt.secrets())
                 .with_job_executor(job_executor),
         )
-        .layer(WriteRateLimitLayer::new(RateLimiter::direct(
-            rate_limits.flight_write_limit,
-        )))
-        .layer(auth_layer);
+        .layer(auth_layer)
+        .layer(WriteRateLimitLayer::new(
+            RateLimiter::direct(rate_limits.flight_write_limit),
+            rate_limits.flight_write_enabled,
+        ));
 
     let server = server
         .add_service(spice_flight_service)
@@ -577,6 +578,9 @@ pub async fn start(
 
 pub struct RateLimits {
     pub flight_write_limit: Quota,
+    /// Whether write rate limiting is enabled. When `false`, the rate limiter
+    /// layer is still present but the check function always succeeds.
+    pub flight_write_enabled: bool,
 }
 
 impl RateLimits {
@@ -590,6 +594,12 @@ impl RateLimits {
         self.flight_write_limit = rate_limit;
         self
     }
+
+    #[must_use]
+    pub fn with_flight_write_enabled(mut self, enabled: bool) -> Self {
+        self.flight_write_enabled = enabled;
+        self
+    }
 }
 
 impl Default for RateLimits {
@@ -599,6 +609,7 @@ impl Default for RateLimits {
             flight_write_limit: Quota::per_minute(
                 NonZeroU32::new(100).unwrap_or_else(|| unreachable!("100 is always non-zero")),
             ),
+            flight_write_enabled: true,
         }
     }
 }

--- a/crates/runtime/tests/flight/do_put.rs
+++ b/crates/runtime/tests/flight/do_put.rs
@@ -246,7 +246,7 @@ async fn test_flight_do_put_rate_limit() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-async fn test_flight_do_put_max_rows_allowed() -> Result<(), anyhow::Error> {
+async fn test_flight_do_put_large_batch_slicing() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
@@ -258,24 +258,22 @@ async fn test_flight_do_put_max_rows_allowed() -> Result<(), anyhow::Error> {
 
             let mut client = create_flight_client(channel, Some("valid"))?;
 
-            assert!(
-                // Simulate a normal batch, followed by a batch that exceeds the allowed number of rows, and then another normal batch.
-                write_record_batches(
-                    &mut client,
-                    vec![
-                        test_record_batch()?,
-                        large_test_record_batch()?,
-                        test_record_batch()?
-                    ]
-                    .into_iter()
-                )
-                .await
-                .is_err(),
-                "Expected an error but got a successful result"
-            );
+            // Simulate a normal batch, followed by a batch that exceeds the per-batch
+            // row limit (35,000 rows), and then another normal batch. The large batch
+            // should be automatically sliced rather than rejected.
+            write_record_batches(
+                &mut client,
+                vec![
+                    test_record_batch()?,
+                    large_test_record_batch()?,
+                    test_record_batch()?
+                ]
+                .into_iter()
+            )
+            .await?;
 
             let query = df
-                .query_builder("SELECT * from my_table")
+                .query_builder("SELECT count(*) AS row_count from my_table")
                 .build()
                 .run()
                 .await?;
@@ -283,7 +281,8 @@ async fn test_flight_do_put_max_rows_allowed() -> Result<(), anyhow::Error> {
             let results: Vec<RecordBatch> = query.data.try_collect::<Vec<RecordBatch>>().await?;
             let results_str =
                 arrow::util::pretty::pretty_format_batches(&results).expect("pretty batches");
-            insta::assert_snapshot!("max_rows_allowed_table_content", results_str);
+            // 3 rows (test_record_batch) + 35,000 rows (large_test_record_batch) + 3 rows (test_record_batch) = 35,006
+            insta::assert_snapshot!("large_batch_slicing_row_count", results_str);
 
             Ok(())
         })

--- a/crates/runtime/tests/flight/snapshots/integration__flight__do_put__large_batch_slicing_row_count.snap
+++ b/crates/runtime/tests/flight/snapshots/integration__flight__do_put__large_batch_slicing_row_count.snap
@@ -2,5 +2,8 @@
 source: crates/runtime/tests/flight/do_put.rs
 expression: results_str
 ---
-++
-++
++-----------+
+| row_count |
++-----------+
+| 35006     |
++-----------+

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -280,10 +280,24 @@ impl Default for TelemetryConfig {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Flight {
     pub max_message_size: Option<String>,
+
+    /// Whether to enable rate limiting on Flight DoPut (write) requests.
+    /// Defaults to `true`. Set to `false` to disable write rate limiting for bulk ingest workloads.
+    #[serde(default = "default_true")]
+    pub do_put_rate_limit_enabled: bool,
+}
+
+impl Default for Flight {
+    fn default() -> Self {
+        Self {
+            max_message_size: None,
+            do_put_rate_limit_enabled: true,
+        }
+    }
 }
 
 impl Flight {


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Supports specifying a Cayenne catalog for writing dynamic tables with DDL. Configure with `spicepod.yaml` configuration:

```yaml
catalogs:
  - name: my_cayenne
    from: cayenne
    access: read_write_create # Enable DDL operations and data insertion
    params:
      # When S3 configurations are not specified, the Cayenne acceleration data is stored locally in `.spice` or the specified location
      cayenne_data_dir: ./.spice
```

* Adds a runtime configuration to disable the rate limiter on the FlightSQL `DoPut` path
* Updates the FlightSQL `DoPut` idle timeout builder to use deadline resets on a sleep instead of rebuilding a sleep on every loop, for a slight performance improvement
* Removes the batch row limit as it seems to be unnecessary?
