### PR TITLE
Fix expect test scripts in  E2E Installation AI test

### DIFF
--- a/test/models/chat_01.exp
+++ b/test/models/chat_01.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 # Runtime response timeout
-set timeout 30:
+set timeout 30
 
 spawn spice chat
 

--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 # Runtime response timeout
-set timeout 30:
+set timeout 30
 
 spawn spice chat
 

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -30,10 +30,10 @@ proc perform_search {search_term expected_term} {
     }
 }
 expect "search>"
-perform_search "Spice runtime error" {1 +[0-9]+ +.* +[0-9]+\.[0-9]+ +spice\.public\.issues}
+perform_search "Spice runtime error" {1 +\S+ +.* +[0-9]+\.[0-9]+ +spice\.public\.issues}
 
 expect "search>"
-perform_search "friends" {1 +[0-9]+ +.* +[0-9]+\.[0-9]+ +spice\.public\.catalog_page}
+perform_search "friends" {1 +\S+ +.* +[0-9]+\.[0-9]+ +spice\.public\.catalog_page}
 
 # Signal to exit (Ctrl+C)
 send \x03


### PR DESCRIPTION
## 📝 Summary

Fix failing E2E expect test scripts:

- `search_01.exp`: Update Key column regex from `[0-9]+` to `\S+` to match quoted string IDs (e.g. `"I_kwDOF31SUc6dwFXZ"`)
- `chat_01.exp`, `chat_01_simple.exp`: Remove trailing colon from `set timeout 30:` → `set timeout 30`

Example test run:
- https://github.com/spiceai/spiceai/actions/runs/22705820148
