### PR TITLE
Unset `AWS_ENDPOINT_URL` when empty

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -355,6 +355,8 @@ jobs:
       - name: Run the benchmark test (with overrides) - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
+          [ -z "$AWS_ENDPOINT_URL" ] && unset AWS_ENDPOINT_URL
+          
           rm -rf .spice/data
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" testoperator run bench \
             -s /usr/local/bin/spiced \

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -289,6 +289,8 @@ jobs:
       - name: Run the benchmark test - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
+          [ -z "$AWS_ENDPOINT_URL" ] && unset AWS_ENDPOINT_URL
+
           rm -rf .spice/data
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" testoperator run bench \
             -s /usr/local/bin/spiced \


### PR DESCRIPTION
## 📝 Summary

Fixes [bench - tpch - federated/glue[parquet].yaml](https://github.com/spiceai/spiceai/actions/runs/22583487153/job/65421833960):
```
thread 'tokio-runtime-worker' (1154) panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-smithy-types-1.4.5/src/endpoint.rs:131:9:
assertion left != right failed: URL was unset
left: ""
right: ""
```