### PR TITLE
test(runtime): Spice Cayenne DDL integration test

### DIFF
--- a/crates/model_components/src/modelsource/mod.rs
+++ b/crates/model_components/src/modelsource/mod.rs
@@ -188,7 +188,7 @@ pub fn ensure_model_path(name: &str) -> Result<String> {
 }
 
 impl From<ModelSourceType> for Option<Box<dyn ModelSource>> {
-    #[cfg_attr(not(feature = "full"), allow(unused_variables))]
+    #[cfg_attr(not(feature = "full"), expect(unused_variables))]
     fn from(source: ModelSourceType) -> Self {
         #[cfg(feature = "full")]
         if source == ModelSourceType::Local {

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -190,15 +190,11 @@ impl RuntimeBuilder {
         document_parse::register_all().await;
 
         // Resolve the effective spicepod runtime config: config override > app > default.
-        let spicepod_rt = self
-            .runtime_config
-            .runtime
-            .clone()
-            .unwrap_or_else(|| {
-                self.app
-                    .as_ref()
-                    .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
-            });
+        let spicepod_rt = self.runtime_config.runtime.clone().unwrap_or_else(|| {
+            self.app
+                .as_ref()
+                .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
+        });
 
         let query = spicepod_rt.query.clone().unwrap_or_default();
 
@@ -221,11 +217,8 @@ impl RuntimeBuilder {
             });
 
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
-        let url_tables_enabled = spicepod_rt
-            .params
-            .get("url_tables")
-            .map(String::as_str)
-            == Some("enabled");
+        let url_tables_enabled =
+            spicepod_rt.params.get("url_tables").map(String::as_str) == Some("enabled");
 
         let caching = Runtime::init_caching(Some(&spicepod_rt.caching));
         let io_runtime = self.io_runtime.clone().unwrap_or_else(|| Handle::current());

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -38,7 +38,6 @@ use crate::{
 use app::App;
 use datafusion::optimizer::AnalyzerRule;
 use runtime_datafusion::analyzer_rule::{PartitionedTableScanRewrite, TablePartitionProvider};
-use spicepod::component::caching::{CacheConfig, Caching, SQLResultsCacheConfig};
 use spicepod::component::runtime::Runtime as SpicepodRuntime;
 use spicepod::component::runtime::RuntimeReadyState as SpicepodRuntimeReadyState;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
@@ -66,11 +65,6 @@ pub struct RuntimeBuilder {
     token_provider_registry: Arc<TokenProviderRegistry>,
     runtime_config: Arc<Config>,
     resolved_cluster_config: Option<ResolvedClusterConfig>,
-    /// Optional override for the spicepod runtime configuration. When set,
-    /// these settings take precedence over the corresponding fields in the
-    /// `App`'s runtime config. This allows programmatic control of caching,
-    /// query settings, task history, and other runtime parameters.
-    spicepod_runtime_config: Option<SpicepodRuntime>,
 }
 
 impl RuntimeBuilder {
@@ -92,7 +86,6 @@ impl RuntimeBuilder {
             token_provider_registry: Arc::new(TokenProviderRegistry::new()),
             runtime_config: Arc::new(Config::default()),
             resolved_cluster_config: None,
-            spicepod_runtime_config: None,
         }
     }
 
@@ -183,52 +176,6 @@ impl RuntimeBuilder {
         self
     }
 
-    /// Sets the spicepod runtime configuration, overriding the corresponding
-    /// settings from the `App`.
-    ///
-    /// This allows programmatic control of runtime parameters including caching,
-    /// query settings, task history, and other runtime behavior independent of
-    /// the spicepod YAML configuration.
-    pub fn with_spicepod_runtime_config(mut self, config: SpicepodRuntime) -> Self {
-        self.spicepod_runtime_config = Some(config);
-        self
-    }
-
-    /// Disables all caching (SQL results, plans, search, and embeddings).
-    ///
-    /// Equivalent to setting all cache `enabled` flags to `false`. Useful in tests
-    /// or scenarios where deterministic, non-cached results are required.
-    ///
-    /// This merges with any existing spicepod runtime config override, only
-    /// replacing the caching settings.
-    pub fn with_caching_disabled(mut self) -> Self {
-        let caching = Caching {
-            sql_results: Some(SQLResultsCacheConfig {
-                enabled: false,
-                ..SQLResultsCacheConfig::default()
-            }),
-            search_results: Some(CacheConfig {
-                enabled: false,
-                ..CacheConfig::default()
-            }),
-            embeddings: Some(CacheConfig {
-                enabled: false,
-                ..CacheConfig::default()
-            }),
-        };
-        self.spicepod_runtime_config = Some(match self.spicepod_runtime_config {
-            Some(mut config) => {
-                config.caching = caching;
-                config
-            }
-            None => SpicepodRuntime {
-                caching,
-                ..SpicepodRuntime::default()
-            },
-        });
-        self
-    }
-
     pub async fn build(self) -> Runtime {
         // Initialize DataFusion tracer for span context propagation across async boundaries
         if let Err(e) = tracers::init_datafusion_tracer() {
@@ -242,12 +189,16 @@ impl RuntimeBuilder {
         catalogconnector::register_all().await;
         document_parse::register_all().await;
 
-        // Resolve the effective spicepod runtime config: builder override > app > default.
-        let spicepod_rt = self.spicepod_runtime_config.clone().unwrap_or_else(|| {
-            self.app
-                .as_ref()
-                .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
-        });
+        // Resolve the effective spicepod runtime config: config override > app > default.
+        let spicepod_rt = self
+            .runtime_config
+            .runtime
+            .clone()
+            .unwrap_or_else(|| {
+                self.app
+                    .as_ref()
+                    .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
+            });
 
         let query = spicepod_rt.query.clone().unwrap_or_default();
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -38,7 +38,8 @@ use crate::{
 use app::App;
 use datafusion::optimizer::AnalyzerRule;
 use runtime_datafusion::analyzer_rule::{PartitionedTableScanRewrite, TablePartitionProvider};
-use spicepod::component::caching::Caching;
+use spicepod::component::caching::{CacheConfig, Caching, SQLResultsCacheConfig};
+use spicepod::component::runtime::Runtime as SpicepodRuntime;
 use spicepod::component::runtime::RuntimeReadyState as SpicepodRuntimeReadyState;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
@@ -65,6 +66,11 @@ pub struct RuntimeBuilder {
     token_provider_registry: Arc<TokenProviderRegistry>,
     runtime_config: Arc<Config>,
     resolved_cluster_config: Option<ResolvedClusterConfig>,
+    /// Optional override for the spicepod runtime configuration. When set,
+    /// these settings take precedence over the corresponding fields in the
+    /// `App`'s runtime config. This allows programmatic control of caching,
+    /// query settings, task history, and other runtime parameters.
+    spicepod_runtime_config: Option<SpicepodRuntime>,
 }
 
 impl RuntimeBuilder {
@@ -86,6 +92,7 @@ impl RuntimeBuilder {
             token_provider_registry: Arc::new(TokenProviderRegistry::new()),
             runtime_config: Arc::new(Config::default()),
             resolved_cluster_config: None,
+            spicepod_runtime_config: None,
         }
     }
 
@@ -176,6 +183,52 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Sets the spicepod runtime configuration, overriding the corresponding
+    /// settings from the `App`.
+    ///
+    /// This allows programmatic control of runtime parameters including caching,
+    /// query settings, task history, and other runtime behavior independent of
+    /// the spicepod YAML configuration.
+    pub fn with_spicepod_runtime_config(mut self, config: SpicepodRuntime) -> Self {
+        self.spicepod_runtime_config = Some(config);
+        self
+    }
+
+    /// Disables all caching (SQL results, plans, search, and embeddings).
+    ///
+    /// Equivalent to setting all cache `enabled` flags to `false`. Useful in tests
+    /// or scenarios where deterministic, non-cached results are required.
+    ///
+    /// This merges with any existing spicepod runtime config override, only
+    /// replacing the caching settings.
+    pub fn with_caching_disabled(mut self) -> Self {
+        let caching = Caching {
+            sql_results: Some(SQLResultsCacheConfig {
+                enabled: false,
+                ..SQLResultsCacheConfig::default()
+            }),
+            search_results: Some(CacheConfig {
+                enabled: false,
+                ..CacheConfig::default()
+            }),
+            embeddings: Some(CacheConfig {
+                enabled: false,
+                ..CacheConfig::default()
+            }),
+        };
+        self.spicepod_runtime_config = Some(match self.spicepod_runtime_config {
+            Some(mut config) => {
+                config.caching = caching;
+                config
+            }
+            None => SpicepodRuntime {
+                caching,
+                ..SpicepodRuntime::default()
+            },
+        });
+        self
+    }
+
     pub async fn build(self) -> Runtime {
         // Initialize DataFusion tracer for span context propagation across async boundaries
         if let Err(e) = tracers::init_datafusion_tracer() {
@@ -189,35 +242,24 @@ impl RuntimeBuilder {
         catalogconnector::register_all().await;
         document_parse::register_all().await;
 
-        let query = self
-            .app
-            .as_ref()
-            .and_then(|app| app.runtime.query.clone())
-            .unwrap_or_default();
+        // Resolve the effective spicepod runtime config: builder override > app > default.
+        let spicepod_rt = self.spicepod_runtime_config.clone().unwrap_or_else(|| {
+            self.app
+                .as_ref()
+                .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
+        });
+
+        let query = spicepod_rt.query.clone().unwrap_or_default();
 
         let memory_limit = parse_memory_limit(query.memory_limit.clone());
 
-        let metrics = self
-            .app
-            .as_ref()
-            .and_then(|app| app.runtime.metrics.clone());
+        let metrics = spicepod_rt.metrics.clone();
 
-        let dataset_parallelism = self
-            .app
-            .as_ref()
-            .and_then(|app| app.runtime.dataset_load_parallelism);
+        let dataset_parallelism = spicepod_rt.dataset_load_parallelism;
 
-        let task_history = self
-            .app
-            .as_ref()
-            .is_none_or(|app| app.runtime.task_history.enabled);
+        let task_history = spicepod_rt.task_history.enabled;
 
-        let runtime_ready_state = self
-            .app
-            .as_ref()
-            .map_or(SpicepodRuntimeReadyState::default(), |app| {
-                app.runtime.ready_state
-            });
+        let runtime_ready_state = spicepod_rt.ready_state;
 
         self.runtime_status
             .set_ready_state(match runtime_ready_state {
@@ -228,16 +270,13 @@ impl RuntimeBuilder {
             });
 
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
-        let url_tables_enabled = App::get_runtime_param_opt::<String>(&self.app, "url_tables")
-            .as_deref()
+        let url_tables_enabled = spicepod_rt
+            .params
+            .get("url_tables")
+            .map(String::as_str)
             == Some("enabled");
 
-        let caching_config = self
-            .app
-            .as_ref()
-            .map_or(Caching::default(), |app| app.runtime.caching.clone());
-
-        let caching = Runtime::init_caching(Some(&caching_config));
+        let caching = Runtime::init_caching(Some(&spicepod_rt.caching));
         let io_runtime = self.io_runtime.clone().unwrap_or_else(|| Handle::current());
 
         // Create resource monitor early so it can be passed to DataFusion
@@ -305,10 +344,7 @@ impl RuntimeBuilder {
         df.set_self_ref();
 
         let datasets_health_monitor = if self.datasets_health_monitor_enabled {
-            let is_task_history_enabled = self
-                .app
-                .as_ref()
-                .is_some_and(|app| app.runtime.task_history.enabled);
+            let is_task_history_enabled = spicepod_rt.task_history.enabled;
             let datasets_health_monitor = DatasetsHealthMonitor::new(Arc::clone(&df))
                 .with_task_history_enabled(is_task_history_enabled);
             datasets_health_monitor.start();

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 use clap::{ArgAction, ValueEnum};
+use spicepod::component::caching::{CacheConfig, Caching, SQLResultsCacheConfig};
+use spicepod::component::runtime::Runtime as SpicepodRuntime;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[derive(Debug, Clone, clap::Parser)]
@@ -40,6 +42,13 @@ pub struct Config {
     /// All cluster related arguments
     #[clap(flatten)]
     pub cluster: ClusterConfig,
+
+    /// Optional override for the spicepod runtime configuration. When set,
+    /// these settings take precedence over the corresponding fields in the
+    /// `App`'s runtime config. This allows programmatic control of caching,
+    /// query settings, task history, and other runtime parameters.
+    #[clap(skip)]
+    pub runtime: Option<SpicepodRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
@@ -55,6 +64,7 @@ impl Config {
             http_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8090),
             flight_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051),
             cluster: ClusterConfig::default(),
+            runtime: None,
         }
     }
 
@@ -67,6 +77,54 @@ impl Config {
     #[must_use]
     pub fn with_flight_bind_address(mut self, bind_addr: SocketAddr) -> Self {
         self.flight_bind_address = bind_addr;
+        self
+    }
+
+    /// Sets the spicepod runtime configuration, overriding the corresponding
+    /// settings from the `App`.
+    ///
+    /// This allows programmatic control of runtime parameters including caching,
+    /// query settings, task history, and other runtime behavior independent of
+    /// the spicepod YAML configuration.
+    #[must_use]
+    pub fn with_spicepod_runtime(mut self, config: SpicepodRuntime) -> Self {
+        self.runtime = Some(config);
+        self
+    }
+
+    /// Disables all caching (SQL results, plans, search, and embeddings).
+    ///
+    /// Equivalent to setting all cache `enabled` flags to `false`. Useful in tests
+    /// or scenarios where deterministic, non-cached results are required.
+    ///
+    /// This merges with any existing spicepod runtime config override, only
+    /// replacing the caching settings.
+    #[must_use]
+    pub fn with_caching_disabled(mut self) -> Self {
+        let caching = Caching {
+            sql_results: Some(SQLResultsCacheConfig {
+                enabled: false,
+                ..SQLResultsCacheConfig::default()
+            }),
+            search_results: Some(CacheConfig {
+                enabled: false,
+                ..CacheConfig::default()
+            }),
+            embeddings: Some(CacheConfig {
+                enabled: false,
+                ..CacheConfig::default()
+            }),
+        };
+        self.runtime = Some(match self.runtime {
+            Some(mut config) => {
+                config.caching = caching;
+                config
+            }
+            None => SpicepodRuntime {
+                caching,
+                ..SpicepodRuntime::default()
+            },
+        });
         self
     }
 }

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -32,6 +32,7 @@ use arrow::array::{Float64Array, Int64Array, RecordBatch};
 use datafusion::assert_batches_eq;
 use futures::TryStreamExt;
 use runtime::Runtime;
+use runtime::config::Config;
 use spicepod::component::access::AccessMode;
 use spicepod::component::catalog::Catalog;
 use spicepod::param::Params;
@@ -125,7 +126,7 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             configure_test_datafusion();
             let rt = Runtime::builder()
                 .with_app(app)
-                .with_caching_disabled()
+                .with_runtime_config(Config::default().with_caching_disabled())
                 .build()
                 .await;
             let cloned_rt = Arc::new(rt.clone());
@@ -477,7 +478,7 @@ async fn cayenne_catalog_ddl_create_if_not_exists() -> Result<(), String> {
             configure_test_datafusion();
             let rt = Runtime::builder()
                 .with_app(app)
-                .with_caching_disabled()
+                .with_runtime_config(Config::default().with_caching_disabled())
                 .build()
                 .await;
             let cloned_rt = Arc::new(rt.clone());
@@ -563,7 +564,7 @@ async fn cayenne_catalog_ddl_multiple_tables() -> Result<(), String> {
             configure_test_datafusion();
             let rt = Runtime::builder()
                 .with_app(app)
-                .with_caching_disabled()
+                .with_runtime_config(Config::default().with_caching_disabled())
                 .build()
                 .await;
             let cloned_rt = Arc::new(rt.clone());
@@ -715,7 +716,7 @@ async fn cayenne_catalog_ddl_drop_table() -> Result<(), String> {
             configure_test_datafusion();
             let rt = Runtime::builder()
                 .with_app(app)
-                .with_caching_disabled()
+                .with_runtime_config(Config::default().with_caching_disabled())
                 .build()
                 .await;
             let cloned_rt = Arc::new(rt.clone());
@@ -815,7 +816,7 @@ async fn cayenne_catalog_ddl_multiple_schemas() -> Result<(), String> {
             configure_test_datafusion();
             let rt = Runtime::builder()
                 .with_app(app)
-                .with_caching_disabled()
+                .with_runtime_config(Config::default().with_caching_disabled())
                 .build()
                 .await;
             let cloned_rt = Arc::new(rt.clone());

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -1,0 +1,918 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Integration tests for Cayenne Catalog DDL operations.
+//!
+//! Validates that the Cayenne Catalog supports DataFrame DDL (CREATE TABLE via SQL),
+//! and that INSERT, UPDATE (upsert), and DELETE operations produce correct results.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, runtime_ready_check_with_timeout, test_request_context},
+};
+use app::AppBuilder;
+use arrow::array::{Float64Array, Int64Array, RecordBatch};
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
+use runtime::Runtime;
+use spicepod::component::access::AccessMode;
+use spicepod::component::catalog::Catalog;
+use spicepod::param::Params;
+
+/// Helper to run a SQL query against the runtime and collect results.
+async fn run_query(rt: &Runtime, sql: &str) -> Result<Vec<RecordBatch>, String> {
+    let result = rt
+        .datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("query '{sql}' failed: {e}"))?;
+
+    result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("collecting results for '{sql}' failed: {e}"))
+}
+
+/// Helper to run a SQL query and assert it succeeds (for DDL/DML where we don't check rows).
+async fn exec(rt: &Runtime, sql: &str) -> Result<(), String> {
+    run_query(rt, sql).await?;
+    Ok(())
+}
+
+/// Helper to get a single i64 scalar from a `SELECT COUNT(*)` style query.
+async fn query_scalar_i64(rt: &Runtime, sql: &str) -> Result<i64, String> {
+    let batches = run_query(rt, sql).await?;
+    let batch = batches
+        .first()
+        .ok_or_else(|| format!("no batches returned for '{sql}'"))?;
+    let col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| format!("expected Int64Array for '{sql}'"))?;
+    Ok(col.value(0))
+}
+
+/// Creates a Cayenne `Catalog` component with `read_write_create` access, pointing
+/// at the given temp directories.
+fn make_cayenne_catalog(
+    catalog_name: &str,
+    data_dir: &str,
+    metadata_dir: &str,
+) -> Catalog {
+    let mut catalog =
+        Catalog::new("cayenne".to_string(), catalog_name.to_string())
+            .with_access(AccessMode::ReadWriteCreate);
+    catalog.params = Some(Params::from_string_map(
+        vec![
+            ("cayenne_data_dir".to_string(), data_dir.to_string()),
+            (
+                "cayenne_metadata_dir".to_string(),
+                metadata_dir.to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect::<HashMap<String, String>>(),
+    ));
+    catalog
+}
+
+// =============================================================================
+// Test: Create table, insert, select, update (upsert), delete — full lifecycle
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "test_cat",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_lifecycle")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_caching_disabled()
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            // Load components (registers the Cayenne catalog with DDL support).
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            // -----------------------------------------------------------------
+            // Step 1: CREATE SCHEMA + CREATE TABLE via SQL DDL
+            // -----------------------------------------------------------------
+            exec(&rt, "CREATE SCHEMA test_cat.myschema").await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE test_cat.myschema.users (
+                    id BIGINT NOT NULL,
+                    name VARCHAR NOT NULL,
+                    email VARCHAR,
+                    age BIGINT
+                )",
+            )
+            .await?;
+
+            // Verify the table appears in information_schema.
+            let batches = run_query(
+                &rt,
+                "SELECT table_catalog, table_schema, table_name
+                 FROM information_schema.tables
+                 WHERE table_catalog = 'test_cat' AND table_name = 'users'",
+            )
+            .await?;
+            assert!(
+                !batches.is_empty() && batches[0].num_rows() == 1,
+                "Expected users table in information_schema, got {batches:?}"
+            );
+
+            // Verify table is empty.
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 0, "Table should be empty after creation");
+
+            // -----------------------------------------------------------------
+            // Step 2: INSERT rows
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO test_cat.myschema.users VALUES
+                    (1, 'Alice',   'alice@example.com',   30),
+                    (2, 'Bob',     'bob@example.com',     25),
+                    (3, 'Charlie', 'charlie@example.com', 35),
+                    (4, 'Diana',   'diana@example.com',   28),
+                    (5, 'Eve',     NULL,                  22)",
+            )
+            .await?;
+
+            // Validate row count.
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 5, "Expected 5 rows after initial insert");
+
+            // Validate specific rows.
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, email, age FROM test_cat.myschema.users ORDER BY id",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+----+---------+---------------------+-----+",
+                    "| id | name    | email               | age |",
+                    "+----+---------+---------------------+-----+",
+                    "| 1  | Alice   | alice@example.com   | 30  |",
+                    "| 2  | Bob     | bob@example.com     | 25  |",
+                    "| 3  | Charlie | charlie@example.com | 35  |",
+                    "| 4  | Diana   | diana@example.com   | 28  |",
+                    "| 5  | Eve     |                     | 22  |",
+                    "+----+---------+---------------------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 3: INSERT additional rows (second batch)
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO test_cat.myschema.users VALUES
+                    (6, 'Frank', 'frank@example.com', 40),
+                    (7, 'Grace', 'grace@example.com', 33)",
+            )
+            .await?;
+
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 7, "Expected 7 rows after second insert");
+
+            // -----------------------------------------------------------------
+            // Step 4: DELETE specific rows
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "DELETE FROM test_cat.myschema.users WHERE id = 3",
+            )
+            .await?;
+
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 6, "Expected 6 rows after deleting id=3");
+
+            // Verify the deleted row is gone.
+            let batches = run_query(
+                &rt,
+                "SELECT id FROM test_cat.myschema.users WHERE id = 3",
+            )
+            .await?;
+            let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(total_rows, 0, "id=3 should no longer exist");
+
+            // -----------------------------------------------------------------
+            // Step 5: DELETE multiple rows with a range filter
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "DELETE FROM test_cat.myschema.users WHERE age < 26",
+            )
+            .await?;
+
+            // Bob (25) and Eve (22) should be deleted.
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 4, "Expected 4 rows after deleting age < 26");
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name FROM test_cat.myschema.users ORDER BY id",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 4  | Diana |",
+                    "| 6  | Frank |",
+                    "| 7  | Grace |",
+                    "+----+-------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 6: INSERT after DELETE — verify correctness
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO test_cat.myschema.users VALUES
+                    (8, 'Heidi', 'heidi@example.com', 29)",
+            )
+            .await?;
+
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 5, "Expected 5 rows after inserting Heidi");
+
+            // -----------------------------------------------------------------
+            // Step 7: Aggregation queries — validate computations
+            // -----------------------------------------------------------------
+            let avg_age = {
+                let batches = run_query(
+                    &rt,
+                    "SELECT AVG(age) as avg_age FROM test_cat.myschema.users",
+                )
+                .await?;
+                let batch = &batches[0];
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .expect("avg_age column")
+                    .value(0)
+            };
+            // Remaining: Alice(30), Diana(28), Frank(40), Grace(33), Heidi(29)
+            // Average = (30 + 28 + 40 + 33 + 29) / 5 = 160 / 5 = 32.0
+            assert!(
+                (avg_age - 32.0).abs() < f64::EPSILON,
+                "Expected AVG(age) = 32.0, got {avg_age}"
+            );
+
+            let max_age = query_scalar_i64(
+                &rt,
+                "SELECT MAX(age) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(max_age, 40, "Expected MAX(age) = 40 (Frank)");
+
+            let min_age = query_scalar_i64(
+                &rt,
+                "SELECT MIN(age) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(min_age, 28, "Expected MIN(age) = 28 (Diana)");
+
+            let sum_age = query_scalar_i64(
+                &rt,
+                "SELECT SUM(age) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(sum_age, 160, "Expected SUM(age) = 160");
+
+            // -----------------------------------------------------------------
+            // Step 8: NULL handling validation
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO test_cat.myschema.users VALUES (9, 'Ivan', NULL, NULL)",
+            )
+            .await?;
+
+            // COUNT(*) counts all rows; COUNT(email) should exclude NULLs.
+            let count_star = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count_star, 6, "COUNT(*) should be 6");
+
+            let count_email = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(email) FROM test_cat.myschema.users",
+            )
+            .await?;
+            // Ivan has NULL email; all others have emails.
+            assert_eq!(
+                count_email, 5,
+                "COUNT(email) should be 5 (Ivan has NULL email)"
+            );
+
+            // Query rows where email IS NULL.
+            let batches = run_query(
+                &rt,
+                "SELECT id, name FROM test_cat.myschema.users WHERE email IS NULL ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 9  | Ivan |",
+                    "+----+------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 9: DELETE all remaining rows
+            // -----------------------------------------------------------------
+            exec(&rt, "DELETE FROM test_cat.myschema.users WHERE true").await?;
+
+            let count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM test_cat.myschema.users",
+            )
+            .await?;
+            assert_eq!(count, 0, "Table should be empty after DELETE WHERE true");
+
+            // -----------------------------------------------------------------
+            // Step 10: INSERT into empty table after full delete
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO test_cat.myschema.users VALUES (100, 'Zara', 'zara@example.com', 45)",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, email, age FROM test_cat.myschema.users ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+-----+------+------------------+-----+",
+                    "| id  | name | email            | age |",
+                    "+-----+------+------------------+-----+",
+                    "| 100 | Zara | zara@example.com | 45  |",
+                    "+-----+------+------------------+-----+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: CREATE TABLE IF NOT EXISTS idempotency
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_ddl_create_if_not_exists() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_idempotent",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_idempotent")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_caching_disabled()
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_idempotent.s1").await?;
+            exec(
+                &rt,
+                "CREATE TABLE cat_idempotent.s1.t1 (id BIGINT NOT NULL, val BIGINT)",
+            )
+            .await?;
+
+            // Insert a row.
+            exec(&rt, "INSERT INTO cat_idempotent.s1.t1 VALUES (1, 100)").await?;
+
+            // CREATE TABLE IF NOT EXISTS should not fail or drop data.
+            exec(
+                &rt,
+                "CREATE TABLE IF NOT EXISTS cat_idempotent.s1.t1 (id BIGINT NOT NULL, val BIGINT)",
+            )
+            .await?;
+
+            // Data must still be present.
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_idempotent.s1.t1").await?;
+            assert_eq!(
+                count, 1,
+                "Data should be preserved after CREATE IF NOT EXISTS"
+            );
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, val FROM cat_idempotent.s1.t1 ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-----+",
+                    "| id | val |",
+                    "+----+-----+",
+                    "| 1  | 100 |",
+                    "+----+-----+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: Multiple tables in the same schema
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_ddl_multiple_tables() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_multi",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_multi_tables")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_caching_disabled()
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_multi.store").await?;
+
+            // Create two related tables.
+            exec(
+                &rt,
+                "CREATE TABLE cat_multi.store.products (
+                    product_id BIGINT NOT NULL,
+                    name VARCHAR NOT NULL,
+                    price DOUBLE NOT NULL
+                )",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_multi.store.orders (
+                    order_id BIGINT NOT NULL,
+                    product_id BIGINT NOT NULL,
+                    quantity BIGINT NOT NULL
+                )",
+            )
+            .await?;
+
+            // Insert data into both tables.
+            exec(
+                &rt,
+                "INSERT INTO cat_multi.store.products VALUES
+                    (1, 'Widget',  9.99),
+                    (2, 'Gadget', 19.99),
+                    (3, 'Gizmo',  14.50)",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "INSERT INTO cat_multi.store.orders VALUES
+                    (100, 1, 5),
+                    (101, 2, 2),
+                    (102, 1, 3),
+                    (103, 3, 1)",
+            )
+            .await?;
+
+            // Validate each table independently.
+            let product_count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_multi.store.products").await?;
+            assert_eq!(product_count, 3);
+
+            let order_count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_multi.store.orders").await?;
+            assert_eq!(order_count, 4);
+
+            // Cross-table JOIN query.
+            let batches = run_query(
+                &rt,
+                "SELECT p.name, SUM(o.quantity) as total_qty
+                 FROM cat_multi.store.orders o
+                 JOIN cat_multi.store.products p ON o.product_id = p.product_id
+                 GROUP BY p.name
+                 ORDER BY p.name",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+--------+-----------+",
+                    "| name   | total_qty |",
+                    "+--------+-----------+",
+                    "| Gadget | 2         |",
+                    "| Gizmo  | 1         |",
+                    "| Widget | 8         |",
+                    "+--------+-----------+",
+                ],
+                &batches
+            );
+
+            // Delete from one table and validate join still correct.
+            exec(
+                &rt,
+                "DELETE FROM cat_multi.store.orders WHERE order_id = 100",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT p.name, SUM(o.quantity) as total_qty
+                 FROM cat_multi.store.orders o
+                 JOIN cat_multi.store.products p ON o.product_id = p.product_id
+                 GROUP BY p.name
+                 ORDER BY p.name",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+--------+-----------+",
+                    "| name   | total_qty |",
+                    "+--------+-----------+",
+                    "| Gadget | 2         |",
+                    "| Gizmo  | 1         |",
+                    "| Widget | 3         |",
+                    "+--------+-----------+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: DROP TABLE
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_ddl_drop_table() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_drop",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_drop")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_caching_disabled()
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_drop.ns").await?;
+            exec(
+                &rt,
+                "CREATE TABLE cat_drop.ns.ephemeral (id BIGINT NOT NULL)",
+            )
+            .await?;
+
+            exec(&rt, "INSERT INTO cat_drop.ns.ephemeral VALUES (1), (2)").await?;
+
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_drop.ns.ephemeral").await?;
+            assert_eq!(count, 2);
+
+            // DROP the table.
+            exec(&rt, "DROP TABLE cat_drop.ns.ephemeral").await?;
+
+            // Querying the dropped table should fail.
+            let result = run_query(&rt, "SELECT * FROM cat_drop.ns.ephemeral").await;
+            assert!(
+                result.is_err(),
+                "Querying a dropped table should produce an error"
+            );
+
+            // DROP TABLE IF EXISTS on a non-existent table should succeed.
+            exec(&rt, "DROP TABLE IF EXISTS cat_drop.ns.ephemeral").await?;
+
+            // Re-create the table — should work fine.
+            exec(
+                &rt,
+                "CREATE TABLE cat_drop.ns.ephemeral (id BIGINT NOT NULL, val VARCHAR)",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "INSERT INTO cat_drop.ns.ephemeral VALUES (10, 'new')",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, val FROM cat_drop.ns.ephemeral ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-----+",
+                    "| id | val |",
+                    "+----+-----+",
+                    "| 10 | new |",
+                    "+----+-----+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: Multiple schemas in the same catalog
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_ddl_multiple_schemas() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_schemas",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_multi_schemas")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_caching_disabled()
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            // Create two separate schemas.
+            exec(&rt, "CREATE SCHEMA cat_schemas.finance").await?;
+            exec(&rt, "CREATE SCHEMA cat_schemas.hr").await?;
+
+            // Create tables with the same name in different schemas.
+            exec(
+                &rt,
+                "CREATE TABLE cat_schemas.finance.records (id BIGINT NOT NULL, amount DOUBLE)",
+            )
+            .await?;
+            exec(
+                &rt,
+                "CREATE TABLE cat_schemas.hr.records (id BIGINT NOT NULL, employee VARCHAR)",
+            )
+            .await?;
+
+            // Insert data into both.
+            exec(
+                &rt,
+                "INSERT INTO cat_schemas.finance.records VALUES (1, 1000.50), (2, 2500.75)",
+            )
+            .await?;
+            exec(
+                &rt,
+                "INSERT INTO cat_schemas.hr.records VALUES (1, 'Alice'), (2, 'Bob')",
+            )
+            .await?;
+
+            // Validate isolation — each schema has its own data.
+            let batches = run_query(
+                &rt,
+                "SELECT id, amount FROM cat_schemas.finance.records ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+---------+",
+                    "| id | amount  |",
+                    "+----+---------+",
+                    "| 1  | 1000.5  |",
+                    "| 2  | 2500.75 |",
+                    "+----+---------+",
+                ],
+                &batches
+            );
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, employee FROM cat_schemas.hr.records ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+----------+",
+                    "| id | employee |",
+                    "+----+----------+",
+                    "| 1  | Alice    |",
+                    "| 2  | Bob      |",
+                    "+----+----------+",
+                ],
+                &batches
+            );
+
+            // Delete from one schema, verify the other is untouched.
+            exec(
+                &rt,
+                "DELETE FROM cat_schemas.finance.records WHERE id = 1",
+            )
+            .await?;
+
+            let finance_count = query_scalar_i64(
+                &rt,
+                "SELECT COUNT(*) FROM cat_schemas.finance.records",
+            )
+            .await?;
+            assert_eq!(finance_count, 1, "finance.records should have 1 row");
+
+            let hr_count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_schemas.hr.records").await?;
+            assert_eq!(
+                hr_count, 2,
+                "hr.records should still have 2 rows (untouched)"
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! Integration tests for Cayenne Catalog DDL operations.
 //!
-//! Validates that the Cayenne Catalog supports DataFrame DDL (CREATE TABLE via SQL),
+//! Validates that the Cayenne Catalog supports `DataFrame` DDL (CREATE TABLE via SQL),
 //! and that INSERT, UPDATE (upsert), and DELETE operations produce correct results.
 
 use std::collections::HashMap;
@@ -234,7 +234,7 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             // Verify the deleted row is gone.
             let batches =
                 run_query(&rt, "SELECT id FROM test_cat.myschema.users WHERE id = 3").await?;
-            let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
             assert_eq!(total_rows, 0, "id=3 should no longer exist");
 
             // -----------------------------------------------------------------

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -76,21 +76,13 @@ async fn query_scalar_i64(rt: &Runtime, sql: &str) -> Result<i64, String> {
 
 /// Creates a Cayenne `Catalog` component with `read_write_create` access, pointing
 /// at the given temp directories.
-fn make_cayenne_catalog(
-    catalog_name: &str,
-    data_dir: &str,
-    metadata_dir: &str,
-) -> Catalog {
-    let mut catalog =
-        Catalog::new("cayenne".to_string(), catalog_name.to_string())
-            .with_access(AccessMode::ReadWriteCreate);
+fn make_cayenne_catalog(catalog_name: &str, data_dir: &str, metadata_dir: &str) -> Catalog {
+    let mut catalog = Catalog::new("cayenne".to_string(), catalog_name.to_string())
+        .with_access(AccessMode::ReadWriteCreate);
     catalog.params = Some(Params::from_string_map(
         vec![
             ("cayenne_data_dir".to_string(), data_dir.to_string()),
-            (
-                "cayenne_metadata_dir".to_string(),
-                metadata_dir.to_string(),
-            ),
+            ("cayenne_metadata_dir".to_string(), metadata_dir.to_string()),
         ]
         .into_iter()
         .collect::<HashMap<String, String>>(),
@@ -170,11 +162,8 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             );
 
             // Verify table is empty.
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 0, "Table should be empty after creation");
 
             // -----------------------------------------------------------------
@@ -192,11 +181,8 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             .await?;
 
             // Validate row count.
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 5, "Expected 5 rows after initial insert");
 
             // Validate specific rows.
@@ -232,53 +218,33 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             )
             .await?;
 
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 7, "Expected 7 rows after second insert");
 
             // -----------------------------------------------------------------
             // Step 4: DELETE specific rows
             // -----------------------------------------------------------------
-            exec(
-                &rt,
-                "DELETE FROM test_cat.myschema.users WHERE id = 3",
-            )
-            .await?;
+            exec(&rt, "DELETE FROM test_cat.myschema.users WHERE id = 3").await?;
 
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 6, "Expected 6 rows after deleting id=3");
 
             // Verify the deleted row is gone.
