### PR TITLE
feat: Support specifying app resources in spidapter

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -124,6 +124,7 @@ impl CloudClient {
             visibility: visibility.to_string(),
             cname: None,
             tags: None,
+            resources: None,
         };
         self.inner.create_app(&request).await.map_err(into_cli)
     }
@@ -145,6 +146,7 @@ impl CloudClient {
             image_tag: image_tag.map(String::from),
             region: region.map(String::from),
             spicepod: None,
+            resources: None,
         };
         self.inner
             .update_app(app.id, &request)

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -36,6 +36,8 @@ pub struct App {
     pub region: Option<String>,
     pub production_branch: Option<String>,
     pub api_key: Option<String>,
+    #[serde(default)]
+    pub config: Option<AppConfig>,
 }
 
 impl App {
@@ -50,6 +52,44 @@ pub struct AppsResponse {
     pub apps: Vec<App>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub spicepod: Option<serde_json::Value>,
+    pub registry: Option<String>,
+    pub image: Option<String>,
+    pub image_tag: Option<String>,
+    pub update_channel: Option<String>,
+    pub replicas: Option<i32>,
+    pub resources: Option<AppResources>,
+    pub region: Option<String>,
+    pub node_group: Option<String>,
+    pub storage_claim_size_gb: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AppResources {
+    pub limits: AppResourceLimits,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<AppResourceRequests>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AppResourceLimits {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    pub memory: String,
+    #[serde(rename = "ephemeral-storage", skip_serializing_if = "Option::is_none")]
+    pub ephemeral_storage: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AppResourceRequests {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct CreateAppRequest {
     pub name: String,
@@ -60,6 +100,8 @@ pub struct CreateAppRequest {
     pub cname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<AppResources>,
 }
 
 #[derive(Debug, Serialize)]
@@ -76,6 +118,8 @@ pub struct UpdateAppRequest {
     pub region: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spicepod: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<AppResources>,
 }
 
 // ============================================================================

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -19,7 +19,10 @@ use std::{collections::BTreeMap, time::Duration};
 use reqwest::Client;
 use spice_cloud_client::{
     CloudClient,
-    types::{CreateAppRequest, CreateDeploymentRequest, UpdateAppRequest},
+    types::{
+        AppResourceLimits, AppResourceRequests, AppResources, CreateAppRequest,
+        CreateDeploymentRequest, UpdateAppRequest,
+    },
 };
 
 pub(crate) mod secrets;
@@ -75,6 +78,17 @@ pub(crate) async fn ensure_spice_cloud_app(
                 "kind".to_string(),
                 "cluster".to_string(),
             )])),
+            resources: Some(AppResources {
+                limits: AppResourceLimits {
+                    cpu: None,
+                    memory: "8Gi".to_string(),
+                    ephemeral_storage: None,
+                },
+                requests: Some(AppResourceRequests {
+                    cpu: Some("0.1".to_string()),
+                    memory: Some("256Mi".to_string()),
+                }),
+            }),
         })
         .await;
 
@@ -150,6 +164,7 @@ pub(crate) async fn apply_spicepod_to_app(
                 image_tag: None,
                 region: None,
                 spicepod: Some(spicepod_yaml.to_string()),
+                resources: None,
             },
         )
         .await?;


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

This pull request introduces support for specifying resource requirements for Spice Cloud applications by adding new types for resource configuration and updating relevant request structs. It also updates the CLI tool to utilize these new resource fields when creating or updating applications.

**Resource configuration support:**

* Added new structs `AppConfig`, `AppResources`, `AppResourceLimits`, and `AppResourceRequests` to `spice-cloud-client` for representing application configuration and resource requirements, including CPU, memory, and ephemeral storage. (`crates/spice-cloud-client/src/types.rs`)
* Updated the `App` struct to include an optional `config` field of type `AppConfig`. (`crates/spice-cloud-client/src/types.rs`)

**API request enhancements:**

* Extended the `CreateAppRequest` and `UpdateAppRequest` structs to include an optional `resources` field, allowing resource specifications to be sent when creating or updating apps. (`crates/spice-cloud-client/src/types.rs`) [[1]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR103-R104) [[2]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR121-R122)

**CLI tool updates:**

* Updated imports in `spidapter` to include the new resource-related types. (`tools/spidapter/src/commands/mod.rs`)
* Modified `ensure_spice_cloud_app` to set resource limits and requests when creating an app, specifying memory and CPU requirements. (`tools/spidapter/src/commands/mod.rs`)
* Updated `apply_spicepod_to_app` to explicitly set `resources: None` when updating an app. (`tools/spidapter/src/commands/mod.rs`)
