### PR TITLE
feat: spidapter supports ADBC sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18159,16 +18159,17 @@ dependencies = [
 name = "spidapter"
 version = "2.0.0-unstable"
 dependencies = [
+ "anyhow",
  "arrow",
  "async-trait",
  "clap",
  "reqwest 0.12.24",
  "runtime-secrets",
+ "rustls 0.23.36",
  "serde_json",
  "spice-cloud-client",
  "spicepod",
  "system-adapter-protocol",
- "test-framework",
  "tokio",
  "uuid 1.20.0",
  "yaml",
@@ -18825,7 +18826,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=2153680f3c42bd66632fd3f180016c0d5a984d64#2153680f3c42bd66632fd3f180016c0d5a984d64"
+source = "git+https://github.com/spiceai/spicebench.git?rev=523a2fdcbee64982e14db992c8811207d370d05c#523a2fdcbee64982e14db992c8811207d370d05c"
 dependencies = [
  "arrow-schema",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "2153680f3c42bd66632fd3f180016c0d5a984d64", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "523a2fdcbee64982e14db992c8811207d370d05c", features = ["server"] } # branch: trunk
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [
@@ -314,7 +314,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 turso = { version = "0.4.4", default-features = false }
 twox-hash = "2.1.2"
 url = { version = "2.5", features = ["serde"] }
-util = { path = "crates/util" }
+util = { path = "crates/util", default-features = false }
 uuid = "1"
 
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -61,7 +61,7 @@ tracing.workspace = true
 tracing-log = "0.2.0"
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
-util = { path = "../../crates/util" }
+util = { path = "../../crates/util"}
 
 # Non-default features should be added to `lint-rust` make target.
 [features]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -13,7 +13,7 @@ serde.workspace = true
 snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tracing.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 [features]
 default = []

--- a/crates/aws-sdk-credential-bridge/Cargo.toml
+++ b/crates/aws-sdk-credential-bridge/Cargo.toml
@@ -25,7 +25,7 @@ secrecy.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-util.workspace = true
+util = { workspace = true, default-features = false, features = [] }
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 tracing = { workspace = true }
 turso = { workspace = true, optional = true }
 url = { workspace = true }
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 uuid = { workspace = true, features = ["v7"] }
 vortex = { workspace = true }
 vortex-datafusion = { workspace = true }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -100,7 +100,7 @@ tracing.workspace = true
 turso = { workspace = true, optional = true }
 twox-hash.workspace = true
 url.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 uuid.workspace = true
 zip = "7.2.0"
 tokio-stream.workspace = true

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -34,7 +34,7 @@ snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
 tokio-util = { workspace = true }
 tracing.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/dynamodb-streams/Cargo.toml
+++ b/crates/dynamodb-streams/Cargo.toml
@@ -17,7 +17,7 @@ tokio.workspace = true
 tracing.workspace = true
 futures.workspace = true
 serde.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 humantime.workspace = true
 
 [dev-dependencies]

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,7 +41,7 @@ tokenizers.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "4d40be8a2bd5b44710728124d0c32bc13d79beaa", optional = true } # branch: spiceai-upgrade
 mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "4d40be8a2bd5b44710728124d0c32bc13d79beaa", package = "mistralrs-core", optional = true } # branch: spiceai-upgrade

--- a/crates/model_components/Cargo.toml
+++ b/crates/model_components/Cargo.toml
@@ -26,7 +26,7 @@ spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
 tract-onnx = "0.22.0"
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 [features]
 dev = []

--- a/crates/runtime-acceleration/Cargo.toml
+++ b/crates/runtime-acceleration/Cargo.toml
@@ -39,7 +39,7 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 url.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 uuid = { version = "1", features = ["v7"] }
 
 [features]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -171,7 +171,7 @@ tracing-subscriber.workspace = true
 turso = { workspace = true, optional = true }
 twox-hash.workspace = true
 url.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 utoipa = { version = "5", features = ["axum_extras"], optional = true }
 utoipa-swagger-ui = { version = ">=8.1.1", features = [
     "axum",

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -32,7 +32,7 @@ snafu.workspace = true
 tantivy = { workspace = true, optional = true }
 tokio.workspace = true
 tracing.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 [features]
 default = ["text_search", "s3_vectors"]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -21,7 +21,7 @@ snafu.workspace = true
 sysinfo.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 
 [features]
 anonymous_telemetry = []

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -55,7 +55,7 @@ time = "0.3"
 tokio.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
-util = { path = "../util" }
+util = { path = "../util", features = ["datafusion"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -21,5 +21,9 @@ tracing = { workspace = true }
 tracing-subscriber.workspace = true
 arrow.workspace = true
 arrow-schema.workspace = true
-datafusion.workspace = true
+datafusion = { workspace = true, optional = true }
 parking_lot.workspace = true
+
+[features]
+default = ["datafusion"]
+datafusion = ["dep:datafusion"]

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -24,6 +24,7 @@ pub mod fibonacci_backoff;
 pub mod home_dir;
 pub mod levenshtein;
 pub mod retry_strategy;
+#[cfg(feature = "datafusion")]
 pub mod security;
 pub use backoff::Error as RetryError;
 pub use backoff::ExponentialBackoff;
@@ -32,9 +33,12 @@ mod tracing_util;
 use tokio::{sync::oneshot, time::Instant};
 pub use tracing_util::in_tracing_context;
 pub mod arrow;
+#[cfg(feature = "datafusion")]
 pub mod expr;
+#[cfg(feature = "datafusion")]
 pub mod stream_utils;
 pub mod time_format;
+#[cfg(feature = "datafusion")]
 pub mod timestamp_filter;
 
 #[expect(clippy::cast_precision_loss)]

--- a/tools/spidapter/Cargo.toml
+++ b/tools/spidapter/Cargo.toml
@@ -10,42 +10,16 @@ version.workspace = true
 
 [dependencies]
 arrow.workspace = true
+anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 reqwest.workspace = true
-runtime-secrets = { path = "../../crates/runtime-secrets" }
+runtime-secrets = { path = "../../crates/runtime-secrets", default-features = false }
 spice-cloud-client.workspace = true
 serde_json.workspace = true
 spicepod = { path = "../../crates/spicepod", default-features = false }
 system-adapter-protocol.workspace = true
 uuid.workspace = true
 yaml = { path = "../../crates/yaml" }
-test-framework = { path = "../../crates/test-framework" }
+rustls.workspace = true
 tokio.workspace = true
-
-[features]
-default = ["append"]
-anonymous_telemetry = []
-aws-secrets-manager = []
-clickhouse = []
-databricks = []
-debezium = []
-delta_lake = []
-dremio = []
-duckdb = []
-flightsql = []
-ftp = []
-imap = []
-keyring-secret-store = []
-models = []
-mssql = []
-mysql = []
-odbc = []
-postgres = []
-sharepoint = []
-snowflake = []
-spark = []
-sqlite = []
-turso = []
-
-append = ["test-framework/file_append"]

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -21,7 +21,6 @@ use spice_cloud_client::{
     CloudClient,
     types::{CreateAppRequest, CreateDeploymentRequest, UpdateAppRequest},
 };
-use test_framework::anyhow;
 
 pub(crate) mod secrets;
 

--- a/tools/spidapter/src/commands/secrets.rs
+++ b/tools/spidapter/src/commands/secrets.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use runtime_secrets::{ExposeSecret, Secrets};
 use spice_cloud_client::CloudClient;
-use test_framework::anyhow;
 
 /// Set a single secret on a Spice Cloud app.
 pub(crate) async fn set_secret(

--- a/tools/spidapter/src/main.rs
+++ b/tools/spidapter/src/main.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use clap::Parser;
-use test_framework::{anyhow, rustls};
 
 mod args;
 mod commands;

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -15,19 +15,20 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use arrow::datatypes::DataType;
 use async_trait::async_trait;
 use spice_cloud_client::CloudClient;
 use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
 use spicepod::component::ComponentOrReference;
+use spicepod::component::catalog::Catalog;
 use spicepod::component::dataset::Dataset;
 use spicepod::component::runtime::{Runtime, TelemetryConfig};
 use spicepod::param::Params;
 use spicepod::spec::SpicepodDefinition;
 use system_adapter_protocol::{
     AdbcDriver, DatasetConfig, Handler, IngestionMetrics, MetricsResponse, ResourceMetrics, Server,
-    SetupResponse, TeardownResponse,
+    SetupResponse, TeardownResponse, EtlSinkType,
 };
-use test_framework::anyhow;
 use uuid::Uuid;
 
 use crate::args::StdioArgs;
@@ -50,6 +51,7 @@ struct SetupConfig {
     /// Per-dataset `from` URIs, keyed by dataset name.
     etl_region: Option<String>,
     etl_endpoint: Option<String>,
+    etl_sink_type: Option<EtlSinkType>,
 }
 
 impl SetupConfig {
@@ -57,7 +59,13 @@ impl SetupConfig {
         Self {
             etl_region: metadata_string(metadata, "etl_region"),
             etl_endpoint: metadata_string(metadata, "etl_endpoint"),
+            etl_sink_type: None
         }
+    }
+
+    fn set_etl_sink_type(mut self, sink_type: Option<EtlSinkType>) -> Self {
+        self.etl_sink_type = sink_type;
+        self
     }
 }
 
@@ -100,13 +108,14 @@ impl Handler for SpidapterHandler {
         run_id: Uuid,
         metadata: HashMap<String, serde_json::Value>,
         datasets: HashMap<String, DatasetConfig>,
+        etl_sink_type: Option<EtlSinkType>,
     ) -> Result<SetupResponse, String> {
         eprintln!(
             "[stdio] setup: run_id={run_id}, metadata_keys={:?}",
             metadata.keys().collect::<Vec<_>>()
         );
 
-        let setup_config = SetupConfig::from_metadata(&metadata);
+        let setup_config = SetupConfig::from_metadata(&metadata).set_etl_sink_type(etl_sink_type);
 
         let state = provision_spice_cloud_app(
             run_id,
@@ -135,6 +144,7 @@ impl Handler for SpidapterHandler {
                     serde_json::Value::String(state.api_key.clone()),
                 ),
             ]),
+            catalog_namespace: etl_sink_type.as_ref().filter(|t| matches!(t, EtlSinkType::Adbc)).map(|_| "spicebench.bench".to_string()),
         };
 
         self.runs.insert(run_id, state);
@@ -237,6 +247,141 @@ pub async fn run_stdio_server(args: &StdioArgs) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Stdio server error: {e}"))
 }
 
+async fn post_setup_sink_action(
+    setup_config: &SetupConfig,
+    datasets: &HashMap<String, DatasetConfig>,
+    cname: &str,
+    api_key: &str,
+) -> anyhow::Result<()> {
+    if let Some(EtlSinkType::Adbc) = setup_config.etl_sink_type {
+        eprintln!("[stdio] Executing post-setup actions for ADBC sink...");
+
+        let create_table_statements = generate_adbc_create_table_statements(datasets)?;
+        if create_table_statements.is_empty() {
+            eprintln!("[stdio] No datasets configured for ADBC sink, skipping table creation");
+            return Ok(());
+        }
+
+        let sql_url = format!("https://{cname}.spiceai.io/v1/sql");
+        let sql_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()?;
+
+        for statement in create_table_statements {
+            eprintln!("[stdio] Running post-setup SQL: {statement}");
+            let response = sql_client
+                .post(&sql_url)
+                .header("X-API-Key", api_key)
+                .body(statement.clone())
+                .send()
+                .await?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<failed to read error body>".to_string());
+                return Err(anyhow::anyhow!(
+                    "Failed to execute post-setup SQL against {sql_url}: status={status}, sql={statement}, body={body}"
+                ));
+            }
+        }
+
+        eprintln!("[stdio] ADBC post-setup table creation complete");
+    } else {
+        eprintln!("[stdio] No ETL sink type specified or ETL sink requires no additional steps, skipping post-setup actions");
+    }
+    Ok(())
+}
+
+fn generate_adbc_create_table_statements(
+    datasets: &HashMap<String, DatasetConfig>,
+) -> anyhow::Result<Vec<String>> {
+    let mut dataset_names = datasets.keys().cloned().collect::<Vec<_>>();
+    dataset_names.sort_unstable();
+
+    dataset_names
+        .into_iter()
+        .map(|dataset_name| {
+            let dataset = datasets
+                .get(&dataset_name)
+                .ok_or_else(|| anyhow::anyhow!("Dataset '{dataset_name}' was not found"))?;
+            generate_adbc_create_table_statement(&dataset_name, dataset)
+        })
+        .collect()
+}
+
+fn generate_adbc_create_table_statement(
+    dataset_name: &str,
+    dataset: &DatasetConfig,
+) -> anyhow::Result<String> {
+    let quoted_dataset_name = quote_identifier(dataset_name);
+
+    let column_definitions = dataset
+        .schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let column_name = quote_identifier(field.name());
+            let data_type = adbc_sql_type_for_arrow(field.data_type())?;
+            let nullable = if field.is_nullable() { "" } else { " NOT NULL" };
+            Ok(format!("{column_name} {data_type}{nullable}"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    if column_definitions.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Dataset '{dataset_name}' has no columns; cannot generate CREATE TABLE statement"
+        ));
+    }
+
+    Ok(format!(
+        "CREATE TABLE spicebench.bench.{quoted_dataset_name} ({})",
+        column_definitions.join(", ")
+    ))
+}
+
+fn adbc_sql_type_for_arrow(data_type: &DataType) -> anyhow::Result<String> {
+    let sql_type = match data_type {
+        DataType::Boolean => "BOOLEAN".to_string(),
+        DataType::Int8 => "TINYINT".to_string(),
+        DataType::Int16 => "SMALLINT".to_string(),
+        DataType::Int32 => "INT".to_string(),
+        DataType::Int64 => "BIGINT".to_string(),
+        DataType::UInt8 => "TINYINT UNSIGNED".to_string(),
+        DataType::UInt16 => "SMALLINT UNSIGNED".to_string(),
+        DataType::UInt32 => "INT UNSIGNED".to_string(),
+        DataType::UInt64 => "BIGINT UNSIGNED".to_string(),
+        DataType::Float16 => "FLOAT".to_string(),
+        DataType::Float32 => "FLOAT".to_string(),
+        DataType::Float64 => "DOUBLE".to_string(),
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale)
+        | DataType::Decimal256(precision, scale) => format!("DECIMAL({precision}, {scale})"),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => "TEXT".to_string(),
+        DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_) => "BLOB".to_string(),
+        DataType::Date32 | DataType::Date64 => "DATE".to_string(),
+        DataType::Time32(_) | DataType::Time64(_) => "TIME".to_string(),
+        DataType::Timestamp(_, _) => "TIMESTAMP".to_string(),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "Unsupported Arrow type for ADBC sink table creation: {data_type:?}"
+            ));
+        }
+    };
+
+    Ok(sql_type)
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
 // ── Spice Cloud provisioning ─────────────────────────────────────────
 
 /// Provision a Spice Cloud app from the setup request.