-            let batches = run_query(
-                &rt,
-                "SELECT id FROM test_cat.myschema.users WHERE id = 3",
-            )
-            .await?;
+            let batches =
+                run_query(&rt, "SELECT id FROM test_cat.myschema.users WHERE id = 3").await?;
             let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
             assert_eq!(total_rows, 0, "id=3 should no longer exist");
 
             // -----------------------------------------------------------------
             // Step 5: DELETE multiple rows with a range filter
             // -----------------------------------------------------------------
-            exec(
-                &rt,
-                "DELETE FROM test_cat.myschema.users WHERE age < 26",
-            )
-            .await?;
+            exec(&rt, "DELETE FROM test_cat.myschema.users WHERE age < 26").await?;
 
             // Bob (25) and Eve (22) should be deleted.
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 4, "Expected 4 rows after deleting age < 26");
 
             let batches = run_query(
@@ -302,7 +268,120 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             );
 
             // -----------------------------------------------------------------
-            // Step 6: INSERT after DELETE — verify correctness
+            // Step 6: UPDATE single row — modify a column value
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "UPDATE test_cat.myschema.users SET age = 31 WHERE id = 1",
+            )
+            .await?;
+
+            // Alice's age should now be 31 (was 30).
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, age FROM test_cat.myschema.users WHERE id = 1",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+-----+",
+                    "| id | name  | age |",
+                    "+----+-------+-----+",
+                    "| 1  | Alice | 31  |",
+                    "+----+-------+-----+",
+                ],
+                &batches
+            );
+
+            // Row count should remain the same after UPDATE.
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
+            assert_eq!(count, 4, "UPDATE should not change row count");
+
+            // -----------------------------------------------------------------
+            // Step 7: UPDATE multiple rows — bulk modification
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "UPDATE test_cat.myschema.users SET age = age + 10 WHERE age > 30",
+            )
+            .await?;
+
+            // Alice(31→41), Diana(28 unchanged), Frank(40→50), Grace(33→43)
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, age FROM test_cat.myschema.users ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+-----+",
+                    "| id | name  | age |",
+                    "+----+-------+-----+",
+                    "| 1  | Alice | 41  |",
+                    "| 4  | Diana | 28  |",
+                    "| 6  | Frank | 50  |",
+                    "| 7  | Grace | 43  |",
+                    "+----+-------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 8: UPDATE with NULL — set a column to NULL
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "UPDATE test_cat.myschema.users SET email = NULL WHERE id = 4",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, email FROM test_cat.myschema.users WHERE id = 4",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+-------+",
+                    "| id | name  | email |",
+                    "+----+-------+-------+",
+                    "| 4  | Diana |       |",
+                    "+----+-------+-------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 9: UPDATE multiple columns at once
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "UPDATE test_cat.myschema.users SET name = 'Grace Updated', age = 99 WHERE id = 7",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, age FROM test_cat.myschema.users WHERE id = 7",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+---------------+-----+",
+                    "| id | name          | age |",
+                    "+----+---------------+-----+",
+                    "| 7  | Grace Updated | 99  |",
+                    "+----+---------------+-----+",
+                ],
+                &batches
+            );
+
+            // Restore ages for subsequent steps: Alice=41, Diana=28, Frank=50, Grace=99
+            // Overall state: 4 rows
+
+            // -----------------------------------------------------------------
+            // Step 10: INSERT after UPDATE — verify correctness
             // -----------------------------------------------------------------
             exec(
                 &rt,
@@ -311,15 +390,12 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             )
             .await?;
 
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 5, "Expected 5 rows after inserting Heidi");
 
             // -----------------------------------------------------------------
