### PR TITLE
feat(spidapter): add local backend mode with single executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18164,6 +18164,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "clap",
+ "dirs",
  "reqwest 0.12.24",
  "runtime-secrets",
  "rustls 0.23.36",

--- a/tools/spidapter/Cargo.toml
+++ b/tools/spidapter/Cargo.toml
@@ -13,6 +13,7 @@ arrow.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
+dirs = "6"
 reqwest.workspace = true
 runtime-secrets = { path = "../../crates/runtime-secrets", default-features = false }
 spice-cloud-client.workspace = true

--- a/tools/spidapter/README.md
+++ b/tools/spidapter/README.md
@@ -29,6 +29,26 @@ or:
 cargo run -p spidapter -- stdio
 ```
 
+### `setup()` backend selection
+
+By default, `setup()` provisions Spice Cloud (`SPIDAPTER_BACKEND=scp`).
+
+To run against a local scheduler + executor topology instead, set:
+
+```sh
+SPIDAPTER_BACKEND=local
+```
+
+When `SPIDAPTER_BACKEND=local`, `spidapter`:
+
+- starts a local `spiced --role scheduler`
+- starts exactly one local `spiced --role executor`
+- returns FlightSQL ADBC connection params pointing at the local scheduler
+
+This mode requires `spice` and `spiced` binaries to be available in `PATH`.
+
+`spidapter` local mode binds local cluster services on `0.0.0.0`, uses `127.0.0.1` for local client connectivity, and starts one scheduler plus one executor. Use this mode only for local development on trusted machines.
+
 ### Protocol
 
 - Transport: stdio

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
+
+use tokio::process::{Child, Command as TokioCommand};
 
 use arrow::datatypes::DataType;
 use async_trait::async_trait;
@@ -23,7 +28,7 @@ use spicepod::component::ComponentOrReference;
 use spicepod::component::access::AccessMode;
 use spicepod::component::catalog::Catalog;
 use spicepod::component::dataset::Dataset;
-use spicepod::component::runtime::{Flight, Runtime, TelemetryConfig};
+use spicepod::component::runtime::{ApiKey, ApiKeyAuth, Auth, Flight, Runtime, TelemetryConfig};
 use spicepod::param::Params;
 use spicepod::spec::SpicepodDefinition;
 use system_adapter_protocol::{
@@ -36,16 +41,87 @@ use uuid::Uuid;
 use crate::args::StdioArgs;
 use crate::commands;
 
+const SPIDAPTER_BACKEND_ENV: &str = "SPIDAPTER_BACKEND";
+const LOCAL_BIND_HOST: &str = "0.0.0.0";
+const LOCAL_CONNECT_HOST: &str = "127.0.0.1";
+const LOCAL_SPICED_BINARY: &str = "spiced";
+const LOCAL_SPICE_BINARY: &str = "spice";
+
 /// State for an active benchmark run provisioned via `setup`.
-struct RunState {
-    /// Spice Cloud app ID.
-    app_id: i64,
-    /// API key for the app (used for Flight SQL authentication).
-    api_key: String,
-    /// Flight SQL endpoint URL derived from the cname.
+enum RunState {
+    Scp {
+        /// Spice Cloud app ID.
+        app_id: i64,
+        /// API key for the app (used for Flight SQL authentication).
+        api_key: String,
+        /// Flight SQL endpoint URL derived from the cname.
+        flight_url: String,
+        /// Cloud client used during provisioning (reused for teardown).
+        cloud: CloudClient,
+    },
+    Local(Box<LocalRunState>),
+}
+
+impl RunState {
+    fn flight_url(&self) -> &str {
+        match self {
+            Self::Scp { flight_url, .. } => flight_url.as_str(),
+            Self::Local(state) => state.flight_url.as_str(),
+        }
+    }
+
+    fn password(&self) -> &str {
+        match self {
+            Self::Scp { api_key, .. } => api_key.as_str(),
+            Self::Local(_) => "",
+        }
+    }
+}
+
+struct LocalRunState {
+    scheduler_child: Child,
+    executor_child: Child,
     flight_url: String,
-    /// Cloud client used during provisioning (reused for teardown).
-    cloud: CloudClient,
+    flight_api_key: Option<String>,
+    sql_url: String,
+    working_dir: PathBuf,
+}
+
+impl Drop for LocalRunState {
+    fn drop(&mut self) {
+        let _ = self.executor_child.start_kill();
+        let _ = self.scheduler_child.start_kill();
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackendMode {
+    Scp,
+    Local,
+}
+
+impl BackendMode {
+    fn from_env() -> Result<Self, String> {
+        let raw = match std::env::var(SPIDAPTER_BACKEND_ENV) {
+            Ok(value) => value,
+            Err(std::env::VarError::NotPresent) => return Ok(Self::Scp),
+            Err(err) => {
+                return Err(format!("Failed to read {SPIDAPTER_BACKEND_ENV}: {err}"));
+            }
+        };
+
+        parse_backend_mode(&raw)
+    }
+}
+
+fn parse_backend_mode(raw_value: &str) -> Result<BackendMode, String> {
+    match raw_value.trim().to_ascii_lowercase().as_str() {
+        "" | "scp" => Ok(BackendMode::Scp),
+        "local" => Ok(BackendMode::Local),
+        value => Err(format!(
+            "Invalid {SPIDAPTER_BACKEND_ENV} value '{value}'. Supported values: scp, local"
+        )),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -150,37 +226,62 @@ impl Handler for SpidapterHandler {
         );
 
         let setup_config = SetupConfig::from_metadata(&metadata).set_etl_sink_type(etl_sink_type);
+        let backend = BackendMode::from_env()?;
 
-        let state = provision_spice_cloud_app(
-            run_id,
-            self.api_url_override.as_deref(),
-            self.ready_wait,
-            self.channel.as_deref(),
-            &setup_config,
-            &datasets,
-        )
-        .await
+        let state = match backend {
+            BackendMode::Scp => {
+                provision_spice_cloud_app(
+                    run_id,
+                    self.api_url_override.as_deref(),
+                    self.ready_wait,
+                    self.channel.as_deref(),
+                    &setup_config,
+                    &datasets,
+                )
+                .await
+            }
+            BackendMode::Local => {
+                provision_local_spiced_cluster(
+                    run_id,
+                    Duration::from_secs(self.ready_wait),
+                    &setup_config,
+                    &datasets,
+                )
+                .await
+            }
+        }
         .map_err(|e| format!("Setup failed: {e}"))?;
+
+        let mut db_kwargs = HashMap::from([
+            (
+                "uri".to_string(),
+                serde_json::Value::String(state.flight_url().to_string()),
+            ),
+            (
+                "username".to_string(),
+                serde_json::Value::String(String::new()),
+            ),
+            (
+                "password".to_string(),
+                serde_json::Value::String(state.password().to_string()),
+            ),
+        ]);
+
+        if let RunState::Local(local_state) = &state
+            && let Some(api_key) = &local_state.flight_api_key
+        {
+            db_kwargs.insert(
+                "adbc.flight.sql.rpc.call_header.authorization".to_string(),
+                serde_json::Value::String(format!("Bearer {api_key}")),
+            );
+        }
 
         let response = SetupResponse {
             driver: AdbcDriver::Flightsql,
-            db_kwargs: HashMap::from([
-                (
-                    "uri".to_string(),
-                    serde_json::Value::String(state.flight_url.clone()),
-                ),
-                (
-                    "username".to_string(),
-                    serde_json::Value::String(String::new()),
-                ),
-                (
-                    "password".to_string(),
-                    serde_json::Value::String(state.api_key.clone()),
-                ),
-            ]),
+            db_kwargs,
             catalog_namespace: etl_sink_type
                 .as_ref()
-                .filter(|t| matches!(t, EtlSinkType::Adbc))
+                .filter(|sink_type| matches!(sink_type, EtlSinkType::Adbc))
                 .map(|_| "spicebench.bench".to_string()),
             read_driver: None,
         };
@@ -195,54 +296,65 @@ impl Handler for SpidapterHandler {
             .get(&run_id)
             .ok_or_else(|| format!("No active run found for {run_id}"))?;
 
-        let cloud_metrics = state
-            .cloud
-            .get_app_metrics(state.app_id, None)
-            .await
-            .map_err(|e| format!("Failed to fetch metrics: {e}"))?;
+        match state {
+            RunState::Scp { app_id, cloud, .. } => {
+                let cloud_metrics = cloud
+                    .get_app_metrics(*app_id, None)
+                    .await
+                    .map_err(|e| format!("Failed to fetch metrics: {e}"))?;
 
-        let pods = cloud_metrics.metrics.values().collect::<Vec<_>>();
+                let pods = cloud_metrics.metrics.values().collect::<Vec<_>>();
 
-        let resource = if pods.is_empty() {
-            ResourceMetrics::default()
-        } else {
-            ResourceMetrics {
-                // Sum cumulative CPU seconds across all pods
-                cpu_usage_percent: Some(
-                    pods.iter()
-                        .filter_map(|p| p.cpu_usage_percent)
-                        .sum::<f64>()
-                        .max(0.0),
-                ),
-                memory_usage_bytes: sum_opt_u64(&pods, |p| p.memory_usage_bytes),
-                disk_read_bytes: Some(
-                    sum_opt_f64_as_u64(&pods, |p| p.disk_read_bytes).unwrap_or_default(),
-                ),
-                disk_write_bytes: Some(
-                    sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes).unwrap_or_default(),
-                ),
-                disk_read_iops: Some(
-                    sum_opt_f64_as_u64(&pods, |p| p.disk_read_operations).unwrap_or_default(),
-                ),
-                disk_write_iops: Some(
-                    sum_opt_f64_as_u64(&pods, |p| p.disk_write_operations).unwrap_or_default(),
-                ),
+                let resource = if pods.is_empty() {
+                    ResourceMetrics::default()
+                } else {
+                    ResourceMetrics {
+                        // Sum cumulative CPU seconds across all pods
+                        cpu_usage_percent: Some(
+                            pods.iter()
+                                .filter_map(|pod| pod.cpu_usage_percent)
+                                .sum::<f64>()
+                                .max(0.0),
+                        ),
+                        memory_usage_bytes: sum_opt_u64(&pods, |pod| pod.memory_usage_bytes),
+                        disk_read_bytes: Some(
+                            sum_opt_f64_as_u64(&pods, |pod| pod.disk_read_bytes)
+                                .unwrap_or_default(),
+                        ),
+                        disk_write_bytes: Some(
+                            sum_opt_f64_as_u64(&pods, |pod| pod.disk_write_bytes)
+                                .unwrap_or_default(),
+                        ),
+                        disk_read_iops: Some(
+                            sum_opt_f64_as_u64(&pods, |pod| pod.disk_read_operations)
+                                .unwrap_or_default(),
+                        ),
+                        disk_write_iops: Some(
+                            sum_opt_f64_as_u64(&pods, |pod| pod.disk_write_operations)
+                                .unwrap_or_default(),
+                        ),
+                    }
+                };
+
+                let ingestion = cloud_metrics
+                    .ingestion
+                    .map(|ingestion| IngestionMetrics {
+                        rows_ingested: ingestion.rows_ingested,
+                        bytes_ingested: ingestion.bytes_ingested,
+                        ..IngestionMetrics::default()
+                    })
+                    .unwrap_or_default();
+
+                Ok(MetricsResponse {
+                    resource,
+                    ingestion,
+                })
             }
-        };
-
-        let ingestion = cloud_metrics
-            .ingestion
-            .map(|i| IngestionMetrics {
-                rows_ingested: i.rows_ingested,
-                bytes_ingested: i.bytes_ingested,
-                ..IngestionMetrics::default()
-            })
-            .unwrap_or_default();
-
-        Ok(MetricsResponse {
-            resource,
-            ingestion,
-        })
+            RunState::Local(_) => Ok(MetricsResponse {
+                resource: ResourceMetrics::default(),
+                ingestion: IngestionMetrics::default(),
+            }),
+        }
     }
 
     async fn teardown(&mut self, run_id: Uuid) -> Result<TeardownResponse, String> {
@@ -253,17 +365,24 @@ impl Handler for SpidapterHandler {
             return Ok(TeardownResponse { ok: true });
         };
 
-        eprintln!(
-            "[stdio] teardown: deleting app {} at {}",
-            state.app_id,
-            state.cloud.base_url()
-        );
+        match state {
+            RunState::Scp { app_id, cloud, .. } => {
+                eprintln!(
+                    "[stdio] teardown: deleting app {app_id} at {}",
+                    cloud.base_url()
+                );
+                commands::delete_app(&cloud, app_id)
+                    .await
+                    .map_err(|e| format!("Failed to delete app {app_id}: {e}"))?;
+                eprintln!("[stdio] teardown: app {app_id} deleted");
+            }
+            RunState::Local(mut local_state) => {
+                teardown_local_run(&mut local_state)
+                    .await
+                    .map_err(|e| format!("Failed to teardown local run {run_id}: {e}"))?;
+            }
+        }
 
-        commands::delete_app(&state.cloud, state.app_id)
-            .await
-            .map_err(|e| format!("Failed to delete app {}: {e}", state.app_id))?;
-
-        eprintln!("[stdio] teardown: app {} deleted", state.app_id);
         Ok(TeardownResponse { ok: true })
     }
 }
@@ -280,8 +399,8 @@ pub async fn run_stdio_server(args: &StdioArgs) -> anyhow::Result<()> {
 async fn post_setup_sink_action(
     setup_config: &SetupConfig,
     datasets: &HashMap<String, DatasetConfig>,
-    cname: &str,
-    api_key: &str,
+    sql_url: &str,
+    api_key: Option<&str>,
 ) -> anyhow::Result<()> {
     if setup_config.sink_type == Some(EtlSinkType::Adbc) {
         eprintln!("[stdio] Executing post-setup actions for ADBC sink...");
@@ -292,7 +411,6 @@ async fn post_setup_sink_action(
             return Ok(());
         }
 
-        let sql_url = format!("https://{cname}.spiceai.io/v1/sql");
         let sql_client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60))
             .build()?;
@@ -302,12 +420,11 @@ async fn post_setup_sink_action(
             eprintln!("[stdio] Running post-setup SQL: {statement}");
 
             loop {
-                let response = sql_client
-                    .post(&sql_url)
-                    .header("X-API-Key", api_key)
-                    .body(statement.clone())
-                    .send()
-                    .await?;
+                let mut request = sql_client.post(sql_url).body(statement.clone());
+                if let Some(key) = api_key {
+                    request = request.header("X-API-Key", key);
+                }
+                let response = request.send().await?;
 
                 if response.status().is_success() {
                     break;
@@ -381,9 +498,35 @@ fn generate_adbc_create_table_statement(
         ));
     }
 
+    let mut table_elements = column_definitions;
+    if !dataset.primary_key_columns.is_empty() {
+        let schema_columns = dataset
+            .schema
+            .fields()
+            .iter()
+            .map(|field| field.name().clone())
+            .collect::<HashSet<_>>();
+
+        for primary_key_column in &dataset.primary_key_columns {
+            if !schema_columns.contains(primary_key_column) {
+                return Err(anyhow::anyhow!(
+                    "Dataset '{dataset_name}' has primary key column '{primary_key_column}' that is not present in the schema"
+                ));
+            }
+        }
+
+        let primary_keys = dataset
+            .primary_key_columns
+            .iter()
+            .map(|column| quote_identifier(column))
+            .collect::<Vec<_>>()
+            .join(", ");
+        table_elements.push(format!("PRIMARY KEY ({primary_keys})"));
+    }
+
     Ok(format!(
-        "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_dataset_name} ({})",
-        column_definitions.join(", ")
+        "CREATE TABLE spicebench.bench.{quoted_dataset_name} ({})",
+        table_elements.join(", ")
     ))
 }
 
@@ -466,7 +609,7 @@ async fn provision_spice_cloud_app(
 
     eprintln!("[stdio] App ID: {app_id}");
 
-    let spicepod_yaml = generate_initial_spicepod(&run_id, setup_config, datasets)?;
+    let spicepod_yaml = generate_initial_spicepod(&run_id, setup_config, datasets, None)?;
     eprintln!("[stdio] Generated spicepod:\n{spicepod_yaml}");
 
     eprintln!("[stdio] Uploading spicepod to app...");
@@ -498,14 +641,493 @@ async fn provision_spice_cloud_app(
 
     eprintln!("[stdio] Spice Cloud deployment ready for app '{app_name}' at {flight_url}");
 
-    post_setup_sink_action(setup_config, datasets, &cname, &api_key).await?;
+    let sql_url = format!("https://{cname}.spiceai.io/v1/sql");
+    post_setup_sink_action(setup_config, datasets, &sql_url, Some(&api_key)).await?;
 
-    Ok(RunState {
+    Ok(RunState::Scp {
         app_id,
         api_key,
         flight_url,
         cloud,
     })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LocalPorts {
+    scheduler_http: u16,
+    scheduler_flight: u16,
+    scheduler_node: u16,
+    executor_http: u16,
+    executor_flight: u16,
+    executor_node: u16,
+}
+
+#[derive(Debug, Clone)]
+struct LocalPkiPaths {
+    ca_cert: PathBuf,
+    scheduler_cert: PathBuf,
+    scheduler_key: PathBuf,
+    executor_cert: PathBuf,
+    executor_key: PathBuf,
+}
+
+async fn provision_local_spiced_cluster(
+    run_id: Uuid,
+    ready_wait: Duration,
+    setup_config: &SetupConfig,
+    datasets: &HashMap<String, DatasetConfig>,
+) -> anyhow::Result<RunState> {
+    let ports = allocate_local_ports(LOCAL_BIND_HOST)?;
+
+    let working_dir = create_local_working_dir(run_id).await?;
+    let local_flight_api_key = (setup_config.sink_type == Some(EtlSinkType::Adbc))
+        .then(|| format!("spidapter-local-{run_id}"));
+
+    let setup_result = async {
+        let scheduler_dir = working_dir.join("scheduler");
+        let executor_dir = working_dir.join("executor-0");
+        tokio::fs::create_dir_all(&scheduler_dir).await?;
+        tokio::fs::create_dir_all(&executor_dir).await?;
+
+        let spicepod_yaml = generate_initial_spicepod(
+            &run_id,
+            setup_config,
+            datasets,
+            local_flight_api_key.as_deref(),
+        )?;
+        let spicepod_path = write_local_spicepod(&spicepod_yaml, &working_dir).await?;
+
+        let run_id_str = run_id.to_string();
+        let short_run_id = run_id_str.split('-').next().unwrap_or_default();
+        let process_id = std::process::id();
+        let scheduler_cert_name = format!("spidapter-scheduler-{short_run_id}-{process_id}");
+        let executor_cert_name = format!("spidapter-executor-{short_run_id}-{process_id}");
+
+        let pki_paths = ensure_local_cluster_pki(
+            LOCAL_SPICE_BINARY,
+            LOCAL_CONNECT_HOST,
+            &scheduler_cert_name,
+            &executor_cert_name,
+        )
+        .await?;
+
+        Ok::<(PathBuf, PathBuf, PathBuf, LocalPkiPaths), anyhow::Error>((
+            scheduler_dir,
+            executor_dir,
+            spicepod_path,
+            pki_paths,
+        ))
+    }
+    .await;
+
+    let (scheduler_dir, executor_dir, spicepod_path, pki_paths) = match setup_result {
+        Ok(result) => result,
+        Err(error) => {
+            let _ = cleanup_local_artifacts(&working_dir).await;
+            return Err(error);
+        }
+    };
+
+    let scheduler_args = scheduler_spiced_args(
+        LOCAL_BIND_HOST,
+        LOCAL_CONNECT_HOST,
+        ports,
+        &pki_paths,
+        spicepod_path.as_path(),
+    );
+    let mut scheduler_child = match spawn_local_spiced(
+        LOCAL_SPICED_BINARY,
+        &scheduler_dir,
+        &scheduler_args,
+        "scheduler",
+    ) {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = cleanup_local_artifacts(&working_dir).await;
+            return Err(error);
+        }
+    };
+
+    let scheduler_http_url = format!("http://{}:{}", LOCAL_CONNECT_HOST, ports.scheduler_http);
+    let scheduler_sql_url = format!("{scheduler_http_url}/v1/sql");
+
+    if let Err(error) = wait_for_local_http_ready(
+        &scheduler_http_url,
+        &mut scheduler_child,
+        ready_wait,
+        "scheduler",
+    )
+    .await
+    {
+        let _ = stop_child_process(&mut scheduler_child, "scheduler").await;
+        let _ = cleanup_local_artifacts(&working_dir).await;
+        return Err(error);
+    }
+
+    let executor_args =
+        executor_spiced_args(LOCAL_BIND_HOST, LOCAL_CONNECT_HOST, ports, &pki_paths);
+    let mut executor_child = match spawn_local_spiced(
+        LOCAL_SPICED_BINARY,
+        &executor_dir,
+        &executor_args,
+        "executor",
+    ) {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = stop_child_process(&mut scheduler_child, "scheduler").await;
+            let _ = cleanup_local_artifacts(&working_dir).await;
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = wait_for_local_sql_ready(
+        &scheduler_sql_url,
+        &mut scheduler_child,
+        &mut executor_child,
+        ready_wait,
+        local_flight_api_key.as_deref(),
+    )
+    .await
+    {
+        let _ = stop_child_process(&mut executor_child, "executor").await;
+        let _ = stop_child_process(&mut scheduler_child, "scheduler").await;
+        let _ = cleanup_local_artifacts(&working_dir).await;
+        return Err(error);
+    }
+
+    if let Err(error) = post_setup_sink_action(
+        setup_config,
+        datasets,
+        &scheduler_sql_url,
+        local_flight_api_key.as_deref(),
+    )
+    .await
+    {
+        let _ = stop_child_process(&mut executor_child, "executor").await;
+        let _ = stop_child_process(&mut scheduler_child, "scheduler").await;
+        let _ = cleanup_local_artifacts(&working_dir).await;
+        return Err(error);
+    }
+
+    Ok(RunState::Local(Box::new(LocalRunState {
+        scheduler_child,
+        executor_child,
+        flight_url: format!("grpc://{}:{}", LOCAL_CONNECT_HOST, ports.scheduler_flight),
+        flight_api_key: local_flight_api_key,
+        sql_url: scheduler_sql_url,
+        working_dir,
+    })))
+}
+
+async fn create_local_working_dir(run_id: Uuid) -> anyhow::Result<PathBuf> {
+    let run_dir = std::env::temp_dir().join(format!("spidapter-local-{run_id}"));
+    if tokio::fs::metadata(&run_dir).await.is_ok() {
+        tokio::fs::remove_dir_all(&run_dir).await?;
+    }
+    tokio::fs::create_dir_all(&run_dir).await?;
+    Ok(run_dir)
+}
+
+async fn write_local_spicepod(spicepod_yaml: &str, working_dir: &Path) -> anyhow::Result<PathBuf> {
+    let spicepod_path = working_dir.join("spicepod.yaml");
+    tokio::fs::write(&spicepod_path, spicepod_yaml).await?;
+    Ok(spicepod_path)
+}
+
+fn allocate_local_ports(host: &str) -> anyhow::Result<LocalPorts> {
+    Ok(LocalPorts {
+        scheduler_http: reserve_local_port(host)?,
+        scheduler_flight: reserve_local_port(host)?,
+        scheduler_node: reserve_local_port(host)?,
+        executor_http: reserve_local_port(host)?,
+        executor_flight: reserve_local_port(host)?,
+        executor_node: reserve_local_port(host)?,
+    })
+}
+
+fn reserve_local_port(host: &str) -> anyhow::Result<u16> {
+    let listener = TcpListener::bind((host, 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn pki_dir() -> anyhow::Result<PathBuf> {
+    let home_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Home directory not found; cannot resolve ~/.spice/pki"))?;
+    Ok(home_dir.join(".spice").join("pki"))
+}
+
+async fn ensure_local_cluster_pki(
+    spice_cli_path: &str,
+    host: &str,
+    scheduler_cert_name: &str,
+    executor_cert_name: &str,
+) -> anyhow::Result<LocalPkiPaths> {
+    let pki_dir = pki_dir()?;
+    let ca_cert = pki_dir.join("ca.crt");
+    let ca_key = pki_dir.join("ca.key");
+
+    if !ca_cert.exists() || !ca_key.exists() {
+        eprintln!("[stdio] local backend: generating cluster CA with spice cluster tls init");
+        run_spice_cli_command(
+            spice_cli_path,
+            vec!["cluster".to_string(), "tls".to_string(), "init".to_string()],
+        )
+        .await?;
+    }
+
+    add_tls_certificate(spice_cli_path, scheduler_cert_name, host).await?;
+    add_tls_certificate(spice_cli_path, executor_cert_name, host).await?;
+
+    Ok(LocalPkiPaths {
+        ca_cert,
+        scheduler_cert: pki_dir.join(format!("{scheduler_cert_name}.crt")),
+        scheduler_key: pki_dir.join(format!("{scheduler_cert_name}.key")),
+        executor_cert: pki_dir.join(format!("{executor_cert_name}.crt")),
+        executor_key: pki_dir.join(format!("{executor_cert_name}.key")),
+    })
+}
+
+async fn add_tls_certificate(
+    spice_cli_path: &str,
+    cert_name: &str,
+    host: &str,
+) -> anyhow::Result<()> {
+    let mut args = vec![
+        "cluster".to_string(),
+        "tls".to_string(),
+        "add".to_string(),
+        cert_name.to_string(),
+    ];
+
+    if !host.is_empty() {
+        args.push("--host".to_string());
+        args.push(host.to_string());
+    }
+
+    run_spice_cli_command(spice_cli_path, args).await
+}
+
+async fn run_spice_cli_command(binary_path: &str, args: Vec<String>) -> anyhow::Result<()> {
+    let binary_path = binary_path.to_string();
+    let command_display = format!("{binary_path} {}", args.join(" "));
+    let command_display_for_spawn = command_display.clone();
+    let args_for_spawn = args;
+
+    let status = tokio::task::spawn_blocking(move || {
+        StdCommand::new(&binary_path)
+            .args(&args_for_spawn)
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .status()
+            .map_err(|error| {
+                anyhow::anyhow!("Failed to execute '{command_display_for_spawn}': {error}")
+            })
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("Failed to join command '{command_display}': {error}"))??;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Command '{command_display}' failed with status {status}"
+        ));
+    }
+
+    Ok(())
+}
+
+fn scheduler_spiced_args(
+    bind_host: &str,
+    advertise_host: &str,
+    ports: LocalPorts,
+    pki_paths: &LocalPkiPaths,
+    spicepod_path: &Path,
+) -> Vec<String> {
+    vec![
+        "--role".to_string(),
+        "scheduler".to_string(),
+        "--http".to_string(),
+        format!("{bind_host}:{}", ports.scheduler_http),
+        "--flight".to_string(),
+        format!("{bind_host}:{}", ports.scheduler_flight),
+        "--node-bind-address".to_string(),
+        format!("{bind_host}:{}", ports.scheduler_node),
+        "--node-advertise-address".to_string(),
+        advertise_host.to_string(),
+        "--node-mtls-ca-certificate-file".to_string(),
+        pki_paths.ca_cert.display().to_string(),
+        "--node-mtls-certificate-file".to_string(),
+        pki_paths.scheduler_cert.display().to_string(),
+        "--node-mtls-key-file".to_string(),
+        pki_paths.scheduler_key.display().to_string(),
+        spicepod_path.display().to_string(),
+    ]
+}
+
+fn executor_spiced_args(
+    bind_host: &str,
+    scheduler_host: &str,
+    ports: LocalPorts,
+    pki_paths: &LocalPkiPaths,
+) -> Vec<String> {
+    vec![
+        "--role".to_string(),
+        "executor".to_string(),
+        "--scheduler-address".to_string(),
+        format!("https://{scheduler_host}:{}", ports.scheduler_node),
+        "--http".to_string(),
+        format!("{bind_host}:{}", ports.executor_http),
+        "--flight".to_string(),
+        format!("{bind_host}:{}", ports.executor_flight),
+        "--node-bind-address".to_string(),
+        format!("{bind_host}:{}", ports.executor_node),
+        "--node-advertise-address".to_string(),
+        scheduler_host.to_string(),
+        "--node-mtls-ca-certificate-file".to_string(),
+        pki_paths.ca_cert.display().to_string(),
+        "--node-mtls-certificate-file".to_string(),
+        pki_paths.executor_cert.display().to_string(),
+        "--node-mtls-key-file".to_string(),
+        pki_paths.executor_key.display().to_string(),
+    ]
+}
+
+fn spawn_local_spiced(
+    spiced_path: &str,
+    current_dir: &Path,
+    args: &[String],
+    process_name: &str,
+) -> anyhow::Result<Child> {
+    eprintln!(
+        "[stdio] local backend: launching {process_name} process: {spiced_path} {}",
+        args.join(" ")
+    );
+
+    TokioCommand::new(spiced_path)
+        .kill_on_drop(true)
+        .args(args)
+        .current_dir(current_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("Failed to start local {process_name} process: {error}"))
+}
+
+async fn wait_for_local_http_ready(
+    http_url: &str,
+    child: &mut Child,
+    timeout: Duration,
+    process_name: &str,
+) -> anyhow::Result<()> {
+    let ready_url = format!("{http_url}/health");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+
+    let started = tokio::time::Instant::now();
+    loop {
+        ensure_process_is_running(child, process_name)?;
+
+        if started.elapsed() > timeout {
+            return Err(anyhow::anyhow!(
+                "Timed out after {}s waiting for local {process_name} readiness at {ready_url}",
+                timeout.as_secs()
+            ));
+        }
+
+        match client.get(&ready_url).send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+        }
+    }
+}
+
+async fn wait_for_local_sql_ready(
+    sql_url: &str,
+    scheduler_child: &mut Child,
+    executor_child: &mut Child,
+    timeout: Duration,
+    api_key: Option<&str>,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+
+    let started = tokio::time::Instant::now();
+    loop {
+        ensure_process_is_running(scheduler_child, "scheduler")?;
+        ensure_process_is_running(executor_child, "executor")?;
+
+        if started.elapsed() > timeout {
+            return Err(anyhow::anyhow!(
+                "Timed out after {}s waiting for local SQL readiness at {sql_url}",
+                timeout.as_secs()
+            ));
+        }
+
+        let mut request = client.post(sql_url).body("SELECT 1");
+        if let Some(key) = api_key {
+            request = request.header("X-API-Key", key);
+        }
+
+        match request.send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+        }
+    }
+}
+
+fn ensure_process_is_running(child: &mut Child, process_name: &str) -> anyhow::Result<()> {
+    if let Some(status) = child.try_wait()? {
+        return Err(anyhow::anyhow!(
+            "Local {process_name} process exited early with status {status}"
+        ));
+    }
+    Ok(())
+}
+
+async fn teardown_local_run(local_state: &mut LocalRunState) -> anyhow::Result<()> {
+    eprintln!(
+        "[stdio] teardown: stopping local executor process (sql endpoint: {})",
+        local_state.sql_url
+    );
+    stop_child_process(&mut local_state.executor_child, "executor").await?;
+
+    eprintln!("[stdio] teardown: stopping local scheduler process");
+    stop_child_process(&mut local_state.scheduler_child, "scheduler").await?;
+
+    cleanup_local_artifacts(&local_state.working_dir).await
+}
+
+async fn stop_child_process(child: &mut Child, process_name: &str) -> anyhow::Result<()> {
+    if let Some(status) = child.try_wait()? {
+        eprintln!("[stdio] local backend: {process_name} already stopped with status {status}");
+        return Ok(());
+    }
+
+    child.kill().await.map_err(|error| {
+        anyhow::anyhow!("Failed to terminate local {process_name} process: {error}")
+    })?;
+
+    let status = child.wait().await.map_err(|error| {
+        anyhow::anyhow!("Failed to wait for local {process_name} process: {error}")
+    })?;
+
+    eprintln!("[stdio] local backend: {process_name} stopped with status {status}");
+    Ok(())
+}
+
+async fn cleanup_local_artifacts(working_dir: &Path) -> anyhow::Result<()> {
+    if tokio::fs::metadata(working_dir).await.is_ok() {
+        tokio::fs::remove_dir_all(working_dir).await?;
+        eprintln!(
+            "[stdio] local backend: removed artifacts in {}",
+            working_dir.display()
+        );
+    }
+
+    Ok(())
 }
 
 fn generate_hive_spicepod(
@@ -565,7 +1187,7 @@ fn generate_hive_spicepod(
     yaml::to_string(&spicepod).map_err(|e| anyhow::anyhow!("Failed to serialize spicepod: {e}"))
 }
 
-fn generate_adbc_spicepod(run_id: &Uuid) -> anyhow::Result<String> {
+fn generate_adbc_spicepod(run_id: &Uuid, flight_api_key: Option<&str>) -> anyhow::Result<String> {
     let run_id_str = run_id.to_string();
     let short_id = run_id_str.split('-').next().unwrap_or_default();
 
@@ -575,6 +1197,14 @@ fn generate_adbc_spicepod(run_id: &Uuid) -> anyhow::Result<String> {
             enabled: false,
             ..TelemetryConfig::default()
         },
+        auth: flight_api_key.map(|key| Auth {
+            api_key: Some(ApiKeyAuth {
+                enabled: true,
+                keys: vec![ApiKey::ReadWrite {
+                    key: key.to_string(),
+                }],
+            }),
+        }),
         flight: Some(Flight {
             do_put_rate_limit_enabled: false,
             ..Flight::default()
@@ -594,9 +1224,10 @@ fn generate_initial_spicepod(
     run_id: &Uuid,
     setup_config: &SetupConfig,
     datasets: &HashMap<String, DatasetConfig>,
+    flight_api_key: Option<&str>,
 ) -> anyhow::Result<String> {
     match setup_config.sink_type {
-        Some(EtlSinkType::Adbc) => generate_adbc_spicepod(run_id),
+        Some(EtlSinkType::Adbc) => generate_adbc_spicepod(run_id, flight_api_key),
         _ => generate_hive_spicepod(run_id, setup_config, datasets),
     }
 }
@@ -619,6 +1250,29 @@ mod tests {
     }
 
     #[test]
+    fn backend_mode_parser_defaults_to_scp() {
+        assert!(matches!(parse_backend_mode(""), Ok(BackendMode::Scp)));
+        assert!(matches!(parse_backend_mode("scp"), Ok(BackendMode::Scp)));
+    }
+
+    #[test]
+    fn backend_mode_parser_supports_local() {
+        assert!(matches!(
+            parse_backend_mode("LOCAL"),
+            Ok(BackendMode::Local)
+        ));
+    }
+
+    #[test]
+    fn backend_mode_parser_rejects_unknown_values() {
+        let error = parse_backend_mode("unexpected").expect_err("invalid backend should fail");
+        assert!(
+            error.contains("Invalid SPIDAPTER_BACKEND value"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn generate_spicepod_includes_dataset_entries() {
         let setup_config = SetupConfig {
             region: Some("us-west-2".to_string()),
@@ -638,7 +1292,7 @@ mod tests {
             },
         )]);
 
-        let spicepod = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets)
+        let spicepod = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets, None)
             .expect("spicepod should generate");
 
         assert!(spicepod.contains("from: \"s3://bucket/path/my_table/\""));
@@ -674,7 +1328,7 @@ mod tests {
             },
         )]);
 
-        let err = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets)
+        let err = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets, None)
             .expect_err("missing source should fail");
         assert!(
             err.to_string().contains("missing_table"),
@@ -707,12 +1361,34 @@ mod tests {
         )
         .expect("statement should generate");
 
-        assert!(statement.contains("CREATE TABLE IF NOT EXISTS spicebench.bench.\"orders\""));
+        assert!(statement.contains("CREATE TABLE spicebench.bench.\"orders\""));
         assert!(statement.contains("\"id\" BIGINT NOT NULL"));
         assert!(statement.contains("\"name\" TEXT"));
         assert!(statement.contains("\"price\" DECIMAL(10, 2)"));
         assert!(statement.contains("\"created_at\" TIMESTAMP"));
         assert!(statement.contains("PRIMARY KEY (\"id\")"));
+    }
+
+    #[test]
+    fn adbc_create_table_statement_errors_when_primary_key_missing_in_schema() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+        let err = generate_adbc_create_table_statement(
+            "events",
+            &DatasetConfig {
+                schema,
+                location: Some("s3://bucket/path/events/".to_string()),
+                primary_key_columns: vec!["missing_column".to_string()],
+                time_column: None,
+                partition_columns: Vec::new(),
+            },
+        )
+        .expect_err("primary key not in schema should fail");
+
+        assert!(
+            err.to_string().contains("is not present in the schema"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `SPIDAPTER_BACKEND` routing in `spidapter` setup (`scp` default, `local` new path)
- implement local setup/teardown lifecycle that starts a scheduler plus exactly one executor
- generate local cluster certificates via `spice cluster tls init` and `spice cluster tls add`
- wait for local readiness before returning ADBC config
- keep the setup response contract unchanged (FlightSQL `driver` + `db_kwargs`)
- update spidapter README with local backend env vars and single-executor note

## Validation
- `cargo check -p spidapter`
- `cargo test -p spidapter`
