### PR TITLE
fix(cayenne): stream PK retention deletes and run OOM regression in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -133,6 +133,7 @@ jobs:
           fi
 
           cargo nextest archive -p runtime --test integration --features ${FEATURES} --archive-file integration.tar.zst
+          cargo nextest archive -p runtime --test retention_oom --features ${FEATURES} --archive-file retention_oom.tar.zst
           cargo nextest archive -p runtime --test integration_aws_sdk --features databricks,delta_lake --archive-file integration_aws_sdk.tar.zst
           cargo nextest archive -p aws-sdk-credential-bridge --test credential_provider --archive-file integration_aws_sdk_credential_bridge.tar.zst
           cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
@@ -145,6 +146,14 @@ jobs:
         with:
           name: integration-test-archive
           path: ./integration.tar.zst
+          retention-days: 1
+
+      - name: Upload retention OOM test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5
+        with:
+          name: integration-retention-oom-test-archive
+          path: ./retention_oom.tar.zst
           retention-days: 1
 
       - name: Upload AWS SDK test archive
@@ -216,6 +225,13 @@ jobs:
         with:
           name: integration-test-archive
           path: ./integration_test
+
+      - name: Download retention OOM test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v6
+        with:
+          name: integration-retention-oom-test-archive
+          path: ./retention_oom_test
 
       - name: Set up Nextest
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -300,6 +316,12 @@ jobs:
           else
             INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --partition '${{ matrix.partition }}' --archive-file ./integration_test/integration.tar.zst --skip spiceai_integration_test
           fi
+
+      - name: Run retention OOM regression test
+        if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3'
+        run: |
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./retention_oom_test/retention_oom.tar.zst
+
       - name: Upload integration snapshots artifact
         id: create_snapshot_archive
         if: github.event.inputs.update_snapshots == 'always' && needs.check_changes.outputs.relevant_changes == 'true'

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -60,11 +60,14 @@ use data_components::delete::DeletionSink;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::execution::context::SessionContext;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
+use datafusion::physical_plan::{collect, execute_stream};
 use datafusion_catalog::TableProvider;
 use datafusion_common::tree_node::TreeNode;
 use datafusion_common::DFSchema;
+use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_expr::Expr;
-use datafusion_physical_plan::collect;
+use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
+use futures::StreamExt;
 use std::sync::{Arc, RwLock};
 
 // Position-based deletion methods implemented in sink/position_based.rs
