### PR TITLE
fix: Use Python venv for schema validation in CI

### DIFF
--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -89,7 +89,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          python3 -m pip install --user check-jsonschema
+          python3 -m venv .venv
+          .venv/bin/python -m pip install check-jsonschema
 
           echo "## Schema Validation Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -97,7 +98,7 @@ jobs:
           VALIDATION_FAILED=0
           for file in tools/spicepodschema/tests/*.yaml; do
             filename=$(basename "$file")
-            if python3 -m check_jsonschema --schemafile .schema/spicepod.schema.json "$file" 2>&1; then
+            if .venv/bin/check-jsonschema --schemafile .schema/spicepod.schema.json "$file" 2>&1; then
               echo "✅ \`$filename\` - Valid" >> $GITHUB_STEP_SUMMARY
             else
               echo "❌ \`$filename\` - Invalid" >> $GITHUB_STEP_SUMMARY
@@ -105,7 +106,7 @@ jobs:
               echo "<details><summary>Validation errors</summary>" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
-              python3 -m check_jsonschema --schemafile .schema/spicepod.schema.json "$file" --verbose 2>&1 || true >> $GITHUB_STEP_SUMMARY
+              { .venv/bin/check-jsonschema --schemafile .schema/spicepod.schema.json "$file" --verbose 2>&1 || true; } >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
               echo "</details>" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The self-hosted macOS runner has Python 3.14 via Homebrew, which enforces PEP 668 (externally managed environments). `pip install --user` is blocked, so `check-jsonschema` was never installed and all validations silently failed.

Use a virtual environment instead to install and run `check-jsonschema`.

Fixes the validation step in the [Generate Spicepod JSON schema](https://github.com/spiceai/spiceai/actions/runs/22647095842) workflow.