### PR TITLE
feat(runtime): introduce RuntimeReadyState to control readiness criteria

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -356,7 +356,7 @@ jobs:
             image=moby/buildkit:latest
 
       - name: Build ARM64 Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: Dockerfile.local
@@ -401,7 +401,7 @@ jobs:
             image=moby/buildkit:latest
 
       - name: Build AMD64 Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: Dockerfile.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3754,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3779,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clickhouse-rs"
@@ -6419,13 +6419,14 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "dialoguer"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console 0.16.2",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -6477,7 +6478,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7039,7 +7040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9268,7 +9269,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9904,7 +9905,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9977,7 +9978,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12053,7 +12054,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13789,8 +13790,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.16.1",
- "parking_lot 0.12.5",
+ "hashbrown 0.5.0",
+ "parking_lot 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -14343,7 +14344,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14681,7 +14682,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14719,9 +14720,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16414,7 +16415,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16515,7 +16516,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17125,7 +17126,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17767,7 +17768,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -19074,7 +19075,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -22353,7 +22354,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d
 candle-transformers = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0", package = "candle-transformers" }
 charset = "0.1.5"
 chrono = "0.4.42"
-clap = { version = "4.5.60", features = ["derive", "env"] }
+clap = { version = "4.5.54", features = ["derive", "env"] }
 clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0.2.1", features = [
     "tokio_io",
     "tls",

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -77,17 +77,9 @@ impl CloudClient {
     // Apps
     // ========================================================================
 
-    pub async fn get_app_metrics(
-        &self,
-        app_id: i64,
-        window: Option<&str>,
-    ) -> Result<MetricsResponse> {
-        self.inner
-            .get_app_metrics(app_id, window)
-            .await
-            .map_err(into_cli)
+    pub async fn get_app_metrics(&self, app_id: i64) -> Result<MetricsResponse> {
+        self.inner.get_app_metrics(app_id).await.map_err(into_cli)
     }
-
     pub async fn list_apps(&self) -> Result<Vec<App>> {
         self.inner.list_apps().await.map_err(into_cli)
     }

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -217,10 +217,6 @@ pub struct MetricsArgs {
     /// App name in org/app format (uses linked app if not specified)
     #[arg(long)]
     pub app: Option<String>,
-
-    /// Window for counter metrics (e.g. 1m, 5m, 1h). Parsed as a duration.
-    #[arg(long, value_parser = parse_window)]
-    pub window: Option<String>,
 }
 
 // ============================================================================
@@ -1023,15 +1019,12 @@ async fn execute_metrics(args: &MetricsArgs) -> Result<()> {
     let app_name = require_app(args.app.as_deref())?;
     let app = client.get_app(&app_name).await?;
 
-    let response = client
-        .get_app_metrics(app.id, args.window.as_deref())
-        .await?;
+    let response = client.get_app_metrics(app.id).await?;
 
     if response.metrics.is_empty() {
         println!("No metrics available for {app_name}");
         return Ok(());
     }
-    let has_window = args.window.is_some();
 
     let mut table = TableOutput::new(vec![
         "POD",
@@ -1048,14 +1041,12 @@ async fn execute_metrics(args: &MetricsArgs) -> Result<()> {
                 .map_or_else(|| "-".to_string(), |v| format!("{v:.1}")),
             m.memory_usage_bytes
                 .map_or_else(|| "-".to_string(), format_bytes),
-            m.disk_read_bytes
-                .map_or_else(|| "-".to_string(), |v| format_bytes_f64(v, has_window)),
-            m.disk_read_iops
-                .map_or_else(|| "-".to_string(), |v| format!("{v:.1}")),
-            m.disk_write_bytes
-                .map_or_else(|| "-".to_string(), |v| format_bytes_f64(v, has_window)),
-            m.disk_write_iops
-                .map_or_else(|| "-".to_string(), |v| format!("{v:.1}")),
+            m.filesystem_usage_bytes
+                .map_or_else(|| "-".to_string(), format_bytes),
+            m.filesystem_available_bytes
+                .map_or_else(|| "-".to_string(), format_bytes),
+            m.filesystem_capacity_bytes
+                .map_or_else(|| "-".to_string(), format_bytes),
         ]);
     }
     table.print();
@@ -1106,46 +1097,9 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-fn format_bytes_f64(bytes: f64, is_windowed: bool) -> String {
-    const KIB: f64 = 1024.0;
-    const MIB: f64 = KIB * 1024.0;
-    const GIB: f64 = MIB * 1024.0;
-
-    if is_windowed {
-        // increase() over window — show as a delta amount
-        if bytes >= GIB {
-            format!("{:.1} GiB", bytes / GIB)
-        } else if bytes >= MIB {
-            format!("{:.1} MiB", bytes / MIB)
-        } else if bytes >= KIB {
-            format!("{:.1} KiB", bytes / KIB)
-        } else {
-            format!("{bytes:.0} B")
-        }
-    } else {
-        // Raw cumulative counter — show total bytes
-        if bytes >= GIB {
-            format!("{:.1} GiB", bytes / GIB)
-        } else if bytes >= MIB {
-            format!("{:.1} MiB", bytes / MIB)
-        } else if bytes >= KIB {
-            format!("{:.1} KiB", bytes / KIB)
-        } else {
-            format!("{bytes:.0} B")
-        }
-    }
-}
-
 // ============================================================================
 // Helper functions
 // ============================================================================
-
-/// Validate that `--window` parses as a duration via `fundu`.
-fn parse_window(s: &str) -> std::result::Result<String, String> {
-    fundu::parse_duration(s)
-        .map(|_| s.to_string())
-        .map_err(|e| format!("invalid duration '{s}': {e}"))
-}
 
 /// Get the app name from the flag or the linked app.
 fn require_app(flag_value: Option<&str>) -> Result<String> {

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -14,7 +14,7 @@ arrow = { workspace = true, features = ["chrono-tz"] }
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 arrow-json.workspace = true
 clap.workspace = true
-dialoguer = "0.12"
+dialoguer = "0.11"
 dirs = "6"
 flight_client = { path = "../flight_client" }
 futures.workspace = true

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -39,6 +39,7 @@ use app::App;
 use datafusion::optimizer::AnalyzerRule;
 use runtime_datafusion::analyzer_rule::{PartitionedTableScanRewrite, TablePartitionProvider};
 use spicepod::component::caching::Caching;
+use spicepod::component::runtime::RuntimeReadyState as SpicepodRuntimeReadyState;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
 use tokio::runtime::Handle;
@@ -210,6 +211,16 @@ impl RuntimeBuilder {
             .app
             .as_ref()
             .is_none_or(|app| app.runtime.task_history.enabled);
+
+        let runtime_ready_state = self
+            .app
+            .as_ref()
+            .map_or(SpicepodRuntimeReadyState::default(), |app| app.runtime.ready_state);
+
+        self.runtime_status.set_ready_state(match runtime_ready_state {
+            SpicepodRuntimeReadyState::OnLoad => status::RuntimeReadyState::OnLoad,
+            SpicepodRuntimeReadyState::OnRegistration => status::RuntimeReadyState::OnRegistration,
+        });
 
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
         let url_tables_enabled = App::get_runtime_param_opt::<String>(&self.app, "url_tables")

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -21,21 +21,17 @@ use ::cache::{
     key::CacheKey,
     result::{CacheStatus, query::QueryResult},
 };
-use arrow::array::UInt64Array;
 use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
     common::ParamValues,
-    datasource::memory::MemorySourceConfig,
     error::DataFusionError,
     execution::{SendableRecordBatchStream, TaskContext},
-    logical_expr::dml::InsertOp,
-    logical_expr::{Expr, LogicalPlan},
+    logical_expr::LogicalPlan,
     physical_plan::{ExecutionPlan, execute_stream, stream::RecordBatchStreamAdapter},
 };
-use datafusion_expr::expr_rewriter::unnormalize_col;
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
 use tokio::time::Instant;
@@ -71,7 +67,6 @@ use super::managed_runtime;
 use crate::datafusion::{
     DataFusion, query::cache::RequestCacheManager, sql_validator::validate_sql_query_operations,
 };
-use data_components::delete::get_deletion_provider;
 use managed_runtime::ManagedRuntimeError;
 use opentelemetry::KeyValue;
 use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
@@ -687,27 +682,24 @@ impl Query {
                         }
                     };
                     (stream, df_plan)
-                } else if let LogicalPlan::Dml(dml) = &*plan
-                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
-                {
+                } else if let LogicalPlan::Dml(dml) = &*plan && matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
                     // DELETE operations need special handling because DataFusion doesn't
                     // support DELETE natively. We intercept the DML Delete plan, extract
                     // the filter predicates, and delegate to the DeletionTableProvider.
-                    let delete_plan =
-                        match create_delete_physical_plan(dml, &ctx.df, &session).await {
-                            Ok(p) => p,
-                            Err(e) => {
-                                let e = find_datafusion_root(e);
-                                let error_code = ErrorCode::from(&e);
-                                handle_error!(
-                                    tracker,
-                                    &request_context,
-                                    error_code,
-                                    e,
-                                    UnableToExecuteQuery
-                                )
-                            }
-                        };
+                    let delete_plan = match create_delete_physical_plan(dml, &ctx.df).await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let error_code = ErrorCode::from(&e);
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                error_code,
+                                e,
+                                UnableToExecuteQuery
+                            )
+                        }
+                    };
 
                     let task_ctx = Arc::new(TaskContext::from(&session));
                     let stream = match execute_stream(Arc::clone(&delete_plan), task_ctx) {
@@ -725,45 +717,6 @@ impl Query {
                         }
                     };
                     (stream, delete_plan)