@@ -251,10 +254,17 @@ impl CayenneDeletionSink {
         ctx: &SessionContext,
         tables: &[Arc<ListingTable>],
     ) -> super::super::Result<u64> {
-        use arrow::array::{Array, Int64Array};
-        use arrow::datatypes::{DataType, Field};
+        const PK_DELETE_FLUSH_BATCH_SIZE: usize = 50_000;
 
         let table_name = &self.table_metadata.table_name;
+
+        let _flush_batch_size_i64 =
+            convert_to_i64_box(PK_DELETE_FLUSH_BATCH_SIZE, "pk delete flush batch size").map_err(
+                |e| Error::Internal {
+                    table: table_name.clone(),
+                    message: e.to_string(),
+                },
+            )?;
 
         // For position-based deletion, use the streaming per-file approach directly.
         // This avoids loading all data into memory and provides correct file-local row IDs.
@@ -262,151 +272,269 @@ impl CayenneDeletionSink {
             return self.delete_filtered_rows_position_based(ctx, tables).await;
         }
 
-        // PK-based strategies (Int64Pk, RowConverterBased) need to scan all data
-        // to extract primary key values for deletion.
+        let coerced_filters = self.coerce_filters_for_schema()?;
+        let physical_filters = self.build_physical_filters(&coerced_filters)?;
 
-        // Collect batches from all tables
-        let mut all_batches = Vec::new();
-        for table in tables {
-            let scan_plan = table.scan(&ctx.state(), None, &[], None).await?;
-            let batches = collect(scan_plan, ctx.task_ctx()).await?;
-            all_batches.extend(batches);
-        }
-
-        // If no data, nothing to delete
-        if all_batches.is_empty() {
-            return Ok(0);
-        }
-
-        // Flatten all batches into one for simpler processing
-        let concatenated_batch = arrow::compute::concat_batches(&self.schema, &all_batches)?;
-        let total_rows = concatenated_batch.num_rows();
-
-        // Create a batch with row_id column added (needed for filtering)
-        let total_rows_i64 =
-            convert_to_i64_box(total_rows, "total rows").map_err(|e| Error::Internal {
-                table: table_name.clone(),
-                message: e.to_string(),
-            })?;
-        let row_id_array = Int64Array::from_iter_values(0..total_rows_i64);
-
-        let mut fields = vec![Field::new("__row_id", DataType::Int64, false)];
-        for field in self.schema.fields() {
-            fields.push((**field).clone());
-        }
-        let schema_with_rowid = Arc::new(arrow::datatypes::Schema::new(fields));
-
-        let mut columns_with_rowid = vec![Arc::new(row_id_array) as Arc<dyn Array>];
-        columns_with_rowid.extend_from_slice(concatenated_batch.columns());
-
-        let batch_with_rowid =
-            arrow::array::RecordBatch::try_new(Arc::clone(&schema_with_rowid), columns_with_rowid)?;
-
-        // Create a new session context with the row_id data
-        let ctx_new = SessionContext::new();
-        let mem_table_with_rowid = datafusion::datasource::MemTable::try_new(
-            Arc::clone(&schema_with_rowid),
-            vec![vec![batch_with_rowid]],
-        )?;
-        ctx_new.register_table("data_with_rowid", Arc::new(mem_table_with_rowid))?;
-
-        // Start with selecting all columns so filters can reference them
-        let mut filtered_df = ctx_new.sql("SELECT * FROM data_with_rowid").await?;
-
-        // Apply all filters with type coercion
-        // The filter expressions may have been parsed with different literal types (e.g., Int64)
-        // than the actual column types in the data (e.g., Int32). We use TypeCoercionRewriter
-        // to insert appropriate CAST operations to make the comparison valid.
-        let df_schema = DFSchema::try_from(schema_with_rowid.as_ref().clone())?;
-        for filter in &self.filters {
-            let mut rewriter = TypeCoercionRewriter::new(&df_schema);
-            let coerced_filter = filter.clone().rewrite(&mut rewriter)?.data;
-            filtered_df = filtered_df.filter(coerced_filter)?;
-        }
-
-        // Collect filtered results (includes __row_id and all original columns)
-        let filtered_batches = filtered_df.collect().await?;
-
-        if filtered_batches.is_empty() {
-            return Ok(0);
-        }
-
-        // Use the appropriate deletion strategy based on table configuration
         match &self.pk_deletion_strategy {
             PkDeletionStrategyWithCache::Int64Pk { .. } => {
-                // Int64 PK deletion - extract PK values directly
-                // Note: column indices are offset by 1 because __row_id is at index 0
-                let first_batch = filtered_batches.first().ok_or_else(|| Error::Internal {
-                    table: table_name.clone(),
-                    message: "Expected at least one batch after filtering (checked above)"
-                        .to_string(),
-                })?;
-                let filtered_concat =
-                    arrow::compute::concat_batches(&first_batch.schema(), &filtered_batches)?;
+                let mut pending_pk_values: Vec<i64> =
+                    Vec::with_capacity(PK_DELETE_FLUSH_BATCH_SIZE);
+                let mut delete_sequence: Option<i64> = None;
+                let mut deleted_rows: u64 = 0;
 
-                let pk_column_index =
-                    self.pk_column_indices
-                        .first()
-                        .ok_or_else(|| Error::Internal {
-                            table: table_name.clone(),
-                            message: "Int64 PK strategy requires exactly one PK column index"
-                                .to_string(),
-                        })?;
+                for table in tables {
+                    let scan_plan = table.scan(&ctx.state(), None, &[], None).await?;
+                    let mut stream = execute_stream(scan_plan, ctx.task_ctx())?;
 
-                let pk_column = filtered_concat.column(*pk_column_index + 1); // +1 for __row_id offset
-                let pk_array =
-                    pk_column
-                        .as_any()
-                        .downcast_ref::<Int64Array>()
-                        .ok_or_else(|| Error::Internal {
-                            table: table_name.clone(),
-                            message: format!(
-                                "Expected Int64Array for PK column at index {pk_column_index}, got {:?}",
-                                pk_column.data_type()
-                            ),
-                        })?;
+                    while let Some(batch_result) = stream.next().await {
+                        let batch =
+                            self.apply_physical_filters_to_batch(batch_result?, &physical_filters)?;
+                        if batch.num_rows() == 0 {
+                            continue;
+                        }
 
-                let pk_values: Vec<i64> = pk_array.values().iter().copied().collect();
-                self.persist_int64_pk_deletions(pk_values).await
+                        pending_pk_values.extend(self.extract_int64_pk_values(&batch)?);
+
+                        if pending_pk_values.len() >= PK_DELETE_FLUSH_BATCH_SIZE {
+                            let chunk_values = std::mem::take(&mut pending_pk_values);
+                            let chunk_deleted = self
+                                .persist_int64_pk_chunk_with_shared_sequence(
+                                    chunk_values,
+                                    &mut delete_sequence,
+                                )
+                                .await?;
+                            deleted_rows =
+                                deleted_rows.checked_add(chunk_deleted).ok_or_else(|| {
+                                    Error::Internal {
+                                        table: table_name.clone(),
+                                        message: "Deleted row count overflowed u64".to_string(),
+                                    }
+                                })?;
+                        }
+                    }
+                }
+
+                if !pending_pk_values.is_empty() {
+                    let chunk_values = std::mem::take(&mut pending_pk_values);
+                    let chunk_deleted = self
+                        .persist_int64_pk_chunk_with_shared_sequence(
+                            chunk_values,
+                            &mut delete_sequence,
+                        )
+                        .await?;
+                    deleted_rows =
+                        deleted_rows
+                            .checked_add(chunk_deleted)
+                            .ok_or_else(|| Error::Internal {
+                                table: table_name.clone(),
+                                message: "Deleted row count overflowed u64".to_string(),
+                            })?;
+                }
+
+                Ok(deleted_rows)
             }
             PkDeletionStrategyWithCache::RowConverterBased { .. } => {
-                // RowConverter-based deletion for composite/non-integer PKs
-                if let Some(ref row_converter) = self.pk_row_converter {
-                    let filtered_concat = arrow::compute::concat_batches(
-                        &filtered_batches[0].schema(),
-                        &filtered_batches,
-                    )?;
-
-                    let pk_columns: Vec<ArrayRef> = self
-                        .pk_column_indices
-                        .iter()
-                        .map(|&idx| Arc::clone(filtered_concat.column(idx + 1))) // +1 for __row_id offset
-                        .collect();
-
-                    let rows = row_converter.convert_columns(&pk_columns)?;
-                    let row_keys: Vec<Box<[u8]>> = rows
-                        .iter()
-                        .map(|row| row.as_ref().to_vec().into_boxed_slice())
-                        .collect();
-
-                    self.persist_key_based_deletions(row_keys).await
-                } else {
-                    Err(Error::Internal {
+                let Some(row_converter) = self.pk_row_converter.as_ref() else {
+                    return Err(Error::Internal {
                         table: table_name.clone(),
                         message: "RowConverter not available for RowConverterBased strategy"
                             .to_string(),
-                    })
+                    });
+                };
+
+                let mut pending_row_keys: Vec<Box<[u8]>> =
+                    Vec::with_capacity(PK_DELETE_FLUSH_BATCH_SIZE);
+                let mut delete_sequence: Option<i64> = None;
+                let mut deleted_rows: u64 = 0;
+
+                for table in tables {
+                    let scan_plan = table.scan(&ctx.state(), None, &[], None).await?;
+                    let mut stream = execute_stream(scan_plan, ctx.task_ctx())?;
+
+                    while let Some(batch_result) = stream.next().await {
+                        let batch =
+                            self.apply_physical_filters_to_batch(batch_result?, &physical_filters)?;
+                        if batch.num_rows() == 0 {
+                            continue;
+                        }
+
+                        pending_row_keys.extend(self.extract_row_keys(&batch, row_converter)?);
+
+                        if pending_row_keys.len() >= PK_DELETE_FLUSH_BATCH_SIZE {
+                            let chunk_keys = std::mem::take(&mut pending_row_keys);
+                            let chunk_deleted = self
+                                .persist_key_based_chunk_with_shared_sequence(
+                                    chunk_keys,
+                                    &mut delete_sequence,
+                                )
+                                .await?;
+                            deleted_rows =
+                                deleted_rows.checked_add(chunk_deleted).ok_or_else(|| {
+                                    Error::Internal {
+                                        table: table_name.clone(),
+                                        message: "Deleted row count overflowed u64".to_string(),
+                                    }
+                                })?;
+                        }
+                    }
                 }
+
+                if !pending_row_keys.is_empty() {
+                    let chunk_keys = std::mem::take(&mut pending_row_keys);
+                    let chunk_deleted = self
+                        .persist_key_based_chunk_with_shared_sequence(
+                            chunk_keys,
+                            &mut delete_sequence,
+                        )
+                        .await?;
+                    deleted_rows =
+                        deleted_rows
+                            .checked_add(chunk_deleted)
+                            .ok_or_else(|| Error::Internal {
+                                table: table_name.clone(),
+                                message: "Deleted row count overflowed u64".to_string(),
+                            })?;
+                }
+
+                Ok(deleted_rows)
             }
             PkDeletionStrategyWithCache::PositionBased { .. } => {
-                unreachable!("PositionBased strategy should have returned early via delete_filtered_rows_streaming_position_based")
+                unreachable!(
+                    "PositionBased strategy should have returned early via delete_filtered_rows_position_based"
+                )
             }
         }
+    }
+
+    fn coerce_filters_for_schema(&self) -> super::super::Result<Vec<Expr>> {
+        let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+        let mut coerced_filters = Vec::with_capacity(self.filters.len());
+
+        for filter in &self.filters {
+            let mut rewriter = TypeCoercionRewriter::new(&df_schema);
+            coerced_filters.push(filter.clone().rewrite(&mut rewriter)?.data);
+        }
+
+        Ok(coerced_filters)
+    }
+
+    fn build_physical_filters(
+        &self,
+        filters: &[Expr],
+    ) -> super::super::Result<Vec<Arc<dyn PhysicalExpr>>> {
+        let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+        let execution_props = ExecutionProps::new();
+
+        let physical_filters = filters
+            .iter()
+            .map(|filter| create_physical_expr(filter, &df_schema, &execution_props))
+            .collect::<datafusion_common::Result<Vec<_>>>()?;
+
+        Ok(physical_filters)
+    }
+
+    fn apply_physical_filters_to_batch(
+        &self,
+        mut batch: arrow::record_batch::RecordBatch,
+        physical_filters: &[Arc<dyn PhysicalExpr>],
+    ) -> super::super::Result<arrow::record_batch::RecordBatch> {
+        let table_name = &self.table_metadata.table_name;
+
+        for filter in physical_filters {
+            if batch.num_rows() == 0 {
+                break;
+            }
+
+            let filter_value = filter.evaluate(&batch)?;
+            let filter_array = filter_value.into_array(batch.num_rows())?;
+            let filter_array = filter_array
+                .as_any()
+                .downcast_ref::<arrow::array::BooleanArray>()
+                .ok_or_else(|| Error::Internal {
+                    table: table_name.clone(),
+                    message: format!(
+                        "Filter expression did not evaluate to BooleanArray, got {:?}",
+                        filter_array.data_type()
+                    ),
+                })?;
+
+            batch = arrow::compute::filter_record_batch(&batch, filter_array)?;
+        }
+
+        Ok(batch)
+    }
+
+    async fn persist_key_based_chunk_with_shared_sequence(
+        &self,
+        row_keys: Vec<Box<[u8]>>,
+        delete_sequence: &mut Option<i64>,
+    ) -> super::super::Result<u64> {
+        if row_keys.is_empty() {
+            return Ok(0);
+        }
+
+        let sequence = if let Some(sequence) = delete_sequence {
+            *sequence
+        } else {
+            let sequence = self
+                .catalog
+                .increment_sequence_number(self.table_metadata.table_id)
+                .await?;
+            *delete_sequence = Some(sequence);
+            sequence
+        };
+
+        self.persist_key_based_deletions_with_sequence(row_keys, sequence)
+            .await
+    }
+
+    async fn persist_int64_pk_chunk_with_shared_sequence(
+        &self,
+        pk_values: Vec<i64>,
+        delete_sequence: &mut Option<i64>,
+    ) -> super::super::Result<u64> {
+        if pk_values.is_empty() {
+            return Ok(0);
+        }
+
+        let sequence = if let Some(sequence) = delete_sequence {
+            *sequence
+        } else {
+            let sequence = self
+                .catalog
+                .increment_sequence_number(self.table_metadata.table_id)
+                .await?;
+            *delete_sequence = Some(sequence);
+            sequence
+        };
+
+        self.persist_int64_pk_deletions_with_sequence(pk_values, sequence)
+            .await
     }
 
     async fn persist_key_based_deletions(
         &self,
         row_keys: Vec<Box<[u8]>>,
+    ) -> super::super::Result<u64> {
+        let filtered_row_keys = Self::filter_existing_key_deletions(row_keys);
+
+        if filtered_row_keys.is_empty() {
+            return Ok(0);
+        }
+
+        let delete_sequence = self
+            .catalog
+            .increment_sequence_number(self.table_metadata.table_id)
+            .await?;
+
+        self.persist_key_based_deletions_with_sequence(filtered_row_keys, delete_sequence)
+            .await
+    }
+
+    async fn persist_key_based_deletions_with_sequence(
+        &self,
+        row_keys: Vec<Box<[u8]>>,
+        delete_sequence: i64,
     ) -> super::super::Result<u64> {
         let table_name = &self.table_metadata.table_name;
 
@@ -421,9 +549,7 @@ impl CayenneDeletionSink {
                             .to_string(),
                 })?;
 
-        let filtered_row_keys = Self::filter_existing_key_deletions(row_keys);
-
-        if filtered_row_keys.is_empty() {
+        if row_keys.is_empty() {
             return Ok(0);
         }
 
@@ -436,29 +562,19 @@ impl CayenneDeletionSink {
                     table: table_name.clone(),
                     lock: DELETION_CACHE_LOCK_POISONED,
                 })?;
-            filtered_row_keys
+            row_keys
                 .iter()
                 .filter(|key| !guard.contains_key(key.as_ref()))
                 .count()
         };
 
