### PR TITLE
fix: Set catalog mode to readwritecreate in spidapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18826,7 +18826,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=523a2fdcbee64982e14db992c8811207d370d05c#523a2fdcbee64982e14db992c8811207d370d05c"
+source = "git+https://github.com/spiceai/spicebench.git?rev=27754b5810745e3afc7bb703ecc13aa9835732ea#27754b5810745e3afc7bb703ecc13aa9835732ea"
 dependencies = [
  "arrow-schema",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "523a2fdcbee64982e14db992c8811207d370d05c", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "27754b5810745e3afc7bb703ecc13aa9835732ea", features = ["server"] } # branch: trunk
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -74,6 +74,12 @@ impl Catalog {
             metrics: None,
         }
     }
+
+    #[must_use]
+    pub fn with_access(mut self, access: AccessMode) -> Self {
+        self.access = access;
+        self
+    }
 }
 
 impl WithDependsOn<Catalog> for Catalog {

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -197,6 +197,7 @@ impl Handler for SpidapterHandler {
                 .as_ref()
                 .filter(|t| matches!(t, EtlSinkType::Adbc))
                 .map(|_| "spicebench.bench".to_string()),
+            read_driver: None,
         };
 
         self.runs.insert(run_id, state);

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -20,9 +20,10 @@ use async_trait::async_trait;
 use spice_cloud_client::CloudClient;
 use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
 use spicepod::component::ComponentOrReference;
+use spicepod::component::access::AccessMode;
 use spicepod::component::catalog::Catalog;
 use spicepod::component::dataset::Dataset;
-use spicepod::component::runtime::{Runtime, TelemetryConfig};
+use spicepod::component::runtime::{Flight, Runtime, TelemetryConfig};
 use spicepod::param::Params;
 use spicepod::spec::SpicepodDefinition;
 use system_adapter_protocol::{
@@ -561,15 +562,17 @@ fn generate_adbc_spicepod(run_id: &Uuid) -> anyhow::Result<String> {
             enabled: false,
             ..TelemetryConfig::default()
         },
+        flight: Some(Flight {
+            do_put_rate_limit_enabled: false,
+            ..Flight::default()
+        }),
         ..Runtime::default()
     };
 
-    spicepod
-        .catalogs
-        .push(ComponentOrReference::Component(Catalog::new(
-            "cayenne".to_string(),
-            "spicebench".to_string(),
-        )));
+    spicepod.catalogs.push(ComponentOrReference::Component(
+        Catalog::new("cayenne".to_string(), "spicebench".to_string())
+            .with_access(AccessMode::ReadWriteCreate),
+    ));
     yaml::to_string(&spicepod).map_err(|e| anyhow::anyhow!("Failed to serialize spicepod: {e}"))
 }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Sets the Catalog access mode to ReadWriteCreate, which is required for DDL and ingestion with spidapter
* Disables the DoPut rate limiter in the spidapter Catalog spicepod
