### PR TITLE
Implement Cayenne S3 Express multi-zone live test with data validation

### DIFF
--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -58,7 +58,9 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use data_components::delete::DeletionSink;
 use datafusion::datasource::listing::ListingTable;
+use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
+use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
 use datafusion::physical_plan::{collect, execute_stream};
 use datafusion_catalog::TableProvider;
@@ -98,6 +100,8 @@ pub struct CayenneDeletionSink {
     pk_column_indices: Vec<usize>,
     /// Additional listing tables from protected snapshots that should also be scanned for deletions.
     protected_snapshot_tables: Vec<Arc<ListingTable>>,
+    /// Shared `RuntimeEnv` for S3 object store access.
+    runtime_env: Arc<RuntimeEnv>,
 }
 
 impl CayenneDeletionSink {
@@ -113,6 +117,7 @@ impl CayenneDeletionSink {
         pk_row_converter: Option<Arc<RowConverter>>,
         pk_column_indices: Vec<usize>,
         protected_snapshot_tables: Vec<Arc<ListingTable>>,
+        runtime_env: Arc<RuntimeEnv>,
     ) -> Self {
         Self {
             table_metadata,
@@ -124,6 +129,7 @@ impl CayenneDeletionSink {
             pk_row_converter,
             pk_column_indices,
             protected_snapshot_tables,
+            runtime_env,
         }
     }
 
@@ -764,7 +770,10 @@ impl CayenneDeletionSink {
 #[async_trait]
 impl DeletionSink for CayenneDeletionSink {
     async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-        let ctx = SessionContext::new();
+        let ctx = SessionContext::new_with_config_rt(
+            SessionConfig::default(),
+            Arc::clone(&self.runtime_env),
+        );
 
         let listing_table = {
             let guard = self.listing_table.read().map_err(|_| Error::LockPoisoned {

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -39,6 +39,7 @@ use crate::provider::Error;
 use async_trait::async_trait;
 use data_components::delete::DeletionSink;
 use datafusion::datasource::listing::ListingTable;
+use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion_catalog::TableProvider;
@@ -307,11 +308,13 @@ impl FileBasedDeletionSink {
                 .clone()
         };
 
-        // A single throwaway SessionContext for the entire operation. It only
-        // provides the object-store registry.
+        // Use the shared RuntimeEnv which has S3 object stores pre-registered.
         // Vortex footer/segment caches live inside the VortexFormat embedded in the
         // shared ListingTable and are unaffected by this SessionContext.
-        let ctx = SessionContext::new();
+        let ctx = SessionContext::new_with_config_rt(
+            SessionConfig::default(),
+            Arc::clone(&self.runtime_env),
+        );
 
         // Get the object store for file deletion
         let object_store_url = listing_table

--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -314,6 +314,10 @@ impl CayenneDataSink {
             rows
         };
 
+        // Refresh the listing table before retention/sort so newly written files are visible.
+        // Without this, sort rewrite can read stale data and drop fresh append rows.
+        self.table.refresh_listing_table()?;
+
         // Apply retention filters, sort, and refresh listing table.
         self.apply_retention_if_configured().await?;
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1195,6 +1195,14 @@ impl CayenneTableProvider {
             Self::load_protected_snapshots(Arc::clone(&catalog), table_id, &pk_deletion_strategy)
                 .await?;
 
+        // Register the S3 object store in the shared RuntimeEnv once during
+        // construction. Every code path that creates a SessionContext from
+        // `self.context.runtime_env()` (e.g. `create_session_context`, keyset
+        // loading, deletion sinks) will automatically inherit the store.
+        if let Some(ref config) = object_store_config {
+            Self::register_object_store_if_needed(context.runtime_env(), config);
+        }
+
         let provider = Self {
             current_snapshot_id: Arc::new(RwLock::new(table_metadata.current_snapshot_id.clone())),
             table_metadata,
@@ -1741,7 +1749,7 @@ impl CayenneTableProvider {
             guard.clone()
         };
 
-        let ctx = SessionContext::new();
+        let ctx = self.create_session_context();
         // Only read PK columns - no need to load all columns for keyset building
         let pk_projection = pk_indices.to_vec();
 
@@ -2766,22 +2774,17 @@ impl CayenneTableProvider {
         Ok(())
     }
 
-    /// Create a `SessionContext` for data operations, registering object store if configured.
+    /// Create a `SessionContext` for data operations using the shared `RuntimeEnv`.
+    ///
+    /// The shared `RuntimeEnv` (from [`CayenneContext`]) already has the S3 object
+    /// store registered during construction, so all sessions created here inherit
+    /// it automatically. This also shares the `list_files` cache and other
+    /// runtime-level caches with the main Spice query engine.
     fn create_session_context(&self) -> SessionContext {
-        let ctx = SessionContext::new();
-        let is_s3 = self.table_metadata.path.starts_with("s3://");
-
-        // Register object store if configured for remote storage (e.g., S3 Express One Zone)
-        if let Some(ref config) = self.object_store_config {
-            Self::register_object_store_if_needed(&ctx.runtime_env(), config);
-        } else if is_s3 {
-            tracing::warn!(
-                "Creating SessionContext for S3 table {} but no object_store_config!",
-                self.table_metadata.table_name
-            );
-        }
-
-        ctx
+        SessionContext::new_with_config_rt(
+            SessionConfig::default(),
+            Arc::clone(self.context.runtime_env()),
+        )
     }
 
     /// Wrap a plan with a `FilterExec` that enforces the retention filter.
@@ -2835,6 +2838,7 @@ impl CayenneTableProvider {
             self.pk_row_converter.as_ref().map(Arc::clone),
             self.pk_column_indices.clone(),
             Vec::new(), // Retention filters don't need to scan protected snapshots
+            Arc::clone(self.context.runtime_env()),
         );
 
         let deleted_count =
@@ -4221,6 +4225,7 @@ impl CayenneTableProvider {
                 self.pk_row_converter.as_ref().map(Arc::clone),
                 self.pk_column_indices.clone(),
                 snapshot_tables,
+                Arc::clone(self.context.runtime_env()),
             )),
             &self.table_metadata.schema,
         )))

--- a/crates/cayenne/tests/integration_test.rs
+++ b/crates/cayenne/tests/integration_test.rs
@@ -951,16 +951,18 @@ async fn test_cayenne_sorted_insert_impl(
 
     // Create table with sort configuration
     let ctx = SessionContext::new();
-    let table = CayenneTableProvider::create_table(
-        Arc::<cayenne::CayenneCatalog>::clone(catalog),
-        table_options,
-        ctx.runtime_env(),
-    )
-    .await?;
+    let table: Arc<dyn TableProvider> = Arc::new(
+        CayenneTableProvider::create_table(
+            Arc::<cayenne::CayenneCatalog>::clone(catalog),
+            table_options,
+            ctx.runtime_env(),
+        )
+        .await?,
+    );
     println!("✓ Table created with sort_columns=['timestamp']");
 
     // Register with DataFusion
-    ctx.register_table("sorted_table", Arc::new(table))?;
+    ctx.register_table("sorted_table", Arc::clone(&table))?;
     println!("✓ Table registered with DataFusion");
 
     // Insert data in random order - sorting should reorder it
@@ -1026,21 +1028,36 @@ async fn test_cayenne_sorted_insert_impl(
     );
     println!("✓ Data is correctly sorted by timestamp column");
 
-    // Insert more data in random order
-    ctx.sql(
-        "INSERT INTO sorted_table VALUES \
+    // Insert more data in random order via a fresh context to avoid stale state.
+    let write_ctx = SessionContext::new();
+    write_ctx.register_table("sorted_table", Arc::clone(&table))?;
+    write_ctx
+        .sql(
+            "INSERT INTO sorted_table VALUES \
          (8, 800, 'eighth'), \
          (6, 600, 'sixth'), \
          (9, 900, 'ninth'), \
          (7, 700, 'seventh')",
-    )
-    .await?
-    .collect()
-    .await?;
+        )
+        .await?
+        .collect()
+        .await?;
     println!("✓ Inserted 4 more rows in random order");
 
+    // Use a fresh SessionContext and reopen provider to avoid stale table state after writes.
+    let verify_ctx = SessionContext::new();
+    let reopened_table: Arc<dyn TableProvider> = Arc::new(
+        cayenne::CayenneTableProviderBuilder::new(
+            Arc::<cayenne::CayenneCatalog>::clone(catalog),
+            verify_ctx.runtime_env(),
+        )
+        .open("sorted_table")
+        .await?,
+    );
+    verify_ctx.register_table("sorted_table", reopened_table)?;
+
     // Query all data again
-    let df = ctx
+    let df = verify_ctx
         .sql("SELECT timestamp, value, name FROM sorted_table ORDER BY timestamp")
         .await?;
     let results = df.collect().await?;
@@ -1068,7 +1085,7 @@ async fn test_cayenne_sorted_insert_impl(
     println!("✓ All data remains sorted after second insert");
 
     // Test range query - with proper sorting, zone maps should enable efficient pruning
-    let df = ctx
+    let df = verify_ctx
         .sql(
             "SELECT * FROM sorted_table WHERE timestamp >= 3 AND timestamp <= 7 ORDER BY timestamp",
         )

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-pub(crate) mod s3;
+pub mod s3;
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -412,14 +412,6 @@ impl CayenneAccelerator {
             .boxed()
             .context(AccelerationCreationFailedSnafu)?;
 
-        if paths.len() > 1 {
-            return Err(Error::InvalidConfiguration {
-                detail: Arc::from(
-                    "Cayenne multi-zone S3 Express writes are not implemented yet. Configure a single zone in 'cayenne_s3_zone_ids' or use a single-zone 'cayenne_file_path'.",
-                ),
-            });
-        }
-
         paths
             .first()
             .cloned()
@@ -882,14 +874,6 @@ impl DataAccelerator for CayenneAccelerator {
                 }));
             }
 
-            if s3::is_multi_zone_s3_express(source) {
-                return Err(Box::new(Error::InvalidConfiguration {
-                    detail: Arc::from(
-                        "Cayenne multi-zone S3 Express writes are not implemented yet. Configure a single zone in 'cayenne_s3_zone_ids' or use a single-zone 'cayenne_file_path'.",
-                    ),
-                }));
-            }
-
             // Validate that refresh_append_overlap is not specified
             if acceleration.refresh_append_overlap.is_some() {
                 return Err(Box::new(Error::InvalidConfiguration {
@@ -905,23 +889,99 @@ impl DataAccelerator for CayenneAccelerator {
 
         // Handle S3 Express One Zone configuration
         if is_s3_express {
-            // Automatically create the bucket if it doesn't exist and we have the required info
-            let (bucket_name, zone_id, region, access_key, secret_key, session_token) =
-                s3::get_s3_bucket_info(source, &dir_path).boxed()?;
-            if s3::create_s3_express_bucket_if_needed(
-                &bucket_name,
-                &zone_id,
-                &region,
-                access_key,
-                secret_key,
-                session_token,
-            )
-            .await
-            .boxed()?
-            {
-                tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket created)");
+            if s3::is_multi_zone_s3_express(source) {
+                let zone_ids = s3::get_s3_zone_ids(source);
+                let dataset_name = source.name().to_string().replace(['.', '/'], "_");
+                let app_name = source.app().name.clone();
+
+                let acceleration = source.acceleration().ok_or_else(|| {
+                    Box::new(Error::InvalidConfiguration {
+                        detail: Arc::from(
+                            "Acceleration settings are required for multi-zone S3 Express initialization",
+                        ),
+                    }) as Box<dyn std::error::Error + Send + Sync>
+                })?;
+
+                let s3_auth = acceleration
+                    .params
+                    .get("cayenne_s3_auth")
+                    .map_or("iam_role", String::as_str);
+                let (access_key, secret_key, session_token) = if s3_auth == "key" {
+                    (
+                        acceleration.params.get("cayenne_s3_key").cloned(),
+                        acceleration.params.get("cayenne_s3_secret").cloned(),
+                        acceleration.params.get("cayenne_s3_session_token").cloned(),
+                    )
+                } else {
+                    (None, None, None)
+                };
+
+                for zone_id in &zone_ids {
+                    let bucket_name = s3::generate_bucket_name(&app_name, &dataset_name, zone_id)
+                        .map_err(|source| {
+                            Box::new(Error::S3Error { source })
+                                as Box<dyn std::error::Error + Send + Sync>
+                        })?;
+
+                    let region = acceleration
+                        .params
+                        .get("cayenne_s3_region")
+                        .cloned()
+                        .or_else(|| s3::derive_region_from_zone(zone_id))
+                        .ok_or_else(|| Error::InvalidConfiguration {
+                            detail: Arc::from(format!(
+                                "Could not determine region for S3 Express zone '{zone_id}'. Specify 'cayenne_s3_region' parameter"
+                            )),
+                        })?;
+
+                    let created = s3::create_s3_express_bucket_if_needed(
+                        &bucket_name,
+                        zone_id,
+                        &region,
+                        access_key.clone(),
+                        secret_key.clone(),
+                        session_token.clone(),
+                    )
+                    .await
+                    .map_err(|source| {
+                        Box::new(Error::S3Error { source })
+                            as Box<dyn std::error::Error + Send + Sync>
+                    })?;
+
+                    if created {
+                        tracing::info!(
+                            "Using S3 Express One Zone storage replica: s3://{bucket_name}/{dataset_name}/ (bucket created)"
+                        );
+                    } else {
+                        tracing::info!(
+                            "Using S3 Express One Zone storage replica: s3://{bucket_name}/{dataset_name}/ (bucket exists)"
+                        );
+                    }
+                }
+
+                tracing::info!(
+                    "Using multi-zone S3 Express One Zone storage: {} zone(s), primary path {dir_path}",
+                    zone_ids.len()
+                );
             } else {
-                tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket exists)");
+                // Automatically create the bucket if it doesn't exist and we have the required info
+                let (bucket_name, zone_id, region, access_key, secret_key, session_token) =
+                    s3::get_s3_bucket_info(source, &dir_path).boxed()?;
+                if s3::create_s3_express_bucket_if_needed(
+                    &bucket_name,
+                    &zone_id,
+                    &region,
+                    access_key,
+                    secret_key,
+                    session_token,
+                )
+                .await
+                .boxed()?
+                {
+                    tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket created)");
+                } else {
+                    tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket exists)");
+                }
             }
             tracing::debug!(
                 "S3 Express One Zone is optimized for low-latency access within the same AWS Availability Zone. Access from outside AWS may experience higher latency."
@@ -1657,6 +1717,45 @@ mod tests {
         };
         assert!(dir_path.contains("cayenne_data_accelerator_test"));
         assert!(dir_path.ends_with('/'));
+    }
+
+    #[tokio::test]
+    async fn test_cayenne_multi_zone_primary_path_generation() {
+        let app = AppBuilder::new("test-app").build();
+        let rt = crate::Runtime::builder().build().await;
+
+        let mut dataset = DatasetBuilder::try_new(
+            "orders.dataset".to_string(),
+            "orders.dataset",
+        )
+        .expect("Failed to create builder")
+        .with_app(Arc::new(app))
+        .with_runtime(Arc::new(rt))
+        .build()
+        .expect("Failed to build dataset");
+
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::Cayenne,
+            mode: Mode::File,
+            params: [(
+                "cayenne_s3_zone_ids".to_string(),
+                "usw2-az1,usw2-az2".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        let accelerator = CayenneAccelerator::new();
+        let primary_data_dir = accelerator
+            .resolve_storage_config(&dataset)
+            .expect("Expected primary multi-zone path");
+
+        assert!(
+            primary_data_dir.starts_with("s3://spice-test-app-orders-dataset--usw2-az1--x-s3/"),
+            "Expected first zone to be primary path, got: {primary_data_dir}"
+        );
+        assert!(primary_data_dir.ends_with("/orders_dataset/"));
     }
 
     #[test]

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -324,7 +324,7 @@ impl CayenneAccelerator {
     /// Returns a vector of S3 paths, one for each zone. The first zone is the primary zone
     /// used for reads; all zones are used for writes (ACID replication).
     fn cayenne_data_dirs_multi_zone(&self, source: &dyn AccelerationSource) -> Result<Vec<String>> {
-        let zone_ids = s3::get_s3_zone_ids(source);
+        let zone_ids = s3::get_s3_zone_ids(source).context(S3Snafu)?;
         if zone_ids.is_empty() {
             // No multi-zone config, return single path
             return Ok(vec![self.cayenne_data_dir(source)?]);
@@ -890,7 +890,9 @@ impl DataAccelerator for CayenneAccelerator {
         // Handle S3 Express One Zone configuration
         if is_s3_express {
             if s3::is_multi_zone_s3_express(source) {
-                let zone_ids = s3::get_s3_zone_ids(source);
+                let zone_ids = s3::get_s3_zone_ids(source).map_err(|source| {
+                    Box::new(Error::S3Error { source }) as Box<dyn std::error::Error + Send + Sync>
+                })?;
                 let dataset_name = source.name().to_string().replace(['.', '/'], "_");
                 let app_name = source.app().name.clone();
 
@@ -919,9 +921,9 @@ impl DataAccelerator for CayenneAccelerator {
                 for zone_id in &zone_ids {
                     let bucket_name = s3::generate_bucket_name(&app_name, &dataset_name, zone_id)
                         .map_err(|source| {
-                            Box::new(Error::S3Error { source })
-                                as Box<dyn std::error::Error + Send + Sync>
-                        })?;
+                        Box::new(Error::S3Error { source })
+                            as Box<dyn std::error::Error + Send + Sync>
+                    })?;
 
                     let region = acceleration
                         .params
@@ -978,7 +980,9 @@ impl DataAccelerator for CayenneAccelerator {
                 .await
                 .boxed()?
                 {
-                    tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket created)");
+                    tracing::info!(
+                        "Using S3 Express One Zone storage: {dir_path} (bucket created)"
+                    );
                 } else {
                     tracing::info!("Using S3 Express One Zone storage: {dir_path} (bucket exists)");
                 }
@@ -1724,15 +1728,12 @@ mod tests {
         let app = AppBuilder::new("test-app").build();
         let rt = crate::Runtime::builder().build().await;
 
-        let mut dataset = DatasetBuilder::try_new(
-            "orders.dataset".to_string(),
-            "orders.dataset",
-        )
-        .expect("Failed to create builder")
-        .with_app(Arc::new(app))
-        .with_runtime(Arc::new(rt))
-        .build()
-        .expect("Failed to build dataset");
+        let mut dataset = DatasetBuilder::try_new("orders.dataset".to_string(), "orders.dataset")
+            .expect("Failed to create builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::new(rt))
+            .build()
+            .expect("Failed to build dataset");
 
         dataset.acceleration = Some(Acceleration {
             engine: Engine::Cayenne,

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -31,6 +31,7 @@ use runtime_parameters::ParameterSpec;
 use runtime_secrets::get_params_with_secrets;
 use secrecy::ExposeSecret;
 use snafu::{ResultExt, Snafu};
+use tokio::sync::Mutex;
 use url::Url;
 
 use super::AccelerationSource;
@@ -382,19 +383,21 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        let mut uploads: Vec<ZoneMultipartUpload> = Vec::with_capacity(self.zones.len());
+        let mut uploads: Vec<Arc<Mutex<ZoneMultipartUpload>>> =
+            Vec::with_capacity(self.zones.len());
         for zone in &self.zones {
             match zone.store.put_multipart_opts(location, opts.clone()).await {
                 Ok(upload) => {
-                    uploads.push(ZoneMultipartUpload {
+                    uploads.push(Arc::new(Mutex::new(ZoneMultipartUpload {
                         zone_id: zone.zone_id.clone(),
                         store: Arc::clone(&zone.store),
                         upload,
-                    });
+                    })));
                 }
                 Err(err) => {
                     // Abort any already-started uploads to avoid leaked multipart state.
-                    for mut started in uploads {
+                    for started in uploads {
+                        let mut started = started.lock().await;
                         if let Err(abort_err) = started.upload.abort().await {
                             tracing::warn!(
                                 "Failed to abort multipart upload for zone '{}' after zone '{}' init failure: {abort_err}",
@@ -621,33 +624,54 @@ struct ZoneMultipartUpload {
 struct MultiZoneMultipartUpload {
     location: Path,
     total_zones: usize,
-    uploads: Vec<ZoneMultipartUpload>,
+    uploads: Vec<Arc<Mutex<ZoneMultipartUpload>>>,
 }
 
 #[async_trait::async_trait]
 impl MultipartUpload for MultiZoneMultipartUpload {
     fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
-        let mut part_futures = Vec::with_capacity(self.uploads.len());
-        for zone_upload in &mut self.uploads {
-            part_futures.push((
-                zone_upload.zone_id.clone(),
-                zone_upload.upload.put_part(data.clone()),
-            ));
+        let uploads = self.uploads.iter().map(Arc::clone).collect::<Vec<_>>();
+        let mut part_futures = Vec::with_capacity(uploads.len());
+        for zone_upload in &uploads {
+            let zone_upload = Arc::clone(zone_upload);
+            let part_data = data.clone();
+            part_futures.push(async move {
+                let (zone_id, upload_part) = {
+                    let mut zone_upload = zone_upload.lock().await;
+                    (
+                        zone_upload.zone_id.clone(),
+                        zone_upload.upload.put_part(part_data),
+                    )
+                };
+                (zone_id, upload_part.await)
+            });
         }
 
         Box::pin(async move {
-            let results = join_all(
-                part_futures
-                    .into_iter()
-                    .map(|(zone_id, fut)| async move { (zone_id, fut.await) }),
-            )
-            .await;
+            let results = join_all(part_futures).await;
+            let mut first_error: Option<object_store::Error> = None;
 
             for (zone_id, result) in results {
                 if let Err(err) = result {
                     tracing::warn!("Failed multipart part upload in zone '{zone_id}': {err}");
-                    return Err(err);
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
                 }
+            }
+
+            if let Some(err) = first_error {
+                // Best-effort abort on part upload failure to avoid leaked multipart uploads.
+                for zone_upload in uploads {
+                    let mut zone_upload = zone_upload.lock().await;
+                    if let Err(abort_err) = zone_upload.upload.abort().await {
+                        tracing::warn!(
+                            "Failed multipart abort in zone '{}' after part upload failure: {abort_err}",
+                            zone_upload.zone_id
+                        );
+                    }
+                }
+                return Err(err);
             }
             Ok(())
         })
@@ -658,7 +682,8 @@ impl MultipartUpload for MultiZoneMultipartUpload {
         let mut successful_zone_ids = Vec::new();
         let mut failed_zone_details = Vec::new();
 
-        for zone_upload in &mut self.uploads {
+        for zone_upload in &self.uploads {
+            let mut zone_upload = zone_upload.lock().await;
             match zone_upload.upload.complete().await {
                 Ok(put_result) => {
                     if first_success.is_none() {
@@ -688,12 +713,14 @@ impl MultipartUpload for MultiZoneMultipartUpload {
             .iter()
             .map(std::string::String::as_str)
             .collect();
-        let rollback_targets: Vec<(String, Arc<dyn ObjectStore>)> = self
-            .uploads
-            .iter()
-            .filter(|zone_upload| successful_set.contains(zone_upload.zone_id.as_str()))
-            .map(|zone_upload| (zone_upload.zone_id.clone(), Arc::clone(&zone_upload.store)))
-            .collect();
+        let mut rollback_targets: Vec<(String, Arc<dyn ObjectStore>)> = Vec::new();
+        for zone_upload in &self.uploads {
+            let zone_upload = zone_upload.lock().await;
+            if successful_set.contains(zone_upload.zone_id.as_str()) {
+                rollback_targets
+                    .push((zone_upload.zone_id.clone(), Arc::clone(&zone_upload.store)));
+            }
+        }
 
         for (zone_id, store) in rollback_targets {
             if let Err(err) = store.delete(&self.location).await {
@@ -719,7 +746,8 @@ impl MultipartUpload for MultiZoneMultipartUpload {
 
     async fn abort(&mut self) -> object_store::Result<()> {
         let mut first_error: Option<object_store::Error> = None;
-        for zone_upload in &mut self.uploads {
+        for zone_upload in &self.uploads {
+            let mut zone_upload = zone_upload.lock().await;
             if let Err(err) = zone_upload.upload.abort().await {
                 tracing::warn!(
                     "Failed multipart abort in zone '{}': {err}",

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -74,7 +74,7 @@ pub enum Error {
 
     #[snafu(display(
         "Multi-zone S3 Express One Zone write failed: {failed_count} of {total_zones} zone(s) failed. \
-        Failure details: {failed_zones}. Successful writes have been rolled back for ACID consistency."
+        Failure details: {failed_zones}. Rollback was attempted for successful zones."
     ))]
     MultiZoneWriteFailed {
         failed_count: usize,
@@ -183,17 +183,20 @@ impl MultiZoneS3ExpressStore {
         }
     }
 
-    async fn rollback_put(&self, location: &Path, successful_zone_ids: &[String]) {
+    async fn rollback_put(&self, location: &Path, successful_zone_ids: &[String]) -> Vec<String> {
         let successful_set: HashSet<&str> = successful_zone_ids
             .iter()
             .map(std::string::String::as_str)
             .collect();
+
+        let mut rollback_failures = Vec::new();
 
         for zone in &self.zones {
             if !successful_set.contains(zone.zone_id.as_str()) {
                 continue;
             }
             if let Err(e) = zone.store.delete(location).await {
+                rollback_failures.push(format!("rollback {}: {e}", zone.zone_id));
                 tracing::warn!(
                     "{}",
                     Error::MultiZoneRollbackFailed {
@@ -203,19 +206,24 @@ impl MultiZoneS3ExpressStore {
                 );
             }
         }
+
+        rollback_failures
     }
 
-    async fn rollback_copy(&self, to: &Path, successful_zone_ids: &[String]) {
+    async fn rollback_copy(&self, to: &Path, successful_zone_ids: &[String]) -> Vec<String> {
         let successful_set: HashSet<&str> = successful_zone_ids
             .iter()
             .map(std::string::String::as_str)
             .collect();
+
+        let mut rollback_failures = Vec::new();
 
         for zone in &self.zones {
             if !successful_set.contains(zone.zone_id.as_str()) {
                 continue;
             }
             if let Err(e) = zone.store.delete(to).await {
+                rollback_failures.push(format!("rollback {}: {e}", zone.zone_id));
                 tracing::warn!(
                     "{}",
                     Error::MultiZoneRollbackFailed {
@@ -225,6 +233,8 @@ impl MultiZoneS3ExpressStore {
                 );
             }
         }
+
+        rollback_failures
     }
 
     fn build_list_stream_for_zone(
@@ -362,7 +372,8 @@ impl ObjectStore for MultiZoneS3ExpressStore {
             });
         }
 
-        self.rollback_put(location, &successful_zone_ids).await;
+        let rollback_failures = self.rollback_put(location, &successful_zone_ids).await;
+        failed_zone_details.extend(rollback_failures);
         Err(self.multi_zone_write_error(&failed_zone_details))
     }
 
@@ -540,7 +551,8 @@ impl ObjectStore for MultiZoneS3ExpressStore {
             return Ok(());
         }
 
-        self.rollback_copy(to, &successful_zone_ids).await;
+        let rollback_failures = self.rollback_copy(to, &successful_zone_ids).await;
+        failed_zone_details.extend(rollback_failures);
         Err(self.multi_zone_write_error(&failed_zone_details))
     }
 
@@ -567,7 +579,8 @@ impl ObjectStore for MultiZoneS3ExpressStore {
             return Ok(());
         }
 
-        self.rollback_copy(to, &successful_zone_ids).await;
+        let rollback_failures = self.rollback_copy(to, &successful_zone_ids).await;
+        failed_zone_details.extend(rollback_failures);
         Err(self.multi_zone_write_error(&failed_zone_details))
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -14,18 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::{HashSet, hash_map::DefaultHasher};
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_bucket_name};
+use futures::StreamExt;
 use futures::future::join_all;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
-    path::Path,
-    ClientOptions, RetryConfig, aws::AmazonS3Builder, client::SpawnedReqwestConnector,
+    ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RetryConfig, aws::AmazonS3Builder,
+    client::SpawnedReqwestConnector, path::Path,
 };
 use runtime_parameters::ParameterSpec;
 use runtime_secrets::get_params_with_secrets;
@@ -74,9 +73,19 @@ pub enum Error {
 
     #[snafu(display(
         "Multi-zone S3 Express One Zone write failed: {failed_count} of {total_zones} zone(s) failed. \
-        Failed zones: {failed_zones}. Successful writes have been rolled back for ACID consistency."
+        Failure details: {failed_zones}. Successful writes have been rolled back for ACID consistency."
     ))]
     MultiZoneWriteFailed {
+        failed_count: usize,
+        total_zones: usize,
+        failed_zones: String,
+    },
+
+    #[snafu(display(
+        "Multi-zone S3 Express One Zone delete failed for {failed_count} of {total_zones} zone(s). \
+        Failure details: {failed_zones}. Some replicas may still retain the object."
+    ))]
+    MultiZoneDeleteFailed {
         failed_count: usize,
         total_zones: usize,
         failed_zones: String,
@@ -118,41 +127,43 @@ impl MultiZoneS3ExpressStore {
         self.zones.len()
     }
 
-    /// Returns a deterministic read order for the given object path, distributing
-    /// primary reads across zones by hashing the path.
+    /// Returns a deterministic read order for all read operations.
     ///
-    /// **Design tradeoff**: `list()` always reads from zone 0 while `get()`/`head()`
-    /// stripe across zones via this method. This is acceptable because writes are
-    /// replicated atomically to all zones, so every zone holds the same object set.
-    /// If a primary zone is temporarily unavailable, get/head falls back to the next
-    /// zone in the order. An inconsistency would only arise from external out-of-band
-    /// mutations, which are outside the supported contract.
-    fn striped_read_order(&self, location: &Path) -> Vec<usize> {
+    /// Always prefers zone 0 (the listing primary) and falls back to other zones on
+    /// read failures. Keeping list/get/head aligned to the same primary zone avoids
+    /// potential metadata/content mismatches if replicas drift.
+    fn read_order(&self) -> Vec<usize> {
         if self.zones.is_empty() {
             return Vec::new();
         }
-
-        let mut hasher = DefaultHasher::new();
-        location.as_ref().hash(&mut hasher);
-        let primary_idx = (hasher.finish() as usize) % self.zones.len();
-
         let mut order = Vec::with_capacity(self.zones.len());
-        order.push(primary_idx);
+        order.push(0);
         for idx in 0..self.zones.len() {
-            if idx != primary_idx {
+            if idx != 0 {
                 order.push(idx);
             }
         }
         order
     }
 
-    fn multi_zone_write_error(&self, failed_zone_ids: &[String]) -> object_store::Error {
+    fn multi_zone_write_error(&self, failed_zone_details: &[String]) -> object_store::Error {
         object_store::Error::Generic {
             store: MULTI_ZONE_STORE_NAME,
             source: Box::new(Error::MultiZoneWriteFailed {
-                failed_count: failed_zone_ids.len(),
+                failed_count: failed_zone_details.len(),
                 total_zones: self.stores_len(),
-                failed_zones: failed_zone_ids.join(", "),
+                failed_zones: failed_zone_details.join(", "),
+            }),
+        }
+    }
+
+    fn multi_zone_delete_error(&self, failed_zone_details: &[String]) -> object_store::Error {
+        object_store::Error::Generic {
+            store: MULTI_ZONE_STORE_NAME,
+            source: Box::new(Error::MultiZoneDeleteFailed {
+                failed_count: failed_zone_details.len(),
+                total_zones: self.stores_len(),
+                failed_zones: failed_zone_details.join(", "),
             }),
         }
     }
@@ -231,7 +242,7 @@ impl ObjectStore for MultiZoneS3ExpressStore {
 
         let mut first_success: Option<PutResult> = None;
         let mut successful_zone_ids = Vec::new();
-        let mut failed_zone_ids = Vec::new();
+        let mut failed_zone_details = Vec::new();
 
         for (zone_id, result) in results {
             match result {
@@ -243,12 +254,12 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                 }
                 Err(err) => {
                     tracing::warn!("Multi-zone put failed for zone '{zone_id}': {err}");
-                    failed_zone_ids.push(zone_id);
+                    failed_zone_details.push(format!("{zone_id}: {err}"));
                 }
             }
         }
 
-        if failed_zone_ids.is_empty() {
+        if failed_zone_details.is_empty() {
             return first_success.ok_or_else(|| object_store::Error::Generic {
                 store: MULTI_ZONE_STORE_NAME,
                 source: "No successful multi-zone write result".into(),
@@ -256,7 +267,7 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         }
 
         self.rollback_put(location, &successful_zone_ids).await;
-        Err(self.multi_zone_write_error(&failed_zone_ids))
+        Err(self.multi_zone_write_error(&failed_zone_details))
     }
 
     async fn put_multipart_opts(
@@ -297,8 +308,12 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         }))
     }
 
-    async fn get_opts(&self, location: &Path, options: GetOptions) -> object_store::Result<GetResult> {
-        let read_order = self.striped_read_order(location);
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let read_order = self.read_order();
         let mut last_err: Option<object_store::Error> = None;
 
         for idx in read_order {
@@ -323,7 +338,7 @@ impl ObjectStore for MultiZoneS3ExpressStore {
     }
 
     async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        let read_order = self.striped_read_order(location);
+        let read_order = self.read_order();
         let mut last_err: Option<object_store::Error> = None;
 
         for idx in read_order {
@@ -348,7 +363,7 @@ impl ObjectStore for MultiZoneS3ExpressStore {
     }
 
     async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        let mut failed_zone_ids = Vec::new();
+        let mut failed_zone_details = Vec::new();
         for zone in &self.zones {
             if let Err(err) = zone.store.delete(location).await {
                 tracing::warn!(
@@ -356,14 +371,14 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                     location,
                     zone.zone_id
                 );
-                failed_zone_ids.push(zone.zone_id.clone());
+                failed_zone_details.push(format!("{}: {err}", zone.zone_id));
             }
         }
 
-        if failed_zone_ids.is_empty() {
+        if failed_zone_details.is_empty() {
             Ok(())
         } else {
-            Err(self.multi_zone_write_error(&failed_zone_ids))
+            Err(self.multi_zone_delete_error(&failed_zone_details))
         }
     }
 
@@ -371,9 +386,17 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         &self,
         prefix: Option<&Path>,
     ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
-        // Listing from the first zone is sufficient because writes are replicated atomically.
-        // If replication ever diverges due to external mutation, list consistency degrades
-        // predictably to the primary zone.
+        if self.zones.is_empty() {
+            let path = prefix.map_or_else(String::new, std::string::ToString::to_string);
+            return futures::stream::once(async {
+                Err(object_store::Error::NotFound {
+                    path,
+                    source: "No configured S3 zones".into(),
+                })
+            })
+            .boxed();
+        }
+
         self.zones[0].store.list(prefix)
     }
 
@@ -382,16 +405,44 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+        if self.zones.is_empty() {
+            let path = offset.to_string();
+            return futures::stream::once(async {
+                Err(object_store::Error::NotFound {
+                    path,
+                    source: "No configured S3 zones".into(),
+                })
+            })
+            .boxed();
+        }
+
         self.zones[0].store.list_with_offset(prefix, offset)
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
-        self.zones[0].store.list_with_delimiter(prefix).await
+        let mut last_err: Option<object_store::Error> = None;
+        for zone in &self.zones {
+            match zone.store.list_with_delimiter(prefix).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    tracing::debug!(
+                        "S3 Express list_with_delimiter failed for zone '{}': {err}",
+                        zone.zone_id
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| object_store::Error::NotFound {
+            path: prefix.map_or_else(String::new, std::string::ToString::to_string),
+            source: "No configured S3 zones".into(),
+        }))
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
         let mut successful_zone_ids = Vec::new();
-        let mut failed_zone_ids = Vec::new();
+        let mut failed_zone_details = Vec::new();
 
         for zone in &self.zones {
             match zone.store.copy(from, to).await {
@@ -403,22 +454,22 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                         to,
                         zone.zone_id
                     );
-                    failed_zone_ids.push(zone.zone_id.clone());
+                    failed_zone_details.push(format!("{}: {err}", zone.zone_id));
                 }
             }
         }
 
-        if failed_zone_ids.is_empty() {
+        if failed_zone_details.is_empty() {
             return Ok(());
         }
 
         self.rollback_copy(to, &successful_zone_ids).await;
-        Err(self.multi_zone_write_error(&failed_zone_ids))
+        Err(self.multi_zone_write_error(&failed_zone_details))
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
         let mut successful_zone_ids = Vec::new();
-        let mut failed_zone_ids = Vec::new();
+        let mut failed_zone_details = Vec::new();
 
         for zone in &self.zones {
             match zone.store.copy_if_not_exists(from, to).await {
@@ -430,17 +481,17 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                         to,
                         zone.zone_id
                     );
-                    failed_zone_ids.push(zone.zone_id.clone());
+                    failed_zone_details.push(format!("{}: {err}", zone.zone_id));
                 }
             }
         }
 
-        if failed_zone_ids.is_empty() {
+        if failed_zone_details.is_empty() {
             return Ok(());
         }
 
         self.rollback_copy(to, &successful_zone_ids).await;
-        Err(self.multi_zone_write_error(&failed_zone_ids))
+        Err(self.multi_zone_write_error(&failed_zone_details))
     }
 }
 
@@ -463,13 +514,18 @@ impl MultipartUpload for MultiZoneMultipartUpload {
     fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
         let mut part_futures = Vec::with_capacity(self.uploads.len());
         for zone_upload in &mut self.uploads {
-            part_futures.push((zone_upload.zone_id.clone(), zone_upload.upload.put_part(data.clone())));
+            part_futures.push((
+                zone_upload.zone_id.clone(),
+                zone_upload.upload.put_part(data.clone()),
+            ));
         }
 
         Box::pin(async move {
-            let results = join_all(part_futures.into_iter().map(|(zone_id, fut)| async move {
-                (zone_id, fut.await)
-            }))
+            let results = join_all(
+                part_futures
+                    .into_iter()
+                    .map(|(zone_id, fut)| async move { (zone_id, fut.await) }),
+            )
             .await;
 
             for (zone_id, result) in results {
@@ -655,25 +711,47 @@ pub fn is_multi_zone_s3_express(source: &dyn AccelerationSource) -> bool {
 /// Parses the `cayenne_s3_zone_ids` parameter as a comma-separated list of zone IDs.
 /// Normalizes entries (trim + lowercase) and deduplicates, preserving first-seen order.
 /// Returns an empty vector if the parameter is not set.
-pub fn get_s3_zone_ids(source: &dyn AccelerationSource) -> Vec<String> {
+pub fn get_s3_zone_ids(source: &dyn AccelerationSource) -> Result<Vec<String>> {
     source
         .acceleration()
         .and_then(|a| a.params.get("cayenne_s3_zone_ids"))
-        .map(|zone_ids| {
+        .map_or_else(
+            || Ok(Vec::new()),
+            |zone_ids| {
             let mut seen = HashSet::new();
+            let mut ordered = Vec::new();
+            let mut duplicates = Vec::new();
             zone_ids
                 .split(',')
                 .map(|s| s.trim().to_lowercase())
-                .filter(|s| !s.is_empty() && seen.insert(s.clone()))
-                .collect()
-        })
-        .unwrap_or_default()
+                .filter(|s| !s.is_empty())
+                .for_each(|zone_id| {
+                    if seen.insert(zone_id.clone()) {
+                        ordered.push(zone_id);
+                    } else {
+                        duplicates.push(zone_id);
+                    }
+                });
+
+            if !duplicates.is_empty() {
+                return Err(Error::InvalidConfiguration {
+                    detail: Arc::from(format!(
+                        "Duplicate values found in 'cayenne_s3_zone_ids': {}. Use a unique, comma-separated zone list.",
+                        duplicates.join(", ")
+                    )),
+                });
+            }
+
+                Ok(ordered)
+            },
+        )
 }
 
 /// Extracts the zone ID from an S3 Express One Zone bucket name.
 ///
 /// S3 Express One Zone bucket names have the format: `{base-name}--{zone-id}--x-s3`
 /// Example: `mybucket--usw2-az1--x-s3` returns `Some("usw2-az1")`
+#[must_use]
 pub fn extract_zone_id_from_bucket(bucket_name: &str) -> Option<&str> {
     // Find the last occurrence of "--x-s3"
     let suffix_start = bucket_name.rfind("--x-s3")?;
@@ -1163,6 +1241,7 @@ pub fn get_s3_bucket_info(
 ///
 /// Zone IDs follow the pattern: `{region-code}-az{n}` (e.g., `usw2-az1`, `use1-az4`)
 /// We need to map the abbreviated region code to the full AWS region name.
+#[must_use]
 pub fn derive_region_from_zone(zone_id: &str) -> Option<String> {
     // Extract the region prefix from zone ID (e.g., "usw2" from "usw2-az1")
     let region_prefix = zone_id.split("-az").next()?;
@@ -1211,15 +1290,15 @@ pub fn derive_region_from_zone(zone_id: &str) -> Option<String> {
 
 #[derive(Debug, Clone)]
 struct ResolvedS3Params {
-    s3_region: Option<String>,
-    s3_endpoint: Option<String>,
-    s3_key: Option<String>,
-    s3_secret: Option<String>,
-    s3_session_token: Option<String>,
-    s3_auth: String,
-    s3_client_timeout: Option<String>,
-    s3_allow_http: bool,
-    s3_unsigned_payload: bool,
+    region: Option<String>,
+    endpoint: Option<String>,
+    key: Option<String>,
+    secret: Option<String>,
+    session_token: Option<String>,
+    auth: String,
+    client_timeout: Option<String>,
+    allow_http: bool,
+    unsigned_payload: bool,
 }
 
 async fn resolve_s3_params(source: &dyn AccelerationSource) -> ResolvedS3Params {
@@ -1246,15 +1325,15 @@ async fn resolve_s3_params(source: &dyn AccelerationSource) -> ResolvedS3Params 
         get_param("cayenne_s3_unsigned_payload").is_none_or(|v| !v.eq_ignore_ascii_case("false"));
 
     ResolvedS3Params {
-        s3_region,
-        s3_endpoint,
-        s3_key,
-        s3_secret,
-        s3_session_token,
-        s3_auth,
-        s3_client_timeout,
-        s3_allow_http,
-        s3_unsigned_payload,
+        region: s3_region,
+        endpoint: s3_endpoint,
+        key: s3_key,
+        secret: s3_secret,
+        session_token: s3_session_token,
+        auth: s3_auth,
+        client_timeout: s3_client_timeout,
+        allow_http: s3_allow_http,
+        unsigned_payload: s3_unsigned_payload,
     }
 }
 
@@ -1279,7 +1358,7 @@ async fn build_single_s3_store_for_path(
         .to_string();
 
     let effective_region = params
-        .s3_region
+        .region
         .clone()
         .or_else(|| derive_region_from_zone(&zone_id))
         .ok_or_else(|| Error::InvalidConfiguration {
@@ -1292,7 +1371,7 @@ async fn build_single_s3_store_for_path(
     let mut s3_builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket_name)
         .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
-        .with_allow_http(params.s3_allow_http)
+        .with_allow_http(params.allow_http)
         .with_region(effective_region.clone());
 
     let retry_config = RetryConfig {
@@ -1302,28 +1381,28 @@ async fn build_single_s3_store_for_path(
     };
     s3_builder = s3_builder.with_retry(retry_config);
 
-    let mut client_options = ClientOptions::default()
-        .with_timeout(std::time::Duration::from_secs(120));
+    let mut client_options =
+        ClientOptions::default().with_timeout(std::time::Duration::from_secs(120));
 
     s3_builder = s3_builder
         .with_s3_express(true)
         .with_virtual_hosted_style_request(true)
-        .with_unsigned_payload(params.s3_unsigned_payload);
+        .with_unsigned_payload(params.unsigned_payload);
 
-    if params.s3_endpoint.is_none() {
+    if params.endpoint.is_none() {
         let express_endpoint =
             format!("https://{bucket_name}.s3express-{zone_id}.{effective_region}.amazonaws.com");
         s3_builder = s3_builder.with_endpoint(&express_endpoint);
     }
 
-    if let Some(endpoint) = &params.s3_endpoint {
+    if let Some(endpoint) = &params.endpoint {
         s3_builder = s3_builder.with_endpoint(endpoint);
         if endpoint.starts_with("http://") {
             client_options = client_options.with_allow_http(true);
         }
     }
 
-    if let Some(timeout) = &params.s3_client_timeout {
+    if let Some(timeout) = &params.client_timeout {
         client_options = client_options.with_timeout(
             fundu::parse_duration(timeout)
                 .boxed()
@@ -1332,11 +1411,11 @@ async fn build_single_s3_store_for_path(
     }
 
     let mut load_credentials_from_environment = true;
-    if params.s3_auth == "key" {
-        if let (Some(key), Some(secret)) = (params.s3_key.clone(), params.s3_secret.clone()) {
+    if params.auth == "key" {
+        if let (Some(key), Some(secret)) = (params.key.clone(), params.secret.clone()) {
             s3_builder = s3_builder.with_access_key_id(key);
             s3_builder = s3_builder.with_secret_access_key(secret);
-            if let Some(token) = params.s3_session_token.clone() {
+            if let Some(token) = params.session_token.clone() {
                 s3_builder = s3_builder.with_token(token);
             }
             load_credentials_from_environment = false;
@@ -1404,7 +1483,7 @@ pub async fn build_s3_object_store(
 
     let resolved = resolve_s3_params(source).await;
 
-    let zone_ids = get_s3_zone_ids(source);
+    let zone_ids = get_s3_zone_ids(source)?;
     if zone_ids.len() > 1 {
         let dataset_name = source.name().to_string().replace(['.', '/'], "_");
         let app_name = source.app().name.clone();
@@ -1538,11 +1617,18 @@ mod tests {
             self.inner.get_opts(location, options).await
         }
 
+        async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+            self.inner.head(location).await
+        }
+
         async fn delete(&self, location: &Path) -> object_store::Result<()> {
             self.inner.delete(location).await
         }
 
-        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
             self.inner.list(prefix)
         }
 
@@ -1554,7 +1640,10 @@ mod tests {
             self.inner.list_with_offset(prefix, offset)
         }
 
-        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> object_store::Result<ListResult> {
             self.inner.list_with_delimiter(prefix).await
         }
 
@@ -1772,7 +1861,11 @@ mod tests {
 
         let location = Path::from("table/snapshot/data.vtx");
         let write_result = multi_zone_store
-            .put_opts(&location, PutPayload::from("test-data".to_string()), PutOptions::default())
+            .put_opts(
+                &location,
+                PutPayload::from("test-data".to_string()),
+                PutOptions::default(),
+            )
             .await;
         assert!(write_result.is_err(), "multi-zone write should fail");
 
@@ -1799,17 +1892,9 @@ mod tests {
             },
         ]);
 
-        let location = Path::from("table/snapshot/striped-key.vtx");
-        let preferred_idx = multi_zone_store.striped_read_order(&location)[0];
-        let fallback_idx = if preferred_idx == 0 { 1 } else { 0 };
+        let location = Path::from("table/snapshot/primary-fallback-key.vtx");
 
-        let fallback_store = if fallback_idx == 0 {
-            Arc::clone(&zone_a)
-        } else {
-            Arc::clone(&zone_b)
-        };
-
-        fallback_store
+        zone_b
             .put_opts(
                 &location,
                 PutPayload::from("fallback-zone-data".to_string()),

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -14,10 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::{HashSet, hash_map::DefaultHasher};
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_bucket_name};
+use futures::future::join_all;
 use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    path::Path,
     ClientOptions, RetryConfig, aws::AmazonS3Builder, client::SpawnedReqwestConnector,
 };
 use runtime_parameters::ParameterSpec;
@@ -88,6 +95,452 @@ pub enum Error {
     InvalidConfiguration { detail: Arc<str> },
 }
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+const MULTI_ZONE_STORE_NAME: &str = "S3ExpressMultiZone";
+
+#[derive(Debug, Clone)]
+struct ZoneStore {
+    zone_id: String,
+    store: Arc<dyn ObjectStore>,
+}
+
+#[derive(Debug)]
+struct MultiZoneS3ExpressStore {
+    zones: Vec<ZoneStore>,
+}
+
+impl MultiZoneS3ExpressStore {
+    fn new(zones: Vec<ZoneStore>) -> Self {
+        Self { zones }
+    }
+
+    fn stores_len(&self) -> usize {
+        self.zones.len()
+    }
+
+    fn striped_read_order(&self, location: &Path) -> Vec<usize> {
+        if self.zones.is_empty() {
+            return Vec::new();
+        }
+
+        let mut hasher = DefaultHasher::new();
+        location.as_ref().hash(&mut hasher);
+        let primary_idx = (hasher.finish() as usize) % self.zones.len();
+
+        let mut order = Vec::with_capacity(self.zones.len());
+        order.push(primary_idx);
+        for idx in 0..self.zones.len() {
+            if idx != primary_idx {
+                order.push(idx);
+            }
+        }
+        order
+    }
+
+    fn multi_zone_write_error(&self, failed_zone_ids: &[String]) -> object_store::Error {
+        object_store::Error::Generic {
+            store: MULTI_ZONE_STORE_NAME,
+            source: Box::new(Error::MultiZoneWriteFailed {
+                failed_count: failed_zone_ids.len(),
+                total_zones: self.stores_len(),
+                failed_zones: failed_zone_ids.join(", "),
+            }),
+        }
+    }
+
+    async fn rollback_put(&self, location: &Path, successful_zone_ids: &[String]) {
+        let successful_set: HashSet<&str> = successful_zone_ids
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+
+        for zone in &self.zones {
+            if !successful_set.contains(zone.zone_id.as_str()) {
+                continue;
+            }
+            if let Err(e) = zone.store.delete(location).await {
+                tracing::warn!(
+                    "{}",
+                    Error::MultiZoneRollbackFailed {
+                        zone: zone.zone_id.clone(),
+                        reason: e.to_string(),
+                    }
+                );
+            }
+        }
+    }
+
+    async fn rollback_copy(&self, to: &Path, successful_zone_ids: &[String]) {
+        let successful_set: HashSet<&str> = successful_zone_ids
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+
+        for zone in &self.zones {
+            if !successful_set.contains(zone.zone_id.as_str()) {
+                continue;
+            }
+            if let Err(e) = zone.store.delete(to).await {
+                tracing::warn!(
+                    "{}",
+                    Error::MultiZoneRollbackFailed {
+                        zone: zone.zone_id.clone(),
+                        reason: e.to_string(),
+                    }
+                );
+            }
+        }
+    }
+}
+
+impl Display for MultiZoneS3ExpressStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{MULTI_ZONE_STORE_NAME}")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for MultiZoneS3ExpressStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        let mut put_futures = Vec::with_capacity(self.zones.len());
+        for zone in &self.zones {
+            put_futures.push(async {
+                let result = zone
+                    .store
+                    .put_opts(location, payload.clone(), opts.clone())
+                    .await;
+                (zone.zone_id.clone(), result)
+            });
+        }
+
+        let results = join_all(put_futures).await;
+
+        let mut first_success: Option<PutResult> = None;
+        let mut successful_zone_ids = Vec::new();
+        let mut failed_zone_ids = Vec::new();
+
+        for (zone_id, result) in results {
+            match result {
+                Ok(put_result) => {
+                    if first_success.is_none() {
+                        first_success = Some(put_result);
+                    }
+                    successful_zone_ids.push(zone_id);
+                }
+                Err(_) => failed_zone_ids.push(zone_id),
+            }
+        }
+
+        if failed_zone_ids.is_empty() {
+            return first_success.ok_or_else(|| object_store::Error::Generic {
+                store: MULTI_ZONE_STORE_NAME,
+                source: "No successful multi-zone write result".into(),
+            });
+        }
+
+        self.rollback_put(location, &successful_zone_ids).await;
+        Err(self.multi_zone_write_error(&failed_zone_ids))
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        let mut uploads: Vec<ZoneMultipartUpload> = Vec::with_capacity(self.zones.len());
+        for zone in &self.zones {
+            let upload = zone
+                .store
+                .put_multipart_opts(location, opts.clone())
+                .await?;
+            uploads.push(ZoneMultipartUpload {
+                zone_id: zone.zone_id.clone(),
+                store: Arc::clone(&zone.store),
+                upload,
+            });
+        }
+
+        Ok(Box::new(MultiZoneMultipartUpload {
+            location: location.clone(),
+            total_zones: self.stores_len(),
+            uploads,
+        }))
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> object_store::Result<GetResult> {
+        let read_order = self.striped_read_order(location);
+        let mut last_err: Option<object_store::Error> = None;
+
+        for idx in read_order {
+            let zone = &self.zones[idx];
+            match zone.store.get_opts(location, options.clone()).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    tracing::debug!(
+                        "S3 Express read failed for zone '{}' and object '{}': {err}",
+                        zone.zone_id,
+                        location
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| object_store::Error::NotFound {
+            path: location.to_string(),
+            source: "No configured S3 zones".into(),
+        }))
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        let read_order = self.striped_read_order(location);
+        let mut last_err: Option<object_store::Error> = None;
+
+        for idx in read_order {
+            let zone = &self.zones[idx];
+            match zone.store.head(location).await {
+                Ok(meta) => return Ok(meta),
+                Err(err) => {
+                    tracing::debug!(
+                        "S3 Express head failed for zone '{}' and object '{}': {err}",
+                        zone.zone_id,
+                        location
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| object_store::Error::NotFound {
+            path: location.to_string(),
+            source: "No configured S3 zones".into(),
+        }))
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        let mut failed_zone_ids = Vec::new();
+        for zone in &self.zones {
+            if let Err(err) = zone.store.delete(location).await {
+                tracing::warn!(
+                    "Failed to delete object '{}' from zone '{}': {err}",
+                    location,
+                    zone.zone_id
+                );
+                failed_zone_ids.push(zone.zone_id.clone());
+            }
+        }
+
+        if failed_zone_ids.is_empty() {
+            Ok(())
+        } else {
+            Err(self.multi_zone_write_error(&failed_zone_ids))
+        }
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+        // Listing from the first zone is sufficient because writes are replicated atomically.
+        // If replication ever diverges due to external mutation, list consistency degrades
+        // predictably to the primary zone.
+        self.zones[0].store.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.zones[0].store.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.zones[0].store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let mut successful_zone_ids = Vec::new();
+        let mut failed_zone_ids = Vec::new();
+
+        for zone in &self.zones {
+            match zone.store.copy(from, to).await {
+                Ok(()) => successful_zone_ids.push(zone.zone_id.clone()),
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to copy object '{}' -> '{}' in zone '{}': {err}",
+                        from,
+                        to,
+                        zone.zone_id
+                    );
+                    failed_zone_ids.push(zone.zone_id.clone());
+                }
+            }
+        }
+
+        if failed_zone_ids.is_empty() {
+            return Ok(());
+        }
+
+        self.rollback_copy(to, &successful_zone_ids).await;
+        Err(self.multi_zone_write_error(&failed_zone_ids))
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let mut successful_zone_ids = Vec::new();
+        let mut failed_zone_ids = Vec::new();
+
+        for zone in &self.zones {
+            match zone.store.copy_if_not_exists(from, to).await {
+                Ok(()) => successful_zone_ids.push(zone.zone_id.clone()),
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to copy_if_not_exists '{}' -> '{}' in zone '{}': {err}",
+                        from,
+                        to,
+                        zone.zone_id
+                    );
+                    failed_zone_ids.push(zone.zone_id.clone());
+                }
+            }
+        }
+
+        if failed_zone_ids.is_empty() {
+            return Ok(());
+        }
+
+        self.rollback_copy(to, &successful_zone_ids).await;
+        Err(self.multi_zone_write_error(&failed_zone_ids))
+    }
+}
+
+#[derive(Debug)]
+struct ZoneMultipartUpload {
+    zone_id: String,
+    store: Arc<dyn ObjectStore>,
+    upload: Box<dyn MultipartUpload>,
+}
+
+#[derive(Debug)]
+struct MultiZoneMultipartUpload {
+    location: Path,
+    total_zones: usize,
+    uploads: Vec<ZoneMultipartUpload>,
+}
+
+#[async_trait::async_trait]
+impl MultipartUpload for MultiZoneMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
+        let mut part_futures = Vec::with_capacity(self.uploads.len());
+        for zone_upload in &mut self.uploads {
+            part_futures.push((zone_upload.zone_id.clone(), zone_upload.upload.put_part(data.clone())));
+        }
+
+        Box::pin(async move {
+            let results = join_all(part_futures.into_iter().map(|(zone_id, fut)| async move {
+                (zone_id, fut.await)
+            }))
+            .await;
+
+            for (zone_id, result) in results {
+                if let Err(err) = result {
+                    tracing::warn!("Failed multipart part upload in zone '{zone_id}': {err}");
+                    return Err(err);
+                }
+            }
+            Ok(())
+        })
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        let mut first_success: Option<PutResult> = None;
+        let mut successful_zone_ids = Vec::new();
+        let mut failed_zone_ids = Vec::new();
+
+        for zone_upload in &mut self.uploads {
+            match zone_upload.upload.complete().await {
+                Ok(put_result) => {
+                    if first_success.is_none() {
+                        first_success = Some(put_result);
+                    }
+                    successful_zone_ids.push(zone_upload.zone_id.clone());
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed multipart completion in zone '{}': {err}",
+                        zone_upload.zone_id
+                    );
+                    failed_zone_ids.push(zone_upload.zone_id.clone());
+                    let _ = zone_upload.upload.abort().await;
+                }
+            }
+        }
+
+        if failed_zone_ids.is_empty() {
+            return first_success.ok_or_else(|| object_store::Error::Generic {
+                store: MULTI_ZONE_STORE_NAME,
+                source: "No successful multi-zone multipart completion result".into(),
+            });
+        }
+
+        let successful_set: HashSet<&str> = successful_zone_ids
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+        let rollback_targets: Vec<(String, Arc<dyn ObjectStore>)> = self
+            .uploads
+            .iter()
+            .filter(|zone_upload| successful_set.contains(zone_upload.zone_id.as_str()))
+            .map(|zone_upload| (zone_upload.zone_id.clone(), Arc::clone(&zone_upload.store)))
+            .collect();
+
+        for (zone_id, store) in rollback_targets {
+            if let Err(err) = store.delete(&self.location).await {
+                tracing::warn!(
+                    "{}",
+                    Error::MultiZoneRollbackFailed {
+                        zone: zone_id,
+                        reason: err.to_string(),
+                    }
+                );
+            }
+        }
+
+        Err(object_store::Error::Generic {
+            store: MULTI_ZONE_STORE_NAME,
+            source: Box::new(Error::MultiZoneWriteFailed {
+                failed_count: failed_zone_ids.len(),
+                total_zones: self.total_zones,
+                failed_zones: failed_zone_ids.join(", "),
+            }),
+        })
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        let mut first_error: Option<object_store::Error> = None;
+        for zone_upload in &mut self.uploads {
+            if let Err(err) = zone_upload.upload.abort().await {
+                tracing::warn!(
+                    "Failed multipart abort in zone '{}': {err}",
+                    zone_upload.zone_id
+                );
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        Ok(())
+    }
+}
 
 pub(crate) const S3_PARAMS_LEN: usize = 10;
 pub(crate) const S3_PARAMETERS: [ParameterSpec; S3_PARAMS_LEN] = [
@@ -729,38 +1182,20 @@ pub fn derive_region_from_zone(zone_id: &str) -> Option<String> {
     Some(region.to_string())
 }
 
-/// Build an S3 object store for S3 Express One Zone storage.
-///
-/// Returns `None` if the path is not an S3 path, or an error if S3 configuration is invalid.
-pub async fn build_s3_object_store(
-    source: &dyn AccelerationSource,
-    data_path: String,
-) -> Result<Option<cayenne::metadata::ObjectStoreConfig>> {
-    // Check if this is S3 Express One Zone storage
-    if !is_s3_express_data_path(source) {
-        return Ok(None);
-    }
+#[derive(Debug, Clone)]
+struct ResolvedS3Params {
+    s3_region: Option<String>,
+    s3_endpoint: Option<String>,
+    s3_key: Option<String>,
+    s3_secret: Option<String>,
+    s3_session_token: Option<String>,
+    s3_auth: String,
+    s3_client_timeout: Option<String>,
+    s3_allow_http: bool,
+    s3_unsigned_payload: bool,
+}
 
-    if !is_s3_express_path(&data_path) {
-        return Ok(None);
-    }
-
-    tracing::debug!(
-        "Building S3 Express One Zone object store for path: {}",
-        data_path
-    );
-
-    // Parse the S3 URL
-    let url = Url::parse(&data_path).boxed().context(InvalidS3UrlSnafu {
-        url: data_path.clone(),
-    })?;
-
-    // Get bucket name from URL
-    let bucket_name = get_bucket_name(&url).boxed().context(InvalidS3UrlSnafu {
-        url: data_path.clone(),
-    })?;
-
-    // Get params with secrets resolved
+async fn resolve_s3_params(source: &dyn AccelerationSource) -> ResolvedS3Params {
     let raw_params = source
         .acceleration()
         .map(|a| a.params.clone())
@@ -768,7 +1203,6 @@ pub async fn build_s3_object_store(
     let secrets = source.runtime().secrets();
     let params = get_params_with_secrets(secrets, &raw_params).await;
 
-    // Helper to get param value with secret exposed
     let get_param =
         |key: &str| -> Option<String> { params.get(key).map(|v| v.expose_secret().to_string()) };
 
@@ -781,87 +1215,88 @@ pub async fn build_s3_object_store(
     let s3_client_timeout = get_param("cayenne_s3_client_timeout");
     let s3_allow_http =
         get_param("cayenne_s3_allow_http").is_some_and(|v| v.eq_ignore_ascii_case("true"));
-    // Default to unsigned payload (true) for better performance; can be disabled if needed
     let s3_unsigned_payload =
         get_param("cayenne_s3_unsigned_payload").is_none_or(|v| !v.eq_ignore_ascii_case("false"));
 
-    // Extract zone ID from bucket name for S3 Express One Zone endpoint
-    let zone_id = extract_zone_id_from_bucket(bucket_name);
+    ResolvedS3Params {
+        s3_region,
+        s3_endpoint,
+        s3_key,
+        s3_secret,
+        s3_session_token,
+        s3_auth,
+        s3_client_timeout,
+        s3_allow_http,
+        s3_unsigned_payload,
+    }
+}
 
-    // Derive region from zone_id if not explicitly provided
-    let derived_region = zone_id.and_then(derive_region_from_zone);
+async fn build_single_s3_store_for_path(
+    data_path: &str,
+    params: &ResolvedS3Params,
+) -> Result<(Url, Arc<dyn ObjectStore>, String)> {
+    let url = Url::parse(data_path).boxed().context(InvalidS3UrlSnafu {
+        url: data_path.to_string(),
+    })?;
 
-    // Use explicit region if provided, otherwise use derived region. If neither is available, fail fast.
-    let effective_region = s3_region
-        .or(derived_region)
+    let bucket_name = get_bucket_name(&url).boxed().context(InvalidS3UrlSnafu {
+        url: data_path.to_string(),
+    })?;
+
+    let zone_id = extract_zone_id_from_bucket(bucket_name)
+        .ok_or_else(|| Error::InvalidConfiguration {
+            detail: Arc::from(format!(
+                "S3 Express bucket name '{bucket_name}' does not contain a valid zone ID"
+            )),
+        })?
+        .to_string();
+
+    let effective_region = params
+        .s3_region
+        .clone()
+        .or_else(|| derive_region_from_zone(&zone_id))
         .ok_or_else(|| Error::InvalidConfiguration {
             detail: Arc::from(
                 "Cannot determine AWS region for S3 Express One Zone. Specify 'cayenne_s3_region' or use an S3 Express bucket name that encodes the zone (bucket--<zone>--x-s3).",
             ),
         })?;
 
-    // Build the S3 object store
     let io_runtime = tokio::runtime::Handle::current();
     let mut s3_builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket_name)
         .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
-        .with_allow_http(s3_allow_http)
+        .with_allow_http(params.s3_allow_http)
         .with_region(effective_region.clone());
 
-    // Configure longer retry timeout for S3 Express uploads from outside AWS
-    // S3 Express One Zone is optimized for same-AZ access; from outside AWS,
-    // uploads can be slow and need more time to complete.
     let retry_config = RetryConfig {
         max_retries: 3,
-        retry_timeout: std::time::Duration::from_secs(600), // 10 minutes
+        retry_timeout: std::time::Duration::from_secs(600),
         ..Default::default()
     };
     s3_builder = s3_builder.with_retry(retry_config);
 
-    let mut client_options = ClientOptions::default();
+    let mut client_options = ClientOptions::default()
+        .with_timeout(std::time::Duration::from_secs(120));
 
-    // Set default timeout for S3 Express One Zone requests.
-    // Can be overridden via cayenne_s3_client_timeout parameter.
-    let default_timeout = std::time::Duration::from_secs(120); // 2 minutes per request
-    client_options = client_options.with_timeout(default_timeout);
+    s3_builder = s3_builder
+        .with_s3_express(true)
+        .with_virtual_hosted_style_request(true)
+        .with_unsigned_payload(params.s3_unsigned_payload);
 
-    // For S3 Express One Zone buckets, enable special handling:
-    // - with_s3_express(true) enables CreateSession API for session tokens
-    // - with_virtual_hosted_style_request(true) uses {bucket}.endpoint format
-    // - with_unsigned_payload(s3_unsigned_payload) optionally skips SHA-256 computation for request body
-    //   (S3 Express One Zone uses session-based auth, making payload signing unnecessary)
-    // - Endpoint format with virtual-hosted-style: https://{bucket}.s3express-{zone-id}.{region}.amazonaws.com
-    if let Some(zid) = zone_id {
-        tracing::debug!(
-            "Detected S3 Express One Zone bucket (zone: {}), enabling S3 Express mode (unsigned_payload: {})",
-            zid,
-            s3_unsigned_payload
-        );
-        s3_builder = s3_builder
-            .with_s3_express(true)
-            .with_virtual_hosted_style_request(true)
-            .with_unsigned_payload(s3_unsigned_payload);
-
-        // For S3 Express with virtual-hosted-style, the endpoint should include the bucket name
-        // Format: https://{bucket}.s3express-{zone-id}.{region}.amazonaws.com
-        if s3_endpoint.is_none() {
-            let express_endpoint =
-                format!("https://{bucket_name}.s3express-{zid}.{effective_region}.amazonaws.com");
-            tracing::debug!("Using S3 Express One Zone endpoint: {express_endpoint}");
-            s3_builder = s3_builder.with_endpoint(&express_endpoint);
-        }
+    if params.s3_endpoint.is_none() {
+        let express_endpoint =
+            format!("https://{bucket_name}.s3express-{zone_id}.{effective_region}.amazonaws.com");
+        s3_builder = s3_builder.with_endpoint(&express_endpoint);
     }
 
-    // Apply explicit endpoint if provided (overrides auto-generated)
-    if let Some(ref endpoint) = s3_endpoint {
-        tracing::debug!("Using explicit S3 endpoint: {}", endpoint);
+    if let Some(endpoint) = &params.s3_endpoint {
         s3_builder = s3_builder.with_endpoint(endpoint);
         if endpoint.starts_with("http://") {
             client_options = client_options.with_allow_http(true);
         }
     }
 
-    if let Some(ref timeout) = s3_client_timeout {
+    if let Some(timeout) = &params.s3_client_timeout {
         client_options = client_options.with_timeout(
             fundu::parse_duration(timeout)
                 .boxed()
@@ -870,13 +1305,11 @@ pub async fn build_s3_object_store(
     }
 
     let mut load_credentials_from_environment = true;
-
-    // Handle explicit key/secret credentials
-    if s3_auth == "key" {
-        if let (Some(key), Some(secret)) = (s3_key, s3_secret) {
+    if params.s3_auth == "key" {
+        if let (Some(key), Some(secret)) = (params.s3_key.clone(), params.s3_secret.clone()) {
             s3_builder = s3_builder.with_access_key_id(key);
             s3_builder = s3_builder.with_secret_access_key(secret);
-            if let Some(token) = s3_session_token {
+            if let Some(token) = params.s3_session_token.clone() {
                 s3_builder = s3_builder.with_token(token);
             }
             load_credentials_from_environment = false;
@@ -891,13 +1324,10 @@ pub async fn build_s3_object_store(
 
     s3_builder = s3_builder.with_client_options(client_options);
 
-    // Load credentials from environment if not using explicit keys
     if load_credentials_from_environment {
-        tracing::debug!("Loading S3 credentials from environment for Cayenne");
         match aws_sdk_credential_bridge::get_or_init_sdk_config().await {
             Ok(Some(sdk_config)) => {
                 if sdk_config.credentials_provider().is_some() {
-                    tracing::debug!("Using S3 credentials provider from SDK config");
                     s3_builder = s3_builder.with_credentials(Arc::new(
                         S3CredentialProvider::from_config(sdk_config.as_ref())
                             .boxed()
@@ -921,15 +1351,79 @@ pub async fn build_s3_object_store(
         .boxed()
         .context(ObjectStoreCreationSnafu)?;
 
+    Ok((url, Arc::new(store), zone_id))
+}
+
+/// Build an S3 object store for S3 Express One Zone storage.
+///
+/// Returns `None` if the path is not an S3 path, or an error if S3 configuration is invalid.
+pub async fn build_s3_object_store(
+    source: &dyn AccelerationSource,
+    data_path: String,
+) -> Result<Option<cayenne::metadata::ObjectStoreConfig>> {
+    // Check if this is S3 Express One Zone storage
+    if !is_s3_express_data_path(source) {
+        return Ok(None);
+    }
+
+    if !is_s3_express_path(&data_path) {
+        return Ok(None);
+    }
+
+    tracing::debug!(
+        "Building S3 Express One Zone object store for path: {}",
+        data_path
+    );
+
+    let resolved = resolve_s3_params(source).await;
+
+    let zone_ids = get_s3_zone_ids(source);
+    if zone_ids.len() > 1 {
+        let dataset_name = source.name().to_string().replace(['.', '/'], "_");
+        let app_name = source.app().name.clone();
+
+        let mut zone_stores = Vec::with_capacity(zone_ids.len());
+        let mut primary_url: Option<Url> = None;
+
+        for zone_id in &zone_ids {
+            let bucket_name = generate_bucket_name(&app_name, &dataset_name, zone_id)?;
+            let zone_data_path = format!("s3://{bucket_name}/{dataset_name}/");
+            let (url, store, resolved_zone_id) =
+                build_single_s3_store_for_path(&zone_data_path, &resolved).await?;
+
+            if primary_url.is_none() {
+                primary_url = Some(url.clone());
+            }
+
+            zone_stores.push(ZoneStore {
+                zone_id: resolved_zone_id,
+                store,
+            });
+        }
+
+        let primary_url = primary_url.ok_or_else(|| Error::InvalidConfiguration {
+            detail: Arc::from("Failed to determine primary S3 Express URL for multi-zone setup"),
+        })?;
+
+        tracing::info!(
+            "Configured multi-zone S3 Express object store with {} zone(s)",
+            zone_stores.len()
+        );
+
+        return Ok(Some(cayenne::metadata::ObjectStoreConfig {
+            url: primary_url,
+            store: Arc::new(MultiZoneS3ExpressStore::new(zone_stores)),
+        }));
+    }
+
+    let (url, store, _) = build_single_s3_store_for_path(&data_path, &resolved).await?;
+
     tracing::info!(
         "S3 Express One Zone object store configured for data path: {}",
         data_path
     );
 
-    Ok(Some(cayenne::metadata::ObjectStoreConfig {
-        url,
-        store: Arc::new(store),
-    }))
+    Ok(Some(cayenne::metadata::ObjectStoreConfig { url, store }))
 }
 
 /// Returns true if the provided error or any of its sources indicates an authentication failure.
@@ -968,6 +1462,83 @@ pub fn is_auth_error(error: &(dyn std::error::Error + 'static)) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use futures::stream::BoxStream;
+    use object_store::{Error as ObjectStoreError, ListResult};
+    use object_store::{PutMultipartOptions, PutOptions, PutPayload, PutResult};
+    use object_store::{memory::InMemory, path::Path};
+
+    #[derive(Debug)]
+    struct FailingPutStore {
+        inner: Arc<InMemory>,
+    }
+
+    impl Display for FailingPutStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingPutStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for FailingPutStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            _payload: PutPayload,
+            _opts: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            Err(ObjectStoreError::Generic {
+                store: "FailingPutStore",
+                source: format!("forced put failure for {location}").into(),
+            })
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            _location: &Path,
+            _opts: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            Err(ObjectStoreError::NotSupported {
+                source: "multipart not supported in FailingPutStore test double".into(),
+            })
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn delete(&self, location: &Path) -> object_store::Result<()> {
+            self.inner.delete(location).await
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+            self.inner.copy(from, to).await
+        }
+
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+            self.inner.copy_if_not_exists(from, to).await
+        }
+    }
 
     #[test]
     fn test_is_s3_express_path() {
@@ -1152,5 +1723,82 @@ mod tests {
         // Unknown zone format
         assert_eq!(derive_region_from_zone("unknown-az1"), None);
         assert_eq!(derive_region_from_zone("invalid"), None);
+    }
+
+    #[tokio::test]
+    async fn test_multi_zone_put_rolls_back_on_partial_failure() {
+        let healthy_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let failing_store = Arc::new(FailingPutStore {
+            inner: Arc::new(InMemory::new()),
+        }) as Arc<dyn ObjectStore>;
+
+        let multi_zone_store = MultiZoneS3ExpressStore::new(vec![
+            ZoneStore {
+                zone_id: "use1-az1".to_string(),
+                store: Arc::clone(&healthy_store),
+            },
+            ZoneStore {
+                zone_id: "use1-az2".to_string(),
+                store: failing_store,
+            },
+        ]);
+
+        let location = Path::from("table/snapshot/data.vtx");
+        let write_result = multi_zone_store
+            .put_opts(&location, PutPayload::from("test-data".to_string()), PutOptions::default())
+            .await;
+        assert!(write_result.is_err(), "multi-zone write should fail");
+
+        let head_result = healthy_store.head(&location).await;
+        assert!(
+            matches!(head_result, Err(ObjectStoreError::NotFound { .. })),
+            "successful zone should be rolled back when any replica write fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_striped_read_with_cross_zone_fallback() {
+        let zone_a = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let zone_b = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+
+        let multi_zone_store = MultiZoneS3ExpressStore::new(vec![
+            ZoneStore {
+                zone_id: "usw2-az1".to_string(),
+                store: Arc::clone(&zone_a),
+            },
+            ZoneStore {
+                zone_id: "usw2-az2".to_string(),
+                store: Arc::clone(&zone_b),
+            },
+        ]);
+
+        let location = Path::from("table/snapshot/striped-key.vtx");
+        let preferred_idx = multi_zone_store.striped_read_order(&location)[0];
+        let fallback_idx = if preferred_idx == 0 { 1 } else { 0 };
+
+        let fallback_store = if fallback_idx == 0 {
+            Arc::clone(&zone_a)
+        } else {
+            Arc::clone(&zone_b)
+        };
+
+        fallback_store
+            .put_opts(
+                &location,
+                PutPayload::from("fallback-zone-data".to_string()),
+                PutOptions::default(),
+            )
+            .await
+            .expect("fallback zone write should succeed");
+
+        let bytes: Bytes = multi_zone_store
+            .get_opts(&location, GetOptions::default())
+            .await
+            .expect("read should succeed via cross-zone fallback")
+            .bytes()
+            .await
+            .expect("read bytes should succeed");
+
+        assert_eq!(bytes.as_ref(), b"fallback-zone-data");
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -470,22 +470,46 @@ impl ObjectStore for MultiZoneS3ExpressStore {
     }
 
     async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        let mut all_not_found = true;
+        let mut last_not_found: Option<object_store::Error> = None;
         let mut failed_zone_details = Vec::new();
         for zone in &self.zones {
-            if let Err(err) = zone.store.delete(location).await {
-                tracing::warn!(
-                    "Failed to delete object '{}' from zone '{}': {err}",
-                    location,
-                    zone.zone_id
-                );
-                failed_zone_details.push(format!("{}: {err}", zone.zone_id));
+            match zone.store.delete(location).await {
+                Ok(()) => {
+                    // At least one zone confirmed the delete.
+                    all_not_found = false;
+                }
+                Err(err) => match err {
+                    object_store::Error::NotFound { .. } => {
+                        tracing::debug!(
+                            "Object '{}' not found in zone '{}' during delete: {err}",
+                            location,
+                            zone.zone_id
+                        );
+                        last_not_found = Some(err);
+                    }
+                    _ => {
+                        tracing::warn!(
+                            "Failed to delete object '{}' from zone '{}': {err}",
+                            location,
+                            zone.zone_id
+                        );
+                        failed_zone_details.push(format!("{}: {err}", zone.zone_id));
+                        all_not_found = false;
+                    }
+                },
             }
         }
 
-        if failed_zone_details.is_empty() {
-            Ok(())
-        } else {
+        if !failed_zone_details.is_empty() {
             Err(self.multi_zone_delete_error(&failed_zone_details))
+        } else if all_not_found {
+            Err(last_not_found.unwrap_or_else(|| object_store::Error::NotFound {
+                path: location.to_string(),
+                source: "No configured S3 zones".into(),
+            }))
+        } else {
+            Ok(())
         }
     }
 
@@ -631,7 +655,7 @@ impl MultipartUpload for MultiZoneMultipartUpload {
     async fn complete(&mut self) -> object_store::Result<PutResult> {
         let mut first_success: Option<PutResult> = None;
         let mut successful_zone_ids = Vec::new();
-        let mut failed_zone_ids = Vec::new();
+        let mut failed_zone_details = Vec::new();
 
         for zone_upload in &mut self.uploads {
             match zone_upload.upload.complete().await {
@@ -646,13 +670,13 @@ impl MultipartUpload for MultiZoneMultipartUpload {
                         "Failed multipart completion in zone '{}': {err}",
                         zone_upload.zone_id
                     );
-                    failed_zone_ids.push(zone_upload.zone_id.clone());
+                    failed_zone_details.push(format!("{}: {err}", zone_upload.zone_id));
                     let _ = zone_upload.upload.abort().await;
                 }
             }
         }
 
-        if failed_zone_ids.is_empty() {
+        if failed_zone_details.is_empty() {
             return first_success.ok_or_else(|| object_store::Error::Generic {
                 store: MULTI_ZONE_STORE_NAME,
                 source: "No successful multi-zone multipart completion result".into(),
@@ -685,9 +709,9 @@ impl MultipartUpload for MultiZoneMultipartUpload {
         Err(object_store::Error::Generic {
             store: MULTI_ZONE_STORE_NAME,
             source: Box::new(Error::MultiZoneWriteFailed {
-                failed_count: failed_zone_ids.len(),
+                failed_count: failed_zone_details.len(),
                 total_zones: self.total_zones,
-                failed_zones: failed_zone_ids.join(", "),
+                failed_zones: failed_zone_details.join(", "),
             }),
         })
     }

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -479,16 +479,15 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                     // At least one zone confirmed the delete.
                     all_not_found = false;
                 }
-                Err(err) => match err {
-                    object_store::Error::NotFound { .. } => {
+                Err(err) => {
+                    if let object_store::Error::NotFound { .. } = err {
                         tracing::debug!(
                             "Object '{}' not found in zone '{}' during delete: {err}",
                             location,
                             zone.zone_id
                         );
                         last_not_found = Some(err);
-                    }
-                    _ => {
+                    } else {
                         tracing::warn!(
                             "Failed to delete object '{}' from zone '{}': {err}",
                             location,
@@ -497,17 +496,19 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                         failed_zone_details.push(format!("{}: {err}", zone.zone_id));
                         all_not_found = false;
                     }
-                },
+                }
             }
         }
 
         if !failed_zone_details.is_empty() {
             Err(self.multi_zone_delete_error(&failed_zone_details))
         } else if all_not_found {
-            Err(last_not_found.unwrap_or_else(|| object_store::Error::NotFound {
-                path: location.to_string(),
-                source: "No configured S3 zones".into(),
-            }))
+            Err(
+                last_not_found.unwrap_or_else(|| object_store::Error::NotFound {
+                    path: location.to_string(),
+                    source: "No configured S3 zones".into(),
+                }),
+            )
         } else {
             Ok(())
         }

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -118,6 +118,15 @@ impl MultiZoneS3ExpressStore {
         self.zones.len()
     }
 
+    /// Returns a deterministic read order for the given object path, distributing
+    /// primary reads across zones by hashing the path.
+    ///
+    /// **Design tradeoff**: `list()` always reads from zone 0 while `get()`/`head()`
+    /// stripe across zones via this method. This is acceptable because writes are
+    /// replicated atomically to all zones, so every zone holds the same object set.
+    /// If a primary zone is temporarily unavailable, get/head falls back to the next
+    /// zone in the order. An inconsistency would only arise from external out-of-band
+    /// mutations, which are outside the supported contract.
     fn striped_read_order(&self, location: &Path) -> Vec<usize> {
         if self.zones.is_empty() {
             return Vec::new();
@@ -232,7 +241,10 @@ impl ObjectStore for MultiZoneS3ExpressStore {
                     }
                     successful_zone_ids.push(zone_id);
                 }
-                Err(_) => failed_zone_ids.push(zone_id),
+                Err(err) => {
+                    tracing::warn!("Multi-zone put failed for zone '{zone_id}': {err}");
+                    failed_zone_ids.push(zone_id);
+                }
             }
         }
 
@@ -254,15 +266,28 @@ impl ObjectStore for MultiZoneS3ExpressStore {
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
         let mut uploads: Vec<ZoneMultipartUpload> = Vec::with_capacity(self.zones.len());
         for zone in &self.zones {
-            let upload = zone
-                .store
-                .put_multipart_opts(location, opts.clone())
-                .await?;
-            uploads.push(ZoneMultipartUpload {
-                zone_id: zone.zone_id.clone(),
-                store: Arc::clone(&zone.store),
-                upload,
-            });
+            match zone.store.put_multipart_opts(location, opts.clone()).await {
+                Ok(upload) => {
+                    uploads.push(ZoneMultipartUpload {
+                        zone_id: zone.zone_id.clone(),
+                        store: Arc::clone(&zone.store),
+                        upload,
+                    });
+                }
+                Err(err) => {
+                    // Abort any already-started uploads to avoid leaked multipart state.
+                    for mut started in uploads {
+                        if let Err(abort_err) = started.upload.abort().await {
+                            tracing::warn!(
+                                "Failed to abort multipart upload for zone '{}' after zone '{}' init failure: {abort_err}",
+                                started.zone_id,
+                                zone.zone_id,
+                            );
+                        }
+                    }
+                    return Err(err);
+                }
+            }
         }
 
         Ok(Box::new(MultiZoneMultipartUpload {
@@ -628,16 +653,18 @@ pub fn is_multi_zone_s3_express(source: &dyn AccelerationSource) -> bool {
 /// Returns the list of zone IDs for S3 Express One Zone storage.
 ///
 /// Parses the `cayenne_s3_zone_ids` parameter as a comma-separated list of zone IDs.
+/// Normalizes entries (trim + lowercase) and deduplicates, preserving first-seen order.
 /// Returns an empty vector if the parameter is not set.
 pub fn get_s3_zone_ids(source: &dyn AccelerationSource) -> Vec<String> {
     source
         .acceleration()
         .and_then(|a| a.params.get("cayenne_s3_zone_ids"))
         .map(|zone_ids| {
+            let mut seen = HashSet::new();
             zone_ids
                 .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
+                .map(|s| s.trim().to_lowercase())
+                .filter(|s| !s.is_empty() && seen.insert(s.clone()))
                 .collect()
         })
         .unwrap_or_default()

--- a/crates/runtime/src/dataaccelerator/cayenne/s3.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/s3.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_bucket_name};
 use futures::StreamExt;
 use futures::future::join_all;
+use futures::stream::BoxStream;
 use object_store::{
     ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, RetryConfig, aws::AmazonS3Builder,
@@ -118,6 +119,20 @@ struct MultiZoneS3ExpressStore {
     zones: Vec<ZoneStore>,
 }
 
+#[derive(Clone)]
+enum ListMode {
+    Prefix(Option<Path>),
+    Offset { prefix: Option<Path>, offset: Path },
+}
+
+struct ListFallbackState {
+    zones: Vec<ZoneStore>,
+    mode: ListMode,
+    current_zone_idx: usize,
+    current_stream: Option<BoxStream<'static, object_store::Result<ObjectMeta>>>,
+    emitted_from_current: bool,
+}
+
 impl MultiZoneS3ExpressStore {
     fn new(zones: Vec<ZoneStore>) -> Self {
         Self { zones }
@@ -210,6 +225,87 @@ impl MultiZoneS3ExpressStore {
                 );
             }
         }
+    }
+
+    fn build_list_stream_for_zone(
+        zone: &ZoneStore,
+        mode: &ListMode,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        match mode {
+            ListMode::Prefix(prefix) => zone.store.list(prefix.as_ref()),
+            ListMode::Offset { prefix, offset } => {
+                zone.store.list_with_offset(prefix.as_ref(), offset)
+            }
+        }
+    }
+
+    fn list_with_fallback(
+        &self,
+        mode: ListMode,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        if self.zones.is_empty() {
+            let path = match &mode {
+                ListMode::Prefix(prefix) => prefix
+                    .as_ref()
+                    .map_or_else(String::new, std::string::ToString::to_string),
+                ListMode::Offset { offset, .. } => offset.to_string(),
+            };
+            return futures::stream::once(async {
+                Err(object_store::Error::NotFound {
+                    path,
+                    source: "No configured S3 zones".into(),
+                })
+            })
+            .boxed();
+        }
+
+        let initial_state = ListFallbackState {
+            zones: self.zones.clone(),
+            mode,
+            current_zone_idx: 0,
+            current_stream: None,
+            emitted_from_current: false,
+        };
+
+        futures::stream::unfold(initial_state, |mut state| async move {
+            loop {
+                if state.current_stream.is_none() {
+                    if state.current_zone_idx >= state.zones.len() {
+                        return None;
+                    }
+
+                    let zone = state.zones[state.current_zone_idx].clone();
+                    state.current_stream = Some(Self::build_list_stream_for_zone(&zone, &state.mode));
+                    state.emitted_from_current = false;
+                }
+
+                let next_item = {
+                    let Some(stream) = state.current_stream.as_mut() else {
+                        unreachable!("current_stream should be initialized before polling");
+                    };
+                    stream.next().await
+                };
+
+                match next_item {
+                    Some(Ok(meta)) => {
+                        state.emitted_from_current = true;
+                        return Some((Ok(meta), state));
+                    }
+                    Some(Err(err)) if !state.emitted_from_current => {
+                        let zone_id = state.zones[state.current_zone_idx].zone_id.clone();
+                        tracing::debug!(
+                            "S3 Express list stream failed for zone '{}' before yielding rows: {err}",
+                            zone_id
+                        );
+                        state.current_zone_idx += 1;
+                        state.current_stream = None;
+                    }
+                    Some(Err(err)) => return Some((Err(err), state)),
+                    None => return None,
+                }
+            }
+        })
+        .boxed()
     }
 }
 
@@ -386,18 +482,7 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         &self,
         prefix: Option<&Path>,
     ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
-        if self.zones.is_empty() {
-            let path = prefix.map_or_else(String::new, std::string::ToString::to_string);
-            return futures::stream::once(async {
-                Err(object_store::Error::NotFound {
-                    path,
-                    source: "No configured S3 zones".into(),
-                })
-            })
-            .boxed();
-        }
-
-        self.zones[0].store.list(prefix)
+        self.list_with_fallback(ListMode::Prefix(prefix.cloned()))
     }
 
     fn list_with_offset(
@@ -405,18 +490,10 @@ impl ObjectStore for MultiZoneS3ExpressStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
-        if self.zones.is_empty() {
-            let path = offset.to_string();
-            return futures::stream::once(async {
-                Err(object_store::Error::NotFound {
-                    path,
-                    source: "No configured S3 zones".into(),
-                })
-            })
-            .boxed();
-        }
-
-        self.zones[0].store.list_with_offset(prefix, offset)
+        self.list_with_fallback(ListMode::Offset {
+            prefix: prefix.cloned(),
+            offset: offset.clone(),
+        })
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -447,15 +447,25 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
         }
     }
 
-    if zone_pool.len() < 2 {
-        return Err(format!(
-            "At least 2 S3 zone IDs are required for acceleration tests, found {}",
-            zone_pool.len()
-        ));
+    if zone_pool.is_empty() {
+        return Err(
+            "At least 1 S3 zone ID is required for acceleration tests".to_string(),
+        );
+    }
+
+    // Clean stale Cayenne catalog metadata from previous test runs.
+    // The catalog is a local SQLite DB that persists across test invocations.
+    // If a previous run created a table with a different configuration (e.g.
+    // different PK/on_conflict), re-creation will fail with
+    // "already exists with different configuration" unless the old entry is removed.
+    let cayenne_db = std::path::PathBuf::from(".spice/data/metadata/cayenne.db");
+    if cayenne_db.exists() {
+        let _ = std::fs::remove_file(&cayenne_db);
+        tracing::info!("Removed stale Cayenne catalog metadata");
     }
 
     test_request_context().scope(async {
-        for zone_count in [2usize, 3] {
+        for zone_count in [1usize, 2, 3] {
             if zone_pool.len() < zone_count {
                 tracing::info!(
                     "Skipping {zone_count}-zone scenario: only {} zone(s) available",
@@ -467,6 +477,21 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             let scenario_zone_ids = zone_pool[..zone_count].join(",");
             let table_name = format!("taxi_multi_zone_live_{zone_count}z");
             let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
+
+            // Clean stale S3 data from previous test runs for this scenario.
+            // Each zone bucket may contain Vortex files from a prior run whose
+            // metadata no longer matches the current table configuration.
+            for zone_id in &zone_pool[..zone_count] {
+                let bucket_name = generated_zone_bucket_name(&app_name, &table_name, zone_id)?;
+                if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
+                    let prefix = ObjectPath::from(format!("{table_name}/"));
+                    let mut stream = store.list(Some(&prefix));
+                    while let Some(Ok(meta)) = stream.next().await {
+                        let _ = store.delete(&meta.location).await;
+                    }
+                    tracing::info!("Cleaned S3 data for {table_name} in zone {zone_id}");
+                }
+            }
 
             let mut dataset = Dataset::new(
                 "s3://spiceai-public-datasets/taxi_small_samples/taxi_sample.parquet",
@@ -596,14 +621,44 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
                 "Cayenne write mutation validated: appended VendorID={new_vendor_id}, count {baseline_count} → {post_append_count}"
             );
 
-            let scenario_zones = zone_pool[..zone_count].to_vec();
-            validate_s3_replica_integrity_direct(&app_name, &table_name, &region, &scenario_zones)
-                .await?;
+            if zone_count >= 2 {
+                let scenario_zones = zone_pool[..zone_count].to_vec();
+                validate_s3_replica_integrity_direct(&app_name, &table_name, &region, &scenario_zones)
+                    .await?;
 
-            tracing::info!(
-                "Cayenne S3 Express replica consistency validated for {zone_count}-zone scenario ({scenario_zone_ids})"
-            );
+                tracing::info!(
+                    "Cayenne S3 Express replica consistency validated for {zone_count}-zone scenario ({scenario_zone_ids})"
+                );
+            } else {
+                tracing::info!(
+                    "Cayenne S3 Express 1-zone scenario validated (no replica to compare)"
+                );
+            }
         }
+
+        // --- Post-test cleanup: remove S3 data and local metadata ---
+        // Clean up all zone buckets for every scenario that ran so subsequent
+        // test invocations start from a clean slate.
+        for zone_count in 1..=zone_pool.len() {
+            let table_name = format!("taxi_multi_zone_live_{zone_count}z");
+            let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
+            for zone_id in &zone_pool[..zone_count] {
+                if let Ok(bucket_name) = generated_zone_bucket_name(&app_name, &table_name, zone_id) {
+                    if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
+                        let prefix = ObjectPath::from(format!("{table_name}/"));
+                        let mut stream = store.list(Some(&prefix));
+                        while let Some(Ok(meta)) = stream.next().await {
+                            let _ = store.delete(&meta.location).await;
+                        }
+                    }
+                }
+            }
+        }
+        let cayenne_db = std::path::PathBuf::from(".spice/data/metadata/cayenne.db");
+        if cayenne_db.exists() {
+            let _ = std::fs::remove_file(&cayenne_db);
+        }
+        tracing::info!("Post-test cleanup complete: removed S3 data and local Cayenne catalog");
 
         Ok(())
     }).await

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -440,7 +440,9 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
     // "already exists with different configuration" unless the old entry is removed.
     let cayenne_db = std::path::PathBuf::from(".spice/data/metadata/cayenne.db");
     if cayenne_db.exists() {
-        let _ = std::fs::remove_file(&cayenne_db);
+        tokio::fs::remove_file(&cayenne_db)
+            .await
+            .map_err(|e| format!("failed to remove stale Cayenne catalog metadata: {e}"))?;
         tracing::info!("Removed stale Cayenne catalog metadata");
     }
 
@@ -639,7 +641,9 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
         }
         let cayenne_db = std::path::PathBuf::from(".spice/data/metadata/cayenne.db");
         if cayenne_db.exists() {
-            let _ = std::fs::remove_file(&cayenne_db);
+            tokio::fs::remove_file(&cayenne_db)
+                .await
+                .map_err(|e| format!("failed to remove Cayenne catalog metadata: {e}"))?;
         }
         tracing::info!("Post-test cleanup complete: removed S3 data and local Cayenne catalog");
 

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+use aws_sdk_credential_bridge::{S3CredentialProvider, get_or_init_sdk_config};
 use crate::configure_test_datafusion;
 use crate::utils::runtime_ready_check_with_timeout;
 use crate::{
@@ -24,13 +26,296 @@ use crate::{
     utils::{register_test_connectors, test_request_context},
 };
 use app::AppBuilder;
-use futures::TryStreamExt;
-use runtime::Runtime;
-use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
+use datafusion::sql::TableReference;
+use futures::{StreamExt, TryStreamExt};
+use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
+use runtime::dataupdate::{DataUpdate, UpdateType};
+use runtime::{Runtime, accelerated_table::AcceleratedTable};
+use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode};
+use spicepod::component::access::AccessMode;
 use spicepod::component::dataset::Dataset;
 use spicepod::param::Params;
 use spicepod::partitioning::PartitionedBy;
 use test_framework::queries::QuerySet;
+
+/// Append a single row to a Cayenne-accelerated table through the Runtime write path.
+///
+/// This exercises the full Cayenne write pipeline:
+///   `write_data` → `AcceleratedTable::insert_into` → `CayenneTableProvider::insert_into`
+///   → `CayenneDataSink::write_all_append` → `chunk_and_write_parallel_to_snapshot`
+///
+/// The row schema is derived from the existing table schema so that only the
+/// `VendorID` column is explicitly set; all other columns get NULL values.
+async fn append_one_row_via_cayenne_accelerator(
+    rt: &Runtime,
+    table_name: &str,
+    vendor_id: i64,
+) -> Result<(), String> {
+    use arrow::array::{ArrayRef, Int64Array, new_null_array};
+    use arrow::datatypes::DataType;
+
+    let table_ref = TableReference::bare(table_name);
+
+    // Get the table's schema from the runtime catalog
+    let table_provider = rt
+        .datafusion()
+        .get_table(&table_ref)
+        .await
+        .ok_or_else(|| format!("table {table_name} not found in catalog"))?;
+    let schema = table_provider.schema();
+
+    // Build column arrays: VendorID gets the provided value, everything else is NULL.
+    let columns: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if field.name() == "VendorID" {
+                Arc::new(Int64Array::from(vec![vendor_id])) as ArrayRef
+            } else {
+                new_null_array(field.data_type(), 1)
+            }
+        })
+        .collect();
+
+    // Cast VendorID to match exact schema type (source may use non-Int64)
+    let columns: Vec<ArrayRef> = columns
+        .into_iter()
+        .zip(schema.fields())
+        .map(|(col, field)| {
+            if col.data_type() != field.data_type() {
+                arrow::compute::cast(&col, field.data_type())
+                    .unwrap_or_else(|_| new_null_array(field.data_type(), 1))
+            } else {
+                col
+            }
+        })
+        .collect();
+
+    let batch = RecordBatch::try_new(Arc::clone(&schema), columns)
+        .map_err(|e| format!("failed to build RecordBatch for append: {e}"))?;
+
+    let data_update = DataUpdate {
+        schema: Arc::clone(&schema),
+        data: vec![batch],
+        update_type: UpdateType::Append,
+    };
+
+    rt.datafusion()
+        .write_data(&table_ref, data_update)
+        .await
+        .map_err(|e| format!("Cayenne append write_data failed: {e}"))?;
+
+    Ok(())
+}
+
+async fn run_sql(rt: &Runtime, sql: &str) -> Result<Vec<RecordBatch>, String> {
+    let query_result = rt
+        .datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("query failed: {e}"))?;
+
+    query_result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("collect failed: {e}"))
+}
+
+fn first_i64_cell(batches: &[RecordBatch]) -> Result<i64, String> {
+    let first_batch = batches
+        .first()
+        .ok_or_else(|| "query returned no batches".to_string())?;
+
+    if first_batch.num_rows() != 1 {
+        return Err(format!(
+            "expected single-row result, got {} row(s)",
+            first_batch.num_rows()
+        ));
+    }
+
+    let col = first_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .ok_or_else(|| "unexpected result column type, expected Int64".to_string())?;
+    Ok(col.value(0))
+}
+
+fn s3_sanitize_component(input: &str) -> String {
+    input
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn generated_zone_bucket_name(
+    app_name: &str,
+    dataset_name: &str,
+    zone_id: &str,
+) -> Result<String, String> {
+    let sanitized_app = s3_sanitize_component(app_name);
+    let sanitized_dataset = s3_sanitize_component(dataset_name);
+    if sanitized_app.is_empty() || sanitized_dataset.is_empty() {
+        return Err("app or dataset name is empty after S3 sanitization".to_string());
+    }
+
+    let suffix_len = 2_usize.saturating_add(zone_id.len()).saturating_add(6);
+    let required_fixed_len = 6_usize.saturating_add(1).saturating_add(suffix_len);
+    if required_fixed_len >= 63 {
+        return Err(format!(
+            "zone ID '{zone_id}' is too long for S3 directory bucket naming"
+        ));
+    }
+
+    let max_name_len = 63_usize.saturating_sub(required_fixed_len);
+    let base_name = format!("{sanitized_app}-{sanitized_dataset}");
+    let truncated_name = if base_name.len() > max_name_len {
+        base_name[..max_name_len].trim_end_matches('-').to_string()
+    } else {
+        base_name
+    };
+
+    if truncated_name.is_empty() {
+        return Err("bucket name became empty after truncation".to_string());
+    }
+
+    Ok(format!("spice-{truncated_name}--{zone_id}--x-s3"))
+}
+
+async fn build_zone_store(
+    bucket_name: &str,
+    zone_id: &str,
+    region: &str,
+) -> Result<Arc<dyn ObjectStore>, String> {
+    let endpoint = format!(
+        "https://{bucket_name}.s3express-{zone_id}.{region}.amazonaws.com"
+    );
+
+    let mut builder = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket_name)
+        .with_region(region)
+        .with_s3_express(true)
+        .with_virtual_hosted_style_request(true)
+        .with_unsigned_payload(true)
+        .with_endpoint(&endpoint)
+        .with_client_options(ClientOptions::default());
+
+    if let (Ok(key), Ok(secret)) = (
+        std::env::var("AWS_ACCESS_KEY_ID"),
+        std::env::var("AWS_SECRET_ACCESS_KEY"),
+    ) {
+        builder = builder.with_access_key_id(key).with_secret_access_key(secret);
+        if let Ok(token) = std::env::var("AWS_SESSION_TOKEN") {
+            builder = builder.with_token(token);
+        }
+    } else {
+        let config = get_or_init_sdk_config()
+            .await
+            .map_err(|e| format!("failed to initialize AWS credentials: {e}"))?;
+        let Some(config) = config else {
+            return Err(
+                "AWS credentials are required; configure AWS_PROFILE or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
+                    .to_string(),
+            );
+        };
+        let provider = S3CredentialProvider::from_config(config.as_ref())
+            .map_err(|e| format!("failed to create S3 credential provider: {e}"))?;
+        builder = builder.with_credentials(Arc::new(provider));
+    }
+
+    let store = builder
+        .build()
+        .map_err(|e| format!("failed to build S3 object store for {bucket_name}: {e}"))?;
+    Ok(Arc::new(store))
+}
+
+async fn list_objects_under_prefix(
+    store: &Arc<dyn ObjectStore>,
+    prefix: &str,
+) -> Result<BTreeMap<String, u64>, String> {
+    let mut objects = BTreeMap::new();
+    let mut stream = store.list(Some(&ObjectPath::from(prefix.to_string())));
+
+    while let Some(entry) = stream.next().await {
+        let meta = entry.map_err(|e| format!("failed listing '{prefix}': {e}"))?;
+        objects.insert(meta.location.as_ref().to_string(), meta.size);
+    }
+
+    Ok(objects)
+}
+
+// Validation-only helper:
+// This performs direct S3 reads to verify Cayenne's replication side effects.
+// All acceleration operations in the test itself must go through Cayenne via Runtime/DataFusion APIs.
+async fn validate_s3_replica_integrity_direct(
+    app_name: &str,
+    table_name: &str,
+    region: &str,
+    zone_ids: &[String],
+) -> Result<(), String> {
+    if zone_ids.len() < 2 {
+        return Err("replica integrity validation requires at least 2 zone IDs".to_string());
+    }
+
+    let mut zone_stores = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let bucket_name = generated_zone_bucket_name(app_name, table_name, zone_id)?;
+        let store = build_zone_store(&bucket_name, zone_id, region).await?;
+        zone_stores.push((zone_id.clone(), bucket_name, store));
+    }
+
+    let prefix = format!("{table_name}/");
+    let (primary_zone, _primary_bucket, primary_store) = &zone_stores[0];
+    let primary_objects = list_objects_under_prefix(primary_store, &prefix).await?;
+    if primary_objects.is_empty() {
+        return Err(format!(
+            "no objects found in primary zone {primary_zone} under prefix {prefix}"
+        ));
+    }
+
+    for (zone_id, _bucket, store) in zone_stores.iter().skip(1) {
+        let replica_objects = list_objects_under_prefix(store, &prefix).await?;
+        if replica_objects != primary_objects {
+            return Err(format!(
+                "object set mismatch between primary zone {primary_zone} and replica zone {zone_id}"
+            ));
+        }
+
+        for object_path in primary_objects.keys() {
+            let object_path = ObjectPath::from(object_path.clone());
+            let primary_bytes = primary_store
+                .get(&object_path)
+                .await
+                .map_err(|e| format!("failed to fetch primary object {object_path}: {e}"))?
+                .bytes()
+                .await
+                .map_err(|e| format!("failed to read primary object {object_path}: {e}"))?;
+            let replica_bytes = store
+                .get(&object_path)
+                .await
+                .map_err(|e| format!("failed to fetch replica object {object_path}: {e}"))?
+                .bytes()
+                .await
+                .map_err(|e| format!("failed to read replica object {object_path}: {e}"))?;
+
+            if primary_bytes != replica_bytes {
+                return Err(format!(
+                    "content mismatch for object {object_path} between primary zone {primary_zone} and replica zone {zone_id}"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
 
 fn make_s3_tpch_dataset(name: &str, partition_by: Option<String>) -> Dataset {
     let mut dataset = Dataset::new(
@@ -134,4 +419,192 @@ async fn test_cayenne_with_partitioned_tpch() -> Result<(), String> {
             Ok(())
         })
         .await
+}
+
+#[tokio::test]
+#[ignore = "requires AWS credentials for S3 Express One Zone live test"]
+async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    // Keep test input minimal: hardcoded defaults with optional env overrides.
+    // Defaults include two known-good zones. A third zone can be provided via env.
+    let zone_ids = std::env::var("CAYENNE_S3_ZONE_IDS")
+        .unwrap_or_else(|_| "usw2-az1,usw2-az4".to_string());
+    let region = std::env::var("CAYENNE_S3_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+
+    let mut zone_pool: Vec<String> = zone_ids
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    if let Ok(third_zone) = std::env::var("CAYENNE_S3_ZONE_ID_3") {
+        let third_zone = third_zone.trim();
+        if !third_zone.is_empty() && !zone_pool.iter().any(|z| z == third_zone) {
+            zone_pool.push(third_zone.to_string());
+        }
+    }
+
+    if zone_pool.len() < 2 {
+        return Err(format!(
+            "At least 2 S3 zone IDs are required for acceleration tests, found {}",
+            zone_pool.len()
+        ));
+    }
+
+    test_request_context().scope(async {
+        for zone_count in [2usize, 3] {
+            if zone_pool.len() < zone_count {
+                tracing::info!(
+                    "Skipping {zone_count}-zone scenario: only {} zone(s) available",
+                    zone_pool.len()
+                );
+                continue;
+            }
+
+            let scenario_zone_ids = zone_pool[..zone_count].join(",");
+            let table_name = format!("taxi_multi_zone_live_{zone_count}z");
+            let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
+
+            let mut dataset = Dataset::new(
+                "s3://spiceai-public-datasets/taxi_small_samples/taxi_sample.parquet",
+                table_name.clone(),
+            );
+            dataset.access = AccessMode::ReadWrite;
+            dataset.params = Some(Params::from_string_map(
+                vec![
+                    ("file_format".to_string(), "parquet".to_string()),
+                    ("client_timeout".to_string(), "120s".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+
+            let accel_params = Params::from_string_map(
+                vec![
+                    ("cayenne_s3_zone_ids".to_string(), scenario_zone_ids.clone()),
+                    ("cayenne_s3_region".to_string(), region.clone()),
+                ]
+                .into_iter()
+                .collect(),
+            );
+
+            let on_conflict = HashMap::from([(
+                "VendorID".to_string(),
+                OnConflictBehavior::Upsert,
+            )]);
+
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                engine: Some("cayenne".to_string()),
+                mode: Mode::File,
+                refresh_mode: Some(RefreshMode::Full),
+                primary_key: Some("VendorID".to_string()),
+                on_conflict,
+                params: Some(accel_params),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new(app_name.clone())
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(240)) => {
+                    return Err(format!("Timed out waiting for datasets to load for {zone_count}-zone scenario"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(300)).await;
+
+            let table_ref = TableReference::bare(table_name.as_str());
+            if !rt.datafusion().is_accelerated(&table_ref).await {
+                return Err(format!(
+                    "Expected {table_name} to be registered as an accelerated table for {zone_count}-zone scenario"
+                ));
+            }
+
+            let accelerated_provider = rt
+                .datafusion()
+                .get_accelerated_table_provider(&table_name)
+                .await
+                .map_err(|e| format!("failed to resolve accelerated provider: {e}"))?;
+            if accelerated_provider
+                .as_any()
+                .downcast_ref::<AcceleratedTable>()
+                .is_none()
+            {
+                return Err(format!(
+                    "Expected provider for {table_name} to be AcceleratedTable in {zone_count}-zone scenario"
+                ));
+            }
+
+            // Cayenne operation path (not direct S3): query through Runtime/DataFusion
+            // against the accelerated table backed by Cayenne.
+            let baseline_count = first_i64_cell(
+                &run_sql(&rt, &format!("SELECT COUNT(*) AS c FROM {table_name}")).await?,
+            )?;
+
+            if baseline_count <= 0 {
+                return Err(format!(
+                    "Expected accelerated table {table_name} to contain rows before lifecycle ops, got count={baseline_count}"
+                ));
+            }
+
+            // --- Cayenne write mutation: append one row through Cayenne accelerator ---
+            // Uses a VendorID that does NOT exist to avoid upsert deduplication.
+            // The row is written through Runtime/DataFusion → AcceleratedTable → CayenneTableProvider.
+            let new_vendor_id: i64 = 999_999;
+            append_one_row_via_cayenne_accelerator(&rt, &table_name, new_vendor_id).await?;
+
+            // Wait for the SQL results cache to expire (TTL=1s) so the next query
+            // reads fresh data from the Cayenne-accelerated table.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+            // Verify the appended row is visible through Cayenne
+            let post_append_count = first_i64_cell(
+                &run_sql(&rt, &format!("SELECT COUNT(*) AS c FROM {table_name}")).await?,
+            )?;
+            if post_append_count != baseline_count + 1 {
+                return Err(format!(
+                    "Expected {table_name} row count to increase by 1 after append (baseline={baseline_count}), got {post_append_count}"
+                ));
+            }
+
+            // Verify the specific row exists
+            let new_row_count = first_i64_cell(
+                &run_sql(
+                    &rt,
+                    &format!("SELECT COUNT(*) AS c FROM {table_name} WHERE \"VendorID\" = {new_vendor_id}"),
+                )
+                .await?,
+            )?;
+            if new_row_count != 1 {
+                return Err(format!(
+                    "Expected exactly 1 row with VendorID={new_vendor_id} after append, got {new_row_count}"
+                ));
+            }
+
+            tracing::info!(
+                "Cayenne write mutation validated: appended VendorID={new_vendor_id}, count {baseline_count} → {post_append_count}"
+            );
+
+            let scenario_zones = zone_pool[..zone_count].to_vec();
+            validate_s3_replica_integrity_direct(&app_name, &table_name, &region, &scenario_zones)
+                .await?;
+
+            tracing::info!(
+                "Cayenne S3 Express replica consistency validated for {zone_count}-zone scenario ({scenario_zone_ids})"
+            );
+        }
+
+        Ok(())
+    }).await
 }

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -31,6 +31,7 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
 use runtime::dataupdate::{DataUpdate, UpdateType};
 use runtime::{Runtime, accelerated_table::AcceleratedTable};
+use runtime::dataaccelerator::cayenne::s3::generate_bucket_name;
 use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode};
 use spicepod::component::access::AccessMode;
 use spicepod::component::dataset::Dataset;
@@ -52,7 +53,6 @@ async fn append_one_row_via_cayenne_accelerator(
     vendor_id: i64,
 ) -> Result<(), String> {
     use arrow::array::{ArrayRef, Int64Array, new_null_array};
-    use arrow::datatypes::DataType;
 
     let table_ref = TableReference::bare(table_name);
 
@@ -83,13 +83,19 @@ async fn append_one_row_via_cayenne_accelerator(
         .zip(schema.fields())
         .map(|(col, field)| {
             if col.data_type() != field.data_type() {
-                arrow::compute::cast(&col, field.data_type())
-                    .unwrap_or_else(|_| new_null_array(field.data_type(), 1))
+                arrow::compute::cast(&col, field.data_type()).map_err(|e| {
+                    format!(
+                        "failed to cast column '{}' from {:?} to {:?}: {e}",
+                        field.name(),
+                        col.data_type(),
+                        field.data_type()
+                    )
+                })
             } else {
-                col
+                Ok(col)
             }
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let batch = RecordBatch::try_new(Arc::clone(&schema), columns)
         .map_err(|e| format!("failed to build RecordBatch for append: {e}"))?;
@@ -142,52 +148,6 @@ fn first_i64_cell(batches: &[RecordBatch]) -> Result<i64, String> {
         .downcast_ref::<arrow::array::Int64Array>()
         .ok_or_else(|| "unexpected result column type, expected Int64".to_string())?;
     Ok(col.value(0))
-}
-
-fn s3_sanitize_component(input: &str) -> String {
-    input
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .split('-')
-        .filter(|segment| !segment.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
-}
-
-fn generated_zone_bucket_name(
-    app_name: &str,
-    dataset_name: &str,
-    zone_id: &str,
-) -> Result<String, String> {
-    let sanitized_app = s3_sanitize_component(app_name);
-    let sanitized_dataset = s3_sanitize_component(dataset_name);
-    if sanitized_app.is_empty() || sanitized_dataset.is_empty() {
-        return Err("app or dataset name is empty after S3 sanitization".to_string());
-    }
-
-    let suffix_len = 2_usize.saturating_add(zone_id.len()).saturating_add(6);
-    let required_fixed_len = 6_usize.saturating_add(1).saturating_add(suffix_len);
-    if required_fixed_len >= 63 {
-        return Err(format!(
-            "zone ID '{zone_id}' is too long for S3 directory bucket naming"
-        ));
-    }
-
-    let max_name_len = 63_usize.saturating_sub(required_fixed_len);
-    let base_name = format!("{sanitized_app}-{sanitized_dataset}");
-    let truncated_name = if base_name.len() > max_name_len {
-        base_name[..max_name_len].trim_end_matches('-').to_string()
-    } else {
-        base_name
-    };
-
-    if truncated_name.is_empty() {
-        return Err("bucket name became empty after truncation".to_string());
-    }
-
-    Ok(format!("spice-{truncated_name}--{zone_id}--x-s3"))
 }
 
 async fn build_zone_store(
@@ -267,7 +227,8 @@ async fn validate_s3_replica_integrity_direct(
 
     let mut zone_stores = Vec::with_capacity(zone_ids.len());
     for zone_id in zone_ids {
-        let bucket_name = generated_zone_bucket_name(app_name, table_name, zone_id)?;
+        let bucket_name = generate_bucket_name(app_name, table_name, zone_id)
+            .map_err(|e| format!("failed to generate bucket name: {e}"))?;
         let store = build_zone_store(&bucket_name, zone_id, region).await?;
         zone_stores.push((zone_id.clone(), bucket_name, store));
     }
@@ -482,7 +443,8 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             // Each zone bucket may contain Vortex files from a prior run whose
             // metadata no longer matches the current table configuration.
             for zone_id in &zone_pool[..zone_count] {
-                let bucket_name = generated_zone_bucket_name(&app_name, &table_name, zone_id)?;
+                let bucket_name = generate_bucket_name(&app_name, &table_name, zone_id)
+                    .map_err(|e| format!("failed to generate bucket name: {e}"))?;
                 if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
                     let prefix = ObjectPath::from(format!("{table_name}/"));
                     let mut stream = store.list(Some(&prefix));
@@ -643,7 +605,7 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             let table_name = format!("taxi_multi_zone_live_{zone_count}z");
             let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
             for zone_id in &zone_pool[..zone_count] {
-                if let Ok(bucket_name) = generated_zone_bucket_name(&app_name, &table_name, zone_id) {
+                if let Ok(bucket_name) = generate_bucket_name(&app_name, &table_name, zone_id) {
                     if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
                         let prefix = ObjectPath::from(format!("{table_name}/"));
                         let mut stream = store.list(Some(&prefix));

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -18,7 +18,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
-use aws_sdk_credential_bridge::{S3CredentialProvider, get_or_init_sdk_config};
 use crate::configure_test_datafusion;
 use crate::utils::runtime_ready_check_with_timeout;
 use crate::{
@@ -26,12 +25,13 @@ use crate::{
     utils::{register_test_connectors, test_request_context},
 };
 use app::AppBuilder;
+use aws_sdk_credential_bridge::{S3CredentialProvider, get_or_init_sdk_config};
 use datafusion::sql::TableReference;
 use futures::{StreamExt, TryStreamExt};
 use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
+use runtime::dataaccelerator::cayenne::s3::generate_bucket_name;
 use runtime::dataupdate::{DataUpdate, UpdateType};
 use runtime::{Runtime, accelerated_table::AcceleratedTable};
-use runtime::dataaccelerator::cayenne::s3::generate_bucket_name;
 use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode};
 use spicepod::component::access::AccessMode;
 use spicepod::component::dataset::Dataset;
@@ -64,25 +64,20 @@ async fn append_one_row_via_cayenne_accelerator(
         .ok_or_else(|| format!("table {table_name} not found in catalog"))?;
     let schema = table_provider.schema();
 
-    // Build column arrays: VendorID gets the provided value, everything else is NULL.
+    // Build column arrays and cast to the exact schema type when needed.
     let columns: Vec<ArrayRef> = schema
         .fields()
         .iter()
         .map(|field| {
-            if field.name() == "VendorID" {
+            let col = if field.name() == "VendorID" {
                 Arc::new(Int64Array::from(vec![vendor_id])) as ArrayRef
             } else {
                 new_null_array(field.data_type(), 1)
-            }
-        })
-        .collect();
+            };
 
-    // Cast VendorID to match exact schema type (source may use non-Int64)
-    let columns: Vec<ArrayRef> = columns
-        .into_iter()
-        .zip(schema.fields())
-        .map(|(col, field)| {
-            if col.data_type() != field.data_type() {
+            if col.data_type() == field.data_type() {
+                Ok(col)
+            } else {
                 arrow::compute::cast(&col, field.data_type()).map_err(|e| {
                     format!(
                         "failed to cast column '{}' from {:?} to {:?}: {e}",
@@ -91,8 +86,6 @@ async fn append_one_row_via_cayenne_accelerator(
                         field.data_type()
                     )
                 })
-            } else {
-                Ok(col)
             }
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -155,9 +148,7 @@ async fn build_zone_store(
     zone_id: &str,
     region: &str,
 ) -> Result<Arc<dyn ObjectStore>, String> {
-    let endpoint = format!(
-        "https://{bucket_name}.s3express-{zone_id}.{region}.amazonaws.com"
-    );
+    let endpoint = format!("https://{bucket_name}.s3express-{zone_id}.{region}.amazonaws.com");
 
     let mut builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket_name)
@@ -172,7 +163,9 @@ async fn build_zone_store(
         std::env::var("AWS_ACCESS_KEY_ID"),
         std::env::var("AWS_SECRET_ACCESS_KEY"),
     ) {
-        builder = builder.with_access_key_id(key).with_secret_access_key(secret);
+        builder = builder
+            .with_access_key_id(key)
+            .with_secret_access_key(secret);
         if let Ok(token) = std::env::var("AWS_SESSION_TOKEN") {
             builder = builder.with_token(token);
         }
@@ -210,6 +203,39 @@ async fn list_objects_under_prefix(
     }
 
     Ok(objects)
+}
+
+fn normalize_zone_ids(raw_zone_ids: &str) -> Vec<String> {
+    let mut zone_pool: Vec<String> = Vec::new();
+    for raw_zone in raw_zone_ids.split(',') {
+        let normalized = raw_zone.trim().to_ascii_lowercase();
+        if !normalized.is_empty() && !zone_pool.iter().any(|z| z == &normalized) {
+            zone_pool.push(normalized);
+        }
+    }
+    zone_pool
+}
+
+async fn cleanup_s3_table_data(
+    app_name: &str,
+    table_name: &str,
+    region: &str,
+    zone_ids: &[String],
+) {
+    for zone_id in zone_ids {
+        let Ok(bucket_name) = generate_bucket_name(app_name, table_name, zone_id) else {
+            continue;
+        };
+        let Ok(store) = build_zone_store(&bucket_name, zone_id, region).await else {
+            continue;
+        };
+
+        let prefix = ObjectPath::from(format!("{table_name}/"));
+        let mut stream = store.list(Some(&prefix));
+        while let Some(Ok(meta)) = stream.next().await {
+            let _ = store.delete(&meta.location).await;
+        }
+    }
 }
 
 // Validation-only helper:
@@ -390,28 +416,21 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
 
     // Keep test input minimal: hardcoded defaults with optional env overrides.
     // Defaults include two known-good zones. A third zone can be provided via env.
-    let zone_ids = std::env::var("CAYENNE_S3_ZONE_IDS")
-        .unwrap_or_else(|_| "usw2-az1,usw2-az4".to_string());
+    let zone_ids =
+        std::env::var("CAYENNE_S3_ZONE_IDS").unwrap_or_else(|_| "usw2-az1,usw2-az4".to_string());
     let region = std::env::var("CAYENNE_S3_REGION").unwrap_or_else(|_| "us-west-2".to_string());
 
-    let mut zone_pool: Vec<String> = zone_ids
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(std::string::ToString::to_string)
-        .collect();
+    let mut zone_pool = normalize_zone_ids(&zone_ids);
 
     if let Ok(third_zone) = std::env::var("CAYENNE_S3_ZONE_ID_3") {
-        let third_zone = third_zone.trim();
-        if !third_zone.is_empty() && !zone_pool.iter().any(|z| z == third_zone) {
-            zone_pool.push(third_zone.to_string());
+        let normalized = third_zone.trim().to_ascii_lowercase();
+        if !normalized.is_empty() && !zone_pool.iter().any(|z| z == &normalized) {
+            zone_pool.push(normalized);
         }
     }
 
     if zone_pool.is_empty() {
-        return Err(
-            "At least 1 S3 zone ID is required for acceleration tests".to_string(),
-        );
+        return Err("At least 1 S3 zone ID is required for acceleration tests".to_string());
     }
 
     // Clean stale Cayenne catalog metadata from previous test runs.
@@ -439,22 +458,12 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             let table_name = format!("taxi_multi_zone_live_{zone_count}z");
             let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
 
-            // Clean stale S3 data from previous test runs for this scenario.
-            // Each zone bucket may contain Vortex files from a prior run whose
-            // metadata no longer matches the current table configuration.
-            for zone_id in &zone_pool[..zone_count] {
-                let bucket_name = generate_bucket_name(&app_name, &table_name, zone_id)
-                    .map_err(|e| format!("failed to generate bucket name: {e}"))?;
-                if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
-                    let prefix = ObjectPath::from(format!("{table_name}/"));
-                    let mut stream = store.list(Some(&prefix));
-                    while let Some(Ok(meta)) = stream.next().await {
-                        let _ = store.delete(&meta.location).await;
-                    }
-                    tracing::info!("Cleaned S3 data for {table_name} in zone {zone_id}");
-                }
-            }
+            let scenario_zones = zone_pool[..zone_count].to_vec();
 
+            // Clean stale S3 data from previous test runs for this scenario.
+            cleanup_s3_table_data(&app_name, &table_name, &region, &scenario_zones).await;
+
+            let scenario_result: Result<(), String> = async {
             let mut dataset = Dataset::new(
                 "s3://spiceai-public-datasets/taxi_small_samples/taxi_sample.parquet",
                 table_name.clone(),
@@ -546,9 +555,15 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             }
 
             // --- Cayenne write mutation: append one row through Cayenne accelerator ---
-            // Uses a VendorID that does NOT exist to avoid upsert deduplication.
+            // Derive a guaranteed-unique VendorID to avoid upsert deduplication.
             // The row is written through Runtime/DataFusion → AcceleratedTable → CayenneTableProvider.
-            let new_vendor_id: i64 = 999_999;
+            let new_vendor_id: i64 = first_i64_cell(
+                &run_sql(
+                    &rt,
+                    &format!(r#"SELECT COALESCE(MAX("VendorID"), 0) + 1 AS c FROM {table_name}"#),
+                )
+                .await?,
+            )?;
             append_one_row_via_cayenne_accelerator(&rt, &table_name, new_vendor_id).await?;
 
             // Wait for the SQL results cache to expire (TTL=1s) so the next query
@@ -584,7 +599,6 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             );
 
             if zone_count >= 2 {
-                let scenario_zones = zone_pool[..zone_count].to_vec();
                 validate_s3_replica_integrity_direct(&app_name, &table_name, &region, &scenario_zones)
                     .await?;
 
@@ -596,6 +610,13 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
                     "Cayenne S3 Express 1-zone scenario validated (no replica to compare)"
                 );
             }
+
+            Ok(())
+            }
+            .await;
+
+            cleanup_s3_table_data(&app_name, &table_name, &region, &scenario_zones).await;
+            scenario_result?;
         }
 
         // --- Post-test cleanup: remove S3 data and local metadata ---
@@ -605,13 +626,13 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
             let table_name = format!("taxi_multi_zone_live_{zone_count}z");
             let app_name = format!("test_cayenne_s3_express_multi_zone_live_{zone_count}z");
             for zone_id in &zone_pool[..zone_count] {
-                if let Ok(bucket_name) = generate_bucket_name(&app_name, &table_name, zone_id) {
-                    if let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await {
-                        let prefix = ObjectPath::from(format!("{table_name}/"));
-                        let mut stream = store.list(Some(&prefix));
-                        while let Some(Ok(meta)) = stream.next().await {
-                            let _ = store.delete(&meta.location).await;
-                        }
+                if let Ok(bucket_name) = generate_bucket_name(&app_name, &table_name, zone_id)
+                    && let Ok(store) = build_zone_store(&bucket_name, zone_id, &region).await
+                {
+                    let prefix = ObjectPath::from(format!("{table_name}/"));
+                    let mut stream = store.list(Some(&prefix));
+                    while let Some(Ok(meta)) = stream.next().await {
+                        let _ = store.delete(&meta.location).await;
                     }
                 }
             }


### PR DESCRIPTION
- Added functionality to append a single row to a Cayenne-accelerated table via the Runtime write path.
- Introduced helper functions for S3 bucket name generation and object listing.
- Implemented validation of S3 replica integrity by comparing primary and replica zone objects.
- Created a new test case for validating Cayenne's behavior with multiple S3 zones, including data insertion and integrity checks.
- Enhanced error handling and logging for better traceability during test execution.