-        // Get a fresh sequence number from the catalog for this deletion operation.
-        // This ensures each delete has a unique, monotonically increasing sequence number
-        // that's higher than any previous operation.
-        let delete_sequence = self
-            .catalog
-            .increment_sequence_number(self.table_metadata.table_id)
-            .await?;
-
-        // Create a temporary metadata with the fresh sequence number
+        // Create a temporary metadata with the delete sequence number
         let mut temp_metadata = self.table_metadata.clone();
         temp_metadata.current_sequence_number = delete_sequence;
 
         let writer = DeletionVectorWriter::new(&temp_metadata);
         let mut results = writer
-            .write(vec![DeletionVectorWriteSpec::new_key_based(
-                filtered_row_keys,
-            )])
+            .write(vec![DeletionVectorWriteSpec::new_key_based(row_keys)])
             .await?;
 
         let Some(result) = results.pop() else {
@@ -518,6 +634,26 @@ impl CayenneDeletionSink {
     }
 
     async fn persist_int64_pk_deletions(&self, pk_values: Vec<i64>) -> super::super::Result<u64> {
+        let filtered_pk_values = Self::filter_existing_int64_pk_deletions(pk_values);
+
+        if filtered_pk_values.is_empty() {
+            return Ok(0);
+        }
+
+        let delete_sequence = self
+            .catalog
+            .increment_sequence_number(self.table_metadata.table_id)
+            .await?;
+
+        self.persist_int64_pk_deletions_with_sequence(filtered_pk_values, delete_sequence)
+            .await
+    }
+
+    async fn persist_int64_pk_deletions_with_sequence(
+        &self,
+        pk_values: Vec<i64>,
+        delete_sequence: i64,
+    ) -> super::super::Result<u64> {
         let table_name = &self.table_metadata.table_name;
 
         // Get the int64 pk cache from the PkDeletionStrategy (only valid for Int64Pk)
@@ -531,9 +667,7 @@ impl CayenneDeletionSink {
                             .to_string(),
                 })?;
 
-        let filtered_pk_values = Self::filter_existing_int64_pk_deletions(pk_values);
-
-        if filtered_pk_values.is_empty() {
+        if pk_values.is_empty() {
             return Ok(0);
         }
 
@@ -546,29 +680,21 @@ impl CayenneDeletionSink {
                     table: table_name.clone(),
                     lock: DELETION_CACHE_LOCK_POISONED,
                 })?;
-            filtered_pk_values
+            pk_values
                 .iter()
                 .filter(|pk| !guard.contains_key(*pk))
                 .count()
         };
 
