### PR TITLE
feat: add Cayenne UPDATE support for distributed ingestion

### DIFF
--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -37,6 +37,7 @@ use snafu::prelude::*;
 use crate::component::catalog::Catalog;
 use crate::parameters::Parameters;
 use crate::spice_data_base_path;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use data_components::RefreshableCatalogProvider;
 
 #[derive(Debug, Snafu)]
@@ -291,7 +292,7 @@ impl RefreshableCatalogProvider for CayenneCatalogProvider {
 
         if !new_schemas.is_empty() {
             let total_tables: usize = grouped.values().map(Vec::len).sum();
-            tracing::info!(
+            tracing::debug!(
                 "Loaded {total_tables} existing Cayenne table{} across {} namespace{}",
                 if total_tables == 1 { "" } else { "s" },
                 new_schemas.len(),
@@ -402,7 +403,13 @@ impl CayenneSchemaProvider {
                 let builder = CayenneTableProviderBuilder::new(Arc::clone(catalog));
 
                 match builder.open(table_name).await {
-                    Ok(provider) => Ok(Some(Arc::new(provider))),
+                    Ok(provider) => {
+                        let provider = Arc::new(provider);
+                        let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                        Ok(Some(Arc::new(DeletionTableProviderAdapter::new(
+                            deletion_provider,
+                        ))))
+                    }
                     Err(e) => {
                         tracing::warn!("Failed to open Cayenne table '{table_name}': {e}");
                         Ok(None)

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -37,8 +37,8 @@ use snafu::prelude::*;
 use crate::component::catalog::Catalog;
 use crate::parameters::Parameters;
 use crate::spice_data_base_path;
-use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use data_components::RefreshableCatalogProvider;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -41,6 +41,7 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_table_providers::UnsupportedTypeAction;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
 use super::get_cayenne_provider;
 use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
@@ -313,11 +314,17 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     if !schema_provider.table_exist(&table_name) {
                         let builder =
                             CayenneTableProviderBuilder::new(Arc::clone(&metadata_catalog));
-                        if let Ok(provider) = builder.open(&metadata_table_name).await
-                            && let Err(e) = schema_provider
-                                .register_table(table_name.clone(), Arc::new(provider))
-                        {
-                            tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
+                        if let Ok(provider) = builder.open(&metadata_table_name).await {
+                            let provider = Arc::new(provider);
+                            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
+                                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
+                            if let Err(e) = schema_provider
+                                .register_table(table_name.clone(), wrapped_provider)
+                            {
+                                tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
+                            }
+                        }
                         }
                     }
 
@@ -368,6 +375,11 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 ))
             })?;
 
+            let provider = Arc::new(provider);
+            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
+                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
+
             // Ensure the schema exists, creating it on demand if needed
             let schema_provider = if let Some(s) = cayenne_provider.schema_provider(&df_schema_name)
             {
@@ -384,7 +396,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 Arc::clone(&new_schema) as Arc<dyn SchemaProvider>
             };
 
-            schema_provider.register_table(table_name.clone(), Arc::new(provider))?;
+            schema_provider.register_table(table_name.clone(), wrapped_provider)?;
 
             // Forward the CREATE TABLE DDL to executor nodes
             if let Some(ref registry) = executor_registry {

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -33,6 +33,7 @@ use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use cayenne::CayenneTableProviderBuilder;
 use cayenne::metadata::CreateTableOptions;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use datafusion::catalog::{CatalogProviderList, SchemaProvider};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
@@ -41,7 +42,6 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_table_providers::UnsupportedTypeAction;
-use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
 use super::get_cayenne_provider;
 use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
@@ -319,8 +319,8 @@ impl ExecutionPlan for CayenneCreateTableExec {
                             let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
                             let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
                                 Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
-                            if let Err(e) = schema_provider
-                                .register_table(table_name.clone(), wrapped_provider)
+                            if let Err(e) =
+                                schema_provider.register_table(table_name.clone(), wrapped_provider)
                             {
                                 tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
                             }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -325,7 +325,6 @@ impl ExecutionPlan for CayenneCreateTableExec {
                                 tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
                             }
                         }
-                        }
                     }
 
                     let batch = RecordBatch::try_new(

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -21,8 +21,8 @@ use ::cache::{
     key::CacheKey,
     result::{CacheStatus, query::QueryResult},
 };
-use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow::array::UInt64Array;
+use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
@@ -71,12 +71,12 @@ use super::managed_runtime;
 use crate::datafusion::{
     DataFusion, query::cache::RequestCacheManager, sql_validator::validate_sql_query_operations,
 };
+use data_components::delete::get_deletion_provider;
 use managed_runtime::ManagedRuntimeError;
 use opentelemetry::KeyValue;
 use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use tokio::runtime::Handle;
-use data_components::delete::get_deletion_provider;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -687,24 +687,27 @@ impl Query {
                         }
                     };
                     (stream, df_plan)
-                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+                } else if let LogicalPlan::Dml(dml) = &*plan
+                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
+                {
                     // DELETE operations need special handling because DataFusion doesn't
                     // support DELETE natively. We intercept the DML Delete plan, extract
                     // the filter predicates, and delegate to the DeletionTableProvider.
-                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df, &session).await {
-                        Ok(p) => p,
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            let error_code = ErrorCode::from(&e);
-                            handle_error!(
-                                tracker,
-                                &request_context,
-                                error_code,
-                                e,
-                                UnableToExecuteQuery
-                            )
-                        }
-                    };
+                    let delete_plan =
+                        match create_delete_physical_plan(dml, &ctx.df, &session).await {
+                            Ok(p) => p,
+                            Err(e) => {
+                                let e = find_datafusion_root(e);
+                                let error_code = ErrorCode::from(&e);
+                                handle_error!(
+                                    tracker,
+                                    &request_context,
+                                    error_code,
+                                    e,
+                                    UnableToExecuteQuery
+                                )
+                            }
+                        };
 
                     let task_ctx = Arc::new(TaskContext::from(&session));
                     let stream = match execute_stream(Arc::clone(&delete_plan), task_ctx) {
@@ -722,25 +725,28 @@ impl Query {
                         }
                     };
                     (stream, delete_plan)
