### PR TITLE
Fix `spice query` CLI response deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18010,10 +18010,11 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "3.2.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=7815fb062ba508636abeff85ade93f93edff5a7e#7815fb062ba508636abeff85ade93f93edff5a7e"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=4c63970cf1d78c71eb69e2f4346d5d4795631b47#4c63970cf1d78c71eb69e2f4346d5d4795631b47"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "arrow-json",
  "backoff",
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,7 +327,7 @@ vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "c536c9a
 vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "c536c9aedc8fdf8e3787a31c43c8e41318cf3956" } # spiceai-52
 
 x509-certificate = "0.25.0"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "7815fb062ba508636abeff85ade93f93edff5a7e" } # branch: trunk
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "4c63970cf1d78c71eb69e2f4346d5d4795631b47" } # branch: trunk
 
 [profile.release-lto]
 inherits = "release"

--- a/bin/spice/src/commands/query/mod.rs
+++ b/bin/spice/src/commands/query/mod.rs
@@ -201,7 +201,7 @@ async fn execute_subcommand(client: &Arc<Client>, cmd: &QuerySubcommand) -> Resu
                     .map(|q| {
                         serde_json::json!({
                             "query_id": q.query_id,
-                            "status": q.state.clone(),
+                            "status": q.status.to_string(),
                             "created_at": q.created_at,
                             "sql_preview": q.sql_preview,
                         })
@@ -219,7 +219,7 @@ async fn execute_subcommand(client: &Arc<Client>, cmd: &QuerySubcommand) -> Resu
                 };
                 table.add_row(vec![
                     q.query_id.clone(),
-                    q.state.clone(),
+                    q.status.to_string(),
                     q.created_at.clone(),
                     sql,
                 ]);


### PR DESCRIPTION
## Summary

Bump `spice-rs` SDK from rev `7815fb062b` to `4c63970cf1` (trunk) to fix response type mismatches between the SDK and the runtime's `/v1/queries` API that caused all `spice query` subcommands to fail with:

```
ERROR Invalid HTTP response: Failed to parse response: error decoding response body
```

## Changes

- **Cargo.toml**: Update `spice-rs` pin to trunk (`4c63970cf1`)
- **bin/spice/src/commands/query/mod.rs**: Update `QuerySummary.state` → `QuerySummary.status` (field was renamed in the SDK to match the runtime)

## Root Cause

The pinned SDK revision had three response type mismatches:

1. `SubmitResponse.status` — SDK expected a nested `StatusResponse` object, runtime sends a `QueryStatus` string enum
2. `StatusResponse` — SDK used field name `state`, runtime sends `status`
3. `QueryInfoResponse.status` — same nested-object vs string-enum mismatch

The trunk of `spice-rs` already had the fix; this PR updates the pin.

Fixes #9587