### PR TITLE
Align Spice.ai connector parameter names across catalog/data connectors

### DIFF
--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -448,7 +448,10 @@ mod tests {
             "test",
             vec![
                 ("spiceai_api_key".to_string(), "api-key".to_string().into()),
-                ("spiceai_token".to_string(), "legacy-token".to_string().into()),
+                (
+                    "spiceai_token".to_string(),
+                    "legacy-token".to_string().into(),
+                ),
             ],
             "spiceai",
             Arc::new(RwLock::new(Secrets::new())),
@@ -466,7 +469,10 @@ mod tests {
     async fn test_api_key_uses_legacy_token_parameter() {
         let params = Parameters::try_new(
             "test",
-            vec![("spiceai_token".to_string(), "legacy-token".to_string().into())],
+            vec![(
+                "spiceai_token".to_string(),
+                "legacy-token".to_string().into(),
+            )],
             "spiceai",
             Arc::new(RwLock::new(Secrets::new())),
             PARAMETERS,

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -122,7 +122,7 @@ impl SpiceCloudPlatformCatalog {
             .expose()
             .unwrap_or_else(|_| "https://data.spiceai.io");
         let mut props = HashMap::new();
-        if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {
+        if let Some(api_key) = self.api_key() {
             props.insert("token".to_string(), api_key.to_string());
         }
 
@@ -197,17 +197,41 @@ impl SpiceCloudPlatformCatalog {
         };
 
         let mut params = HashMap::new();
-        if let ExposedParamLookup::Present(flight_endpoint) =
-            self.params.get("flight_endpoint").expose()
-        {
+        if let Some(flight_endpoint) = self.flight_endpoint() {
             params.insert("spiceai_endpoint".to_string(), flight_endpoint.to_string());
         }
 
-        if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {
+        if let Some(api_key) = self.api_key() {
             params.insert("spiceai_api_key".to_string(), api_key.to_string());
         }
 
         template_dataset.with_params(params)
+    }
+
+    fn flight_endpoint(&self) -> Option<&str> {
+        if let ExposedParamLookup::Present(endpoint) = self.params.get("endpoint").expose() {
+            return Some(endpoint);
+        }
+
+        if let ExposedParamLookup::Present(flight_endpoint) =
+            self.params.get("flight_endpoint").expose()
+        {
+            return Some(flight_endpoint);
+        }
+
+        None
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {
+            return Some(api_key);
+        }
+
+        if let ExposedParamLookup::Present(token) = self.params.get("token").expose() {
+            return Some(token);
+        }
+
+        None
     }
 
     async fn create_data_connector(
@@ -254,6 +278,8 @@ impl SpiceCloudPlatformCatalog {
 
 pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("api_key").secret(),
+    ParameterSpec::component("token").secret(),
+    ParameterSpec::component("endpoint"),
     ParameterSpec::component("flight_endpoint"),
     ParameterSpec::component("http_endpoint"),
 ];
@@ -295,6 +321,11 @@ fn parse_catalog_slug(catalog_slug: &str) -> Result<(String, String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::SecretString;
+    use std::sync::Arc;
+
+    use runtime_secrets::Secrets;
+    use tokio::sync::RwLock;
 
     #[test]
     fn test_parse_catalog_slug_org_and_app() {
@@ -346,5 +377,105 @@ mod tests {
         assert_eq!(org, "MyOrg");
         assert_eq!(app, "MyApp");
         assert_eq!(catalog, "MyCatalog");
+    }
+
+    #[tokio::test]
+    async fn test_flight_endpoint_prefers_endpoint_parameter() {
+        let params = Parameters::try_new(
+            "test",
+            vec![
+                (
+                    "spiceai_endpoint".to_string(),
+                    "grpc://new".to_string().into(),
+                ),
+                (
+                    "spiceai_flight_endpoint".to_string(),
+                    "grpc://legacy".to_string().into(),
+                ),
+            ],
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        let connector = SpiceCloudPlatformCatalog { params };
+
+        assert_eq!(connector.flight_endpoint(), Some("grpc://new"));
+    }
+
+    #[tokio::test]
+    async fn test_flight_endpoint_uses_legacy_flight_endpoint_parameter() {
+        let params = Parameters::try_new(
+            "test",
+            vec![(
+                "spiceai_flight_endpoint".to_string(),
+                "grpc://legacy".to_string().into(),
+            )],
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        let connector = SpiceCloudPlatformCatalog { params };
+
+        assert_eq!(connector.flight_endpoint(), Some("grpc://legacy"));
+    }
+
+    #[tokio::test]
+    async fn test_flight_endpoint_missing_returns_none() {
+        let params = Parameters::try_new(
+            "test",
+            Vec::<(String, SecretString)>::new(),
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        let connector = SpiceCloudPlatformCatalog { params };
+
+        assert_eq!(connector.flight_endpoint(), None);
+    }
+
+    #[tokio::test]
+    async fn test_api_key_prefers_api_key_parameter() {
+        let params = Parameters::try_new(
+            "test",
+            vec![
+                ("spiceai_api_key".to_string(), "api-key".to_string().into()),
+                ("spiceai_token".to_string(), "legacy-token".to_string().into()),
+            ],
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        let connector = SpiceCloudPlatformCatalog { params };
+
+        assert_eq!(connector.api_key(), Some("api-key"));
+    }
+
+    #[tokio::test]
+    async fn test_api_key_uses_legacy_token_parameter() {
+        let params = Parameters::try_new(
+            "test",
+            vec![("spiceai_token".to_string(), "legacy-token".to_string().into())],
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        let connector = SpiceCloudPlatformCatalog { params };
+
+        assert_eq!(connector.api_key(), Some("legacy-token"));
     }
 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -162,6 +162,21 @@ const PARAMETERS: &[ParameterSpec] = &[
 const HEADER_ORG: &str = "spiceai-org";
 const HEADER_APP: &str = "spiceai-app";
 
+fn get_api_key(params: &ConnectorParams) -> Result<secrecy::SecretString> {
+    if let Some(api_key) = params.parameters.get("api_key").ok() {
+        return Ok(api_key.clone());
+    }
+
+    if let Some(token) = params.parameters.get("token").ok() {
+        return Ok(token.clone());
+    }
+
+    MissingRequiredParameterSnafu {
+        parameter: "api_key or token".to_string(),
+    }
+    .fail()
+}
+
 impl DataConnectorFactory for SpiceAIFactory {
     fn as_any(&self) -> &dyn Any {
         self
@@ -187,10 +202,7 @@ impl DataConnectorFactory for SpiceAIFactory {
                 }
             })?;
 
-            let api_key = params
-                .parameters
-                .get("api_key")
-                .ok_or_else(|p| MissingRequiredParameterSnafu { parameter: p.0 }.build())?;
+            let api_key = get_api_key(&params)?;
             let credentials = Credentials::new("", api_key.clone());
 
             let mut flight_client = FlightClient::try_new(url, credentials, None, None)

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -456,6 +456,43 @@ impl CommitChange for SpiceAIChangeCommiter {
 mod tests {
     use super::*;
     use crate::component::dataset::builder::DatasetBuilder;
+    use crate::parameters::Parameters;
+    use runtime_secrets::Secrets;
+    use secrecy::ExposeSecret;
+    use secrecy::SecretString;
+    use tokio::runtime::Handle;
+    use tokio::sync::RwLock;
+
+    async fn make_params(params: Vec<(String, SecretString)>) -> ConnectorParams {
+        let app = app::AppBuilder::new("test").build();
+        let runtime = crate::Runtime::builder().build().await;
+
+        let dataset = DatasetBuilder::try_new("spice.ai/test.table".to_string(), "bar")
+            .expect("failed to create builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::new(runtime))
+            .build()
+            .expect("failed to build dataset");
+
+        let parameters = Parameters::try_new(
+            "test",
+            params,
+            "spiceai",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("parameters should be valid");
+
+        ConnectorParams {
+            parameters,
+            unsupported_type_action: None,
+            component: ConnectorComponent::Dataset(Arc::new(dataset)),
+            app: None,
+            runtime: None,
+            io_runtime: Handle::current(),
+        }
+    }
 
     #[tokio::test]
     async fn test_spice_dataset_path() {
@@ -568,5 +605,44 @@ mod tests {
             let dataset_path = SpiceAI::spice_dataset_path(&dataset).expect("a valid dataset path");
             assert_eq!(dataset_path, expected, "Failed for input: {input}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_prefers_api_key() {
+        let params = make_params(vec![
+            ("spiceai_api_key".to_string(), "api-key".to_string().into()),
+            (
+                "spiceai_token".to_string(),
+                "legacy-token".to_string().into(),
+            ),
+        ])
+        .await;
+
+        let api_key = get_api_key(&params).expect("api key should resolve from api_key");
+        assert_eq!(api_key.expose_secret(), "api-key");
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_uses_legacy_token() {
+        let params = make_params(vec![(
+            "spiceai_token".to_string(),
+            "legacy-token".to_string().into(),
+        )])
+        .await;
+
+        let api_key = get_api_key(&params).expect("api key should resolve from token fallback");
+        assert_eq!(api_key.expose_secret(), "legacy-token");
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_missing_returns_error() {
+        let params = make_params(vec![]).await;
+
+        let error = get_api_key(&params).expect_err("missing credentials should return an error");
+        assert!(matches!(
+            error,
+            Error::MissingRequiredParameter { parameter }
+            if parameter == "api_key or token"
+        ));
     }
 }

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -300,7 +300,7 @@ catalogs:
     from: spice.ai
     params:
       spiceai_api_key: my-api-key
-      # Canonical Flight parameter name for Spice.ai connections.
+      # Canonical Spice.ai endpoint parameter used for Flight connections.
       spiceai_endpoint: https://flight.spiceai.io
       spiceai_http_endpoint: https://api.spiceai.io
 

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -300,7 +300,8 @@ catalogs:
     from: spice.ai
     params:
       spiceai_api_key: my-api-key
-      spiceai_flight_endpoint: https://flight.spiceai.io
+      # Canonical Flight parameter name for Spice.ai connections.
+      spiceai_endpoint: https://flight.spiceai.io
       spiceai_http_endpoint: https://api.spiceai.io
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Align Spice.ai catalog connector endpoint parameter naming with the data connector by supporting endpoint as canonical and flight_endpoint as a legacy fallback.
- Make Spice.ai auth parameter handling consistent across catalog and data connectors by supporting api_key (preferred) and token (legacy alias).
- Add and extend unit tests for endpoint/auth parameter precedence and fallback behavior.
- Normalize spicepod schema fixture examples to canonical spiceai_endpoint naming.

## Validation
- cargo test -p runtime catalogconnector::spice_cloud::tests:: -- --nocapture
- cargo test -p runtime dataconnector::spiceai::tests::test_spice_dataset_path -- --nocapture
- cargo test -p spicepodschema -- --nocapture

Closes #4608