-                } else if let LogicalPlan::Dml(dml) = &*plan
-                    && matches!(&dml.op, datafusion::logical_expr::WriteOp::Update)
-                {
-                    // UPDATE operations are rewritten to an execution plan that:
-                    // 1) materializes updated rows from the DML input,
-                    // 2) deletes matched rows,
-                    // 3) inserts updated rows back.
-                    let update_plan =
-                        match create_update_physical_plan(dml, &ctx.df, &session).await {
-                            Ok(p) => p,
-                            Err(e) => {
-                                let e = find_datafusion_root(e);
-                                let error_code = ErrorCode::from(&e);
-                                handle_error!(
-                                    tracker,
-                                    &request_context,
-                                    error_code,
-                                    e,
-                                    UnableToExecuteQuery
-                                )
-                            }
-                        };
-
-                    let task_ctx = Arc::new(TaskContext::from(&session));
-                    let stream = match execute_stream(Arc::clone(&update_plan), task_ctx) {
-                        Ok(stream) => stream,
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            let error_code = ErrorCode::from(&e);
-                            handle_error!(
-                                tracker,
-                                &request_context,
-                                error_code,
-                                e,
-                                UnableToExecuteQuery
-                            )
-                        }
-                    };
-                    (stream, update_plan)
                 } else {
                     // For regular plans, use the standard physical plan execution
                     let physical_plan = match session.create_physical_plan(&plan).await {
@@ -807,13 +760,9 @@ impl Query {
             let res_stream = if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
                 && !matches!(
                     &*plan,
-                    LogicalPlan::Dml(dml)
-                        if matches!(
-                            &dml.op,
-                            datafusion::logical_expr::WriteOp::Delete
-                                | datafusion::logical_expr::WriteOp::Update
-                        )
-                ) {
+                    LogicalPlan::Dml(dml) if matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete)
+                )
+            {
                 let plan_schema = Arc::clone(plan.schema().inner());
                 let res_schema = res_stream.schema();
 
@@ -1311,10 +1260,11 @@ fn reconcile_stream_nullability(
 async fn create_delete_physical_plan(
     dml: &datafusion::logical_expr::DmlStatement,
     df: &Arc<DataFusion>,
-    session_state: &SessionState,
 ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    use data_components::delete::get_deletion_provider;
+
     // Extract filter expressions from the source plan
-    let filters = extract_dml_filters(&dml.input);
+    let filters = extract_delete_filters(&dml.input);
 
     // Look up the table provider
     let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
@@ -1332,234 +1282,24 @@ async fn create_delete_physical_plan(
         ))
     })?;
 
-    deletion_provider.delete_from(session_state, &filters).await
+    let session_state = df.ctx.state();
+    deletion_provider
+        .delete_from(&session_state, &filters)
+        .await
 }
 
-/// Extract filter expressions from a DML source logical plan.
+/// Extract filter expressions from a DELETE's source logical plan.
 ///
-/// The source plan is generally `Filter(predicate, scan)`, and for `UPDATE`
-/// may be wrapped as `Projection(Filter(...))`.
+/// The source plan is either `Filter(predicate, scan)` or just `scan`.
 /// Returns the individual conjunctive filter expressions, or an empty
 /// vec if there is no WHERE clause.
-fn extract_dml_filters(source: &LogicalPlan) -> Vec<Expr> {
+fn extract_delete_filters(source: &LogicalPlan) -> Vec<datafusion::logical_expr::Expr> {
     use datafusion_expr::utils::split_conjunction_owned;
 
-    match source {
-        LogicalPlan::Filter(filter) => {
-            split_conjunction_owned(unnormalize_col(filter.predicate.clone()))
-        }
-        LogicalPlan::Projection(projection) => extract_dml_filters(projection.input.as_ref()),
-        LogicalPlan::SubqueryAlias(alias) => extract_dml_filters(alias.input.as_ref()),
-        _ => vec![],
-    }
-}
-
-/// Create a physical execution plan for an `UPDATE` statement.
-///
-/// The returned plan executes update semantics as:
-/// 1) materialize updated rows from `dml.input`,
-/// 2) delete matched source rows,
-/// 3) insert updated rows with append mode.
-async fn create_update_physical_plan(
-    dml: &datafusion::logical_expr::DmlStatement,
-    df: &Arc<DataFusion>,
-    session_state: &SessionState,
-) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    let table_provider = df.get_table(&dml.table_name).await.ok_or_else(|| {
-        DataFusionError::Plan(format!(
-            "Table '{}' not found for UPDATE operation",
-            dml.table_name
-        ))
-    })?;
-
-    let deletion_provider =
-        get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
-            DataFusionError::Plan(format!(
-                "Table '{}' does not support UPDATE operations",
-                dml.table_name
-            ))
-        })?;
-
-    let source_plan = session_state.create_physical_plan(&dml.input).await?;
-    let filters = extract_dml_filters(&dml.input);
-
-    Ok(Arc::new(UpdateExec::new(
-        source_plan,
-        table_provider,
-        deletion_provider,
-        session_state.clone(),
-        filters,
-    )))
-}
-
-struct UpdateExec {
-    source_plan: Arc<dyn ExecutionPlan>,
-    table_provider: Arc<dyn datafusion::datasource::TableProvider>,
-    deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
-    session_state: SessionState,
-    filters: Vec<Expr>,
-    properties: datafusion::physical_plan::PlanProperties,
-}
-
-impl UpdateExec {
-    fn new(
-        source_plan: Arc<dyn ExecutionPlan>,
-        table_provider: Arc<dyn datafusion::datasource::TableProvider>,
-        deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
-        session_state: SessionState,
-        filters: Vec<Expr>,
-    ) -> Self {
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
-            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
-        ]));
-        let properties = datafusion::physical_plan::PlanProperties::new(
-            datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
-            datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
-            datafusion::physical_plan::execution_plan::EmissionType::Incremental,
-            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
-        Self {
-            source_plan,
-            table_provider,
-            deletion_provider,
-            session_state,
-            filters,
-            properties,
-        }
-    }
-}
-
-impl std::fmt::Debug for UpdateExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UpdateExec").finish_non_exhaustive()
-    }
-}
-
-impl datafusion::physical_plan::DisplayAs for UpdateExec {
-    fn fmt_as(
-        &self,
-        _t: datafusion::physical_plan::DisplayFormatType,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "UpdateExec")
-    }
-}
-
-impl ExecutionPlan for UpdateExec {
-    fn name(&self) -> &'static str {
-        "UpdateExec"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.source_plan]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        if children.len() != 1 {
-            return Err(DataFusionError::Internal(format!(
-                "UpdateExec requires exactly one child, got {}",
-                children.len()
-            )));
-        }
-
-        Ok(Arc::new(Self::new(
-            Arc::clone(&children[0]),
-            Arc::clone(&self.table_provider),
-            Arc::clone(&self.deletion_provider),
-            self.session_state.clone(),
-            self.filters.clone(),
-        )))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> std::result::Result<SendableRecordBatchStream, DataFusionError> {
-        if partition != 0 {
-            return Err(DataFusionError::Execution(format!(
-                "UpdateExec only supports partition 0, got {partition}"
-            )));
-        }
-
-        let source_plan = Arc::clone(&self.source_plan);
-        let table_provider = Arc::clone(&self.table_provider);
-        let deletion_provider = Arc::clone(&self.deletion_provider);
-        let session_state = self.session_state.clone();
-        let filters = self.filters.clone();
-
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
-            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
-        ]));
-
-        let stream = futures::stream::once(async move {
-            use futures::TryStreamExt;
-
-            let source_stream = execute_stream(Arc::clone(&source_plan), Arc::clone(&context))?;
-            let updated_batches: Vec<RecordBatch> = source_stream.try_collect().await?;
-
-            // Normalize update output to match the target table schema (including nullability)
-            // before performing any destructive operation.
-            let target_schema = table_provider.schema();
-            let normalized_batches = updated_batches
-                .into_iter()
-                .map(|batch| {
-                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
-                })
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(DataFusionError::from)?;
-
-            let delete_plan = deletion_provider
-                .delete_from(&session_state, &filters)
-                .await?;
-            let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
-            let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
-
-            let deleted_count = delete_batches
-                .iter()
-                .flat_map(RecordBatch::columns)
-                .find_map(|arr| {
-                    arr.as_any()
-                        .downcast_ref::<UInt64Array>()
-                        .and_then(|counts| counts.values().first().copied())
-                })
-                .unwrap_or(0);
-
-            if !normalized_batches.is_empty() {
-                let input_exec = MemorySourceConfig::try_new_exec(
-                    &[normalized_batches],
-                    Arc::clone(&target_schema),
-                    None,
-                )?;
-                let insert_plan = table_provider
-                    .insert_into(&session_state, input_exec, InsertOp::Append)
-                    .await?;
-                let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
-                let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
-            }
-
-            let result = RecordBatch::try_from_iter_with_nullable(vec![(
-                "count",
-                Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
-                false,
-            )])
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-
-            Ok(result)
-        });
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    if let LogicalPlan::Filter(filter) = source {
+        split_conjunction_owned(filter.predicate.clone())
+    } else {
+        vec![]
     }
 }
 

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -184,14 +184,14 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
     // (Initializing, Refreshing, Ready, Error, etc.)
     let dataset_statuses = df.runtime_status().get_dataset_statuses();
     if let Some(status) = dataset_statuses.get(&ds.name) {
-        return status.clone();
+        return *status;
     }
 
     // Fallback: if not in runtime status, check if table exists
     if df.table_exists(ds.name.clone()) {
         ComponentStatus::Ready
     } else {
-        ComponentStatus::error()
+        ComponentStatus::Error
     }
 }
 

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -33,6 +33,13 @@ use crate::metrics;
 // Re-export ComponentStatus from the shared API types crate
 pub use runtime_api_types::v1::ComponentStatus;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RuntimeReadyState {
+    #[default]
+    OnLoad,
+    OnRegistration,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct RuntimeStatus {
     /// Stores the current status of all components.
@@ -41,6 +48,8 @@ pub struct RuntimeStatus {
     ever_ready_components: Arc<RwLock<HashSet<String>>>,
     /// Tracks if the runtime is in the process of shutting down.
     is_shutdown: Arc<AtomicBool>,
+    /// Controls how runtime readiness is computed.
+    ready_state: Arc<RwLock<RuntimeReadyState>>,
     /// Per-component notifiers for status change subscriptions.
     notifiers: Arc<RwLock<HashMap<String, watch::Sender<ComponentStatus>>>>,
 }
@@ -52,8 +61,17 @@ impl RuntimeStatus {
             statuses: Arc::new(RwLock::new(HashMap::new())),
             ever_ready_components: Arc::new(RwLock::new(HashSet::new())),
             is_shutdown: Arc::new(AtomicBool::new(false)),
+            ready_state: Arc::new(RwLock::new(RuntimeReadyState::default())),
             notifiers: Arc::new(RwLock::new(HashMap::new())),
         })
+    }
+
+    pub fn set_ready_state(&self, ready_state: RuntimeReadyState) {
+        let mut configured_ready_state = self
+            .ready_state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *configured_ready_state = ready_state;
     }
 
     #[must_use]
