### PR TITLE
Make `lint-rust-fix` support targeted packages and features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,26 @@ lint-rust:
 		-Dclippy::allow_attributes \
 		-Aunfulfilled_lint_expectations
 
+## Optional: PACKAGES="pkg1 pkg2" to lint specific packages instead of the whole workspace
+## Optional: FEATURES="feat1,feat2" to override features (defaults to all workspace features when unset)
+## Example: make lint-rust-fix PACKAGES="runtime data_components" FEATURES="duckdb,postgres"
+PACKAGES ?=
+FEATURES ?=
+ifdef PACKAGES
+_LINT_PKG_FLAGS := $(foreach p,$(PACKAGES),-p $(p))
+_LINT_WORKSPACE_FLAGS := $(_LINT_PKG_FLAGS)
+_FMT_FLAGS := $(_LINT_PKG_FLAGS)
+_FEATURES_FLAGS := $(if $(FEATURES),--features $(FEATURES),)
+else
+_LINT_WORKSPACE_FLAGS := --workspace --exclude libnfs
+_FMT_FLAGS := --all
+_FEATURES_FLAGS := --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp
+endif
+
 lint-rust-fix:
-	cargo fmt --all
+	cargo fmt $(_FMT_FLAGS)
 	## All except metal, cuda, nfs (nfs requires system libnfs library)
-	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --lib --bins --fix --allow-dirty --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp --workspace --exclude libnfs -- \
+	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --lib --bins --fix --allow-dirty $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
@@ -144,7 +160,7 @@ lint-rust-fix:
 		-Dclippy::todo \
 		-Dclippy::assertions_on_result_states \
 		-Dclippy::allow_attributes
-	cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --tests --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp --workspace --exclude libnfs -- \
+	cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --tests $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,8 @@ lint-rust:
 		-Aunfulfilled_lint_expectations
 
 ## Optional: PACKAGES="pkg1 pkg2" to lint specific packages instead of the whole workspace
-## Optional: FEATURES="feat1,feat2" to override features (defaults to all workspace features when unset)
+## Optional: FEATURES="feat1,feat2" to override features
+## Feature defaults: when FEATURES is unset, uses aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp for workspace (unless PACKAGES is set, then uses package defaults)
 ## Example: make lint-rust-fix PACKAGES="runtime data_components" FEATURES="duckdb,postgres"
 PACKAGES ?=
 FEATURES ?=
@@ -135,17 +136,23 @@ ifdef PACKAGES
 _LINT_PKG_FLAGS := $(foreach p,$(PACKAGES),-p $(p))
 _LINT_WORKSPACE_FLAGS := $(_LINT_PKG_FLAGS)
 _FMT_FLAGS := $(_LINT_PKG_FLAGS)
-_FEATURES_FLAGS := $(if $(FEATURES),--features $(FEATURES),)
 else
 _LINT_WORKSPACE_FLAGS := --workspace --exclude libnfs
 _FMT_FLAGS := --all
+endif
+# Apply FEATURES if provided, otherwise default to hardcoded features only for workspace-wide linting
+ifdef FEATURES
+_FEATURES_FLAGS := --features $(FEATURES)
+else ifdef PACKAGES
+_FEATURES_FLAGS :=
+else
 _FEATURES_FLAGS := --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp
 endif
 
 lint-rust-fix:
 	cargo fmt $(_FMT_FLAGS)
 	## All except metal, cuda, nfs (nfs requires system libnfs library)
-	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --lib --bins --fix --allow-dirty $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
+	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --all-targets --fix --allow-dirty $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \


### PR DESCRIPTION
This change makes the `lint-rust-fix` Make target more flexible by allowing callers to scope linting to specific packages and optionally override enabled features.

Make running CI checks locally **much faster**. You can now:

- **Limit linting to specific packages**
  ```bash
  make lint-rust-fix PACKAGES="runtime data_components"
  ```

- **Override enabled features**
  ```bash
  make lint-rust-fix PACKAGES="runtime data_components" FEATURES="duckdb,postgres"
  ```

 - `make lint-rust-fix` is unchanges as before