### PR TITLE
feat(runtime): add runtime ready_state on_registration semantics

### DIFF
--- a/bin/spice/src/commands/datasets.rs
+++ b/bin/spice/src/commands/datasets.rs
@@ -37,14 +37,7 @@ pub struct DatasetsArgs {}
 
 impl TableRow for DatasetInfo {
     fn headers() -> Vec<&'static str> {
-        vec![
-            "NAME",
-            "FROM",
-            "REPLICATION",
-            "ACCELERATION",
-            "STATUS",
-            "ERROR",
-        ]
+        vec!["NAME", "FROM", "REPLICATION", "ACCELERATION", "STATUS", "ERROR"]
     }
 
     fn values(&self) -> Vec<String> {

--- a/bin/spice/src/commands/datasets.rs
+++ b/bin/spice/src/commands/datasets.rs
@@ -37,7 +37,14 @@ pub struct DatasetsArgs {}
 
 impl TableRow for DatasetInfo {
     fn headers() -> Vec<&'static str> {
-        vec!["NAME", "FROM", "REPLICATION", "ACCELERATION", "STATUS"]
+        vec![
+            "NAME",
+            "FROM",
+            "REPLICATION",
+            "ACCELERATION",
+            "STATUS",
+            "ERROR",
+        ]
     }
 
     fn values(&self) -> Vec<String> {
@@ -49,6 +56,7 @@ impl TableRow for DatasetInfo {
             self.status
                 .as_ref()
                 .map_or_else(String::new, ToString::to_string),
+            self.error_message.clone().unwrap_or_default(),
         ]
     }
 }

--- a/bin/spice/src/commands/datasets.rs
+++ b/bin/spice/src/commands/datasets.rs
@@ -37,7 +37,14 @@ pub struct DatasetsArgs {}
 
 impl TableRow for DatasetInfo {
     fn headers() -> Vec<&'static str> {
-        vec!["NAME", "FROM", "REPLICATION", "ACCELERATION", "STATUS", "ERROR"]
+        vec![
+            "NAME",
+            "FROM",
+            "REPLICATION",
+            "ACCELERATION",
+            "STATUS",
+            "ERROR",
+        ]
     }
 
     fn values(&self) -> Vec<String> {

--- a/bin/spice/src/commands/models.rs
+++ b/bin/spice/src/commands/models.rs
@@ -37,7 +37,7 @@ pub struct ModelsArgs {}
 
 impl TableRow for ModelInfo {
     fn headers() -> Vec<&'static str> {
-        vec!["ID", "OWNED_BY", "STATUS"]
+        vec!["ID", "OWNED_BY", "STATUS", "ERROR"]
     }
 
     fn values(&self) -> Vec<String> {
@@ -47,6 +47,7 @@ impl TableRow for ModelInfo {
             self.status
                 .as_ref()
                 .map_or_else(String::new, ToString::to_string),
+            self.error_message.clone().unwrap_or_default(),
         ]
     }
 }

--- a/crates/runtime-api-types/src/v1/datasets.rs
+++ b/crates/runtime-api-types/src/v1/datasets.rs
@@ -19,7 +19,7 @@ limitations under the License.
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::status::ComponentStatus;
+use super::status::{ComponentError, ComponentStatus};
 
 /// Dataset information returned by the `/v1/datasets` endpoint.
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,8 +43,17 @@ pub struct DatasetInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
 
+    /// An optional error type/code for the dataset status.
+    /// Only populated when `status=true` and the dataset status is `Error`.
+    /// Example:
+    /// `{ "category": "dataset", "type": "auth", "code": "dataset.auth" }`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ComponentError>,
+
     /// An optional error message describing why the dataset entered an error state.
-    /// Only populated when the dataset status is `Error` and an error message was recorded.
+    /// Only populated when `status=true`, the dataset status is `Error`, and an error message was recorded.
+    /// This value is intended for user-visible display.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 
     /// Custom properties for the dataset

--- a/crates/runtime-api-types/src/v1/mod.rs
+++ b/crates/runtime-api-types/src/v1/mod.rs
@@ -28,5 +28,5 @@ pub mod workers;
 pub use catalogs::CatalogInfo;
 pub use datasets::DatasetInfo;
 pub use models::{ModelInfo, ModelListResponse, ModelMetadata};
-pub use status::ComponentStatus;
+pub use status::{ComponentError, ComponentErrorCategory, ComponentErrorType, ComponentStatus};
 pub use workers::{WorkerInfo, WorkerListResponse};

--- a/crates/runtime-api-types/src/v1/models.rs
+++ b/crates/runtime-api-types/src/v1/models.rs
@@ -18,7 +18,7 @@ limitations under the License.
 
 use serde::{Deserialize, Serialize};
 
-use super::status::ComponentStatus;
+use super::status::{ComponentError, ComponentStatus};
 
 /// Response wrapper for the `/v1/models` endpoint (OpenAI-compatible format).
 #[derive(Debug, Serialize, Deserialize)]