@@ -199,11 +217,12 @@ impl RuntimeStatus {
             return false;
         }
 
+        let ready_state = *self
+            .ready_state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let statuses = match self.statuses.read() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let ever_ready = match self.ever_ready_components.read() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
@@ -212,10 +231,22 @@ impl RuntimeStatus {
             return false; // No components registered yet
         }
 
-        // Check if all registered components have been ready at least once
-        statuses
-            .keys()
-            .all(|component| ever_ready.contains(component))
+        match ready_state {
+            RuntimeReadyState::OnLoad => {
+                let ever_ready = match self.ever_ready_components.read() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+
+                // Check if all registered components have been ready at least once
+                statuses
+                    .keys()
+                    .all(|component| ever_ready.contains(component))
+            }
+            RuntimeReadyState::OnRegistration => statuses
+                .values()
+                .all(|status| !matches!(status, ComponentStatus::ShuttingDown)),
+        }
     }
 
     /// Returns the status of all registered components.
@@ -428,6 +459,105 @@ mod tests {
             status.get_component_status("dataset:test_dataset"),
             Some(ComponentStatus::Ready)
         );
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_requires_successful_registration() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        // Empty statuses are not ready.
+        assert!(!status.is_ready());
+
+        // Initializing still counts as registered.
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        assert!(status.is_ready());
+
+        // Refreshing stays ready.
+        status.update_dataset(&dataset, ComponentStatus::Refreshing);
+        assert!(status.is_ready());
+
+        // Error still counts as registered for on_registration mode.
+        status.update_dataset(&dataset, ComponentStatus::error());
+        assert!(status.is_ready());
+
+        // Explicit shutting down state for a component is not ready.
+        status.update_dataset(&dataset, ComponentStatus::ShuttingDown);
+        assert!(!status.is_ready());
+
+        // Runtime-level shutdown always forces not ready.
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        assert!(status.is_ready());
+        status.mark_shutdown();
+        assert!(!status.is_ready());
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_allows_mixed_component_states() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        status.update_dataset(&dataset, ComponentStatus::error());
+        status.update_model("test_model", ComponentStatus::Initializing);
+        status.update_tool("test_tool", ComponentStatus::Disabled);
+
+        assert!(status.is_ready());
+
+        status.update_tool("test_tool", ComponentStatus::ShuttingDown);
+        assert!(!status.is_ready());
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_all_component_types() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("dataset_a");
+        let view = TableReference::bare("view_a");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        status.update_catalog("catalog_a", ComponentStatus::Initializing);
+        status.update_dataset(&dataset, ComponentStatus::error());
+        status.update_model("model_a", ComponentStatus::Disabled);
+        status.update_tool("tool_a", ComponentStatus::Refreshing);
+        status.update_tool_catalog("tool_catalog_a", ComponentStatus::Ready);
+        status.update_llm("llm_a", ComponentStatus::error());
+        status.update_embedding("embedding_a", ComponentStatus::Initializing);
+        status.update_view(&view, ComponentStatus::Ready);
+        status.update_worker("worker_a", ComponentStatus::Disabled);
+        status.update_cluster("cluster_node_a", ComponentStatus::error());
+
+        assert!(
+            status.is_ready(),
+            "on_registration should be ready when all components are registered and none are ShuttingDown"
+        );
+
+        status.update_embedding("embedding_a", ComponentStatus::ShuttingDown);
+        assert!(
+            !status.is_ready(),
+            "any component in ShuttingDown should make runtime not ready"
+        );
+    }
+
+    #[test]
+    fn test_is_ready_on_load_still_requires_ever_ready() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnLoad);
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        assert!(!status.is_ready());
+
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        assert!(status.is_ready());
+
+        // Once ever-ready is achieved, transient non-ready states still satisfy OnLoad mode.
+        status.update_dataset(&dataset, ComponentStatus::Refreshing);
+        assert!(status.is_ready());
     }
 
     #[tokio::test]

