### PR TITLE
Enable `postgres-accel` in CI builds for benchmarks

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -108,6 +108,7 @@ jobs:
                 target_arch_go: "amd64",
                 tags: ["default", "odbc"],
                 use_minio: useMinio,
+                is_tagged_release: isTaggedRelease,
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
                 runner: macosRunner,
@@ -116,6 +117,7 @@ jobs:
                 target_arch_go: "arm64",
                 tags: ["default", "metal"],
                 use_minio: false,
+                is_tagged_release: isTaggedRelease,
               }
             ];
 
@@ -129,6 +131,7 @@ jobs:
                 target_arch_go: "arm64",
                 tags: ["default"],
                 use_minio: false,
+                is_tagged_release: isTaggedRelease,
               });
               matrix.push({
                 name: "Windows x64",
@@ -138,6 +141,7 @@ jobs:
                 target_arch_go: "amd64",
                 tags: ["default"],
                 use_minio: false,
+                is_tagged_release: isTaggedRelease,
               });
             }
 
@@ -230,9 +234,16 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      ## Default flavor - build both spiced and spice CLI together (runtime not built on Windows - use WSL)
+      # Default flavor - build both spiced and spice CLI together (runtime not built on Windows - use WSL)
+      # Non-release builds include postgres-accel for benchmark testing
       - name: Build spiced and spice CLI
-        if: contains(matrix.target.tags, 'default') && matrix.target.target_os != 'windows'
+        if: contains(matrix.target.tags, 'default') && matrix.target.target_os != 'windows' && !matrix.target.is_tagged_release
+        working-directory: bin/spiced
+        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models,postgres-accel -p spiced -p spice --target-dir ../../target
+
+      # Release builds exclude optional accelerators from the distributed binary
+      - name: Build spiced and spice CLI (release)
+        if: contains(matrix.target.tags, 'default') && matrix.target.target_os != 'windows' && matrix.target.is_tagged_release
         working-directory: bin/spiced
         run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models -p spiced -p spice --target-dir ../../target
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -323,6 +323,7 @@ jobs:
     timeout-minutes: 5
 
     strategy:
+      fail-fast: false
       matrix:
         acceleration: [{}, { engine: arrow, mode: memory }]
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -415,6 +416,7 @@ jobs:
     timeout-minutes: 5
 
     strategy:
+      fail-fast: false
       matrix:
         acceleration:
           [


### PR DESCRIPTION
## 📝 Summary

Non-tagged-release builds now include the `postgres-accel` feature to allow benchmark spicepods with `engine: postgres` (e.g. `file[parquet]-postgres`, `s3[parquet]-postgres`). This is to detect any potential regression earlier rather than discovering them downstream (enterprise version).

Also adds `fail-fast: false` to multi-matrix E2E jobs** (`e2e_test_ci.yml`): `test_quickstart_s3` and `test_quickstart_data_postgres` have multi-value matrices but were missing `fail-fast: false`, causing a single failure to cancel sibling jobs and hide additional failures.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
