### PR TITLE
Run cayenne tests as part of PR CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ endif
 .PHONY: nextest
 nextest:
 	@cargo nextest run --all --lib $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
+	@cargo nextest run -p cayenne --tests $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
 
 # Also update .github/workflows/integration.yml with changes to this target
 .PHONY: test-integration


### PR DESCRIPTION
## 📝 Summary

Cayenne has 30+ self-contained integration tests in `crates/cayenne/tests/` that were not being run in CI. 

PR adds cayenne integration tests to the `nextest` Makefile target so they run on every PR. Dependencies are already compiled from the first pass, so no additional overhead to run tests is added.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
