### PR TITLE
`AcceleratedTable::scan` use `FederatedTable::scan` when `ClusterRole::Scheduler`

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -251,6 +251,7 @@ pub struct AcceleratedTable {
     last_updated_at: Arc<AtomicI64>,
     /// Sender for batched cache writes. Only used in caching refresh mode.
     batch_write_tx: Option<caching::CacheWriteSender>,
+    cluster_role: Option<ClusterRole>,
 }
 
 impl std::fmt::Debug for AcceleratedTable {
@@ -887,6 +888,7 @@ impl Builder {
             in_flight_revalidations,
             last_updated_at,
             batch_write_tx,
+            cluster_role: self.cluster_role,
         })
     }
 }
@@ -1104,6 +1106,14 @@ impl TableProvider for AcceleratedTable {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         // Check if we're in caching mode
         let is_caching_mode = self.refresh_params.read().await.mode == RefreshMode::Caching;
+
+        if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {
+            // Accelerated tables aren't accelerated on scheduler. Just scan the federated source.
+            let federated_provider = self.federated.table_provider().await;
+            return federated_provider
+                .scan(state, projection, filters, limit)
+                .await;
+        }
 
         // If the initial load hasn't completed yet, we need to handle the loading behavior.
         if !self.refresher().initial_load_completed() && !is_caching_mode {


### PR DESCRIPTION
## 📝 Summary
Following on from #9515. When a scheduler in a cluster attempts to plan a `v1/query`, a physical plan will be created (SQL -> LogicalPlan -> Physical Plan -> Ballista tasks/stages). For an accelerated table a `v1/query` should use the federated source for query, and thus `AcceleratedTable::scan` should use `FederatedTable::scan` when `ClusterRole::Scheduler`.
