### PR TITLE
Make `Refresh::refresh_sql` more robust to alterations over time.

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -994,20 +994,61 @@ impl AcceleratedTable {
         Arc::clone(&self.synchronized_children)
     }
 
-    pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
+    pub async fn update_refresh_sql(
+        &self,
+        refresh_sql: Option<crate::accelerated_table::refresh::RefreshSQL>,
+    ) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
         let mut refresh = self.refresh_params.write().await;
-        refresh.sql.clone_from(&refresh_sql);
+        // Preserve existing partition_filters when updating user SQL
+        let existing_partition_filters = refresh
+            .sql
+            .as_ref()
+            .map(|s| s.partition_filters().to_vec())
+            .unwrap_or_default();
 
-        if !is_spice_internal_dataset(&self.dataset_name) {
-            if let Some(sql_str) = &refresh_sql {
-                tracing::info!("[refresh] Updated refresh SQL for {dataset_name} to {sql_str}");
-            } else {
+        if let Some(mut new_sql) = refresh_sql {
+            if !existing_partition_filters.is_empty() {
+                new_sql.set_partition_filters(existing_partition_filters);
+            }
+            if !is_spice_internal_dataset(&self.dataset_name) {
+                tracing::info!(
+                    "[refresh] Updated refresh SQL for {dataset_name} to {}",
+                    new_sql.display_sql()
+                );
+            }
+            refresh.sql = Some(new_sql);
+        } else {
+            if !is_spice_internal_dataset(&self.dataset_name) {
                 tracing::info!("[refresh] Removed refresh SQL for {dataset_name}");
             }
+            refresh.sql = None;
         }
 
+        Ok(())
+    }
+
+    /// Update only the partition filters on the refresh SQL, preserving user SQL parts.
+    pub async fn update_partition_filters(
+        &self,
+        filters: Vec<datafusion_expr::Expr>,
+    ) -> Result<()> {
+        let mut refresh = self.refresh_params.write().await;
+        if let Some(ref mut sql) = refresh.sql {
+            sql.set_partition_filters(filters);
+        } else {
+            // No user SQL, but we still need partition filters.
+            // Create a minimal RefreshSQL with All columns and only partition filters.
+            let mut sql = crate::accelerated_table::refresh::RefreshSQL::new(
+                self.dataset_name.clone(),
+                crate::accelerated_table::refresh::RefreshSQLColumns::All,
+                vec![],
+                None,
+            );
+            sql.set_partition_filters(filters);
+            refresh.sql = Some(sql);
+        }
         Ok(())
     }
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -994,10 +994,7 @@ impl AcceleratedTable {
         Arc::clone(&self.synchronized_children)
     }
 
-    pub async fn update_refresh_sql(
-        &self,
-        refresh_sql: Option<crate::accelerated_table::refresh::RefreshSQL>,
-    ) -> Result<()> {
+    pub async fn update_refresh_sql(&self, mut refresh_sql: refresh::RefreshSQL) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
         let mut refresh = self.refresh_params.write().await;
@@ -1008,23 +1005,16 @@ impl AcceleratedTable {
             .map(|s| s.partition_filters().to_vec())
             .unwrap_or_default();
 
-        if let Some(mut new_sql) = refresh_sql {
-            if !existing_partition_filters.is_empty() {
-                new_sql.set_partition_filters(existing_partition_filters);
-            }
-            if !is_spice_internal_dataset(&self.dataset_name) {
-                tracing::info!(
-                    "[refresh] Updated refresh SQL for {dataset_name} to {}",
-                    new_sql.display_sql()
-                );
-            }
-            refresh.sql = Some(new_sql);
-        } else {
-            if !is_spice_internal_dataset(&self.dataset_name) {
-                tracing::info!("[refresh] Removed refresh SQL for {dataset_name}");
-            }
-            refresh.sql = None;
+        if !existing_partition_filters.is_empty() {
+            refresh_sql.set_partition_filters(existing_partition_filters);
         }
+        if !is_spice_internal_dataset(&self.dataset_name) {
+            tracing::info!(
+                "[refresh] Updated refresh SQL for {dataset_name} to {}",
+                refresh_sql.display_sql()
+            );
+        }
+        refresh.sql = Some(refresh_sql);
 
         Ok(())
     }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::fmt::Write;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Weak};
 
@@ -121,12 +122,10 @@ impl RefreshSQL {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(" AND ");
-            use std::fmt::Write;
             let _ = write!(sql, " WHERE {where_clause}");
         }
 
         if let Some(limit) = self.limit {
-            use std::fmt::Write;
             let _ = write!(sql, " LIMIT {limit}");
         }
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -334,8 +334,9 @@ impl Refresh {
     /// Apply overrides from a refresh request.
     ///
     /// Note: if the override includes a `sql` string, it is stored as the raw override.
-    /// The caller is responsible for parsing it into a `RefreshSQL` via
-    /// `RefreshSQL::parse()` before use (this requires table name and schema context).
+    /// The caller is responsible for parsing it into a `RefreshSQL` using
+    /// `crate::datafusion::refresh_sql::parse_refresh_sql` before use
+    /// (this requires table name and schema context).
     #[must_use]
     pub fn with_overrides(mut self, overrides: &RefreshOverrides) -> Self {
         if let Some(sql_str) = &overrides.sql {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -63,7 +63,7 @@ pub enum RefreshSQLColumns {
 }
 
 /// Structured representation of refresh SQL, decomposed into validated parts.
-/// The user's `refresh_sql` config is parsed into columns + user_filters + limit.
+/// The user's `refresh_sql` config is parsed into columns + `user_filters` + limit.
 /// System-generated filters (partitions) are stored separately.
 #[derive(Clone, Debug)]
 pub struct RefreshSQL {
@@ -71,13 +71,13 @@ pub struct RefreshSQL {
     table: TableReference,
     /// Column projection (All or specific named columns).
     columns: RefreshSQLColumns,
-    /// User-provided WHERE predicates from refresh_sql, split on top-level AND.
-    /// Stored as sqlparser AST Exprs so they can be recombined with system filters.
+    /// User-provided WHERE predicates from `refresh_sql`, split on top-level `AND`.
+    /// Stored as sqlparser `AST` `Expr`s so they can be recombined with system filters.
     user_filters: Vec<sqlparser::ast::Expr>,
     /// LIMIT clause from user SQL, if any.
     limit: Option<usize>,
-    /// Cluster partition filter expressions (DataFusion Exprs).
-    /// Applied as DataFrame `.filter()` calls at query time.
+    /// Cluster partition filter expressions (`DataFusion` Exprs).
+    /// Applied as `DataFrame` `.filter()` calls at query time.
     partition_filters: Vec<datafusion_expr::Expr>,
 }
 
@@ -100,7 +100,7 @@ impl RefreshSQL {
     }
 
     /// Reconstruct the user SQL from parts: `SELECT {columns} FROM {table} WHERE {user_filters} LIMIT {limit}`.
-    /// This does NOT include partition filters — those are applied as DataFrame filters.
+    /// This does NOT include partition filters — those are applied as `DataFrame` filters.
     #[must_use]
     pub fn to_sql(&self) -> String {
         let columns_str = match &self.columns {
@@ -121,17 +121,19 @@ impl RefreshSQL {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(" AND ");
-            sql.push_str(&format!(" WHERE {where_clause}"));
+            use std::fmt::Write;
+            let _ = write!(sql, " WHERE {where_clause}");
         }
 
         if let Some(limit) = self.limit {
-            sql.push_str(&format!(" LIMIT {limit}"));
+            use std::fmt::Write;
+            let _ = write!(sql, " LIMIT {limit}");
         }
 
         sql
     }
 
-    /// Get the partition filter expressions for DataFrame filtering.
+    /// Get the partition filter expressions for `DataFrame` filtering.
     #[must_use]
     pub fn partition_filters(&self) -> &[datafusion_expr::Expr] {
         &self.partition_filters
@@ -303,7 +305,7 @@ impl Refresh {
     /// Get the display SQL string for logging/status purposes.
     #[must_use]
     pub fn display_sql(&self) -> Option<String> {
-        self.sql.as_ref().map(|s| s.display_sql())
+        self.sql.as_ref().map(RefreshSQL::display_sql)
     }
 
     #[must_use]

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -58,8 +58,8 @@ use tokio::time::sleep;
 pub enum RefreshSQLColumns {
     /// SELECT * — all columns from source.
     All,
-    /// SELECT col1, col2, ... — specific columns by name.
-    Named(Vec<String>),
+    /// SELECT col1, col2, ... — specific columns preserving original quoting/case.
+    Named(Vec<sqlparser::ast::Ident>),
 }
 
 /// Structured representation of refresh SQL, decomposed into validated parts.
@@ -105,7 +105,11 @@ impl RefreshSQL {
     pub fn to_sql(&self) -> String {
         let columns_str = match &self.columns {
             RefreshSQLColumns::All => "*".to_string(),
-            RefreshSQLColumns::Named(cols) => cols.join(", "),
+            RefreshSQLColumns::Named(idents) => idents
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
         };
 
         let mut sql = format!("SELECT {columns_str} FROM {}", self.table);

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -37,6 +37,7 @@ use cache::Caching;
 use data_components::cdc::ChangesStream;
 use datafusion::common::TableReference;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::sqlparser;
 use futures::future::BoxFuture;
 use opentelemetry::KeyValue;
 use rand::Rng;
@@ -51,6 +52,118 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{Mutex, Notify};
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
+
+/// Columns selected in the refresh SQL.
+#[derive(Clone, Debug)]
+pub enum RefreshSQLColumns {
+    /// SELECT * — all columns from source.
+    All,
+    /// SELECT col1, col2, ... — specific columns by name.
+    Named(Vec<String>),
+}
+
+/// Structured representation of refresh SQL, decomposed into validated parts.
+/// The user's `refresh_sql` config is parsed into columns + user_filters + limit.
+/// System-generated filters (partitions) are stored separately.
+#[derive(Clone, Debug)]
+pub struct RefreshSQL {
+    /// The source table this refresh targets.
+    table: TableReference,
+    /// Column projection (All or specific named columns).
+    columns: RefreshSQLColumns,
+    /// User-provided WHERE predicates from refresh_sql, split on top-level AND.
+    /// Stored as sqlparser AST Exprs so they can be recombined with system filters.
+    user_filters: Vec<sqlparser::ast::Expr>,
+    /// LIMIT clause from user SQL, if any.
+    limit: Option<usize>,
+    /// Cluster partition filter expressions (DataFusion Exprs).
+    /// Applied as DataFrame `.filter()` calls at query time.
+    partition_filters: Vec<datafusion_expr::Expr>,
+}
+
+impl RefreshSQL {
+    /// Create a new `RefreshSQL` with the given parts.
+    #[must_use]
+    pub fn new(
+        table: TableReference,
+        columns: RefreshSQLColumns,
+        user_filters: Vec<sqlparser::ast::Expr>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            table,
+            columns,
+            user_filters,
+            limit,
+            partition_filters: vec![],
+        }
+    }
+
+    /// Reconstruct the user SQL from parts: `SELECT {columns} FROM {table} WHERE {user_filters} LIMIT {limit}`.
+    /// This does NOT include partition filters — those are applied as DataFrame filters.
+    #[must_use]
+    pub fn to_sql(&self) -> String {
+        let columns_str = match &self.columns {
+            RefreshSQLColumns::All => "*".to_string(),
+            RefreshSQLColumns::Named(cols) => cols.join(", "),
+        };
+
+        let mut sql = format!("SELECT {columns_str} FROM {}", self.table);
+
+        if !self.user_filters.is_empty() {
+            let where_clause = self
+                .user_filters
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            sql.push_str(&format!(" WHERE {where_clause}"));
+        }
+
+        if let Some(limit) = self.limit {
+            sql.push_str(&format!(" LIMIT {limit}"));
+        }
+
+        sql
+    }
+
+    /// Get the partition filter expressions for DataFrame filtering.
+    #[must_use]
+    pub fn partition_filters(&self) -> &[datafusion_expr::Expr] {
+        &self.partition_filters
+    }
+
+    /// Set the partition filter expressions.
+    pub fn set_partition_filters(&mut self, filters: Vec<datafusion_expr::Expr>) {
+        self.partition_filters = filters;
+    }
+
+    /// For logging/status display. Shows the user SQL and annotates if partition filters are active.
+    #[must_use]
+    pub fn display_sql(&self) -> String {
+        let base = self.to_sql();
+        if self.partition_filters.is_empty() {
+            base
+        } else {
+            format!(
+                "{base} [+{} partition filter(s)]",
+                self.partition_filters.len()
+            )
+        }
+    }
+
+    /// Returns the table reference.
+    #[must_use]
+    pub fn table(&self) -> &TableReference {
+        &self.table
+    }
+
+    /// Returns the columns selection.
+    #[must_use]
+    pub fn columns(&self) -> &RefreshSQLColumns {
+        &self.columns
+    }
+}
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -79,7 +192,10 @@ pub struct Refresh {
     pub(crate) time_partition_format: Option<TimeFormat>,
     pub(crate) check_interval: Option<Duration>,
     pub(crate) max_jitter: Option<Duration>,
-    pub(crate) sql: Option<String>,
+    pub(crate) sql: Option<RefreshSQL>,
+    /// Raw SQL string from an override request, not yet parsed.
+    /// When set, this should be parsed into a `RefreshSQL` before use.
+    pub(crate) override_sql_raw: Option<String>,
     pub(crate) mode: RefreshMode,
     pub(crate) period: Option<Duration>,
     pub(crate) append_overlap: Option<Duration>,
@@ -175,9 +291,15 @@ impl Refresh {
     }
 
     #[must_use]
-    pub fn sql(mut self, sql: String) -> Self {
+    pub fn refresh_sql(mut self, sql: RefreshSQL) -> Self {
         self.sql = Some(sql);
         self
+    }
+
+    /// Get the display SQL string for logging/status purposes.
+    #[must_use]
+    pub fn display_sql(&self) -> Option<String> {
+        self.sql.as_ref().map(|s| s.display_sql())
     }
 
     #[must_use]
@@ -205,10 +327,15 @@ impl Refresh {
         self
     }
 
+    /// Apply overrides from a refresh request.
+    ///
+    /// Note: if the override includes a `sql` string, it is stored as the raw override.
+    /// The caller is responsible for parsing it into a `RefreshSQL` via
+    /// `RefreshSQL::parse()` before use (this requires table name and schema context).
     #[must_use]
     pub fn with_overrides(mut self, overrides: &RefreshOverrides) -> Self {
-        if let Some(sql) = &overrides.sql {
-            self.sql = Some(sql.clone());
+        if let Some(sql_str) = &overrides.sql {
+            self.override_sql_raw = Some(sql_str.clone());
         }
         if let Some(mode) = overrides.mode {
             self.mode = mode;
@@ -435,6 +562,7 @@ impl Default for Refresh {
             check_interval: None,
             max_jitter: None,
             sql: None,
+            override_sql_raw: None,
             mode: RefreshMode::Full,
             period: None,
             append_overlap: None,
@@ -1061,7 +1189,7 @@ async fn notify_refresh_done(
     let mut labels = vec![KeyValue::new("dataset", dataset_name.to_string())];
     let refresh_guard = refresh.read().await;
     if let Some(sql) = &refresh_guard.sql {
-        labels.push(KeyValue::new("sql", sql.clone()));
+        labels.push(KeyValue::new("sql", sql.display_sql()));
     }
 
     metrics::LAST_REFRESH_TIME_MS.record(now.as_secs_f64() * 1000.0, &labels);

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -953,28 +953,26 @@ impl RefreshTask {
             RefreshMode::Caching => UpdateType::Overwrite,
         };
 
-        // If an override SQL string was provided, parse it into a RefreshSQL,
-        // preserving partition filters from the base refresh.
-        let effective_sql = if let Some(override_raw) = &refresh.override_sql_raw {
-            let source_schema = federated_provider.schema();
-            match refresh_sql::parse_refresh_sql(dataset_name.clone(), override_raw, source_schema)
-            {
-                Ok((mut parsed, _schema)) => {
-                    // Preserve partition filters from base refresh
-                    if let Some(base) = &refresh.sql {
-                        parsed.set_partition_filters(base.partition_filters().to_vec());
-                    }
-                    Some(parsed)
+        // If a refresh SQL is explicitly provided for this `RefreshTask` (instead of provided at startup within the
+        // spicepod), parse and use it. Transfer partition filters from the base refresh SQL.
+        let effective_sql = match refresh.override_sql_raw.map(|s| {
+            refresh_sql::parse_refresh_sql(dataset_name.clone(), &s, federated_provider.schema())
+        }) {
+            Some(Ok((mut parsed, _schema))) => {
+                if let Some(base) = &refresh.sql {
+                    parsed.set_partition_filters(base.partition_filters().to_vec());
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to parse override refresh_sql for {dataset_name}, falling back to base: {e}"
-                    );
-                    refresh.sql.clone()
-                }
+                Some(parsed)
             }
-        } else {
-            refresh.sql.clone()
+            Some(Err(e)) => {
+                tracing::error!("Failed to parse override refresh_sql for {dataset_name}: {e}");
+                return Err(RetryError::permanent(
+                    super::Error::FailedToRefreshDataset {
+                        source: DataFusionError::Plan(format!("Invalid override refresh_sql: {e}")),
+                    },
+                ));
+            }
+            None => refresh.sql.clone(),
         };
 
         // Extract SQL string and partition filters from RefreshSQL

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -27,6 +27,7 @@ use crate::datafusion::error::{SpiceExternalError, find_datafusion_root, get_spi
 use crate::datafusion::filter_converter::create_timestamp_filter_convert;
 use crate::datafusion::is_spice_internal_dataset;
 use crate::datafusion::managed_runtime::{self, ManagedRuntimeError};
+use crate::datafusion::refresh_sql;
 use crate::datafusion::schema::BaseSchema;
 use crate::federated_table::FederatedTable;
 use crate::metrics::telemetry::track_bytes_processed;
@@ -952,9 +953,33 @@ impl RefreshTask {
             RefreshMode::Caching => UpdateType::Overwrite,
         };
 
+        // If an override SQL string was provided, parse it into a RefreshSQL,
+        // preserving partition filters from the base refresh.
+        let effective_sql = if let Some(override_raw) = &refresh.override_sql_raw {
+            let source_schema = federated_provider.schema();
+            match refresh_sql::parse_refresh_sql(dataset_name.clone(), override_raw, source_schema)
+            {
+                Ok((mut parsed, _schema)) => {
+                    // Preserve partition filters from base refresh
+                    if let Some(base) = &refresh.sql {
+                        parsed.set_partition_filters(base.partition_filters().to_vec());
+                    }
+                    Some(parsed)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse override refresh_sql for {dataset_name}, falling back to base: {e}"
+                    );
+                    refresh.sql.clone()
+                }
+            }
+        } else {
+            refresh.sql.clone()
+        };
+
         // Extract SQL string and partition filters from RefreshSQL
-        let sql_string = refresh.sql.as_ref().map(|s| s.to_sql());
-        if let Some(ref s) = refresh.sql {
+        let sql_string = effective_sql.as_ref().map(|s| s.to_sql());
+        if let Some(ref s) = effective_sql {
             filters.extend(s.partition_filters().iter().cloned());
         }
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -955,7 +955,7 @@ impl RefreshTask {
 
         // If a refresh SQL is explicitly provided for this `RefreshTask` (instead of provided at startup within the
         // spicepod), parse and use it. Transfer partition filters from the base refresh SQL.
-        let effective_sql = match refresh.override_sql_raw.map(|s| {
+        let effective_sql = match refresh.override_sql_raw.as_ref().map(|s| {
             refresh_sql::parse_refresh_sql(dataset_name.clone(), &s, federated_provider.schema())
         }) {
             Some(Ok((mut parsed, _schema))) => {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -396,8 +396,11 @@ impl RefreshTask {
     }
 
     async fn run_once(&self, refresh: &Refresh) -> Result<(), RetryError<super::Error>> {
-        self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
-            .await;
+        self.set_refresh_status(
+            refresh.display_sql().as_deref(),
+            status::ComponentStatus::Refreshing,
+        )
+        .await;
 
         let dataset_metrics_label_sets = self.get_dataset_label_sets(&refresh.mode).await;
 
@@ -442,8 +445,11 @@ impl RefreshTask {
                         metrics::REFRESH_DATA_FETCHES_SKIPPED.add(1, label_set);
                     }
 
-                    self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Ready)
-                        .await;
+                    self.set_refresh_status(
+                        refresh.display_sql().as_deref(),
+                        status::ComponentStatus::Ready,
+                    )
+                    .await;
                     return Ok(());
                 }
                 Ok(_) => {
@@ -499,8 +505,11 @@ impl RefreshTask {
                 if self.runtime_status.is_shutdown() {
                     return Ok(());
                 }
-                self.log_refresh_error(inner_err_from_retry_ref(&e), refresh.sql.as_deref())
-                    .await;
+                self.log_refresh_error(
+                    inner_err_from_retry_ref(&e),
+                    refresh.display_sql().as_deref(),
+                )
+                .await;
                 return Err(e);
             }
         };
@@ -531,7 +540,7 @@ impl RefreshTask {
             .write_streaming_data_update(
                 Some(start_time),
                 streaming_data_update,
-                refresh.sql.as_deref(),
+                refresh.display_sql().as_deref(),
             )
             .await
         {
@@ -788,8 +797,11 @@ impl RefreshTask {
             tracing::info!("Loading data for {} {dataset_name}", self.component_type());
         }
 
-        self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
-            .await;
+        self.set_refresh_status(
+            refresh.display_sql().as_deref(),
+            status::ComponentStatus::Refreshing,
+        )
+        .await;
 
         let refresh = refresh.clone();
         let mut filters = vec![];
@@ -923,7 +935,7 @@ impl RefreshTask {
 
     async fn get_data_update(
         &self,
-        filters: Vec<Expr>,
+        mut filters: Vec<Expr>,
         refresh: &Refresh,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
         let federated_provider = self.federated.table_provider().await;
@@ -940,12 +952,18 @@ impl RefreshTask {
             RefreshMode::Caching => UpdateType::Overwrite,
         };
 
+        // Extract SQL string and partition filters from RefreshSQL
+        let sql_string = refresh.sql.as_ref().map(|s| s.to_sql());
+        if let Some(ref s) = refresh.sql {
+            filters.extend(s.partition_filters().iter().cloned());
+        }
+
         if let Some(cpu_runtime_handle) = self.cpu_runtime.clone() {
             let dataset_name_for_runtime = dataset_name.clone();
             let filters_for_runtime = filters.clone();
             let update_type_for_runtime = update_type.clone();
             let provider_for_runtime = Arc::clone(&federated_provider);
-            let sql_for_runtime = refresh.sql.clone();
+            let sql_for_runtime = sql_string.clone();
             let request_context = RequestContext::current(AsyncMarker::new().await);
             let span = Span::current();
 
@@ -1010,7 +1028,7 @@ impl RefreshTask {
             &mut ctx,
             dataset_name,
             federated_provider,
-            refresh.sql.clone(),
+            sql_string,
             filters,
         )
         .await

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -956,7 +956,7 @@ impl RefreshTask {
         // If a refresh SQL is explicitly provided for this `RefreshTask` (instead of provided at startup within the
         // spicepod), parse and use it. Transfer partition filters from the base refresh SQL.
         let effective_sql = match refresh.override_sql_raw.as_ref().map(|s| {
-            refresh_sql::parse_refresh_sql(dataset_name.clone(), &s, federated_provider.schema())
+            refresh_sql::parse_refresh_sql(dataset_name.clone(), s, federated_provider.schema())
         }) {
             Some(Ok((mut parsed, _schema))) => {
                 if let Some(base) = &refresh.sql {
@@ -976,7 +976,9 @@ impl RefreshTask {
         };
 
         // Extract SQL string and partition filters from RefreshSQL
-        let sql_string = effective_sql.as_ref().map(|s| s.to_sql());
+        let sql_string = effective_sql
+            .as_ref()
+            .map(super::refresh::RefreshSQL::to_sql);
         if let Some(ref s) = effective_sql {
             filters.extend(s.partition_filters().iter().cloned());
         }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -82,7 +82,7 @@ impl RefreshTask {
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated_table::Result<()> {
         let dataset_name = self.dataset_name.clone();
-        let sql = refresh.read().await.sql.clone();
+        let sql = refresh.read().await.display_sql();
 
         self.set_refresh_status(sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
@@ -126,7 +126,7 @@ impl RefreshTask {
                         }
                         Err(e) => {
                             self.set_refresh_status(
-                                refresh.read().await.sql.clone().as_deref(),
+                                refresh.read().await.display_sql().as_deref(),
                                 status::ComponentStatus::error_with_message(e.to_string()),
                             )
                             .await;
@@ -143,7 +143,7 @@ impl RefreshTask {
                     }
 
                     self.set_refresh_status(
-                        refresh.read().await.sql.clone().as_deref(),
+                        refresh.read().await.display_sql().as_deref(),
                         status::ComponentStatus::error_with_message(e.to_string()),
                     )
                     .await;

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -89,11 +89,23 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Extract partition filter expressions for a table from the assignments map.
-/// Returns the `Vec<Expr>` of partition filters to be applied as DataFrame filters.
+/// Multiple assigned partitions are combined with OR (union semantics), then returned
+/// as a single-element `Vec<Expr>` so that applying them via `.filter()` is correct.
+/// Returns an empty `Vec` if no partitions are assigned.
 #[expect(clippy::implicit_hasher)]
 pub fn get_partition_filter_exprs(
     tbl: &TableReference,
     assignments: &HashMap<TableReference, Vec<Expr>>,
 ) -> Vec<Expr> {
-    assignments.get(tbl).cloned().unwrap_or_default()
+    let partitions = assignments.get(tbl).cloned().unwrap_or_default();
+    if partitions.is_empty() {
+        return vec![];
+    }
+    // Combine multiple partition expressions with OR (union of partitions),
+    // then wrap in a single-element Vec so `.filter()` applies it as one predicate.
+    let combined = partitions
+        .into_iter()
+        .reduce(Expr::or)
+        .unwrap_or_else(|| unreachable!("partitions is not empty"));
+    vec![combined]
 }

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -22,7 +22,7 @@ mod startup;
 
 use std::collections::HashMap;
 
-use datafusion::sql::{TableReference, unparser::expr_to_sql};
+use datafusion::sql::TableReference;
 use datafusion_expr::Expr;
 pub use manager::PartitionManager;
 pub use metadata::{
@@ -88,28 +88,12 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Extract partition filter expressions for a table from the assignments map.
+/// Returns the `Vec<Expr>` of partition filters to be applied as DataFrame filters.
 #[expect(clippy::implicit_hasher)]
-pub fn update_partitioning_filter_in_refresh_sql(
-    current_sql: Option<&str>,
+pub fn get_partition_filter_exprs(
     tbl: &TableReference,
     assignments: &HashMap<TableReference, Vec<Expr>>,
-) -> Result<Option<String>, datafusion::error::DataFusionError> {
-    let partitions = assignments.get(tbl).cloned().unwrap_or_default();
-    if partitions.is_empty() {
-        return Ok(current_sql.map(ToString::to_string));
-    }
-    let filter_expr = partitions
-        .iter()
-        .cloned()
-        .reduce(Expr::or)
-        .unwrap_or_else(|| unreachable!("partitions is not empty"));
-
-    let filter_sql = expr_to_sql(&filter_expr).map(|ast| ast.to_string())?;
-
-    let sql = if let Some(sql) = current_sql {
-        format!("SELECT * FROM ({sql}) AS _partitioned_source WHERE {filter_sql}")
-    } else {
-        format!("SELECT * FROM {tbl} WHERE {filter_sql}")
-    };
-    Ok(Some(sql))
+) -> Vec<Expr> {
+    assignments.get(tbl).cloned().unwrap_or_default()
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -373,7 +373,8 @@ impl DataConnector for Debezium {
 
         let refresh_sql = dataset.refresh_sql();
         let refresh_schema = if let Some(refresh_sql) = &refresh_sql {
-            refresh_sql::validate_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+            refresh_sql::parse_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+                .map(|(_, schema)| schema)
                 .boxed()
                 .map_err(|e| super::DataConnectorError::InvalidConfiguration {
                     dataconnector: "debezium".to_string(),

--- a/crates/runtime/src/dataconnector/kafka.rs
+++ b/crates/runtime/src/dataconnector/kafka.rs
@@ -313,7 +313,8 @@ impl DataConnector for Kafka {
 
         let refresh_sql = dataset.refresh_sql();
         let schema = if let Some(refresh_sql) = &refresh_sql {
-            refresh_sql::validate_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+            refresh_sql::parse_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+                .map(|(_, schema)| schema)
                 .boxed()
                 .map_err(|e| super::DataConnectorError::InvalidConfiguration {
                     dataconnector: "kafka".to_string(),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -965,6 +965,7 @@ impl DataFusion {
             federated_table,
             Arc::clone(&pending_registration.secrets),
             BootstrapStatus::none(), // Sink datasets don't bootstrap from snapshots
+            vec![],
         )
         .await?;
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2051,7 +2051,7 @@ impl DataFusion {
     pub async fn update_refresh_sql(
         &self,
         dataset_name: TableReference,
-        refresh_sql: Option<String>,
+        refresh_sql: String,
     ) -> Result<()> {
         let table = self
             .get_accelerated_table_provider(&dataset_name.to_string())
@@ -2059,29 +2059,24 @@ impl DataFusion {
 
         let refresh_schema = table.schema();
 
-        let parsed = if let Some(sql) = &refresh_sql {
-            let (parsed_sql, selected_schema) = refresh_sql::parse_refresh_sql(
-                dataset_name.clone(),
-                sql,
-                Arc::clone(&refresh_schema),
-            )
-            .context(RefreshSqlSnafu)?;
-            if selected_schema != refresh_schema {
-                return RefreshSqlSchemaChangeDisallowedSnafu {
-                    dataset_name: Arc::from(dataset_name.to_string()),
-                    selected_columns: Arc::from(
-                        selected_schema.fields().iter().map(|f| f.name()).join(", "),
-                    ),
-                    refresh_columns: Arc::from(
-                        refresh_schema.fields().iter().map(|f| f.name()).join(", "),
-                    ),
-                }
-                .fail();
+        let (parsed, selected_schema) = refresh_sql::parse_refresh_sql(
+            dataset_name.clone(),
+            &refresh_sql,
+            Arc::clone(&refresh_schema),
+        )
+        .context(RefreshSqlSnafu)?;
+        if selected_schema != refresh_schema {
+            return RefreshSqlSchemaChangeDisallowedSnafu {
+                dataset_name: Arc::from(dataset_name.to_string()),
+                selected_columns: Arc::from(
+                    selected_schema.fields().iter().map(|f| f.name()).join(", "),
+                ),
+                refresh_columns: Arc::from(
+                    refresh_schema.fields().iter().map(|f| f.name()).join(", "),
+                ),
             }
-            Some(parsed_sql)
-        } else {
-            None
-        };
+            .fail();
+        }
 
         if let Some(accelerated_table) = table.as_any().downcast_ref::<AcceleratedTable>() {
             accelerated_table.update_refresh_sql(parsed).await.context(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1566,16 +1566,17 @@ impl DataFusion {
                     name: dataset.name.to_string(),
                 })?;
 
-        let refresh_sql = dataset.refresh_sql();
-        let refresh_schema = if let Some(refresh_sql) = &refresh_sql {
-            refresh_sql::validate_refresh_sql(
+        let refresh_sql_str = dataset.refresh_sql();
+        let (parsed_refresh_sql, refresh_schema) = if let Some(sql_str) = &refresh_sql_str {
+            let (parsed, schema) = refresh_sql::parse_refresh_sql(
                 dataset.name.clone(),
-                refresh_sql.as_str(),
+                sql_str.as_str(),
                 source_schema,
             )
-            .context(RefreshSqlSnafu)?
+            .context(RefreshSqlSnafu)?;
+            (Some(parsed), schema)
         } else {
-            source_schema
+            (None, source_schema)
         };
 
         let refresh_mode = source.resolve_refresh_mode(acceleration_settings.refresh_mode);
@@ -1598,7 +1599,7 @@ impl DataFusion {
         //
         // For caching mode with DuckDB/Cayenne: constraints enable upsert behavior
         // For caching mode with Arrow: constraints are required for InsertOp::Replace to work correctly
-        let use_constraints = refresh_sql.is_none();
+        let use_constraints = parsed_refresh_sql.is_none();
 
         let constraints = if use_constraints {
             match &*source_table_provider {
@@ -1656,8 +1657,8 @@ impl DataFusion {
             dataset.refresh_retry_enabled(),
             dataset.refresh_retry_max_attempts(),
         );
-        if let Some(sql) = &refresh_sql {
-            refresh = refresh.sql(sql.clone());
+        if let Some(sql) = parsed_refresh_sql {
+            refresh = refresh.refresh_sql(sql);
         }
         if let Some(format) = dataset.time_format {
             refresh = refresh.time_format(format);
@@ -2058,8 +2059,8 @@ impl DataFusion {
 
         let refresh_schema = table.schema();
 
-        if let Some(sql) = &refresh_sql {
-            let selected_schema = refresh_sql::validate_refresh_sql(
+        let parsed = if let Some(sql) = &refresh_sql {
+            let (parsed_sql, selected_schema) = refresh_sql::parse_refresh_sql(
                 dataset_name.clone(),
                 sql,
                 Arc::clone(&refresh_schema),
@@ -2077,11 +2078,35 @@ impl DataFusion {
                 }
                 .fail();
             }
+            Some(parsed_sql)
+        } else {
+            None
+        };
+
+        if let Some(accelerated_table) = table.as_any().downcast_ref::<AcceleratedTable>() {
+            accelerated_table.update_refresh_sql(parsed).await.context(
+                UnableToTriggerRefreshSnafu {
+                    dataset_name: dataset_name.to_string(),
+                },
+            )?;
         }
+
+        Ok(())
+    }
+
+    /// Update only the partition filters on an accelerated table's refresh.
+    pub async fn update_partition_filters(
+        &self,
+        dataset_name: TableReference,
+        filters: Vec<datafusion_expr::Expr>,
+    ) -> Result<()> {
+        let table = self
+            .get_accelerated_table_provider(&dataset_name.to_string())
+            .await?;
 
         if let Some(accelerated_table) = table.as_any().downcast_ref::<AcceleratedTable>() {
             accelerated_table
-                .update_refresh_sql(refresh_sql)
+                .update_partition_filters(filters)
                 .await
                 .context(UnableToTriggerRefreshSnafu {
                     dataset_name: dataset_name.to_string(),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -386,6 +386,10 @@ pub enum Table {
         accelerated_table: Option<Arc<AcceleratedTable>>,
         secrets: Arc<TokioRwLock<Secrets>>,
         bootstrap_status: BootstrapStatus,
+        /// Initial partition filter expressions to apply before the refresher starts.
+        /// These are set on the `Refresh` during table registration to avoid a race
+        /// where the first refresh runs before partition filters are applied.
+        initial_partition_filters: Vec<datafusion_expr::Expr>,
     },
     Federated {
         data_connector: Arc<dyn DataConnector>,
@@ -633,6 +637,7 @@ impl DataFusion {
                 accelerated_table,
                 secrets,
                 bootstrap_status,
+                initial_partition_filters,
             } => {
                 if let Some(accelerated_table) = accelerated_table {
                     tracing::debug!(
@@ -666,6 +671,7 @@ impl DataFusion {
                         federated_read_table,
                         secrets,
                         bootstrap_status,
+                        initial_partition_filters,
                     )
                     .await?
                 }
@@ -1527,6 +1533,7 @@ impl DataFusion {
         federated_read_table: FederatedTable,
         secrets: Arc<TokioRwLock<Secrets>>,
         bootstrap_status: BootstrapStatus,
+        initial_partition_filters: Vec<datafusion_expr::Expr>,
     ) -> Result<AcceleratedTable> {
         tracing::trace!("Creating accelerated table {dataset:?}");
 
@@ -1694,6 +1701,20 @@ impl DataFusion {
         refresh
             .validate_time_format(dataset.name.to_string(), &refresh_schema)
             .context(InvalidTimeColumnTimeFormatSnafu)?;
+
+        // Apply initial partition filters before the refresher starts to avoid a race
+        // where the first refresh runs without partition filters.
+        if !initial_partition_filters.is_empty() {
+            use crate::accelerated_table::refresh::{RefreshSQL, RefreshSQLColumns};
+            if let Some(ref mut sql) = refresh.sql {
+                sql.set_partition_filters(initial_partition_filters);
+            } else {
+                let mut sql =
+                    RefreshSQL::new(dataset.name.clone(), RefreshSQLColumns::All, vec![], None);
+                sql.set_partition_filters(initial_partition_filters);
+                refresh = refresh.refresh_sql(sql);
+            }
+        }
 
         // Create the accelerator write mutex early so it can be shared between the DataConnector, Refresher and the AcceleratedTable.
         let accelerator_write_mutex: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
@@ -1988,6 +2009,7 @@ impl DataFusion {
         federated_read_table: FederatedTable,
         secrets: Arc<TokioRwLock<Secrets>>,
         bootstrap_status: BootstrapStatus,
+        initial_partition_filters: Vec<datafusion_expr::Expr>,
     ) -> Result<Option<Arc<Notify>>> {
         let mut accelerated_table = self
             .create_accelerated_table(
@@ -1996,6 +2018,7 @@ impl DataFusion {
                 federated_read_table,
                 secrets,
                 bootstrap_status,
+                initial_partition_filters,
             )
             .await?;
         let notifier = accelerated_table.refresher().on_complete_notification();

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -111,31 +111,7 @@ pub fn parse_refresh_sql(
                 ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
                 ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
 
-                let limit_value = if let Some(limit) = &query.limit_clause {
-                    let LimitClause::LimitOffset {
-                        limit: limit_expr,
-                        offset,
-                        limit_by,
-                    } = limit
-                    else {
-                        return UnexpectedExpressionSnafu {
-                            expr: "LIMIT <offset>, <limit>",
-                            expected_table,
-                        }
-                        .fail();
-                    };
-
-                    ensure_no_expr!(limit_by.is_empty(), "LIMIT BY", expected_table);
-                    ensure_no_expr!(offset.is_none(), "OFFSET", expected_table);
-
-                    // Extract the numeric LIMIT value if present
-                    limit_expr.as_ref().and_then(|e| match e {
-                        Expr::Value(v) => v.to_string().parse::<usize>().ok(),
-                        _ => None,
-                    })
-                } else {
-                    None
-                };
+                let limit_value = parse_limit(query.limit_clause.as_deref())?;
 
                 ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
                 ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
@@ -234,6 +210,49 @@ pub fn parse_refresh_sql(
             _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
         },
         _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
+    }
+}
+
+/// Extract and validate the LIMIT clause, ensuring it is a simple non-negative integer literal if present, and that no unsupported features like OFFSET or LIMIT BY are used.
+fn parse_limit(limit: Option<&LimitClause>) -> Result<Option<usize>> {
+    let (limit, offset, limit_by) = match limit {
+        Some(LimitClause::LimitOffset {
+            limit,
+            offset,
+            limit_by,
+        }) => (limit, offset, limit_by),
+        None => return Ok(None), // No LIMIT clause specified, treated as no limit
+        _ => {
+            return UnexpectedExpressionSnafu {
+                expr: "LIMIT <offset>, <limit>",
+                expected_table: TableReference::bare("unknown"),
+            }
+            .fail();
+        }
+    };
+
+    ensure_no_expr!(
+        limit_by.is_empty(),
+        "LIMIT BY",
+        TableReference::bare("unknown")
+    );
+    ensure_no_expr!(offset.is_none(), "OFFSET", TableReference::bare("unknown"));
+
+    match &limit {
+        Some(Expr::Value(v)) => v
+            .to_string()
+            .parse::<usize>()
+            .context(UnexpectedExpressionSnafu {
+                expr: "non-negative integer literal LIMIT",
+                expected_table: TableReference::bare("unknown"),
+            })
+            .map(Some),
+        None => Ok(None), // No LIMIT value specified, treated as no limit
+        _ => UnexpectedExpressionSnafu {
+            expr: "non-negative integer literal LIMIT",
+            expected_table: TableReference::bare("unknown"),
+        }
+        .fail(),
     }
 }
 

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -567,12 +567,12 @@ mod tests {
         use sqlparser::ast::{BinaryOperator, Value};
 
         let expr = Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::Number("1".to_string(), false))),
+            left: Box::new(Expr::Value(Value::Number("1".to_string(), false).into())),
             op: BinaryOperator::And,
             right: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
+                left: Box::new(Expr::Value(Value::Number("2".to_string(), false).into())),
                 op: BinaryOperator::And,
-                right: Box::new(Expr::Value(Value::Number("3".to_string(), false))),
+                right: Box::new(Expr::Value(Value::Number("3".to_string(), false).into())),
             }),
         };
 

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -111,7 +111,7 @@ pub fn parse_refresh_sql(
                 ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
                 ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
 
-                let limit_value = parse_limit(&query.limit_clause, &expected_table)?;
+                let limit_value = parse_limit(query.limit_clause.as_ref(), &expected_table)?;
 
                 ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
                 ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
@@ -173,19 +173,14 @@ pub fn parse_refresh_sql(
                                     .map(ToString::to_string)
                                     .collect::<Vec<_>>()
                                     .join(".");
-                                ensure!(
-                                    TableReference::parse_str(&table_name_with_schema)
-                                        == expected_table,
-                                    InvalidSqlStatementSnafu {
-                                        expected_table: expected_table.clone()
-                                    }
-                                );
+                                if TableReference::parse_str(&table_name_with_schema)
+                                    != expected_table
+                                {
+                                    return InvalidSqlStatementSnafu { expected_table }.fail();
+                                }
                             }
                             _ => {
-                                InvalidSqlStatementSnafu {
-                                    expected_table: expected_table.clone(),
-                                }
-                                .fail()?;
+                                return InvalidSqlStatementSnafu { expected_table }.fail();
                             }
                         }
 
@@ -201,10 +196,7 @@ pub fn parse_refresh_sql(
 
                         Ok((refresh_sql, refresh_schema))
                     }
-                    _ => InvalidSqlStatementSnafu {
-                        expected_table: expected_table.clone(),
-                    }
-                    .fail()?,
+                    _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
                 }
             }
             _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
@@ -214,7 +206,7 @@ pub fn parse_refresh_sql(
 }
 
 /// Extract and validate the LIMIT clause, ensuring it is a simple non-negative integer literal if present, and that no unsupported features like OFFSET or LIMIT BY are used.
-fn parse_limit(limit: &Option<LimitClause>, tbl: &TableReference) -> Result<Option<usize>> {
+fn parse_limit(limit: Option<&LimitClause>, tbl: &TableReference) -> Result<Option<usize>> {
     let (limit, offset, limit_by) = match limit {
         Some(LimitClause::LimitOffset {
             limit,

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -29,6 +29,8 @@ use itertools::Itertools;
 use snafu::prelude::*;
 use sqlparser::ast::Statement as SQLStatement;
 
+use crate::accelerated_table::refresh::{RefreshSQL, RefreshSQLColumns};
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
@@ -84,11 +86,13 @@ macro_rules! ensure_no_expr {
     };
 }
 
-pub fn validate_refresh_sql(
+/// Parse and validate a refresh SQL string, returning both a structured `RefreshSQL` and the
+/// validated schema. This replaces the old `validate_refresh_sql` which only returned a schema.
+pub fn parse_refresh_sql(
     expected_table: TableReference,
     refresh_sql: &str,
     source_schema: Arc<Schema>,
-) -> Result<Arc<Schema>> {
+) -> Result<(RefreshSQL, Arc<Schema>)> {
     let mut statements = DFParser::parse_sql_with_dialect(refresh_sql, &PostgreSqlDialect {})
         .context(UnableToParseSqlSnafu)?;
     if statements.len() != 1 {
@@ -107,9 +111,9 @@ pub fn validate_refresh_sql(
                 ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
                 ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
 
-                if let Some(limit) = &query.limit_clause {
+                let limit_value = if let Some(limit) = &query.limit_clause {
                     let LimitClause::LimitOffset {
-                        limit: _,
+                        limit: limit_expr,
                         offset,
                         limit_by,
                     } = limit
@@ -123,14 +127,22 @@ pub fn validate_refresh_sql(
 
                     ensure_no_expr!(limit_by.is_empty(), "LIMIT BY", expected_table);
                     ensure_no_expr!(offset.is_none(), "OFFSET", expected_table);
-                }
+
+                    // Extract the numeric LIMIT value if present
+                    limit_expr.as_ref().and_then(|e| match e {
+                        Expr::Value(v) => v.to_string().parse::<usize>().ok(),
+                        _ => None,
+                    })
+                } else {
+                    None
+                };
 
                 ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
                 ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
 
                 match query.body.as_ref() {
                     SetExpr::Select(select) => {
-                        let refresh_schema = validate_select_columns(
+                        let (columns, refresh_schema) = validate_and_extract_columns(
                             &select.projection,
                             source_schema,
                             &expected_table,
@@ -188,17 +200,35 @@ pub fn validate_refresh_sql(
                                 ensure!(
                                     TableReference::parse_str(&table_name_with_schema)
                                         == expected_table,
-                                    InvalidSqlStatementSnafu { expected_table }
+                                    InvalidSqlStatementSnafu {
+                                        expected_table: expected_table.clone()
+                                    }
                                 );
                             }
                             _ => {
-                                InvalidSqlStatementSnafu { expected_table }.fail()?;
+                                InvalidSqlStatementSnafu {
+                                    expected_table: expected_table.clone(),
+                                }
+                                .fail()?;
                             }
                         }
 
-                        Ok(refresh_schema)
+                        // Extract user WHERE filters, split on top-level AND
+                        let user_filters = select
+                            .selection
+                            .as_ref()
+                            .map(|expr| split_conjunction(expr.clone()))
+                            .unwrap_or_default();
+
+                        let refresh_sql =
+                            RefreshSQL::new(expected_table, columns, user_filters, limit_value);
+
+                        Ok((refresh_sql, refresh_schema))
                     }
-                    _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
+                    _ => InvalidSqlStatementSnafu {
+                        expected_table: expected_table.clone(),
+                    }
+                    .fail()?,
                 }
             }
             _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
@@ -207,17 +237,19 @@ pub fn validate_refresh_sql(
     }
 }
 
-fn validate_select_columns(
+/// Validate select columns and extract both the `RefreshSQLColumns` and the resulting schema.
+fn validate_and_extract_columns(
     select: &Vec<SelectItem>,
     source_schema: Arc<Schema>,
     expected_table: &TableReference,
-) -> Result<Arc<Schema>> {
+) -> Result<(RefreshSQLColumns, Arc<Schema>)> {
     // Wildcard will select all columns
     if select.len() == 1 && matches!(select[0], SelectItem::Wildcard(_)) {
-        return Ok(source_schema);
+        return Ok((RefreshSQLColumns::All, source_schema));
     }
 
     let mut fields = vec![];
+    let mut column_names = vec![];
     for select_item in select {
         match select_item {
             SelectItem::UnnamedExpr(expr) => match expr {
@@ -234,6 +266,7 @@ fn validate_select_columns(
                         .fail();
                     };
                     fields.push(field.clone());
+                    column_names.push(column_name.to_string());
                 }
                 _ => {
                     return OnlyColumnReferencesSnafu {
@@ -257,7 +290,26 @@ fn validate_select_columns(
     // are not included automatically. We verify their presence in the source schema and add them manually if needed.
     fields = include_computed_columns(&fields, &source_schema);
 
-    Ok(Arc::new(Schema::new(fields)))
+    Ok((
+        RefreshSQLColumns::Named(column_names),
+        Arc::new(Schema::new(fields)),
+    ))
+}
+
+/// Split a WHERE expression on top-level AND into individual predicates.
+fn split_conjunction(expr: Expr) -> Vec<Expr> {
+    match expr {
+        Expr::BinaryOp {
+            left,
+            op: sqlparser::ast::BinaryOperator::And,
+            right,
+        } => {
+            let mut parts = split_conjunction(*left);
+            parts.extend(split_conjunction(*right));
+            parts
+        }
+        other => vec![other],
+    }
 }
 
 /// Checks the source schema for associated computed columns (e.g., embeddings)
@@ -345,8 +397,10 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT * FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
-        assert_eq!(result.fields().len(), 3);
+        let (refresh_sql, result_schema) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 3);
+        assert!(matches!(refresh_sql.columns(), RefreshSQLColumns::All));
+        assert_eq!(refresh_sql.to_sql(), "SELECT * FROM test_table");
         Ok(())
     }
 
@@ -356,10 +410,12 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id, name FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
-        assert_eq!(result.fields().len(), 2);
-        assert_eq!(result.field(0).name(), "id");
-        assert_eq!(result.field(1).name(), "name");
+        let (refresh_sql, result_schema) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 2);
+        assert_eq!(result_schema.field(0).name(), "id");
+        assert_eq!(result_schema.field(1).name(), "name");
+        assert!(matches!(refresh_sql.columns(), RefreshSQLColumns::Named(_)));
+        assert_eq!(refresh_sql.to_sql(), "SELECT id, name FROM test_table");
         Ok(())
     }
 
@@ -369,7 +425,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id, invalid_column FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(result, Err(Error::ColumnNotFoundInSource { .. })));
     }
 
@@ -379,7 +435,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id FROM wrong_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(result, Err(Error::InvalidSqlStatement { .. })));
     }
 
@@ -389,7 +445,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id + 1 FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(result, Err(Error::OnlyColumnReferences { .. })));
     }
 
@@ -399,7 +455,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id as user_id FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(result, Err(Error::OnlyColumnReferences { .. })));
     }
 
@@ -409,7 +465,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id FROM test_table GROUP BY id";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(result, Err(Error::UnexpectedExpression { .. })));
     }
 
@@ -419,7 +475,7 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id FROM test_table; SELECT name FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        let result = parse_refresh_sql(table, sql, Arc::clone(&schema));
         assert!(matches!(
             result,
             Err(Error::ExpectedSingleSqlStatement { .. })
@@ -432,12 +488,12 @@ mod tests {
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT id, name FROM test_table";
 
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
-        assert_eq!(result.fields().len(), 4);
-        assert_eq!(result.field(0).name(), "id");
-        assert_eq!(result.field(1).name(), "name");
-        assert_eq!(result.field(2).name(), "name_embedding");
-        assert_eq!(result.field(3).name(), "name_offset");
+        let (_, result_schema) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 4);
+        assert_eq!(result_schema.field(0).name(), "id");
+        assert_eq!(result_schema.field(1).name(), "name");
+        assert_eq!(result_schema.field(2).name(), "name_embedding");
+        assert_eq!(result_schema.field(3).name(), "name_offset");
         Ok(())
     }
 
@@ -452,14 +508,68 @@ mod tests {
 
         // bucket() in a WHERE clause should be accepted by refresh SQL validation.
         let sql = "SELECT * FROM test_table WHERE bucket(50, organization_id) = 0";
-        let result = validate_refresh_sql(table.clone(), sql, Arc::clone(&schema))?;
-        assert_eq!(result.fields().len(), 3);
+        let (refresh_sql, result_schema) =
+            parse_refresh_sql(table.clone(), sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 3);
+        assert_eq!(
+            refresh_sql.to_sql(),
+            "SELECT * FROM test_table WHERE bucket(50, organization_id) = 0"
+        );
 
         // Multiple OR'd bucket() filters (as generated by partition assignment).
         let sql = "SELECT * FROM test_table WHERE bucket(50, organization_id) = 0 OR bucket(50, organization_id) = 1";
-        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
-        assert_eq!(result.fields().len(), 3);
+        let (refresh_sql, result_schema) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 3);
+        // The OR expression stays as a single filter since OR is not top-level AND
+        assert_eq!(
+            refresh_sql.to_sql(),
+            "SELECT * FROM test_table WHERE bucket(50, organization_id) = 0 OR bucket(50, organization_id) = 1"
+        );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_where_with_and() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT * FROM test_table WHERE id > 10 AND name = 'foo'";
+
+        let (refresh_sql, _) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        // Should split on top-level AND into 2 user_filters
+        let reconstructed = refresh_sql.to_sql();
+        assert!(reconstructed.contains("WHERE"));
+        assert!(reconstructed.contains("id > 10"));
+        assert!(reconstructed.contains("name = 'foo'"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_limit() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT * FROM test_table LIMIT 100";
+
+        let (refresh_sql, _) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert!(refresh_sql.to_sql().contains("LIMIT 100"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_conjunction() {
+        use sqlparser::ast::{BinaryOperator, Value};
+
+        let expr = Expr::BinaryOp {
+            left: Box::new(Expr::Value(Value::Number("1".to_string(), false))),
+            op: BinaryOperator::And,
+            right: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
+                op: BinaryOperator::And,
+                right: Box::new(Expr::Value(Value::Number("3".to_string(), false))),
+            }),
+        };
+
+        let parts = split_conjunction(expr);
+        assert_eq!(parts.len(), 3);
     }
 }

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -111,7 +111,7 @@ pub fn parse_refresh_sql(
                 ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
                 ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
 
-                let limit_value = parse_limit(query.limit_clause.as_deref())?;
+                let limit_value = parse_limit(query.limit_clause.as_deref(), &expected_table)?;
 
                 ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
                 ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
@@ -214,7 +214,7 @@ pub fn parse_refresh_sql(
 }
 
 /// Extract and validate the LIMIT clause, ensuring it is a simple non-negative integer literal if present, and that no unsupported features like OFFSET or LIMIT BY are used.
-fn parse_limit(limit: Option<&LimitClause>) -> Result<Option<usize>> {
+fn parse_limit(limit: Option<&LimitClause>, tbl: &TableReference) -> Result<Option<usize>> {
     let (limit, offset, limit_by) = match limit {
         Some(LimitClause::LimitOffset {
             limit,
@@ -225,32 +225,28 @@ fn parse_limit(limit: Option<&LimitClause>) -> Result<Option<usize>> {
         _ => {
             return UnexpectedExpressionSnafu {
                 expr: "LIMIT <offset>, <limit>",
-                expected_table: TableReference::bare("unknown"),
+                expected_table: tbl.clone(),
             }
             .fail();
         }
     };
 
-    ensure_no_expr!(
-        limit_by.is_empty(),
-        "LIMIT BY",
-        TableReference::bare("unknown")
-    );
-    ensure_no_expr!(offset.is_none(), "OFFSET", TableReference::bare("unknown"));
+    ensure_no_expr!(limit_by.is_empty(), "LIMIT BY", tbl.clone());
+    ensure_no_expr!(offset.is_none(), "OFFSET", tbl.clone());
 
     match &limit {
         Some(Expr::Value(v)) => v
             .to_string()
             .parse::<usize>()
-            .context(UnexpectedExpressionSnafu {
+            .map_err(|_| Error::UnexpectedExpression {
                 expr: "non-negative integer literal LIMIT",
-                expected_table: TableReference::bare("unknown"),
+                expected_table: tbl.clone(),
             })
             .map(Some),
         None => Ok(None), // No LIMIT value specified, treated as no limit
         _ => UnexpectedExpressionSnafu {
             expr: "non-negative integer literal LIMIT",
-            expected_table: TableReference::bare("unknown"),
+            expected_table: tbl.clone(),
         }
         .fail(),
     }

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -224,7 +224,7 @@ fn parse_limit(limit: &Option<LimitClause>, tbl: &TableReference) -> Result<Opti
         None => return Ok(None), // No LIMIT clause specified, treated as no limit
         _ => {
             return UnexpectedExpressionSnafu {
-                expr: "LIMIT <offset>, <limit>",
+                expr: "unsupported LIMIT clause; expected LIMIT <non-negative integer literal>",
                 expected_table: tbl.clone(),
             }
             .fail();

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -111,7 +111,7 @@ pub fn parse_refresh_sql(
                 ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
                 ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
 
-                let limit_value = parse_limit(query.limit_clause.as_deref(), &expected_table)?;
+                let limit_value = parse_limit(&query.limit_clause, &expected_table)?;
 
                 ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
                 ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
@@ -214,7 +214,7 @@ pub fn parse_refresh_sql(
 }
 
 /// Extract and validate the LIMIT clause, ensuring it is a simple non-negative integer literal if present, and that no unsupported features like OFFSET or LIMIT BY are used.
-fn parse_limit(limit: Option<&LimitClause>, tbl: &TableReference) -> Result<Option<usize>> {
+fn parse_limit(limit: &Option<LimitClause>, tbl: &TableReference) -> Result<Option<usize>> {
     let (limit, offset, limit_by) = match limit {
         Some(LimitClause::LimitOffset {
             limit,
@@ -264,7 +264,7 @@ fn validate_and_extract_columns(
     }
 
     let mut fields = vec![];
-    let mut column_names = vec![];
+    let mut column_idents = vec![];
     for select_item in select {
         match select_item {
             SelectItem::UnnamedExpr(expr) => match expr {
@@ -281,7 +281,7 @@ fn validate_and_extract_columns(
                         .fail();
                     };
                     fields.push(field.clone());
-                    column_names.push(column_name.to_string());
+                    column_idents.push(ident.clone());
                 }
                 _ => {
                     return OnlyColumnReferencesSnafu {
@@ -306,7 +306,7 @@ fn validate_and_extract_columns(
     fields = include_computed_columns(&fields, &source_schema);
 
     Ok((
-        RefreshSQLColumns::Named(column_names),
+        RefreshSQLColumns::Named(column_idents),
         Arc::new(Schema::new(fields)),
     ))
 }
@@ -586,5 +586,29 @@ mod tests {
 
         let parts = split_conjunction(expr);
         assert_eq!(parts.len(), 3);
+    }
+
+    #[test]
+    fn test_quoted_identifiers_preserved() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("MyCol", DataType::Int64, false),
+            Field::new("another col", DataType::Utf8, false),
+        ]));
+        let table = TableReference::parse_str("test_table");
+        let sql = r#"SELECT "MyCol", "another col" FROM test_table"#;
+
+        let (refresh_sql, result_schema) = parse_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result_schema.fields().len(), 2);
+        // to_sql() should preserve the double-quoting
+        let reconstructed = refresh_sql.to_sql();
+        assert!(
+            reconstructed.contains(r#""MyCol""#),
+            "Expected quoted identifier in: {reconstructed}"
+        );
+        assert!(
+            reconstructed.contains(r#""another col""#),
+            "Expected quoted identifier in: {reconstructed}"
+        );
+        Ok(())
     }
 }

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -227,7 +227,7 @@ pub(crate) struct MessageResponse {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AccelerationRequest {
-    /// SQL statement used for the refresh. Defaults to current `refresh_sql` configured (either from the spicepod or a previous refresh_sql update).
+    /// SQL statement used for the refresh. Defaults to current `refresh_sql` configured (either from the spicepod or a previous `refresh_sql` update).
     pub refresh_sql: Option<String>,
 }
 

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -227,7 +227,7 @@ pub(crate) struct MessageResponse {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AccelerationRequest {
-    /// SQL statement used for the refresh. Defaults to the `refresh_sql` specified in the spicepod.
+    /// SQL statement used for the refresh. Defaults to current `refresh_sql` configured (either from the spicepod or a previous refresh_sql update).
     pub refresh_sql: Option<String>,
 }
 
@@ -431,15 +431,12 @@ pub(crate) async fn acceleration(
             .into_response();
     };
 
-    if payload.refresh_sql.is_none() {
+    let Some(sql) = payload.refresh_sql else {
         return (status::StatusCode::OK).into_response();
-    }
+    };
 
     match df
-        .update_refresh_sql(
-            TableReference::parse_str(&dataset.name),
-            payload.refresh_sql,
-        )
+        .update_refresh_sql(TableReference::parse_str(&dataset.name), sql)
         .await
     {
         Ok(()) => (status::StatusCode::OK).into_response(),

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
-use crate::cluster::partition::update_partitioning_filter_in_refresh_sql;
+use crate::cluster::partition::get_partition_filter_exprs;
 use crate::dataaccelerator::BootstrapStatus;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::caching_engine::CachingEngineSys;
@@ -758,6 +758,7 @@ impl Runtime {
 
         // Apply partition filters if assigned (Executor mode)
         let mut ds = ds;
+        let mut initial_partition_filters = vec![];
         // Only apply partition logic if the dataset is configured for partitioning
         if ds
             .acceleration
@@ -766,22 +767,17 @@ impl Runtime {
             && let Some(assignments) = self.partition_assignments()
         {
             let assignments = assignments.read().await;
-            let mut ds_mod = (*ds).clone();
-            if let Some(new_sql) = update_partitioning_filter_in_refresh_sql(
-                ds.acceleration
-                    .as_ref()
-                    .and_then(|acc| acc.refresh_sql.as_deref()),
-                &ds.name,
-                &assignments,
-            )
-            .context(crate::UnableToConvertPartitionExprSnafu)?
-            {
+            let partition_filters = get_partition_filter_exprs(&ds.name, &assignments);
+            if !partition_filters.is_empty() {
                 tracing::debug!(
-                    "For table={}, adding filters to refresh_sql for assigned partitions. New refresh_sql={new_sql}",
+                    "For table={}, extracted {} partition filter(s) for assigned partitions.",
                     ds.name,
+                    partition_filters.len(),
                 );
+                initial_partition_filters = partition_filters;
+                // Clear partition_by and convert engine to unpartitioned
+                let mut ds_mod = (*ds).clone();
                 if let Some(acc) = ds_mod.acceleration.as_mut() {
-                    acc.refresh_sql = Some(new_sql);
                     acc.partition_by = vec![];
                     acc.engine = acc.engine.to_unpartitioned();
                 }
@@ -840,6 +836,20 @@ impl Runtime {
                 data_connector: source.clone(),
                 connector_component: ConnectorComponent::from(&ds),
             })?;
+
+        // Apply initial partition filters after registration
+        if !initial_partition_filters.is_empty() {
+            if let Err(e) = self
+                .df
+                .update_partition_filters(ds.name.clone(), initial_partition_filters)
+                .await
+            {
+                tracing::warn!(
+                    "Failed to set initial partition filters for {}: {e}",
+                    ds.name
+                );
+            }
+        }
 
         if let Some(notifier) = notifier {
             // spawn a background task to wait for the accelerated table to be ready before creating schedules

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -637,6 +637,7 @@ impl Runtime {
                     federated_table,
                     self.secrets(),
                     BootstrapStatus::None,
+                    vec![],
                 )
                 .await
                 .context(UnableToCreateAcceleratedTableSnafu {
@@ -829,6 +830,7 @@ impl Runtime {
                     accelerated_table,
                     secrets: self.secrets(),
                     bootstrap_status,
+                    initial_partition_filters,
                 },
             )
             .await
@@ -836,20 +838,6 @@ impl Runtime {
                 data_connector: source.clone(),
                 connector_component: ConnectorComponent::from(&ds),
             })?;
-
-        // Apply initial partition filters after registration
-        if !initial_partition_filters.is_empty() {
-            if let Err(e) = self
-                .df
-                .update_partition_filters(ds.name.clone(), initial_partition_filters)
-                .await
-            {
-                tracing::warn!(
-                    "Failed to set initial partition filters for {}: {e}",
-                    ds.name
-                );
-            }
-        }
 
         if let Some(notifier) = notifier {
             // spawn a background task to wait for the accelerated table to be ready before creating schedules

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -35,7 +35,6 @@ use tools::factory::{ToolFactory, default_catalog_names};
 use util::force_shutdown_signal;
 use worker::WorkerRegistry;
 
-use crate::cluster::partition::update_partitioning_filter_in_refresh_sql;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::datafusion::{DataFusion, resolved_equality};
 use crate::model::ENABLE_MODEL_SUPPORT_MESSAGE;
@@ -730,58 +729,15 @@ impl Runtime {
         table: TableReference,
         assignments: &PartitionAssignments,
     ) -> Result<()> {
-        // Re-construct the refresh SQL with the new partitions
-        // 1. Get the dataset to find the base refresh SQL
-        let (dataset_component, app_arc) = {
-            let Some(app_arc) = self.read_app().await else {
-                tracing::debug!("App not initialized when updating partitions for {table}");
-                return Ok(());
-            };
+        let partition_filters =
+            crate::cluster::partition::get_partition_filter_exprs(&table, assignments);
 
-            let Some(ds) = app_arc
-                .datasets
-                .iter()
-                .find(|ds| resolved_equality(ds.name.clone().into(), table.clone()))
-            else {
-                tracing::debug!("Dataset {table} not found in App when updating partitions");
-                return Ok(());
-            };
-            (ds.clone(), Arc::clone(&app_arc))
-        };
-
-        let Ok(dataset) =
-            crate::component::dataset::builder::DatasetBuilder::try_from(dataset_component)
-                .and_then(|mut b| {
-                    b = b.with_app(app_arc);
-                    b.with_runtime(Arc::new(self.clone())).build().context(
-                        UnableToBuildDatasetSnafu {
-                            dataset: table.to_string(),
-                        },
-                    )
-                })
-        else {
-            tracing::warn!("Failed to build dataset {table} when updating partitions");
-            return Ok(());
-        };
-
-        // 2. Construct the new SQL
-        let new_sql = update_partitioning_filter_in_refresh_sql(
-            dataset
-                .acceleration
-                .as_ref()
-                .and_then(|a| a.refresh_sql.as_deref()),
-            &table,
-            assignments,
-        )
-        .context(UnableToConvertPartitionExprSnafu)?;
-
-        // 3. Update the AcceleratedTable
         if let Err(e) = self
             .datafusion()
-            .update_refresh_sql(table.clone(), new_sql)
+            .update_partition_filters(table.clone(), partition_filters)
             .await
         {
-            tracing::error!("Failed to update refresh SQL for {table}: {e}");
+            tracing::error!("Failed to update partition filters for {table}: {e}");
         } else {
             tracing::info!("Updated partition assignments for {table}");
             // Trigger a refresh to load the data for the new partitions

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -36,7 +36,7 @@ use util::force_shutdown_signal;
 use worker::WorkerRegistry;
 
 use crate::dataaccelerator::AcceleratorEngineRegistry;
-use crate::datafusion::{DataFusion, resolved_equality};
+use crate::datafusion::DataFusion;
 use crate::model::ENABLE_MODEL_SUPPORT_MESSAGE;
 use crate::model::LLMResponsesModelStore;
 use crate::{

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -225,7 +225,7 @@ async fn mysql_refresh_retries() -> Result<(), String> {
             rt.datafusion()
                 .update_refresh_sql(
                     TableReference::parse_str("lineitem_retries"),
-                    Some("SELECT * from lineitem_retries limit 10".to_string()),
+                    "SELECT * from lineitem_retries limit 10".to_string(),
                 )
                 .await
                 .map_err(|e| e.to_string())?;

--- a/crates/runtime/tests/refresh_worker_panic/mod.rs
+++ b/crates/runtime/tests/refresh_worker_panic/mod.rs
@@ -137,7 +137,9 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
 
     let refresh_defaults = Refresh::new(RefreshMode::Append).refresh_sql(RefreshSQL::new(
         dataset_name.clone(),
-        runtime::accelerated_table::refresh::RefreshSQLColumns::Named(vec!["value".to_string()]),
+        runtime::accelerated_table::refresh::RefreshSQLColumns::Named(vec![
+            datafusion::sql::sqlparser::ast::Ident::new("value"),
+        ]),
         vec![],
         None,
     ));

--- a/crates/runtime/tests/refresh_worker_panic/mod.rs
+++ b/crates/runtime/tests/refresh_worker_panic/mod.rs
@@ -30,7 +30,7 @@ use datafusion::datasource::memory::MemTable;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::sql::TableReference;
-use runtime::accelerated_table::refresh::Refresh;
+use runtime::accelerated_table::refresh::{Refresh, RefreshSQL};
 use runtime::accelerated_table::{Error as AcceleratedError, RefreshTaskRunner};
 use runtime::component::dataset::acceleration::RefreshMode;
 use runtime::federated_table::FederatedTable;
@@ -135,8 +135,12 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
 
     let dataset_name = TableReference::bare("panic_dataset");
 
-    let refresh_defaults = Refresh::new(RefreshMode::Append)
-        .sql(format!("SELECT value FROM {}", dataset_name.table()));
+    let refresh_defaults = Refresh::new(RefreshMode::Append).refresh_sql(RefreshSQL::new(
+        dataset_name.clone(),
+        runtime::accelerated_table::refresh::RefreshSQLColumns::Named(vec!["value".to_string()]),
+        vec![],
+        None,
+    ));
     let refresh_state = Arc::new(RwLock::new(refresh_defaults));
 
     let runtime_status = status::RuntimeStatus::new();


### PR DESCRIPTION
## 📝 Summary
  - Introduces a structured `RefreshSQL` type that decomposes user `refresh_sql` into validated parts (columns, WHERE predicates, LIMIT) instead of storing it as a raw `Option<String>`
  - Stores cluster partition filters as separate `Vec<Expr>` on `RefreshSQL` rather than wrapping user SQL in a subquery, fixing validation failures when `refresh_sql` is used with `partition_by` in cluster mode.

### Details
Core change is an update to `Refresh`, where `RefreshSQL` is new and defined [here](https://github.com/spiceai/spiceai/pull/9549/changes#diff-fc6c4697d8c3043b806c6861fb6e426c7c4cd15208f51c115e41b956065f563dR69-R82). Remaining changes are to accomodate this (and by extension make refresh_sql and acceleration partition filters play nice together). 

```diff
#[derive(Clone, Debug)]
pub struct Refresh {
    pub(crate) time_column: Option<String>,
    pub(crate) time_format: Option<TimeFormat>,
    pub(crate) time_partition_column: Option<String>,
    pub(crate) time_partition_format: Option<TimeFormat>,
    pub(crate) check_interval: Option<Duration>,
    pub(crate) max_jitter: Option<Duration>,
-   pub(crate) sql: Option<String>,
+   pub(crate) sql: Option<RefreshSQL>,
```

## 🔗 Related
#9513 