### PR TITLE
query: reconcile execution stream nullability with logical plan schema

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -722,7 +722,9 @@ impl Query {
             // and DDL plans (CREATE TABLE/DROP TABLE) as their logical plan schema may
             // differ from the actual execution result (DDL plans may be rewritten by
             // analyzer rules into extension nodes with different output schemas)
-            if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_)) {
+            let res_stream = if matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_)) {
+                res_stream
+            } else {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 
@@ -735,7 +737,15 @@ impl Query {
                         SchemaMismatch
                     )
                 }
-            }
+                // The AggregateStatistics physical optimizer may replace an
+                // AggregateExec with a ProjectionExec containing a literal
+                // value, which changes the output nullability (literals report
+                // nullable = value.is_null()).  Reconcile the execution result
+                // schema with the logical plan schema so downstream consumers
+                // (e.g. FlightSQL GetFlightInfo vs DoGet) see consistent
+                // nullability.
+                reconcile_stream_nullability(res_stream, &plan_schema)
+            };
 
             let final_stream = if cache_manager.should_cache_results() {
                 Self::wrap_stream_with_cache(
@@ -1090,6 +1100,74 @@ pub fn write_to_json_string(
     writer.finish()?;
 
     String::from_utf8(writer.into_inner()).boxed()
+}
+
+/// Reconciles the nullability of a result stream with the logical plan schema.
+///
+/// Physical optimizer rules (e.g. `AggregateStatistics`) may replace aggregate
+/// execution plans with literal projections whose nullability differs from the
+/// logical plan.  For example, `MAX(int64)` is logically nullable (empty input
+/// → NULL) but the optimized literal `ScalarValue::Int64(Some(v))` is
+/// non-nullable.
+///
+/// This function widens non-nullable fields to nullable when the logical plan
+/// schema says they should be nullable, and wraps the stream so every batch
+/// conforms.  This uses the same `try_cast_to` mechanism as `SchemaCastScanExec`.
+fn reconcile_stream_nullability(
+    stream: SendableRecordBatchStream,
+    plan_schema: &Arc<Schema>,
+) -> SendableRecordBatchStream {
+    let exec_schema = stream.schema();
+
+    if exec_schema.fields().len() != plan_schema.fields().len() {
+        tracing::warn!(
+            "Schema field count mismatch during nullability reconciliation: \
+             execution schema has {} fields, logical plan has {}",
+            exec_schema.fields().len(),
+            plan_schema.fields().len(),
+        );
+        return stream;
+    }
+
+    let mut needs_reconciliation = false;
+    for (exec_field, plan_field) in exec_schema.fields().iter().zip(plan_schema.fields()) {
+        if plan_field.is_nullable() && !exec_field.is_nullable() {
+            needs_reconciliation = true;
+            break;
+        }
+    }
+
+    if !needs_reconciliation {
+        return stream;
+    }
+
+    // Build a reconciled schema: widen to nullable where the logical plan says
+    // so, but keep data types and metadata from the execution schema.
+    let reconciled_fields: Vec<Field> = exec_schema
+        .fields()
+        .iter()
+        .zip(plan_schema.fields())
+        .map(|(exec_field, plan_field)| {
+            if plan_field.is_nullable() && !exec_field.is_nullable() {
+                exec_field.as_ref().clone().with_nullable(true)
+            } else {
+                exec_field.as_ref().clone()
+            }
+        })
+        .collect();
+
+    let reconciled =
+        Arc::new(Schema::new(reconciled_fields).with_metadata(exec_schema.metadata().clone()));
+    let target = Arc::clone(&reconciled);
+
+    Box::pin(RecordBatchStreamAdapter::new(
+        reconciled,
+        stream.map(move |batch| {
+            batch.and_then(|b| {
+                arrow_tools::record_batch::try_cast_to(b, Arc::clone(&target)).map_err(Into::into)
+            })
+        }),
+    ))
 }
 
 #[cfg(test)]
@@ -1507,5 +1585,205 @@ mod tests {
         assert_eq!(totals.produced_spills, 40);
         assert_eq!(totals.spilled_bytes, 0);
         assert_eq!(totals.spilled_rows, 200);
+    }
+
+    /// Helper: build a `SendableRecordBatchStream` from a schema and batches.
+    fn stream_from_batches(
+        schema: &Arc<Schema>,
+        batches: Vec<RecordBatch>,
+    ) -> SendableRecordBatchStream {
+        Box::pin(RecordBatchStreamAdapter::new(Arc::clone(schema), {
+            futures::stream::iter(batches.into_iter().map(Ok))
+        }))
+    }
+
+    /// Collect all batches from a `SendableRecordBatchStream`.
+    async fn collect_stream(mut stream: SendableRecordBatchStream) -> Vec<RecordBatch> {
+        let mut batches = Vec::new();
+        while let Some(result) = stream.next().await {
+            batches.push(result.expect("unexpected error in stream"));
+        }
+        batches
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_widens_non_nullable() {
+        // Simulates AggregateStatistics replacing MAX(id) with a literal:
+        // execution schema has non-nullable field, plan schema has nullable.
+        let exec_schema = Arc::new(Schema::new(vec![Field::new(
+            "max(id)",
+            arrow::datatypes::DataType::Int64,
+            false,
+        )]));
+        let plan_schema = Arc::new(Schema::new(vec![Field::new(
+            "max(id)",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&exec_schema),
+            vec![Arc::new(Int64Array::from(vec![42]))],
+        )
+        .expect("batch");
+
+        let stream = stream_from_batches(&exec_schema, vec![batch]);
+        let reconciled = reconcile_stream_nullability(stream, &plan_schema);
+
+        // Schema should now be nullable
+        assert!(
+            reconciled.schema().field(0).is_nullable(),
+            "field should be nullable after reconciliation"
+        );
+
+        // Batch data should be preserved
+        let batches = collect_stream(reconciled).await;
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 1);
+        assert!(
+            batches[0].schema().field(0).is_nullable(),
+            "batch schema should also be nullable"
+        );
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 array");
+        assert_eq!(col.value(0), 42);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_no_op_when_already_matching() {
+        // Both schemas agree: nullable. No wrapping needed.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "max(id)",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![42]))],
+        )
+        .expect("batch");
+
+        let stream = stream_from_batches(&schema, vec![batch]);
+        let reconciled = reconcile_stream_nullability(stream, &schema);
+
+        // Schema unchanged
+        assert_eq!(reconciled.schema(), schema);
+
+        let batches = collect_stream(reconciled).await;
+        assert_eq!(batches.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_no_op_when_non_nullable_in_both() {
+        // Both schemas agree: non-nullable. No wrapping needed.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            arrow::datatypes::DataType::Int64,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![10]))],
+        )
+        .expect("batch");
+
+        let stream = stream_from_batches(&schema, vec![batch]);
+        let reconciled = reconcile_stream_nullability(stream, &schema);
+
+        assert!(!reconciled.schema().field(0).is_nullable());
+
+        let batches = collect_stream(reconciled).await;
+        assert_eq!(batches.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_mixed_fields() {
+        // Multiple fields: only some need reconciliation.
+        let exec_schema = Arc::new(Schema::new(vec![
+            Field::new("name", arrow::datatypes::DataType::Utf8, true), // already nullable
+            Field::new("max(id)", arrow::datatypes::DataType::Int64, false), // needs widening
+            Field::new("count", arrow::datatypes::DataType::Int64, false), // stays non-nullable
+        ]));
+        let plan_schema = Arc::new(Schema::new(vec![
+            Field::new("name", arrow::datatypes::DataType::Utf8, true),
+            Field::new("max(id)", arrow::datatypes::DataType::Int64, true), // nullable in plan
+            Field::new("count", arrow::datatypes::DataType::Int64, false),  // non-nullable in plan
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&exec_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a"])),
+                Arc::new(Int64Array::from(vec![42])),
+                Arc::new(Int64Array::from(vec![10])),
+            ],
+        )
+        .expect("batch");
+
+        let stream = stream_from_batches(&exec_schema, vec![batch]);
+        let reconciled = reconcile_stream_nullability(stream, &plan_schema);
+
+        let schema = reconciled.schema();
+        assert!(schema.field(0).is_nullable(), "name stays nullable");
+        assert!(schema.field(1).is_nullable(), "max(id) widened to nullable");
+        assert!(!schema.field(2).is_nullable(), "count stays non-nullable");
+
+        let batches = collect_stream(reconciled).await;
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 1);
+        assert_eq!(batches[0].schema(), schema);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_field_count_mismatch() {
+        // Different field counts: return stream unchanged.
+        let exec_schema = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            arrow::datatypes::DataType::Int64,
+            false,
+        )]));
+        let plan_schema = Arc::new(Schema::new(vec![
+            Field::new("a", arrow::datatypes::DataType::Int64, true),
+            Field::new("b", arrow::datatypes::DataType::Int64, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&exec_schema),
+            vec![Arc::new(Int64Array::from(vec![1]))],
+        )
+        .expect("batch");
+
+        let stream = stream_from_batches(&exec_schema, vec![batch]);
+        let reconciled = reconcile_stream_nullability(stream, &plan_schema);
+
+        // Should be unchanged — no widening when field counts differ
+        assert!(!reconciled.schema().field(0).is_nullable());
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stream_nullability_empty_stream() {
+        let exec_schema = Arc::new(Schema::new(vec![Field::new(
+            "max(id)",
+            arrow::datatypes::DataType::Int64,
+            false,
+        )]));
+        let plan_schema = Arc::new(Schema::new(vec![Field::new(
+            "max(id)",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]));
+
+        let stream = stream_from_batches(&exec_schema, vec![]);
+        let reconciled = reconcile_stream_nullability(stream, &plan_schema);
+
+        assert!(reconciled.schema().field(0).is_nullable());
+
+        let batches = collect_stream(reconciled).await;
+        assert!(batches.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

FlightSQL schema nullability mismatch on aggregate queries (`GetFlightInfo` vs `DoGet`). When ADBC clients execute `SELECT MAX(col) FROM table` against Cayenne-accelerated datasets, `GetFlightInfo` reports the aggregate output as nullable (correct), but `DoGet` returns a non-nullable schema, causing clients to reject the response.

## Root Cause

1. Cayenne's `CayenneTable::statistics()` reports exact column-level stats (min/max) from Vortex `ListingTable`
2. DataFusion's `AggregateStatistics` physical optimizer sees `SELECT MAX(id)` with `Precision::Exact` stats
3. It replaces `AggregateExec` with `ProjectionExec(expressions::lit(max_value))`
4. `Literal::new(ScalarValue::Int64(Some(42)))` creates `Field::new("lit", Int64, value.is_null())` → `nullable=false`
5. Output schema becomes non-nullable, contradicting logical plan's `nullable=true` (from `Max::is_nullable() -> true`)

This is not Cayenne-specific — it affects any table provider reporting exact column statistics.

## Fix

Reconcile the execution result stream with the logical plan schema in `Query::run_internal()`, right after the existing `verify_schema` check. Fields that the logical plan marks as nullable but the execution reports as non-nullable are widened to nullable, and each batch is adjusted via `try_cast_to` (the same mechanism `SchemaCastScanExec` uses).

A non-nullable array is always valid as a nullable array (it just has no nulls), so this widening is safe.

## Tests

Added 6 unit tests for `reconcile_stream_nullability`:
- Widening non-nullable to nullable (core case)
- No-op when schemas already match (both nullable)
- No-op when both non-nullable
- Mixed fields (some need widening, some don't)
- Field count mismatch (pass through unchanged)
- Empty stream with schema reconciliation

Fixes #9482