### PR TITLE
Fix Cayenne duplicate primary keys after DELETE + UPSERT CDC sequences

### DIFF
--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -48,9 +48,7 @@ pub(crate) use sink::file_based::FileBasedDeletionSink;
 pub use sink::CayenneDeletionSink;
 
 // Crate-internal types used by table.rs
-pub(crate) use filter_exec::{
-    is_pk_visible_i64, is_pk_visible_row_key, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
-};
+pub(crate) use filter_exec::{Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec};
 pub(crate) use vector_io::{
     detect_deletion_type_and_read, DeletionIdentifier, DeletionVectorWriteSpec,
     DeletionVectorWriter,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -24,7 +24,7 @@ use super::constants::{
     PROTECTED_SNAPSHOTS_LOCK_POISONED, WRITE_SEMAPHORE_CLOSED,
 };
 use super::delete::{
-    is_pk_visible_i64, is_pk_visible_row_key, CayenneDeletionSink, DeletionIdentifier,
+    CayenneDeletionSink, DeletionIdentifier,
     DeletionVectorWriteSpec, DeletionVectorWriter, FileBasedDeletionSink,
     Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
 };
@@ -1755,6 +1755,7 @@ impl CayenneTableProvider {
         // Process main listing table batches with the FULL deletion filter (no insert_records).
         // This mirrors scan()'s apply_deletion_filter() which uses all deletions without
         // insert_records when protected snapshots exist.
+        // min_delete_seq_threshold=None means ALL deletions apply.
         Self::process_batches_into_keyset(
             &main_batches,
             &self.pk_deletion_strategy,
@@ -1763,6 +1764,7 @@ impl CayenneTableProvider {
             &projected_pk_indices,
             &deleted_pk_i64,
             &deleted_row_keys,
+            None, // all deletions apply to main listing table
             &self.table_metadata.table_name,
             &mut keyset,
             &mut row_id_base,
@@ -1791,35 +1793,15 @@ impl CayenneTableProvider {
 
             let snapshot_batches = collect(snapshot_plan, ctx.task_ctx()).await?;
 
-            // Build filtered deletion maps: only deletions with seq > max_delete_seq_at_creation
-            let filtered_deleted_pk_i64 = deleted_pk_i64.as_ref().map(|all_deleted| {
-                Arc::new(
-                    all_deleted
-                        .iter()
-                        .filter(|(_pk, &seq)| seq > *max_delete_seq_at_creation)
-                        .map(|(&pk, &seq)| (pk, seq))
-                        .collect::<HashMap<i64, i64>>(),
-                )
-            });
-
-            let filtered_deleted_row_keys = deleted_row_keys.as_ref().map(|all_deleted| {
-                Arc::new(
-                    all_deleted
-                        .iter()
-                        .filter(|(_key, &seq)| seq > *max_delete_seq_at_creation)
-                        .map(|(key, &seq)| (key.clone(), seq))
-                        .collect::<HashMap<Box<[u8]>, i64>>(),
-                )
-            });
-
             Self::process_batches_into_keyset(
                 &snapshot_batches,
                 &self.pk_deletion_strategy,
                 pk_indices,
                 converter,
                 &projected_pk_indices,
-                &filtered_deleted_pk_i64,
-                &filtered_deleted_row_keys,
+                &deleted_pk_i64,
+                &deleted_row_keys,
+                Some(*max_delete_seq_at_creation), // only deletions with seq > threshold apply
                 &self.table_metadata.table_name,
                 &mut keyset,
                 &mut row_id_base,
@@ -1831,9 +1813,17 @@ impl CayenneTableProvider {
 
     /// Process record batches and add visible keys to the keyset.
     ///
-    /// Filters out deleted rows using the provided deletion maps (without `insert_records`).
+    /// Filters out deleted rows using the provided deletion maps. No insert_records are
+    /// used — visibility is determined solely by whether a deletion exists for the key.
+    ///
+    /// `min_delete_seq_threshold`: When `Some(threshold)`, only deletions with
+    /// `seq > threshold` are considered (for protected snapshots). When `None`, all
+    /// deletions apply (for the main listing table). This avoids building filtered
+    /// HashMap copies per snapshot — each row is checked with a single O(1) lookup.
+    ///
     /// Keys from later batches override earlier ones in the keyset, which is correct
     /// because protected snapshots contain data inserted at higher sequence numbers.
+    #[expect(clippy::too_many_arguments)]
     fn process_batches_into_keyset(
         batches: &[RecordBatch],
         pk_deletion_strategy: &PkDeletionStrategyWithCache,
@@ -1842,6 +1832,7 @@ impl CayenneTableProvider {
         projected_pk_indices: &[usize],
         deleted_pk_i64: &Option<Arc<HashMap<i64, i64>>>,
         deleted_row_keys: &Option<Arc<HashMap<Box<[u8]>, i64>>>,
+        min_delete_seq_threshold: Option<i64>,
         table_name: &str,
         keyset: &mut HashMap<OwnedRow, RowLocation>,
         row_id_base: &mut i64,
@@ -1870,16 +1861,21 @@ impl CayenneTableProvider {
                     })?;
 
                 // Check if row is deleted based on pk_deletion_strategy.
-                // No insert_records are passed — for main batches this matches
-                // apply_deletion_filter(), and for protected snapshot batches the
-                // deletion map is already filtered to only relevant sequences.
+                // For main batches (threshold=None): all deletions apply.
+                // For protected snapshots (threshold=Some(T)): only deletions with seq > T apply.
                 let is_deleted = match pk_deletion_strategy {
                     PkDeletionStrategyWithCache::Int64Pk { .. } => {
                         if let (Some(pk_array), Some(deleted_pks)) =
                             (int64_pk_array, deleted_pk_i64)
                         {
                             let pk_value = pk_array.value(row_idx);
-                            !is_pk_visible_i64(pk_value, deleted_pks, None)
+                            match deleted_pks.get(&pk_value) {
+                                None => false, // not deleted
+                                Some(&del_seq) => match min_delete_seq_threshold {
+                                    None => true, // all deletions apply
+                                    Some(threshold) => del_seq > threshold,
+                                },
+                            }
                         } else {
                             false
                         }
@@ -1887,7 +1883,13 @@ impl CayenneTableProvider {
                     PkDeletionStrategyWithCache::RowConverterBased { .. } => {
                         if let Some(deleted_keys) = deleted_row_keys {
                             let key = rows.row(row_idx);
-                            !is_pk_visible_row_key(key.as_ref(), deleted_keys, None)
+                            match deleted_keys.get(key.as_ref()) {
+                                None => false, // not deleted
+                                Some(&del_seq) => match min_delete_seq_threshold {
+                                    None => true, // all deletions apply
+                                    Some(threshold) => del_seq > threshold,
+                                },
+                            }
                         } else {
                             false
                         }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1831,7 +1831,7 @@ impl CayenneTableProvider {
 
     /// Process record batches and add visible keys to the keyset.
     ///
-    /// Filters out deleted rows using the provided deletion maps (without insert_records).
+    /// Filters out deleted rows using the provided deletion maps (without `insert_records`).
     /// Keys from later batches override earlier ones in the keyset, which is correct
     /// because protected snapshots contain data inserted at higher sequence numbers.
     fn process_batches_into_keyset(

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3792,8 +3792,7 @@ impl CayenneTableProvider {
                         Arc::clone(&guard)
                     };
                     // Don't use insert_records for protected snapshot approach
-                    let empty_insert_records: Arc<DeletedRowKeysMap> =
-                        Arc::new(HashMap::new());
+                    let empty_insert_records: Arc<DeletedRowKeysMap> = Arc::new(HashMap::new());
 
                     if !deleted_row_keys.is_empty() {
                         return Ok(Arc::new(KeyBasedDeletionFilterExec::new(
@@ -4672,5 +4671,121 @@ mod tests {
             &format!("{table_name}_types"),
         )
         .await;
+    }
+
+    /// Helper: build a single-column Int64 RecordBatch and the matching RowConverter.
+    fn make_int64_pk_batch(values: &[i64]) -> (RecordBatch, RowConverter) {
+        use arrow::array::Int64Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let schema = Arc::new(Schema::new(vec![Field::new("pk", DataType::Int64, false)]));
+        let col = Arc::new(Int64Array::from(values.to_vec()));
+        let batch = RecordBatch::try_new(schema, vec![col]).expect("valid batch");
+        let converter =
+            RowConverter::new(vec![SortField::new(DataType::Int64)]).expect("valid converter");
+        (batch, converter)
+    }
+
+    #[test]
+    fn test_process_batches_into_keyset_int64pk_filters_deleted() {
+        let (batch, converter) = make_int64_pk_batch(&[1, 2, 3]);
+
+        // Delete pk=2 with del_seq=1
+        let deleted: Arc<HashMap<i64, i64>> = Arc::new(HashMap::from([(2, 1)]));
+        let strategy = PkDeletionStrategyWithCache::Int64Pk {
+            cached_deleted_pk: Arc::new(RwLock::new(Arc::clone(&deleted))),
+            cached_insert_records: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
+        };
+
+        let mut keyset = HashMap::new();
+        let mut row_id_base: i64 = 0;
+
+        CayenneTableProvider::process_batches_into_keyset(
+            &[batch],
+            &strategy,
+            &[0],
+            &converter,
+            &[0],
+            Some(&deleted),
+            None,
+            None, // all deletions apply
+            "test_table",
+            &mut keyset,
+            &mut row_id_base,
+        )
+        .expect("process_batches_into_keyset should succeed");
+
+        assert_eq!(keyset.len(), 2, "pk=2 should be filtered out");
+        assert_eq!(row_id_base, 3);
+    }
+
+    #[test]
+    fn test_process_batches_into_keyset_threshold_filters_partial() {
+        let (batch, converter) = make_int64_pk_batch(&[1, 2, 3]);
+
+        // pk=1 deleted at seq 5, pk=2 deleted at seq 15
+        let deleted: Arc<HashMap<i64, i64>> = Arc::new(HashMap::from([(1, 5), (2, 15)]));
+        let strategy = PkDeletionStrategyWithCache::Int64Pk {
+            cached_deleted_pk: Arc::new(RwLock::new(Arc::clone(&deleted))),
+            cached_insert_records: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
+        };
+
+        let mut keyset = HashMap::new();
+        let mut row_id_base: i64 = 0;
+
+        // threshold=10: only deletions with del_seq > 10 apply
+        CayenneTableProvider::process_batches_into_keyset(
+            &[batch],
+            &strategy,
+            &[0],
+            &converter,
+            &[0],
+            Some(&deleted),
+            None,
+            Some(10),
+            "test_table",
+            &mut keyset,
+            &mut row_id_base,
+        )
+        .expect("process_batches_into_keyset should succeed");
+
+        // pk=1 (del_seq=5 <= 10) => visible, pk=2 (del_seq=15 > 10) => filtered, pk=3 => visible
+        assert_eq!(
+            keyset.len(),
+            2,
+            "only pk=2 should be filtered (del_seq 15 > threshold 10)"
+        );
+        assert_eq!(row_id_base, 3);
+    }
+
+    #[test]
+    fn test_process_batches_into_keyset_no_deletions() {
+        let (batch, converter) = make_int64_pk_batch(&[10, 20, 30]);
+
+        let strategy = PkDeletionStrategyWithCache::Int64Pk {
+            cached_deleted_pk: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
+            cached_insert_records: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
+        };
+
+        let mut keyset = HashMap::new();
+        let mut row_id_base: i64 = 0;
+
+        CayenneTableProvider::process_batches_into_keyset(
+            &[batch],
+            &strategy,
+            &[0],
+            &converter,
+            &[0],
+            None,
+            None,
+            None,
+            "test_table",
+            &mut keyset,
+            &mut row_id_base,
+        )
+        .expect("process_batches_into_keyset should succeed");
+
+        assert_eq!(keyset.len(), 3, "all rows should be in keyset");
+        assert_eq!(row_id_base, 3, "row_id_base should advance by batch size");
     }
 }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -24,9 +24,8 @@ use super::constants::{
     PROTECTED_SNAPSHOTS_LOCK_POISONED, WRITE_SEMAPHORE_CLOSED,
 };
 use super::delete::{
-    CayenneDeletionSink, DeletionIdentifier,
-    DeletionVectorWriteSpec, DeletionVectorWriter, FileBasedDeletionSink,
-    Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
+    CayenneDeletionSink, DeletionIdentifier, DeletionVectorWriteSpec, DeletionVectorWriter,
+    FileBasedDeletionSink, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
 };
 use super::streaming::StreamingExec;
 use crate::catalog::{CatalogError, CatalogResult, MetadataCatalog};
@@ -77,6 +76,9 @@ use vortex_datafusion::VortexFormat;
 use super::context::CayenneContext;
 use super::deletion_strategy::{PkDeletionStrategy, PkDeletionStrategyWithCache};
 use super::vortex_format::DeletionFilteringVortexFormat;
+
+/// Maps serialized primary key bytes to their maximum delete sequence number.
+type DeletedRowKeysMap = HashMap<Box<[u8]>, i64>;
 
 /// Extension trait to extract `UpsertOptions` from `OnConflict`.
 ///
@@ -1762,8 +1764,8 @@ impl CayenneTableProvider {
             pk_indices,
             converter,
             &projected_pk_indices,
-            &deleted_pk_i64,
-            &deleted_row_keys,
+            deleted_pk_i64.as_ref(),
+            deleted_row_keys.as_ref(),
             None, // all deletions apply to main listing table
             &self.table_metadata.table_name,
             &mut keyset,
@@ -1799,8 +1801,8 @@ impl CayenneTableProvider {
                 pk_indices,
                 converter,
                 &projected_pk_indices,
-                &deleted_pk_i64,
-                &deleted_row_keys,
+                deleted_pk_i64.as_ref(),
+                deleted_row_keys.as_ref(),
                 Some(*max_delete_seq_at_creation), // only deletions with seq > threshold apply
                 &self.table_metadata.table_name,
                 &mut keyset,
@@ -1813,13 +1815,13 @@ impl CayenneTableProvider {
 
     /// Process record batches and add visible keys to the keyset.
     ///
-    /// Filters out deleted rows using the provided deletion maps. No insert_records are
+    /// Filters out deleted rows using the provided deletion maps. No `insert_records` are
     /// used — visibility is determined solely by whether a deletion exists for the key.
     ///
     /// `min_delete_seq_threshold`: When `Some(threshold)`, only deletions with
     /// `seq > threshold` are considered (for protected snapshots). When `None`, all
     /// deletions apply (for the main listing table). This avoids building filtered
-    /// HashMap copies per snapshot — each row is checked with a single O(1) lookup.
+    /// `HashMap` copies per snapshot — each row is checked with a single O(1) lookup.
     ///
     /// Keys from later batches override earlier ones in the keyset, which is correct
     /// because protected snapshots contain data inserted at higher sequence numbers.
@@ -1830,8 +1832,8 @@ impl CayenneTableProvider {
         pk_indices: &[usize],
         converter: &RowConverter,
         projected_pk_indices: &[usize],
-        deleted_pk_i64: &Option<Arc<HashMap<i64, i64>>>,
-        deleted_row_keys: &Option<Arc<HashMap<Box<[u8]>, i64>>>,
+        deleted_pk_i64: Option<&Arc<HashMap<i64, i64>>>,
+        deleted_row_keys: Option<&Arc<DeletedRowKeysMap>>,
         min_delete_seq_threshold: Option<i64>,
         table_name: &str,
         keyset: &mut HashMap<OwnedRow, RowLocation>,
@@ -3790,7 +3792,7 @@ impl CayenneTableProvider {
                         Arc::clone(&guard)
                     };
                     // Don't use insert_records for protected snapshot approach
-                    let empty_insert_records: Arc<HashMap<Box<[u8]>, i64>> =
+                    let empty_insert_records: Arc<DeletedRowKeysMap> =
                         Arc::new(HashMap::new());
 
                     if !deleted_row_keys.is_empty() {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1706,14 +1706,72 @@ impl CayenneTableProvider {
         let ctx = SessionContext::new();
         // Only read PK columns - no need to load all columns for keyset building
         let pk_projection = pk_indices.to_vec();
+
+        // Scan main listing table
         let scan_plan = listing_table
             .scan(&ctx.state(), Some(&pk_projection), &[], None)
             .await?;
 
-        let mut all_batches = collect(scan_plan, ctx.task_ctx()).await?;
+        let main_batches = collect(scan_plan, ctx.task_ctx()).await?;
 
-        // Also collect batches from each protected snapshot
-        for snapshot_id in protected_snapshots.keys() {
+        // Load the deletion caches based on pk_deletion_strategy.
+        // Note: PositionBased strategy is never used here since it implies no primary key,
+        // and this function is only called for tables with primary keys.
+        let deleted_pk_i64 = match &self.pk_deletion_strategy {
+            PkDeletionStrategyWithCache::Int64Pk {
+                cached_deleted_pk, ..
+            } => {
+                let guard = cached_deleted_pk.read().map_err(|_| {
+                    CatalogError::InvalidOperationNoSource {
+                        message: DELETION_CACHE_LOCK_POISONED.to_string(),
+                    }
+                })?;
+                Some(Arc::clone(&guard))
+            }
+            _ => None,
+        };
+
+        let deleted_row_keys = match &self.pk_deletion_strategy {
+            PkDeletionStrategyWithCache::RowConverterBased {
+                cached_deleted_row_keys,
+                ..
+            } => {
+                let guard = cached_deleted_row_keys.read().map_err(|_| {
+                    CatalogError::InvalidOperationNoSource {
+                        message: DELETION_CACHE_LOCK_POISONED.to_string(),
+                    }
+                })?;
+                Some(Arc::clone(&guard))
+            }
+            _ => None,
+        };
+
+        let mut keyset = HashMap::with_capacity(1024);
+        let mut row_id_base: i64 = 0;
+
+        // After projection, batch columns are at indices 0..pk_indices.len()
+        let projected_pk_indices: Vec<usize> = (0..pk_indices.len()).collect();
+
+        // Process main listing table batches with the FULL deletion filter (no insert_records).
+        // This mirrors scan()'s apply_deletion_filter() which uses all deletions without
+        // insert_records when protected snapshots exist.
+        Self::process_batches_into_keyset(
+            &main_batches,
+            &self.pk_deletion_strategy,
+            pk_indices,
+            converter,
+            &projected_pk_indices,
+            &deleted_pk_i64,
+            &deleted_row_keys,
+            &self.table_metadata.table_name,
+            &mut keyset,
+            &mut row_id_base,
+        )?;
+
+        // Process each protected snapshot with a PARTIAL deletion filter.
+        // Only deletions with seq > max_delete_seq_at_creation apply, mirroring
+        // scan()'s apply_partial_deletion_filter().
+        for (snapshot_id, max_delete_seq_at_creation) in &protected_snapshots {
             let snapshot_url = Self::snapshot_dir_url(
                 &self.table_metadata.path,
                 self.table_metadata.table_id,
@@ -1727,78 +1785,68 @@ impl CayenneTableProvider {
                 &self.pk_deletion_strategy,
             )?;
 
-            // Only read PK columns - no need to load all columns for keyset building
             let snapshot_plan = snapshot_listing_table
                 .scan(&ctx.state(), Some(&pk_projection), &[], None)
                 .await?;
 
             let snapshot_batches = collect(snapshot_plan, ctx.task_ctx()).await?;
 
-            all_batches.extend(snapshot_batches);
+            // Build filtered deletion maps: only deletions with seq > max_delete_seq_at_creation
+            let filtered_deleted_pk_i64 = deleted_pk_i64.as_ref().map(|all_deleted| {
+                Arc::new(
+                    all_deleted
+                        .iter()
+                        .filter(|(_pk, &seq)| seq > *max_delete_seq_at_creation)
+                        .map(|(&pk, &seq)| (pk, seq))
+                        .collect::<HashMap<i64, i64>>(),
+                )
+            });
+
+            let filtered_deleted_row_keys = deleted_row_keys.as_ref().map(|all_deleted| {
+                Arc::new(
+                    all_deleted
+                        .iter()
+                        .filter(|(_key, &seq)| seq > *max_delete_seq_at_creation)
+                        .map(|(key, &seq)| (key.clone(), seq))
+                        .collect::<HashMap<Box<[u8]>, i64>>(),
+                )
+            });
+
+            Self::process_batches_into_keyset(
+                &snapshot_batches,
+                &self.pk_deletion_strategy,
+                pk_indices,
+                converter,
+                &projected_pk_indices,
+                &filtered_deleted_pk_i64,
+                &filtered_deleted_row_keys,
+                &self.table_metadata.table_name,
+                &mut keyset,
+                &mut row_id_base,
+            )?;
         }
 
-        // Load the appropriate deletion cache based on pk_deletion_strategy.
-        // This ensures keys that were previously deleted are not considered as conflicts.
-        // Note: PositionBased strategy is never used here since it implies no primary key,
-        // and this function is only called for tables with primary keys.
-        let (deleted_pk_i64, insert_records_pk_i64) = match &self.pk_deletion_strategy {
-            PkDeletionStrategyWithCache::Int64Pk {
-                cached_deleted_pk,
-                cached_insert_records,
-            } => {
-                let deleted_guard = cached_deleted_pk.read().map_err(|_| Error::LockPoisoned {
-                    table: self.table_metadata.table_name.clone(),
-                    lock: DELETION_CACHE_LOCK_POISONED,
-                })?;
-                let insert_guard =
-                    cached_insert_records
-                        .read()
-                        .map_err(|_| Error::LockPoisoned {
-                            table: self.table_metadata.table_name.clone(),
-                            lock: DELETION_CACHE_LOCK_POISONED,
-                        })?;
-                (
-                    Some(Arc::clone(&deleted_guard)),
-                    Some(Arc::clone(&insert_guard)),
-                )
-            }
-            _ => (None, None),
-        };
+        Ok(keyset)
+    }
 
-        let (deleted_row_keys, insert_records_row_keys) = match &self.pk_deletion_strategy {
-            PkDeletionStrategyWithCache::RowConverterBased {
-                cached_deleted_row_keys,
-                cached_insert_records,
-            } => {
-                let deleted_guard =
-                    cached_deleted_row_keys
-                        .read()
-                        .map_err(|_| Error::LockPoisoned {
-                            table: self.table_metadata.table_name.clone(),
-                            lock: DELETION_CACHE_LOCK_POISONED,
-                        })?;
-                let insert_guard =
-                    cached_insert_records
-                        .read()
-                        .map_err(|_| Error::LockPoisoned {
-                            table: self.table_metadata.table_name.clone(),
-                            lock: DELETION_CACHE_LOCK_POISONED,
-                        })?;
-                (
-                    Some(Arc::clone(&deleted_guard)),
-                    Some(Arc::clone(&insert_guard)),
-                )
-            }
-            _ => (None, None),
-        };
-
-        let mut keyset = HashMap::with_capacity(1024);
-        let mut row_id_base: i64 = 0;
-
-        // After projection, batch columns are at indices 0..pk_indices.len()
-        let projected_pk_indices: Vec<usize> = (0..pk_indices.len()).collect();
-
-        for batch in all_batches {
+    /// Process record batches and add visible keys to the keyset.
+    ///
+    /// Filters out deleted rows using the provided deletion maps (without insert_records).
+    /// Keys from later batches override earlier ones in the keyset, which is correct
+    /// because protected snapshots contain data inserted at higher sequence numbers.
+    fn process_batches_into_keyset(
+        batches: &[RecordBatch],
+        pk_deletion_strategy: &PkDeletionStrategyWithCache,
+        pk_indices: &[usize],
+        converter: &RowConverter,
+        projected_pk_indices: &[usize],
+        deleted_pk_i64: &Option<Arc<HashMap<i64, i64>>>,
+        deleted_row_keys: &Option<Arc<HashMap<Box<[u8]>, i64>>>,
+        table_name: &str,
+        keyset: &mut HashMap<OwnedRow, RowLocation>,
+        row_id_base: &mut i64,
+    ) -> Result<()> {
+        for batch in batches {
             let pk_columns: Vec<_> = projected_pk_indices
                 .iter()
                 .map(|idx| Arc::clone(batch.column(*idx)))
@@ -1808,48 +1856,42 @@ impl CayenneTableProvider {
 
             // For Int64Pk strategy, get the PK column as Int64Array for efficient lookup
             let int64_pk_array: Option<&arrow::array::Int64Array> =
-                if self.pk_deletion_strategy.is_int64_pk() && pk_indices.len() == 1 {
+                if pk_deletion_strategy.is_int64_pk() && pk_indices.len() == 1 {
                     batch.column(0).as_any().downcast_ref()
                 } else {
                     None
                 };
 
             for row_idx in 0..batch.num_rows() {
-                let row_id = row_id_base
+                let row_id = *row_id_base
                     + i64::try_from(row_idx).map_err(|_| Error::Internal {
-                        table: self.table_metadata.table_name.clone(),
+                        table: table_name.to_string(),
                         message: "Row index exceeds i64::MAX; cannot compute row_id".to_string(),
                     })?;
 
-                // Check if row is deleted based on pk_deletion_strategy
-                let is_deleted = match &self.pk_deletion_strategy {
+                // Check if row is deleted based on pk_deletion_strategy.
+                // No insert_records are passed — for main batches this matches
+                // apply_deletion_filter(), and for protected snapshot batches the
+                // deletion map is already filtered to only relevant sequences.
+                let is_deleted = match pk_deletion_strategy {
                     PkDeletionStrategyWithCache::Int64Pk { .. } => {
                         if let (Some(pk_array), Some(deleted_pks)) =
-                            (int64_pk_array, &deleted_pk_i64)
+                            (int64_pk_array, deleted_pk_i64)
                         {
                             let pk_value = pk_array.value(row_idx);
-                            !is_pk_visible_i64(
-                                pk_value,
-                                deleted_pks,
-                                insert_records_pk_i64.as_deref(),
-                            )
+                            !is_pk_visible_i64(pk_value, deleted_pks, None)
                         } else {
                             false
                         }
                     }
                     PkDeletionStrategyWithCache::RowConverterBased { .. } => {
-                        if let Some(deleted_keys) = &deleted_row_keys {
+                        if let Some(deleted_keys) = deleted_row_keys {
                             let key = rows.row(row_idx);
-                            !is_pk_visible_row_key(
-                                key.as_ref(),
-                                deleted_keys,
-                                insert_records_row_keys.as_deref(),
-                            )
+                            !is_pk_visible_row_key(key.as_ref(), deleted_keys, None)
                         } else {
                             false
                         }
                     }
-                    // PositionBased implies no primary key, but this function requires PKs
                     PkDeletionStrategyWithCache::PositionBased { .. } => {
                         unreachable!("PositionBased strategy should not reach load_existing_keyset")
                     }
@@ -1863,10 +1905,9 @@ impl CayenneTableProvider {
                 let has_null = pk_columns.iter().any(|col| col.is_null(row_idx));
                 if has_null {
                     return Err(Error::DataValidation {
-                        table: self.table_metadata.table_name.clone(),
+                        table: table_name.to_string(),
                         message: format!(
-                            "Null primary key encountered in existing data for table {}",
-                            self.table_metadata.table_name
+                            "Null primary key encountered in existing data for table {table_name}",
                         ),
                     });
                 }
@@ -1886,13 +1927,13 @@ impl CayenneTableProvider {
                 );
             }
 
-            row_id_base += i64::try_from(batch.num_rows()).map_err(|_| Error::Internal {
-                table: self.table_metadata.table_name.clone(),
+            *row_id_base += i64::try_from(batch.num_rows()).map_err(|_| Error::Internal {
+                table: table_name.to_string(),
                 message: "Batch row count exceeds i64::MAX; cannot compute row_id_base".to_string(),
             })?;
         }
 
-        Ok(keyset)
+        Ok(())
     }
 
     /// Prepare an incoming stream for insert by validating `on_conflict` constraints.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4673,7 +4673,7 @@ mod tests {
         .await;
     }
 
-    /// Helper: build a single-column Int64 RecordBatch and the matching RowConverter.
+    /// Helper: build a single-column Int64 `RecordBatch` and the matching `RowConverter`.
     fn make_int64_pk_batch(values: &[i64]) -> (RecordBatch, RowConverter) {
         use arrow::array::Int64Array;
         use arrow::datatypes::{DataType, Field, Schema};

--- a/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
@@ -24,8 +24,10 @@ use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArr
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalog};
 use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionContext;
+use datafusion::prelude::{col, lit, Expr};
 use datafusion_table_providers::util::{
     column_reference::ColumnReference, on_conflict::OnConflict,
 };
@@ -106,6 +108,22 @@ async fn get_ids(ctx: &SessionContext, table_name: &str) -> TestResult<Vec<i64>>
         }
     }
     Ok(ids)
+}
+
+async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
+    let ctx = SessionContext::new();
+    let plan = table.delete_from(&ctx.state(), &[filter]).await?;
+    let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
 }
 
 // =============================================================================
@@ -619,3 +637,173 @@ async fn test_protected_snapshots_readable_with_pending_deletions_impl(
 }
 
 test_with_backends!(test_protected_snapshots_readable_with_pending_deletions_impl);
+
+// =============================================================================
+// Test: Upsert after explicit DELETE must not create duplicate PKs
+// =============================================================================
+//
+// Regression test for stale insert_records bug. The bug scenario:
+// 1. Upsert key=K: writes to protected snapshot S_A, updates cached_insert_records[K]
+// 2. Explicit DELETE key=K: updates cached_deleted_pk[K] to higher seq,
+//    but cached_insert_records[K] stays stale
+// 3. Upsert key=K: load_existing_keyset() checks key=K from S_A using stale
+//    insert_records → decides key is "not visible" → no conflict detected →
+//    writes to new snapshot S_B without deleting S_A's copy
+// 4. Upsert key=K: same → writes to S_C
+// 5. Scan: S_B and S_C both visible → duplicate rows
+//
+// The fix: load_existing_keyset() no longer uses insert_records. It uses only
+// deleted_pk maps with sequence thresholds per snapshot.
+
+async fn test_upsert_after_explicit_delete_no_duplicates_impl(
+    fixture: TestFixture,
+) -> TestResult<()> {
+    let (table, ctx, schema) = setup_upsert_table(&fixture, "delete_upsert").await?;
+
+    // Step 1: Initial insert - PKs 1, 2, 3
+    let batch1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
+            Arc::new(Int64Array::from(vec![100, 200, 300])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_706_000_000_000_000_i64,
+                1_706_000_000_000_000_i64,
+                1_706_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch1).await?;
+
+    assert_eq!(
+        get_row_count(&ctx, "delete_upsert").await?,
+        3,
+        "After initial insert: should have 3 rows"
+    );
+
+    // Step 2: Upsert key=2 - creates pending deletion + protected snapshot S_A
+    // This updates cached_insert_records[2] and cached_deleted_pk[2]
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2])),
+            Arc::new(StringArray::from(vec!["beta_v2"])),
+            Arc::new(Int64Array::from(vec![201])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_709_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch2).await?;
+
+    assert_eq!(
+        get_row_count(&ctx, "delete_upsert").await?,
+        3,
+        "After upsert id=2: should still have 3 rows"
+    );
+
+    // Step 3: Explicit DELETE key=2 - THE CRUCIAL STEP
+    // This updates cached_deleted_pk[2] to a higher sequence number,
+    // but cached_insert_records[2] retains the stale value from step 2.
+    // Note: delete_records may return 0 because the deletion sink counts
+    // only PKs NOT already in the deletion cache, and id=2 was added to
+    // the cache by the upsert in step 2. The deletion vector IS still
+    // written with a higher sequence number.
+    delete_records(&table, col("id").eq(lit(2i64))).await?;
+
+    assert_eq!(
+        get_row_count(&ctx, "delete_upsert").await?,
+        2,
+        "After explicit DELETE id=2: should have 2 rows (ids 1, 3)"
+    );
+
+    // Step 4: Upsert key=2 again - BEFORE THE FIX, this would NOT detect the
+    // conflict because load_existing_keyset() used stale insert_records to
+    // conclude key=2 was "not visible", skipping it in the keyset. The upsert
+    // would write to a new snapshot S_B without removing S_A's copy.
+    let batch3 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2])),
+            Arc::new(StringArray::from(vec!["beta_v3"])),
+            Arc::new(Int64Array::from(vec![202])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_711_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch3).await?;
+
+    assert_eq!(
+        get_row_count(&ctx, "delete_upsert").await?,
+        3,
+        "After re-upsert id=2: should have 3 rows (ids 1, 2, 3)"
+    );
+
+    // Step 5: Upsert key=2 one more time - before the fix, this created yet
+    // another snapshot S_C, also without removing prior copies.
+    let batch4 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2])),
+            Arc::new(StringArray::from(vec!["beta_v4"])),
+            Arc::new(Int64Array::from(vec![203])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_714_000_000_000_000_i64,
+            ])),
+        ],
+    )?;
+    insert_batch(&table, batch4).await?;
+
+    // CRITICAL ASSERTION: Must still have exactly 3 rows, not 5
+    // Before the fix, S_B and S_C would both be visible, producing duplicates.
+    let count = get_row_count(&ctx, "delete_upsert").await?;
+    assert_eq!(
+        count, 3,
+        "After final upsert id=2: should have 3 rows (no duplicates), got {count}"
+    );
+
+    // Verify unique IDs - no duplicates
+    let ids = get_ids(&ctx, "delete_upsert").await?;
+    assert_eq!(
+        ids,
+        vec![1, 2, 3],
+        "Should have exactly ids 1, 2, 3 with no duplicates, got {ids:?}"
+    );
+
+    // Verify id=2 has the latest value (203 from step 5)
+    let df = ctx
+        .sql("SELECT id, name, value FROM delete_upsert WHERE id = 2")
+        .await?;
+    let results = df.collect().await?;
+    assert_eq!(
+        results.iter().map(RecordBatch::num_rows).sum::<usize>(),
+        1,
+        "id=2 should appear exactly once"
+    );
+    let values = results[0]
+        .column(2)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("value column should be Int64Array");
+    assert_eq!(
+        values.value(0),
+        203,
+        "id=2 should have latest value 203 from step 5"
+    );
+    let names = results[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("name column should be StringArray");
+    assert_eq!(
+        names.value(0),
+        "beta_v4",
+        "id=2 should have latest name 'beta_v4' from step 5"
+    );
+
+    Ok(())
+}
+
+test_with_backends!(test_upsert_after_explicit_delete_no_duplicates_impl);


### PR DESCRIPTION
## 📝 Summary

- Fix `load_existing_keyset()` to use per-snapshot deletion filtering, mirroring how `scan()` already handles it correctly
- Extract `process_batches_into_keyset()` helper to avoid code duplication between main and protected snapshot processing paths

### Root Cause ###

`load_existing_keyset()` mixed all batches (main listing table + protected snapshots) together and applied a single global
deletion filter using `cached_insert_records`. After an explicit DELETE, `cached_insert_records` becomes stale (it's only updated during on-conflict upserts, not explicit deletes). This caused keys in protected snapshots to be incorrectly marked as "not visible", so subsequent upserts didn't detect conflicts and wrote duplicate copies to new protected snapshots.

### The bug sequence: ###
  1. Upsert key=11: writes to protected snapshot S_A, `updates cached_insert_records[11]`
  2. DELETE key=11: `updates cached_deleted_pk[11]` to higher seq, but `cached_insert_records[11]` stays stale
  3. Upsert key=11: `load_existing_keyset()` checks key=11 from S_A using stale insert_records → decides key is "not visible" → no
  conflict detected → writes to new snapshot S_B without deleting S_A's copy
  4. Upsert key=11: same → writes to S_C
  5. Scan: S_B and S_C both visible → duplicate rows

### Fix ###

`scan()` already handles this correctly by using different deletion filters per source:
  - Main listing table: all deletions, no insert_records (`apply_deletion_filter`)
  - Each protected snapshot: only deletions with `seq > max_delete_seq_at_creation` (`apply_partial_deletion_filter`)

The fix aligns `load_existing_keyset()` with the same approach instead of using a single global filter with `cached_insert_records`.