-                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Update) {
+                } else if let LogicalPlan::Dml(dml) = &*plan
+                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Update)
+                {
                     // UPDATE operations are rewritten to an execution plan that:
                     // 1) materializes updated rows from the DML input,
                     // 2) deletes matched rows,
                     // 3) inserts updated rows back.
-                    let update_plan = match create_update_physical_plan(dml, &ctx.df, &session).await {
-                        Ok(p) => p,
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            let error_code = ErrorCode::from(&e);
-                            handle_error!(
-                                tracker,
-                                &request_context,
-                                error_code,
-                                e,
-                                UnableToExecuteQuery
-                            )
-                        }
-                    };
+                    let update_plan =
+                        match create_update_physical_plan(dml, &ctx.df, &session).await {
+                            Ok(p) => p,
+                            Err(e) => {
+                                let e = find_datafusion_root(e);
+                                let error_code = ErrorCode::from(&e);
+                                handle_error!(
+                                    tracker,
+                                    &request_context,
+                                    error_code,
+                                    e,
+                                    UnableToExecuteQuery
+                                )
+                            }
+                        };
 
                     let task_ctx = Arc::new(TaskContext::from(&session));
                     let stream = match execute_stream(Arc::clone(&update_plan), task_ctx) {
@@ -807,8 +813,7 @@ impl Query {
                             datafusion::logical_expr::WriteOp::Delete
                                 | datafusion::logical_expr::WriteOp::Update
                         )
-                )
-            {
+                ) {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 
@@ -1327,9 +1332,7 @@ async fn create_delete_physical_plan(
         ))
     })?;
 
-    deletion_provider
-        .delete_from(session_state, &filters)
-        .await
+    deletion_provider.delete_from(session_state, &filters).await
 }
 
 /// Extract filter expressions from a DML source logical plan.
@@ -1342,9 +1345,9 @@ fn extract_dml_filters(source: &LogicalPlan) -> Vec<Expr> {
     use datafusion_expr::utils::split_conjunction_owned;
 
     match source {
-        LogicalPlan::Filter(filter) => split_conjunction_owned(unnormalize_col(
-            filter.predicate.clone(),
-        )),
+        LogicalPlan::Filter(filter) => {
+            split_conjunction_owned(unnormalize_col(filter.predicate.clone()))
+        }
         LogicalPlan::Projection(projection) => extract_dml_filters(projection.input.as_ref()),
         LogicalPlan::SubqueryAlias(alias) => extract_dml_filters(alias.input.as_ref()),
         _ => vec![],
@@ -1369,12 +1372,13 @@ async fn create_update_physical_plan(
         ))
     })?;
 
-    let deletion_provider = get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
-        DataFusionError::Plan(format!(
-            "Table '{}' does not support UPDATE operations",
-            dml.table_name
-        ))
-    })?;
+    let deletion_provider =
+        get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Table '{}' does not support UPDATE operations",
+                dml.table_name
+            ))
+        })?;
 
     let source_plan = session_state.create_physical_plan(&dml.input).await?;
     let filters = extract_dml_filters(&dml.input);
