### PR TITLE
fix: Update datafusion-table-providers dependency to latest revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6062,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=759b567bcff9968648a9d0d3f7f535e9731dc331#759b567bcff9968648a9d0d3f7f535e9731dc331"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=cc38905a6ff37c1156ee528b5dc15c18c8ae9776#cc38905a6ff37c1156ee528b5dc15c18c8ae9776"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -9323,7 +9323,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -13809,8 +13809,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.16.1",
- "parking_lot 0.12.5",
+ "hashbrown 0.5.0",
+ "parking_lot 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -14364,7 +14364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14398,7 +14398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -17145,7 +17145,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1a49882f0f51ac392b9f2e137d7eddb533670f2e" }                # spiceai-52
 
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "759b567bcff9968648a9d0d3f7f535e9731dc331" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "cc38905a6ff37c1156ee528b5dc15c18c8ae9776" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "c6871700b1433cdb460f791ce3bb6433bc9fcd9c" }      # spiceai-52
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "c6871700b1433cdb460f791ce3bb6433bc9fcd9c" } # spiceai-52


### PR DESCRIPTION
Fixes https://github.com/spiceai/cookbook/issues/355

Pulls back in missing Redshift inference support. https://github.com/datafusion-contrib/datafusion-table-providers/commit/cc38905a6ff37c1156ee528b5dc15c18c8ae9776