-        // Get a fresh sequence number from the catalog for this deletion operation.
-        // This ensures each delete has a unique, monotonically increasing sequence number
-        // that's higher than any previous operation.
-        let delete_sequence = self
-            .catalog
-            .increment_sequence_number(self.table_metadata.table_id)
-            .await?;
-
         // For Int64 PK deletions, we store them as key-based deletions
         // where each key is the 8-byte big-endian representation of the i64 value.
         // This allows efficient storage and lookup.
-        let row_keys: Vec<Box<[u8]>> = filtered_pk_values
+        let row_keys: Vec<Box<[u8]>> = pk_values
             .iter()
             .map(|&pk| pk.to_be_bytes().to_vec().into_boxed_slice())
             .collect();
 
-        // Create a temporary metadata with the fresh sequence number
+        // Create a temporary metadata with the delete sequence number
         let mut temp_metadata = self.table_metadata.clone();
         temp_metadata.current_sequence_number = delete_sequence;
 
@@ -593,7 +719,7 @@ impl CayenneDeletionSink {
                 })?;
 
             let mut updated_map = (**guard).clone();
-            for &pk_value in &filtered_pk_values {
+            for &pk_value in &pk_values {
                 // Update with max sequence if key already exists
                 updated_map
                     .entry(pk_value)

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -47,7 +47,7 @@ limitations under the License.
 
 use super::super::constants::{DELETION_CACHE_LOCK_POISONED, LISTING_TABLE_LOCK_POISONED};
 use super::super::deletion_strategy::PkDeletionStrategyWithCache;
-use super::super::utils::{convert_to_i64_box, convert_to_u64_box};
+use super::super::utils::convert_to_u64_box;
 use super::super::Error;
 use super::vector_io::{DeletionIdentifier, DeletionVectorWriteSpec, DeletionVectorWriter};
 use crate::catalog::MetadataCatalog;
@@ -257,14 +257,6 @@ impl CayenneDeletionSink {
         const PK_DELETE_FLUSH_BATCH_SIZE: usize = 50_000;
 
         let table_name = &self.table_metadata.table_name;
-
-        let _flush_batch_size_i64 =
-            convert_to_i64_box(PK_DELETE_FLUSH_BATCH_SIZE, "pk delete flush batch size").map_err(
-                |e| Error::Internal {
-                    table: table_name.clone(),
-                    message: e.to_string(),
-                },
-            )?;
 
         // For position-based deletion, use the streaming per-file approach directly.
         // This avoids loading all data into memory and provides correct file-local row IDs.

--- a/crates/cayenne/src/provider/utils.rs
+++ b/crates/cayenne/src/provider/utils.rs
@@ -48,21 +48,14 @@ use std::convert::TryInto;
 ///
 /// # When to Use
 ///
-/// **Do NOT call this function directly.** Instead, use the type-specific wrapper functions:
-/// - `convert_to_i64()` - For conversions within `DataFusion` error context
-/// - `convert_to_i64_box()` - For conversions in async/trait methods with boxed errors
-/// - `convert_to_u64_box()` - For conversions to `u64` with boxed errors
+/// Use this function when you need a numeric conversion that returns
+/// `datafusion_common::Result<T>`.
 ///
-/// The wrapper functions provide better type inference and appropriate error type handling
-/// for their specific use cases.
+/// For boxed-error conversions to `u64`, prefer `convert_to_u64_box()`.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// // GOOD - Use wrapper functions
-/// let value = convert_to_i64(batch.num_rows(), "batch size")?;
-///
-/// // BAD - Don't call try_convert directly
 /// let value = try_convert::<usize, i64>(batch.num_rows(), "batch size")?;
 /// ```
 pub fn try_convert<T, U>(value: T, context: &str) -> datafusion_common::Result<U>
@@ -77,66 +70,6 @@ where
             std::any::type_name::<U>()
         ))
     })
