### PR TITLE
perf: Cache Turso metastore connection across operations

### DIFF
--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -30,6 +30,7 @@ use turso::{Builder, Connection, Database, Value as TursoValue};
 /// Turso-based metastore backend.
 pub struct TursoMetastore {
     db: Arc<Mutex<Option<Database>>>,
+    conn: Arc<Mutex<Option<Connection>>>,
     connection_string: String,
 }
 
@@ -46,6 +47,7 @@ impl TursoMetastore {
     pub fn new(connection_string: impl Into<String>) -> Self {
         Self {
             db: Arc::new(Mutex::new(None)),
+            conn: Arc::new(Mutex::new(None)),
             connection_string: connection_string.into(),
         }
     }
@@ -91,8 +93,14 @@ impl TursoMetastore {
         Ok(db)
     }
 
-    /// Get a connection from the database.
+    /// Get or create a cached connection from the database.
     async fn get_conn(&self) -> CatalogResult<Connection> {
+        let mut conn_guard = self.conn.lock().await;
+
+        if let Some(conn) = conn_guard.as_ref() {
+            return Ok(conn.clone());
+        }
+
         let db = self.get_db().await?;
         let conn = db.connect().map_err(|e| CatalogError::Database {
             message: format!("Failed to connect to Turso database: {e}"),
@@ -105,6 +113,21 @@ impl TursoMetastore {
                 message: format!("Failed to set busy timeout: {e}"),
             })?;
 
+        // NORMAL synchronous mode: safe with WAL, more performant than FULL
+        conn.execute("PRAGMA synchronous = NORMAL", ())
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to set synchronous mode: {e}"),
+            })?;
+
+        // 32MB cache size (negative value = kilobytes in SQLite/libSQL)
+        conn.execute("PRAGMA cache_size = -32768", ())
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to set cache size: {e}"),
+            })?;
+
+        *conn_guard = Some(conn.clone());
         Ok(conn)
     }
 
@@ -306,22 +329,6 @@ fn convert_turso_error(e: turso::Error) -> CatalogError {
 impl MetastoreBackend for TursoMetastore {
     async fn init_schema(&self) -> CatalogResult<()> {
         let conn = self.get_conn().await?;
-
-        // NORMAL synchronous mode: safe with WAL, more performant than FULL
-        // With WAL mode, NORMAL only syncs at checkpoints, not on every commit
-        conn.execute("PRAGMA synchronous = NORMAL", ())
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set synchronous mode: {e}"),
-            })?;
-
-        // 32MB cache size (negative value = kilobytes in SQLite/libSQL)
-        // Larger cache reduces disk I/O for frequently accessed metadata
-        conn.execute("PRAGMA cache_size = -32768", ())
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set cache size: {e}"),
-            })?;
 
         // Create tables
         let schema_sql = format!(


### PR DESCRIPTION
The Turso metastore backend was creating a new connection on every operation via `db.connect()`, unlike the SQLite backend which caches its connection using `OnceCell` and reuses it. Caching the `Database` alone was not sufficient — each `get_conn()` call still paid the cost of `db.connect()` plus `busy_timeout` setup on every execute/query.

Additionally, the performance PRAGMAs (`synchronous = NORMAL`, `cache_size = -32768`) were set in `init_schema()` on a connection that was immediately discarded, so they never applied to subsequent operations.

Cache the `Connection` in `get_conn()` (matching the SQLite backend) and move PRAGMA setup there so they are applied once and persist.

Benchmark results (Turso vs SQLite):

```
$  cargo bench --features turso -p cayenne --bench metastore_operations

Before (no connection caching):
  init_schema:      1.41x slower (982.0 us vs 697.6 us)
  insert_single:    1.91x slower (75.8 us vs 39.8 us)
  insert_batch/10:  1.72x slower (390.3 us vs 226.3 us)
  insert_batch/100: 1.80x slower (3.72 ms vs 2.07 ms)
  query_single:     1.78x slower (28.0 us vs 15.7 us)
  query_batch/10:   1.78x slower (40.7 us vs 22.9 us)
  query_batch/100:  1.98x slower (124.4 us vs 62.9 us)

After (cached connection + PRAGMAs applied once):
  init_schema:      1.30x slower (911.6 us vs 701.3 us)
  insert_single:    0.99x (38.5 us vs 39.0 us, parity)
  insert_batch/10:  0.89x (194.9 us vs 218.5 us, Turso faster)
  insert_batch/100: 0.82x (1.71 ms vs 2.08 ms, Turso faster)
  query_single:     0.76x (11.9 us vs 15.7 us, Turso faster)
  query_batch/10:   0.87x (19.6 us vs 22.7 us, Turso faster)
  query_batch/100:  1.58x slower (100.2 us vs 63.3 us)
```
