### PR TITLE
Add conditional logging for partition assignments

### DIFF
--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -822,10 +822,12 @@ impl PartitionManagementTask {
             }
         }
 
-        tracing::info!(
-            unassigned_count = unassigned.len(),
-            "Found unassigned partitions"
-        );
+        if !unassigned.is_empty() {
+            tracing::info!(
+                unassigned_count = unassigned.len(),
+                "Found unassigned partitions"
+            );
+        }
 
         unassigned
     }
@@ -1027,12 +1029,13 @@ impl PartitionManagementTask {
             }
         }
 
-        tracing::info!(
-            committed_count = committed.len(),
-            failed_count = failed.len(),
-            "Committed partition assignments"
-        );
-
+        if !committed.is_empty() || !failed.is_empty() {
+            tracing::info!(
+                committed_count = committed.len(),
+                failed_count = failed.len(),
+                "Committed partition assignments"
+            );
+        }
         Ok(CommitResult { committed, failed })
     }
 
@@ -1117,11 +1120,13 @@ impl PartitionManagementTask {
             }
         }
 
-        tracing::info!(
-            success_count,
-            failure_count,
-            "Notified executors of partition assignments"
-        );
+        if !success_count.is_empty() || !failure_count.is_empty() {
+            tracing::info!(
+                success_count,
+                failure_count,
+                "Notified executors of partition assignments"
+            );
+        }
 
         Ok(())
     }

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -1120,7 +1120,7 @@ impl PartitionManagementTask {
             }
         }
 
-        if !success_count.is_empty() || !failure_count.is_empty() {
+        if success_count + failure_count > 0 {
             tracing::info!(
                 success_count,
                 failure_count,


### PR DESCRIPTION
Less noise, avoid `INFO runtime::cluster::partition::scheduler_task: Found unassigned partitions unassigned_count=0`
