### PR TITLE
fix: ensure spidapter only increments attempts on failures

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -382,7 +382,7 @@ fn generate_adbc_create_table_statement(
     }
 
     Ok(format!(
-        "CREATE TABLE spicebench.bench.{quoted_dataset_name} ({})",
+        "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_dataset_name} ({})",
         column_definitions.join(", ")
     ))
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -302,7 +302,6 @@ async fn post_setup_sink_action(
             eprintln!("[stdio] Running post-setup SQL: {statement}");
 
             loop {
-
                 let response = sql_client
                     .post(&sql_url)
                     .header("X-API-Key", api_key)

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -302,7 +302,6 @@ async fn post_setup_sink_action(
             eprintln!("[stdio] Running post-setup SQL: {statement}");
 
             loop {
-                attempts += 1;
 
                 let response = sql_client
                     .post(&sql_url)
@@ -314,6 +313,8 @@ async fn post_setup_sink_action(
                 if response.status().is_success() {
                     break;
                 }
+
+                attempts += 1;
 
                 if attempts >= 3 {
                     let status = response.status();


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Only increments attempt count on actual errors
* Changes SQL from `CREATE TABLE` to `CREATE TABLE IF NOT EXISTS` to be more resilient in setup

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
