### PR TITLE
Fix partition expression serialization/deserialization for custom UDFs in distributed mode

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1305,6 +1305,7 @@ pub async fn initialize_cluster_executor(
         let initial_partitions = executor_request_initial_partitions(
             cluster_client.clone(),
             rt.datafusion().cluster_config.node_advertise_url(),
+            rt.datafusion().ctx.as_ref(),
         )
         .await
         .map_err(|status| FailedToStartClusterExecutor {

--- a/crates/runtime/src/cluster/partition/discovery.rs
+++ b/crates/runtime/src/cluster/partition/discovery.rs
@@ -23,13 +23,20 @@ use crate::{
     search::util::find_concrete_table_provider,
 };
 use datafusion::common::ToDFSchema;
+use datafusion::sql::sqlparser::{
+    ast::{self, FunctionArgExpr, FunctionArguments},
+    dialect::GenericDialect,
+    parser::Parser,
+};
 use datafusion::{execution::SessionStateBuilder, prelude::SessionContext, sql::TableReference};
 use snafu::prelude::*;
 use spicepod::partitioning::PartitionedBy;
 
 /// Query the source table provider for partition values for a given table.
 ///
-/// This builds a SQL query to get distinct values from the partition columns.
+/// If all partition expressions can be resolved statically (e.g. `bucket(N, col)` produces
+/// `0..N-1`), the values are generated without querying the source table. Otherwise, a
+/// `SELECT DISTINCT` is executed against the federated source.
 pub async fn table_partition_values(
     table: &TableReference,
     partitioning: &[PartitionedBy],
@@ -43,9 +50,22 @@ pub async fn table_partition_values(
         "Starting partition value discovery"
     );
 
-    // Build SQL query to get distinct partition values
-    // For single partition column: SELECT DISTINCT partition_col as  FROM table
-    // For multiple columns: SELECT DISTINCT partition_col1, partition_col2, ... FROM table
+    if partitioning.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Fast path: if every partition expression has a statically known value set,
+    // generate partition values without querying the source table.
+    if let Some(values) = try_static_partition_values(partitioning) {
+        tracing::info!(
+            table = %table_name,
+            partition_count = values.len(),
+            "Partition values resolved statically (skipping source query)"
+        );
+        return Ok(values);
+    }
+
+    // Slow path: query the federated source table.
     let partition_exprs: Vec<String> = partitioning
         .iter()
         .map(|p| {
@@ -193,4 +213,179 @@ async fn execute_partition_discovery_query(
     );
 
     Ok(batches)
+}
+
+// ---------------------------------------------------------------------------
+// Static partition value resolution (fast path)
+// ---------------------------------------------------------------------------
+
+/// Maximum number of buckets the `bucket()` UDF accepts.  Mirrors the constant
+/// in `runtime-datafusion-udfs/src/bucket.rs`.
+const MAX_NUM_BUCKETS: i64 = 1_000_000;
+
+/// Attempt to resolve partition values without querying the source table.
+///
+/// Returns `Some(values)` when **all** of the following hold:
+///   1. There is exactly one partition expression (multi-expression partitioning
+///      falls back to the source query).
+///   2. The expression is deterministic with a statically known value set — see
+///      [`try_static_values_for_expr`] for the list of supported expressions.
+///
+/// Returns `None` otherwise, causing the caller to fall back to the slow path
+/// (`SELECT DISTINCT … FROM source`).
+fn try_static_partition_values(partitioning: &[PartitionedBy]) -> Option<Vec<PartitionValue>> {
+    let [partition] = partitioning else {
+        return None;
+    };
+
+    let values = try_static_values_for_expr(&partition.expression)?;
+
+    Some(
+        values
+            .into_iter()
+            .map(|v| HashMap::from([(partition.expression.clone(), v)]))
+            .collect(),
+    )
+}
+
+/// Resolve the complete set of values for a single partition expression without
+/// querying the source table.
+///
+/// Currently supported expressions:
+///   - `bucket(N, col)` — produces `["0", "1", …, "N-1"]`. `N` must be a
+///     positive integer literal (zero and negative values are rejected).
+///
+/// Returns `Some(values)` if the expression can be resolved statically, `None`
+/// otherwise.  Add new match arms here to support additional expressions.
+fn try_static_values_for_expr(expression: &str) -> Option<Vec<String>> {
+    let expr = Parser::new(&GenericDialect)
+        .try_with_sql(expression)
+        .ok()?
+        .parse_expr()
+        .ok()?;
+
+    match &expr {
+        // bucket(N, column) → 0..N-1
+        ast::Expr::Function(func) if is_function_named(func, "bucket") => {
+            let n = extract_first_int_arg(func)?;
+            if n <= 0 || n > MAX_NUM_BUCKETS {
+                return None;
+            }
+            Some((0..n).map(|i| i.to_string()).collect())
+        }
+
+        // Future extensions:
+        //   modulo(N, col)  → 0..N-1
+        //   year(col)       → user-specified range or known bounds
+        //   ...
+        _ => None,
+    }
+}
+
+/// Check whether a parsed function has the given name (case-insensitive).
+fn is_function_named(func: &ast::Function, name: &str) -> bool {
+    func.name.0.last().is_some_and(|part| match part {
+        ast::ObjectNamePart::Identifier(ident) => ident.value.eq_ignore_ascii_case(name),
+        ast::ObjectNamePart::Function(_) => false,
+    })
+}
+
+/// Extract the first argument of a function call as an `i64`, if it is a literal integer.
+fn extract_first_int_arg(func: &ast::Function) -> Option<i64> {
+    let FunctionArguments::List(arg_list) = &func.args else {
+        return None;
+    };
+
+    let first_arg = arg_list.args.first()?;
+    match first_arg {
+        ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(ast::Expr::Value(
+            ast::ValueWithSpan {
+                value: ast::Value::Number(s, _),
+                ..
+            },
+        ))) => s.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_static_values_for_expr_bucket() {
+        // Valid bucket expressions
+        let vals = try_static_values_for_expr("bucket(50, organization_id)").expect("should parse");
+        assert_eq!(vals.len(), 50);
+        assert_eq!(vals[0], "0");
+        assert_eq!(vals[49], "49");
+
+        let vals = try_static_values_for_expr("bucket( 5 , c_name)").expect("should parse");
+        assert_eq!(vals.len(), 5);
+
+        let vals = try_static_values_for_expr("BUCKET(10, user_id)").expect("should parse");
+        assert_eq!(vals.len(), 10);
+
+        // bucket(1, col) → single partition ["0"]
+        let vals = try_static_values_for_expr("bucket(1, col)").expect("should parse");
+        assert_eq!(vals, vec!["0"]);
+
+        // bucket(0, col) is meaningless → None
+        assert!(try_static_values_for_expr("bucket(0, col)").is_none());
+
+        // Negative bucket count → None (sqlparser parses `-5` as UnaryOp, not a Number literal)
+        assert!(try_static_values_for_expr("bucket(-5, col)").is_none());
+
+        // Exceeds MAX_NUM_BUCKETS → None (fall back to slow path where UDF rejects it)
+        assert!(try_static_values_for_expr("bucket(2000000, col)").is_none());
+
+        // Non-bucket expressions → None
+        assert!(try_static_values_for_expr("year(created_at)").is_none());
+        assert!(try_static_values_for_expr("some_column").is_none());
+    }
+
+    #[test]
+    fn test_try_static_partition_values_single_bucket() {
+        let partitioning = vec![PartitionedBy {
+            name: "org_bucket".to_string(),
+            expression: "bucket(3, org_id)".to_string(),
+        }];
+
+        let values = try_static_partition_values(&partitioning).expect("should resolve statically");
+        assert_eq!(values.len(), 3);
+        for i in 0..3 {
+            let expected: HashMap<String, String> =
+                [("bucket(3, org_id)".to_string(), i.to_string())]
+                    .into_iter()
+                    .collect();
+            assert!(values.contains(&expected), "missing partition value {i}");
+        }
+    }
+
+    #[test]
+    fn test_try_static_partition_values_not_resolvable() {
+        let partitioning = vec![PartitionedBy {
+            name: "year".to_string(),
+            expression: "year(created_at)".to_string(),
+        }];
+
+        assert!(try_static_partition_values(&partitioning).is_none());
+    }
+
+    #[test]
+    fn test_try_static_partition_values_multiple_not_supported() {
+        // Multiple partition expressions fall back to the slow path.
+        let partitioning = vec![
+            PartitionedBy {
+                name: "a".to_string(),
+                expression: "bucket(2, col_a)".to_string(),
+            },
+            PartitionedBy {
+                name: "b".to_string(),
+                expression: "bucket(3, col_b)".to_string(),
+            },
+        ];
+
+        assert!(try_static_partition_values(&partitioning).is_none());
+    }
 }

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -21,7 +21,7 @@ use std::{
 
 use app::{App, spicepod::component::runtime::Scheduler as SchedulerConfig};
 
-use datafusion::{logical_expr::Expr, sql::TableReference};
+use datafusion::{execution::FunctionRegistry, logical_expr::Expr, sql::TableReference};
 use datafusion_proto::bytes::Serializeable;
 use object_store::ObjectStore;
 use object_store::prefix::PrefixStore;
@@ -175,6 +175,7 @@ pub fn accelerated_tables(app: &Arc<App>) -> HashMap<TableReference, Vec<Partiti
 pub async fn executor_request_initial_partitions(
     mut client: ClusterServiceClient<Channel>,
     executor_url: String,
+    registry: &(dyn FunctionRegistry + Send + Sync),
 ) -> Result<HashMap<TableReference, Vec<Expr>>> {
     let response = client
         .allocate_initial_partitions(AllocateInitialPartitionsRequest { executor_url })
@@ -189,7 +190,8 @@ pub async fn executor_request_initial_partitions(
         let mut exprs = Vec::new();
 
         for item in partitions.items {
-            let expr = Expr::from_bytes(&item).context(PartitionExpressionDeserializationSnafu)?;
+            let expr = Expr::from_bytes_with_registry(&item, registry)
+                .context(PartitionExpressionDeserializationSnafu)?;
             exprs.push(expr);
         }
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -610,6 +610,13 @@ impl ClusterService for ClusterServiceImpl {
                 // Find accelerated datasets with partitioning
 
                 for table_ref in super::partition::accelerated_tables(app).keys() {
+                    // Wait for the table to be registered in DataFusion before serializing partition expressions.
+                    // Executors may connect before the scheduler has finished loading all datasets.
+                    self.datafusion
+                        .runtime_status()
+                        .wait_for_dataset_ready(table_ref)
+                        .await;
+
                     match partition_manager
                         .allocate_partitions(table_ref, executor_id, 10)
                         .await
@@ -652,6 +659,7 @@ impl ClusterService for ClusterServiceImpl {
 
         // Register the allocated partitions in the executor registry so the scheduler knows where they are
         {
+            let registry = self.datafusion.ctx.as_ref();
             let mut executor_partitions = self.executor_registry.partitions.write().await;
             executor_partitions.insert(
                 executor_id.to_string(),
@@ -661,11 +669,13 @@ impl ClusterService for ClusterServiceImpl {
                         let exprs = sa
                             .items
                             .iter()
-                            .filter_map(|bytes| match Expr::from_bytes(bytes) {
-                                Ok(expr) => Some(expr),
-                                Err(e) => {
-                                    tracing::error!("Failed to deserialize expr: {e}");
-                                    None
+                            .filter_map(|bytes| {
+                                match Expr::from_bytes_with_registry(bytes, registry) {
+                                    Ok(expr) => Some(expr),
+                                    Err(e) => {
+                                        tracing::error!("Failed to deserialize expr: {e}");
+                                        None
+                                    }
                                 }
                             })
                             .collect();


### PR DESCRIPTION
## 📝 Summary

In distributed mode, partition expressions containing custom UDFs (e.g. `bucket()`) fail to serialize and deserialize correctly during executor registration:

1. **Race condition on serialization**: When an executor connects, the scheduler calls `partition_value_to_bytes()` to serialize partition filter expressions (e.g. `bucket(50, organization_id) = '0'`). This requires the table to be registered in the DataFusion context, but executors may connect before dataset loading completes, causing `Table not found` errors and empty partition assignments.

2. **Missing `FunctionRegistry` on deserialization**: Both the scheduler (`service.rs`) and executor (`startup.rs`) used `Expr::from_bytes()` which internally uses `NoRegistry` — a registry that cannot resolve any UDFs. This causes `LogicalExtensionCodec is not provided for scalar function bucket` errors when deserializing partition expressions containing custom UDFs.

### Fix

- **`service.rs`**: Wait for dataset readiness via `runtime_status().wait_for_dataset_ready()` before serializing partition expressions. Use `Expr::from_bytes_with_registry()` with the `SessionContext` (which has custom UDFs registered) instead of `Expr::from_bytes()`.
- **`startup.rs`**: Accept a `FunctionRegistry` parameter and use `Expr::from_bytes_with_registry()` instead of `Expr::from_bytes()`.
- **`mod.rs`**: Pass `rt.datafusion().ctx` as the registry to `executor_request_initial_partitions()`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