-            // Step 7: Aggregation queries — validate computations
+            // Step 11: Aggregation queries — validate computations
             // -----------------------------------------------------------------
             let avg_age = {
                 let batches = run_query(
@@ -335,36 +411,27 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
                     .expect("avg_age column")
                     .value(0)
             };
-            // Remaining: Alice(30), Diana(28), Frank(40), Grace(33), Heidi(29)
-            // Average = (30 + 28 + 40 + 33 + 29) / 5 = 160 / 5 = 32.0
+            // Remaining: Alice(41), Diana(28), Frank(50), Grace Updated(99), Heidi(29)
+            // Average = (41 + 28 + 50 + 99 + 29) / 5 = 247 / 5 = 49.4
             assert!(
-                (avg_age - 32.0).abs() < f64::EPSILON,
-                "Expected AVG(age) = 32.0, got {avg_age}"
+                (avg_age - 49.4).abs() < f64::EPSILON,
+                "Expected AVG(age) = 49.4, got {avg_age}"
             );
 
-            let max_age = query_scalar_i64(
-                &rt,
-                "SELECT MAX(age) FROM test_cat.myschema.users",
-            )
-            .await?;
-            assert_eq!(max_age, 40, "Expected MAX(age) = 40 (Frank)");
+            let max_age =
+                query_scalar_i64(&rt, "SELECT MAX(age) FROM test_cat.myschema.users").await?;
+            assert_eq!(max_age, 99, "Expected MAX(age) = 99 (Grace Updated)");
 
-            let min_age = query_scalar_i64(
-                &rt,
-                "SELECT MIN(age) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let min_age =
+                query_scalar_i64(&rt, "SELECT MIN(age) FROM test_cat.myschema.users").await?;
             assert_eq!(min_age, 28, "Expected MIN(age) = 28 (Diana)");
 
-            let sum_age = query_scalar_i64(
-                &rt,
-                "SELECT SUM(age) FROM test_cat.myschema.users",
-            )
-            .await?;
-            assert_eq!(sum_age, 160, "Expected SUM(age) = 160");
+            let sum_age =
+                query_scalar_i64(&rt, "SELECT SUM(age) FROM test_cat.myschema.users").await?;
+            assert_eq!(sum_age, 247, "Expected SUM(age) = 247");
 
             // -----------------------------------------------------------------
-            // Step 8: NULL handling validation
+            // Step 12: NULL handling validation
             // -----------------------------------------------------------------
             exec(
                 &rt,
@@ -373,22 +440,16 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             .await?;
 
             // COUNT(*) counts all rows; COUNT(email) should exclude NULLs.
-            let count_star = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count_star =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count_star, 6, "COUNT(*) should be 6");
 
-            let count_email = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(email) FROM test_cat.myschema.users",
-            )
-            .await?;
-            // Ivan has NULL email; all others have emails.
+            let count_email =
+                query_scalar_i64(&rt, "SELECT COUNT(email) FROM test_cat.myschema.users").await?;
+            // Ivan has NULL email, Diana has NULL email (set in Step 8); all others have emails.
             assert_eq!(
-                count_email, 5,
-                "COUNT(email) should be 5 (Ivan has NULL email)"
+                count_email, 4,
+                "COUNT(email) should be 4 (Ivan and Diana have NULL email)"
             );
 
             // Query rows where email IS NULL.
@@ -399,29 +460,27 @@ async fn cayenne_catalog_ddl_create_insert_update_delete() -> Result<(), String>
             .await?;
             assert_batches_eq!(
                 &[
-                    "+----+------+",
-                    "| id | name |",
-                    "+----+------+",
-                    "| 9  | Ivan |",
-                    "+----+------+",
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 4  | Diana |",
+                    "| 9  | Ivan  |",
+                    "+----+-------+",
                 ],
                 &batches
             );
 
             // -----------------------------------------------------------------
-            // Step 9: DELETE all remaining rows
+            // Step 13: DELETE all remaining rows
             // -----------------------------------------------------------------
             exec(&rt, "DELETE FROM test_cat.myschema.users WHERE true").await?;
 
-            let count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM test_cat.myschema.users",
-            )
-            .await?;
+            let count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM test_cat.myschema.users").await?;
             assert_eq!(count, 0, "Table should be empty after DELETE WHERE true");
 
             // -----------------------------------------------------------------
