### PR TITLE
Fix CLI when using custom `--http`

### DIFF
--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -38,7 +38,7 @@ pub struct SqlArgs {
     /// Specifies the remote Spice instance endpoint.
     /// Supports http://, https://, grpc://, or grpc+tls:// schemes.
     /// If not provided, uses local spiced runtime.
-    #[arg(long, short = 'e')]
+    #[arg(long)]
     endpoint: Option<String>,
 
     /// (Deprecated) Specifies the remote Spice instance Flight endpoint (treated as gRPC endpoint)

--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -38,7 +38,7 @@ pub struct SqlArgs {
     /// Specifies the remote Spice instance endpoint.
     /// Supports http://, https://, grpc://, or grpc+tls:// schemes.
     /// If not provided, uses local spiced runtime.
-    #[arg(long)]
+    #[arg(long, short = 'e')]
     endpoint: Option<String>,
 
     /// (Deprecated) Specifies the remote Spice instance Flight endpoint (treated as gRPC endpoint)

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -284,16 +284,19 @@ impl RuntimeContext {
         cmd.args(args);
 
         // Add HTTP endpoint (use override if provided, otherwise use context default)
-        cmd.arg("--http");
-        let http_addr = http_endpoint_override.map_or_else(
-            || self.http_socket_address(),
-            |ep| {
-                ep.trim_start_matches("http://")
-                    .trim_start_matches("https://")
-                    .to_string()
-            },
-        );
-        cmd.arg(http_addr);
+        // Skip if --http is already present in the trailing args
+        if !args.iter().any(|a| a == "--http") {
+            cmd.arg("--http");
+            let http_addr = http_endpoint_override.map_or_else(
+                || self.http_socket_address(),
+                |ep| {
+                    ep.trim_start_matches("http://")
+                        .trim_start_matches("https://")
+                        .to_string()
+                },
+            );
+            cmd.arg(http_addr);
+        }
 
         // Add API key if present
         if let Some(api_key) = &self.api_key {


### PR DESCRIPTION
## 📝 Summary

Currenty when providing custom `--http` we get following error:

```bash
error: the argument '--http <BIND_ADDRESS>' cannot be used multiple times
```

This PR fixes it and also adds short `-e` alias for `--endpoint` flag in `spice sql` command