@@ -1405,11 +1409,9 @@ impl UpdateExec {
         session_state: SessionState,
         filters: Vec<Expr>,
     ) -> Self {
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
-            "count",
-            arrow::datatypes::DataType::UInt64,
-            false,
-        )]));
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
         let properties = datafusion::physical_plan::PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
             datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
@@ -1497,11 +1499,9 @@ impl ExecutionPlan for UpdateExec {
         let session_state = self.session_state.clone();
         let filters = self.filters.clone();
 
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
-            "count",
-            arrow::datatypes::DataType::UInt64,
-            false,
-        )]));
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
 
         let stream = futures::stream::once(async move {
             use futures::TryStreamExt;
@@ -1514,11 +1514,15 @@ impl ExecutionPlan for UpdateExec {
             let target_schema = table_provider.schema();
             let normalized_batches = updated_batches
                 .into_iter()
-                .map(|batch| arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema)))
+                .map(|batch| {
+                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
+                })
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(DataFusionError::from)?;
 
-            let delete_plan = deletion_provider.delete_from(&session_state, &filters).await?;
+            let delete_plan = deletion_provider
+                .delete_from(&session_state, &filters)
+                .await?;
             let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
             let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
 
@@ -1545,13 +1549,11 @@ impl ExecutionPlan for UpdateExec {
                 let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
             }
 
-            let result = RecordBatch::try_from_iter_with_nullable(vec![
-                (
-                    "count",
-                    Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
-                    false,
-                ),
-            ])
+            let result = RecordBatch::try_from_iter_with_nullable(vec![(
+                "count",
+                Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
+                false,
+            )])
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
 
             Ok(result)

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -22,16 +22,20 @@ use ::cache::{
     result::{CacheStatus, query::QueryResult},
 };
 use arrow::{array::RecordBatch, datatypes::Schema};
+use arrow::array::UInt64Array;
 use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
     common::ParamValues,
+    datasource::memory::MemorySourceConfig,
     error::DataFusionError,
     execution::{SendableRecordBatchStream, TaskContext},
-    logical_expr::LogicalPlan,
+    logical_expr::dml::InsertOp,
+    logical_expr::{Expr, LogicalPlan},
     physical_plan::{ExecutionPlan, execute_stream, stream::RecordBatchStreamAdapter},
 };
+use datafusion_expr::expr_rewriter::unnormalize_col;
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
 use tokio::time::Instant;
@@ -72,6 +76,7 @@ use opentelemetry::KeyValue;
 use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use tokio::runtime::Handle;