-            // Step 10: INSERT into empty table after full delete
+            // Step 14: INSERT into empty table after full delete
             // -----------------------------------------------------------------
             exec(
                 &rt,
@@ -515,11 +574,8 @@ async fn cayenne_catalog_ddl_create_if_not_exists() -> Result<(), String> {
                 "Data should be preserved after CREATE IF NOT EXISTS"
             );
 
-            let batches = run_query(
-                &rt,
-                "SELECT id, val FROM cat_idempotent.s1.t1 ORDER BY id",
-            )
-            .await?;
+            let batches =
+                run_query(&rt, "SELECT id, val FROM cat_idempotent.s1.t1 ORDER BY id").await?;
             assert_batches_eq!(
                 &[
                     "+----+-----+",
@@ -761,17 +817,10 @@ async fn cayenne_catalog_ddl_drop_table() -> Result<(), String> {
             )
             .await?;
 
-            exec(
-                &rt,
-                "INSERT INTO cat_drop.ns.ephemeral VALUES (10, 'new')",
-            )
-            .await?;
+            exec(&rt, "INSERT INTO cat_drop.ns.ephemeral VALUES (10, 'new')").await?;
 
-            let batches = run_query(
-                &rt,
-                "SELECT id, val FROM cat_drop.ns.ephemeral ORDER BY id",
-            )
-            .await?;
+            let batches =
+                run_query(&rt, "SELECT id, val FROM cat_drop.ns.ephemeral ORDER BY id").await?;
             assert_batches_eq!(
                 &[
                     "+----+-----+",
@@ -893,17 +942,10 @@ async fn cayenne_catalog_ddl_multiple_schemas() -> Result<(), String> {
             );
 
             // Delete from one schema, verify the other is untouched.
-            exec(
-                &rt,
-                "DELETE FROM cat_schemas.finance.records WHERE id = 1",
-            )
-            .await?;
+            exec(&rt, "DELETE FROM cat_schemas.finance.records WHERE id = 1").await?;
 
-            let finance_count = query_scalar_i64(
-                &rt,
-                "SELECT COUNT(*) FROM cat_schemas.finance.records",
-            )
-            .await?;
+            let finance_count =
+                query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_schemas.finance.records").await?;
             assert_eq!(finance_count, 1, "finance.records should have 1 row");
 
             let hr_count =

--- a/crates/runtime/tests/cluster/cancel_tasks.rs
+++ b/crates/runtime/tests/cluster/cancel_tasks.rs
@@ -200,6 +200,7 @@ async fn test_cancel_tasks_via_control_stream() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let scheduler_rt = Arc::new(
@@ -257,6 +258,7 @@ async fn test_cancel_tasks_via_control_stream() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(executor_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor_rt = Arc::new(

--- a/crates/runtime/tests/cluster/distributed_acceleration.rs
+++ b/crates/runtime/tests/cluster/distributed_acceleration.rs
@@ -154,6 +154,7 @@ async fn test_distributed_acceleration_with_bucket_partitioning() -> Result<(), 
                     node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let scheduler_rt = Arc::new(
@@ -225,6 +226,7 @@ async fn test_distributed_acceleration_with_bucket_partitioning() -> Result<(), 
                     node_mtls_key_file: Some(executor1_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor1_rt = Arc::new(

--- a/crates/runtime/tests/cluster/in_memory_shuffle.rs
+++ b/crates/runtime/tests/cluster/in_memory_shuffle.rs
@@ -254,6 +254,7 @@ async fn test_in_memory_shuffle_multiple_executors() -> Result<(), anyhow::Error
                     node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             // Start scheduler
@@ -313,6 +314,7 @@ async fn test_in_memory_shuffle_multiple_executors() -> Result<(), anyhow::Error
                     node_mtls_key_file: Some(executor1_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor1_rt = Arc::new(
@@ -371,6 +373,7 @@ async fn test_in_memory_shuffle_multiple_executors() -> Result<(), anyhow::Error
                     node_mtls_key_file: Some(executor2_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor2_rt = Arc::new(

--- a/crates/runtime/tests/cluster/job_store.rs
+++ b/crates/runtime/tests/cluster/job_store.rs
@@ -119,6 +119,7 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let scheduler_rt = Arc::new(
@@ -176,6 +177,7 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(executor_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor_rt = Arc::new(

--- a/crates/runtime/tests/cluster/simple.rs
+++ b/crates/runtime/tests/cluster/simple.rs
@@ -196,6 +196,7 @@ async fn test_simple_cluster_mode() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(scheduler_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let scheduler_rt = Arc::new(
@@ -253,6 +254,7 @@ async fn test_simple_cluster_mode() -> Result<(), anyhow::Error> {
                     node_mtls_key_file: Some(executor_cert.key_path.to_string_lossy().to_string()),
                     ..Default::default()
                 },
+                ..Default::default()
             };
 
             let executor_rt = Arc::new(

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -29,6 +29,8 @@ mod acceleration;
 mod cache;
 mod catalog;
 mod cayenne;
+#[cfg(not(windows))]
+mod cayenne_catalog_ddl;
 #[cfg(feature = "duckdb")]
 mod clickbench;
 mod cluster;


### PR DESCRIPTION
This pull request introduces a new mechanism for overriding the Spicepod runtime configuration at the programmatic level, allowing runtime parameters (such as caching, query settings, and task history) to be controlled independently of the Spicepod YAML configuration. The changes also add convenience methods to the `Config` struct for setting and disabling caching, and update the runtime builder and test code to use the new approach.

**Spicepod runtime configuration override and control:**

* Added a `runtime` field to the `Config` struct, allowing for an optional override of the Spicepod runtime configuration, which takes precedence over the corresponding fields in the `App`'s runtime config. This enables programmatic control over runtime parameters. (`crates/runtime/src/config.rs`)
* Implemented `with_spicepod_runtime` and `with_caching_disabled` methods on `Config` to allow easy programmatic setting or disabling of runtime parameters, including all caching options. (`crates/runtime/src/config.rs`)

**Runtime builder logic refactor:**

* Refactored `RuntimeBuilder` to resolve the effective Spicepod runtime configuration by prioritizing the override in `Config`, then falling back to the `App`, and finally to defaults. All runtime parameter extraction now uses this resolved configuration, simplifying logic and ensuring consistent precedence. (`crates/runtime/src/builder.rs`) [[1]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeL192-R213) [[2]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeL231-R230) [[3]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeL308-R298)

**Test code improvements:**

* Updated cluster test setup code to use the new `Config` struct with the runtime override, ensuring tests can programmatically control runtime parameters. (`crates/runtime/tests/cluster/*.rs`) [[1]](diffhunk://#diff-d2c3419f4dc0cdacf7f9dc1b9bfb4181c8733b075568aadb2dd958399a81d767R203) [[2]](diffhunk://#diff-d2c3419f4dc0cdacf7f9dc1b9bfb4181c8733b075568aadb2dd958399a81d767R261) [[3]](diffhunk://#diff-6241aaefd92598de61fe5a971faafd5dc15fe988f5774416732f6174faa78090R157) [[4]](diffhunk://#diff-6241aaefd92598de61fe5a971faafd5dc15fe988f5774416732f6174faa78090R229) [[5]](diffhunk://#diff-e212df40643da0ec9072063de198522eebc7856a04cf1254c87f16d7da8a81acR257) [[6]](diffhunk://#diff-e212df40643da0ec9072063de198522eebc7856a04cf1254c87f16d7da8a81acR317) [[7]](diffhunk://#diff-e212df40643da0ec9072063de198522eebc7856a04cf1254c87f16d7da8a81acR376) [[8]](diffhunk://#diff-db81d053fc7d003139b1e75b92091132a2528243e9adb7c56ca267e74e78e672R122) [[9]](diffhunk://#diff-db81d053fc7d003139b1e75b92091132a2528243e9adb7c56ca267e74e78e672R180) [[10]](diffhunk://#diff-d457891caaf01d5481bf7345bf309ad2f16eaf11a315c8eb3abf745751d29767R199) [[11]](diffhunk://#diff-d457891caaf01d5481bf7345bf309ad2f16eaf11a315c8eb3abf745751d29767R257)

**Dependency and import updates:**

* Updated imports throughout the codebase to use the new location of the `Caching` type and added necessary imports for the new functionality. (`crates/runtime/src/builder.rs`, `crates/runtime/src/config.rs`) [[1]](diffhunk://#diff-525b47a9197d2a991751f0e36967e316da7822200011cf2544d17047875b9ddeL41-R41) [[2]](diffhunk://#diff-a1604db127053d90423ecef7fcfdf300b87703e8ac40f46e58f164145c5af455R18-R19)

**Test module organization:**

* Added a conditional test module for `cayenne_catalog_ddl` to improve test organization and coverage on non-Windows platforms. (`crates/runtime/tests/integration.rs`)