@@ -309,6 +454,8 @@ async fn provision_spice_cloud_app(
 
     eprintln!("[stdio] Spice Cloud deployment ready for app '{app_name}' at {flight_url}");
 
+    post_setup_sink_action(setup_config, datasets, &cname, &api_key).await?;
+
     Ok(RunState {
         app_id,
         api_key,
@@ -317,8 +464,7 @@ async fn provision_spice_cloud_app(
     })
 }
 
-/// Generate the spicepod YAML with individual dataset entries sourced from S3 parquet files.
-fn generate_initial_spicepod(
+fn generate_hive_spicepod(
     run_id: &Uuid,
     setup_config: &SetupConfig,
     datasets: &HashMap<String, DatasetConfig>,
@@ -375,6 +521,37 @@ fn generate_initial_spicepod(
     yaml::to_string(&spicepod).map_err(|e| anyhow::anyhow!("Failed to serialize spicepod: {e}"))
 }
 
+fn generate_adbc_spicepod(
+    run_id: &Uuid,
+) -> anyhow::Result<String> {
+    let run_id_str = run_id.to_string();
+    let short_id = run_id_str.split('-').next().unwrap_or_default();
+
+    let mut spicepod = SpicepodDefinition::new(format!("spidapter-{short_id}"));
+    spicepod.runtime = Runtime {
+        telemetry: TelemetryConfig {
+            enabled: false,
+            ..TelemetryConfig::default()
+        },
+        ..Runtime::default()
+    };
+
+    spicepod.catalogs.push(ComponentOrReference::Component(Catalog::new("cayenne".to_string(), "spicebench".to_string())));
+    yaml::to_string(&spicepod).map_err(|e| anyhow::anyhow!("Failed to serialize spicepod: {e}"))
+}
+
+/// Generate the spicepod YAML with individual dataset entries sourced from S3 parquet files.
+fn generate_initial_spicepod(
+    run_id: &Uuid,
+    setup_config: &SetupConfig,
+    datasets: &HashMap<String, DatasetConfig>,
+) -> anyhow::Result<String> {
+    match setup_config.etl_sink_type {
+        Some(EtlSinkType::Adbc) => generate_adbc_spicepod(run_id),
+        _ => generate_hive_spicepod(run_id, setup_config, datasets),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -397,6 +574,7 @@ mod tests {
         let setup_config = SetupConfig {
             etl_region: Some("us-west-2".to_string()),
             etl_endpoint: Some("http://localhost:9000".to_string()),
+            etl_sink_type: None,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -432,6 +610,7 @@ mod tests {
         let setup_config = SetupConfig {
             etl_region: None,
             etl_endpoint: None,
+            etl_sink_type: None,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -450,6 +629,61 @@ mod tests {
             .expect_err("missing source should fail");
         assert!(
             err.to_string().contains("missing_table"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn adbc_create_table_statement_uses_namespace_and_types() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("price", DataType::Decimal128(10, 2), true),
+            Field::new("created_at", DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None), true),
+        ]));
+
+        let statement = generate_adbc_create_table_statement(
+            "orders",
+            &DatasetConfig {
+                schema,
+                location: Some("s3://bucket/path/orders/".to_string()),
+                primary_key_columns: vec!["id".to_string()],
+                time_column: None,
+                partition_columns: Vec::new(),
+            },
+        )
+        .expect("statement should generate");
+
+        assert!(statement.contains("CREATE TABLE IF NOT EXISTS spicebench.bench.\"orders\""));
+        assert!(statement.contains("\"id\" BIGINT NOT NULL"));
+        assert!(statement.contains("\"name\" TEXT"));
+        assert!(statement.contains("\"price\" DECIMAL(10, 2)"));
+        assert!(statement.contains("\"created_at\" TIMESTAMP"));
+        assert!(statement.contains("PRIMARY KEY (\"id\")"));
+    }
+
+    #[test]
+    fn adbc_create_table_statement_errors_for_unsupported_type() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "metadata",
+            DataType::Struct(vec![Field::new("k", DataType::Utf8, true)].into()),
+            true,
+        )]));
+
+        let err = generate_adbc_create_table_statement(
+            "events",
+            &DatasetConfig {
+                schema,
+                location: Some("s3://bucket/path/events/".to_string()),
+                primary_key_columns: Vec::new(),
+                time_column: None,
+                partition_columns: Vec::new(),
+            },
+        )
+        .expect_err("unsupported Arrow type should fail");
+
+        assert!(
+            err.to_string().contains("Unsupported Arrow type"),
             "unexpected error: {err}"
         );
     }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Removes some unnecessary dependencies
* Updates the spidapter for the latest system adapter protocol, and enables support for ADBC sink types
* Generates a Cayenne catalog when sink type = ADBC, and runs create table statements after the spicepod is ready before returning from setup