-}
-
-/// Convert a numeric value to `i64` with `DataFusion` error type.
-///
-/// Use this function when converting numeric values (typically `usize` or `u64`) to `i64`
-/// within `DataFusion` `TableProvider` implementations or execution plans, where the error
-/// type is `datafusion_common::Result<T>`.
-///
-/// # Arguments
-///
-/// * `value` - The numeric value to convert
-/// * `context` - Description of what the value represents (e.g., "batch size", "row count")
-///
-/// # Examples
-///
-/// ```ignore
-/// // Converting batch size in hot path
-/// let batch_size_i64 = convert_to_i64(batch.num_rows(), "batch size")?;
-///
-/// // Converting row index
-/// let row_offset = convert_to_i64(row_idx, "row index")?;
-/// ```
-pub fn convert_to_i64<T>(value: T, context: &str) -> datafusion_common::Result<i64>
-where
-    T: TryInto<i64> + Copy + std::fmt::Display,
-    T::Error: std::error::Error + Send + Sync + 'static,
-{
-    try_convert(value, context)
-}
-
-/// Convert a numeric value to `i64` with boxed error type.
-///
-/// Use this function when converting numeric values to `i64` in contexts that require
-/// boxed errors, such as:
-/// - Async trait methods (`DeletionSink::delete_from`)
-/// - Functions returning `Result<T, Box<dyn Error>>`
-/// - Code that needs to bridge between different error types
-///
-/// # Arguments
-///
-/// * `value` - The numeric value to convert
-/// * `context` - Description of what the value represents (e.g., "deleted row count")
-///
-/// # Examples
-///
-/// ```ignore
-/// // In deletion sink with boxed error return type
-/// let total_rows_i64 = convert_to_i64_box(total_rows, "total row count")?;
-/// let deleted_count_i64 = convert_to_i64_box(deleted_count, "deleted row count")?;
-/// ```
-pub fn convert_to_i64_box<T>(
-    value: T,
-    context: &str,
-) -> Result<i64, Box<dyn std::error::Error + Send + Sync>>
-where
-    T: TryInto<i64> + Copy + std::fmt::Display,
-    T::Error: std::error::Error + Send + Sync + 'static,
-{
-    convert_to_i64(value, context)
-        .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
 }
 
 /// Convert a numeric value to `u64` with boxed error type.

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -360,7 +360,7 @@ async fn build_image_from_host_binary(
 }
 
 fn dockerfile_for_host_binary() -> &'static str {
-    r#"FROM rust:1.91-slim-bookworm
+    r#"FROM rust:1.91-slim-trixie
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
@@ -378,7 +378,7 @@ ENTRYPOINT ["/usr/local/bin/retention_oom"]
 }
 
 fn dockerfile_for_source_build() -> &'static str {
