### PR TITLE
fix: Align CUDA asset names in Dockerfile and install tests with build output

### DIFF
--- a/Dockerfile-cuda-release
+++ b/Dockerfile-cuda-release
@@ -18,7 +18,7 @@ ENV REL_VERSION=${REL_VERSION}
 ENV CUDA_COMPUTE_CAP=${CUDA_COMPUTE_CAP}
 
 RUN set -eux; \
-    asset="spiced_models_cuda_${CUDA_COMPUTE_CAP}_linux_x86_64.tar.gz"; \
+    asset="spiced_cuda_${CUDA_COMPUTE_CAP}_linux_x86_64.tar.gz"; \
     base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${REL_VERSION}/${asset}"; \
     curl -fSLo /tmp/spiced.tar.gz "${base_url}"; \
     tar -C /root -xzf /tmp/spiced.tar.gz; \

--- a/test/scripts/install-scripts-test.sh
+++ b/test/scripts/install-scripts-test.sh
@@ -165,9 +165,9 @@ get_spiced_artifact_name() {
     # Add variant suffix
     if [[ -n "$variant" ]]; then
         if [[ "$variant" == "cuda" ]]; then
-            artifact_name="${artifact_name}_models_cuda_${cuda_version}"
+            artifact_name="${artifact_name}_cuda_${cuda_version}"
         elif [[ "$variant" == "metal" ]]; then
-            artifact_name="${artifact_name}_models_metal"
+            artifact_name="${artifact_name}_metal"
         else
             artifact_name="${artifact_name}_${variant}"
         fi
@@ -199,31 +199,31 @@ test_artifact_name_linux_x86_64_models() {
 test_artifact_name_linux_x86_64_cuda_90() {
     local result
     result=$(get_spiced_artifact_name "linux" "x86_64" "cuda" "90")
-    [[ "$result" == "spiced_models_cuda_90_linux_x86_64.tar.gz" ]]
+    [[ "$result" == "spiced_cuda_90_linux_x86_64.tar.gz" ]]
 }
 
 test_artifact_name_linux_x86_64_cuda_89() {
     local result
     result=$(get_spiced_artifact_name "linux" "x86_64" "cuda" "89")
-    [[ "$result" == "spiced_models_cuda_89_linux_x86_64.tar.gz" ]]
+    [[ "$result" == "spiced_cuda_89_linux_x86_64.tar.gz" ]]
 }
 
 test_artifact_name_linux_x86_64_cuda_87() {
     local result
     result=$(get_spiced_artifact_name "linux" "x86_64" "cuda" "87")
-    [[ "$result" == "spiced_models_cuda_87_linux_x86_64.tar.gz" ]]
+    [[ "$result" == "spiced_cuda_87_linux_x86_64.tar.gz" ]]
 }
 
 test_artifact_name_linux_x86_64_cuda_86() {
     local result
     result=$(get_spiced_artifact_name "linux" "x86_64" "cuda" "86")
-    [[ "$result" == "spiced_models_cuda_86_linux_x86_64.tar.gz" ]]
+    [[ "$result" == "spiced_cuda_86_linux_x86_64.tar.gz" ]]
 }
 
 test_artifact_name_linux_x86_64_cuda_80() {
     local result
     result=$(get_spiced_artifact_name "linux" "x86_64" "cuda" "80")
-    [[ "$result" == "spiced_models_cuda_80_linux_x86_64.tar.gz" ]]
+    [[ "$result" == "spiced_cuda_80_linux_x86_64.tar.gz" ]]
 }
 
 # Test Linux aarch64 artifact names
@@ -255,7 +255,7 @@ test_artifact_name_darwin_aarch64_models() {
 test_artifact_name_darwin_aarch64_metal() {
     local result
     result=$(get_spiced_artifact_name "darwin" "aarch64" "metal")
-    [[ "$result" == "spiced_models_metal_darwin_aarch64.tar.gz" ]]
+    [[ "$result" == "spiced_metal_darwin_aarch64.tar.gz" ]]
 }
 
 # Test Windows artifact names
@@ -318,7 +318,7 @@ test_artifacts_exist_in_latest_release() {
         "spiced_models_linux_x86_64.tar.gz"
         "spiced_models_linux_aarch64.tar.gz"
         "spiced_models_darwin_aarch64.tar.gz"
-        "spiced_models_metal_darwin_aarch64.tar.gz"
+        "spiced_metal_darwin_aarch64.tar.gz"
         "spiced.exe_windows_x86_64.tar.gz"
         "spiced.exe_models_windows_x86_64.tar.gz"
     )


### PR DESCRIPTION
The `build_and_release_cuda` workflow produces assets named `spiced_cuda_<cap>_linux_x86_64.tar.gz`, but `Dockerfile-cuda-release` and `install-scripts-test.sh` still expected the old `spiced_models_cuda_<cap>` naming (with `_models_` infix). This caused the CUDA Docker image build to fail with a 404 when downloading the release binary.

**Changes:**
- `Dockerfile-cuda-release`: `spiced_models_cuda_` → `spiced_cuda_`
- `test/scripts/install-scripts-test.sh`: Update `get_spiced_artifact_name()` and all test assertions to drop the `_models_` infix for CUDA and Metal variants

**Context:** [Failed spiced_docker run](https://github.com/spiceai/spiceai/actions/runs/22699078921/job/65811949933) — the CUDA build step got a 404 because the asset name didn't match what was published to the [v2.0.0-rc.1 release](https://github.com/spiceai/spiceai/releases/tag/v2.0.0-rc.1).