### PR TITLE
Remove default 1s refresh_check_interval from spidapter for hive datasets

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1177,7 +1177,6 @@ fn generate_hive_spicepod(
             engine: Some("cayenne".to_string()),
             mode: Mode::File,
             refresh_mode: Some(RefreshMode::Full),
-            refresh_check_interval: Some("1s".to_string()),
             ..Acceleration::default()
         });
 
@@ -1305,7 +1304,6 @@ mod tests {
         assert!(spicepod.contains("engine: cayenne"));
         assert!(spicepod.contains("mode: file"));
         assert!(spicepod.contains("refresh_mode: full"));
-        assert!(spicepod.contains("refresh_check_interval: 1s"));
         assert!(spicepod.contains("telemetry:"));
         assert!(spicepod.contains("enabled: false"));
     }


### PR DESCRIPTION
## Problem

The spidapter was hardcoding a `refresh_check_interval: 1s` on all accelerated datasets. This caused continuous full refreshes from S3 every second, which is unnecessary and wasteful — particularly for larger TPC-H scale factors where lineitem alone can be 500+ MiB per refresh cycle.

## Solution

Remove the default `refresh_check_interval` from the spidapter-generated acceleration config. Datasets will now use the standard refresh behavior (refresh once on startup) instead of polling every second.