### PR TITLE
feat: Support distributed ingestion in cayenne catalog

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use arrow::{
     array::{Array, RecordBatch, array},
+    compute::cast,
     datatypes::Schema,
 };
 use async_stream::stream;
@@ -531,14 +532,54 @@ impl ExecutionPlan for FlightSqlExec {
         _context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let sql = self.sql().map_err(to_execution_error)?;
+        let target_schema = self.schema();
 
-        let stream_adapter = RecordBatchStreamAdapter::new(
-            self.schema(),
-            query_to_stream(self.client.clone(), sql, Arc::clone(&self.cookie_store)),
+        let stream = query_to_stream(self.client.clone(), sql, Arc::clone(&self.cookie_store)).map(
+            move |result| result.and_then(|batch| coerce_batch_to_schema(&batch, &target_schema)),
         );
+
+        let stream_adapter = RecordBatchStreamAdapter::new(self.schema(), stream);
 
         Ok(Box::pin(stream_adapter))
     }
+}
+
+/// Coerce a [`RecordBatch`] to match a target schema by casting columns whose types
+/// differ but are compatible (e.g. `Utf8` → `Utf8View`). This handles cases where
+/// the Flight IPC layer returns data with slightly different types than the declared schema.
+fn coerce_batch_to_schema(
+    batch: &RecordBatch,
+    target_schema: &SchemaRef,
+) -> DataFusionResult<RecordBatch> {
+    if batch.num_columns() != target_schema.fields().len() {
+        return Err(DataFusionError::Execution(format!(
+            "FlightSQL batch column count mismatch: got {}, expected {}",
+            batch.num_columns(),
+            target_schema.fields().len()
+        )));
+    }
+
+    // Fast path: schemas already match.
+    if batch.schema().fields() == target_schema.fields() {
+        return Ok(batch.clone());
+    }
+
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(target_schema.fields())
+        .map(|(col, target_field)| {
+            if col.data_type() == target_field.data_type() {
+                Ok(Arc::clone(col))
+            } else {
+                cast(col, target_field.data_type())
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+            }
+        })
+        .collect::<DataFusionResult<Vec<_>>>()?;
+
+    RecordBatch::try_new(Arc::clone(target_schema), columns)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
 fn query_to_stream(

--- a/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
+++ b/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
@@ -140,6 +140,7 @@ impl AnalyzerRule for PartitionedTableScanRewrite {
                     },
                 )));
             }
