### PR TITLE
perf: Use prepare_cached() in Turso and SQLite metastore backends

### DIFF
--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -406,7 +406,7 @@ impl MetastoreBackend for SqliteMetastore {
                 .iter()
                 .map(|v| v as &dyn rusqlite::ToSql)
                 .collect();
-            conn.execute(&sql, params_refs.as_slice())?;
+            conn.prepare_cached(&sql)?.execute(params_refs.as_slice())?;
             Ok::<_, rusqlite::Error>(())
         })
         .await
@@ -493,7 +493,7 @@ impl MetastoreBackend for SqliteMetastore {
                     .map(|v| v as &dyn rusqlite::ToSql)
                     .collect();
 
-                let mut stmt = conn.prepare(&sql)?;
+                let mut stmt = conn.prepare_cached(&sql)?;
                 let rows = stmt.query_map(params_refs.as_slice(), |row| {
                     let column_count = row.as_ref().column_count();
                     let mut values = Vec::with_capacity(column_count);

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -416,7 +416,11 @@ impl MetastoreBackend for TursoMetastore {
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
-        conn.execute(params.sql, turso_params)
+        let mut stmt = conn
+            .prepare_cached(params.sql)
+            .await
+            .map_err(convert_turso_error)?;
+        stmt.execute(turso_params)
             .await
             .map_err(convert_turso_error)?;
 
@@ -444,12 +448,18 @@ impl MetastoreBackend for TursoMetastore {
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
-        let mut rows =
-            conn.query(params.sql, turso_params)
-                .await
-                .map_err(|e| CatalogError::Database {
-                    message: format!("Failed to query row: {e}"),
-                })?;
+        let mut stmt = conn
+            .prepare_cached(params.sql)
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to query row: {e}"),
+            })?;
+        let mut rows = stmt
+            .query(turso_params)
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to query row: {e}"),
+            })?;
 
         let row = rows.next().await.map_err(|e| CatalogError::Database {
             message: format!("Failed to fetch row: {e}"),
@@ -481,12 +491,18 @@ impl MetastoreBackend for TursoMetastore {
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
-        let mut rows =
-            conn.query(params.sql, turso_params)
-                .await
-                .map_err(|e| CatalogError::Database {
-                    message: format!("Failed to query rows: {e}"),
-                })?;
+        let mut stmt = conn
+            .prepare_cached(params.sql)
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to query rows: {e}"),
+            })?;
+        let mut rows = stmt
+            .query(turso_params)
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to query rows: {e}"),
+            })?;
 
         let mut results = Vec::new();
 


### PR DESCRIPTION
Reduces SQL parsing overhead by caching prepared statements across repeated calls to execute(), query(), and query_row().

Benchmark results (Turso vs SQLite):

```
  cargo bench --features turso -p cayenne --bench metastore_operations

Before (prepare):
  init_schema:         1.33x slower (919.7 us vs 691.6 us)
  insert_single:       1.02x (39.8 us vs 39.2 us, parity)
  insert_batch/10:     0.93x (208.3 us vs 224.6 us, Turso faster)
  insert_batch/100:    0.82x (1.67 ms vs 2.04 ms, Turso faster)
  query_single:        0.69x (11.0 us vs 16.0 us, Turso faster)
  query_batch/10:      0.96x (21.9 us vs 22.8 us, parity)
  query_batch/100:     1.64x slower (101.3 us vs 61.8 us)

After (prepare_cached):
  init_schema:         1.28x slower (881.7 us vs 689.2 us)
  insert_single:       0.55x (18.9 us vs 34.4 us, Turso faster)
  insert_batch/10:     0.52x (107.2 us vs 204.4 us, Turso faster)
  insert_batch/100:    0.57x (1.05 ms vs 1.86 ms, Turso faster)
  query_single:        0.21x (3.5 us vs 16.6 us, Turso faster)
  query_batch/10:      0.61x (12.2 us vs 19.9 us, Turso faster)
  query_batch/100:     1.48x slower (89.9 us vs 60.8 us)
```