@@ -61,6 +61,19 @@ pub struct ModelInfo {
     /// The status of the model (e.g., `Ready`, `Initializing`, `Error`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
+
+    /// An optional error type/code for the model status.
+    /// Only populated when `status=true` and the model status is `Error`.
+    /// Example:
+    /// `{ "category": "model", "type": "auth", "code": "model.auth" }`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ComponentError>,
+
+    /// An optional error message describing why the model entered an error state.
+    /// Only populated when `status=true`, the model status is `Error`, and an error message was recorded.
+    /// This value is intended for user-visible display.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
 
     /// Optional metadata fields, included when requested via query parameters
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -369,18 +369,25 @@ mod tests {
             ComponentErrorType::from_message(Some("")),
             ComponentErrorType::Unknown
         );
-        assert_eq!(ComponentErrorType::from_message(None), ComponentErrorType::Unknown);
+        assert_eq!(
+            ComponentErrorType::from_message(None),
+            ComponentErrorType::Unknown
+        );
     }
 
     #[test]
     fn test_component_error_from_status_message_generates_stable_code() {
-        let dataset_auth =
-            ComponentError::from_status_message(ComponentErrorCategory::Dataset, Some("invalid_api_key"));
+        let dataset_auth = ComponentError::from_status_message(
+            ComponentErrorCategory::Dataset,
+            Some("invalid_api_key"),
+        );
         assert_eq!(dataset_auth.error_type, ComponentErrorType::Auth);
         assert_eq!(dataset_auth.code, "dataset.auth");
 
-        let model_unknown =
-            ComponentError::from_status_message(ComponentErrorCategory::Model, Some("totally novel failure"));
+        let model_unknown = ComponentError::from_status_message(
+            ComponentErrorCategory::Model,
+            Some("totally novel failure"),
+        );
         assert_eq!(model_unknown.error_type, ComponentErrorType::Unknown);
         assert_eq!(model_unknown.code, "model.unknown");
     }

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -314,3 +314,74 @@ impl<'de> Deserialize<'de> for ComponentStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ComponentError, ComponentErrorCategory, ComponentErrorType};
+
+    #[test]
+    fn test_component_error_type_from_message_classifies_expected_patterns() {
+        assert_eq!(
+            ComponentErrorType::from_message(Some("too many requests from upstream")),
+            ComponentErrorType::RateLimit
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("request timed out after 30s")),
+            ComponentErrorType::Timeout
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("resource not found")),
+            ComponentErrorType::NotFound
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("access denied by policy")),
+            ComponentErrorType::Permission
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("invalid_api_key")),
+            ComponentErrorType::Auth
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("tls handshake failed")),
+            ComponentErrorType::Connection
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("unsupported format in request")),
+            ComponentErrorType::Validation
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("unexpected internal failure")),
+            ComponentErrorType::Internal
+        );
+    }
+
+    #[test]
+    fn test_component_error_type_from_message_handles_ambiguous_and_missing_inputs() {
+        assert_eq!(
+            ComponentErrorType::from_message(Some("Invalid token provided")),
+            ComponentErrorType::Auth
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("INVALID INPUT payload")),
+            ComponentErrorType::Validation
+        );
+        assert_eq!(
+            ComponentErrorType::from_message(Some("")),
+            ComponentErrorType::Unknown
+        );
+        assert_eq!(ComponentErrorType::from_message(None), ComponentErrorType::Unknown);
+    }
+
+    #[test]
+    fn test_component_error_from_status_message_generates_stable_code() {
+        let dataset_auth =
+            ComponentError::from_status_message(ComponentErrorCategory::Dataset, Some("invalid_api_key"));
+        assert_eq!(dataset_auth.error_type, ComponentErrorType::Auth);
+        assert_eq!(dataset_auth.code, "dataset.auth");
+
+        let model_unknown =
+            ComponentError::from_status_message(ComponentErrorCategory::Model, Some("totally novel failure"));
+        assert_eq!(model_unknown.error_type, ComponentErrorType::Unknown);
+        assert_eq!(model_unknown.code, "model.unknown");
+    }
+}

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -19,6 +19,166 @@ limitations under the License.
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentErrorCategory {
+    /// Error originating from a dataset component.
+    Dataset,
+    /// Error originating from a model component.
+    Model,
+    /// Error originating from a worker component.
+    Worker,
+    /// Error originating from runtime infrastructure.
+    Runtime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentErrorType {
+    /// Authentication or credential errors (invalid API key, username/password, token).
+    Auth,
+    /// Connectivity or transport errors (DNS/TLS/socket/network/connect failures).
+    Connection,
+    /// Timeout and deadline errors.
+    Timeout,
+    /// Invalid input or request validation errors.
+    Validation,
+    /// Missing resource errors.
+    NotFound,
+    /// Permission/authorization errors.
+    Permission,
+    /// Upstream rate limiting errors.
+    RateLimit,
+    /// Internal system errors.
+    Internal,
+    /// Unclassified error type.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ComponentError {
+    /// High-level component category where the error originated.
+    pub category: ComponentErrorCategory,
+    /// Canonical error type intended for programmatic handling.
+    #[serde(rename = "type")]
+    pub error_type: ComponentErrorType,
+    /// Stable machine-readable code (`{category}.{type}`), e.g. `dataset.auth`.
+    pub code: String,
+}
+
+impl ComponentError {
+    #[must_use]
+    pub fn from_status_message(category: ComponentErrorCategory, message: Option<&str>) -> Self {
+        let error_type = ComponentErrorType::from_message(message);
+        let code = format!("{}.{}", category.code_prefix(), error_type.code_suffix());
+
+        Self {
+            category,
+            error_type,
+            code,
+        }
+    }
+}
+
+impl ComponentErrorCategory {
+    fn code_prefix(&self) -> &'static str {
+        match self {
+            ComponentErrorCategory::Dataset => "dataset",
+            ComponentErrorCategory::Model => "model",
+            ComponentErrorCategory::Worker => "worker",
+            ComponentErrorCategory::Runtime => "runtime",
+        }
+    }
+}
+
+impl ComponentErrorType {
+    fn from_message(message: Option<&str>) -> Self {
+        let Some(message) = message else {
+            return ComponentErrorType::Unknown;
+        };
+
+        let message = message.to_lowercase();
+
+        if message.contains("rate limit") || message.contains("too many requests") {
+            return ComponentErrorType::RateLimit;
+        }
+
+        if message.contains("timeout") || message.contains("timed out") {
+            return ComponentErrorType::Timeout;
+        }
+
+        if message.contains("not found") || message.contains("does not exist") {
+            return ComponentErrorType::NotFound;
+        }
+
+        if message.contains("forbidden")
+            || message.contains("permission")
+            || message.contains("access denied")
+        {
+            return ComponentErrorType::Permission;
+        }
+
+        if message.contains("auth")
+            || message.contains("unauthorized")
+            || message.contains("invalid api key")
+            || message.contains("invalid_api_key")
+            || message.contains("credential")
+            || message.contains("username")
+            || message.contains("password")
+            || message.contains("token")
+        {
+            return ComponentErrorType::Auth;
+        }
+
+        if message.contains("connect")
+            || message.contains("connection")
+            || message.contains("network")
+            || message.contains("dns")
+            || message.contains("socket")
+            || message.contains("tls")
+            || message.contains("handshake")
+        {
+            return ComponentErrorType::Connection;
+        }
+
+        if message.contains("invalid")
+            || message.contains("malformed")
+            || message.contains("parse")
+            || message.contains("unsupported")
+            || message.contains("missing")
+            || message.contains("bad request")
+        {
+            return ComponentErrorType::Validation;
+        }
+
+        if message.contains("internal")
+            || message.contains("unexpected")
+            || message.contains("panic")
+        {
+            return ComponentErrorType::Internal;
+        }
+
+        ComponentErrorType::Unknown
+    }
+
+    fn code_suffix(&self) -> &'static str {
+        match self {
+            ComponentErrorType::Auth => "auth",
+            ComponentErrorType::Connection => "connection",
+            ComponentErrorType::Timeout => "timeout",
+            ComponentErrorType::Validation => "validation",
+            ComponentErrorType::NotFound => "not_found",
+            ComponentErrorType::Permission => "permission",
+            ComponentErrorType::RateLimit => "rate_limit",
+            ComponentErrorType::Internal => "internal",
+            ComponentErrorType::Unknown => "unknown",
+        }
+    }
+}
+
 /// Represents the status of a component (e.g. dataset, model, etc).
 ///
 /// The `Error` variant optionally carries a human-readable error message describing

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -39,6 +39,7 @@ use app::App;
 use datafusion::optimizer::AnalyzerRule;
 use runtime_datafusion::analyzer_rule::{PartitionedTableScanRewrite, TablePartitionProvider};
 use spicepod::component::caching::Caching;
