### PR TITLE
Fix #9481: Preserve schema in results cache for empty query results

### DIFF
--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -565,6 +565,7 @@ mod tests {
 
         CachedQueryResult::from_batches(
             &[record_batch],
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(input_tables),
             std::time::Instant::now(),
             encoder,
@@ -1033,6 +1034,7 @@ mod tests {
         let encoder = crate::encoding::get_encoder(spicepod::component::caching::Encoding::None);
         let result_other_table = CachedQueryResult::from_batches(
             &[different_table_batch],
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(different_input_tables),
             std::time::Instant::now(),
             encoder,

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -61,18 +61,16 @@ pub struct CachedQueryResult {
 
 impl CachedQueryResult {
     /// Create a new cached query result with raw `RecordBatches`.
+    ///
+    /// The `schema` parameter must be provided explicitly to ensure the correct
+    /// schema is preserved even when `batches` is empty (e.g., 0-row query results).
     #[must_use]
     pub fn new_raw(
         batches: Vec<RecordBatch>,
+        schema: SchemaRef,
         input_tables: Arc<HashSet<TableReference>>,
         cached_at: Instant,
     ) -> Self {
-        let schema = if batches.is_empty() {
-            Arc::new(Schema::empty())
-        } else {
-            batches[0].schema()
-        };
-
         Self {
             data: CachedData::Raw(Arc::new(batches)),
             schema,
@@ -103,21 +101,19 @@ impl CachedQueryResult {
     /// Create a cached query result from record batches.
     /// Only store encoded data if an encoder is provided.
     ///
+    /// The `schema` parameter must be provided explicitly to ensure the correct
+    /// schema is preserved even when `records` is empty (e.g., 0-row query results).
+    ///
     /// # Errors
     ///
     /// Returns an error if encoding fails.
     pub async fn from_batches(
         records: &[RecordBatch],
+        schema: SchemaRef,
         input_tables: Arc<HashSet<TableReference>>,
         cached_at: Instant,
         encoder: Option<Arc<dyn Encoder>>,
     ) -> Result<Self, crate::encoding::Error> {
-        let schema = if records.is_empty() {
-            Arc::new(Schema::empty())
-        } else {
-            records[0].schema()
-        };
-
         // Only store encoded data if an encoder is provided
         let data = if let Some(encoder) = encoder.as_ref() {
             let encoded_data = encoder.encode(records).await?;
@@ -323,7 +319,7 @@ mod tests {
         let input_tables = Arc::new(HashSet::new());
         let cached_at = Instant::now();
 
-        let cached_result = CachedQueryResult::new_raw(batches, input_tables, cached_at);
+        let cached_result = CachedQueryResult::new_raw(batches, Arc::clone(&schema), input_tables, cached_at);
 
         // Calculate expected size
         let expected_size = std::mem::size_of::<CachedQueryResult>() as u64
@@ -376,11 +372,12 @@ mod tests {
 
     #[test]
     fn test_memory_size_empty_batches() {
+        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Int32, false)]));
         let batches = Vec::new();
         let input_tables = Arc::new(HashSet::new());
         let cached_at = Instant::now();
 
-        let cached_result = CachedQueryResult::new_raw(batches, input_tables, cached_at);
+        let cached_result = CachedQueryResult::new_raw(batches, schema, input_tables, cached_at);
 
         let expected_size = std::mem::size_of::<CachedQueryResult>() as u64;
         let actual_size = cached_result.memory_size();
@@ -403,7 +400,7 @@ mod tests {
         .expect("should create batch");
 
         let cached_result =
-            CachedQueryResult::new_raw(vec![batch], Arc::new(HashSet::new()), Instant::now());
+            CachedQueryResult::new_raw(vec![batch], Arc::clone(&schema), Arc::new(HashSet::new()), Instant::now());
 
         let memory_size = cached_result.memory_size();
         let sizeable_size = cached_result.get_memory_size();
@@ -412,6 +409,69 @@ mod tests {
         assert_eq!(
             sizeable_size as u64, memory_size,
             "Sizeable trait should delegate to memory_size()"
+        );
+    }
+
+    /// Regression test for https://github.com/spiceai/spiceai/issues/9481
+    /// Empty query results must preserve the correct schema, not Schema::empty().
+    #[test]
+    fn test_empty_batches_preserve_schema_new_raw() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("value", DataType::Int64, true),
+        ]));
+
+        let cached_result = CachedQueryResult::new_raw(
+            Vec::new(),
+            Arc::clone(&schema),
+            Arc::new(HashSet::new()),
+            Instant::now(),
+        );
+
+        assert_eq!(
+            cached_result.schema.fields().len(),
+            3,
+            "Cached empty result must preserve the original 3-field schema"
+        );
+        assert_eq!(cached_result.schema, schema);
+    }
+
+    /// Regression test for https://github.com/spiceai/spiceai/issues/9481
+    #[tokio::test]
+    async fn test_empty_batches_preserve_schema_from_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("value", DataType::Int64, true),
+        ]));
+
+        let cached_result = CachedQueryResult::from_batches(
+            &[],
+            Arc::clone(&schema),
+            Arc::new(HashSet::new()),
+            Instant::now(),
+            None,
+        )
+        .await
+        .expect("should create cached result");
+
+        assert_eq!(
+            cached_result.schema.fields().len(),
+            3,
+            "Cached empty result must preserve the original 3-field schema"
+        );
+        assert_eq!(cached_result.schema, schema);
+
+        // Verify the CachedStream also reports the correct schema
+        let records = cached_result.records().await.expect("should decode");
+        assert!(records.is_empty(), "Should have no record batches");
+
+        let stream = CachedStream::new(Arc::new(records), Arc::clone(&cached_result.schema));
+        assert_eq!(
+            stream.schema().fields().len(),
+            3,
+            "CachedStream schema must match the original schema"
         );
     }
 }

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -209,6 +209,7 @@ mod tests {
 
         CachedQueryResult::from_batches(
             &[record_batch],
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(input_tables),
             std::time::Instant::now(),
             encoder,

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -37,6 +37,7 @@ pub fn to_cached_record_batch_stream(
     input_tables: Arc<HashSet<TableReference>>,
 ) -> SendableRecordBatchStream {
     let schema = stream.schema();
+    let cache_schema = Arc::clone(&schema);
 
     let cached_result_stream = stream! {
         let mut records: Vec<RecordBatch> = Vec::new();
@@ -64,6 +65,7 @@ pub fn to_cached_record_batch_stream(
 
             match CachedQueryResult::from_batches(
                 &records,
+                cache_schema,
                 input_tables,
                 cached_at,
                 encoder,

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -451,7 +451,7 @@ impl Query {
         cache_key: &RawCacheKey,
         cache_key_u64: u64,
         batches: Vec<arrow::record_batch::RecordBatch>,
-        _schema: arrow::datatypes::SchemaRef,
+        schema: arrow::datatypes::SchemaRef,
         input_tables: Arc<HashSet<TableReference>>,
     ) {
         if let Some(cache_provider) = df.results_cache_provider() {
@@ -460,6 +460,7 @@ impl Query {
 
             match cache::result::query::CachedQueryResult::from_batches(
                 &batches,
+                schema,
                 input_tables,
                 cached_at,
                 encoder,


### PR DESCRIPTION
## Summary

When the SQL results cache stores a query that returns 0 rows, the cached response was served back with a **0-field schema** instead of the correct table schema. This caused FlightSQL ADBC clients to fail with an `inconsistent schema` error because `GetFlightInfo` reports the correct schema (from the logical plan) while `DoGet` returns 0 fields (from the cache).

## Root Cause

`CachedQueryResult::from_batches()` and `CachedQueryResult::new_raw()` derived the schema from `batches[0].schema()`, but when `batches` was empty (0-row results produce no `RecordBatch` items), they fell back to `Schema::empty()` — a schema with 0 fields.

The correct schema was available from the stream (`stream.schema()`) and from the logical plan, but was not passed through to the cached result. In `cache_revalidation_result()`, the schema parameter was even explicitly ignored (`_schema`).

## Changes

- **`CachedQueryResult::new_raw()`** and **`CachedQueryResult::from_batches()`**: Added an explicit `schema: SchemaRef` parameter so the schema is always preserved, regardless of whether batches are empty.
- **`to_cached_record_batch_stream()`** (`utils.rs`): Now passes `stream.schema()` to `from_batches()`.
- **`cache_revalidation_result()`** (`cache.rs`): Now passes the `schema` parameter (previously ignored as `_schema`) to `from_batches()`.
- Updated all test call sites.
- Added regression tests verifying empty results preserve the correct schema.

## Testing

- Added `test_empty_batches_preserve_schema_new_raw` and `test_empty_batches_preserve_schema_from_batches` regression tests.
- All existing cache tests updated and passing.

Fixes #9481