### PR TITLE
feat(flight): add DoPut rows/bytes written metrics for DoPut ETL ingestion tracking

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -30,6 +30,7 @@ use datafusion::{
     error::DataFusionError, execution::SendableRecordBatchStream,
     physical_plan::stream::RecordBatchStreamAdapter, sql::TableReference,
 };
+use opentelemetry::KeyValue;
 use prost::Message as _;
 use runtime_auth::AuthRequestContext;
 use tokio::sync::mpsc::{self, Sender};
@@ -380,7 +381,7 @@ fn create_response_stream(
         let mut write_future = Box::pin(df.write_streaming_data(&path, streaming_update));
 
         if let Some(first_batch) = first_batch {
-            yield handle_record_batch(first_batch, &batch_tx).await;
+            yield handle_record_batch(first_batch, &batch_tx, &path.to_string()).await;
         }
 
         // Use a single pinned Sleep future that is reset on each received message,
@@ -440,7 +441,7 @@ fn create_response_stream(
                             };
 
                             // Only report errors; a success message is sent as the final step upon successful write completion
-                            if let Err(err) = handle_record_batch(new_batch, &batch_tx).await {
+                            if let Err(err) = handle_record_batch(new_batch, &batch_tx, &path.to_string()).await {
                                 yield Err(err);
                                 break;
                             }
@@ -476,8 +477,13 @@ fn create_response_stream(
 async fn handle_record_batch(
     batch: RecordBatch,
     batch_tx: &Sender<Result<RecordBatch, DataFusionError>>,
+    path: &str,
 ) -> Result<PutResult, Status> {
     tracing::trace!("Received batch with {} rows", batch.num_rows());
+
+    let labels = [KeyValue::new("dataset", path.to_string())];
+    metrics::DO_PUT_ROWS_WRITTEN.add(batch.num_rows() as u64, &labels);
+    metrics::DO_PUT_BYTES_WRITTEN.add(batch.get_array_memory_size() as u64, &labels);
 
     if let Err(e) = batch_tx.send(Ok(batch)).await {
         tracing::error!("Error sending record batch to write channel: {e}");

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -56,3 +56,21 @@ pub(crate) static DO_EXCHANGE_DATA_UPDATES_SENT: LazyLock<Counter<u64>> = LazyLo
         .u64_counter("flight_do_exchange_data_updates_sent")
         .build()
 });
+
+pub(crate) static DO_PUT_ROWS_WRITTEN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("flight_do_put_rows_written")
+        .with_description("Cumulative number of rows received and written via Flight DoPut.")
+        .with_unit("rows")
+        .build()
+});
+
+pub(crate) static DO_PUT_BYTES_WRITTEN: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("flight_do_put_bytes_written")
+        .with_description(
+            "Cumulative number of bytes (Arrow in-memory size) received and written via Flight DoPut.",
+        )
+        .with_unit("By")
+        .build()
+});


### PR DESCRIPTION
## Problem

The ADBC ETL path writes data via Flight DoPut directly into Cayenne catalog tables. The metrics `dataset_acceleration_refresh_rows_written` / `..._bytes_written` are only emitted during accelerated table refresh, so the cloud API's `ingestion.rows_ingested` / `ingestion.bytes_ingested` are always empty for ADBC ETL runs.

## Changes

### New counters in `crates/runtime/src/flight/metrics.rs`

Two new `Counter<u64>` statics on the flight meter:
- `flight_do_put_rows_written` — cumulative rows received and forwarded to the write channel via DoPut
- `flight_do_put_bytes_written` — cumulative bytes (Arrow in-memory size) received via DoPut

Follows the same pattern as `DO_EXCHANGE_DATA_UPDATES_SENT`.

### Instrument `handle_record_batch` in `crates/runtime/src/flight/do_put.rs`

- Added a `path: &str` parameter to `handle_record_batch`.
- Before sending the batch through `batch_tx`, records both counters using `batch.num_rows()` and `batch.get_array_memory_size()` (same approach as the refresh task).
- Uses a `dataset` label attribute set to the table path, matching the convention used by the accelerated table metrics.
- Updated both call sites in `create_response_stream` to pass the path.

**Double-count risk is negligible:** In scheduler+executor clusters, the raw forward fast path (`should_forward_raw_cayenne_write`) returns before `create_response_stream` is ever called, so `handle_record_batch` only runs on the executor that performs the actual write.

## Related

Companion cloud API PR: https://github.com/spicehq/cloud/pull/4243