### PR TITLE
feat: Add file:// state_location support for async queries scheduler

### DIFF
--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -69,6 +69,14 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Failed to initialize local filesystem for scheduler state at {location}: {source}"
+    ))]
+    LocalFileSystemInit {
+        location: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
         "Scheduler registration record already exists for {scheduler_id} and is still active"
     ))]
     SchedulerIdConflict { scheduler_id: String },
@@ -421,6 +429,41 @@ pub(super) async fn build_object_store_internal(
     let url = Url::parse(state_location).context(InvalidStateLocationSnafu {
         location: state_location,
     })?;
+
+    if url.scheme() == "file" {
+        // For file:// URLs, reconstruct the local filesystem path.
+        // `file://.data/scheduler-state` → host=".data", path="/scheduler-state" → ".data/scheduler-state"
+        // `file:///absolute/path`        → host=None,    path="/absolute/path"   → "/absolute/path"
+        let local_path = match url.host_str() {
+            Some(host) => {
+                let path_suffix = url.path().trim_start_matches('/');
+                if path_suffix.is_empty() {
+                    std::path::PathBuf::from(host)
+                } else {
+                    std::path::PathBuf::from(format!("{host}/{path_suffix}"))
+                }
+            }
+            None => std::path::PathBuf::from(url.path()),
+        };
+
+        std::fs::create_dir_all(&local_path).map_err(|e| Error::LocalFileSystemInit {
+            location: local_path.display().to_string(),
+            source: Box::new(e),
+        })?;
+
+        let store: Arc<dyn ObjectStore> = Arc::new(
+            object_store::local::LocalFileSystem::new_with_prefix(&local_path).map_err(|e| {
+                Error::LocalFileSystemInit {
+                    location: local_path.display().to_string(),
+                    source: Box::new(e),
+                }
+            })?,
+        );
+
+        // The store is rooted at `local_path`, so the base prefix is empty.
+        return Ok((store, String::new()));
+    }
+
     let base_prefix = url.path().trim_matches('/').to_string();
 
     let store: Arc<dyn ObjectStore> = if url.scheme() == "s3" {


### PR DESCRIPTION
## Problem

The async queries cookbook uses `state_location: file://.data/scheduler-state` in spicepod.yaml, but `file://` URLs are not supported by the scheduler state object store initialization. The scheduler registry task fails silently — no error is logged — and the async API returns 503 forever.

## Solution

Add `file://` URL handling in `build_object_store_internal` in `scheduler_registry.rs`:

- Reconstructs the local filesystem path from the URL (handles both relative `file://.data/path` and absolute `file:///var/path` forms)
- Creates the directory if it doesn't exist (`create_dir_all`)
- Returns a `LocalFileSystem` object store rooted at that directory with an empty base prefix
- Adds a `LocalFileSystemInit` error variant for clear error reporting