+use spicepod::component::runtime::RuntimeReadyState as SpicepodRuntimeReadyState;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
 use tokio::runtime::Handle;
@@ -210,6 +211,16 @@ impl RuntimeBuilder {
             .app
             .as_ref()
             .is_none_or(|app| app.runtime.task_history.enabled);
+
+        let runtime_ready_state = self
+            .app
+            .as_ref()
+            .map_or(SpicepodRuntimeReadyState::default(), |app| app.runtime.ready_state);
+
+        self.runtime_status.set_ready_state(match runtime_ready_state {
+            SpicepodRuntimeReadyState::OnLoad => status::RuntimeReadyState::OnLoad,
+            SpicepodRuntimeReadyState::OnRegistration => status::RuntimeReadyState::OnRegistration,
+        });
 
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
         let url_tables_enabled = App::get_runtime_param_opt::<String>(&self.app, "url_tables")

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -215,12 +215,17 @@ impl RuntimeBuilder {
         let runtime_ready_state = self
             .app
             .as_ref()
-            .map_or(SpicepodRuntimeReadyState::default(), |app| app.runtime.ready_state);
+            .map_or(SpicepodRuntimeReadyState::default(), |app| {
+                app.runtime.ready_state
+            });
 
-        self.runtime_status.set_ready_state(match runtime_ready_state {
-            SpicepodRuntimeReadyState::OnLoad => status::RuntimeReadyState::OnLoad,
-            SpicepodRuntimeReadyState::OnRegistration => status::RuntimeReadyState::OnRegistration,
-        });
+        self.runtime_status
+            .set_ready_state(match runtime_ready_state {
+                SpicepodRuntimeReadyState::OnLoad => status::RuntimeReadyState::OnLoad,
+                SpicepodRuntimeReadyState::OnRegistration => {
+                    status::RuntimeReadyState::OnRegistration
+                }
+            });
 
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
         let url_tables_enabled = App::get_runtime_param_opt::<String>(&self.app, "url_tables")

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -76,6 +76,9 @@ pub(crate) struct Property {
 ///
 /// Use `status=true` query parameter to include the current status of each dataset in the response.
 /// Possible status values: `initializing`, `ready`, `disabled`, `error`, `refreshing`, `shuttingdown`.
+/// When `status=true` and a dataset is in `Error`, the response also includes:
+/// - `error`: structured code object with `category`, `type`, and stable `code`
+/// - `error_message`: user-visible details
 #[cfg_attr(feature = "openapi", utoipa::path(
     get,
     path = "/v1/datasets",
@@ -83,7 +86,7 @@ pub(crate) struct Property {
     tag = "Datasets",
     params(DatasetQueryParams, DatasetFilter),
     responses(
-        (status = 200, description = "List of datasets. When `status=true` is specified, each dataset includes a `status` field.", content((
+        (status = 200, description = "List of datasets. When `status=true` is specified, each dataset includes `status` and error metadata (`error`, `error_message`) when applicable.", content((
             DatasetResponseItem = "application/json",
             example = json!([
                 {
@@ -91,30 +94,40 @@ pub(crate) struct Property {
                     "name": "daily_journal_accelerated",
                     "replication_enabled": false,
                     "acceleration_enabled": true,
-                    "status": "Ready"
+                    "status": "Ready",
+                    "error": null,
+                    "error_message": null
                 },
                 {
                     "from": "databricks:hive_metastore.default.messages",
                     "name": "messages_accelerated",
                     "replication_enabled": false,
                     "acceleration_enabled": true,
-                    "status": "Refreshing"
+                    "status": "Error",
+                    "error": {
+                        "category": "dataset",
+                        "type": "auth",
+                        "code": "dataset.auth"
+                    },
+                    "error_message": "Unable to authenticate with datasource credentials"
                 },
                 {
                     "from": "postgres:aidemo_messages",
                     "name": "general",
                     "replication_enabled": false,
                     "acceleration_enabled": false,
-                    "status": "Initializing"
+                    "status": "Initializing",
+                    "error": null,
+                    "error_message": null
                 }
             ])
         ), (
             String = "text/csv",
             example = "
-from,name,replication_enabled,acceleration_enabled,status
-postgres:syncs,daily_journal_accelerated,false,true,Ready
-databricks:hive_metastore.default.messages,messages_accelerated,false,true,Refreshing
-postgres:aidemo_messages,general,false,false,Initializing
+from,name,replication_enabled,acceleration_enabled,status,error,error_message
+postgres:syncs,daily_journal_accelerated,false,true,Ready,,
+databricks:hive_metastore.default.messages,messages_accelerated,false,true,Error,dataset.auth,Unable to authenticate with datasource credentials
+postgres:aidemo_messages,general,false,false,Initializing,,
 "
         ))),
         (status = 500, description = "Internal server error occurred while processing datasets", content((
@@ -165,6 +178,16 @@ pub(crate) async fn get(
             } else {
                 None
             };
+            let error = status.as_ref().and_then(|s| {
+                if s.is_error() {
+                    Some(runtime_api_types::v1::ComponentError::from_status_message(
+                        runtime_api_types::v1::ComponentErrorCategory::Dataset,
+                        s.error_message(),
+                    ))
+                } else {
+                    None
+                }
+            });
             let error_message = status
                 .as_ref()
                 .and_then(|s| s.error_message().map(String::from));
@@ -175,6 +198,7 @@ pub(crate) async fn get(
                 acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
                 properties: dataset_properties(d),
                 status,
+                error,
                 error_message,
             }
         })

--- a/crates/runtime/src/http/v1/models.rs
+++ b/crates/runtime/src/http/v1/models.rs
@@ -106,6 +106,9 @@ fn generate_metadata(
 /// List Models
 ///
 /// List all models, both machine learning and language models, available in the runtime.
+/// When `status=true` and a model is in `Error`, the response also includes:
+/// - `error`: structured code object with `category`, `type`, and stable `code`
+/// - `error_message`: user-visible details
 #[cfg_attr(feature = "openapi", utoipa::path(
     get,
     path = "/v1/models",
@@ -123,23 +126,31 @@ fn generate_metadata(
                         "object": "model",
                         "owned_by": "openai",
                         "datasets": null,
-                        "status": "ready"
+                        "status": "ready",
+                        "error": null,
+                        "error_message": null
                     },
                     {
                         "id": "text-embedding-ada-002",
                         "object": "model",
                         "owned_by": "openai-internal",
                         "datasets": ["text-dataset-1", "text-dataset-2"],
-                        "status": "ready"
+                        "status": "error",
+                        "error": {
+                            "category": "model",
+                            "type": "auth",
+                            "code": "model.auth"
+                        },
+                        "error_message": "Invalid API key"
                     }
                 ]
             })
         ), (
             String = "text/csv",
             example = "
-id,object,owned_by,datasets,status
-gpt-4,model,openai,,ready
-text-embedding-ada-002,model,openai-internal,\"text-dataset-1,text-dataset-2\",ready
+id,object,owned_by,datasets,status,error,error_message
+gpt-4,model,openai,,ready,,
+text-embedding-ada-002,model,openai-internal,\"text-dataset-1,text-dataset-2\",error,model.auth,Invalid API key
 "
         ))),
         (status = 500, description = "Internal server error occurred while processing models", content((
@@ -186,12 +197,28 @@ pub(crate) async fn get(
                 } else {
                     Some(m.datasets.clone())
                 };
+                let status = statuses.get(&m.name).cloned();
+                let error = status.as_ref().and_then(|s| {
+                    if s.is_error() {
+                        Some(runtime_api_types::v1::ComponentError::from_status_message(
+                            runtime_api_types::v1::ComponentErrorCategory::Model,
+                            s.error_message(),
+                        ))
+                    } else {
+                        None
+                    }
+                });
+                let error_message = status
+                    .as_ref()
+                    .and_then(|s| s.error_message().map(String::from));
                 OpenAIModel {
                     id: m.name.clone(),
                     object: "model".to_string(),
                     owned_by: m.from.clone(),
                     datasets: d,
-                    status: statuses.get(&m.name).cloned(),
+                    status,
+                    error,
+                    error_message,
                     metadata: generate_metadata(&m.name, &metadata_keys, &responses_models),
                 }
             })
@@ -213,12 +240,28 @@ pub(crate) async fn get(
     let worker_registry = rt.workers.read().await;
     models.extend(worker_registry.iter().filter_map(|(name, worker)| {
         Arc::clone(worker).as_model()?;
+        let status = worker_statuses.get(name).cloned();
+        let error = status.as_ref().and_then(|s| {
+            if s.is_error() {
+                Some(runtime_api_types::v1::ComponentError::from_status_message(
+                    runtime_api_types::v1::ComponentErrorCategory::Worker,
+                    s.error_message(),
+                ))
+            } else {
+                None
+            }
+        });
+        let error_message = status
+            .as_ref()
+            .and_then(|s| s.error_message().map(String::from));
         Some(OpenAIModel {
             id: name.clone(),
             object: "model".to_string(),
             owned_by: "spiceai".to_string(),
             datasets: None,
-            status: worker_statuses.get(name).cloned(),
+            status,
+            error,
+            error_message,
             metadata: generate_metadata(name, &metadata_keys, &responses_models),
         })
     }));

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -238,11 +238,14 @@ impl RuntimeStatus {
                     Err(poisoned) => poisoned.into_inner(),
                 };
 
-                // Check if all registered components have been ready at least once
+                // OnLoad readiness: a component counts as ready if it has been ready at least once.
+                // All registered components must appear in the ever-ready set before we report ready.
                 statuses
                     .keys()
                     .all(|component| ever_ready.contains(component))
             }
+            // OnRegistration readiness: treat Error/Disabled/Initializing as ready-enough.
+            // Only components in ShuttingDown state block overall readiness.
             RuntimeReadyState::OnRegistration => statuses
                 .values()
                 .all(|status| !matches!(status, ComponentStatus::ShuttingDown)),
@@ -462,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_ready_on_registration_requires_successful_registration() {
+    fn test_is_ready_on_registration_requires_registered_component() {
         let status = RuntimeStatus::new();
         let dataset = TableReference::bare("test_dataset");
 

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -33,6 +33,13 @@ use crate::metrics;
 // Re-export ComponentStatus from the shared API types crate
 pub use runtime_api_types::v1::ComponentStatus;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RuntimeReadyState {
+    #[default]
+    OnLoad,
+    OnRegistration,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct RuntimeStatus {
     /// Stores the current status of all components.
@@ -41,6 +48,8 @@ pub struct RuntimeStatus {
     ever_ready_components: Arc<RwLock<HashSet<String>>>,
     /// Tracks if the runtime is in the process of shutting down.
     is_shutdown: Arc<AtomicBool>,
+    /// Controls how runtime readiness is computed.
+    ready_state: Arc<RwLock<RuntimeReadyState>>,
     /// Per-component notifiers for status change subscriptions.
     notifiers: Arc<RwLock<HashMap<String, watch::Sender<ComponentStatus>>>>,
 }
@@ -52,8 +61,17 @@ impl RuntimeStatus {
             statuses: Arc::new(RwLock::new(HashMap::new())),
             ever_ready_components: Arc::new(RwLock::new(HashSet::new())),
             is_shutdown: Arc::new(AtomicBool::new(false)),
+            ready_state: Arc::new(RwLock::new(RuntimeReadyState::default())),
             notifiers: Arc::new(RwLock::new(HashMap::new())),
         })
+    }
+
+    pub fn set_ready_state(&self, ready_state: RuntimeReadyState) {
+        let mut configured_ready_state = self
+            .ready_state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *configured_ready_state = ready_state;
     }
 
     #[must_use]
@@ -199,11 +217,12 @@ impl RuntimeStatus {
             return false;
         }
 
+        let ready_state = *self
+            .ready_state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let statuses = match self.statuses.read() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let ever_ready = match self.ever_ready_components.read() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
@@ -212,10 +231,22 @@ impl RuntimeStatus {
             return false; // No components registered yet
         }
 
-        // Check if all registered components have been ready at least once
-        statuses
-            .keys()
-            .all(|component| ever_ready.contains(component))
+        match ready_state {
+            RuntimeReadyState::OnLoad => {
+                let ever_ready = match self.ever_ready_components.read() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+
+                // Check if all registered components have been ready at least once
+                statuses
+                    .keys()
+                    .all(|component| ever_ready.contains(component))
+            }
+            RuntimeReadyState::OnRegistration => statuses
+                .values()
+                .all(|status| !matches!(status, ComponentStatus::ShuttingDown)),
+        }
     }
 
     /// Returns the status of all registered components.
@@ -428,6 +459,105 @@ mod tests {
             status.get_component_status("dataset:test_dataset"),
             Some(ComponentStatus::Ready)
         );
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_requires_successful_registration() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        // Empty statuses are not ready.
+        assert!(!status.is_ready());
+
+        // Initializing still counts as registered.
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        assert!(status.is_ready());
+
+        // Refreshing stays ready.
+        status.update_dataset(&dataset, ComponentStatus::Refreshing);
+        assert!(status.is_ready());
+
+        // Error still counts as registered for on_registration mode.
+        status.update_dataset(&dataset, ComponentStatus::error());
+        assert!(status.is_ready());
+
+        // Explicit shutting down state for a component is not ready.
+        status.update_dataset(&dataset, ComponentStatus::ShuttingDown);
+        assert!(!status.is_ready());
+
+        // Runtime-level shutdown always forces not ready.
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        assert!(status.is_ready());
+        status.mark_shutdown();
+        assert!(!status.is_ready());
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_allows_mixed_component_states() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        status.update_dataset(&dataset, ComponentStatus::error());
+        status.update_model("test_model", ComponentStatus::Initializing);
+        status.update_tool("test_tool", ComponentStatus::Disabled);
+
+        assert!(status.is_ready());
+
+        status.update_tool("test_tool", ComponentStatus::ShuttingDown);
+        assert!(!status.is_ready());
+    }
+
+    #[test]
+    fn test_is_ready_on_registration_all_component_types() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("dataset_a");
+        let view = TableReference::bare("view_a");
+
+        status.set_ready_state(RuntimeReadyState::OnRegistration);
+
+        status.update_catalog("catalog_a", ComponentStatus::Initializing);
+        status.update_dataset(&dataset, ComponentStatus::error());
+        status.update_model("model_a", ComponentStatus::Disabled);
+        status.update_tool("tool_a", ComponentStatus::Refreshing);
+        status.update_tool_catalog("tool_catalog_a", ComponentStatus::Ready);
+        status.update_llm("llm_a", ComponentStatus::error());
+        status.update_embedding("embedding_a", ComponentStatus::Initializing);
+        status.update_view(&view, ComponentStatus::Ready);
+        status.update_worker("worker_a", ComponentStatus::Disabled);
+        status.update_cluster("cluster_node_a", ComponentStatus::error());
+
+        assert!(
+            status.is_ready(),
+            "on_registration should be ready when all components are registered and none are ShuttingDown"
+        );
+
+        status.update_embedding("embedding_a", ComponentStatus::ShuttingDown);
+        assert!(
+            !status.is_ready(),
+            "any component in ShuttingDown should make runtime not ready"
+        );
+    }
+
+    #[test]
+    fn test_is_ready_on_load_still_requires_ever_ready() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("test_dataset");
+
+        status.set_ready_state(RuntimeReadyState::OnLoad);
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        assert!(!status.is_ready());
+
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        assert!(status.is_ready());
+
+        // Once ever-ready is achieved, transient non-ready states still satisfy OnLoad mode.
+        status.update_dataset(&dataset, ComponentStatus::Refreshing);
+        assert!(status.is_ready());
     }
 
     #[tokio::test]

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -24,7 +24,9 @@ use std::{
 
 use rand::Rng;
 use runtime::{Runtime, auth::EndpointAuth, config::Config, status::ComponentStatus};
+use runtime_api_types::v1::ComponentError;
 use serde::Deserialize;
+use serde_json::Value;
 use spicepod::component::dataset::Dataset;
 
 use crate::{
@@ -48,6 +50,8 @@ struct DatasetResponse {
     replication_enabled: bool,
     acceleration_enabled: bool,
     status: Option<String>,
+    error: Option<ComponentError>,
+    error_message: Option<String>,
 }
 
 /// Tests that the `/v1/datasets?status=true` endpoint returns the correct status
@@ -110,13 +114,16 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             let status = rt.status();
             let dataset_statuses = status.get_dataset_statuses();
             let dataset_ref = datafusion::sql::TableReference::bare("test_dataset");
-            let runtime_status = dataset_statuses
-                .get(&dataset_ref)
-                .expect("test_dataset should have a status");
+            let runtime_status = dataset_statuses.get(&dataset_ref).expect("test_dataset should have a status");
             assert_eq!(
                 *runtime_status,
                 ComponentStatus::Ready,
                 "Dataset should be Ready in RuntimeStatus"
+            );
+
+            status.update_dataset(
+                &dataset_ref,
+                ComponentStatus::error_with_message("UnableToConnectInvalidUsernameOrPassword"),
             );
 
             // Call the /v1/datasets?status=true API
@@ -143,8 +150,22 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             // Verify the status from the API matches RuntimeStatus
             assert_eq!(
                 test_dataset.status,
-                Some("Ready".to_string()),
-                "API status should match RuntimeStatus (Ready)"
+                Some("Error".to_string()),
+                "API status should match RuntimeStatus (Error)"
+            );
+            assert_eq!(
+                test_dataset.error,
+                Some(ComponentError {
+                    category: runtime_api_types::v1::ComponentErrorCategory::Dataset,
+                    error_type: runtime_api_types::v1::ComponentErrorType::Auth,
+                    code: "dataset.auth".to_string(),
+                }),
+                "API error should provide an error type/code when status=true"
+            );
+            assert_eq!(
+                test_dataset.error_message,
+                Some("UnableToConnectInvalidUsernameOrPassword".to_string()),
+                "API error_message should be included when status=true and status is Error"
             );
 
             // Additional checks
@@ -219,7 +240,27 @@ async fn test_datasets_api_without_status_param() -> Result<(), anyhow::Error> {
 
             assert!(response.status().is_success());
 
-            let datasets: Vec<DatasetResponse> = response.json().await?;
+            let datasets_json: Vec<Value> = response.json().await?;
+
+            let test_dataset_json = datasets_json
+                .iter()
+                .find(|d| d.get("name").and_then(Value::as_str) == Some("test_dataset_no_status"))
+                .expect("test_dataset_no_status should be in the response");
+
+            assert!(
+                test_dataset_json.get("status").is_none(),
+                "status should be omitted when status=true is not provided"
+            );
+            assert!(
+                test_dataset_json.get("error").is_none(),
+                "error should be omitted when status=true is not provided"
+            );
+            assert!(
+                test_dataset_json.get("error_message").is_none(),
+                "error_message should be omitted when status=true is not provided"
+            );
+
+            let datasets: Vec<DatasetResponse> = serde_json::from_value(Value::Array(datasets_json))?;
 
             let test_dataset = datasets
                 .iter()
@@ -230,6 +271,14 @@ async fn test_datasets_api_without_status_param() -> Result<(), anyhow::Error> {
             assert_eq!(
                 test_dataset.status, None,
                 "Status should be None when status param is not provided"
+            );
+            assert_eq!(
+                test_dataset.error, None,
+                "Error should be None when status param is not provided"
+            );
+            assert_eq!(
+                test_dataset.error_message, None,
+                "Error message should be None when status param is not provided"
             );
 
             rt.shutdown().await;

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -121,11 +121,6 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
                 "Dataset should be Ready in RuntimeStatus"
             );
 
-            status.update_dataset(
-                &dataset_ref,
-                ComponentStatus::error_with_message("UnableToConnectInvalidUsernameOrPassword"),
-            );
-
             // Call the /v1/datasets?status=true API
             let http_url = format!("http://127.0.0.1:{http_port}/v1/datasets?status=true");
             let response = http_client
@@ -142,6 +137,35 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             let datasets: Vec<DatasetResponse> = response.json().await?;
 
             // Find our test dataset
+            let test_dataset = datasets
+                .iter()
+                .find(|d| d.name == "test_dataset")
+                .expect("test_dataset should be in the response");
+
+            assert_eq!(
+                test_dataset.status,
+                Some("Ready".to_string()),
+                "API status should initially reflect RuntimeStatus (Ready)"
+            );
+
+            status.update_dataset(
+                &dataset_ref,
+                ComponentStatus::error_with_message("UnableToConnectInvalidUsernameOrPassword"),
+            );
+
+            let response = http_client
+                .get(&http_url)
+                .send()
+                .await
+                .expect("valid response");
+
+            assert!(
+                response.status().is_success(),
+                "API should return success status"
+            );
+
+            let datasets: Vec<DatasetResponse> = response.json().await?;
+
             let test_dataset = datasets
                 .iter()
                 .find(|d| d.name == "test_dataset")

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -114,7 +114,9 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             let status = rt.status();
             let dataset_statuses = status.get_dataset_statuses();
             let dataset_ref = datafusion::sql::TableReference::bare("test_dataset");
-            let runtime_status = dataset_statuses.get(&dataset_ref).expect("test_dataset should have a status");
+            let runtime_status = dataset_statuses
+                .get(&dataset_ref)
+                .expect("test_dataset should have a status");
             assert_eq!(
                 *runtime_status,
                 ComponentStatus::Ready,
@@ -284,7 +286,8 @@ async fn test_datasets_api_without_status_param() -> Result<(), anyhow::Error> {
                 "error_message should be omitted when status=true is not provided"
             );
 
-            let datasets: Vec<DatasetResponse> = serde_json::from_value(Value::Array(datasets_json))?;
+            let datasets: Vec<DatasetResponse> =
+                serde_json::from_value(Value::Array(datasets_json))?;
 
             let test_dataset = datasets
                 .iter()

--- a/crates/runtime/tests/models/models_http_endpoint.rs
+++ b/crates/runtime/tests/models/models_http_endpoint.rs
@@ -3,6 +3,7 @@ use app::AppBuilder;
 use insta::assert_json_snapshot;
 use reqwest::Client;
 use runtime::{Runtime, auth::EndpointAuth, status::ComponentStatus};
+use runtime_api_types::v1::ComponentError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
@@ -25,6 +26,12 @@ pub(crate) struct OpenAIModel {
     datasets: Option<Vec<String>>,
 
     status: Option<ComponentStatus>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<ComponentError>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<Metadata>,
@@ -115,6 +122,43 @@ async fn test_models_http_endpoint() -> Result<(), Error> {
                 response.json().await.map_err(anyhow::Error::from)?;
 
             assert_json_snapshot!("models_response_with_status", &models_response);
+
+            rt.status().update_model(
+                "chat_model",
+                ComponentStatus::error_with_message("invalid_api_key"),
+            );
+
+            let url = format!("{http_base_url}/v1/models?status=true");
+            let response = client.get(&url).send().await.map_err(anyhow::Error::from)?;
+
+            assert!(
+                response.status().is_success(),
+                "Expected 200 OK, got {}",
+                response.status()
+            );
+
+            let models_response: OpenAIModelResponse =
+                response.json().await.map_err(anyhow::Error::from)?;
+
+            let chat_model = models_response
+                .data
+                .iter()
+                .find(|model| model.id == "chat_model")
+                .expect("chat_model should be returned by /v1/models");
+
+            assert_eq!(chat_model.status, Some(ComponentStatus::Error(None)));
+            assert_eq!(
+                chat_model.error,
+                Some(ComponentError {
+                    category: runtime_api_types::v1::ComponentErrorCategory::Model,
+                    error_type: runtime_api_types::v1::ComponentErrorType::Auth,
+                    code: "model.auth".to_string(),
+                })
+            );
+            assert_eq!(
+                chat_model.error_message,
+                Some("invalid_api_key".to_string())
+            );
 
             let url = format!("{http_base_url}/v1/models?metadata_fields=supports_responses_api");
             let response = client.get(&url).send().await.map_err(anyhow::Error::from)?;

--- a/crates/runtime/tests/ready_state/mod.rs
+++ b/crates/runtime/tests/ready_state/mod.rs
@@ -55,8 +55,7 @@ use runtime::{
     component::dataset::Dataset,
     dataconnector::{
         self, ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-        NewDataConnectorResult,
-        parameters::ConnectorParams,
+        NewDataConnectorResult, parameters::ConnectorParams,
     },
     parameters::ParameterSpec,
 };
@@ -460,10 +459,12 @@ impl DataConnector for AuthErrorDataConnector {
         &self,
         dataset: &Dataset,
     ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
-        Err(DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
-            dataconnector: "auth-error".to_string(),
-            connector_component: ConnectorComponent::from(dataset),
-        })
+        Err(
+            DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
+                dataconnector: "auth-error".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+            },
+        )
     }
 }
 
@@ -513,8 +514,11 @@ async fn register_slow_loading_providers() {
 }
 
 async fn register_auth_error_provider() {
-    dataconnector::register_connector_factory("auth-error", AuthErrorDataConnectorProvider::new_arc())
-        .await;
+    dataconnector::register_connector_factory(
+        "auth-error",
+        AuthErrorDataConnectorProvider::new_arc(),
+    )
+    .await;
 }
 
 fn get_native_dataset(
@@ -1078,7 +1082,10 @@ async fn test_runtime_on_registration_ready_when_dataset_is_error() -> Result<()
 
             let app = AppBuilder::new("runtime_on_registration_dataset_error")
                 .with_runtime(runtime)
-                .with_dataset(SpicepodDataset::new("auth-error://dummy", "bad_s3_credentials"))
+                .with_dataset(SpicepodDataset::new(
+                    "auth-error://dummy",
+                    "bad_s3_credentials",
+                ))
                 .build();
 
             configure_test_datafusion();
@@ -1121,9 +1128,14 @@ async fn test_runtime_on_registration_ready_when_dataset_is_error() -> Result<()
                 .iter()
                 .find(|(name, _)| name.to_string() == "bad_s3_credentials")
                 .map(|(_, status)| status.clone())
-                .ok_or_else(|| anyhow::anyhow!("Dataset status for bad_s3_credentials not found"))?;
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Dataset status for bad_s3_credentials not found")
+                })?;
 
-            assert!(matches!(dataset_status, runtime::status::ComponentStatus::Error(_)));
+            assert!(matches!(
+                dataset_status,
+                runtime::status::ComponentStatus::Error(_)
+            ));
             assert!(rt.status().is_ready());
 
             Ok(())

--- a/crates/runtime/tests/ready_state/mod.rs
+++ b/crates/runtime/tests/ready_state/mod.rs
@@ -461,7 +461,7 @@ impl DataConnector for AuthErrorDataConnector {
         dataset: &Dataset,
     ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
         Err(DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
-            dataconnector: "s3".to_string(),
+            dataconnector: "auth-error".to_string(),
             connector_component: ConnectorComponent::from(dataset),
         })
     }

--- a/crates/runtime/tests/ready_state/mod.rs
+++ b/crates/runtime/tests/ready_state/mod.rs
@@ -54,7 +54,8 @@ use runtime::{
     Runtime,
     component::dataset::Dataset,
     dataconnector::{
-        self, DataConnector, DataConnectorError, DataConnectorFactory, NewDataConnectorResult,
+        self, ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
+        NewDataConnectorResult,
         parameters::ConnectorParams,
     },
     parameters::ParameterSpec,
@@ -63,6 +64,7 @@ use runtime_request_context::{AsyncMarker, Protocol, RequestContext};
 use spicepod::{
     acceleration::Acceleration,
     component::dataset::{Dataset as SpicepodDataset, ReadyState},
+    component::runtime::{Runtime as SpicepodRuntime, RuntimeReadyState},
 };
 
 use crate::{configure_test_datafusion, init_tracing};
@@ -445,6 +447,56 @@ impl DataConnectorFactory for SlowFederatedDataConnectorProvider {
     }
 }
 
+#[derive(Debug)]
+struct AuthErrorDataConnector;
+
+#[async_trait]
+impl DataConnector for AuthErrorDataConnector {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> Result<Arc<dyn TableProvider>, DataConnectorError> {
+        Err(DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
+            dataconnector: "s3".to_string(),
+            connector_component: ConnectorComponent::from(dataset),
+        })
+    }
+}
+
+struct AuthErrorDataConnectorProvider;
+
+impl AuthErrorDataConnectorProvider {
+    fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+#[async_trait]
+impl DataConnectorFactory for AuthErrorDataConnectorProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn create(
+        &self,
+        _params: ConnectorParams,
+    ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(AuthErrorDataConnector) as Arc<dyn DataConnector>) })
+    }
+
+    fn prefix(&self) -> &'static str {
+        "auth-error"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        &[]
+    }
+}
+
 // Register our data connector providers
 async fn register_slow_loading_providers() {
     dataconnector::register_connector_factory(
@@ -458,6 +510,11 @@ async fn register_slow_loading_providers() {
         SlowFederatedDataConnectorProvider::new_arc(),
     )
     .await;
+}
+
+async fn register_auth_error_provider() {
+    dataconnector::register_connector_factory("auth-error", AuthErrorDataConnectorProvider::new_arc())
+        .await;
 }
 
 fn get_native_dataset(
@@ -999,6 +1056,75 @@ async fn test_ready_state_mixed_duckdb_acceleration() -> Result<(), anyhow::Erro
 
             assert_eq!(results.len(), 1, "Query should return 1 record batch");
             assert_eq!(results[0].num_rows(), 5, "Should have 5 rows of data");
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_runtime_on_registration_ready_when_dataset_is_error() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    register_auth_error_provider().await;
+
+    let request_context = Arc::new(RequestContext::builder(Protocol::Http).build());
+    request_context
+        .scope(async {
+            let runtime = SpicepodRuntime {
+                ready_state: RuntimeReadyState::OnRegistration,
+                ..Default::default()
+            };
+
+            let app = AppBuilder::new("runtime_on_registration_dataset_error")
+                .with_runtime(runtime)
+                .with_dataset(SpicepodDataset::new("auth-error://dummy", "bad_s3_credentials"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let rt_for_load = Arc::new(rt.clone());
+            let load_handle = tokio::spawn(async move {
+                rt_for_load.load_components().await;
+            });
+
+            let wait_result = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                loop {
+                    let statuses = rt.status().get_dataset_statuses();
+                    let dataset_status = statuses
+                        .iter()
+                        .find(|(name, _)| name.to_string() == "bad_s3_credentials")
+                        .map(|(_, status)| status.clone());
+
+                    if let Some(status) = dataset_status
+                        && matches!(status, runtime::status::ComponentStatus::Error(_))
+                        && rt.status().is_ready()
+                    {
+                        break;
+                    }
+
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            })
+            .await;
+
+            load_handle.abort();
+
+            assert!(
+                wait_result.is_ok(),
+                "Timed out waiting for runtime ready with dataset error in on_registration mode"
+            );
+
+            let statuses = rt.status().get_dataset_statuses();
+            let dataset_status = statuses
+                .iter()
+                .find(|(name, _)| name.to_string() == "bad_s3_credentials")
+                .map(|(_, status)| status.clone())
+                .ok_or_else(|| anyhow::anyhow!("Dataset status for bad_s3_credentials not found"))?;
+
+            assert!(matches!(dataset_status, runtime::status::ComponentStatus::Error(_)));
+            assert!(rt.status().is_ready());
 
             Ok(())
         })

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -72,6 +72,10 @@ pub struct Runtime {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown_timeout: Option<String>,
 
+    /// Controls when the runtime is considered ready for the `/v1/ready` endpoint.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub ready_state: RuntimeReadyState,
+
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
     /// are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -102,6 +106,20 @@ impl Runtime {
             Ok(None)
         }
     }
+}
+
+/// Controls when the runtime readiness probe reports the runtime as ready.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeReadyState {
+    /// Runtime becomes ready after all registered components have reached `Ready` at least once.
+    #[default]
+    OnLoad,
+    /// Runtime becomes ready once all registered components are successfully registered,
+    /// even if they are not yet in `Ready` state.
+    OnRegistration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -770,6 +788,9 @@ pub struct RuntimeDeserializer {
     /// and components to shut down cleanly during runtime termination
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown_timeout: Option<String>,
+    /// Controls when the runtime is considered ready for the `/v1/ready` endpoint.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub ready_state: RuntimeReadyState,
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
     /// are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -848,6 +869,7 @@ impl TryFrom<RuntimeDeserializer> for Runtime {
             cors: deserializer.cors,
             flight: deserializer.flight,
             shutdown_timeout: deserializer.shutdown_timeout,
+            ready_state: deserializer.ready_state,
             output_level: deserializer.output_level,
             query: if query == Query::default() {
                 None
@@ -1733,5 +1755,25 @@ mod tests {
             "caching.sql_results should take priority"
         );
         assert_eq!(sql_results.item_ttl, Some("30s".to_string()));
+    }
+
+    #[test]
+    fn test_runtime_ready_state_default() {
+        let yaml = r"
+            caching:
+              sql_results:
+                enabled: true
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.ready_state, RuntimeReadyState::OnLoad);
+    }
+
+    #[test]
+    fn test_runtime_ready_state_on_registration() {
+        let yaml = r"
+            ready_state: on_registration
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.ready_state, RuntimeReadyState::OnRegistration);
     }
 }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -117,8 +117,9 @@ pub enum RuntimeReadyState {
     /// Runtime becomes ready after all registered components have reached `Ready` at least once.
     #[default]
     OnLoad,
-    /// Runtime becomes ready once all registered components are successfully registered,
-    /// even if they are not yet in `Ready` state.
+    /// Runtime becomes ready once all components have been registered/initialized at least once,
+    /// regardless of whether they are currently `Ready`, `Error`, or `Disabled`,
+    /// as long as none is `ShuttingDown`.
     OnRegistration,
 }
 


