### PR TITLE
Support partitioning in Arrow accelerator

### DIFF
--- a/crates/runtime-acceleration/src/engine.rs
+++ b/crates/runtime-acceleration/src/engine.rs
@@ -17,6 +17,7 @@ use std::fmt::Display;
 pub enum Engine {
     #[default]
     Arrow,
+    PartitionedArrow,
     DuckDB,
     PartitionedDuckDB,
     TableModePartitionedDuckDB,
@@ -31,6 +32,7 @@ impl Engine {
     #[must_use]
     pub fn to_unpartitioned(&self) -> Engine {
         match self {
+            Engine::PartitionedArrow => Engine::Arrow,
             Engine::PartitionedDuckDB | Engine::TableModePartitionedDuckDB => Engine::DuckDB,
             other => *other,
         }
@@ -40,7 +42,7 @@ impl Engine {
 impl Display for Engine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Engine::Arrow => write!(f, "arrow"),
+            Engine::Arrow | Engine::PartitionedArrow => write!(f, "arrow"),
             Engine::DuckDB | Engine::PartitionedDuckDB | Engine::TableModePartitionedDuckDB => {
                 write!(f, "duckdb")
             }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -187,6 +187,19 @@ impl PartitionTableProvider {
         self
     }
 
+    /// Returns the table providers for all current partitions.
+    ///
+    /// Callers can use this to apply per-partition operations (e.g., index maintenance)
+    /// that are not part of the standard `TableProvider` interface.
+    pub async fn partition_table_providers(&self) -> Vec<Arc<dyn TableProvider>> {
+        self.partitions
+            .read()
+            .await
+            .values()
+            .map(|p| Arc::clone(&p.table_provider))
+            .collect()
+    }
+
     /// Collects all partition column references from all partition expressions.
     fn all_partition_columns(&self) -> std::collections::HashSet<&datafusion::common::Column> {
         self.partition_by

--- a/crates/runtime/src/accelerated_table/sink/table.rs
+++ b/crates/runtime/src/accelerated_table/sink/table.rs
@@ -22,6 +22,7 @@ use datafusion::{
     physical_plan::collect, prelude::SessionContext,
 };
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
+use runtime_table_partition::provider::PartitionTableProvider;
 use util::RetryError;
 
 use crate::{
@@ -94,19 +95,33 @@ impl TableSink {
             return Err(retry_from_df_error(e));
         }
 
-        // Perform post-write index maintenance (e.g., rebuild hash indexes) if the table supports it
-        match perform_index_maintenance(self.table_provider.as_ref()).await {
-            Ok(true) => {
-                tracing::debug!("TableSink: index maintenance completed successfully");
-            }
-            Ok(false) => {
-                // Table doesn't support index maintenance - this is expected for most tables
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "TableSink: index maintenance failed after write: {e}. Index may be stale until next refresh."
-                );
-                // Don't fail the write - data was successfully written, index rebuild is best-effort
+        // Perform post-write index maintenance (e.g., rebuild hash indexes) if the table supports it.
+        // For partitioned tables each partition holds its own IndexedMemTable, so we iterate over
+        // all partition providers and trigger maintenance on each one individually.
+        let providers_to_maintain: Vec<Arc<dyn TableProvider>> = if let Some(p) = self
+            .table_provider
+            .as_any()
+            .downcast_ref::<PartitionTableProvider>()
+        {
+            p.partition_table_providers().await
+        } else {
+            vec![Arc::clone(&self.table_provider)]
+        };
+
+        for provider in providers_to_maintain {
+            match perform_index_maintenance(provider.as_ref()).await {
+                Ok(true) => {
+                    tracing::debug!("TableSink: index maintenance completed successfully");
+                }
+                Ok(false) => {
+                    // Table doesn't support index maintenance - this is expected for most tables
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "TableSink: index maintenance failed after write: {e}. Index may be stale until next refresh."
+                    );
+                    // Don't fail the write - data was successfully written, index rebuild is best-effort
+                }
             }
         }
 

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -400,6 +400,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
                 name: engine_str.to_string(),
             }
         })? {
+            Engine::Arrow if !acceleration.partition_by.is_empty() => Engine::PartitionedArrow,
             #[cfg(feature = "duckdb")]
             Engine::DuckDB if !acceleration.partition_by.is_empty() => {
                 match get_duckdb_partition_mode(&params) {

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -418,12 +418,18 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             .is_some_and(|v| v.as_string().eq_ignore_ascii_case("enabled"));
 
         // Indexes require hash_index to be enabled for Arrow engine
-        if engine == Engine::Arrow && !indexes.is_empty() && !hash_index_enabled {
+        if matches!(engine, Engine::Arrow | Engine::PartitionedArrow)
+            && !indexes.is_empty()
+            && !hash_index_enabled
+        {
             tracing::warn!(
                 "Indexes specified but hash_index is not enabled for Arrow engine. Add 'hash_index: enabled' to use indexes for fast lookups."
             );
         }
-        if engine == Engine::Arrow && primary_key.is_some() && !hash_index_enabled {
+        if matches!(engine, Engine::Arrow | Engine::PartitionedArrow)
+            && primary_key.is_some()
+            && !hash_index_enabled
+        {
             tracing::warn!(
                 "Primary key specified but hash_index is not enabled for Arrow engine. \
                  Add 'hash_index: enabled' to use primary_key for fast lookups. Note, hash_index is experimental in Arrow acceleration."
@@ -431,7 +437,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
         }
         // Note: The warning for hash_index being experimental is logged once
         // at dataset registration time in init/dataset.rs, not during parsing.
-        if engine == Engine::Arrow && !on_conflict.is_empty() {
+        if matches!(engine, Engine::Arrow | Engine::PartitionedArrow) && !on_conflict.is_empty() {
             tracing::warn!(
                 "Conflict resolution is not supported for Arrow engine acceleration. Ignoring on_conflict."
             );

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -74,13 +74,6 @@ impl DataAccelerator for ArrowAccelerator {
         source: Option<&dyn AccelerationSource>,
         partition_by: Vec<PartitionedBy>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        ensure!(
-            partition_by.is_empty(),
-            super::InvalidConfigurationSnafu {
-                msg: "Arrow data accelerator does not support the `partition_by` parameter but it was provided".to_string()
-            }
-        );
-
         // For caching mode, strip primary key constraints since Arrow uses InsertOp::Replace
         // which overwrites the entire table. Primary key constraints cause uniqueness validation
         // errors during inserts because Arrow doesn't support upsert operations.

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -72,7 +72,7 @@ impl DataAccelerator for ArrowAccelerator {
         &self,
         mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<PartitionedBy>,
+        _partition_by: Vec<PartitionedBy>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         // For caching mode, strip primary key constraints since Arrow uses InsertOp::Replace
         // which overwrites the entire table. Primary key constraints cause uniqueness validation

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -43,6 +43,7 @@ use tokio::sync::RwLock;
 pub mod arrow;
 #[cfg(not(windows))]
 pub mod cayenne;
+pub mod partitioned_arrow;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
 #[cfg(feature = "duckdb")]

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -43,9 +43,9 @@ use tokio::sync::RwLock;
 pub mod arrow;
 #[cfg(not(windows))]
 pub mod cayenne;
-pub mod partitioned_arrow;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
+pub mod partitioned_arrow;
 #[cfg(feature = "duckdb")]
 pub mod partitioned_duckdb;
 #[cfg(feature = "postgres-accel")]

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -36,9 +36,7 @@ use runtime_table_partition::{
 use snafu::prelude::*;
 
 use crate::{
-    component::dataset::acceleration::Engine,
-    parameters::ParameterSpec,
-    register_data_accelerator,
+    component::dataset::acceleration::Engine, parameters::ParameterSpec, register_data_accelerator,
 };
 
 use super::{AccelerationSource, DataAccelerator};

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use std::{any::Any, sync::Arc};
 
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use data_components::arrow::ArrowFactory;
 use datafusion::{
@@ -46,20 +45,14 @@ pub(crate) struct ArrowPartitionCreator {
     cmd: CreateExternalTable,
     arrow_factory: ArrowFactory,
     partition_by: Vec<PartitionedBy>,
-    schema: SchemaRef,
 }
 
 impl ArrowPartitionCreator {
-    pub(crate) fn new(
-        cmd: CreateExternalTable,
-        partition_by: Vec<PartitionedBy>,
-        schema: SchemaRef,
-    ) -> Self {
+    pub(crate) fn new(cmd: CreateExternalTable, partition_by: Vec<PartitionedBy>) -> Self {
         Self {
             cmd,
             arrow_factory: ArrowFactory::new(),
             partition_by,
-            schema,
         }
     }
 }
@@ -161,14 +154,14 @@ impl DataAccelerator for PartitionedArrowAccelerator {
             }
         );
 
-        let schema = Arc::new(cmd.schema.as_arrow().clone());
-        let creator = Arc::new(ArrowPartitionCreator::new(
-            cmd,
-            partition_by.clone(),
-            Arc::clone(&schema),
-        ));
-        let table_provider =
-            Arc::new(PartitionTableProvider::new(creator, partition_by, schema).await?);
+        let table_provider = Arc::new(
+            PartitionTableProvider::new(
+                Arc::new(ArrowPartitionCreator::new(cmd, partition_by.clone())),
+                partition_by,
+                Arc::new(cmd.schema.as_arrow().clone()),
+            )
+            .await?,
+        );
 
         Ok(table_provider as Arc<dyn TableProvider>)
     }

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -153,15 +153,10 @@ impl DataAccelerator for PartitionedArrowAccelerator {
                 msg: "PartitionedArrow accelerator requires non-empty `partition_by`".to_string()
             }
         );
-
-        let table_provider = Arc::new(
-            PartitionTableProvider::new(
-                Arc::new(ArrowPartitionCreator::new(cmd, partition_by.clone())),
-                partition_by,
-                Arc::new(cmd.schema.as_arrow().clone()),
-            )
-            .await?,
-        );
+        let schema = Arc::new(cmd.schema.as_arrow().clone());
+        let creator = Arc::new(ArrowPartitionCreator::new(cmd, partition_by.clone()));
+        let table_provider =
+            Arc::new(PartitionTableProvider::new(creator, partition_by, schema).await?);
 
         Ok(table_provider as Arc<dyn TableProvider>)
     }

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use data_components::arrow::ArrowFactory;
 use datafusion::{
     catalog::TableProviderFactory,
+    common::Constraints,
     datasource::TableProvider,
     error::DataFusionError,
     logical_expr::{CreateExternalTable, TableProviderFilterPushDown},
@@ -28,14 +29,16 @@ use datafusion::{
 };
 use runtime_table_partition::{
     Partition,
-    creator::{Error as CreatorError, PartitionCreator},
+    creator::{CreatePartitionSnafu, Error as CreatorError, PartitionCreator},
     expression::PartitionedBy,
     provider::PartitionTableProvider,
 };
 use snafu::prelude::*;
 
 use crate::{
-    component::dataset::acceleration::Engine, parameters::ParameterSpec, register_data_accelerator,
+    component::dataset::acceleration::{Engine, RefreshMode},
+    parameters::ParameterSpec,
+    register_data_accelerator,
 };
 
 use super::{AccelerationSource, DataAccelerator};
@@ -84,7 +87,8 @@ impl PartitionCreator for ArrowPartitionCreator {
         let table_provider =
             TableProviderFactory::create(&self.arrow_factory, &ctx.state(), &self.cmd)
                 .await
-                .map_err(|e| CreatorError::CreatePartition { source: e.into() })?;
+                .boxed()
+                .context(CreatePartitionSnafu)?;
 
         Ok(Partition {
             partition_values,
@@ -154,9 +158,7 @@ impl DataAccelerator for PartitionedArrowAccelerator {
             }
         );
 
-        if let Some(source) = source
-            && let Some(acceleration) = source.acceleration()
-        {
+        if let Some(acceleration) = source.as_ref().and_then(|s| s.acceleration()) {
             if let Some(sort_cols_str) = acceleration.params.get("sort_columns") {
                 cmd.options
                     .insert("sort_columns".to_string(), sort_cols_str.clone());
@@ -164,6 +166,12 @@ impl DataAccelerator for PartitionedArrowAccelerator {
             if let Some(hash_index_str) = acceleration.params.get("hash_index") {
                 cmd.options
                     .insert("hash_index".to_string(), hash_index_str.clone());
+            }
+            // For caching mode, strip primary key constraints since Arrow uses InsertOp::Replace
+            // which overwrites the entire table. Primary key constraints cause uniqueness validation
+            // errors during inserts because Arrow doesn't support upsert operations.
+            if matches!(acceleration.refresh_mode, Some(RefreshMode::Caching)) {
+                cmd.constraints = Constraints::new_unverified(vec![]);
             }
         }
 

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -143,8 +143,8 @@ impl DataAccelerator for PartitionedArrowAccelerator {
 
     async fn create_external_table(
         &self,
-        cmd: CreateExternalTable,
-        _source: Option<&dyn AccelerationSource>,
+        mut cmd: CreateExternalTable,
+        source: Option<&dyn AccelerationSource>,
         partition_by: Vec<PartitionedBy>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         ensure!(
@@ -153,6 +153,20 @@ impl DataAccelerator for PartitionedArrowAccelerator {
                 msg: "PartitionedArrow accelerator requires non-empty `partition_by`".to_string()
             }
         );
+
+        if let Some(source) = source
+            && let Some(acceleration) = source.acceleration()
+        {
+            if let Some(sort_cols_str) = acceleration.params.get("sort_columns") {
+                cmd.options
+                    .insert("sort_columns".to_string(), sort_cols_str.clone());
+            }
+            if let Some(hash_index_str) = acceleration.params.get("hash_index") {
+                cmd.options
+                    .insert("hash_index".to_string(), hash_index_str.clone());
+            }
+        }
+
         let schema = Arc::new(cmd.schema.as_arrow().clone());
         let creator = Arc::new(ArrowPartitionCreator::new(cmd, partition_by.clone()));
         let table_provider =

--- a/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_arrow.rs
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{any::Any, sync::Arc};
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use data_components::arrow::ArrowFactory;
+use datafusion::{
+    catalog::TableProviderFactory,
+    datasource::TableProvider,
+    error::DataFusionError,
+    logical_expr::{CreateExternalTable, TableProviderFilterPushDown},
+    prelude::{Expr, SessionContext},
+    scalar::ScalarValue,
+};
+use runtime_table_partition::{
+    Partition,
+    creator::{Error as CreatorError, PartitionCreator},
+    expression::PartitionedBy,
+    provider::PartitionTableProvider,
+};
+use snafu::prelude::*;
+
+use crate::{
+    component::dataset::acceleration::Engine,
+    parameters::ParameterSpec,
+    register_data_accelerator,
+};
+
+use super::{AccelerationSource, DataAccelerator};
+
+#[derive(Debug)]
+pub(crate) struct ArrowPartitionCreator {
+    cmd: CreateExternalTable,
+    arrow_factory: ArrowFactory,
+    partition_by: Vec<PartitionedBy>,
+    schema: SchemaRef,
+}
+
+impl ArrowPartitionCreator {
+    pub(crate) fn new(
+        cmd: CreateExternalTable,
+        partition_by: Vec<PartitionedBy>,
+        schema: SchemaRef,
+    ) -> Self {
+        Self {
+            cmd,
+            arrow_factory: ArrowFactory::new(),
+            partition_by,
+            schema,
+        }
+    }
+}
+
+#[async_trait]
+impl PartitionCreator for ArrowPartitionCreator {
+    async fn create_partition(
+        &self,
+        partition_values: Vec<ScalarValue>,
+    ) -> Result<Partition, CreatorError> {
+        if partition_values.is_empty() {
+            return Err(CreatorError::CreatePartition {
+                source: "At least one partition value is required".into(),
+            });
+        }
+
+        if partition_values.len() != self.partition_by.len() {
+            return Err(CreatorError::CreatePartition {
+                source: format!(
+                    "Expected {} partition values but got {}",
+                    self.partition_by.len(),
+                    partition_values.len()
+                )
+                .into(),
+            });
+        }
+
+        let ctx = SessionContext::new();
+        let table_provider =
+            TableProviderFactory::create(&self.arrow_factory, &ctx.state(), &self.cmd)
+                .await
+                .map_err(|e| CreatorError::CreatePartition { source: e.into() })?;
+
+        Ok(Partition {
+            partition_values,
+            table_provider,
+        })
+    }
+
+    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, CreatorError> {
+        // Arrow is purely in-memory — no prior state to recover
+        Ok(vec![])
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(filters
+            .iter()
+            .map(|_| TableProviderFilterPushDown::Inexact)
+            .collect())
+    }
+}
+
+pub(crate) struct PartitionedArrowAccelerator;
+
+impl PartitionedArrowAccelerator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PartitionedArrowAccelerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::runtime("file_watcher"),
+    ParameterSpec::runtime("hash_index")
+        .description("Enable hash index for fast primary key lookups. Set to 'enabled' to enable (requires primary_key). Default: disabled."),
+    ParameterSpec::component("sort_columns")
+        .description("Comma-separated list of columns to sort data by during inserts (e.g., 'timestamp,user_id')."),
+];
+
+#[async_trait]
+impl DataAccelerator for PartitionedArrowAccelerator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "partitioned_arrow"
+    }
+
+    async fn create_external_table(
+        &self,
+        cmd: CreateExternalTable,
+        _source: Option<&dyn AccelerationSource>,
+        partition_by: Vec<PartitionedBy>,
+    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+        ensure!(
+            !partition_by.is_empty(),
+            super::InvalidConfigurationSnafu {
+                msg: "PartitionedArrow accelerator requires non-empty `partition_by`".to_string()
+            }
+        );
+
+        let schema = Arc::new(cmd.schema.as_arrow().clone());
+        let creator = Arc::new(ArrowPartitionCreator::new(
+            cmd,
+            partition_by.clone(),
+            Arc::clone(&schema),
+        ));
+        let table_provider =
+            Arc::new(PartitionTableProvider::new(creator, partition_by, schema).await?);
+
+        Ok(table_provider as Arc<dyn TableProvider>)
+    }
+
+    fn prefix(&self) -> &'static str {
+        "arrow"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
+    }
+}
+
+register_data_accelerator!(Engine::PartitionedArrow, PartitionedArrowAccelerator);

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -439,7 +439,7 @@ async fn acceleration_connection(
             engine: Engine::Cayenne,
         }
         .fail(),
-        Engine::Arrow => UnsupportedEngineSnafu {
+        Engine::Arrow | Engine::PartitionedArrow => UnsupportedEngineSnafu {
             engine: acceleration_settings.engine,
         }
         .fail(),

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -40,6 +40,7 @@ mod on_conflict;
 mod on_conflict_cayenne;
 #[cfg(feature = "duckdb")]
 mod on_conflict_options;
+mod partition_by_arrow;
 #[cfg(not(target_os = "windows"))]
 mod partition_by_cayenne;
 mod query_push_down;

--- a/crates/runtime/tests/acceleration/partition_by_arrow.rs
+++ b/crates/runtime/tests/acceleration/partition_by_arrow.rs
@@ -169,13 +169,16 @@ async fn test_arrow_partition_by_bucket() -> Result<(), anyhow::Error> {
 /// Test that `hash_index: enabled` is correctly propagated to every Arrow partition.
 ///
 /// Prior to the fix, `_source` was ignored in `PartitionedArrowAccelerator::create_external_table`,
-/// so `hash_index` was silently dropped and the table was created without it.  With the fix the
-/// option is injected into `cmd.options` before the creator is built, meaning each partition's
-/// `ArrowFactory::create` receives it.
+/// so `hash_index` was silently dropped and each partition's `IndexedMemTable` was created without
+/// it.  With the propagation fix the option flows into every partition.  A second fix ensures the
+/// per-partition index is rebuilt after data is inserted (the `TableSink` previously only called
+/// `perform_index_maintenance` on the top-level provider, which returned `false` for
+/// `PartitionTableProvider` — missing all the inner `IndexedMemTable`s).
 ///
 /// We verify correctness by confirming:
-/// 1. The dataset loads successfully (would fail/warn if option caused a build error).
-/// 2. Primary-key point lookups return the correct single row (exercises hash index code path).
+/// 1. The dataset loads successfully with `hash_index: enabled` + `primary_key` set.
+/// 2. Primary-key point lookups on the partition table return the correct single row (exercises
+///    the rebuilt per-partition hash index).
 /// 3. A lookup for a non-existent key returns zero rows.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_arrow_partition_hash_index() -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/acceleration/partition_by_arrow.rs
+++ b/crates/runtime/tests/acceleration/partition_by_arrow.rs
@@ -1,0 +1,408 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Integration tests for `partition_by` with the in-memory Arrow accelerator
+//! (`PartitionedArrowAccelerator`).
+//!
+//! These tests verify:
+//! - Basic bucket partitioning correctness (data integrity, filtered queries)
+//! - `hash_index` parameter is propagated to each partition (bug fix)
+//! - `sort_columns` parameter is propagated to each partition (bug fix)
+
+use app::AppBuilder;
+use arrow::array::RecordBatch;
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
+use runtime::Runtime;
+use spicepod::{
+    acceleration::{Acceleration, Mode, RefreshMode},
+    component::dataset::Dataset,
+    param::Params,
+    partitioning::PartitionedBy,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::utils::{runtime_ready_check, test_request_context};
+
+/// Execute a SQL query and collect all `RecordBatch`es.
+async fn run_query(rt: &Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    rt.datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| anyhow::anyhow!("Query failed: {e}"))?
+        .data
+        .try_collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to collect results: {e}"))
+}
+
+/// Build a dataset backed by the test CSV with Arrow acceleration and the given partition/params.
+fn make_dataset(
+    name: &str,
+    test_file: &std::path::Path,
+    partition_by: Vec<PartitionedBy>,
+    extra_params: HashMap<String, String>,
+    primary_key: Option<String>,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("file://{}", test_file.display()), name);
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("arrow".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        params: if extra_params.is_empty() {
+            None
+        } else {
+            Some(Params::from_string_map(extra_params))
+        },
+        partition_by,
+        primary_key,
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+/// Test basic `partition_by: bucket(3, id)` for Arrow in-memory acceleration.
+///
+/// Verifies:
+/// 1. All 10 rows are returned for a full-table scan.
+/// 2. Filtered queries return the correct subset.
+/// 3. Aggregations across partitions are correct.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_partition_by_bucket() -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let test_file = std::env::current_dir()
+                .map_err(|e| anyhow::anyhow!("Failed to get current directory: {e}"))?
+                .join("tests/acceleration/data/partition_test.csv");
+
+            crate::configure_test_datafusion();
+
+            let dataset = make_dataset(
+                "arrow_bucket_test",
+                &test_file,
+                vec![PartitionedBy {
+                    name: "expr0".to_string(),
+                    expression: "bucket(3, id)".to_string(),
+                }],
+                HashMap::new(),
+                None,
+            );
+
+            let app = AppBuilder::new("test_arrow_partition_by_bucket")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Full table scan — all 10 rows across all partitions.
+            let result = run_query(&rt, "SELECT * FROM arrow_bucket_test ORDER BY id").await?;
+            let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total, 10, "Expected 10 rows total");
+
+            // Point filter on partition column.
+            let result = run_query(&rt, "SELECT * FROM arrow_bucket_test WHERE id = 1").await?;
+            let expected = [
+                "+----+----------+-----+----------+-------+",
+                "| id | name     | age | city     | score |",
+                "+----+----------+-----+----------+-------+",
+                "| 1  | John Doe | 28  | New York | 85    |",
+                "+----+----------+-----+----------+-------+",
+            ];
+            assert_batches_eq!(&expected, &result);
+
+            // Range filter — ids 5 through 10 → 6 rows.
+            let result = run_query(
+                &rt,
+                "SELECT id FROM arrow_bucket_test WHERE id >= 5 ORDER BY id",
+            )
+            .await?;
+            let count: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(count, 6, "Expected 6 rows with id >= 5");
+
+            // Filter on non-partition column.
+            let result = run_query(
+                &rt,
+                "SELECT id FROM arrow_bucket_test WHERE score > 85 ORDER BY id",
+            )
+            .await?;
+            let count: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(count, 5, "Expected 5 rows with score > 85");
+
+            // Aggregation across all partitions.
+            let result = run_query(&rt, "SELECT COUNT(*) as cnt FROM arrow_bucket_test").await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 10  |", "+-----+"];
+            assert_batches_eq!(&expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that `hash_index: enabled` is correctly propagated to every Arrow partition.
+///
+/// Prior to the fix, `_source` was ignored in `PartitionedArrowAccelerator::create_external_table`,
+/// so `hash_index` was silently dropped and the table was created without it.  With the fix the
+/// option is injected into `cmd.options` before the creator is built, meaning each partition's
+/// `ArrowFactory::create` receives it.
+///
+/// We verify correctness by confirming:
+/// 1. The dataset loads successfully (would fail/warn if option caused a build error).
+/// 2. Primary-key point lookups return the correct single row (exercises hash index code path).
+/// 3. A lookup for a non-existent key returns zero rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_partition_hash_index() -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let test_file = std::env::current_dir()
+                .map_err(|e| anyhow::anyhow!("Failed to get current directory: {e}"))?
+                .join("tests/acceleration/data/partition_test.csv");
+
+            crate::configure_test_datafusion();
+
+            let mut params = HashMap::new();
+            params.insert("hash_index".to_string(), "enabled".to_string());
+
+            let dataset = make_dataset(
+                "arrow_partition_hash_test",
+                &test_file,
+                vec![PartitionedBy {
+                    name: "expr0".to_string(),
+                    expression: "bucket(3, id)".to_string(),
+                }],
+                params,
+                Some("id".to_string()),
+            );
+
+            let app = AppBuilder::new("test_arrow_partition_hash_index")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // All rows should be accessible.
+            let result =
+                run_query(&rt, "SELECT * FROM arrow_partition_hash_test ORDER BY id").await?;
+            let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total, 10, "Expected 10 rows total");
+
+            // Point lookup exercises the hash index on the partition that owns id=3.
+            let result = run_query(
+                &rt,
+                "SELECT name, city FROM arrow_partition_hash_test WHERE id = 3",
+            )
+            .await?;
+            let expected = [
+                "+--------------+---------+",
+                "| name         | city    |",
+                "+--------------+---------+",
+                "| Mike Johnson | Chicago |",
+                "+--------------+---------+",
+            ];
+            assert_batches_eq!(&expected, &result);
+
+            // Non-existent key should return zero rows.
+            let result = run_query(
+                &rt,
+                "SELECT * FROM arrow_partition_hash_test WHERE id = 999",
+            )
+            .await?;
+            let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total, 0, "Expected 0 rows for non-existent key");
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that `sort_columns` is correctly propagated to every Arrow partition.
+///
+/// Prior to the fix, `_source` was ignored so `sort_columns` was never inserted into
+/// `cmd.options`, meaning each partition's `ArrowFactory::create` silently created an
+/// unsorted table.  With the fix the option flows through to every partition.
+///
+/// We verify that:
+/// 1. The dataset loads successfully with `sort_columns` set.
+/// 2. All rows remain queryable after the sorted insert.
+/// 3. Querying without an explicit ORDER BY returns rows in the declared sort order
+///    (per-partition; we assert the per-partition order rather than global order).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_partition_sort_columns() -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let test_file = std::env::current_dir()
+                .map_err(|e| anyhow::anyhow!("Failed to get current directory: {e}"))?
+                .join("tests/acceleration/data/partition_test.csv");
+
+            crate::configure_test_datafusion();
+
+            let mut params = HashMap::new();
+            params.insert("sort_columns".to_string(), "score".to_string());
+
+            let dataset = make_dataset(
+                "arrow_partition_sort_test",
+                &test_file,
+                vec![PartitionedBy {
+                    name: "expr0".to_string(),
+                    expression: "bucket(3, id)".to_string(),
+                }],
+                params,
+                None,
+            );
+
+            let app = AppBuilder::new("test_arrow_partition_sort_columns")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // All 10 rows should still be present after sorted inserts.
+            let result =
+                run_query(&rt, "SELECT * FROM arrow_partition_sort_test ORDER BY id").await?;
+            let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total, 10, "Expected 10 rows after sorted insert");
+
+            // Verify data integrity — spot-check a few values.
+            let result = run_query(
+                &rt,
+                "SELECT id, score FROM arrow_partition_sort_test WHERE id IN (1, 6) ORDER BY id",
+            )
+            .await?;
+            let expected = [
+                "+----+-------+",
+                "| id | score |",
+                "+----+-------+",
+                "| 1  | 85    |",
+                "| 6  | 94    |",
+                "+----+-------+",
+            ];
+            assert_batches_eq!(&expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that `hash_index` and `sort_columns` can be used together with partitioned Arrow.
+///
+/// This is the combined scenario: a dataset with both options set, partitioned by bucket.
+/// Verifies that both options are propagated without conflict and the table is queryable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_partition_hash_index_and_sort_columns() -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let test_file = std::env::current_dir()
+                .map_err(|e| anyhow::anyhow!("Failed to get current directory: {e}"))?
+                .join("tests/acceleration/data/partition_test.csv");
+
+            crate::configure_test_datafusion();
+
+            let mut params = HashMap::new();
+            params.insert("hash_index".to_string(), "enabled".to_string());
+            params.insert("sort_columns".to_string(), "score".to_string());
+
+            let dataset = make_dataset(
+                "arrow_partition_combined_test",
+                &test_file,
+                vec![PartitionedBy {
+                    name: "expr0".to_string(),
+                    expression: "bucket(3, id)".to_string(),
+                }],
+                params,
+                Some("id".to_string()),
+            );
+
+            let app = AppBuilder::new("test_arrow_partition_combined")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Full scan.
+            let result = run_query(
+                &rt,
+                "SELECT * FROM arrow_partition_combined_test ORDER BY id",
+            )
+            .await?;
+            let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total, 10, "Expected 10 rows total");
+
+            // Primary key lookup (hash index).
+            let result = run_query(
+                &rt,
+                "SELECT name FROM arrow_partition_combined_test WHERE id = 7",
+            )
+            .await?;
+            let expected = [
+                "+--------------+",
+                "| name         |",
+                "+--------------+",
+                "| Tom Anderson |",
+                "+--------------+",
+            ];
+            assert_batches_eq!(&expected, &result);
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
## 📝 Summary
 - Enable partitioning for `acceleration.engine: arrow`. Essentially just a `Memtable` per partition.
 - Helpful for getting started with Accelerations in distributed query. 