+use data_components::delete::get_deletion_provider;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -686,7 +691,7 @@ impl Query {
                     // DELETE operations need special handling because DataFusion doesn't
                     // support DELETE natively. We intercept the DML Delete plan, extract
                     // the filter predicates, and delegate to the DeletionTableProvider.
-                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df).await {
+                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df, &session).await {
                         Ok(p) => p,
                         Err(e) => {
                             let e = find_datafusion_root(e);
@@ -717,6 +722,42 @@ impl Query {
                         }
                     };
                     (stream, delete_plan)
+                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Update) {
+                    // UPDATE operations are rewritten to an execution plan that:
+                    // 1) materializes updated rows from the DML input,
+                    // 2) deletes matched rows,
+                    // 3) inserts updated rows back.
+                    let update_plan = match create_update_physical_plan(dml, &ctx.df, &session).await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
+
+                    let task_ctx = Arc::new(TaskContext::from(&session));
+                    let stream = match execute_stream(Arc::clone(&update_plan), task_ctx) {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
+                    (stream, update_plan)
                 } else {
                     // For regular plans, use the standard physical plan execution
                     let physical_plan = match session.create_physical_plan(&plan).await {
@@ -760,7 +801,12 @@ impl Query {
             let res_stream = if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
                 && !matches!(
                     &*plan,
-                    LogicalPlan::Dml(dml) if matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
+                    LogicalPlan::Dml(dml)
+                        if matches!(
+                            &dml.op,
+                            datafusion::logical_expr::WriteOp::Delete
+                                | datafusion::logical_expr::WriteOp::Update
+                        )
                 )
             {
                 let plan_schema = Arc::clone(plan.schema().inner());
@@ -1260,11 +1306,10 @@ fn reconcile_stream_nullability(
 async fn create_delete_physical_plan(
     dml: &datafusion::logical_expr::DmlStatement,
     df: &Arc<DataFusion>,
+    session_state: &SessionState,
 ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    use data_components::delete::get_deletion_provider;
-
     // Extract filter expressions from the source plan
-    let filters = extract_delete_filters(&dml.input);
+    let filters = extract_dml_filters(&dml.input);
 
     // Look up the table provider
     let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
@@ -1282,24 +1327,237 @@ async fn create_delete_physical_plan(
         ))
     })?;
 
-    let session_state = df.ctx.state();
     deletion_provider
-        .delete_from(&session_state, &filters)
+        .delete_from(session_state, &filters)
         .await
 }
 
-/// Extract filter expressions from a DELETE's source logical plan.
+/// Extract filter expressions from a DML source logical plan.
 ///
-/// The source plan is either `Filter(predicate, scan)` or just `scan`.
+/// The source plan is generally `Filter(predicate, scan)`, and for `UPDATE`
+/// may be wrapped as `Projection(Filter(...))`.
 /// Returns the individual conjunctive filter expressions, or an empty
 /// vec if there is no WHERE clause.
-fn extract_delete_filters(source: &LogicalPlan) -> Vec<datafusion::logical_expr::Expr> {
+fn extract_dml_filters(source: &LogicalPlan) -> Vec<Expr> {
     use datafusion_expr::utils::split_conjunction_owned;
 
-    if let LogicalPlan::Filter(filter) = source {
-        split_conjunction_owned(filter.predicate.clone())
-    } else {
-        vec![]
+    match source {
+        LogicalPlan::Filter(filter) => split_conjunction_owned(unnormalize_col(
+            filter.predicate.clone(),
+        )),
+        LogicalPlan::Projection(projection) => extract_dml_filters(projection.input.as_ref()),
+        LogicalPlan::SubqueryAlias(alias) => extract_dml_filters(alias.input.as_ref()),
+        _ => vec![],
+    }
+}
+
+/// Create a physical execution plan for an `UPDATE` statement.
+///
+/// The returned plan executes update semantics as:
+/// 1) materialize updated rows from `dml.input`,
+/// 2) delete matched source rows,
+/// 3) insert updated rows with append mode.
+async fn create_update_physical_plan(
+    dml: &datafusion::logical_expr::DmlStatement,
+    df: &Arc<DataFusion>,
+    session_state: &SessionState,
+) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Table '{}' not found for UPDATE operation",
+            dml.table_name
+        ))
+    })?;
+
+    let deletion_provider = get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Table '{}' does not support UPDATE operations",
+            dml.table_name
+        ))
+    })?;
+
+    let source_plan = session_state.create_physical_plan(&dml.input).await?;
+    let filters = extract_dml_filters(&dml.input);
+
+    Ok(Arc::new(UpdateExec::new(
+        source_plan,
+        table_provider,
+        deletion_provider,
+        session_state.clone(),
+        filters,
+    )))
+}
+
+struct UpdateExec {
+    source_plan: Arc<dyn ExecutionPlan>,
+    table_provider: Arc<dyn datafusion::datasource::TableProvider>,
+    deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
+    session_state: SessionState,
+    filters: Vec<Expr>,
+    properties: datafusion::physical_plan::PlanProperties,
+}
+
+impl UpdateExec {
+    fn new(
+        source_plan: Arc<dyn ExecutionPlan>,
+        table_provider: Arc<dyn datafusion::datasource::TableProvider>,
+        deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
+        session_state: SessionState,
+        filters: Vec<Expr>,
+    ) -> Self {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+            "count",
+            arrow::datatypes::DataType::UInt64,
+            false,
+        )]));
+        let properties = datafusion::physical_plan::PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Incremental,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self {
+            source_plan,
+            table_provider,
+            deletion_provider,
+            session_state,
+            filters,
+            properties,
+        }
+    }
+}
+
+impl std::fmt::Debug for UpdateExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpdateExec").finish_non_exhaustive()
+    }
+}
+
+impl datafusion::physical_plan::DisplayAs for UpdateExec {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "UpdateExec")
+    }
+}
+
+impl ExecutionPlan for UpdateExec {
+    fn name(&self) -> &'static str {
+        "UpdateExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.source_plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "UpdateExec requires exactly one child, got {}",
+                children.len()
+            )));
+        }
+
+        Ok(Arc::new(Self::new(
+            Arc::clone(&children[0]),
+            Arc::clone(&self.table_provider),
+            Arc::clone(&self.deletion_provider),
+            self.session_state.clone(),
+            self.filters.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> std::result::Result<SendableRecordBatchStream, DataFusionError> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(format!(
+                "UpdateExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let source_plan = Arc::clone(&self.source_plan);
+        let table_provider = Arc::clone(&self.table_provider);
+        let deletion_provider = Arc::clone(&self.deletion_provider);
+        let session_state = self.session_state.clone();
+        let filters = self.filters.clone();
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+            "count",
+            arrow::datatypes::DataType::UInt64,
+            false,
+        )]));
+
+        let stream = futures::stream::once(async move {
+            use futures::TryStreamExt;
+
+            let source_stream = execute_stream(Arc::clone(&source_plan), Arc::clone(&context))?;
+            let updated_batches: Vec<RecordBatch> = source_stream.try_collect().await?;
+
+            // Normalize update output to match the target table schema (including nullability)
+            // before performing any destructive operation.
+            let target_schema = table_provider.schema();
+            let normalized_batches = updated_batches
+                .into_iter()
+                .map(|batch| arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema)))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(DataFusionError::from)?;
+
+            let delete_plan = deletion_provider.delete_from(&session_state, &filters).await?;
+            let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
+            let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
+
+            let deleted_count = delete_batches
+                .iter()
+                .flat_map(RecordBatch::columns)
+                .find_map(|arr| {
+                    arr.as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .and_then(|counts| counts.values().first().copied())
+                })
+                .unwrap_or(0);
+
+            if !normalized_batches.is_empty() {
+                let input_exec = MemorySourceConfig::try_new_exec(
+                    &[normalized_batches],
+                    Arc::clone(&target_schema),
+                    None,
+                )?;
+                let insert_plan = table_provider
+                    .insert_into(&session_state, input_exec, InsertOp::Append)
+                    .await?;
+                let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
+                let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
+            }
+
+            let result = RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    "count",
+                    Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
+                    false,
+                ),
+            ])
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+            Ok(result)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 }
 

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -29,8 +29,9 @@ use crate::datafusion::DataFusion;
 /// Reads (SELECT queries) are allowed on all tables.
 /// INSERT and DELETE operations are only allowed on datasets that are configured as writable,
 /// and are not allowed on internal Spice tables.
