### PR TITLE
Properly install postgres in `install-postgres` action

### DIFF
--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -27,7 +27,9 @@ runs:
         # macos-15 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
         brew update
         brew install postgresql
-        brew services start postgresql
+        export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+        echo "/opt/homebrew/opt/postgresql@18/bin" >> $GITHUB_PATH
+        brew services start postgresql@18
         sleep 5
         createuser -s postgres
         psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"


### PR DESCRIPTION
## 📝 Summary

`brew install postgresql` now installs `postgresql@18` which is keg-only — binaries (createuser, psql, createdb) are not symlinked into /opt/homebrew/bin and thus not on PATH.