### PR TITLE
feat: Cayenne catalog supports CREATE SCHEMA

### DIFF
--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -180,6 +180,29 @@ impl CayenneCatalogProvider {
         &self.metadata_dir
     }
 
+    /// Returns the schema provider for a namespace if it exists.
+    #[must_use]
+    pub fn schema_provider(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas
+            .read()
+            .ok()
+            .and_then(|schemas| schemas.get(name).cloned())
+    }
+
+    /// Registers or replaces a schema provider for a namespace.
+    pub fn register_schema_provider(
+        &self,
+        name: &str,
+        schema: Arc<dyn SchemaProvider>,
+    ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
+        match self.schemas.write() {
+            Ok(mut schemas) => Ok(schemas.insert(name.to_string(), schema)),
+            Err(_) => Err(datafusion::error::DataFusionError::Internal(
+                "Failed to acquire write lock on Cayenne schemas".to_string(),
+            )),
+        }
+    }
+
     /// Parse Vortex configuration from catalog parameters.
     fn parse_vortex_config(params: &Parameters) -> VortexConfig {
         let mut config = VortexConfig::default();
@@ -228,10 +251,7 @@ impl CatalogProvider for CayenneCatalogProvider {
     }
 
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        self.schemas
-            .read()
-            .ok()
-            .and_then(|schemas| schemas.get(name).cloned())
+        self.schema_provider(name)
     }
 
     fn register_schema(
@@ -239,12 +259,7 @@ impl CatalogProvider for CayenneCatalogProvider {
         name: &str,
         schema: Arc<dyn SchemaProvider>,
     ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
-        match self.schemas.write() {
-            Ok(mut schemas) => Ok(schemas.insert(name.to_string(), schema)),
-            Err(_) => Err(datafusion::error::DataFusionError::Internal(
-                "Failed to acquire write lock on Cayenne schemas".to_string(),
-            )),
-        }
+        self.register_schema_provider(name, schema)
     }
 }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Analyzer rule that intercepts DDL plans (`CREATE TABLE` / `DROP TABLE`)
+//! Analyzer rule that intercepts DDL plans (`CREATE TABLE` / `DROP TABLE` / `CREATE SCHEMA`)
 //! targeting Cayenne-backed DDL-enabled catalogs and rewrites them into
 //! custom [`LogicalPlan::Extension`] nodes.
 
@@ -30,8 +30,17 @@ use datafusion::logical_expr::{Extension, LogicalPlan};
 use datafusion::optimizer::AnalyzerRule;
 
 use super::is_cayenne_catalog;
-use super::logical_nodes::{CayenneCreateTableNode, CayenneDropTableNode};
+use super::logical_nodes::{
+    CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
+};
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+
+fn parse_qualified_schema_name(name: &str) -> (String, String) {
+    match name.split_once('.') {
+        Some((catalog_name, schema_name)) => (catalog_name.to_string(), schema_name.to_string()),
+        None => (SPICE_DEFAULT_CATALOG.to_string(), name.to_string()),
+    }
+}
 
 /// Analyzer rule that rewrites DDL targeting Cayenne catalogs into
 /// custom extension nodes for Cayenne catalog operations.
@@ -160,7 +169,49 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     node: Arc::new(node),
                 }))
             }
+            LogicalPlan::Ddl(DdlStatement::CreateCatalogSchema(create)) => {
+                let (catalog_name, schema_name) =
+                    parse_qualified_schema_name(create.schema_name.as_str());
+
+                if !self.is_ddl_enabled(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                let node = CayenneCreateSchemaNode::new(
+                    schema_name,
+                    create.if_not_exists,
+                    catalog_name,
+                );
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(node),
+                }))
+            }
             _ => Ok(plan),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_qualified_schema_name;
+    use crate::datafusion::SPICE_DEFAULT_CATALOG;
+
+    #[test]
+    fn parse_qualified_schema_name_extracts_catalog_and_schema() {
+        let (catalog, schema) = parse_qualified_schema_name("spicebench.bench");
+        assert_eq!(catalog, "spicebench");
+        assert_eq!(schema, "bench");
+    }
+
+    #[test]
+    fn parse_qualified_schema_name_uses_default_catalog_when_unqualified() {
+        let (catalog, schema) = parse_qualified_schema_name("bench");
+        assert_eq!(catalog, SPICE_DEFAULT_CATALOG);
+        assert_eq!(schema, "bench");
     }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -144,6 +144,91 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
     }
 }
 