### PR DESCRIPTION
This pull request adds structured error reporting to the dataset and model API responses, allowing clients to programmatically identify error types and categories, and to display user-friendly error messages. The changes introduce new error fields and enums, update API documentation and examples, and implement logic to populate these fields when a dataset or model is in an error state.

Structured error reporting enhancements:

* Introduced new enums `ComponentErrorCategory` and `ComponentErrorType`, and the struct `ComponentError`, to represent error category, type, and a stable code for programmatic handling. Also implemented logic to classify error messages and generate codes. (`crates/runtime-api-types/src/v1/status.rs`)
* Updated the `DatasetInfo` and `ModelInfo` structs to include optional `error` and `error_message` fields, populated when the status is `Error`. (`crates/runtime-api-types/src/v1/datasets.rs`, `crates/runtime-api-types/src/v1/models.rs`) [[1]](diffhunk://#diff-003ec912e1fdf566e1a9f6e8462132799ab82d174e13ca8ae7fb05c44e29bfdbR46-R56) [[2]](diffhunk://#diff-081e8de3772413d473e93e4c581d0e1368f06190237ecf12e8dba2cfe2b5b0f1R65-R77)
* Modified API endpoints for datasets and models to populate the new error fields when applicable, using the new error classification logic. (`crates/runtime/src/http/v1/datasets.rs`, `crates/runtime/src/http/v1/models.rs`) [[1]](diffhunk://#diff-f9566632e29ee7f608e91f1265776f1692986c0bddf7f5f1f2998e1a17965e4fR181-R190) [[2]](diffhunk://#diff-f9566632e29ee7f608e91f1265776f1692986c0bddf7f5f1f2998e1a17965e4fR201) [[3]](diffhunk://#diff-29d1764bd2e7bf28579bf8275a8aa0db023ce69d783d548b6b3774265e760bb3R200-R221)

API documentation and example improvements:

* Updated OpenAPI documentation and response examples for the `/v1/datasets` and `/v1/models` endpoints to show the new error fields and demonstrate their usage in both JSON and CSV formats. (`crates/runtime/src/http/v1/datasets.rs`, `crates/runtime/src/http/v1/models.rs`) [[1]](diffhunk://#diff-f9566632e29ee7f608e91f1265776f1692986c0bddf7f5f1f2998e1a17965e4fR79-R130) [[2]](diffhunk://#diff-29d1764bd2e7bf28579bf8275a8aa0db023ce69d783d548b6b3774265e760bb3R109-R111) [[3]](diffhunk://#diff-29d1764bd2e7bf28579bf8275a8aa0db023ce69d783d548b6b3774265e760bb3L126-R153)

Codebase integration and testing:

* Exported new error types from the API types module and integrated them into the runtime logic. Added unit tests for error classification and code generation. (`crates/runtime-api-types/src/v1/mod.rs`, `crates/runtime-api-types/src/v1/status.rs`) [[1]](diffhunk://#diff-5f016c7a6a7d01256fbaf4afc9bd4db09bb73a5e53fba863b0204f36b661a61cL31-R31) [[2]](diffhunk://#diff-a39288ca907c4d31710dac79de5e4015b366cefe3c5fb5deaa6b0247fdf9afaaR317-R394)

These enhancements provide more robust and actionable error metadata for clients interacting with datasets and models, improving both developer experience and user-facing error handling.