### PR TITLE
feat: Return dataset error message in datasets API

### DIFF
--- a/crates/runtime-api-types/src/v1/datasets.rs
+++ b/crates/runtime-api-types/src/v1/datasets.rs
@@ -44,8 +44,7 @@ pub struct DatasetInfo {
     pub status: Option<ComponentStatus>,
 
     /// An optional error message describing why the dataset entered an error state.
-    /// Only present when the dataset status is `Error` and an error message was recorded.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Only populated when the dataset status is `Error` and an error message was recorded.
     pub error_message: Option<String>,
 
     /// Custom properties for the dataset

--- a/crates/runtime-api-types/src/v1/datasets.rs
+++ b/crates/runtime-api-types/src/v1/datasets.rs
@@ -43,6 +43,11 @@ pub struct DatasetInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
 
+    /// An optional error message describing why the dataset entered an error state.
+    /// Only present when the dataset status is `Error` and an error message was recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+
     /// Custom properties for the dataset
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub properties: HashMap<String, serde_json::Value>,

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -20,27 +20,85 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 /// Represents the status of a component (e.g. dataset, model, etc).
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+///
+/// The `Error` variant optionally carries a human-readable error message describing
+/// what caused the component to enter the error state. Use [`ComponentStatus::error`]
+/// for an error without a message, or [`ComponentStatus::error_with_message`] to
+/// include one.
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ComponentStatus {
     /// The component is initializing and not yet ready
-    Initializing = 0,
+    Initializing,
 
     /// The component is ready to accept connections
-    Ready = 1,
+    Ready,
 
     /// The component is disabled and not running
-    Disabled = 2,
+    Disabled,
 
-    /// An error occurred in the component
-    Error = 3,
+    /// An error occurred in the component, with an optional error message
+    Error(Option<String>),
 
     /// The component is in the process of refreshing its state
-    Refreshing = 4,
+    Refreshing,
 
     /// The component is in the process of shutting down
-    ShuttingDown = 5,
+    ShuttingDown,
 }
+
+impl ComponentStatus {
+    /// Returns the numeric discriminant for this status, matching the original enum ordering.
+    /// Used for metrics recording.
+    #[must_use]
+    pub fn discriminant(&self) -> u64 {
+        match self {
+            ComponentStatus::Initializing => 0,
+            ComponentStatus::Ready => 1,
+            ComponentStatus::Disabled => 2,
+            ComponentStatus::Error(_) => 3,
+            ComponentStatus::Refreshing => 4,
+            ComponentStatus::ShuttingDown => 5,
+        }
+    }
+
+    /// Creates an `Error` status with no message.
+    #[must_use]
+    pub fn error() -> Self {
+        ComponentStatus::Error(None)
+    }
+
+    /// Creates an `Error` status with the given message.
+    #[must_use]
+    pub fn error_with_message(message: impl Into<String>) -> Self {
+        ComponentStatus::Error(Some(message.into()))
+    }
+
+    /// Returns the error message if this is an `Error` status with a message.
+    #[must_use]
+    pub fn error_message(&self) -> Option<&str> {
+        match self {
+            ComponentStatus::Error(msg) => msg.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this status is an `Error` variant (regardless of message content).
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self, ComponentStatus::Error(_))
+    }
+}
+
+/// Two `ComponentStatus` values are considered equal if they are the same variant,
+/// regardless of any inner data (e.g. the error message in `Error`).
+impl PartialEq for ComponentStatus {
+    fn eq(&self, other: &Self) -> bool {
+        self.discriminant() == other.discriminant()
+    }
+}
+
+impl Eq for ComponentStatus {}
 
 impl Display for ComponentStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -48,9 +106,50 @@ impl Display for ComponentStatus {
             ComponentStatus::Initializing => write!(f, "Initializing"),
             ComponentStatus::Ready => write!(f, "Ready"),
             ComponentStatus::Disabled => write!(f, "Disabled"),
-            ComponentStatus::Error => write!(f, "Error"),
+            ComponentStatus::Error(_) => write!(f, "Error"),
             ComponentStatus::Refreshing => write!(f, "Refreshing"),
             ComponentStatus::ShuttingDown => write!(f, "ShuttingDown"),
+        }
+    }
+}
+
+/// Serializes as a plain string (e.g. `"Error"`) regardless of any inner data,
+/// preserving backward compatibility with existing API consumers.
+impl Serialize for ComponentStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Deserializes from a plain string (e.g. `"Error"`). The `Error` variant
+/// always deserializes with `None` for the inner message.
+impl<'de> Deserialize<'de> for ComponentStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "Initializing" => Ok(ComponentStatus::Initializing),
+            "Ready" => Ok(ComponentStatus::Ready),
+            "Disabled" => Ok(ComponentStatus::Disabled),
+            "Error" => Ok(ComponentStatus::Error(None)),
+            "Refreshing" => Ok(ComponentStatus::Refreshing),
+            "ShuttingDown" => Ok(ComponentStatus::ShuttingDown),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &[
+                    "Initializing",
+                    "Ready",
+                    "Disabled",
+                    "Error",
+                    "Refreshing",
+                    "ShuttingDown",
+                ],
+            )),
         }
     }
 }

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -27,6 +27,7 @@ use std::fmt::Display;
 /// include one.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = String, example = "Ready"))]
 pub enum ComponentStatus {
     /// The component is initializing and not yet ready
     Initializing,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1261,11 +1261,15 @@ mod tests {
             delay: Duration,
         ) -> bool {
             for _attempt in 0..max_attempts {
+                let Ok(desired_discriminant) = u8::try_from(desired.discriminant()) else {
+                    return false;
+                };
+
                 let metrics = registry.gather();
                 if let Some(metric) = metrics.iter().find(|m| {
                     m.name() == "dataset_load_state" && m.get_field_type() == MetricType::GAUGE
                 }) && let Some(gauge) = metric.get_metric()[0].get_gauge().as_ref()
-                    && gauge.value().is_eq(f64::from(desired.discriminant()))
+                    && gauge.value().is_eq(f64::from(desired_discriminant))
                 {
                     return true;
                 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1265,7 +1265,7 @@ mod tests {
                 if let Some(metric) = metrics.iter().find(|m| {
                     m.name() == "dataset_load_state" && m.get_field_type() == MetricType::GAUGE
                 }) && let Some(gauge) = metric.get_metric()[0].get_gauge().as_ref()
-                    && gauge.value().is_eq(f64::from(desired as i32))
+                    && gauge.value().is_eq(f64::from(desired.discriminant()))
                 {
                     return true;
                 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -740,8 +740,11 @@ impl RefreshTask {
 
         let _lock_guard = self.accelerator_write_mutex.lock().await;
         if let Err(e) = sink.insert_into(record_batch_stream, overwrite).await {
-            self.set_refresh_status(sql, status::ComponentStatus::error_with_message(e.to_string()))
-                .await;
+            self.set_refresh_status(
+                sql,
+                status::ComponentStatus::error_with_message(e.to_string()),
+            )
+            .await;
             return Err(e);
         }
 
@@ -1331,7 +1334,8 @@ impl RefreshTask {
     async fn update_component_status(&self, status: status::ComponentStatus) {
         // main component status update
         if self.is_view_acceleration() {
-            self.runtime_status.update_view(&self.dataset_name, status.clone());
+            self.runtime_status
+                .update_view(&self.dataset_name, status.clone());
         } else {
             self.runtime_status
                 .update_dataset(&self.dataset_name, status.clone());
@@ -1375,8 +1379,11 @@ impl RefreshTask {
                 "Failed to load data for {} {table_name}: S3 upload speed too slow. This typically occurs when uploading to S3 Express One Zone from outside AWS or over a slow network connection. Consider: (1) Running Spice closer to your S3 bucket (same region/AZ), (2) Reducing dataset size or using incremental refresh, (3) Increasing 'cayenne_target_file_size_mb' to reduce the number of files uploaded.",
                 self.component_type(),
             );
-            self.set_refresh_status(refresh_sql, status::ComponentStatus::error_with_message(error.to_string()))
-                .await;
+            self.set_refresh_status(
+                refresh_sql,
+                status::ComponentStatus::error_with_message(error.to_string()),
+            )
+            .await;
             return;
         }
 
@@ -1406,8 +1413,11 @@ impl RefreshTask {
             self.component_type(),
             include_source_to_table_name(&self.dataset_name, self.federated_source.as_deref()),
         );
-        self.set_refresh_status(refresh_sql, status::ComponentStatus::error_with_message(error.to_string()))
-            .await;
+        self.set_refresh_status(
+            refresh_sql,
+            status::ComponentStatus::error_with_message(error.to_string()),
+        )
+        .await;
     }
 
     /// Updates `last_updated_at` timestamp based on refresh type and row count.

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -740,7 +740,7 @@ impl RefreshTask {
 
         let _lock_guard = self.accelerator_write_mutex.lock().await;
         if let Err(e) = sink.insert_into(record_batch_stream, overwrite).await {
-            self.set_refresh_status(sql, status::ComponentStatus::Error)
+            self.set_refresh_status(sql, status::ComponentStatus::error_with_message(e.to_string()))
                 .await;
             return Err(e);
         }
@@ -1292,17 +1292,20 @@ impl RefreshTask {
     }
 
     async fn set_refresh_status(&self, sql: Option<&str>, status: status::ComponentStatus) {
+        let is_error = status.is_error();
+        let is_ready = status == status::ComponentStatus::Ready;
+
         // runtime status update
         self.update_component_status(status).await;
 
         // telemetry update
         for dataset_name in self.get_dataset_names().await {
-            if status == status::ComponentStatus::Error {
+            if is_error {
                 let labels = [KeyValue::new("dataset", dataset_name.to_string())];
                 metrics::REFRESH_ERRORS.add(1, &labels);
             }
 
-            if status == status::ComponentStatus::Ready {
+            if is_ready {
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default();
@@ -1328,16 +1331,16 @@ impl RefreshTask {
     async fn update_component_status(&self, status: status::ComponentStatus) {
         // main component status update
         if self.is_view_acceleration() {
-            self.runtime_status.update_view(&self.dataset_name, status);
+            self.runtime_status.update_view(&self.dataset_name, status.clone());
         } else {
             self.runtime_status
-                .update_dataset(&self.dataset_name, status);
+                .update_dataset(&self.dataset_name, status.clone());
         }
 
         // synchronized tables can be datasets only
         for synchronized_table in self.sink.read().await.synchronized_tables() {
             self.runtime_status
-                .update_dataset(&synchronized_table.child_dataset_name(), status);
+                .update_dataset(&synchronized_table.child_dataset_name(), status.clone());
         }
     }
 
@@ -1372,7 +1375,7 @@ impl RefreshTask {
                 "Failed to load data for {} {table_name}: S3 upload speed too slow. This typically occurs when uploading to S3 Express One Zone from outside AWS or over a slow network connection. Consider: (1) Running Spice closer to your S3 bucket (same region/AZ), (2) Reducing dataset size or using incremental refresh, (3) Increasing 'cayenne_target_file_size_mb' to reduce the number of files uploaded.",
                 self.component_type(),
             );
-            self.set_refresh_status(refresh_sql, status::ComponentStatus::Error)
+            self.set_refresh_status(refresh_sql, status::ComponentStatus::error_with_message(error.to_string()))
                 .await;
             return;
         }
@@ -1403,7 +1406,7 @@ impl RefreshTask {
             self.component_type(),
             include_source_to_table_name(&self.dataset_name, self.federated_source.as_deref()),
         );
-        self.set_refresh_status(refresh_sql, status::ComponentStatus::Error)
+        self.set_refresh_status(refresh_sql, status::ComponentStatus::error_with_message(error.to_string()))
             .await;
     }
 

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -127,7 +127,7 @@ impl RefreshTask {
                         Err(e) => {
                             self.set_refresh_status(
                                 refresh.read().await.sql.clone().as_deref(),
-                                status::ComponentStatus::Error,
+                                status::ComponentStatus::error_with_message(e.to_string()),
                             )
                             .await;
                             if !self.runtime_status.is_shutdown() {
@@ -144,7 +144,7 @@ impl RefreshTask {
 
                     self.set_refresh_status(
                         refresh.read().await.sql.clone().as_deref(),
-                        status::ComponentStatus::Error,
+                        status::ComponentStatus::error_with_message(e.to_string()),
                     )
                     .await;
                 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1856,7 +1856,7 @@ impl DataFusion {
                 tracing::error!(
                     "Failed to create view {table}. Dependent table {missing_table} does not exist."
                 );
-                status.update_view(&table, status::ComponentStatus::Error);
+                status.update_view(&table, status::ComponentStatus::error());
                 return None;
             }
 
@@ -1867,7 +1867,7 @@ impl DataFusion {
                 Ok(tbl) => tbl,
                 Err(e) => {
                     tracing::error!("Failed to create view {table}: {e}");
-                    status.update_view(&table, status::ComponentStatus::Error);
+                    status.update_view(&table, status::ComponentStatus::error());
                     return None;
                 }
             };
@@ -1883,7 +1883,7 @@ impl DataFusion {
                     }
                     Err(e) => {
                         tracing::error!("Failed to create view {table}: {e}");
-                        status.update_view(&table, status::ComponentStatus::Error);
+                        status.update_view(&table, status::ComponentStatus::error());
                         return None;
                     }
                 }
@@ -1892,7 +1892,7 @@ impl DataFusion {
             // non-accelerated view
             if let Err(e) = ctx.register_table(table.clone(), tbl_provider) {
                 tracing::error!("Failed to create view {table}: {e}");
-                status.update_view(&table, status::ComponentStatus::Error);
+                status.update_view(&table, status::ComponentStatus::error());
                 return None;
             }
             tracing::info!("{}", view_registered_trace(&table, None));

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1856,7 +1856,12 @@ impl DataFusion {
                 tracing::error!(
                     "Failed to create view {table}. Dependent table {missing_table} does not exist."
                 );
-                status.update_view(&table, status::ComponentStatus::error());
+                status.update_view(
+                    &table,
+                    status::ComponentStatus::error_with_message(format!(
+                        "Dependent table {missing_table} does not exist"
+                    )),
+                );
                 return None;
             }
 
@@ -1867,7 +1872,10 @@ impl DataFusion {
                 Ok(tbl) => tbl,
                 Err(e) => {
                     tracing::error!("Failed to create view {table}: {e}");
-                    status.update_view(&table, status::ComponentStatus::error());
+                    status.update_view(
+                        &table,
+                        status::ComponentStatus::error_with_message(e.to_string()),
+                    );
                     return None;
                 }
             };
@@ -1883,7 +1891,10 @@ impl DataFusion {
                     }
                     Err(e) => {
                         tracing::error!("Failed to create view {table}: {e}");
-                        status.update_view(&table, status::ComponentStatus::error());
+                        status.update_view(
+                            &table,
+                            status::ComponentStatus::error_with_message(e.to_string()),
+                        );
                         return None;
                     }
                 }
@@ -1892,7 +1903,10 @@ impl DataFusion {
             // non-accelerated view
             if let Err(e) = ctx.register_table(table.clone(), tbl_provider) {
                 tracing::error!("Failed to create view {table}: {e}");
-                status.update_view(&table, status::ComponentStatus::error());
+                status.update_view(
+                    &table,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
                 return None;
             }
             tracing::info!("{}", view_registered_trace(&table, None));

--- a/crates/runtime/src/http/v1/catalogs.rs
+++ b/crates/runtime/src/http/v1/catalogs.rs
@@ -42,6 +42,7 @@ pub(crate) struct CatalogFilter {
 }
 
 // Re-export shared type for backwards compatibility
+pub use runtime_api_types::v1::CatalogInfo;
 pub use runtime_api_types::v1::CatalogInfo as CatalogResponseItem;
 
 const APPLICATION_JSON: MediaType = MediaType::from_parts(APPLICATION, JSON, None, &[]);

--- a/crates/runtime/src/http/v1/catalogs.rs
+++ b/crates/runtime/src/http/v1/catalogs.rs
@@ -42,7 +42,6 @@ pub(crate) struct CatalogFilter {
 }
 
 // Re-export shared type for backwards compatibility
-pub use runtime_api_types::v1::CatalogInfo;
 pub use runtime_api_types::v1::CatalogInfo as CatalogResponseItem;
 
 const APPLICATION_JSON: MediaType = MediaType::from_parts(APPLICATION, JSON, None, &[]);

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -165,7 +165,9 @@ pub(crate) async fn get(
             } else {
                 None
             };
-            let error_message = status.as_ref().and_then(|s| s.error_message().map(String::from));
+            let error_message = status
+                .as_ref()
+                .and_then(|s| s.error_message().map(String::from));
             DatasetResponseItem {
                 from: d.from.clone(),
                 name: d.name.to_quoted_string(),

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -159,17 +159,22 @@ pub(crate) async fn get(
 
     let resp: Vec<_> = datasets
         .iter()
-        .map(|d| DatasetResponseItem {
-            from: d.from.clone(),
-            name: d.name.to_quoted_string(),
-            replication_enabled: d.replication.as_ref().is_some_and(|f| f.enabled),
-            acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
-            properties: dataset_properties(d),
-            status: if params.status {
+        .map(|d| {
+            let status = if params.status {
                 Some(dataset_status(&df, d))
             } else {
                 None
-            },
+            };
+            let error_message = status.as_ref().and_then(|s| s.error_message().map(String::from));
+            DatasetResponseItem {
+                from: d.from.clone(),
+                name: d.name.to_quoted_string(),
+                replication_enabled: d.replication.as_ref().is_some_and(|f| f.enabled),
+                acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
+                properties: dataset_properties(d),
+                status,
+                error_message,
+            }
         })
         .collect();
 

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -184,14 +184,14 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
     // (Initializing, Refreshing, Ready, Error, etc.)
     let dataset_statuses = df.runtime_status().get_dataset_statuses();
     if let Some(status) = dataset_statuses.get(&ds.name) {
-        return *status;
+        return status.clone();
     }
 
     // Fallback: if not in runtime status, check if table exists
     if df.table_exists(ds.name.clone()) {
         ComponentStatus::Ready
     } else {
-        ComponentStatus::Error
+        ComponentStatus::error()
     }
 }
 

--- a/crates/runtime/src/http/v1/models.rs
+++ b/crates/runtime/src/http/v1/models.rs
@@ -191,7 +191,7 @@ pub(crate) async fn get(
                     object: "model".to_string(),
                     owned_by: m.from.clone(),
                     datasets: d,
-                    status: statuses.get(&m.name).copied(),
+                    status: statuses.get(&m.name).cloned(),
                     metadata: generate_metadata(&m.name, &metadata_keys, &responses_models),
                 }
             })
@@ -218,7 +218,7 @@ pub(crate) async fn get(
             object: "model".to_string(),
             owned_by: "spiceai".to_string(),
             datasets: None,
-            status: worker_statuses.get(name).copied(),
+            status: worker_statuses.get(name).cloned(),
             metadata: generate_metadata(name, &metadata_keys, &responses_models),
         })
     }));

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -123,7 +123,7 @@ pub(crate) async fn get(
                     Ok(status) => status,
                     Err(e) => {
                         tracing::error!("Error getting metrics status from {metrics_url}: {e}");
-                        ComponentStatus::error()
+                        ComponentStatus::error_with_message(e.to_string())
                     }
                 },
                 None => ComponentStatus::Disabled,
@@ -173,7 +173,7 @@ async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
         Ok(_) => ComponentStatus::Ready,
         Err(e) => {
             tracing::error!("Error connecting to flight when checking status: {e}");
-            ComponentStatus::error()
+            ComponentStatus::error_with_message(e.to_string())
         }
     }
 }

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -112,7 +112,7 @@ pub(crate) async fn get(
         },
         ConnectionDetails {
             name: "flight",
-            status: flight_status,
+            status: flight_status.clone(),
             endpoint: flight_url.clone(),
         },
         ConnectionDetails {
@@ -123,7 +123,7 @@ pub(crate) async fn get(
                     Ok(status) => status,
                     Err(e) => {
                         tracing::error!("Error getting metrics status from {metrics_url}: {e}");
-                        ComponentStatus::Error
+                        ComponentStatus::error()
                     }
                 },
                 None => ComponentStatus::Disabled,
@@ -132,7 +132,7 @@ pub(crate) async fn get(
         // OpenTelemetry is served on the same gRPC port as Flight
         ConnectionDetails {
             name: "opentelemetry",
-            status: flight_status,
+            status: flight_status.clone(),
             endpoint: flight_url,
         },
     ];
@@ -173,7 +173,7 @@ async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
         Ok(_) => ComponentStatus::Ready,
         Err(e) => {
             tracing::error!("Error connecting to flight when checking status: {e}");
-            ComponentStatus::Error
+            ComponentStatus::error()
         }
     }
 }
@@ -185,6 +185,6 @@ async fn get_metrics_status(
     if resp.status().is_success() && resp.text().await? == "OK" {
         Ok(ComponentStatus::Ready)
     } else {
-        Ok(ComponentStatus::Error)
+        Ok(ComponentStatus::error())
     }
 }

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -56,8 +56,10 @@ impl Runtime {
                 Ok(connector) => connector,
                 Err(err) => {
                     let catalog_name = &catalog.name;
-                    self.status
-                        .update_catalog(catalog_name, status::ComponentStatus::error());
+                    self.status.update_catalog(
+                        catalog_name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
                     metrics::catalogs::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
                     return Err(RetryError::transient(err));
@@ -90,8 +92,10 @@ impl Runtime {
         let Some(catalog_connector) = catalogconnector::create_new_connector(&source, params).await
         else {
             let catalog_name = &catalog.name;
-            self.status
-                .update_catalog(catalog_name, status::ComponentStatus::error());
+            self.status.update_catalog(
+                catalog_name,
+                status::ComponentStatus::error_with_message(err.to_string()),
+            );
             metrics::catalogs::LOAD_ERROR.add(1, &[]);
             let err = crate::Error::UnknownCatalogConnector {
                 catalog_connector: source,

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -92,14 +92,14 @@ impl Runtime {
         let Some(catalog_connector) = catalogconnector::create_new_connector(&source, params).await
         else {
             let catalog_name = &catalog.name;
-            self.status.update_catalog(
-                catalog_name,
-                status::ComponentStatus::error_with_message(err.to_string()),
-            );
             metrics::catalogs::LOAD_ERROR.add(1, &[]);
             let err = crate::Error::UnknownCatalogConnector {
                 catalog_connector: source,
             };
+            self.status.update_catalog(
+                catalog_name,
+                status::ComponentStatus::error_with_message(err.to_string()),
+            );
             warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
             return Err(err);
         };

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -57,7 +57,7 @@ impl Runtime {
                 Err(err) => {
                     let catalog_name = &catalog.name;
                     self.status
-                        .update_catalog(catalog_name, status::ComponentStatus::Error);
+                        .update_catalog(catalog_name, status::ComponentStatus::error());
                     metrics::catalogs::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
                     return Err(RetryError::transient(err));
@@ -91,7 +91,7 @@ impl Runtime {
         else {
             let catalog_name = &catalog.name;
             self.status
-                .update_catalog(catalog_name, status::ComponentStatus::Error);
+                .update_catalog(catalog_name, status::ComponentStatus::error());
             metrics::catalogs::LOAD_ERROR.add(1, &[]);
             let err = crate::Error::UnknownCatalogConnector {
                 catalog_connector: source,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -159,7 +159,7 @@ impl Runtime {
                     path_table_ref
                 );
                 self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::Error);
+                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(format!("Parent dataset '{path_table_ref}' doesn't exist")));
             }
         }
 
@@ -235,7 +235,7 @@ impl Runtime {
             Err(err) => {
                 let ds_name = &ds.name;
                 self.status
-                    .update_dataset(ds_name, status::ComponentStatus::Error);
+                    .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
                 warn_spaced!(
                     spaced_tracer,
@@ -286,7 +286,7 @@ impl Runtime {
             metrics::datasets::LOAD_ERROR.add(1, &[]);
             error_spaced!(spaced_tracer, "{}{err}", "");
             self.status
-                .update_dataset(ds_name, status::ComponentStatus::Error);
+                .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
             return;
         }
 
@@ -308,7 +308,7 @@ impl Runtime {
                     let ds_name = &ds.name;
                     runtime
                         .status
-                        .update_dataset(ds_name, status::ComponentStatus::Error);
+                        .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
                     metrics::datasets::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                     return Err(RetryError::transient(err));
@@ -372,7 +372,7 @@ impl Runtime {
                     federated_table
                 } else {
                     self.status
-                        .update_dataset(&ds.name, status::ComponentStatus::Error);
+                        .update_dataset(&ds.name, status::ComponentStatus::error_with_message(err.to_string()));
                     metrics::datasets::LOAD_ERROR.add(1, &[]);
                     if let DataConnectorError::UnsupportedDataType { .. } = err {
                         error_spaced!(spaced_tracer, "{}{err}", "");
@@ -447,7 +447,7 @@ impl Runtime {
             }
             Err(err) => {
                 self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::Error);
+                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(err.to_string()));
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
                 if let Error::UnableToAttachDataConnector {
                     source: crate::datafusion::Error::RefreshSql { .. },
@@ -553,13 +553,13 @@ impl Runtime {
                     .is_err()
                 {
                     self.status
-                        .update_dataset(&ds.name, status::ComponentStatus::Error);
+                        .update_dataset(&ds.name, status::ComponentStatus::error());
                 }
             }
             Err(e) => {
                 tracing::error!("Unable to update dataset {}: {e}", ds.name);
                 self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::Error);
+                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(e.to_string()));
             }
         }
     }
@@ -958,7 +958,7 @@ impl Runtime {
                     Ok(accelerator) => accelerator,
                     Err(err) => {
                         let ds_name = &ds.name;
-                        status.update_dataset(ds_name, status::ComponentStatus::Error);
+                        status.update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
                         metrics::datasets::LOAD_ERROR.add(1, &[]);
                         warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                         return (ds.name.clone(), Err(err));
@@ -978,7 +978,7 @@ impl Runtime {
                     }
                     Err(err) => {
                         let ds_name = &ds.name;
-                        status.update_dataset(ds_name, status::ComponentStatus::Error);
+                        status.update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
                         metrics::datasets::LOAD_ERROR.add(1, &[]);
                         warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                         (ds.name.clone(), Err(err))

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -158,8 +158,12 @@ impl Runtime {
                     path_table_ref,
                     path_table_ref
                 );
-                self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(format!("Parent dataset '{path_table_ref}' doesn't exist")));
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(format!(
+                        "Parent dataset '{path_table_ref}' doesn't exist"
+                    )),
+                );
             }
         }
 
@@ -234,8 +238,10 @@ impl Runtime {
             Ok(data_connector) => data_connector,
             Err(err) => {
                 let ds_name = &ds.name;
-                self.status
-                    .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
+                self.status.update_dataset(
+                    ds_name,
+                    status::ComponentStatus::error_with_message(err.to_string()),
+                );
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
                 warn_spaced!(
                     spaced_tracer,
@@ -285,8 +291,10 @@ impl Runtime {
             let ds_name = &ds.name;
             metrics::datasets::LOAD_ERROR.add(1, &[]);
             error_spaced!(spaced_tracer, "{}{err}", "");
-            self.status
-                .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
+            self.status.update_dataset(
+                ds_name,
+                status::ComponentStatus::error_with_message(err.to_string()),
+            );
             return;
         }
 
@@ -306,9 +314,10 @@ impl Runtime {
                     }
 
                     let ds_name = &ds.name;
-                    runtime
-                        .status
-                        .update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
+                    runtime.status.update_dataset(
+                        ds_name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
                     metrics::datasets::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                     return Err(RetryError::transient(err));
@@ -371,8 +380,10 @@ impl Runtime {
                     );
                     federated_table
                 } else {
-                    self.status
-                        .update_dataset(&ds.name, status::ComponentStatus::error_with_message(err.to_string()));
+                    self.status.update_dataset(
+                        &ds.name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
                     metrics::datasets::LOAD_ERROR.add(1, &[]);
                     if let DataConnectorError::UnsupportedDataType { .. } = err {
                         error_spaced!(spaced_tracer, "{}{err}", "");
@@ -446,8 +457,10 @@ impl Runtime {
                 Ok(())
             }
             Err(err) => {
-                self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(err.to_string()));
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(err.to_string()),
+                );
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
                 if let Error::UnableToAttachDataConnector {
                     source: crate::datafusion::Error::RefreshSql { .. },
@@ -542,7 +555,7 @@ impl Runtime {
                     .remove_dataset(ds.name.clone(), ds.acceleration.as_ref())
                     .await;
 
-                if Arc::clone(&self)
+                if let Err(e) = Arc::clone(&self)
                     .register_loaded_dataset(
                         Arc::clone(&ds),
                         Arc::clone(&connector),
@@ -550,16 +563,19 @@ impl Runtime {
                         BootstrapStatus::None,
                     )
                     .await
-                    .is_err()
                 {
-                    self.status
-                        .update_dataset(&ds.name, status::ComponentStatus::error());
+                    self.status.update_dataset(
+                        &ds.name,
+                        status::ComponentStatus::error_with_message(e.to_string()),
+                    );
                 }
             }
             Err(e) => {
                 tracing::error!("Unable to update dataset {}: {e}", ds.name);
-                self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::error_with_message(e.to_string()));
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
             }
         }
     }
@@ -958,7 +974,10 @@ impl Runtime {
                     Ok(accelerator) => accelerator,
                     Err(err) => {
                         let ds_name = &ds.name;
-                        status.update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
+                        status.update_dataset(
+                            ds_name,
+                            status::ComponentStatus::error_with_message(err.to_string()),
+                        );
                         metrics::datasets::LOAD_ERROR.add(1, &[]);
                         warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                         return (ds.name.clone(), Err(err));
@@ -978,7 +997,10 @@ impl Runtime {
                     }
                     Err(err) => {
                         let ds_name = &ds.name;
-                        status.update_dataset(ds_name, status::ComponentStatus::error_with_message(err.to_string()));
+                        status.update_dataset(
+                            ds_name,
+                            status::ComponentStatus::error_with_message(err.to_string()),
+                        );
                         metrics::datasets::LOAD_ERROR.add(1, &[]);
                         warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                         (ds.name.clone(), Err(err))

--- a/crates/runtime/src/init/embedding.rs
+++ b/crates/runtime/src/init/embedding.rs
@@ -69,7 +69,7 @@ impl Runtime {
                     Err(e) => {
                         metrics::embeddings::LOAD_ERROR.add(1, &[]);
                         self.status
-                            .update_embedding(&in_embed.name, status::ComponentStatus::Error);
+                            .update_embedding(&in_embed.name, status::ComponentStatus::error());
                         tracing::warn!(
                             "Failed to load Embedding Model {}. {} Verify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/embeddings",
                             in_embed.name,

--- a/crates/runtime/src/init/embedding.rs
+++ b/crates/runtime/src/init/embedding.rs
@@ -68,8 +68,10 @@ impl Runtime {
                     }
                     Err(e) => {
                         metrics::embeddings::LOAD_ERROR.add(1, &[]);
-                        self.status
-                            .update_embedding(&in_embed.name, status::ComponentStatus::error());
+                        self.status.update_embedding(
+                            &in_embed.name,
+                            status::ComponentStatus::error_with_message(e.to_string()),
+                        );
                         tracing::warn!(
                             "Failed to load Embedding Model {}. {} Verify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/embeddings",
                             in_embed.name,

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -112,7 +112,7 @@ impl Runtime {
             if let Err(err) = verify_local_files_exist(m) {
                 metrics::models::LOAD_ERROR.add(1, &[]);
                 self.status
-                    .update_model(&model.name, status::ComponentStatus::Error);
+                    .update_model(&model.name, status::ComponentStatus::error());
                 tracing::warn!("{err}");
                 return;
             }
@@ -171,7 +171,7 @@ impl Runtime {
             Err(e) => {
                 metrics::models::LOAD_ERROR.add(1, &[]);
                 self.status
-                    .update_model(&model.name, status::ComponentStatus::Error);
+                    .update_model(&model.name, status::ComponentStatus::error());
 
                 // Try to fetch available models to help user debug the issue
                 let error_msg = e.to_string();

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -111,8 +111,10 @@ impl Runtime {
             // Otherwise, we will fail to determine the model type and the error will be confusing.
             if let Err(err) = verify_local_files_exist(m) {
                 metrics::models::LOAD_ERROR.add(1, &[]);
-                self.status
-                    .update_model(&model.name, status::ComponentStatus::error());
+                self.status.update_model(
+                    &model.name,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
                 tracing::warn!("{err}");
                 return;
             }
@@ -170,8 +172,10 @@ impl Runtime {
             }
             Err(e) => {
                 metrics::models::LOAD_ERROR.add(1, &[]);
-                self.status
-                    .update_model(&model.name, status::ComponentStatus::error());
+                self.status.update_model(
+                    &model.name,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
 
                 // Try to fetch available models to help user debug the issue
                 let error_msg = e.to_string();

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -113,7 +113,7 @@ impl Runtime {
                 metrics::models::LOAD_ERROR.add(1, &[]);
                 self.status.update_model(
                     &model.name,
-                    status::ComponentStatus::error_with_message(e.to_string()),
+                    status::ComponentStatus::error_with_message(err.to_string()),
                 );
                 tracing::warn!("{err}");
                 return;

--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -110,8 +110,10 @@ impl Runtime {
                 }
                 Err(e) => {
                     metrics::tools::LOAD_ERROR.add(1, &[]);
-                    self.status
-                        .update_tool(&tool.name, status::ComponentStatus::error());
+                    self.status.update_tool(
+                        &tool.name,
+                        status::ComponentStatus::error_with_message(e.to_string()),
+                    );
                     tracing::warn!(
                         "Unable to load tool '{}' from spicepod. Error: {}",
                         tool.name,

--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -111,7 +111,7 @@ impl Runtime {
                 Err(e) => {
                     metrics::tools::LOAD_ERROR.add(1, &[]);
                     self.status
-                        .update_tool(&tool.name, status::ComponentStatus::Error);
+                        .update_tool(&tool.name, status::ComponentStatus::error());
                     tracing::warn!(
                         "Unable to load tool '{}' from spicepod. Error: {}",
                         tool.name,

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -165,7 +165,7 @@ impl Runtime {
                             if log_errors.0 {
                                 metrics::views::LOAD_ERROR.add(1, &[]);
                                 tracing::error!("View '{}' has invalid SQL: {}", view.name, e);
-                                status.update_view(&view.name, status::ComponentStatus::Error);
+                                status.update_view(&view.name, status::ComponentStatus::error());
                             }
                             return None;
                         }
@@ -175,7 +175,7 @@ impl Runtime {
                         if log_errors.0 {
                             metrics::views::LOAD_ERROR.add(1, &[]);
                             tracing::error!("View '{}' has empty SQL statement", view.name);
-                            status.update_view(&view.name, status::ComponentStatus::Error);
+                            status.update_view(&view.name, status::ComponentStatus::error());
                         }
                         return None;
                     }
@@ -187,7 +187,7 @@ impl Runtime {
                                 "View '{}' contains multiple SQL statements. Only one SELECT statement is allowed per view",
                                 view.name
                             );
-                            status.update_view(&view.name, status::ComponentStatus::Error);
+                            status.update_view(&view.name, status::ComponentStatus::error());
                         }
                         return None;
                     }
@@ -210,7 +210,7 @@ impl Runtime {
                                 "View '{}' must contain a SELECT query",
                                 view.name
                             );
-                            status.update_view(&view.name, status::ComponentStatus::Error);
+                            status.update_view(&view.name, status::ComponentStatus::error());
                         }
                         return None;
                     }
@@ -262,7 +262,7 @@ impl Runtime {
                 Err(err) => {
                     let view_name = &view.name;
                     self.status
-                        .update_view(view_name, status::ComponentStatus::Error);
+                        .update_view(view_name, status::ComponentStatus::error());
                     metrics::views::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", view_name.table());
                     continue;
@@ -280,7 +280,7 @@ impl Runtime {
                 Err(err) => {
                     let view_name = &view.name;
                     self.status
-                        .update_view(view_name, status::ComponentStatus::Error);
+                        .update_view(view_name, status::ComponentStatus::error());
                     metrics::views::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", view_name.table());
                 }
@@ -324,7 +324,7 @@ impl Runtime {
             .context(UnableToAttachViewSnafu)
             .inspect_err(|_| {
                 self.status
-                    .update_view(&view.name, status::ComponentStatus::Error);
+                    .update_view(&view.name, status::ComponentStatus::error());
             })?;
 
         let runtime = Arc::clone(&self);

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -165,7 +165,7 @@ impl Runtime {
                             if log_errors.0 {
                                 metrics::views::LOAD_ERROR.add(1, &[]);
                                 tracing::error!("View '{}' has invalid SQL: {}", view.name, e);
-                                status.update_view(&view.name, status::ComponentStatus::error());
+                                status.update_view(&view.name, status::ComponentStatus::error_with_message(e.to_string()));
                             }
                             return None;
                         }
@@ -175,7 +175,7 @@ impl Runtime {
                         if log_errors.0 {
                             metrics::views::LOAD_ERROR.add(1, &[]);
                             tracing::error!("View '{}' has empty SQL statement", view.name);
-                            status.update_view(&view.name, status::ComponentStatus::error());
+                            status.update_view(&view.name, status::ComponentStatus::error_with_message("Empty SQL statement".to_string()));
                         }
                         return None;
                     }
@@ -187,7 +187,7 @@ impl Runtime {
                                 "View '{}' contains multiple SQL statements. Only one SELECT statement is allowed per view",
                                 view.name
                             );
-                            status.update_view(&view.name, status::ComponentStatus::error());
+                            status.update_view(&view.name, status::ComponentStatus::error_with_message("Multiple SQL statements".to_string()));
                         }
                         return None;
                     }
@@ -210,7 +210,7 @@ impl Runtime {
                                 "View '{}' must contain a SELECT query",
                                 view.name
                             );
-                            status.update_view(&view.name, status::ComponentStatus::error());
+                            status.update_view(&view.name, status::ComponentStatus::error_with_message("View must contain a SELECT query".to_string()));
                         }
                         return None;
                     }
@@ -261,8 +261,10 @@ impl Runtime {
                 Ok(accelerator) => accelerator,
                 Err(err) => {
                     let view_name = &view.name;
-                    self.status
-                        .update_view(view_name, status::ComponentStatus::error());
+                    self.status.update_view(
+                        view_name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
                     metrics::views::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", view_name.table());
                     continue;
@@ -279,8 +281,10 @@ impl Runtime {
                 }
                 Err(err) => {
                     let view_name = &view.name;
-                    self.status
-                        .update_view(view_name, status::ComponentStatus::error());
+                    self.status.update_view(
+                        view_name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
                     metrics::views::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", view_name.table());
                 }
@@ -322,9 +326,11 @@ impl Runtime {
         let register_task = df
             .register_view(Arc::clone(view), secrets)
             .context(UnableToAttachViewSnafu)
-            .inspect_err(|_| {
-                self.status
-                    .update_view(&view.name, status::ComponentStatus::error());
+            .inspect_err(|e| {
+                self.status.update_view(
+                    &view.name,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
             })?;
 
         let runtime = Arc::clone(&self);

--- a/crates/runtime/src/init/worker.rs
+++ b/crates/runtime/src/init/worker.rs
@@ -51,7 +51,7 @@ impl Runtime {
             Err(e) => {
                 tracing::error!("Failed to load worker [{}]: {e}", cfg.name);
                 self.status
-                    .update_worker(&cfg.name, status::ComponentStatus::Error);
+                    .update_worker(&cfg.name, status::ComponentStatus::error());
                 return;
             }
         };
@@ -78,7 +78,7 @@ impl Runtime {
         {
             tracing::error!("Failed to create scheduler for worker [{}]: {e}", cfg.name);
             self.status
-                .update_worker(&cfg.name, status::ComponentStatus::Error);
+                .update_worker(&cfg.name, status::ComponentStatus::error());
         } else {
             tracing::info!("Scheduler for worker [{}] created successfully", cfg.name);
         }
@@ -94,7 +94,7 @@ impl Runtime {
         {
             tracing::error!("Failed to remove scheduler for worker [{}]: {e}", cfg.name);
             self.status
-                .update_worker(&cfg.name, status::ComponentStatus::Error);
+                .update_worker(&cfg.name, status::ComponentStatus::error());
             return;
         }
 

--- a/crates/runtime/src/init/worker.rs
+++ b/crates/runtime/src/init/worker.rs
@@ -50,8 +50,10 @@ impl Runtime {
             Ok(worker) => worker,
             Err(e) => {
                 tracing::error!("Failed to load worker [{}]: {e}", cfg.name);
-                self.status
-                    .update_worker(&cfg.name, status::ComponentStatus::error());
+                self.status.update_worker(
+                    &cfg.name,
+                    status::ComponentStatus::error_with_message(e.to_string()),
+                );
                 return;
             }
         };
@@ -77,8 +79,10 @@ impl Runtime {
             .await
         {
             tracing::error!("Failed to create scheduler for worker [{}]: {e}", cfg.name);
-            self.status
-                .update_worker(&cfg.name, status::ComponentStatus::error());
+            self.status.update_worker(
+                &cfg.name,
+                status::ComponentStatus::error_with_message(e.to_string()),
+            );
         } else {
             tracing::info!("Scheduler for worker [{}] created successfully", cfg.name);
         }
@@ -93,8 +97,10 @@ impl Runtime {
             .await
         {
             tracing::error!("Failed to remove scheduler for worker [{}]: {e}", cfg.name);
-            self.status
-                .update_worker(&cfg.name, status::ComponentStatus::error());
+            self.status.update_worker(
+                &cfg.name,
+                status::ComponentStatus::error_with_message(e.to_string()),
+            );
             return;
         }
 

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -67,7 +67,7 @@ impl RuntimeStatus {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        statuses.insert(component_name.to_string(), status);
+        statuses.insert(component_name.to_string(), status.clone());
 
         if status == ComponentStatus::Ready {
             let mut ever_ready = match self.ever_ready_components.write() {
@@ -83,77 +83,87 @@ impl RuntimeStatus {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(sender) = notifiers.get(component_name) {
-            let _ = sender.send(status); // Ignore error if no receivers
+            let _ = sender.send(status.clone()); // Ignore error if no receivers
         }
     }
 
     pub fn update_catalog(&self, catalog_name: impl Into<String>, status: ComponentStatus) {
         let catalog_name = catalog_name.into();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("catalog:{catalog_name}"), status);
-        metrics::catalogs::STATUS.record(status as u64, &[KeyValue::new("catalog", catalog_name)]);
+        metrics::catalogs::STATUS.record(metric_value, &[KeyValue::new("catalog", catalog_name)]);
     }
 
     pub fn update_dataset(&self, dataset: &TableReference, status: ComponentStatus) {
         let ds_name = dataset.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("dataset:{ds_name}"), status);
-        metrics::datasets::STATUS.record(status as u64, &[KeyValue::new("dataset", ds_name)]);
+        metrics::datasets::STATUS.record(metric_value, &[KeyValue::new("dataset", ds_name)]);
     }
 
     pub fn update_model(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("model:{model_name}"), status);
-        metrics::models::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
+        metrics::models::STATUS.record(metric_value, &[KeyValue::new("model", model_name)]);
     }
 
     pub fn update_tool(&self, tool_name: &str, status: ComponentStatus) {
         let tool_name = tool_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("tool:{tool_name}"), status);
-        metrics::tools::STATUS.record(status as u64, &[KeyValue::new("tool", tool_name)]);
+        metrics::tools::STATUS.record(metric_value, &[KeyValue::new("tool", tool_name)]);
     }
 
     pub fn update_tool_catalog(&self, catalog_name: &str, status: ComponentStatus) {
         let name = catalog_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("tool_catalog:{name}"), status);
-        metrics::tools::STATUS.record(status as u64, &[KeyValue::new("tool_catalog", name)]);
+        metrics::tools::STATUS.record(metric_value, &[KeyValue::new("tool_catalog", name)]);
     }
 
     pub fn update_llm(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("llm:{model_name}"), status);
-        metrics::llms::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
+        metrics::llms::STATUS.record(metric_value, &[KeyValue::new("model", model_name)]);
     }
 
     pub fn update_embedding(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("embedding:{model_name}"), status);
-        metrics::embeddings::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
+        metrics::embeddings::STATUS.record(metric_value, &[KeyValue::new("model", model_name)]);
     }
     pub fn update_view(&self, view_name: &TableReference, status: ComponentStatus) {
         let view_name = view_name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("view:{view_name}"), status);
-        metrics::views::STATUS.record(status as u64, &[KeyValue::new("view", view_name)]);
+        metrics::views::STATUS.record(metric_value, &[KeyValue::new("view", view_name)]);
     }
 
     /// Update the status of a worker
     pub fn update_worker(&self, name: &str, status: ComponentStatus) {
         let worker_name = name.to_string();
+        let metric_value = status.discriminant();
         self.update_component_status(&format!("worker:{worker_name}"), status);
-        metrics::models::STATUS.record(status as u64, &[KeyValue::new("worker", worker_name)]);
+        metrics::models::STATUS.record(metric_value, &[KeyValue::new("worker", worker_name)]);
     }
 
     /// Update the status of a cluster node
     pub fn update_cluster(&self, node_name: &str, status: ComponentStatus) {
         let cluster_node_name = node_name.to_string();
-        self.update_component_status(&format!("cluster:{cluster_node_name}"), status);
 
         // Record cluster node status metric
         // Map ComponentStatus to cluster status values: 0=Unknown, 1=Healthy, 2=Unhealthy, 3=Draining
-        let status_value = match status {
+        let status_value = match &status {
             ComponentStatus::Initializing => 0,
             ComponentStatus::Ready | ComponentStatus::Refreshing => 1, // Refreshing is still healthy
-            ComponentStatus::Disabled | ComponentStatus::Error => 2,
+            ComponentStatus::Disabled | ComponentStatus::Error(_) => 2,
             ComponentStatus::ShuttingDown => 3, // Draining
         };
+
+        self.update_component_status(&format!("cluster:{cluster_node_name}"), status);
         metrics::cluster::set_node_status(&cluster_node_name, node_name, status_value);
     }
 
@@ -165,7 +175,7 @@ impl RuntimeStatus {
             Err(poisoned) => poisoned.into_inner(),
         };
         let full_name = format!("worker:{name}");
-        components.get(&full_name).copied()
+        components.get(&full_name).cloned()
     }
 
     /// Checks if all registered components have been ready at least once and the runtime is not shutting down.
@@ -256,7 +266,7 @@ impl RuntimeStatus {
 
         statuses
             .iter()
-            .filter_map(|(k, v)| k.strip_prefix(prefix).map(|name| (name.into(), *v)))
+            .filter_map(|(k, v)| k.strip_prefix(prefix).map(|name| (name.into(), v.clone())))
             .collect()
     }
 
@@ -272,7 +282,7 @@ impl RuntimeStatus {
             .statuses
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        statuses.get(component_name).copied()
+        statuses.get(component_name).cloned()
     }
 
     /// Gets or creates a notifier for a component, returning a receiver to watch for status changes.

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -83,7 +83,7 @@ impl RuntimeStatus {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(sender) = notifiers.get(component_name) {
-            let _ = sender.send(status.clone()); // Ignore error if no receivers
+            let _ = sender.send(status); // Ignore error if no receivers
         }
     }
 

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -554,7 +554,6 @@ fn get_acceleration_row_count(duckdb_path: &str, table_name: &str) -> usize {
 
 async fn wait_for_dataset_error(rt: &Runtime, dataset_name: &str, timeout_secs: u64) -> bool {
     use datafusion::sql::TableReference;
-    use runtime::status::ComponentStatus;
 
     let table_ref = TableReference::bare(dataset_name);
     let start = std::time::Instant::now();

--- a/crates/runtime/tests/dynamodb/streams.rs
+++ b/crates/runtime/tests/dynamodb/streams.rs
@@ -565,7 +565,7 @@ async fn wait_for_dataset_error(rt: &Runtime, dataset_name: &str, timeout_secs: 
         // Check dataset status
         let statuses = rt.datafusion().runtime_status().get_dataset_statuses();
         if let Some(status) = statuses.get(&table_ref)
-            && *status == ComponentStatus::Error
+            && status.is_error()
         {
             return true;
         }

--- a/crates/runtime/tests/view/mod.rs
+++ b/crates/runtime/tests/view/mod.rs
@@ -561,7 +561,7 @@ async fn test_view_sql_validation() -> Result<(), anyhow::Error> {
                 let view_statuses = rt.status().get_view_statuses();
                 let view_status = view_statuses.get(&TableReference::bare("invalid_syntax_view"));
                 if let Some(status) = view_status {
-                    if *status != runtime::status::ComponentStatus::Error {
+                    if !status.is_error() {
                         return Err(anyhow::anyhow!(
                             "Invalid SQL view should be in error state, got {status:?}"
                         ));
@@ -597,7 +597,7 @@ async fn test_view_sql_validation() -> Result<(), anyhow::Error> {
                 let view_statuses = rt.status().get_view_statuses();
                 let view_status = view_statuses.get(&TableReference::bare("empty_sql_view"));
                 if let Some(status) = view_status {
-                    if *status != runtime::status::ComponentStatus::Error {
+                    if !status.is_error() {
                         return Err(anyhow::anyhow!(
                             "Empty SQL view should be in error state, got {status:?}"
                         ));
@@ -633,7 +633,7 @@ async fn test_view_sql_validation() -> Result<(), anyhow::Error> {
                 let view_statuses = rt.status().get_view_statuses();
                 let view_status = view_statuses.get(&TableReference::bare("multi_statement_view"));
                 if let Some(status) = view_status {
-                    if *status != runtime::status::ComponentStatus::Error {
+                    if !status.is_error() {
                         return Err(anyhow::anyhow!(
                             "Multi-statement view should be in error state, got {status:?}"
                         ));
@@ -669,7 +669,7 @@ async fn test_view_sql_validation() -> Result<(), anyhow::Error> {
                 let view_statuses = rt.status().get_view_statuses();
                 let view_status = view_statuses.get(&TableReference::bare("insert_view"));
                 if let Some(status) = view_status {
-                    if *status != runtime::status::ComponentStatus::Error {
+                    if !status.is_error() {
                         return Err(anyhow::anyhow!(
                             "Non-SELECT view should be in error state, got {status:?}"
                         ));


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a `error_message` property to the `/datasets` response API. When `?status=true`, in addition to returning the dataset status the error message is also returned - if available.