+
             Ok(Transformed::yes(LogicalPlan::Union(Union {
                 inputs: sub_scans,
                 schema: Arc::clone(plan.schema()),

--- a/crates/runtime-request-context/src/context.rs
+++ b/crates/runtime-request-context/src/context.rs
@@ -53,6 +53,9 @@ pub struct RequestContext {
     extensions: RwLock<Extensions>,
     trace_parent: Option<TraceParent>,
     nested_query_level: AtomicI16,
+    /// The raw `authorization` header value from the incoming request, if present.
+    /// Used to forward credentials when proxying requests (e.g. scheduler → executor).
+    authorization_header: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -235,6 +238,12 @@ impl RequestContext {
         &self.trace_parent
     }
 
+    /// Returns the raw `authorization` header value from the incoming request, if present.
+    #[must_use]
+    pub fn authorization_header(&self) -> Option<&str> {
+        self.authorization_header.as_deref()
+    }
+
     pub fn extension<T>(&self) -> Option<T>
     where
         T: Extension + Clone,
@@ -301,6 +310,7 @@ pub struct RequestContextBuilder {
     baggage: Vec<KeyValue>,
     extensions: Extensions,
     trace_parent: Option<TraceParent>,
+    authorization_header: Option<String>,
 }
 
 impl RequestContextBuilder {
@@ -315,6 +325,7 @@ impl RequestContextBuilder {
             baggage: vec![],
             extensions: Extensions::default(),
             trace_parent: None,
+            authorization_header: None,
         }
     }
 
@@ -353,6 +364,11 @@ impl RequestContextBuilder {
         };
 
         self.baggage.extend(baggage::from_headers(headers));
+
+        self.authorization_header = headers
+            .get(http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
 
         match super::extract_trace_parent(headers) {
             Ok(trace_parent) => {
@@ -491,6 +507,7 @@ impl RequestContextBuilder {
             extensions: RwLock::new(self.extensions),
             trace_parent: self.trace_parent,
             nested_query_level: AtomicI16::new(0),
+            authorization_header: self.authorization_header,
         }
     }
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -262,10 +262,12 @@ impl RuntimeBuilder {
             executor_registry, ..
         }) = distributed.as_ref()
         {
-            df_builder =
-                df_builder.with_analyzer_rules(vec![Arc::new(PartitionedTableScanRewrite::new(
-                    Arc::clone(executor_registry) as Arc<dyn TablePartitionProvider>,
-                ))
+            df_builder = df_builder
+                .with_executor_registry(Arc::clone(executor_registry))
+                .with_analyzer_rules(vec![Arc::new(PartitionedTableScanRewrite::new(Arc::clone(
+                    executor_registry,
+                )
+                    as Arc<dyn TablePartitionProvider>))
                     as Arc<dyn AnalyzerRule + Send + Sync>]);
         }
 

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -38,6 +38,7 @@ use crate::component::catalog::Catalog;
 use crate::parameters::Parameters;
 use crate::spice_data_base_path;
 use data_components::RefreshableCatalogProvider;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -291,7 +292,7 @@ impl RefreshableCatalogProvider for CayenneCatalogProvider {
 
         if !new_schemas.is_empty() {
             let total_tables: usize = grouped.values().map(Vec::len).sum();
-            tracing::info!(
+            tracing::debug!(
                 "Loaded {total_tables} existing Cayenne table{} across {} namespace{}",
                 if total_tables == 1 { "" } else { "s" },
                 new_schemas.len(),
@@ -402,7 +403,13 @@ impl CayenneSchemaProvider {
                 let builder = CayenneTableProviderBuilder::new(Arc::clone(catalog));
 
                 match builder.open(table_name).await {
-                    Ok(provider) => Ok(Some(Arc::new(provider))),
+                    Ok(provider) => {
+                        let provider = Arc::new(provider);
+                        let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                        Ok(Some(Arc::new(DeletionTableProviderAdapter::new(
+                            deletion_provider,
+                        ))))
+                    }
                     Err(e) => {
                         tracing::warn!("Failed to open Cayenne table '{table_name}': {e}");
                         Ok(None)

--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -36,6 +36,8 @@ use tokio::sync::{RwLock, mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::accelerated_table::AcceleratedTable;
+#[cfg(not(windows))]
+use cayenne::CayenneTableProvider;
 
 /// Error type for executor registry operations.
 #[derive(Debug, Snafu)]
@@ -306,13 +308,27 @@ fn flight_sql_table_provider(
 }
 
 impl TablePartitionProvider for ExecutorRegistry {
-    /// Determines if the given table scan should be partitioned. Executors in [`ExecutorRegistry`] will only have partitions for accelerated tables.
+    /// Determines if the given table scan should be partitioned. Executors in [`ExecutorRegistry`] will only have partitions for accelerated tables and Cayenne tables.
     fn should_partition(&self, tbl: &TableScan) -> bool {
         let Some(default) = tbl.source.as_any().downcast_ref::<DefaultTableSource>() else {
             return false;
         };
 
-        is_accelerated_table_provider(&default.table_provider)
+        if is_accelerated_table_provider(&default.table_provider) {
+            return true;
+        }
+
+        #[cfg(not(windows))]
+        if default
+            .table_provider
+            .as_any()
+            .downcast_ref::<CayenneTableProvider>()
+            .is_some()
+        {
+            return true;
+        }
+
+        false
     }
 
     fn get_partitions(

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -395,7 +395,7 @@ fn update_scheduler_pollers(
 mod composite_flight_service;
 mod control_stream_client;
 pub mod datafusion;
-mod executor_registry;
+pub(crate) mod executor_registry;
 pub mod metrics_collector;
 pub mod partition;
 mod scheduler_registry;

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -16,13 +16,17 @@ limitations under the License.
 
 use super::ClusterTlsConfig;
 use super::composite_flight_service::CompositeFlightService;
+use crate::auth::EndpointAuth;
 use crate::cluster::executor_registry::ExecutorRegistry;
 use crate::cluster::{ClusterServiceImpl, SchedulerPeers};
 use crate::flight::middleware::{RequestContextLayer, WriteRateLimitLayer};
-use crate::flight::{Error, RateLimits, Service as SpiceFlightService, is_address_in_use_error};
+use crate::flight::{
+    Error, RateLimits, Service as SpiceFlightService, is_address_in_use_error, session_auth,
+};
 use crate::{Runtime, metrics as runtime_metrics};
 use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer;
 use governor::RateLimiter;
+use runtime_auth::layer::flight::BasicAuthLayer;
 use runtime_proto::cluster_service_server::ClusterServiceServer;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
@@ -175,9 +179,20 @@ pub async fn start_internal_cluster_server(
 pub async fn start_executor_flight_server(
     bind_address: std::net::SocketAddr,
     rt: Arc<Runtime>,
+    endpoint_auth: EndpointAuth,
     shutdown_signal: Option<CancellationToken>,
 ) -> ClusterServerResult<()> {
     let tls_config = rt.df.cluster_config.tls_config();
+    let has_flight_auth = endpoint_auth.flight_basic_auth.is_some();
+
+    // In executor mode, never allow unauthenticated Flight DoPut without mTLS.
+    // Scheduler-trusted forwarding mode requires authenticated scheduler identity via mTLS.
+    if !has_flight_auth && tls_config.is_none() {
+        return Err(Error::InsecureConfiguration {
+            message: "Executor Flight server requires either API key auth or cluster mTLS. Configure endpoint auth or enable mTLS for scheduler-trusted forwarding.".to_string(),
+        });
+    }
+
     let mut server = Server::builder();
 
     if let Some(tls_config) = tls_config {
@@ -195,23 +210,40 @@ pub async fn start_executor_flight_server(
         );
     }
 
+    if !has_flight_auth {
+        tracing::warn!(
+            "Executor Flight API key auth is disabled; accepting scheduler-trusted DoPut requires cluster mTLS"
+        );
+    }
+
     // Create composite Flight service that handles both Ballista and Spice protocols
-    let spice_service = SpiceFlightService::new(None);
+    let spice_service =
+        SpiceFlightService::new(endpoint_auth.flight_basic_auth.as_ref().map(Arc::clone));
     let session_store = spice_service.session_store();
     let composite_service = CompositeFlightService::new(spice_service);
 
     // Get app for request context
     let app = rt.app.read().await.as_ref().map(Arc::clone);
 
+    // Wrap the auth in session-awareness to accept session IDs as bearer tokens
+    let session_aware_auth = session_auth::with_session_awareness(
+        endpoint_auth.flight_basic_auth,
+        session_store.clone(),
+    );
+    let auth_layer = tower::ServiceBuilder::new()
+        .layer(BasicAuthLayer::new(session_aware_auth))
+        .into_inner();
+
     // Get job executor if available (cluster mode)
     let job_executor = rt.job_executor();
 
-    // Add middleware layers for request context and rate limiting
+    // Add middleware layers for request context, auth, and rate limiting
     let mut server = server
         .layer(
             RequestContextLayer::new(app, rt.datafusion(), session_store, rt.secrets())
                 .with_job_executor(job_executor),
         )
+        .layer(auth_layer)
         .layer(WriteRateLimitLayer::new(
             RateLimiter::direct(RateLimits::default().flight_write_limit),
             true,

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -61,7 +61,7 @@ use runtime_proto::{
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::task::{Context, Poll};
 use tokio::sync::RwLock as TokioRwLock;
 use tokio::sync::mpsc;
@@ -73,7 +73,7 @@ use tonic::{
     transport::{ClientTlsConfig, Endpoint},
 };
 
-use crate::cluster::executor_registry::ExecutorRegistry;
+use crate::cluster::executor_registry::{ExecutorRegistry, TablePartitions};
 use crate::cluster::partition::PartitionManager;
 use crate::cluster::{SchedulerPeers, partition::partition_value_to_bytes};
 use crate::datafusion::{DataFusion, SPICE_RUNTIME_SCHEMA};
@@ -652,27 +652,33 @@ impl ClusterService for ClusterServiceImpl {
 
         // Register the allocated partitions in the executor registry so the scheduler knows where they are
         {
+            let mut partition_map: TablePartitions = table_partitions
+                .iter()
+                .map(|(tbl, sa)| {
+                    let exprs = sa
+                        .items
+                        .iter()
+                        .filter_map(|bytes| match Expr::from_bytes(bytes) {
+                            Ok(expr) => Some(expr),
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize expr: {e}");
+                                None
+                            }
+                        })
+                        .collect();
+                    (TableReference::parse_str(tbl), exprs)
+                })
+                .collect();
+
+            // Register Cayenne tables as single unpartitioned entries (empty filter expressions).
+            // This tells the scheduler that queries targeting these tables should be forwarded to this executor.
+            #[cfg(not(windows))]
+            for table_ref in discover_cayenne_tables(&self.datafusion).await {
+                partition_map.entry(table_ref).or_default();
+            }
+
             let mut executor_partitions = self.executor_registry.partitions.write().await;
-            executor_partitions.insert(
-                executor_id.to_string(),
-                table_partitions
-                    .iter()
-                    .map(|(tbl, sa)| {
-                        let exprs = sa
-                            .items
-                            .iter()
-                            .filter_map(|bytes| match Expr::from_bytes(bytes) {
-                                Ok(expr) => Some(expr),
-                                Err(e) => {
-                                    tracing::error!("Failed to deserialize expr: {e}");
-                                    None
-                                }
-                            })
-                            .collect();
-                        (TableReference::parse_str(tbl), exprs)
-                    })
-                    .collect(),
-            );
+            executor_partitions.insert(executor_id.to_string(), partition_map);
         }
 
         Ok(Response::new(AllocateInitialPartitionsResponse {
@@ -776,6 +782,74 @@ async fn notify_scheduler_executor_shutdown(
 
     Ok(())
 }
+/// Discovers all Cayenne table references registered in the `DataFusion` catalog.
+///
+/// Iterates through all catalogs, identifies Cayenne-backed catalogs, and returns
+/// fully qualified [`TableReference`]s for each table found. These are used to
+/// register unpartitioned entries in the executor's partition map so that queries
+/// for Cayenne tables are forwarded to the executor.
+#[cfg(not(windows))]
+async fn discover_cayenne_tables(datafusion: &DataFusion) -> Vec<TableReference> {
+    use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
+    use crate::datafusion::cayenne_ddl::is_cayenne_catalog;
+
+    let mut tables = Vec::new();
+    let mut seen = HashSet::new();
+    for catalog_name in datafusion.ctx.catalog_names() {
+        let Some(catalog) = datafusion.ctx.catalog(&catalog_name) else {
+            continue;
+        };
+        if !is_cayenne_catalog(catalog.as_ref()) {
+            continue;
+        }
+        for schema_name in catalog.schema_names() {
+            let Some(schema) = catalog.schema(&schema_name) else {
+                continue;
+            };
+
+            // Prefer metadata-catalog discovery to avoid relying on in-memory schema cache.
+            if let Some(cayenne_schema) = schema.as_any().downcast_ref::<CayenneSchemaProvider>() {
+                let namespace_prefix = format!("{}/", cayenne_schema.namespace());
+                match cayenne_schema.metadata_catalog().list_table_names().await {
+                    Ok(all_table_names) => {
+                        for full_name in all_table_names {
+                            let Some(short_name) = full_name.strip_prefix(&namespace_prefix) else {
+                                continue;
+                            };
+                            let key = (
+                                catalog_name.clone(),
+                                schema_name.clone(),
+                                short_name.to_string(),
+                            );
+                            if seen.insert(key.clone()) {
+                                tables.push(TableReference::full(key.0, key.1, key.2));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to list Cayenne metadata tables for {catalog_name}.{schema_name}: {e}"
+                        );
+                    }
+                }
+                continue;
+            }
+
+            for table_name in schema.table_names() {
+                let key = (
+                    catalog_name.clone(),
+                    schema_name.clone(),
+                    table_name.clone(),
+                );
+                if seen.insert(key.clone()) {
+                    tables.push(TableReference::full(key.0, key.1, key.2));
+                }
+            }
+        }
+    }
+    tables
+}
+
 /// Encodes a slice of `RecordBatch` into Arrow IPC streaming format.
 ///
 /// Returns an empty vec if no batches are provided.

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -25,6 +25,7 @@ use super::{
     SPICE_RUNTIME_SCHEMA,
 };
 use crate::cluster::ResolvedClusterConfig;
+use crate::cluster::executor_registry::ExecutorRegistry;
 use crate::{dataaccelerator::AcceleratorEngineRegistry, datafusion::SPICE_SCP_SCHEMA};
 use crate::{metrics::telemetry::track_bytes_processed, status};
 use cache::Caching;
@@ -129,6 +130,7 @@ pub struct DataFusionBuilder {
     url_tables_enabled: bool,
     /// Arbitrary additional analyzer rules.
     additional_analyzer_rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>>,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
 }
 
 pub(crate) fn get_df_default_config() -> SessionConfig {
@@ -173,6 +175,7 @@ impl DataFusionBuilder {
             resource_monitor: None,
             url_tables_enabled: false,
             additional_analyzer_rules: vec![],
+            executor_registry: None,
         }
     }
 
@@ -266,6 +269,13 @@ impl DataFusionBuilder {
         self
     }
 
+    /// Sets the executor registry for distributed write forwarding (scheduler mode only).
+    #[must_use]
+    pub fn with_executor_registry(mut self, registry: Arc<ExecutorRegistry>) -> Self {
+        self.executor_registry = Some(registry);
+        self
+    }
+
     /// Builds the `DataFusion` instance.
     ///
     /// # Panics
@@ -287,6 +297,7 @@ impl DataFusionBuilder {
             .with_query_planner(Arc::new(
                 ExtensionPlanQueryPlanner::from_extension_planners(default_extension_planners(
                     Arc::clone(&datafusion_ref),
+                    self.executor_registry.clone(),
                 )),
             ))
             .with_runtime_env(runtime_env(
@@ -460,6 +471,7 @@ impl DataFusionBuilder {
             scheduler_server: RwLock::new(None),
             executor: RwLock::new(None),
             executor_stream_registry: RwLock::new(None),
+            executor_registry: self.executor_registry,
         }
     }
 }
@@ -595,6 +607,7 @@ pub(crate) fn runtime_env(
 
 pub(crate) fn default_extension_planners(
     datafusion_ref: super::iceberg_ddl::SharedDataFusionRef,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
 ) -> Vec<Arc<dyn ExtensionPlanner + Send + Sync>> {
     vec![
         Arc::new(IndexTableScanExtensionPlanner::new()),
@@ -602,7 +615,7 @@ pub(crate) fn default_extension_planners(
         Arc::new(CacheInvalidationExtensionPlanner::new()),
         Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new(datafusion_ref)),
         #[cfg(not(windows))]
-        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new()),
+        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new(executor_registry)),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -44,7 +44,104 @@ use datafusion_table_providers::UnsupportedTypeAction;
 
 use super::get_cayenne_provider;
 use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
+use crate::cluster::executor_registry::ExecutorRegistry;
 use crate::dataaccelerator::cayenne::transform_schema_for_vortex;
+
+/// Maps an Arrow [`DataType`] to a SQL type string suitable for DDL forwarding.
+///
+/// Returns a SQL type that `DataFusion`'s SQL parser can understand in a
+/// `CREATE TABLE` statement.
+fn arrow_datatype_to_sql(dt: &DataType) -> DFResult<String> {
+    match dt {
+        DataType::Boolean => Ok("BOOLEAN".to_string()),
+        DataType::Int8 => Ok("TINYINT".to_string()),
+        DataType::Int16 => Ok("SMALLINT".to_string()),
+        DataType::Int32 => Ok("INT".to_string()),
+        DataType::Int64 => Ok("BIGINT".to_string()),
+        DataType::UInt8 => Ok("TINYINT UNSIGNED".to_string()),
+        DataType::UInt16 => Ok("SMALLINT UNSIGNED".to_string()),
+        DataType::UInt32 => Ok("INT UNSIGNED".to_string()),
+        DataType::UInt64 => Ok("BIGINT UNSIGNED".to_string()),
+        DataType::Float16 | DataType::Float32 => Ok("FLOAT".to_string()),
+        DataType::Float64 => Ok("DOUBLE".to_string()),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok("VARCHAR".to_string()),
+        DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_) => Ok("BYTEA".to_string()),
+        DataType::Date32 | DataType::Date64 => Ok("DATE".to_string()),
+        DataType::Time32(_) | DataType::Time64(_) => Ok("TIME".to_string()),
+        DataType::Timestamp(_, _) => Ok("TIMESTAMP".to_string()),
+        DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => Ok(format!("DECIMAL({p},{s})")),
+        DataType::Dictionary(_, value_type) => arrow_datatype_to_sql(value_type.as_ref()),
+        other => Err(DataFusionError::Execution(format!(
+            "Unsupported Arrow type for forwarded Cayenne DDL: {other}"
+        ))),
+    }
+}
+
+/// Forwards a DDL SQL statement to connected executor nodes.
+///
+/// Iterates over [`ExecutorRegistry::flight_sql_clients`] and sends the SQL
+/// via `FlightSqlClient::execute`, then drains returned endpoints with `do_get`
+/// so the statement is actually executed on the remote executor.
+///
+/// Returns an error when at least one executor was targeted but all forwards failed.
+async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
+    let clients = executor_registry.flight_sql_clients.read().await;
+    if clients.is_empty() {
+        tracing::debug!(
+            sql,
+            "Skipping Cayenne DDL forwarding because no executors are connected"
+        );
+        return Ok(());
+    }
+
+    let mut success_count = 0usize;
+    for (executor_id, client) in clients.iter() {
+        let mut client = client.clone();
+        let result: Result<(), String> = async {
+            use futures::StreamExt;
+
+            let flight_info = client
+                .execute(sql.to_string(), None)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            for endpoint in flight_info.endpoint {
+                let Some(ticket) = endpoint.ticket else {
+                    continue;
+                };
+
+                let mut stream = client.do_get(ticket).await.map_err(|e| e.to_string())?;
+                while let Some(batch) = stream.next().await {
+                    batch.map_err(|e| e.to_string())?;
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                success_count += 1;
+                tracing::debug!(executor_id, sql, "Forwarded Cayenne DDL to executor");
+            }
+            Err(e) => {
+                tracing::warn!(executor_id, sql, error = %e, "Failed to forward Cayenne DDL to executor");
+            }
+        }
+    }
+
+    if success_count == 0 {
+        return Err(DataFusionError::Execution(format!(
+            "Failed to forward Cayenne DDL to any executor: {sql}"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Creates a result schema for DDL operations (single "result" column).
 fn ddl_result_schema() -> SchemaRef {
@@ -69,10 +166,10 @@ pub struct CayenneCreateTableExec {
     table_name: String,
     arrow_schema: Arc<Schema>,
     if_not_exists: bool,
-    _or_replace: bool,
     df_catalog_name: String,
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
     properties: PlanProperties,
 }
 
@@ -93,10 +190,10 @@ impl CayenneCreateTableExec {
         table_name: String,
         arrow_schema: Arc<Schema>,
         if_not_exists: bool,
-        or_replace: bool,
         df_catalog_name: String,
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
+        executor_registry: Option<Arc<ExecutorRegistry>>,
     ) -> Self {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -109,10 +206,10 @@ impl CayenneCreateTableExec {
             table_name,
             arrow_schema,
             if_not_exists,
-            _or_replace: or_replace,
             df_catalog_name,
             df_schema_name,
             catalog_list,
+            executor_registry,
             properties,
         }
     }
@@ -163,6 +260,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
         let df_catalog_name = self.df_catalog_name.clone();
         let df_schema_name = self.df_schema_name.clone();
         let catalog_list = Arc::clone(&self.catalog_list);
+        let executor_registry = self.executor_registry.clone();
         let result_schema = ddl_result_schema();
 
         let stream = futures::stream::once(async move {
@@ -193,6 +291,36 @@ impl ExecutionPlan for CayenneCreateTableExec {
 
             if exists {
                 if if_not_exists {
+                    // Table exists in metadata (e.g. after restart). Ensure it is also
+                    // registered in the in-memory DataFusion schema provider immediately
+                    // rather than waiting for periodic catalog refresh.
+                    let schema_provider =
+                        if let Some(s) = cayenne_provider.schema_provider(&df_schema_name) {
+                            s
+                        } else {
+                            let new_schema = Arc::new(CayenneSchemaProvider::new_empty(
+                                Arc::clone(&metadata_catalog),
+                                df_schema_name.clone(),
+                            ));
+                            cayenne_provider.register_schema_provider(
+                                &df_schema_name,
+                                Arc::clone(&new_schema) as Arc<dyn SchemaProvider>,
+                            )?;
+                            Arc::clone(&new_schema) as Arc<dyn SchemaProvider>
+                        };
+
+                    // Open and register the existing table provider if not already present.
+                    if !schema_provider.table_exist(&table_name) {
+                        let builder =
+                            CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
+                        if let Ok(provider) = builder.open(&metadata_table_name).await
+                            && let Err(e) = schema_provider
+                                .register_table(table_name.clone(), Arc::new(provider))
+                        {
+                            tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
+                        }
+                    }
+
                     let batch = RecordBatch::try_new(
                         result_schema,
                         vec![Arc::new(StringArray::from(vec![format!(
@@ -257,6 +385,24 @@ impl ExecutionPlan for CayenneCreateTableExec {
             };
 
             schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+
+            // Forward the CREATE TABLE DDL to executor nodes
+            if let Some(ref registry) = executor_registry {
+                let columns_sql: Vec<String> = arrow_schema
+                    .fields()
+                    .iter()
+                    .map(|f| {
+                        let null_str = if f.is_nullable() { "" } else { " NOT NULL" };
+                        let sql_type = arrow_datatype_to_sql(f.data_type())?;
+                        Ok(format!("\"{}\" {sql_type}{null_str}", f.name()))
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                let ddl_sql = format!(
+                    "CREATE TABLE IF NOT EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\" ({})",
+                    columns_sql.join(", ")
+                );
+                forward_ddl_to_executors(registry, &ddl_sql).await?;
+            }
 
             let batch = RecordBatch::try_new(
                 result_schema,
@@ -429,6 +575,7 @@ pub struct CayenneDropTableExec {
     df_catalog_name: String,
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
     properties: PlanProperties,
 }
 
@@ -451,6 +598,7 @@ impl CayenneDropTableExec {
         df_catalog_name: String,
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
+        executor_registry: Option<Arc<ExecutorRegistry>>,
     ) -> Self {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -465,6 +613,7 @@ impl CayenneDropTableExec {
             df_catalog_name,
             df_schema_name,
             catalog_list,
+            executor_registry,
             properties,
         }
     }
@@ -514,6 +663,7 @@ impl ExecutionPlan for CayenneDropTableExec {
         let df_catalog_name = self.df_catalog_name.clone();
         let df_schema_name = self.df_schema_name.clone();
         let catalog_list = Arc::clone(&self.catalog_list);
+        let executor_registry = self.executor_registry.clone();
         let result_schema = ddl_result_schema();
 
         let stream = futures::stream::once(async move {
@@ -558,9 +708,19 @@ impl ExecutionPlan for CayenneDropTableExec {
                 )));
             }
 
-            // Deregister from the DataFusion catalog
-            if let Some(schema_provider) = df_catalog.schema(&df_schema_name) {
-                let _ = schema_provider.deregister_table(&table_name);
+            // Deregister from the `DataFusion` catalog
+            if let Some(schema_provider) = df_catalog.schema(&df_schema_name)
+                && let Err(err) = schema_provider.deregister_table(&table_name)
+            {
+                tracing::error!(table_name, error = %err, "Failed to deregister Cayenne table from DataFusion schema provider");
+            }
+
+            // Forward the DROP TABLE DDL to executor nodes
+            if let Some(ref registry) = executor_registry {
+                let ddl_sql = format!(
+                    "DROP TABLE IF EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\""
+                );
+                forward_ddl_to_executors(registry, &ddl_sql).await?;
             }
 
             let batch = RecordBatch::try_new(

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -33,6 +33,7 @@ use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use cayenne::CayenneTableProviderBuilder;
 use cayenne::metadata::CreateTableOptions;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use datafusion::catalog::{CatalogProviderList, SchemaProvider};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
@@ -313,11 +314,16 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     if !schema_provider.table_exist(&table_name) {
                         let builder =
                             CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
-                        if let Ok(provider) = builder.open(&metadata_table_name).await
-                            && let Err(e) = schema_provider
-                                .register_table(table_name.clone(), Arc::new(provider))
-                        {
-                            tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
+                        if let Ok(provider) = builder.open(&metadata_table_name).await {
+                            let provider = Arc::new(provider);
+                            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
+                                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
+                            if let Err(e) =
+                                schema_provider.register_table(table_name.clone(), wrapped_provider)
+                            {
+                                tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
+                            }
                         }
                     }
 
@@ -368,6 +374,11 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 ))
             })?;
 
+            let provider = Arc::new(provider);
+            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
+                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
+
             // Ensure the schema exists, creating it on demand if needed
             let schema_provider = if let Some(s) = cayenne_provider.schema_provider(&df_schema_name)
             {
@@ -384,7 +395,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 Arc::clone(&new_schema) as Arc<dyn SchemaProvider>
             };
 
-            schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+            schema_provider.register_table(table_name.clone(), wrapped_provider)?;
 
             // Forward the CREATE TABLE DDL to executor nodes
             if let Some(ref registry) = executor_registry {

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -30,21 +30,27 @@ use super::logical_nodes::{CayenneCreateSchemaNode, CayenneCreateTableNode, Caye
 use super::physical_plans::{
     CayenneCreateSchemaExec, CayenneCreateTableExec, CayenneDropTableExec,
 };
+use crate::cluster::executor_registry::ExecutorRegistry;
 
 /// Extension planner for Cayenne DDL operations.
+///
+/// When an [`ExecutorRegistry`] is provided (scheduler mode), the physical
+/// plans will forward DDL statements to executor nodes after local execution.
 #[derive(Debug)]
-pub struct CayenneDdlExtensionPlanner;
+pub struct CayenneDdlExtensionPlanner {
+    executor_registry: Option<Arc<ExecutorRegistry>>,
+}
 
 impl CayenneDdlExtensionPlanner {
     #[must_use]
-    pub fn new() -> Self {
-        Self
+    pub fn new(executor_registry: Option<Arc<ExecutorRegistry>>) -> Self {
+        Self { executor_registry }
     }
 }
 
 impl Default for CayenneDdlExtensionPlanner {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -65,10 +71,10 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 create.table_name.clone(),
                 Arc::clone(&create.arrow_schema),
                 create.if_not_exists,
-                create.or_replace,
                 create.df_catalog_name.clone(),
                 create.df_schema_name.clone(),
                 catalog_list,
+                self.executor_registry.clone(),
             ))));
         }
 
@@ -88,6 +94,7 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 drop.df_catalog_name.clone(),
                 drop.df_schema_name.clone(),
                 catalog_list,
+                self.executor_registry.clone(),
             ))));
         }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -48,7 +48,7 @@ use crate::view::prepare_view;
 use crate::{status, view};
 
 use {
-    crate::cluster::{ExecutorControlStreamRegistry, ResolvedClusterConfig},
+    crate::cluster::{ExecutorControlStreamRegistry, ExecutorRegistry, ResolvedClusterConfig},
     ballista_executor::executor::Executor,
     ballista_scheduler::scheduler_server::SchedulerServer,
     datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode},
@@ -78,6 +78,7 @@ use datafusion::sql::{ResolvedTableReference, TableReference};
 use datafusion_expr::Expr;
 use datafusion_federation::FederatedTableProviderAdaptor;
 use error::find_datafusion_root;
+use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use query::QueryBuilder;
 #[cfg(any(
@@ -107,6 +108,7 @@ use tokio::sync::{Mutex, Notify};
 use tokio::sync::{RwLock as TokioRwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
+use tokio_stream::wrappers::ReceiverStream;
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
 
@@ -221,6 +223,9 @@ pub enum Error {
         table_name: String,
         source: DataFusionError,
     },
+
+    #[snafu(display("No executors available to forward write for table {table_name}"))]
+    NoExecutorsAvailable { table_name: String },
 
     #[snafu(display("Failed to refresh the dataset {dataset_name}. {source}"))]
     UnableToTriggerRefresh {
@@ -435,6 +440,8 @@ pub struct DataFusion {
     /// Registry of connected executor control streams for `PollNow` broadcasts.
     /// Only used in scheduler mode.
     pub executor_stream_registry: RwLock<Option<ExecutorControlStreamRegistry>>,
+    /// Executor registry for distributed write forwarding (scheduler mode only).
+    pub(crate) executor_registry: Option<Arc<ExecutorRegistry>>,
 }
 
 impl std::fmt::Debug for DataFusion {
@@ -841,35 +848,30 @@ impl DataFusion {
         &self,
         table_reference: &TableReference,
     ) -> Result<Arc<dyn TableProvider>> {
+        let catalog_name = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
         let table_name = table_reference.table();
+        let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
 
-        if let Some(schema_name) = table_reference.schema()
-            && let Some(schema) = self.schema(schema_name)
-        {
-            let table_provider = schema
-                .table(table_name)
-                .await
-                .map_err(find_datafusion_root)
-                .context(UnableToGetTableSnafu)?
-                .ok_or_else(|| {
-                    TableMissingSnafu {
-                        schema: schema_name.to_string(),
-                        table: table_name.to_string(),
-                    }
-                    .build()
-                })
-                .boxed()
-                .context(UnableToGetSchemaTableSnafu)?;
+        let catalog_provider =
+            self.resolve_catalog_provider(table_reference)
+                .context(CatalogMissingSnafu {
+                    catalog: catalog_name.to_string(),
+                })?;
 
-            return Ok(table_provider);
-        }
+        let schema_provider = Self::resolve_schema_provider(&catalog_provider, table_reference)
+            .context(SchemaMissingSnafu {
+                schema: schema_name.to_string(),
+            })?;
 
-        let table_provider = self
-            .ctx
-            .table_provider(TableReference::bare(table_name.to_string()))
+        let table_provider = schema_provider
+            .table(table_name)
             .await
             .map_err(find_datafusion_root)
-            .context(UnableToGetTableSnafu)?;
+            .context(UnableToGetTableSnafu)?
+            .context(TableMissingSnafu {
+                schema: schema_name.to_string(),
+                table: table_name.to_string(),
+            })?;
 
         Ok(table_provider)
     }
@@ -1002,6 +1004,16 @@ impl DataFusion {
         )
         .context(SchemaMismatchSnafu)?;
 
+        // In distributed scheduler mode, forward Cayenne table writes to an executor
+        if self.should_forward_cayenne_write(table_reference, &*table_provider) {
+            let streaming_update = StreamingDataUpdate::try_from(data_update)
+                .map_err(find_datafusion_root)
+                .context(UnableToCreateStreamingUpdateSnafu)?;
+            return self
+                .forward_write_to_executor(table_reference, streaming_update)
+                .await;
+        }
+
         let overwrite = match data_update.update_type {
             UpdateType::Overwrite => InsertOp::Overwrite,
             UpdateType::Append => InsertOp::Append,
@@ -1059,6 +1071,13 @@ impl DataFusion {
         verify_schema(table_provider.schema().fields(), update_schema.fields())
             .context(SchemaMismatchSnafu)?;
 
+        // In distributed scheduler mode, forward Cayenne table writes to an executor
+        if self.should_forward_cayenne_write(table_reference, &*table_provider) {
+            return self
+                .forward_write_to_executor(table_reference, streaming_update)
+                .await;
+        }
+
         let overwrite = match streaming_update.update_type {
             UpdateType::Overwrite => InsertOp::Overwrite,
             UpdateType::Append => InsertOp::Append,
@@ -1087,14 +1106,363 @@ impl DataFusion {
         Ok(())
     }
 
-    pub async fn get_arrow_schema(&self, dataset: impl Into<TableReference>) -> Result<Schema> {
-        let data_frame = self
-            .ctx
-            .table(dataset)
+    /// Returns `true` if this is a scheduler node and the table is a Cayenne table,
+    /// meaning the write should be forwarded to an executor.
+    fn should_forward_cayenne_write(
+        &self,
+        _table_reference: &TableReference,
+        table_provider: &dyn TableProvider,
+    ) -> bool {
+        // Only forward if we have an executor registry (i.e., we are a scheduler)
+        let Some(executor_registry) = &self.executor_registry else {
+            return false;
+        };
+
+        // Check if the table provider is a CayenneTableProvider
+        if table_provider
+            .as_any()
+            .downcast_ref::<cayenne::CayenneTableProvider>()
+            .is_none()
+        {
+            return false;
+        }
+
+        // Check if there are any connected executors with flight clients
+        let Ok(clients) = executor_registry.flight_sql_clients.try_read() else {
+            return false;
+        };
+        !clients.is_empty()
+    }
+
+    /// Forwards a streaming write to an executor node via Flight `DoPut`.
+    async fn forward_write_to_executor(
+        &self,
+        table_reference: &TableReference,
+        streaming_update: StreamingDataUpdate,
+    ) -> Result<()> {
+        let Some(executor_registry) = self.executor_registry.as_ref() else {
+            return NoExecutorsAvailableSnafu {
+                table_name: table_reference.to_string(),
+            }
+            .fail();
+        };
+
+        // Get an executor's FlightSqlClient
+        let (executor_id, client) = {
+            let clients = executor_registry.flight_sql_clients.read().await;
+            let Some((executor_id, client)) = clients.iter().next() else {
+                tracing::error!(
+                    "No executors available to forward Cayenne write for table {table_reference}"
+                );
+                return NoExecutorsAvailableSnafu {
+                    table_name: table_reference.to_string(),
+                }
+                .fail();
+            };
+            (executor_id.clone(), client.clone())
+        };
+
+        tracing::debug!("Forwarding Cayenne write for table {table_reference} to executor");
+
+        // Resolve the table reference to a fully qualified form so the executor
+        // can locate it regardless of its default catalog/schema settings.
+        let resolved = table_reference
+            .clone()
+            .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+        let descriptor_path = vec![
+            resolved.catalog.to_string(),
+            resolved.schema.to_string(),
+            resolved.table.to_string(),
+        ];
+        let resolved_table = TableReference::full(
+            resolved.catalog.to_string(),
+            resolved.schema.to_string(),
+            resolved.table.to_string(),
+        );
+
+        // Register before the write to minimize post-write routing races.
+        self.register_forwarded_table_partition(executor_registry, &executor_id, resolved_table)
+            .await;
+
+        let schema = streaming_update.data.schema();
+        let stream = streaming_update.data;
+
+        // Build a flight data stream from the record batches.
+        let flight_data_encoder = arrow_flight::encode::FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .build(futures::stream::unfold(stream, |mut s| async move {
+                match s.next().await {
+                    Some(Ok(batch)) => Some((Ok(batch), s)),
+                    Some(Err(e)) => Some((
+                        Err(arrow_flight::error::FlightError::Arrow(
+                            arrow_schema::ArrowError::ExternalError(Box::new(e)),
+                        )),
+                        s,
+                    )),
+                    None => None,
+                }
+            }));
+
+        // Stream directly into the executor's `DoPut` without buffering.
+        let (tx, rx) = tokio::sync::mpsc::channel::<arrow_flight::FlightData>(64);
+        let (encode_result_tx, encode_result_rx) =
+            tokio::sync::oneshot::channel::<std::result::Result<(), String>>();
+        let io_runtime = self.io_runtime.clone();
+
+        io_runtime.spawn(async move {
+            let mut first = true;
+            let mut flight_data_encoder = Box::pin(flight_data_encoder);
+            loop {
+                match flight_data_encoder.next().await {
+                    Some(Ok(mut fd)) => {
+                        if first {
+                            fd.flight_descriptor = Some(arrow_flight::FlightDescriptor::new_path(
+                                descriptor_path.clone(),
+                            ));
+                            first = false;
+                        }
+
+                        if tx.send(fd).await.is_err() {
+                            let _ = encode_result_tx.send(Ok(()));
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        let _ = encode_result_tx.send(Err(e.to_string()));
+                        break;
+                    }
+                    None => {
+                        let _ = encode_result_tx.send(Ok(()));
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Forward the authorization header from the original request so the
+        // executor can validate the caller's credentials.
+        let auth_header = runtime_request_context::RequestContext::current(
+            runtime_request_context::AsyncMarker::new().await,
+        )
+        .authorization_header()
+        .map(str::to_string);
+
+        let mut request = tonic::Request::new(ReceiverStream::new(rx));
+        if let Some(auth_value) = auth_header
+            && let Ok(val) = auth_value.parse()
+        {
+            request.metadata_mut().insert("authorization", val);
+        }
+
+        let table_name = table_reference.to_string();
+        let mut inner_client = client.into_inner();
+        let response =
+            inner_client
+                .do_put(request)
+                .await
+                .map_err(|e| Error::UnableToExecuteTableInsert {
+                    table_name: table_name.clone(),
+                    source: DataFusionError::External(Box::new(e)),
+                })?;
+
+        // Wait for the server to acknowledge.
+        response
+            .into_inner()
+            .try_collect::<Vec<_>>()
             .await
-            .map_err(find_datafusion_root)
-            .context(UnableToGetTableSnafu)?;
-        Ok(data_frame.schema().as_arrow().clone())
+            .map_err(|e| Error::UnableToExecuteTableInsert {
+                table_name: table_name.clone(),
+                source: DataFusionError::External(Box::new(e)),
+            })?;
+
+        match encode_result_rx.await {
+            Ok(Ok(())) | Err(_) => {}
+            Ok(Err(e)) => {
+                return Err(Error::UnableToExecuteTableInsert {
+                    table_name,
+                    source: DataFusionError::Execution(format!(
+                        "Failed to encode forwarded Flight stream: {e}"
+                    )),
+                });
+            }
+        }
+
+        tracing::debug!(
+            "Successfully forwarded Cayenne write for table {table_reference} to executor"
+        );
+
+        Ok(())
+    }
+
+    async fn register_forwarded_table_partition(
+        &self,
+        executor_registry: &ExecutorRegistry,
+        executor_id: &str,
+        resolved_table: TableReference,
+    ) {
+        let mut partitions = executor_registry.partitions.write().await;
+        partitions
+            .entry(executor_id.to_string())
+            .or_default()
+            .entry(resolved_table)
+            .or_default();
+    }
+
+    /// Forwards a raw `FlightData` stream to an executor via Flight `DoPut`.
+    ///
+    /// This avoids scheduler-side decode/re-encode overhead and is used as a fast path
+    /// for scheduler -> executor Cayenne write-through ingestion.
+    pub(crate) async fn forward_flight_data_stream_to_executor<S>(
+        &self,
+        table_reference: &TableReference,
+        inbound_stream: S,
+    ) -> Result<()>
+    where
+        S: futures::Stream<Item = std::result::Result<arrow_flight::FlightData, tonic::Status>>
+            + Send
+            + 'static,
+    {
+        let Some(executor_registry) = self.executor_registry.as_ref() else {
+            return NoExecutorsAvailableSnafu {
+                table_name: table_reference.to_string(),
+            }
+            .fail();
+        };
+
+        // Get an executor's FlightSqlClient
+        let (executor_id, client) = {
+            let clients = executor_registry.flight_sql_clients.read().await;
+            let Some((executor_id, client)) = clients.iter().next() else {
+                tracing::error!(
+                    "No executors available to forward Cayenne write for table {table_reference}"
+                );
+                return NoExecutorsAvailableSnafu {
+                    table_name: table_reference.to_string(),
+                }
+                .fail();
+            };
+            (executor_id.clone(), client.clone())
+        };
+
+        tracing::debug!(
+            "Forwarding raw Cayenne DoPut stream for table {table_reference} to executor"
+        );
+
+        let resolved = table_reference
+            .clone()
+            .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+        let descriptor_path = vec![
+            resolved.catalog.to_string(),
+            resolved.schema.to_string(),
+            resolved.table.to_string(),
+        ];
+        let resolved_table = TableReference::full(
+            resolved.catalog.to_string(),
+            resolved.schema.to_string(),
+            resolved.table.to_string(),
+        );
+
+        // Register before the write to minimize post-write routing races.
+        self.register_forwarded_table_partition(executor_registry, &executor_id, resolved_table)
+            .await;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<arrow_flight::FlightData>(64);
+        let (copy_result_tx, copy_result_rx) =
+            tokio::sync::oneshot::channel::<std::result::Result<(), tonic::Status>>();
+
+        let io_runtime = self.io_runtime.clone();
+        io_runtime.spawn(async move {
+            let mut inbound_stream = Box::pin(inbound_stream);
+            let mut is_first = true;
+            loop {
+                match inbound_stream.next().await {
+                    Some(Ok(mut fd)) => {
+                        if is_first {
+                            if let Some(descriptor) = fd.flight_descriptor.as_mut() {
+                                descriptor.path.clone_from(&descriptor_path);
+                            } else {
+                                fd.flight_descriptor =
+                                    Some(arrow_flight::FlightDescriptor::new_path(
+                                        descriptor_path.clone(),
+                                    ));
+                            }
+                            is_first = false;
+                        }
+
+                        if tx.send(fd).await.is_err() {
+                            let _ = copy_result_tx.send(Ok(()));
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        let _ = copy_result_tx.send(Err(e));
+                        break;
+                    }
+                    None => {
+                        let _ = copy_result_tx.send(Ok(()));
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Forward the authorization header from the original request so the
+        // executor can validate the caller's credentials when configured.
+        let auth_header = runtime_request_context::RequestContext::current(
+            runtime_request_context::AsyncMarker::new().await,
+        )
+        .authorization_header()
+        .map(str::to_string);
+
+        let mut request = tonic::Request::new(ReceiverStream::new(rx));
+        if let Some(auth_value) = auth_header
+            && let Ok(val) = auth_value.parse()
+        {
+            request.metadata_mut().insert("authorization", val);
+        }
+
+        let table_name = table_reference.to_string();
+        let mut inner_client = client.into_inner();
+        let response =
+            inner_client
+                .do_put(request)
+                .await
+                .map_err(|e| Error::UnableToExecuteTableInsert {
+                    table_name: table_name.clone(),
+                    source: DataFusionError::External(Box::new(e)),
+                })?;
+
+        // Wait for the server to acknowledge.
+        response
+            .into_inner()
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| Error::UnableToExecuteTableInsert {
+                table_name: table_name.clone(),
+                source: DataFusionError::External(Box::new(e)),
+            })?;
+
+        match copy_result_rx.await {
+            Ok(Ok(())) | Err(_) => {}
+            Ok(Err(e)) => {
+                return Err(Error::UnableToExecuteTableInsert {
+                    table_name,
+                    source: DataFusionError::External(Box::new(e)),
+                });
+            }
+        }
+
+        tracing::debug!(
+            "Successfully forwarded raw Cayenne DoPut stream for table {table_reference} to executor"
+        );
+
+        Ok(())
+    }
+
+    pub async fn get_arrow_schema(&self, dataset: impl Into<TableReference>) -> Result<Schema> {
+        let table_reference = dataset.into();
+        let table_provider = self.get_table_provider(&table_reference).await?;
+        Ok(table_provider.schema().as_ref().clone())
     }
 
     #[must_use]

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -21,17 +21,21 @@ use ::cache::{
     key::CacheKey,
     result::{CacheStatus, query::QueryResult},
 };
+use arrow::array::UInt64Array;
 use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
     common::ParamValues,
+    datasource::memory::MemorySourceConfig,
     error::DataFusionError,
     execution::{SendableRecordBatchStream, TaskContext},
-    logical_expr::LogicalPlan,
+    logical_expr::dml::InsertOp,
+    logical_expr::{Expr, LogicalPlan},
     physical_plan::{ExecutionPlan, execute_stream, stream::RecordBatchStreamAdapter},
 };
+use datafusion_expr::expr_rewriter::unnormalize_col;
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
 use tokio::time::Instant;
@@ -67,6 +71,7 @@ use super::managed_runtime;
 use crate::datafusion::{
     DataFusion, query::cache::RequestCacheManager, sql_validator::validate_sql_query_operations,
 };
+use data_components::delete::get_deletion_provider;
 use managed_runtime::ManagedRuntimeError;
 use opentelemetry::KeyValue;
 use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
@@ -682,24 +687,27 @@ impl Query {
                         }
                     };
                     (stream, df_plan)
-                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+                } else if let LogicalPlan::Dml(dml) = &*plan
+                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
+                {
                     // DELETE operations need special handling because DataFusion doesn't
                     // support DELETE natively. We intercept the DML Delete plan, extract
                     // the filter predicates, and delegate to the DeletionTableProvider.
-                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df).await {
-                        Ok(p) => p,
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            let error_code = ErrorCode::from(&e);
-                            handle_error!(
-                                tracker,
-                                &request_context,
-                                error_code,
-                                e,
-                                UnableToExecuteQuery
-                            )
-                        }
-                    };
+                    let delete_plan =
+                        match create_delete_physical_plan(dml, &ctx.df, &session).await {
+                            Ok(p) => p,
+                            Err(e) => {
+                                let e = find_datafusion_root(e);
+                                let error_code = ErrorCode::from(&e);
+                                handle_error!(
+                                    tracker,
+                                    &request_context,
+                                    error_code,
+                                    e,
+                                    UnableToExecuteQuery
+                                )
+                            }
+                        };
 
                     let task_ctx = Arc::new(TaskContext::from(&session));
                     let stream = match execute_stream(Arc::clone(&delete_plan), task_ctx) {
@@ -717,6 +725,45 @@ impl Query {
                         }
                     };
                     (stream, delete_plan)
+                } else if let LogicalPlan::Dml(dml) = &*plan
+                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Update)
+                {
+                    // UPDATE operations are rewritten to an execution plan that:
+                    // 1) materializes updated rows from the DML input,
+                    // 2) deletes matched rows,
+                    // 3) inserts updated rows back.
+                    let update_plan =
+                        match create_update_physical_plan(dml, &ctx.df, &session).await {
+                            Ok(p) => p,
+                            Err(e) => {
+                                let e = find_datafusion_root(e);
+                                let error_code = ErrorCode::from(&e);
+                                handle_error!(
+                                    tracker,
+                                    &request_context,
+                                    error_code,
+                                    e,
+                                    UnableToExecuteQuery
+                                )
+                            }
+                        };
+
+                    let task_ctx = Arc::new(TaskContext::from(&session));
+                    let stream = match execute_stream(Arc::clone(&update_plan), task_ctx) {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
+                    (stream, update_plan)
                 } else {
                     // For regular plans, use the standard physical plan execution
                     let physical_plan = match session.create_physical_plan(&plan).await {
@@ -760,9 +807,13 @@ impl Query {
             let res_stream = if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
                 && !matches!(
                     &*plan,
-                    LogicalPlan::Dml(dml) if matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
-                )
-            {
+                    LogicalPlan::Dml(dml)
+                        if matches!(
+                            &dml.op,
+                            datafusion::logical_expr::WriteOp::Delete
+                                | datafusion::logical_expr::WriteOp::Update
+                        )
+                ) {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 
@@ -1260,11 +1311,10 @@ fn reconcile_stream_nullability(
 async fn create_delete_physical_plan(
     dml: &datafusion::logical_expr::DmlStatement,
     df: &Arc<DataFusion>,
+    session_state: &SessionState,
 ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    use data_components::delete::get_deletion_provider;
-
     // Extract filter expressions from the source plan
-    let filters = extract_delete_filters(&dml.input);
+    let filters = extract_dml_filters(&dml.input);
 
     // Look up the table provider
     let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
@@ -1282,24 +1332,234 @@ async fn create_delete_physical_plan(
         ))
     })?;
 
-    let session_state = df.ctx.state();
-    deletion_provider
-        .delete_from(&session_state, &filters)
-        .await
+    deletion_provider.delete_from(session_state, &filters).await
 }
 
-/// Extract filter expressions from a DELETE's source logical plan.
+/// Extract filter expressions from a DML source logical plan.
 ///
-/// The source plan is either `Filter(predicate, scan)` or just `scan`.
+/// The source plan is generally `Filter(predicate, scan)`, and for `UPDATE`
+/// may be wrapped as `Projection(Filter(...))`.
 /// Returns the individual conjunctive filter expressions, or an empty
 /// vec if there is no WHERE clause.
-fn extract_delete_filters(source: &LogicalPlan) -> Vec<datafusion::logical_expr::Expr> {
+fn extract_dml_filters(source: &LogicalPlan) -> Vec<Expr> {
     use datafusion_expr::utils::split_conjunction_owned;
 
-    if let LogicalPlan::Filter(filter) = source {
-        split_conjunction_owned(filter.predicate.clone())
-    } else {
-        vec![]
+    match source {
+        LogicalPlan::Filter(filter) => {
+            split_conjunction_owned(unnormalize_col(filter.predicate.clone()))
+        }
+        LogicalPlan::Projection(projection) => extract_dml_filters(projection.input.as_ref()),
+        LogicalPlan::SubqueryAlias(alias) => extract_dml_filters(alias.input.as_ref()),
+        _ => vec![],
+    }
+}
+
+/// Create a physical execution plan for an `UPDATE` statement.
+///
+/// The returned plan executes update semantics as:
+/// 1) materialize updated rows from `dml.input`,
+/// 2) delete matched source rows,
+/// 3) insert updated rows with append mode.
+async fn create_update_physical_plan(
+    dml: &datafusion::logical_expr::DmlStatement,
+    df: &Arc<DataFusion>,
+    session_state: &SessionState,
+) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Table '{}' not found for UPDATE operation",
+            dml.table_name
+        ))
+    })?;
+
+    let deletion_provider =
+        get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Table '{}' does not support UPDATE operations",
+                dml.table_name
+            ))
+        })?;
+
+    let source_plan = session_state.create_physical_plan(&dml.input).await?;
+    let filters = extract_dml_filters(&dml.input);
+
+    Ok(Arc::new(UpdateExec::new(
+        source_plan,
+        table_provider,
+        deletion_provider,
+        session_state.clone(),
+        filters,
+    )))
+}
+
+struct UpdateExec {
+    source_plan: Arc<dyn ExecutionPlan>,
+    table_provider: Arc<dyn datafusion::datasource::TableProvider>,
+    deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
+    session_state: SessionState,
+    filters: Vec<Expr>,
+    properties: datafusion::physical_plan::PlanProperties,
+}
+
+impl UpdateExec {
+    fn new(
+        source_plan: Arc<dyn ExecutionPlan>,
+        table_provider: Arc<dyn datafusion::datasource::TableProvider>,
+        deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
+        session_state: SessionState,
+        filters: Vec<Expr>,
+    ) -> Self {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
+        let properties = datafusion::physical_plan::PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Incremental,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self {
+            source_plan,
+            table_provider,
+            deletion_provider,
+            session_state,
+            filters,
+            properties,
+        }
+    }
+}
+
+impl std::fmt::Debug for UpdateExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpdateExec").finish_non_exhaustive()
+    }
+}
+
+impl datafusion::physical_plan::DisplayAs for UpdateExec {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "UpdateExec")
+    }
+}
+
+impl ExecutionPlan for UpdateExec {
+    fn name(&self) -> &'static str {
+        "UpdateExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.source_plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "UpdateExec requires exactly one child, got {}",
+                children.len()
+            )));
+        }
+
+        Ok(Arc::new(Self::new(
+            Arc::clone(&children[0]),
+            Arc::clone(&self.table_provider),
+            Arc::clone(&self.deletion_provider),
+            self.session_state.clone(),
+            self.filters.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> std::result::Result<SendableRecordBatchStream, DataFusionError> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(format!(
+                "UpdateExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let source_plan = Arc::clone(&self.source_plan);
+        let table_provider = Arc::clone(&self.table_provider);
+        let deletion_provider = Arc::clone(&self.deletion_provider);
+        let session_state = self.session_state.clone();
+        let filters = self.filters.clone();
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
+
+        let stream = futures::stream::once(async move {
+            use futures::TryStreamExt;
+
+            let source_stream = execute_stream(Arc::clone(&source_plan), Arc::clone(&context))?;
+            let updated_batches: Vec<RecordBatch> = source_stream.try_collect().await?;
+
+            // Normalize update output to match the target table schema (including nullability)
+            // before performing any destructive operation.
+            let target_schema = table_provider.schema();
+            let normalized_batches = updated_batches
+                .into_iter()
+                .map(|batch| {
+                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
+                })
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(DataFusionError::from)?;
+
+            let delete_plan = deletion_provider
+                .delete_from(&session_state, &filters)
+                .await?;
+            let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
+            let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
+
+            let deleted_count = delete_batches
+                .iter()
+                .flat_map(RecordBatch::columns)
+                .find_map(|arr| {
+                    arr.as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .and_then(|counts| counts.values().first().copied())
+                })
+                .unwrap_or(0);
+
+            if !normalized_batches.is_empty() {
+                let input_exec = MemorySourceConfig::try_new_exec(
+                    &[normalized_batches],
+                    Arc::clone(&target_schema),
+                    None,
+                )?;
+                let insert_plan = table_provider
+                    .insert_into(&session_state, input_exec, InsertOp::Append)
+                    .await?;
+                let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
+                let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
+            }
+
+            let result = RecordBatch::try_from_iter_with_nullable(vec![(
+                "count",
+                Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
+                false,
+            )])
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+            Ok(result)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 }
 

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -29,8 +29,9 @@ use crate::datafusion::DataFusion;
 /// Reads (SELECT queries) are allowed on all tables.
 /// INSERT and DELETE operations are only allowed on datasets that are configured as writable,
 /// and are not allowed on internal Spice tables.
+/// UPDATE operations are only allowed on writable Cayenne catalog tables.
 /// DDL operations are only allowed on catalogs configured with `access: read_write_create`.
-/// DML (other than allowed INSERT/DELETE), COPY, and Statement operations are not permitted.
+/// DML (other than allowed INSERT/DELETE/UPDATE), COPY, and Statement operations are not permitted.
 ///
 /// # Returns
 /// * `Ok(())` if the plan is valid
@@ -108,6 +109,35 @@ pub fn validate_sql_query_operations(
                         dml.table_name
                     )
                 }
+            } else if matches!(&dml.op, datafusion::logical_expr::WriteOp::Update) {
+                if super::is_spice_internal_dataset(&dml.table_name) {
+                    return plan_err!(
+                        "UPDATE operations are not allowed on Spice system dataset '{}'.",
+                        dml.table_name
+                    );
+                }
+
+                let target_catalog = dml
+                    .table_name
+                    .catalog()
+                    .unwrap_or(super::SPICE_DEFAULT_CATALOG);
+
+                if !df.is_catalog_writable(target_catalog) {
+                    return plan_err!(
+                        "UPDATE operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
+                        dml.table_name
+                    );
+                }
+
+                if !is_cayenne_catalog(df, target_catalog) {
+                    return plan_err!(
+                        "UPDATE operations are only supported on writable Cayenne catalog tables. Table '{}', catalog '{}' is not Cayenne-backed.",
+                        dml.table_name,
+                        target_catalog
+                    );
+                }
+
+                Ok(TreeNodeRecursion::Continue)
             } else { plan_err!("Operation is not allowed: {}", dml.name()) }
         }
         LogicalPlan::Copy(_) => {
@@ -125,6 +155,22 @@ pub fn validate_sql_query_operations(
         _ => Ok(TreeNodeRecursion::Continue),
     })?;
     Ok(())
+}
+
+fn is_cayenne_catalog(df: &Arc<DataFusion>, catalog_name: &str) -> bool {
+    #[cfg(not(windows))]
+    {
+        df.ctx
+            .catalog(catalog_name)
+            .is_some_and(|catalog| super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref()))
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = df;
+        let _ = catalog_name;
+        false
+    }
 }
 
 /// Validates DDL operations. DDL is only allowed on catalogs with `access: read_write_create`.

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -39,6 +39,7 @@ use tonic::{Request, Response, Status, Streaming};
 use async_stream::stream;
 
 use crate::{
+    config::ClusterRole,
     datafusion::{DataFusion, request_context_extension::get_current_datafusion},
     dataupdate::{StreamingDataUpdate, UpdateType},
     timing::TimedStream,
@@ -88,23 +89,38 @@ pub(crate) async fn handle(
             }
             Command::CommandStatementIngest(ingest_cmd) => {
                 // Handle FlightSQL bulk ingestion command
-                // Extract the table reference from the command
-                let table_ref = if let Some(catalog) = &ingest_cmd.catalog {
-                    if let Some(schema) = &ingest_cmd.schema {
-                        TableReference::full(
-                            catalog.as_str(),
-                            schema.as_str(),
-                            ingest_cmd.table.as_str(),
-                        )
-                    } else {
-                        TableReference::partial(catalog.as_str(), ingest_cmd.table.as_str())
+                // Prefer descriptor path when command is under-qualified (table only).
+                // This preserves fully-qualified paths forwarded by the scheduler.
+                match (ingest_cmd.catalog.as_ref(), ingest_cmd.schema.as_ref()) {
+                    (Some(catalog), Some(schema)) => Some(vec![
+                        catalog.clone(),
+                        schema.clone(),
+                        ingest_cmd.table.clone(),
+                    ]),
+                    // If command is under-qualified, prefer descriptor path if present,
+                    // because scheduler forwarding includes fully-qualified path parts.
+                    (Some(catalog), None) => {
+                        if fd.path.is_empty() {
+                            Some(vec![catalog.clone(), ingest_cmd.table.clone()])
+                        } else {
+                            None
+                        }
                     }
-                } else if let Some(schema) = &ingest_cmd.schema {
-                    TableReference::partial(schema.as_str(), ingest_cmd.table.as_str())
-                } else {
-                    TableReference::bare(ingest_cmd.table.as_str())
-                };
-                Some(vec![table_ref.to_string()])
+                    (None, Some(schema)) => {
+                        if fd.path.is_empty() {
+                            Some(vec![schema.clone(), ingest_cmd.table.clone()])
+                        } else {
+                            None
+                        }
+                    }
+                    (None, None) => {
+                        if fd.path.is_empty() {
+                            Some(vec![ingest_cmd.table.clone()])
+                        } else {
+                            None
+                        }
+                    }
+                }
             }
             _ => None,
         }
@@ -117,7 +133,10 @@ pub(crate) async fn handle(
         rate_limit_check()?;
     }
 
-    match RequestContext::current(AsyncMarker::new().await).auth_principal() {
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
+    match context.auth_principal() {
         Some(principal) => {
             if !principal
                 .groups()
@@ -130,9 +149,15 @@ pub(crate) async fn handle(
             }
         }
         None => {
-            return Err(Status::unauthenticated(
-                "Flight DoPut requires authentication.\nFor auth details, visit https://spiceai.org/docs/api/auth",
-            ));
+            if allow_scheduler_trusted_executor_write(&datafusion) {
+                tracing::debug!(
+                    "Allowing unauthenticated DoPut on executor in mTLS scheduler-trusted mode"
+                );
+            } else {
+                return Err(Status::unauthenticated(
+                    "Flight DoPut requires authentication.\nFor auth details, visit https://spiceai.org/docs/api/auth",
+                ));
+            }
         }
     }
 
@@ -154,18 +179,42 @@ pub(crate) async fn handle(
         return Err(Status::invalid_argument("No path provided"));
     }
 
-    let path = TableReference::parse_str(&path_vec.join("."));
+    let path = match path_vec.len() {
+        3 => TableReference::full(
+            path_vec[0].as_str(),
+            path_vec[1].as_str(),
+            path_vec[2].as_str(),
+        ),
+        2 => TableReference::partial(path_vec[0].as_str(), path_vec[1].as_str()),
+        _ => TableReference::parse_str(&path_vec.join(".")),
+    };
+    let path = normalize_path_table_reference(path, &datafusion);
 
     // Initializing tracking here so that both counter and duration have consistent path dimensions
     let start = metrics::track_flight_request("do_put", Some(&path.to_string())).await;
-
-    let context = RequestContext::current(AsyncMarker::new().await);
-    let datafusion = get_current_datafusion(&context);
 
     if !datafusion.is_writable(&path) && !datafusion.is_path_catalog_writable(&path) {
         return Err(Status::invalid_argument(format!(
             "Path doesn't exist or is not writable: {path}",
         )));
+    }
+
+    // Fast path: for scheduler -> executor Cayenne writes, forward raw FlightData
+    // directly to executor to avoid decode/re-encode overhead on scheduler.
+    if should_forward_raw_cayenne_write(&datafusion, &path).await {
+        use futures::stream;
+
+        let inbound = futures::StreamExt::chain(
+            stream::once(async move { Ok(first_message.clone()) }),
+            streaming_flight,
+        );
+        datafusion
+            .forward_flight_data_stream_to_executor(&path, inbound)
+            .await
+            .map_err(|e| Status::internal(format!("Write operation failed: {e}")))?;
+
+        let output = futures::stream::iter(vec![Ok(PutResult::default())]);
+        return Ok(Response::new(Box::pin(output)));
     }
 
     let schema = try_schema_from_flatbuffer_bytes(&first_message.data_header)
@@ -184,12 +233,123 @@ pub(crate) async fn handle(
     }
 
     let first_message = first_message.clone();
-    let response_stream =
-        create_response_stream(path, schema, datafusion, streaming_flight, &first_message);
+    let response_stream = create_response_stream(
+        path,
+        schema,
+        Arc::clone(&datafusion),
+        streaming_flight,
+        &first_message,
+    );
+    let response_stream = context.scope_stream(response_stream);
 
     let timed_stream = TimedStream::new(response_stream, move || start);
 
     Ok(Response::new(Box::pin(timed_stream)))
+}
+
+fn allow_scheduler_trusted_executor_write(datafusion: &DataFusion) -> bool {
+    datafusion.cluster_config.effective_role() == Some(ClusterRole::Executor)
+        && datafusion.cluster_config.tls_config().is_some()
+}
+
+async fn should_forward_raw_cayenne_write(datafusion: &DataFusion, path: &TableReference) -> bool {
+    if datafusion.cluster_config.effective_role() != Some(ClusterRole::Scheduler) {
+        return false;
+    }
+
+    let Some(executor_registry) = datafusion.executor_registry.as_ref() else {
+        return false;
+    };
+
+    let Ok(clients) = executor_registry.flight_sql_clients.try_read() else {
+        return false;
+    };
+    if clients.is_empty() {
+        return false;
+    }
+    drop(clients);
+
+    let Some(table_provider) = datafusion.get_table(path).await else {
+        return false;
+    };
+
+    table_provider
+        .as_any()
+        .downcast_ref::<cayenne::CayenneTableProvider>()
+        .is_some()
+}
+
+fn normalize_path_table_reference(path: TableReference, datafusion: &DataFusion) -> TableReference {
+    // NOTE: this uses synchronous `table_exist` checks on schema providers. These
+    // checks are expected to be in-memory lookups in current catalog implementations.
+    match path {
+        TableReference::Full { .. } => path,
+        TableReference::Partial { schema, table } => {
+            let matching_catalogs = datafusion
+                .ctx
+                .catalog_names()
+                .into_iter()
+                .filter(|catalog_name| {
+                    datafusion
+                        .ctx
+                        .catalog(catalog_name)
+                        .and_then(|catalog| catalog.schema(schema.as_ref()))
+                        .is_some_and(|schema_provider| {
+                            schema_provider.table_exist(table.as_ref())
+                                || datafusion.is_catalog_writable(catalog_name)
+                        })
+                })
+                .collect::<Vec<_>>();
+
+            if matching_catalogs.len() == 1 {
+                return TableReference::full(
+                    matching_catalogs[0].clone(),
+                    schema.to_string(),
+                    table.to_string(),
+                );
+            }
+
+            TableReference::partial(schema, table)
+        }
+        TableReference::Bare { table } => {
+            let table_name = table.to_string();
+            let matching_tables = datafusion
+                .ctx
+                .catalog_names()
+                .into_iter()
+                .flat_map(|catalog_name| {
+                    let table_name_for_catalog = table_name.clone();
+                    datafusion
+                        .ctx
+                        .catalog(&catalog_name)
+                        .into_iter()
+                        .flat_map(move |catalog| {
+                            let catalog_name = catalog_name.clone();
+                            let table_name = table_name_for_catalog.clone();
+                            catalog
+                                .schema_names()
+                                .into_iter()
+                                .filter_map(move |schema_name| {
+                                    let table_name = table_name.clone();
+                                    catalog
+                                        .schema(&schema_name)
+                                        .filter(|schema_provider| {
+                                            schema_provider.table_exist(table_name.as_str())
+                                        })
+                                        .map(|_| (catalog_name.clone(), schema_name, table_name))
+                                })
+                        })
+                })
+                .collect::<Vec<_>>();
+
+            if matching_tables.len() == 1 {
+                let (catalog, schema, table_name) = matching_tables[0].clone();
+                return TableReference::full(catalog, schema, table_name);
+            }
+
+            TableReference::bare(table_name)
+        }
+    }
 }
 
 fn create_response_stream(

--- a/crates/runtime/src/flight/flightsql/statement_update.rs
+++ b/crates/runtime/src/flight/flightsql/statement_update.rs
@@ -28,6 +28,7 @@ use prost::Message;
 use tonic::{Response, Status};
 
 use crate::{
+    config::ClusterRole,
     datafusion::request_context_extension::get_current_datafusion,
     flight::{Service, metrics},
 };
@@ -48,6 +49,8 @@ pub(crate) async fn do_put(
     // Authenticate — this handler is dispatched before the generic DoPut auth
     // check, so we must verify credentials here.
     let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     match context.auth_principal() {
         Some(principal) => {
             if !principal
@@ -61,13 +64,17 @@ pub(crate) async fn do_put(
             }
         }
         None => {
-            return Err(Status::unauthenticated(
-                "Flight DoPut requires authentication.\nFor auth details, visit https://spiceai.org/docs/api/auth",
-            ));
+            if allow_scheduler_trusted_executor_write(&datafusion) {
+                tracing::debug!(
+                    "Allowing unauthenticated statement DoPut on executor in mTLS scheduler-trusted mode"
+                );
+            } else {
+                return Err(Status::unauthenticated(
+                    "Flight DoPut requires authentication.\nFor auth details, visit https://spiceai.org/docs/api/auth",
+                ));
+            }
         }
     }
-
-    let datafusion = get_current_datafusion(&context);
 
     let sql = &cmd.query;
     tracing::trace!("do_put_statement_update: {sql}");
@@ -107,6 +114,11 @@ pub(crate) async fn do_put(
     })]);
 
     Ok(Response::new(Box::pin(output)))
+}
+
+fn allow_scheduler_trusted_executor_write(datafusion: &crate::datafusion::DataFusion) -> bool {
+    datafusion.cluster_config.effective_role() == Some(ClusterRole::Executor)
+        && datafusion.cluster_config.tls_config().is_some()
 }
 
 /// Extract affected row count from execution results.

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -71,7 +71,7 @@ mod handshake;
 mod metrics;
 pub mod middleware;
 mod session;
-mod session_auth;
+pub(crate) mod session_auth;
 mod util;
 
 pub use session::SessionStore;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1056,6 +1056,7 @@ impl Runtime {
         let flight_shutdown = CancellationToken::new();
         let self_ref = Arc::clone(&self);
         let cloned_tls_config = tls_config.clone();
+        let executor_endpoint_auth = endpoint_auth.clone();
         let flight_future: std::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>> =
             if self.df.cluster_config.effective_role() == Some(ClusterRole::Executor) {
                 Box::pin(
@@ -1066,6 +1067,7 @@ impl Runtime {
                             cluster::start_executor_flight_server(
                                 config.flight_bind_address,
                                 Arc::clone(&self_ref),
+                                executor_endpoint_auth,
                                 Some(flight_shutdown),
                             )
                             .await


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds support for executing DDL across all executors for Cayenne catalog
* Adds support for passing through DoPut from the scheduler into the first executor

**Limitations:**

Cayenne catalog distributed ingestion is very early alpha and has some limitations:

* Only supports 1 scheduler and 1 executor
* Does not distribute `INSERT INTO` SQL DDL calls
* Does not recover data from executors which are lost - if the executor disappears, the ingested data is gone
* Does not support dynamically adding/removing executors, and makes no guarantees on the executor order in which data is ingested