### PR TITLE
fix: drop and recreate Cayenne table on configuration change

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -246,10 +246,11 @@ impl MetadataCatalog for CayenneCatalog {
                         return Ok(table_id);
                     }
 
-                    // Configuration changed - return error to prevent accidental reuse of existing table with incompatible schema or settings
-                    return Err(CatalogError::ChangedConfiguration {
-                        table_name: table_name.clone(),
-                    });
+                    // Configuration changed - drop the old table and recreate with new config
+                    tracing::info!(
+                        "Table '{table_name}' configuration changed, dropping and recreating"
+                    );
+                    self.drop_table(&table_name).await?;
                 }
                 Err(e) => {
                     return Err(CatalogError::InvalidMetadata {


### PR DESCRIPTION
## Summary

The configuration change detection added in #9529 returned a `ChangedConfiguration` error instead of implementing the intended drop-and-recreate behavior. This caused `create_table` to fail when data-affecting fields (primary keys, sort columns, schema, etc.) changed between restarts.

Replace the error with a call to `drop_table()` followed by table recreation, matching the original design and fixing the two failing tests introduced alongside the detection logic.

## Changes

- `crates/cayenne/src/cayenne_catalog.rs`: When `configuration_matches()` returns `false`, drop the existing table and fall through to creation instead of returning `ChangedConfiguration` error.

## Validation

```
cargo test -p cayenne --lib
test result: ok. 66 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```

Previously failing tests now pass:
- `cayenne_catalog::tests::test_create_table_detects_config_change`
- `cayenne_catalog::tests::test_create_table_detects_sort_columns_change`

## Related

- Fixes behavior from #9529