### PR TITLE
Update testoperator dispatch to use release/2.0 branch

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         branch:
           - 'trunk'
-          - 'release/1.11'
+          - 'release/2.0'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
Updates the scheduled testoperator dispatch matrix from `release/1.11` to `release/2.0` so nightly benchmarks run against the current release branch.