### PR TITLE
fix(cluster): rewrite table scans inside subqueries for distributed execution

### DIFF
--- a/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
+++ b/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
@@ -20,7 +20,7 @@ use datafusion::{
     arrow::datatypes::SchemaRef,
     common::{
         Result,
-        tree_node::{Transformed, TransformedResult, TreeNode},
+        tree_node::{Transformed, TransformedResult},
     },
     config::ConfigOptions,
     datasource::{DefaultTableSource, TableProvider},
@@ -94,7 +94,7 @@ impl AnalyzerRule for PartitionedTableScanRewrite {
         plan: LogicalPlan,
         _config: &ConfigOptions,
     ) -> Result<LogicalPlan, DataFusionError> {
-        plan.transform_up(|plan| {
+        plan.transform_up_with_subqueries(|plan| {
             let LogicalPlan::TableScan(scan) = &plan else {
                 return Ok(Transformed::no(plan));
             };


### PR DESCRIPTION
## Problem

The `PartitionedTableScanRewrite` analyzer rule uses `transform_up()` which only walks `LogicalPlan` nodes. Table scans inside subquery expressions (`EXISTS`, `IN`, scalar subqueries) live inside `Expr` nodes and are never visited, so they are not rewritten to `FlightSqlExec` for routing to executors.

After DataFusion's optimizer decorrelates these subqueries into joins, the unrewritten table scans call `AcceleratedTable::scan()` on the **scheduler**, where `initial_load_completed` is always `false` (the scheduler never loads acceleration data). This causes `"Acceleration not ready"` errors for any query containing subqueries.

### Affected queries

All TPC-H queries with subqueries fail permanently on the scheduler:
- **Always fail**: q2, q4, q11, q16, q17, q18, q20, q21, q22
- **Work correctly** (no subqueries): q1, q3, q5–q10, q12–q14, q19

This was the root cause of persistent "Acceleration not ready" failures in [spicebench CI run #22443384646](https://github.com/spiceai/spicebench/actions/runs/22443384646), where subquery queries showed ~80 failures each while simple JOIN queries had only 2–4 early startup failures.

## Fix

Use `transform_up_with_subqueries()` instead of `transform_up()`. This is a DataFusion `TreeNode` API that additionally enters subquery expressions (`Expr::ScalarSubquery`, `Expr::Exists`, `Expr::InSubquery`) and recursively transforms their inner `LogicalPlan` trees — ensuring all table scans are rewritten regardless of nesting.

## Verification

Confirmed locally with a scheduler + executor cluster:

**Before** (q22 with scalar subquery + EXISTS):
```
physical_plan_error: External error: Acceleration not ready; loading initial data for customer
```

**After**: All 22 TPC-H queries produce physical plans with `FlightSqlExec` routing to the executor.

Ref: spiceai/spicebench#147