+/// Logical plan node for `CREATE SCHEMA` on a Cayenne catalog.
+#[derive(Debug)]
+pub struct CayenneCreateSchemaNode {
+    /// The schema name to create.
+    pub schema_name: String,
+    /// If true, do not error if the schema already exists.
+    pub if_not_exists: bool,
+    /// The `DataFusion` catalog name.
+    pub df_catalog_name: String,
+    /// Output schema (single "result" column).
+    output_schema: DFSchemaRef,
+}
+
+impl CayenneCreateSchemaNode {
+    #[must_use]
+    pub fn new(schema_name: String, if_not_exists: bool, df_catalog_name: String) -> Self {
+        Self {
+            schema_name,
+            if_not_exists,
+            df_catalog_name,
+            output_schema: ddl_output_schema(),
+        }
+    }
+}
+
+impl Hash for CayenneCreateSchemaNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.schema_name.hash(state);
+        self.df_catalog_name.hash(state);
+    }
+}
+
+impl PartialEq for CayenneCreateSchemaNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema_name == other.schema_name && self.df_catalog_name == other.df_catalog_name
+    }
+}
+
+impl Eq for CayenneCreateSchemaNode {}
+
+impl PartialOrd for CayenneCreateSchemaNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.schema_name.partial_cmp(&other.schema_name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for CayenneCreateSchemaNode {
+    fn name(&self) -> &'static str {
+        "CayenneCreateSchema"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneCreateSchema: {}.{}",
+            self.df_catalog_name, self.schema_name
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(Self {
+            schema_name: self.schema_name.clone(),
+            if_not_exists: self.if_not_exists,
+            df_catalog_name: self.df_catalog_name.clone(),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}
+
 /// Logical plan node for `DROP TABLE` on a Cayenne catalog.
 #[derive(Debug)]
 pub struct CayenneDropTableNode {

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 //! Cayenne DDL support: analyzer rule, logical nodes, extension planner,
-//! and physical execution plans for `CREATE TABLE` / `DROP TABLE` on
+//! and physical execution plans for `CREATE TABLE` / `DROP TABLE` / `CREATE SCHEMA` on
 //! Cayenne-backed DDL-enabled catalogs.
 //!
 //! Reuses the shared DDL options infrastructure from [`super::iceberg_ddl::acceleration_options`]

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -19,6 +19,9 @@ limitations under the License.
 //! `CayenneCreateTableExec` creates a new table in the Cayenne metadata catalog
 //! with data stored in S3 Express One Zone via Vortex columnar format.
 //!
+//! `CayenneCreateSchemaExec` registers a schema namespace in the DataFusion catalog
+//! for Cayenne-backed DDL catalogs.
+//!
 //! `CayenneDropTableExec` removes a table from both the Cayenne metadata catalog
 //! and the DataFusion catalog.
 
@@ -239,14 +242,14 @@ impl ExecutionPlan for CayenneCreateTableExec {
             })?;
 
             // Ensure the schema exists, creating it on demand if needed
-            let schema_provider = match df_catalog.schema(&df_schema_name) {
+            let schema_provider = match cayenne_provider.schema_provider(&df_schema_name) {
                 Some(s) => s,
                 None => {
                     let new_schema = Arc::new(CayenneSchemaProvider::new_empty(
                         Arc::clone(&metadata_catalog),
                         df_schema_name.clone(),
                     ));
-                    df_catalog.register_schema(
+                    cayenne_provider.register_schema_provider(
                         &df_schema_name,
                         Arc::clone(&new_schema) as Arc<dyn SchemaProvider>,
                     )?;
@@ -260,6 +263,154 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 result_schema,
                 vec![Arc::new(StringArray::from(vec![format!(
                     "Table '{table_name}' created"
+                )]))],
+            )?;
+            Ok(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            ddl_result_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Physical plan for creating a Cayenne schema.
+pub struct CayenneCreateSchemaExec {
+    schema_name: String,
+    if_not_exists: bool,
+    df_catalog_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for CayenneCreateSchemaExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CayenneCreateSchemaExec")
+            .field("schema_name", &self.schema_name)
+            .field("if_not_exists", &self.if_not_exists)
+            .field("df_catalog_name", &self.df_catalog_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneCreateSchemaExec {
+    #[must_use]
+    pub fn new(
+        schema_name: String,
+        if_not_exists: bool,
+        df_catalog_name: String,
+        catalog_list: Arc<dyn CatalogProviderList>,
+    ) -> Self {
+        let schema = ddl_result_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            schema_name,
+            if_not_exists,
+            df_catalog_name,
+            catalog_list,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for CayenneCreateSchemaExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CayenneCreateSchemaExec: {}.{}",
+            self.df_catalog_name, self.schema_name
+        )
+    }
+}
+
+impl ExecutionPlan for CayenneCreateSchemaExec {
+    fn name(&self) -> &'static str {
+        "CayenneCreateSchemaExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let schema_name = self.schema_name.clone();
+        let if_not_exists = self.if_not_exists;
+        let df_catalog_name = self.df_catalog_name.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
+        let result_schema = ddl_result_schema();
+
+        let stream = futures::stream::once(async move {
+            let df_catalog = catalog_list.catalog(&df_catalog_name).ok_or_else(|| {
+                DataFusionError::Execution(format!("Catalog '{df_catalog_name}' not found"))
+            })?;
+
+            let cayenne_provider = get_cayenne_provider(df_catalog.as_ref()).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "Catalog '{df_catalog_name}' is not a Cayenne catalog"
+                ))
+            })?;
+
+            if cayenne_provider.schema_provider(&schema_name).is_some() {
+                if if_not_exists {
+                    let batch = RecordBatch::try_new(
+                        result_schema,
+                        vec![Arc::new(StringArray::from(vec![format!(
+                            "Schema '{schema_name}' already exists"
+                        )]))],
+                    )?;
+                    return Ok(batch);
+                }
+
+                return Err(DataFusionError::Execution(format!(
+                    "Schema '{schema_name}' already exists in catalog '{df_catalog_name}'"
+                )));
+            }
+
+            let schema_provider = Arc::new(CayenneSchemaProvider::new_empty(
+                Arc::clone(cayenne_provider.metadata_catalog()),
+                schema_name.clone(),
+            ));
+
+            cayenne_provider
+                .register_schema_provider(
+                    &schema_name,
+                    Arc::clone(&schema_provider) as Arc<dyn SchemaProvider>,
+                )
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to create schema '{schema_name}' in catalog '{df_catalog_name}': {e}"
+                    ))
+                })?;
+
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(StringArray::from(vec![format!(
+                    "Schema '{schema_name}' created"
                 )]))],
             )?;
             Ok(batch)

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -26,8 +26,12 @@ use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
-use super::logical_nodes::{CayenneCreateTableNode, CayenneDropTableNode};
-use super::physical_plans::{CayenneCreateTableExec, CayenneDropTableExec};
+use super::logical_nodes::{
+    CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
+};
+use super::physical_plans::{
+    CayenneCreateSchemaExec, CayenneCreateTableExec, CayenneDropTableExec,
+};
 
 /// Extension planner for Cayenne DDL operations.
 #[derive(Debug)]
@@ -60,6 +64,15 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 create.or_replace,
                 create.df_catalog_name.clone(),
                 create.df_schema_name.clone(),
+                catalog_list,
+            ))));
+        }
+
+        if let Some(create_schema) = node.as_any().downcast_ref::<CayenneCreateSchemaNode>() {
+            return Ok(Some(Arc::new(CayenneCreateSchemaExec::new(
+                create_schema.schema_name.clone(),
+                create_schema.if_not_exists,
+                create_schema.df_catalog_name.clone(),
                 catalog_list,
             ))));
         }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds support for `CREATE SCHEMA` via the Cayenne catalog, and automatically creates missing schemas when performing table creations like `CREATE TABLE my_catalog.my_schema.my_table ()`