--- a/crates/runtime/tests/ready_state/mod.rs
+++ b/crates/runtime/tests/ready_state/mod.rs
@@ -54,7 +54,8 @@ use runtime::{
     Runtime,
     component::dataset::Dataset,
     dataconnector::{
-        self, DataConnector, DataConnectorError, DataConnectorFactory, NewDataConnectorResult,
+        self, ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
+        NewDataConnectorResult,
         parameters::ConnectorParams,
     },
     parameters::ParameterSpec,
@@ -63,6 +64,7 @@ use runtime_request_context::{AsyncMarker, Protocol, RequestContext};
 use spicepod::{
     acceleration::Acceleration,
     component::dataset::{Dataset as SpicepodDataset, ReadyState},
+    component::runtime::{Runtime as SpicepodRuntime, RuntimeReadyState},
 };
 
 use crate::{configure_test_datafusion, init_tracing};
@@ -445,6 +447,56 @@ impl DataConnectorFactory for SlowFederatedDataConnectorProvider {
     }
 }
 
+#[derive(Debug)]
+struct AuthErrorDataConnector;
+
+#[async_trait]
+impl DataConnector for AuthErrorDataConnector {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
+        Err(DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
+            dataconnector: "s3".to_string(),
+            connector_component: ConnectorComponent::from(dataset),
+        })
+    }
+}
+
+struct AuthErrorDataConnectorProvider;
+
+impl AuthErrorDataConnectorProvider {
+    fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+#[async_trait]
+impl DataConnectorFactory for AuthErrorDataConnectorProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn create(
+        &self,
+        _params: ConnectorParams,
+    ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(AuthErrorDataConnector) as Arc<dyn DataConnector>) })
+    }
+
+    fn prefix(&self) -> &'static str {
+        "auth-error"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        &[]
+    }
+}
+
 // Register our data connector providers
 async fn register_slow_loading_providers() {
     dataconnector::register_connector_factory(
@@ -458,6 +510,11 @@ async fn register_slow_loading_providers() {
         SlowFederatedDataConnectorProvider::new_arc(),
     )
     .await;
+}
+
+async fn register_auth_error_provider() {
+    dataconnector::register_connector_factory("auth-error", AuthErrorDataConnectorProvider::new_arc())
+        .await;
 }
 
 fn get_native_dataset(
@@ -999,6 +1056,75 @@ async fn test_ready_state_mixed_duckdb_acceleration() -> Result<(), anyhow::Erro
 
             assert_eq!(results.len(), 1, "Query should return 1 record batch");
             assert_eq!(results[0].num_rows(), 5, "Should have 5 rows of data");
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_runtime_on_registration_ready_when_dataset_is_error() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    register_auth_error_provider().await;
+
+    let request_context = Arc::new(RequestContext::builder(Protocol::Http).build());
+    request_context
+        .scope(async {
+            let runtime = SpicepodRuntime {
+                ready_state: RuntimeReadyState::OnRegistration,
+                ..Default::default()
+            };
+
+            let app = AppBuilder::new("runtime_on_registration_dataset_error")
+                .with_runtime(runtime)
+                .with_dataset(SpicepodDataset::new("auth-error://dummy", "bad_s3_credentials"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let rt_for_load = Arc::new(rt.clone());
+            let load_handle = tokio::spawn(async move {
+                rt_for_load.load_components().await;
+            });
+
+            let wait_result = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                loop {
+                    let statuses = rt.status().get_dataset_statuses();
+                    let dataset_status = statuses
+                        .iter()
+                        .find(|(name, _)| name.to_string() == "bad_s3_credentials")
+                        .map(|(_, status)| status.clone());
+
+                    if let Some(status) = dataset_status
+                        && matches!(status, runtime::status::ComponentStatus::Error(_))
+                        && rt.status().is_ready()
+                    {
+                        break;
+                    }
+
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            })
+            .await;
+
+            load_handle.abort();
+
+            assert!(
+                wait_result.is_ok(),
+                "Timed out waiting for runtime ready with dataset error in on_registration mode"
+            );
+
+            let statuses = rt.status().get_dataset_statuses();
+            let dataset_status = statuses
+                .iter()
+                .find(|(name, _)| name.to_string() == "bad_s3_credentials")
+                .map(|(_, status)| status.clone())
+                .ok_or_else(|| anyhow::anyhow!("Dataset status for bad_s3_credentials not found"))?;
+
+            assert!(matches!(dataset_status, runtime::status::ComponentStatus::Error(_)));
+            assert!(rt.status().is_ready());
 
             Ok(())
         })

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -487,17 +487,15 @@ impl CloudClient {
     // ========================================================================
 
     /// Get metrics for an app's pods.
-    pub async fn get_app_metrics(
-        &self,
-        app_id: i64,
-        window: Option<&str>,
-    ) -> Result<MetricsResponse> {
+    pub async fn get_app_metrics(&self, app_id: i64) -> Result<MetricsResponse> {
         let url = format!("{}/v1/apps/{}/metrics", self.base_url, app_id);
-        let mut request = self.client.get(&url).bearer_auth(self.token_str());
-        if let Some(w) = window {
-            request = request.query(&[("window", w)]);
-        }
-        let response = request.send().await.context(HttpRequestSnafu)?;
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(self.token_str())
+            .send()
+            .await
+            .context(HttpRequestSnafu)?;
 
         self.handle_response(response).await
     }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -72,6 +72,10 @@ pub struct Runtime {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown_timeout: Option<String>,
 
+    /// Controls when the runtime is considered ready for the `/v1/ready` endpoint.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub ready_state: RuntimeReadyState,
+
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
     /// are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -102,6 +106,20 @@ impl Runtime {
             Ok(None)
         }
     }
+}
+
+/// Controls when the runtime readiness probe reports the runtime as ready.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeReadyState {
+    /// Runtime becomes ready after all registered components have reached `Ready` at least once.
+    #[default]
+    OnLoad,
+    /// Runtime becomes ready once all registered components are successfully registered,
+    /// even if they are not yet in `Ready` state.
+    OnRegistration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -770,6 +788,9 @@ pub struct RuntimeDeserializer {
     /// and components to shut down cleanly during runtime termination
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown_timeout: Option<String>,
+    /// Controls when the runtime is considered ready for the `/v1/ready` endpoint.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub ready_state: RuntimeReadyState,
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
     /// are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -848,6 +869,7 @@ impl TryFrom<RuntimeDeserializer> for Runtime {
             cors: deserializer.cors,
             flight: deserializer.flight,
             shutdown_timeout: deserializer.shutdown_timeout,
+            ready_state: deserializer.ready_state,
             output_level: deserializer.output_level,
             query: if query == Query::default() {
                 None
@@ -1733,5 +1755,25 @@ mod tests {
             "caching.sql_results should take priority"
         );
         assert_eq!(sql_results.item_ttl, Some("30s".to_string()));
+    }
+
+    #[test]
+    fn test_runtime_ready_state_default() {
+        let yaml = r"
+            caching:
+              sql_results:
+                enabled: true
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.ready_state, RuntimeReadyState::OnLoad);
+    }
+
+    #[test]
+    fn test_runtime_ready_state_on_registration() {
+        let yaml = r"
+            ready_state: on_registration
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.ready_state, RuntimeReadyState::OnRegistration);
     }
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -78,54 +78,6 @@ fn metadata_string(metadata: &HashMap<String, serde_json::Value>, key: &str) -> 
         .map(ToString::to_string)
 }
 
-/// Average non-`None` `f64` values extracted from pods.
-#[expect(clippy::cast_precision_loss)]
-fn avg_opt(
-    pods: &[&spice_cloud_client::types::PodMetrics],
-    f: fn(&spice_cloud_client::types::PodMetrics) -> Option<f64>,
-) -> Option<f64> {
-    let (sum, count) = pods.iter().fold((0.0, 0_u64), |(s, c), p| {
-        if let Some(v) = f(p) {
-            (s + v, c + 1)
-        } else {
-            (s, c)
-        }
-    });
-    (count > 0).then_some(sum / (count as f64))
-}
-
-/// Sum non-`None` `u64` values extracted from pods.
-fn sum_opt_u64(
-    pods: &[&spice_cloud_client::types::PodMetrics],
-    f: fn(&spice_cloud_client::types::PodMetrics) -> Option<u64>,
-) -> Option<u64> {
-    let (sum, any) = pods.iter().fold((0_u64, false), |(s, any), p| {
-        if let Some(v) = f(p) {
-            (s.saturating_add(v), true)
-        } else {
-            (s, any)
-        }
-    });
-    any.then_some(sum)
-}
-
-/// Sum non-`None` `f64` values and convert to `u64`.
-#[expect(clippy::cast_sign_loss)]
-#[expect(clippy::cast_possible_truncation)]
-fn sum_opt_f64_as_u64(
-    pods: &[&spice_cloud_client::types::PodMetrics],
-    f: fn(&spice_cloud_client::types::PodMetrics) -> Option<f64>,
-) -> Option<u64> {
-    let (sum, any) = pods.iter().fold((0.0_f64, false), |(s, any), p| {
-        if let Some(v) = f(p) {
-            (s + v, true)
-        } else {
-            (s, any)
-        }
-    });
-    any.then_some(sum.round() as u64)
-}
-
 /// System adapter handler that provisions Spice Cloud apps.
 struct SpidapterHandler {
     /// Active runs keyed by run ID.
@@ -210,7 +162,7 @@ impl Handler for SpidapterHandler {
 
         let cloud_metrics = state
             .cloud
-            .get_app_metrics(state.app_id, None)
+            .get_app_metrics(state.app_id)
             .await
             .map_err(|e| format!("Failed to fetch metrics: {e}"))?;
 
@@ -219,13 +171,35 @@ impl Handler for SpidapterHandler {
         let resource = if pods.is_empty() {
             ResourceMetrics::default()
         } else {
+            let avg_cpu = match pods
+                .iter()
+                .filter_map(|p| p.cpu_usage_percent.is_some().then_some(1.0))
+                .sum::<f64>()
+            {
+                0.0 => None,
+                n => Some(pods.iter().filter_map(|p| p.cpu_usage_percent).sum::<f64>() / n),
+            };
+
+            let total_memory = match pods
+                .iter()
+                .filter_map(|p| p.memory_usage_bytes.is_some().then_some(1_u64))
+                .sum::<u64>()
+            {
+                0 => None,
+                n => Some(
+                    pods.iter()
+                        .filter_map(|p| p.memory_usage_bytes)
+                        .sum::<u64>()
+                        / n,
+                ),
+            };
             ResourceMetrics {
-                cpu_usage_percent: avg_opt(&pods, |p| p.cpu_usage_percent),
-                memory_usage_bytes: sum_opt_u64(&pods, |p| p.memory_usage_bytes),
-                disk_read_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_read_bytes),
-                disk_write_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes),
-                disk_read_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_read_iops),
-                disk_write_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_write_iops),
+                cpu_usage_percent: avg_cpu,
+                memory_usage_bytes: total_memory,
+                disk_read_bytes: None,
+                disk_write_bytes: None,
+                disk_read_iops: None,
+                disk_write_iops: None,
             }
         };
 


