### PR TITLE
docs: update distribution details and add NAS support in release notes

### DIFF
--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -6,6 +6,18 @@ The Spice open source project provides multiple distribution variants to support
 
 > **Note:** Variant distributions (data, allocators, CUDA) are only available in **nightly images** for the open source project. All features and distributions are available in the [Spice Cloud Platform](https://spice.ai/pricing) and [Spice.ai Enterprise](https://spice.ai/pricing).
 
+## Distribution Availability
+
+| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
+| ---------------------- | ---------------- | ----------- | ---------- |
+| Default (Data + AI)    | ✅                | ✅           | ✅          |
+| Data-only              | Nightly only     | ✅           | ✅          |
+| NAS (SMB + NFS)        | Nightly only     | ❌           | ✅          |
+| Metal (macOS)          | ✅                | ✅           | ✅          |
+| CUDA (Linux)           | Nightly only     | ✅           | ✅          |
+| Allocator variants     | Nightly only     | ✅           | ✅          |
+| ODBC connector         | Local build only | ✅           | ✅          |
+
 ## Default Distribution
 
 The default distribution includes all features including AI/ML model support. This is the recommended distribution for most users.
@@ -112,6 +124,24 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-cuda
 CUDA_COMPUTE_CAP=89 make install-cuda
 ```
 
+## NAS Distribution
+
+The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+
+> **[Enterprise](https://spice.ai/pricing):** The NAS distribution is available in nightly builds and with Spice.ai Enterprise.
+
+**Included Features:**
+
+- All default features
+- SMB data connector
+- NFS data connector
+
+**Local Build:**
+
+```bash
+make install-nas
+```
+
 ## Allocator Variants
 
 Different memory allocators can significantly impact performance depending on workload characteristics.
@@ -154,13 +184,13 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-sysalloc
 
 ## Platform Support
 
-| Platform                      | Default | Data            | Metal | CUDA            |
-| ----------------------------- | ------- | --------------- | ----- | --------------- |
-| Linux x86_64                  | ✅       | Nightly         | ❌     | Nightly         |
-| Linux aarch64                 | ✅       | Nightly         | ❌     | ❌               |
-| macOS aarch64 (Apple Silicon) | ✅       | Nightly         | ✅     | ❌               |
-| Windows (WSL)                 | ✅       | Nightly         | ❌     | Nightly         |
-| Windows (Native)              | ❌       | Enterprise only | ❌     | Enterprise only |
+| Platform                      | Default | Data            | NAS             | Metal | CUDA            |
+| ----------------------------- | ------- | --------------- | --------------- | ----- | --------------- |
+| Linux x86_64                  | ✅       | Nightly         | Nightly         | ❌     | Nightly         |
+| Linux aarch64                 | ✅       | Nightly         | Nightly         | ❌     | ❌               |
+| macOS aarch64 (Apple Silicon) | ✅       | Nightly         | Nightly         | ✅     | ❌               |
+| Windows (WSL)                 | ✅       | Nightly         | Nightly         | ❌     | Nightly         |
+| Windows (Native)              | ❌       | Enterprise only | Enterprise only | ❌     | Enterprise only |
 
 > **Note:** Native Windows support for the Spice runtime is available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users on Windows should use Windows Subsystem for Linux (WSL).
 
@@ -170,6 +200,7 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-sysalloc
 | --------------------------------------- | ---------------------------- |
 | General purpose with AI capabilities    | Default                      |
 | Data federation only, minimal footprint | Data (nightly)               |
+| Network attached storage (SMB/NFS)      | NAS                          |
 | macOS with GPU acceleration             | Metal                        |
 | Linux with NVIDIA GPU                   | CUDA (nightly)               |
 | Memory allocation benchmarking          | Allocator variants (nightly) |
@@ -179,13 +210,11 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-sysalloc
 Some connectors require additional dependencies and are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing):
 
 - **ODBC** - Connect to any ODBC-compatible data source
-- **NFS** - Network File System support
 
 These can be built locally for development and testing:
 
 ```bash
 make install-odbc
-make install-nfs
 ```
 
 ## Building Custom Distributions

--- a/docs/release_notes/v2.0.0-rc.1.md
+++ b/docs/release_notes/v2.0.0-rc.1.md
@@ -15,6 +15,26 @@ Highlights in this release candidate include:
 
 Spice v2.0 includes several [breaking changes](#breaking-changes). Review the breaking changes section before upgrading.
 
+## Distribution Changes
+
+AI/ML support including local LLM/ML model and hosted LLM inference is now included in the default Spice build and image. The separate `models` build variant has been removed.
+
+With models now included by default, the data-only distribution (without AI/ML support) is only published in nightly builds. Official production-ready data-only distributions are available exclusively through [Spice Cloud](https://spice.ai/pricing) and the Enterprise release.
+
+A new Network Attached Storage (NAS) distribution with built-in SMB and NFS data connector support is also now available in nightly builds and with [Spice.ai Enterprise](https://spice.ai/pricing).
+
+| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
+| ---------------------- | ---------------- | ----------- | ---------- |
+| Default                | ✅                | ✅           | ✅          |
+| Data                   | Nightly only     | ✅           | ✅          |
+| NAS (SMB + NFS)        | Nightly only     | ❌           | ✅          |
+| Metal (macOS)          | ✅                | ✅           | ✅          |
+| CUDA (Linux)           | Nightly only     | ✅           | ✅          |
+| Allocator variants     | Nightly only     | ✅           | ✅          |
+| ODBC connector         | Local build only | ✅           | ✅          |
+
+For more details, see the [Distributions documentation](../DISTRIBUTIONS.md).
+
 ## What's New in v2.0.0-rc.1
 
 ### Active-Active HA Distributed Query
@@ -85,10 +105,6 @@ The [Spice Cayenne data accelerator](https://spiceai.org/docs/components/data-ac
 - **`--output=json` Flag**: Machine-readable JSON output for CLI commands, enabling scripting and automation
 - **`spice login --output`**: New output modes (`env`, `json`, `keychain`) for flexible credential management
 - **`spice cloud metrics`**: New command for Spice Cloud deployment metrics
-
-### Models Included by Default
-
-Local LLM/ML model inference (via `mistral.rs`) is now included in the default Spice build. The separate `models` build variant has been removed. This simplifies installation and ensures all users have access to local AI inference capabilities.
 
 ### Error Propagation for Dataset and Model Status APIs
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the availability and features of different Spice distribution variants, introduces the new NAS distribution, and removes outdated information about separate model builds. The changes make it easier for users to understand which features are included in each distribution and how to access them across open source, cloud, and enterprise offerings.

**Distribution availability and documentation updates:**

* Added a comprehensive table to `docs/DISTRIBUTIONS.md` showing which distributions and variants are available for open source, Spice Cloud, and Enterprise, including the new NAS (SMB/NFS) distribution. [[1]](diffhunk://#diff-abafaa6b7c220fbf35f8bafba15ee896357b2cdd9f0dad0da45419ab36d2b8cfR9-R20) [[2]](diffhunk://#diff-8156eab1c1ce31bb174ddf6e7b0c9aa6fee9000913a8098a88053f0a4e29e89bR18-R37)
* Documented the NAS distribution with details on features, build instructions, and clarified its availability in nightly builds and Enterprise.
* Updated platform support tables to include NAS distribution and clarified its availability across different operating systems and deployment targets.

**Feature and connector changes:**

* Removed references to the separate `models` build variant, noting that AI/ML support is now included by default. Clarified that the data-only distribution is only published in nightly builds for open source, with production-ready versions available via cloud or enterprise. [[1]](diffhunk://#diff-8156eab1c1ce31bb174ddf6e7b0c9aa6fee9000913a8098a88053f0a4e29e89bR18-R37) [[2]](diffhunk://#diff-8156eab1c1ce31bb174ddf6e7b0c9aa6fee9000913a8098a88053f0a4e29e89bL89-L92)
* Updated connector documentation to reflect that NFS support is now part of the NAS distribution, and adjusted local build instructions accordingly.

**Distribution purpose clarification:**

* Clarified the purpose of each distribution variant, including the new NAS option, in the summary table for easier selection by users.