### PR TITLE
build(deps): consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -356,7 +356,7 @@ jobs:
             image=moby/buildkit:latest
 
       - name: Build ARM64 Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.local
@@ -401,7 +401,7 @@ jobs:
             image=moby/buildkit:latest
 
       - name: Build AMD64 Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.local

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4
+        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4
+        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4
+        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 1
 
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8 # v15
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ needs.resolve-run.outputs.run_id }}
@@ -213,7 +213,7 @@ jobs:
           fetch-depth: 1
 
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8 # v15
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ needs.resolve-run.outputs.run_id }}

--- a/.github/workflows/spice_mssql_tpch_bench_docker.yml
+++ b/.github/workflows/spice_mssql_tpch_bench_docker.yml
@@ -91,7 +91,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./test/tpc-bench/mssql-tpch
           file: ./test/tpc-bench/mssql-tpch/Dockerfile

--- a/.github/workflows/spice_mysql_bench_docker.yml
+++ b/.github/workflows/spice_mysql_bench_docker.yml
@@ -97,7 +97,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./test/tpc-bench/mysql-bench
           file: ./test/tpc-bench/mysql-bench/Dockerfile

--- a/.github/workflows/spice_mysql_tpcds_bench_docker.yml
+++ b/.github/workflows/spice_mysql_tpcds_bench_docker.yml
@@ -83,7 +83,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./test/tpc-bench/mysql-tpcds-bench
           file: ./test/tpc-bench/mysql-tpcds-bench/Dockerfile

--- a/.github/workflows/spice_postgres_bench_docker.yml
+++ b/.github/workflows/spice_postgres_bench_docker.yml
@@ -47,7 +47,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./test/tpch/postgres-bench
           file: ./test/tpch/postgres-bench/Dockerfile

--- a/.github/workflows/spice_postgres_tpcds_bench_docker.yml
+++ b/.github/workflows/spice_postgres_tpcds_bench_docker.yml
@@ -47,7 +47,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./test/tpc-bench/postgres-tpcds-bench
           file: ./test/tpc-bench/postgres-tpcds-bench/Dockerfile

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -181,7 +181,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_amd64 == 'true' }}
       - &build-amd64-image
         name: Package AMD64 ${{ env.IMAGE_TAG }} image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile-release
@@ -250,7 +250,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_arm64 == 'true' }}
       - &build-arm64-image
         name: Package ARM64 ${{ env.IMAGE_TAG }} image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile-release
@@ -300,7 +300,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
 
       - name: Package CUDA image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile-cuda-release

--- a/.github/workflows/spiced_docker_dev.yml
+++ b/.github/workflows/spiced_docker_dev.yml
@@ -127,7 +127,7 @@ jobs:
           fi
 
       - name: Build ARM64 image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -184,7 +184,7 @@ jobs:
           fi
 
       - name: Build AMD64 image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/spidapter_build_and_release.yml
+++ b/.github/workflows/spidapter_build_and_release.yml
@@ -86,7 +86,7 @@ jobs:
         run: cp tools/spidapter/Dockerfile ./build/Dockerfile
 
       - name: Build image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./build
           file: ./build/Dockerfile

--- a/.github/workflows/testoperator_build_and_release.yml
+++ b/.github/workflows/testoperator_build_and_release.yml
@@ -86,7 +86,7 @@ jobs:
         run: cp tools/testoperator/Dockerfile ./build/Dockerfile
 
       - name: Build image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./build
           file: ./build/Dockerfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19855,9 +19855,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d
 candle-transformers = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0", package = "candle-transformers" }
 charset = "0.1.5"
 chrono = "0.4.42"
-clap = { version = "4.5.54", features = ["derive", "env"] }
+clap = { version = "4.5.60", features = ["derive", "env"] }
 clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0.2.1", features = [
     "tokio_io",
     "tls",

--- a/bin/spice/Cargo.toml
+++ b/bin/spice/Cargo.toml
@@ -73,7 +73,7 @@ comfy-table = "7"
 rustyline = "17"
 
 # Interactive CLI prompts (arrow-key selection)
-dialoguer = "0.11"
+dialoguer = "0.12"
 
 # Random number generation (for auth codes)
 rand = "0.9"

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -14,7 +14,7 @@ arrow = { workspace = true, features = ["chrono-tz"] }
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 arrow-json.workspace = true
 clap.workspace = true
-dialoguer = "0.11"
+dialoguer = "0.12"
 dirs = "6"
 flight_client = { path = "../flight_client" }
 futures.workspace = true

--- a/tools/pr-builds/Cargo.toml
+++ b/tools/pr-builds/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-dialoguer = "0.11.0"
+dialoguer = "0.12.0"
 dirs = "6.0.0"
 flate2 = "1.1.9"
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Combines the following dependabot PRs into a single update:

- bump clap from 4.5.54 to 4.5.58
- bump ctrlc from 3.5.1 to 3.5.2
- bump dialoguer from 0.11.0 to 0.12.0
- bump tonic from 0.14.2 to 0.14.4
- bump tracing-test from 0.2.5 to 0.2.6
- bump dawidd6/action-download-artifact from 14 to 15
- bump docker/build-push-action from 6.18.0 to 6.19.2
- bump github/codeql-action from 4.32.2 to 4.32.4