-    r#"FROM rust:1.91-slim-bookworm
+    r#"FROM rust:1.91-slim-trixie
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -57,10 +57,6 @@ enum ExecutableFormat {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[cfg(not(target_os = "windows"))]
-#[cfg_attr(
-    not(feature = "extended_tests"),
-    ignore = "Extended test - run with --features extended_tests"
-)]
 async fn test_cayenne_pk_delete_oom_repro() -> Result<(), anyhow::Error> {
     init_tracing();
 
@@ -134,7 +130,6 @@ async fn run_outer_container_repro() -> Result<(), anyhow::Error> {
         .arg("-e")
         .arg(format!("{INNER_PAYLOAD_BYTES_ENV}={payload_bytes}"))
         .arg(&image_tag)
-        .arg("--ignored")
         .arg("--exact")
         .arg(TEST_NAME)
         .arg("--nocapture")

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -87,8 +87,7 @@ async fn run_outer_container_repro() -> Result<(), anyhow::Error> {
     let payload_bytes = env_usize(INNER_PAYLOAD_BYTES_ENV, DEFAULT_PAYLOAD_BYTES)?;
 
     eprintln!(
-        "Running containerized retention delete regression with rows={rows}, payload_bytes={payload_bytes}, memory_limit={}MiB",
-        CONTAINER_MEMORY_LIMIT_MB
+        "Running containerized retention delete regression with rows={rows}, payload_bytes={payload_bytes}, memory_limit={CONTAINER_MEMORY_LIMIT_MB}MiB"
     );
 
     let image_tag = format!(

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -1,0 +1,530 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    collections::HashMap,
+    io::{BufWriter, Read as _, Write as _},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use app::AppBuilder;
+use arrow::{
+    array::{Int64Array, UInt64Array},
+    record_batch::RecordBatch,
+};
+use futures::StreamExt;
+use runtime::Runtime;
+use spicepod::{
+    acceleration::{Acceleration, Mode, RefreshMode},
+    component::dataset::Dataset,
+    param::Params,
+};
+use tokio::process::Command;
+use tracing_subscriber::EnvFilter;
+
+const INNER_MODE_ENV: &str = "SPICE_OOM_REPRO_INNER";
+const INNER_ROWS_ENV: &str = "SPICE_OOM_REPRO_ROWS";
+const INNER_PAYLOAD_BYTES_ENV: &str = "SPICE_OOM_REPRO_PAYLOAD_BYTES";
+
+const DEFAULT_ROWS: usize = 1_500_000;
+const DEFAULT_PAYLOAD_BYTES: usize = 256;
+const CONTAINER_MEMORY_LIMIT_MB: usize = 768;
+
+const TEST_NAME: &str = "test_cayenne_pk_delete_oom_repro";
+
+#[derive(Debug, Clone, Copy)]
+enum ExecutableFormat {
+    Elf,
+    MachO,
+    Unknown,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[cfg(not(target_os = "windows"))]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
+async fn test_cayenne_pk_delete_oom_repro() -> Result<(), anyhow::Error> {
+    init_tracing();
+
+    if std::env::var_os(INNER_MODE_ENV).is_some() {
+        run_inner_workload().await
+    } else {
+        run_outer_container_repro().await
+    }
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("runtime=info,cayenne=debug,info")),
+        )
+        .with_ansi(true)
+        .try_init();
+}
+
+async fn run_outer_container_repro() -> Result<(), anyhow::Error> {
+    if !docker_is_available().await {
+        eprintln!("Docker is not available, skipping retention OOM reproduction test.");
+        return Ok(());
+    }
+
+    let rows = env_usize(INNER_ROWS_ENV, DEFAULT_ROWS)?;
+    let payload_bytes = env_usize(INNER_PAYLOAD_BYTES_ENV, DEFAULT_PAYLOAD_BYTES)?;
+
+    eprintln!(
+        "Running containerized retention delete regression with rows={rows}, payload_bytes={payload_bytes}, memory_limit={}MiB",
+        CONTAINER_MEMORY_LIMIT_MB
+    );
+
+    let image_tag = format!(
+        "spice-retention-oom-repro-{}",
+        uuid::Uuid::now_v7().simple()
+    );
+
+    let host_test_binary = std::env::current_exe().context("failed to locate test executable")?;
+    let executable_format = detect_executable_format(&host_test_binary)?;
+
+    match executable_format {
+        ExecutableFormat::Elf => {
+            eprintln!(
+                "Using Linux fast-path: packaging host ELF test binary at {}",
+                host_test_binary.display()
+            );
+            build_image_from_host_binary(&image_tag, &host_test_binary).await?;
+        }
+        ExecutableFormat::MachO | ExecutableFormat::Unknown => {
+            let workspace_root = workspace_root()?;
+            eprintln!(
+                "Using source-build Docker fallback for format {:?} (workspace={})",
+                executable_format,
+                workspace_root.display()
+            );
+            build_image_from_source(&image_tag, &workspace_root).await?;
+        }
+    }
+
+    let run_output = Command::new("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg(format!("--memory={CONTAINER_MEMORY_LIMIT_MB}m"))
+        .arg(format!("--memory-swap={CONTAINER_MEMORY_LIMIT_MB}m"))
+        .arg("-e")
+        .arg(format!("{INNER_MODE_ENV}=1"))
+        .arg("-e")
+        .arg(format!("{INNER_ROWS_ENV}={rows}"))
+        .arg("-e")
+        .arg(format!("{INNER_PAYLOAD_BYTES_ENV}={payload_bytes}"))
+        .arg(&image_tag)
+        .arg("--ignored")
+        .arg("--exact")
+        .arg(TEST_NAME)
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .output()
+        .await
+        .context("failed to execute docker run")?;
+
+    let _ = remove_docker_image(&image_tag).await;
+
+    let exit_code = run_output.status.code().unwrap_or_default();
+    if exit_code != 0 {
+        return Err(anyhow::anyhow!(
+            "Expected containerized retention delete to complete without OOM (exit=0), got exit={exit_code}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&run_output.stdout),
+            String::from_utf8_lossy(&run_output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
+async fn run_inner_workload() -> Result<(), anyhow::Error> {
+    let rows = env_usize(INNER_ROWS_ENV, DEFAULT_ROWS)?;
+    let payload_bytes = env_usize(INNER_PAYLOAD_BYTES_ENV, DEFAULT_PAYLOAD_BYTES)?;
+
+    eprintln!("Running inner retention workload with rows={rows}, payload_bytes={payload_bytes}");
+
+    let temp_dir = tempfile::tempdir()?;
+    let csv_path = temp_dir.path().join("source.csv");
+    write_large_csv(&csv_path, rows, payload_bytes)?;
+
+    let csv_size_bytes = std::fs::metadata(&csv_path)
+        .context("failed to read generated csv metadata")?
+        .len();
+    eprintln!(
+        "Generated source CSV at {} ({} bytes)",
+        csv_path.display(),
+        csv_size_bytes
+    );
+
+    let cayenne_dir = temp_dir.path().join("cayenne");
+    let metadata_dir = temp_dir.path().join("metadata");
+    std::fs::create_dir_all(&cayenne_dir)?;
+    std::fs::create_dir_all(&metadata_dir)?;
+
+    runtime::dataconnector::register_all().await;
+    runtime::catalogconnector::register_all().await;
+
+    let mut params = HashMap::new();
+    params.insert(
+        "cayenne_file_path".to_string(),
+        cayenne_dir.display().to_string(),
+    );
+    params.insert(
+        "cayenne_metadata_dir".to_string(),
+        metadata_dir.display().to_string(),
+    );
+
+    let mut dataset = Dataset::new(format!("file://{}", csv_path.display()), "oom_events");
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("cayenne".to_string()),
+        mode: Mode::File,
+        refresh_mode: Some(RefreshMode::Full),
+        primary_key: Some("id".to_string()),
+        retention_sql: Some("DELETE FROM oom_events WHERE id >= 0".to_string()),
+        retention_check_enabled: true,
+        retention_check_interval: Some("1s".to_string()),
+        params: Some(Params::from_string_map(params)),
+        ..Acceleration::default()
+    });
+
+    let app = AppBuilder::new("retention_oom_repro")
+        .with_dataset(dataset)
+        .build();
+
+    let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
+
+    tokio::select! {
+        () = tokio::time::sleep(Duration::from_secs(300)) => {
+            return Err(anyhow::anyhow!("Timed out waiting for runtime components to load"));
+        }
+        () = Arc::clone(&runtime).load_components() => {}
+    }
+
+    wait_until_runtime_ready(&runtime, Duration::from_secs(120)).await?;
+
+    let loaded_rows = query_single_u64(&runtime, "SELECT COUNT(*) FROM oom_events").await?;
+    eprintln!("Loaded rows currently visible in Cayenne table: {loaded_rows}");
+
+    let expected_rows = u64::try_from(rows).unwrap_or_default();
+    if loaded_rows == 0 {
+        return Err(anyhow::anyhow!(
+            "Expected at least one row to be visible before retention finishes, but found 0"
+        ));
+    }
+
+    if loaded_rows > expected_rows {
+        return Err(anyhow::anyhow!(
+            "Visible row count {loaded_rows} exceeded generated input rows {expected_rows}"
+        ));
+    }
+
+    eprintln!("Waiting for retention worker to execute PK-based delete...");
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let remaining_rows = query_single_u64(&runtime, "SELECT COUNT(*) FROM oom_events").await?;
+    eprintln!("Remaining rows after retention worker: {remaining_rows}");
+
+    if remaining_rows != 0 {
+        return Err(anyhow::anyhow!(
+            "Expected retention to delete all rows, but {remaining_rows} rows remain"
+        ));
+    }
+
+    eprintln!("Retention delete completed without OOM.");
+    Ok(())
+}
+
+fn workspace_root() -> Result<PathBuf, anyhow::Error> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            anyhow::anyhow!("Failed to determine workspace root from CARGO_MANIFEST_DIR")
+        })
+}
+
+fn detect_executable_format(path: &Path) -> Result<ExecutableFormat, anyhow::Error> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open executable at {}", path.display()))?;
+
+    let mut header = [0_u8; 4];
+    if let Err(error) = file.read_exact(&mut header) {
+        if error.kind() == std::io::ErrorKind::UnexpectedEof {
+            return Ok(ExecutableFormat::Unknown);
+        }
+
+        return Err(error)
+            .with_context(|| format!("failed to read executable header from {}", path.display()));
+    }
+
+    if header[0] == 0x7F && header[1] == b'E' && header[2] == b'L' && header[3] == b'F' {
+        return Ok(ExecutableFormat::Elf);
+    }
+
+    let magic = u32::from_be_bytes(header);
+    if matches!(
+        magic,
+        0xFEED_FACE
+            | 0xFEED_FACF
+            | 0xCEFA_EDFE
+            | 0xCFFA_EDFE
+            | 0xCAFE_BABE
+            | 0xBEBA_FECA
+            | 0xCAFE_BABF
+            | 0xBFBA_FECA
+    ) {
+        return Ok(ExecutableFormat::MachO);
+    }
+
+    Ok(ExecutableFormat::Unknown)
+}
+
+async fn build_image_from_source(
+    image_tag: &str,
+    workspace_root: &Path,
+) -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let dockerfile_path = temp_dir.path().join("Dockerfile.retention-oom");
+    std::fs::write(&dockerfile_path, dockerfile_for_source_build())?;
+
+    let build_status = Command::new("docker")
+        .arg("build")
+        .arg("-f")
+        .arg(&dockerfile_path)
+        .arg("-t")
+        .arg(image_tag)
+        .arg(workspace_root)
+        .status()
+        .await
+        .context("failed to execute docker build")?;
+
+    if !build_status.success() {
+        return Err(anyhow::anyhow!("docker build failed for image {image_tag}"));
+    }
+
+    Ok(())
+}
+
+async fn build_image_from_host_binary(
+    image_tag: &str,
+    host_test_binary: &Path,
+) -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let dockerfile_path = temp_dir.path().join("Dockerfile.retention-oom");
+    let staged_binary = temp_dir.path().join("retention_oom");
+
+    std::fs::copy(host_test_binary, &staged_binary).with_context(|| {
+        format!(
+            "failed to copy host test binary from {} to {}",
+            host_test_binary.display(),
+            staged_binary.display()
+        )
+    })?;
+
+    std::fs::write(&dockerfile_path, dockerfile_for_host_binary())?;
+
+    let build_status = Command::new("docker")
+        .arg("build")
+        .arg("-f")
+        .arg(&dockerfile_path)
+        .arg("-t")
+        .arg(image_tag)
+        .arg(temp_dir.path())
+        .status()
+        .await
+        .context("failed to execute docker build for host binary fast-path")?;
+
+    if !build_status.success() {
+        return Err(anyhow::anyhow!(
+            "docker build failed for host binary image {image_tag}"
+        ));
+    }
+
+    Ok(())
+}
+
+fn dockerfile_for_host_binary() -> &'static str {
+    r#"FROM rust:1.91-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        libprotobuf-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY retention_oom /usr/local/bin/retention_oom
+RUN chmod +x /usr/local/bin/retention_oom
+
+ENTRYPOINT ["/usr/local/bin/retention_oom"]
+"#
+}
+
+fn dockerfile_for_source_build() -> &'static str {
+    r#"FROM rust:1.91-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        cmake \
+        libprotobuf-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        pkg-config \
+        protobuf-compiler \
+        unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . /workspace
+
+ENV CARGO_INCREMENTAL=0
+ENV PROTOC=/usr/bin/protoc
+ENV PROTOC_INCLUDE=/usr/include
+RUN cargo test -p runtime --test retention_oom --no-run --locked
+
+RUN cat <<'EOF' >/usr/local/bin/run-retention-oom.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+for candidate in /workspace/target/debug/deps/retention_oom-*; do
+  case "$candidate" in
+    *.d) continue ;;
+    *) exec "$candidate" "$@" ;;
+  esac
+done
+
+echo "retention_oom test binary not found" >&2
+exit 1
+EOF
+RUN chmod +x /usr/local/bin/run-retention-oom.sh
+
+ENTRYPOINT ["/usr/local/bin/run-retention-oom.sh"]
+"#
+}
+
+fn write_large_csv(path: &Path, rows: usize, payload_bytes: usize) -> Result<(), anyhow::Error> {
+    let file = std::fs::File::create(path)?;
+    let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, file);
+
+    writer.write_all(b"id,payload\n")?;
+
+    let payload = "x".repeat(payload_bytes);
+    for i in 0..rows {
+        writeln!(writer, "{i},{payload}")?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize, anyhow::Error> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<usize>()
+            .with_context(|| format!("Failed to parse {name} as usize: {value}")),
+        Err(_) => Ok(default),
+    }
+}
+
+async fn docker_is_available() -> bool {
+    matches!(
+        Command::new("docker")
+            .arg("info")
+            .status()
+            .await,
+        Ok(status) if status.success()
+    )
+}
+
+async fn remove_docker_image(image_tag: &str) -> Result<(), anyhow::Error> {
+    let _ = Command::new("docker")
+        .arg("image")
+        .arg("rm")
+        .arg("-f")
+        .arg(image_tag)
+        .status()
+        .await;
+
+    Ok(())
+}
+
+async fn wait_until_runtime_ready(rt: &Runtime, timeout: Duration) -> Result<(), anyhow::Error> {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < timeout {
+        if rt.status().is_ready() {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(anyhow::anyhow!(
+        "Timed out waiting for runtime to become ready"
+    ))
+}
+
+async fn execute_sql(rt: &Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    let mut result = rt.datafusion().query_builder(sql).build().run().await?;
+
+    let mut batches = Vec::new();
+    while let Some(batch) = result.data.next().await {
+        batches.push(batch?);
+    }
+
+    Ok(batches)
+}
+
+async fn query_single_u64(rt: &Arc<Runtime>, sql: &str) -> Result<u64, anyhow::Error> {
+    let batches = execute_sql(rt, sql).await?;
+    let batch = batches
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("Query returned no batches: {sql}"))?;
+
+    if batch.num_rows() != 1 {
+        return Err(anyhow::anyhow!(
+            "Expected single-row scalar result for '{sql}', got {} rows",
+            batch.num_rows()
+        ));
+    }
+
+    let column = batch.column(0);
+
+    if let Some(values) = column.as_any().downcast_ref::<UInt64Array>() {
+        return Ok(values.value(0));
+    }
+
+    if let Some(values) = column.as_any().downcast_ref::<Int64Array>() {
+        let value = values.value(0);
+        return u64::try_from(value).context("Scalar count value was negative");
+    }
+
+    Err(anyhow::anyhow!(
+        "Unexpected scalar array type for query '{sql}': {:?}",
+        column.data_type()
+    ))
+}


### PR DESCRIPTION
## Summary

Fixes #9256

The PK-based filtered delete path in Cayenne (`Int64Pk` and `RowConverterBased` strategies) previously materialized the entire dataset in memory to apply retention filters: it collected all batches from every listing table, concatenated them into a single `RecordBatch`, added a synthetic `__row_id` column, registered a temporary `MemTable`, ran SQL filters through DataFusion, and then extracted PK values from the full result set. For large tables this caused OOM.

This PR replaces that approach with a streaming, chunked implementation:

### Core changes (`crates/cayenne/src/provider/delete/sink.rs`)

- **Stream instead of collect**: each listing table is now scanned via `execute_stream` and processed one batch at a time, eliminating the need to hold the full dataset in memory.
- **Physical filter evaluation per-batch**: filters are coerced once upfront (`coerce_filters_for_schema`) and compiled to `PhysicalExpr` (`build_physical_filters`), then applied to each streamed batch with `apply_physical_filters_to_batch`. This replaces the `MemTable` + SQL roundtrip.
- **Chunked persistence**: PK values (int64 or row-converter keys) are accumulated in a buffer and flushed to deletion vectors every 50,000 rows (`PK_DELETE_FLUSH_BATCH_SIZE`). New `persist_int64_pk_chunk_with_shared_sequence` and `persist_key_based_chunk_with_shared_sequence` methods ensure all chunks within a single retention pass share one sequence number.
- **Refactored persistence internals**: `persist_int64_pk_deletions` and `persist_key_based_deletions` now delegate to `_with_sequence` variants that accept a pre-allocated sequence number, separating filtering/dedup of already-deleted keys from sequence allocation.

### Removed dead code (`crates/cayenne/src/provider/utils.rs`)

- `convert_to_i64` and `convert_to_i64_box` helper functions are removed — they were only used by the old `__row_id`-based approach.

### OOM regression test (`crates/runtime/tests/retention_oom.rs`)

A new Docker-based integration test that verifies PK retention deletes complete without OOM under constrained memory:

- The **outer harness** builds a Docker image (fast-path: copies host ELF binary; fallback: full `cargo build` from source for macOS), then runs the test inside a container limited to 768 MiB.
- The **inner workload** generates a large CSV (default: 1.5M rows × 256-byte payload ≈ ~400 MB), loads it into a Cayenne-accelerated dataset with `retention_sql` that deletes all rows, and asserts the retention worker completes successfully with 0 rows remaining.
- Configurable via `SPICE_OOM_REPRO_ROWS` and `SPICE_OOM_REPRO_PAYLOAD_BYTES` environment variables.

### CI (`.github/workflows/integration.yml`)

- The retention OOM test is built, archived, and uploaded as a separate artifact (`retention_oom.tar.zst`).
- It runs on one integration partition (`count:1/3`) to avoid redundant execution across partitions.