### PR TITLE
Fix scheduler panic and cancel race condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=b4a797c54bc9b04e61581cd36793166f31ebdbb8#b4a797c54bc9b04e61581cd36793166f31ebdbb8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=b4a797c54bc9b04e61581cd36793166f31ebdbb8#b4a797c54bc9b04e61581cd36793166f31ebdbb8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2329,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=b4a797c54bc9b04e61581cd36793166f31ebdbb8#b4a797c54bc9b04e61581cd36793166f31ebdbb8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,9 +389,9 @@ datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "7
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "cc38905a6ff37c1156ee528b5dc15c18c8ae9776" } # spiceai-52
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "b4a797c54bc9b04e61581cd36793166f31ebdbb8" }      # spiceai-52
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "b4a797c54bc9b04e61581cd36793166f31ebdbb8" } # spiceai-52
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "b4a797c54bc9b04e61581cd36793166f31ebdbb8" } # spiceai-52
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" }      # spiceai-52
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" } # spiceai-52
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" } # spiceai-52
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "9d26fb3662d2edb8f382d4d0f7899c303549f0d0" } # spiceai-0.18.2
 

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -179,7 +179,8 @@ impl JobExecutor {
 
         // Check for early cancellation
         if cancel.is_cancelled() {
-            job_store.cancel_job(job_id).await?;
+            // Don't call cancel_job here - executor.cancel() already updates the
+            // job state via its own cancel_job call.
             return Ok(());
         }
 
@@ -243,7 +244,9 @@ impl JobExecutor {
                 if let Err(e) = query_handle.cancel().await {
                     tracing::error!("Failed to cancel the distributed query '{job_id}': {e}");
                 }
-                job_store.cancel_job(job_id).await?;
+                // Don't call cancel_job here - executor.cancel() already updates the
+                // job state. Doing it here would race with the OCC write and cause
+                // ConcurrentModification errors.
                 Ok(())
             },
             () = timeout_fut => {

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -185,15 +185,46 @@ impl JobStore {
     }
 
     /// Marks a job as cancelled.
+    ///
+    /// Retries with fibonacci backoff on concurrent modification errors (e.g.,
+    /// background task updated the state between our read and write). On retry,
+    /// re-reads the state and returns early if the job already reached a terminal
+    /// state.
     pub async fn cancel_job(&self, job_id: &str) -> Result<JobState> {
-        let mut state = self.get_job(job_id).await?;
-        if state.is_terminal() {
-            // Already in terminal state, return as-is
-            return Ok(state);
+        use util::fibonacci_backoff::FibonacciBackoffBuilder;
+
+        let mut backoff = FibonacciBackoffBuilder::new().max_retries(Some(3)).build();
+
+        loop {
+            let mut state = self.get_job(job_id).await?;
+            if state.is_terminal() {
+                return Ok(state);
+            }
+            state.set_cancelled();
+            match self.write_job_state(&mut state).await {
+                Ok(()) => return Ok(state),
+                Err(super::error::Error::ConcurrentModification { .. }) => {
+                    if let Some(duration) = backoff.next_duration() {
+                        tracing::debug!(
+                            job_id = %job_id,
+                            "Concurrent modification on cancel, retrying"
+                        );
+                        tokio::time::sleep(duration).await;
+                    } else {
+                        // Max retries exhausted — re-read state in case another
+                        // writer already cancelled the job.
+                        let state = self.get_job(job_id).await?;
+                        if state.is_terminal() {
+                            return Ok(state);
+                        }
+                        return Err(super::error::Error::ConcurrentModification {
+                            job_id: job_id.to_string(),
+                        });
+                    }
+                }
+                Err(e) => return Err(e),
+            }
         }
-        state.set_cancelled();
-        self.write_job_state(&mut state).await?;
-        Ok(state)
     }
 
     /// Writes result chunks for a completed job from a stream of record batches.


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #9636:

### Bug 1: Scheduler panic after executor heartbeat timeout

When an executor heartbeat times out, `reset_tasks()` sets `task_infos[partition_id]` to `None`. If the executor later reconnects and sends late status updates, `update_task_info()` panics on `.unwrap()` of the `None` value.

**Fix:** Updated datafusion-ballista (spiceai/datafusion-ballista#23) to replace `.unwrap()` with a `let-else` that logs a warning and returns `false`.

### Bug 2: Cancel returns HTTP 500 `Concurrent modification detected`

When `executor.cancel(job_id)` is called, the background task may simultaneously update the job state (e.g. `set_job_running`), causing an OCC version conflict on the `cancel_job` write. The `ConcurrentModification` error propagates as HTTP 500 to the user.

**Fix:**
- `cancel_job()` now retries with fibonacci backoff on `ConcurrentModification`, re-reading the state each time (consistent with the retry pattern used in partition management).
- Removed duplicate `cancel_job()` calls from the background task's `tokio::select!` cancel branch — `executor.cancel()` is the sole updater of cancellation state.

## Changes

- `Cargo.toml` / `Cargo.lock`: bump datafusion-ballista to ba7a1d47 (panic fix)
- `crates/runtime/src/jobs/store.rs`: `cancel_job()` retries with fibonacci backoff on OCC conflict
- `crates/runtime/src/jobs/executor.rs`: remove duplicate `cancel_job()` calls from background task

## Testing

- Ballista: 3 new unit tests for `update_task_info` with `None` slot (spiceai/datafusion-ballista#23)
- Manual: set up scheduler + executor with S3 state location, submitted 6 async queries and cancelled them all — all returned HTTP 200 with CANCELLED status (previously returned HTTP 500)

Fixes #9636