+/// UPDATE operations are only allowed on writable Cayenne catalog tables.
 /// DDL operations are only allowed on catalogs configured with `access: read_write_create`.
-/// DML (other than allowed INSERT/DELETE), COPY, and Statement operations are not permitted.
+/// DML (other than allowed INSERT/DELETE/UPDATE), COPY, and Statement operations are not permitted.
 ///
 /// # Returns
 /// * `Ok(())` if the plan is valid
@@ -108,6 +109,35 @@ pub fn validate_sql_query_operations(
                         dml.table_name
                     )
                 }
+            } else if matches!(&dml.op, datafusion::logical_expr::WriteOp::Update) {
+                if super::is_spice_internal_dataset(&dml.table_name) {
+                    return plan_err!(
+                        "UPDATE operations are not allowed on Spice system dataset '{}'.",
+                        dml.table_name
+                    );
+                }
+
+                let target_catalog = dml
+                    .table_name
+                    .catalog()
+                    .unwrap_or(super::SPICE_DEFAULT_CATALOG);
+
+                if !df.is_catalog_writable(target_catalog) {
+                    return plan_err!(
+                        "UPDATE operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
+                        dml.table_name
+                    );
+                }
+
+                if !is_cayenne_catalog(df, target_catalog) {
+                    return plan_err!(
+                        "UPDATE operations are only supported on writable Cayenne catalog tables. Table '{}', catalog '{}' is not Cayenne-backed.",
+                        dml.table_name,
+                        target_catalog
+                    );
+                }
+
+                Ok(TreeNodeRecursion::Continue)
             } else { plan_err!("Operation is not allowed: {}", dml.name()) }
         }
         LogicalPlan::Copy(_) => {
@@ -125,6 +155,22 @@ pub fn validate_sql_query_operations(
         _ => Ok(TreeNodeRecursion::Continue),
     })?;
     Ok(())
+}
+
+fn is_cayenne_catalog(df: &Arc<DataFusion>, catalog_name: &str) -> bool {
+    #[cfg(not(windows))]
+    {
+        df.ctx
+            .catalog(catalog_name)
+            .is_some_and(|catalog| super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref()))
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = df;
+        let _ = catalog_name;
+        false
+    }
 }
 
 /// Validates DDL operations. DDL is only allowed on catalogs with `access: read_write_create`.


### PR DESCRIPTION
## Summary
- add SQL validator support for `UPDATE` on writable Cayenne catalog tables
- execute `UPDATE` with a physical plan that performs delete + append semantics
- register Cayenne table providers through deletion adapters needed by update/delete paths

## Notes
- stacked on top of `peasee/260225-distributed-cayenne-v2`