### PR DESCRIPTION
This pull request introduces several dependency updates and significant refactoring of the DataFusion query execution logic, particularly around DML operations. The most notable change is the complete removal of support for `UPDATE` statements in the runtime's DataFusion query layer, simplifying the codebase and focusing support on `DELETE` operations. Additionally, there are improvements to runtime readiness state handling and minor dependency version adjustments.

**Key changes:**

### DataFusion Query Execution Refactor

* Removed all code and logic related to handling `UPDATE` statements in the DataFusion query layer, including the custom `UpdateExec` physical plan and related filter extraction utilities. The runtime now only handles `DELETE` DML operations, which simplifies the code and maintenance. (`crates/runtime/src/datafusion/query.rs`) [[1]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L690-R689) [[2]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L728-L766) [[3]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L810-R765) [[4]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L1314-R1267) [[5]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L1335-R1302)
* Refactored delete handling: replaced the generic DML filter extraction with a function specific to `DELETE` filters, and streamlined the creation of the physical plan for delete operations. (`crates/runtime/src/datafusion/query.rs`) [[1]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L1314-R1267) [[2]](diffhunk://#diff-f823f2bc54e891055dd1c812e0be239a0b479e01018e29409d7dd85da9ca67e3L1335-R1302)

### Runtime Readiness State

* Added a new `RuntimeReadyState` enum and associated logic to `RuntimeStatus`, allowing the runtime readiness state to be configured and set explicitly. This is now set in the builder based on the application configuration. (`crates/runtime/src/status.rs`, `crates/runtime/src/builder.rs`) [[1]](diffhunk://#diff-5fb8ae39f5710bd9c5916ca85443f978ec5568569b3d330c7567aa1c828214e6R36-R42) [[2]](diffhunk://#diff-5fb8ae39f5710bd9c5916ca85443f978ec5568569b3d330c7567aa1c828214e6R51-R52) [[3]](diffhunk://#diff-5fb8ae39f5710bd9c5916ca85443f978ec5568569b3d330c7567aa1c828214e6R64-R76) [[4]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeR42) [[5]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeR215-R224)

### Dependency Updates

* Updated `docker/build-push-action` to a newer commit for both ARM64 and AMD64 Docker image builds in the GitHub Actions workflow. (`.github/workflows/build_nightly.yml`) [[1]](diffhunk://#diff-66d23226f08f05ae86a7d6e764cf30f998e952aa9fd60bfba3dcf61572cf3db4L359-R359) [[2]](diffhunk://#diff-66d23226f08f05ae86a7d6e764cf30f998e952aa9fd60bfba3dcf61572cf3db4L404-R404)
* Downgraded `clap` from `4.5.60` to `4.5.54` and `dialoguer` from `0.12` to `0.11` in relevant `Cargo.toml` files for compatibility. (`Cargo.toml`, `crates/repl/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L145-R145) [[2]](diffhunk://#diff-02afd6297f818a22fba590aa7f18d25ba4197df42c16aa284a90e8d4926083edL17-R17)

### Minor Fixes

* Fixed dataset status reporting to return the correct enum variant by value instead of cloning. (`crates/runtime/src/http/v1/mod.rs`)