### PR TITLE
Refactor Cayenne IDs to use UUIDv7 strings

### DIFF
--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -325,7 +325,8 @@ pub trait MetadataCatalog: Send + Sync {
     ///
     /// This is used when a protected snapshot is superseded by a newer one.
     /// The old sequence record becomes orphaned and can be cleaned up.
-    async fn clear_snapshot_sequence(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()>;
+    async fn clear_snapshot_sequence(&self, table_id: &str, snapshot_id: &str)
+        -> CatalogResult<()>;
 
     /// Atomically update snapshot and clear delete files in a single transaction.
     async fn commit_compaction(&self, table_id: &str, new_snapshot_id: &str) -> CatalogResult<()>;

--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -212,44 +212,44 @@ pub trait MetadataCatalog: Send + Sync {
     async fn list_table_names(&self) -> CatalogResult<Vec<String>>;
 
     /// Create a new table.
-    async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64>;
+    async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<String>;
 
     /// Get table metadata by name.
     async fn get_table(&self, table_name: &str) -> CatalogResult<TableMetadata>;
 
     /// Set the current snapshot ID for a table (`UUIDv7` string).
-    async fn set_current_snapshot(&self, table_id: i64, snapshot_id: &str) -> CatalogResult<()>;
+    async fn set_current_snapshot(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()>;
 
     /// Increment the table's sequence number and return the new value.
     ///
     /// Sequence numbers are used to order operations (inserts and deletes).
     /// This method atomically increments and returns the new sequence.
-    async fn increment_sequence_number(&self, table_id: i64) -> CatalogResult<i64>;
+    async fn increment_sequence_number(&self, table_id: &str) -> CatalogResult<i64>;
 
     /// Get the current sequence number for a table.
-    async fn get_sequence_number(&self, table_id: i64) -> CatalogResult<i64>;
+    async fn get_sequence_number(&self, table_id: &str) -> CatalogResult<i64>;
 
     /// Add a delete file (deletion vector) for a data file.
     ///
     /// Tracks a deletion vector file that marks rows as deleted in a specific
     /// virtual file (`ListingTable`).
-    async fn add_delete_file(&self, delete_file: DeleteFile) -> CatalogResult<i64>;
+    async fn add_delete_file(&self, delete_file: DeleteFile) -> CatalogResult<String>;
 
     /// Get all active delete files for a table (across all virtual files).
-    async fn get_table_delete_files(&self, table_id: i64) -> CatalogResult<Vec<DeleteFile>>;
+    async fn get_table_delete_files(&self, table_id: &str) -> CatalogResult<Vec<DeleteFile>>;
 
     /// Remove delete files (deletion vectors) by ID for a table.
     async fn remove_delete_files(
         &self,
-        table_id: i64,
-        delete_file_ids: &[i64],
+        table_id: &str,
+        delete_file_ids: &[String],
     ) -> CatalogResult<()>;
 
     /// Clear all delete files for a table.
     ///
     /// This is called after compaction to remove deletion vectors that have been
     /// applied to the data files.
-    async fn clear_delete_files(&self, table_id: i64) -> CatalogResult<()>;
+    async fn clear_delete_files(&self, table_id: &str) -> CatalogResult<()>;
 
     /// Add an insert record for a primary key with its sequence number.
     ///
@@ -266,7 +266,7 @@ pub trait MetadataCatalog: Send + Sync {
     /// * `sequence_number` - The sequence at which this insert occurred
     async fn add_insert_record(
         &self,
-        table_id: i64,
+        table_id: &str,
         pk_bytes: Vec<u8>,
         sequence_number: i64,
     ) -> CatalogResult<()>;
@@ -276,7 +276,7 @@ pub trait MetadataCatalog: Send + Sync {
     /// More efficient than calling `add_insert_record` multiple times.
     async fn add_insert_records_batch(
         &self,
-        table_id: i64,
+        table_id: &str,
         pk_bytes_list: Vec<Vec<u8>>,
         sequence_number: i64,
     ) -> CatalogResult<()>;
@@ -284,12 +284,12 @@ pub trait MetadataCatalog: Send + Sync {
     /// Get all insert records for a table.
     ///
     /// Returns a map of PK bytes to their sequence numbers.
-    async fn get_insert_records(&self, table_id: i64) -> CatalogResult<HashMap<Box<[u8]>, i64>>;
+    async fn get_insert_records(&self, table_id: &str) -> CatalogResult<HashMap<Box<[u8]>, i64>>;
 
     /// Clear all insert records for a table.
     ///
     /// Called after compaction when deletions and insert records have been merged.
-    async fn clear_insert_records(&self, table_id: i64) -> CatalogResult<()>;
+    async fn clear_insert_records(&self, table_id: &str) -> CatalogResult<()>;
 
     /// Set the sequence number for a snapshot.
     ///
@@ -298,7 +298,7 @@ pub trait MetadataCatalog: Send + Sync {
     /// snapshots with sequence <= `delete_sequence`.
     async fn set_snapshot_sequence(
         &self,
-        table_id: i64,
+        table_id: &str,
         snapshot_id: &str,
         sequence_number: i64,
     ) -> CatalogResult<()>;
@@ -308,7 +308,7 @@ pub trait MetadataCatalog: Send + Sync {
     /// Returns `None` if the snapshot has no sequence (created before sequence tracking).
     async fn get_snapshot_sequence(
         &self,
-        table_id: i64,
+        table_id: &str,
         snapshot_id: &str,
     ) -> CatalogResult<Option<i64>>;
 
@@ -318,38 +318,23 @@ pub trait MetadataCatalog: Send + Sync {
     /// that have sequence tracking enabled.
     async fn get_all_snapshot_sequences(
         &self,
-        table_id: i64,
+        table_id: &str,
     ) -> CatalogResult<HashMap<String, i64>>;
 
     /// Clear the sequence record for a specific snapshot.
     ///
     /// This is used when a protected snapshot is superseded by a newer one.
     /// The old sequence record becomes orphaned and can be cleaned up.
-    async fn clear_snapshot_sequence(&self, table_id: i64, snapshot_id: &str) -> CatalogResult<()>;
+    async fn clear_snapshot_sequence(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()>;
 
     /// Atomically update snapshot and clear delete files in a single transaction.
-    ///
-    /// This ensures ACID compliance during compaction: the snapshot update and
-    /// deletion of obsolete delete files happen together or not at all.
-    /// This prevents data inconsistency if the operation is interrupted.
-    ///
-    /// # Atomicity Guarantee
-    ///
-    /// If this operation fails or is interrupted:
-    /// - The old snapshot remains active
-    /// - All delete files remain intact
-    /// - The system remains in a consistent state
-    ///
-    /// On success:
-    /// - The new snapshot is active
-    /// - All delete files for the table are removed (they were applied during compaction)
-    async fn commit_compaction(&self, table_id: i64, new_snapshot_id: &str) -> CatalogResult<()>;
+    async fn commit_compaction(&self, table_id: &str, new_snapshot_id: &str) -> CatalogResult<()>;
 
     /// Add a partition to a table.
-    async fn add_partition(&self, partition: PartitionMetadata) -> CatalogResult<i64>;
+    async fn add_partition(&self, partition: PartitionMetadata) -> CatalogResult<String>;
 
     /// Get all partitions for a table.
-    async fn get_partitions(&self, table_id: i64) -> CatalogResult<Vec<PartitionMetadata>>;
+    async fn get_partitions(&self, table_id: &str) -> CatalogResult<Vec<PartitionMetadata>>;
 
     /// Shutdown the catalog, performing any necessary cleanup (e.g., WAL checkpoint, optimize).
     /// Default implementation does nothing.

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -310,7 +310,8 @@ impl MetadataCatalog for CayenneCatalog {
         })?;
 
         // Insert table metadata with initial snapshot
-        self.metastore
+        let insert_result = self
+            .metastore
             .execute_helper(ExecuteParams {
                 sql: r"
                     INSERT INTO cayenne_table (
@@ -333,7 +334,25 @@ impl MetadataCatalog for CayenneCatalog {
                     MetastoreValue::Text(vortex_config_json),
                 ],
             })
-            .await?;
+            .await;
+
+        match insert_result {
+            Ok(()) => {}
+            Err(CatalogError::ConstraintViolation { .. }) => {
+                let existing_id: String = self
+                    .metastore
+                    .query_row_helper(
+                        QueryRowParams {
+                            sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
+                            params: vec![MetastoreValue::Text(table_name.clone())],
+                        },
+                        |row| row.get_string(0),
+                    )
+                    .await?;
+                return Ok(existing_id);
+            }
+            Err(e) => return Err(e),
+        }
 
         // Create the initial snapshot directory (only for local paths)
         // Directory structure: [base_path]/[table_id]/[snapshot_id]/
@@ -705,7 +724,13 @@ impl MetadataCatalog for CayenneCatalog {
 
         for (i, pk_bytes) in pk_bytes_list.into_iter().enumerate() {
             let base = i * 4 + 1; // SQLite params are 1-indexed
-            values_parts.push(format!("(?{}, ?{}, ?{}, ?{})", base, base + 1, base + 2, base + 3));
+            values_parts.push(format!(
+                "(?{}, ?{}, ?{}, ?{})",
+                base,
+                base + 1,
+                base + 2,
+                base + 3
+            ));
             params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
             params.push(MetastoreValue::Text(table_id.to_string()));
             params.push(MetastoreValue::Blob(pk_bytes));
@@ -845,7 +870,11 @@ impl MetadataCatalog for CayenneCatalog {
         Ok(results.into_iter().collect())
     }
 
-    async fn clear_snapshot_sequence(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()> {
+    async fn clear_snapshot_sequence(
+        &self,
+        table_id: &str,
+        snapshot_id: &str,
+    ) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_snapshot_sequence WHERE table_id = ?1 AND snapshot_id = ?2",
@@ -1303,11 +1332,12 @@ mod tests {
         let mut handles = vec![];
         for _ in 0..10 {
             let catalog_clone = Arc::clone(&catalog);
+            let table_id = table_id.clone();
 
             let handle = tokio::spawn(async move {
                 let partition = PartitionMetadata {
                     partition_id: String::new(), // Will be assigned by catalog
-                    table_id: table_id.clone(),
+                    table_id,
                     partition_columns: vec!["date".to_string()],
                     partition_values: vec!["2024-01-01".to_string()],
                     path: "/tmp/cayenne_test_partition/partition_20240101".to_string(),
@@ -1342,7 +1372,7 @@ mod tests {
 
         // Verify the partition exists and can be queried
         let partitions = catalog
-            .get_partitions(table_id)
+            .get_partitions(&table_id)
             .await
             .expect("Failed to get partitions");
 
@@ -1370,9 +1400,11 @@ mod tests {
         catalog.init().await.expect("Failed to initialize catalog");
 
         // Create a table via the catalog API to get a valid table_id
-        let schema = Arc::new(arrow_schema::Schema::new(vec![
-            arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
-        ]));
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
         let table_options = CreateTableOptions {
             table_name: "test_table".to_string(),
             schema,
@@ -1391,11 +1423,12 @@ mod tests {
         let mut handles = vec![];
         for i in 0..10 {
             let catalog_clone = Arc::clone(&catalog);
+            let table_id = table_id.clone();
 
             let handle = tokio::spawn(async move {
                 let delete_file = DeleteFile {
                     delete_file_id: String::new(), // Will be assigned by catalog
-                    table_id: table_id.clone(),
+                    table_id,
                     source_data_file_path: None,
                     path: format!("/tmp/delete_file_{i}.parquet"),
                     path_is_relative: false,

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -220,19 +220,19 @@ impl MetadataCatalog for CayenneCatalog {
             .await
     }
 
-    async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64> {
+    async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<String> {
         let table_name = options.table_name.clone();
         let base_path = options.base_path.clone();
 
         // Check if table already exists first (read-only check)
-        let existing_table_id: Option<i64> = self
+        let existing_table_id: Option<String> = self
             .metastore
             .query_row_helper(
                 QueryRowParams {
                     sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
                     params: vec![MetastoreValue::Text(table_name.clone())],
                 },
-                |row| row.get_i64(0),
+                |row| row.get_string(0),
             )
             .await
             .ok();
@@ -295,8 +295,8 @@ impl MetadataCatalog for CayenneCatalog {
 
         let partition_column = options.partition_column.clone();
 
-        // Generate table UUID
-        let table_uuid = uuid::Uuid::now_v7().to_string();
+        // Generate table ID (UUIDv7)
+        let table_id = uuid::Uuid::now_v7().to_string();
 
         // Generate initial snapshot UUID
         let initial_snapshot_id = uuid::Uuid::now_v7().to_string();
@@ -314,14 +314,14 @@ impl MetadataCatalog for CayenneCatalog {
             .execute_helper(ExecuteParams {
                 sql: r"
                     INSERT INTO cayenne_table (
-                        table_uuid, table_name, path, path_is_relative, schema_json, primary_key_json,
+                        table_id, table_name, path, path_is_relative, schema_json, primary_key_json,
                         on_conflict_json, current_snapshot_id, partition_column, vortex_config_json
                     ) VALUES (
                      ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
                     )
                 ",
                 params: vec![
-                    MetastoreValue::Text(table_uuid),
+                    MetastoreValue::Text(table_id.clone()),
                     MetastoreValue::Text(table_name.clone()),
                     MetastoreValue::Text(base_path.clone()),
                     MetastoreValue::Bool(false), // path_is_relative
@@ -335,26 +335,12 @@ impl MetadataCatalog for CayenneCatalog {
             })
             .await?;
 
-        // Retrieve the assigned table ID
-        let table_id: i64 = self
-            .metastore
-            .query_row_helper(
-                QueryRowParams {
-                    sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
-                    params: vec![MetastoreValue::Text(table_name.clone())],
-                },
-                |row| row.get_i64(0),
-            )
-            .await?;
-
-        // Create the initial snapshot directory
-        // Directory structure: [base_path]/[table_id]/[snapshot_id]/
         // Create the initial snapshot directory (only for local paths)
         // Directory structure: [base_path]/[table_id]/[snapshot_id]/
         // For S3 paths, directories are virtual and created when files are written
         if !base_path.starts_with("s3://") {
             let snapshot_dir = std::path::PathBuf::from(&base_path)
-                .join(table_id.to_string())
+                .join(&table_id)
                 .join(&initial_snapshot_id);
 
             tokio::fs::create_dir_all(&snapshot_dir)
@@ -372,7 +358,7 @@ impl MetadataCatalog for CayenneCatalog {
             .query_helper(
                 QueryParams {
                     sql: r"
-                    SELECT table_id, table_uuid,
+                    SELECT table_id,
                            table_name, path, path_is_relative, schema_json, primary_key_json,
                            on_conflict_json, current_snapshot_id, partition_column, vortex_config_json,
                            current_sequence_number
@@ -383,18 +369,17 @@ impl MetadataCatalog for CayenneCatalog {
                     params: vec![MetastoreValue::Text(table_name_owned.clone())],
                 },
                 |row| {
-                    let table_id = row.get_i64(0)?;
-                    let table_uuid = row.get_string(1)?;
-                    let table_name = row.get_string(2)?;
-                    let path = row.get_string(3)?;
-                    let path_is_relative = row.get_bool(4)?;
-                    let schema_json = row.get_string(5)?;
-                    let primary_key_json = row.get_optional_string(6)?;
-                    let on_conflict_json = row.get_optional_string(7)?;
-                    let current_snapshot_id = row.get_string(8)?;
-                    let partition_column = row.get_optional_string(9)?;
-                    let vortex_config_json = row.get_optional_string(10)?;
-                    let current_sequence_number = row.get_optional_i64(11)?.unwrap_or(0);
+                    let table_id = row.get_string(0)?;
+                    let table_name = row.get_string(1)?;
+                    let path = row.get_string(2)?;
+                    let path_is_relative = row.get_bool(3)?;
+                    let schema_json = row.get_string(4)?;
+                    let primary_key_json = row.get_optional_string(5)?;
+                    let on_conflict_json = row.get_optional_string(6)?;
+                    let current_snapshot_id = row.get_string(7)?;
+                    let partition_column = row.get_optional_string(8)?;
+                    let vortex_config_json = row.get_optional_string(9)?;
+                    let current_sequence_number = row.get_optional_i64(10)?.unwrap_or(0);
 
                     // Deserialize schema using Arrow IPC format
                     let schema = {
@@ -459,7 +444,6 @@ impl MetadataCatalog for CayenneCatalog {
 
                     Ok(TableMetadata {
                         table_id,
-                        table_uuid,
                         table_name,
                         path,
                         path_is_relative,
@@ -486,13 +470,13 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
-    async fn set_current_snapshot(&self, table_id: i64, snapshot_id: &str) -> CatalogResult<()> {
+    async fn set_current_snapshot(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "UPDATE cayenne_table SET current_snapshot_id = ?1 WHERE table_id = ?2",
                 params: vec![
                     MetastoreValue::Text(snapshot_id.to_string()),
-                    MetastoreValue::Integer(table_id),
+                    MetastoreValue::Text(table_id.to_string()),
                 ],
             })
             .await
@@ -501,21 +485,25 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
-    async fn add_delete_file(&self, delete_file: DeleteFile) -> CatalogResult<i64> {
+    async fn add_delete_file(&self, delete_file: DeleteFile) -> CatalogResult<String> {
+        // Generate delete file ID (UUIDv7)
+        let delete_file_id = uuid::Uuid::now_v7().to_string();
+
         // Insert delete file record
         let insert_result = self
             .metastore
             .execute_helper(ExecuteParams {
                 sql: r"
                 INSERT INTO cayenne_delete_file (
-                    table_id, path, path_is_relative,
+                    delete_file_id, table_id, path, path_is_relative,
                     format, delete_count, file_size_bytes, source_data_file_path, sequence_number
                 ) VALUES (
-                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9
                 )
             ",
                 params: vec![
-                    MetastoreValue::Integer(delete_file.table_id),
+                    MetastoreValue::Text(delete_file_id.clone()),
+                    MetastoreValue::Text(delete_file.table_id.clone()),
                     MetastoreValue::Text(delete_file.path.clone()),
                     MetastoreValue::Bool(delete_file.path_is_relative),
                     MetastoreValue::Text(delete_file.format.clone()),
@@ -531,44 +519,40 @@ impl MetadataCatalog for CayenneCatalog {
             .await;
 
         match insert_result {
-            // Success or constraint violation (another concurrent operation inserted first)
-            // Either way, retrieve the delete_file_id by falling through
-            Ok(()) | Err(CatalogError::ConstraintViolation { .. }) => {}
-            Err(e) => {
-                return Err(CatalogError::FailedToAddDeleteFile {
-                    source: Box::new(e),
-                })
+            Ok(()) => Ok(delete_file_id),
+            Err(CatalogError::ConstraintViolation { .. }) => {
+                // Another concurrent operation inserted first — retrieve the existing ID
+                let existing_id: String = self
+                    .metastore
+                    .query_row_helper(
+                        QueryRowParams {
+                            sql: r"
+                            SELECT delete_file_id
+                            FROM cayenne_delete_file
+                            WHERE table_id = ?1 AND path = ?2
+                            ORDER BY delete_file_id DESC
+                            LIMIT 1
+                        ",
+                            params: vec![
+                                MetastoreValue::Text(delete_file.table_id.clone()),
+                                MetastoreValue::Text(delete_file.path.clone()),
+                            ],
+                        },
+                        |row| row.get_string(0),
+                    )
+                    .await
+                    .map_err(|e| CatalogError::FailedToAddDeleteFile {
+                        source: Box::new(e),
+                    })?;
+                Ok(existing_id)
             }
-        }
-
-        // Retrieve the assigned delete_file_id
-        let delete_file_id: i64 = self
-            .metastore
-            .query_row_helper(
-                QueryRowParams {
-                    sql: r"
-                    SELECT delete_file_id
-                    FROM cayenne_delete_file
-                    WHERE table_id = ?1 AND path = ?2
-                    ORDER BY delete_file_id DESC
-                    LIMIT 1
-                ",
-                    params: vec![
-                        MetastoreValue::Integer(delete_file.table_id),
-                        MetastoreValue::Text(delete_file.path.clone()),
-                    ],
-                },
-                |row| row.get_i64(0),
-            )
-            .await
-            .map_err(|e| CatalogError::FailedToAddDeleteFile {
+            Err(e) => Err(CatalogError::FailedToAddDeleteFile {
                 source: Box::new(e),
-            })?;
-
-        Ok(delete_file_id)
+            }),
+        }
     }
 
-    async fn get_table_delete_files(&self, table_id: i64) -> CatalogResult<Vec<DeleteFile>> {
+    async fn get_table_delete_files(&self, table_id: &str) -> CatalogResult<Vec<DeleteFile>> {
         self.metastore
             .query_helper(
                 QueryParams {
@@ -576,12 +560,12 @@ impl MetadataCatalog for CayenneCatalog {
                         format, delete_count, file_size_bytes, source_data_file_path, sequence_number 
                  FROM cayenne_delete_file 
                  WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Integer(table_id)],
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
                 },
                 |row| {
                     Ok(DeleteFile {
-                        delete_file_id: row.get_i64(0)?,
-                        table_id: row.get_i64(1)?,
+                        delete_file_id: row.get_string(0)?,
+                        table_id: row.get_string(1)?,
                         source_data_file_path: row.get_optional_string(7)?,
                         path: row.get_string(2)?,
                         path_is_relative: row.get_bool(3)?,
@@ -603,8 +587,8 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn remove_delete_files(
         &self,
-        table_id: i64,
-        delete_file_ids: &[i64],
+        table_id: &str,
+        delete_file_ids: &[String],
     ) -> CatalogResult<()> {
         if delete_file_ids.is_empty() {
             return Ok(());
@@ -622,9 +606,9 @@ impl MetadataCatalog for CayenneCatalog {
         );
 
         let mut params = Vec::with_capacity(delete_file_ids.len() + 1);
-        params.push(MetastoreValue::Integer(table_id));
+        params.push(MetastoreValue::Text(table_id.to_string()));
         for id in delete_file_ids {
-            params.push(MetastoreValue::Integer(*id));
+            params.push(MetastoreValue::Text(id.clone()));
         }
 
         self.metastore
@@ -632,11 +616,11 @@ impl MetadataCatalog for CayenneCatalog {
             .await
     }
 
-    async fn clear_delete_files(&self, table_id: i64) -> CatalogResult<()> {
+    async fn clear_delete_files(&self, table_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_delete_file WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.to_string())],
             })
             .await
             .map_err(|e| CatalogError::FailedToGetTableDeleteFiles {
@@ -645,12 +629,12 @@ impl MetadataCatalog for CayenneCatalog {
         Ok(())
     }
 
-    async fn increment_sequence_number(&self, table_id: i64) -> CatalogResult<i64> {
+    async fn increment_sequence_number(&self, table_id: &str) -> CatalogResult<i64> {
         // Atomically increment and return the new sequence number
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "UPDATE cayenne_table SET current_sequence_number = current_sequence_number + 1 WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.to_string())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -662,12 +646,12 @@ impl MetadataCatalog for CayenneCatalog {
         self.get_sequence_number(table_id).await
     }
 
-    async fn get_sequence_number(&self, table_id: i64) -> CatalogResult<i64> {
+    async fn get_sequence_number(&self, table_id: &str) -> CatalogResult<i64> {
         self.metastore
             .query_row_helper(
                 QueryRowParams {
                     sql: "SELECT current_sequence_number FROM cayenne_table WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Integer(table_id)],
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
                 },
                 |row| row.get_i64(0),
             )
@@ -680,16 +664,18 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn add_insert_record(
         &self,
-        table_id: i64,
+        table_id: &str,
         pk_bytes: Vec<u8>,
         sequence_number: i64,
     ) -> CatalogResult<()> {
+        let insert_record_id = uuid::Uuid::now_v7().to_string();
         // Use INSERT OR REPLACE to update sequence if PK already exists
         self.metastore
             .execute_helper(ExecuteParams {
-                sql: "INSERT OR REPLACE INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3)",
+                sql: "INSERT OR REPLACE INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3, ?4)",
                 params: vec![
-                    MetastoreValue::Integer(table_id),
+                    MetastoreValue::Text(insert_record_id),
+                    MetastoreValue::Text(table_id.to_string()),
                     MetastoreValue::Blob(pk_bytes),
                     MetastoreValue::Integer(sequence_number),
                 ],
@@ -704,7 +690,7 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn add_insert_records_batch(
         &self,
-        table_id: i64,
+        table_id: &str,
         pk_bytes_list: Vec<Vec<u8>>,
         sequence_number: i64,
     ) -> CatalogResult<()> {
@@ -715,18 +701,19 @@ impl MetadataCatalog for CayenneCatalog {
         // Build a batch insert with all PKs
         // Using INSERT OR REPLACE to update sequence if PK already exists
         let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
-        let mut params = Vec::with_capacity(pk_bytes_list.len() * 3);
+        let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
 
         for (i, pk_bytes) in pk_bytes_list.into_iter().enumerate() {
-            let base = i * 3 + 1; // SQLite params are 1-indexed
-            values_parts.push(format!("(?{}, ?{}, ?{})", base, base + 1, base + 2));
-            params.push(MetastoreValue::Integer(table_id));
+            let base = i * 4 + 1; // SQLite params are 1-indexed
+            values_parts.push(format!("(?{}, ?{}, ?{}, ?{})", base, base + 1, base + 2, base + 3));
+            params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
+            params.push(MetastoreValue::Text(table_id.to_string()));
             params.push(MetastoreValue::Blob(pk_bytes));
             params.push(MetastoreValue::Integer(sequence_number));
         }
 
         let sql = format!(
-            "INSERT OR REPLACE INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES {}",
+            "INSERT OR REPLACE INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
             values_parts.join(", ")
         );
 
@@ -742,14 +729,14 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn get_insert_records(
         &self,
-        table_id: i64,
+        table_id: &str,
     ) -> CatalogResult<std::collections::HashMap<Box<[u8]>, i64>> {
         let results: Vec<(Vec<u8>, i64)> = self
             .metastore
             .query_helper(
                 QueryParams {
                     sql: "SELECT pk_bytes, sequence_number FROM cayenne_insert_record WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Integer(table_id)],
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
                 },
                 |row| {
                     let pk_bytes = row.get_blob(0)?;
@@ -769,11 +756,11 @@ impl MetadataCatalog for CayenneCatalog {
             .collect())
     }
 
-    async fn clear_insert_records(&self, table_id: i64) -> CatalogResult<()> {
+    async fn clear_insert_records(&self, table_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.to_string())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -785,7 +772,7 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn set_snapshot_sequence(
         &self,
-        table_id: i64,
+        table_id: &str,
         snapshot_id: &str,
         sequence_number: i64,
     ) -> CatalogResult<()> {
@@ -793,7 +780,7 @@ impl MetadataCatalog for CayenneCatalog {
             .execute_helper(ExecuteParams {
                 sql: "INSERT OR REPLACE INTO cayenne_snapshot_sequence (table_id, snapshot_id, sequence_number) VALUES (?1, ?2, ?3)",
                 params: vec![
-                    MetastoreValue::Integer(table_id),
+                    MetastoreValue::Text(table_id.to_string()),
                     MetastoreValue::Text(snapshot_id.to_string()),
                     MetastoreValue::Integer(sequence_number),
                 ],
@@ -808,7 +795,7 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn get_snapshot_sequence(
         &self,
-        table_id: i64,
+        table_id: &str,
         snapshot_id: &str,
     ) -> CatalogResult<Option<i64>> {
         let results: Vec<i64> = self
@@ -817,7 +804,7 @@ impl MetadataCatalog for CayenneCatalog {
                 QueryParams {
                     sql: "SELECT sequence_number FROM cayenne_snapshot_sequence WHERE table_id = ?1 AND snapshot_id = ?2",
                     params: vec![
-                        MetastoreValue::Integer(table_id),
+                        MetastoreValue::Text(table_id.to_string()),
                         MetastoreValue::Text(snapshot_id.to_string()),
                     ],
                 },
@@ -834,14 +821,14 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn get_all_snapshot_sequences(
         &self,
-        table_id: i64,
+        table_id: &str,
     ) -> CatalogResult<HashMap<String, i64>> {
         let results: Vec<(String, i64)> = self
             .metastore
             .query_helper(
                 QueryParams {
                     sql: "SELECT snapshot_id, sequence_number FROM cayenne_snapshot_sequence WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Integer(table_id)],
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
                 },
                 |row| {
                     let snapshot_id = row.get_string(0)?;
@@ -858,12 +845,12 @@ impl MetadataCatalog for CayenneCatalog {
         Ok(results.into_iter().collect())
     }
 
-    async fn clear_snapshot_sequence(&self, table_id: i64, snapshot_id: &str) -> CatalogResult<()> {
+    async fn clear_snapshot_sequence(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_snapshot_sequence WHERE table_id = ?1 AND snapshot_id = ?2",
                 params: vec![
-                    MetastoreValue::Integer(table_id),
+                    MetastoreValue::Text(table_id.to_string()),
                     MetastoreValue::Text(snapshot_id.to_string()),
                 ],
             })
@@ -874,7 +861,7 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
-    async fn commit_compaction(&self, table_id: i64, new_snapshot_id: &str) -> CatalogResult<()> {
+    async fn commit_compaction(&self, table_id: &str, new_snapshot_id: &str) -> CatalogResult<()> {
         // Execute all operations atomically using a transaction batch.
         // SQLite's execute_batch runs all statements in a single transaction,
         // ensuring atomicity: either all succeed or none takes effect.
@@ -891,10 +878,10 @@ impl MetadataCatalog for CayenneCatalog {
         // but data is not corrupted).
         let batch_sql = format!(
             "BEGIN TRANSACTION; \
-             DELETE FROM cayenne_delete_file WHERE table_id = {table_id}; \
-             DELETE FROM cayenne_insert_record WHERE table_id = {table_id}; \
-             DELETE FROM cayenne_snapshot_sequence WHERE table_id = {table_id}; \
-             UPDATE cayenne_table SET current_snapshot_id = '{new_snapshot_id}' WHERE table_id = {table_id}; \
+             DELETE FROM cayenne_delete_file WHERE table_id = '{table_id}'; \
+             DELETE FROM cayenne_insert_record WHERE table_id = '{table_id}'; \
+             DELETE FROM cayenne_snapshot_sequence WHERE table_id = '{table_id}'; \
+             UPDATE cayenne_table SET current_snapshot_id = '{new_snapshot_id}' WHERE table_id = '{table_id}'; \
              COMMIT;"
         );
 
@@ -908,7 +895,7 @@ impl MetadataCatalog for CayenneCatalog {
         Ok(())
     }
 
-    async fn add_partition(&self, partition: PartitionMetadata) -> CatalogResult<i64> {
+    async fn add_partition(&self, partition: PartitionMetadata) -> CatalogResult<String> {
         // Validate partition metadata invariants before persisting
         // Without this, invalid metadata could cause incorrect partition lookups at query time
         if partition.partition_columns.is_empty() {
@@ -951,11 +938,11 @@ impl MetadataCatalog for CayenneCatalog {
                 QueryRowParams {
                     sql: "SELECT partition_id FROM cayenne_partition WHERE table_id = ?1 AND partition_key = ?2",
                     params: vec![
-                        MetastoreValue::Integer(partition.table_id),
+                        MetastoreValue::Text(partition.table_id.clone()),
                         MetastoreValue::Text(partition_key.clone()),
                     ],
                 },
-                |row| row.get_i64(0),
+                |row| row.get_string(0),
             )
             .await;
 
@@ -964,18 +951,21 @@ impl MetadataCatalog for CayenneCatalog {
             return Ok(id);
         }
 
+        let partition_id = uuid::Uuid::now_v7().to_string();
+
         // Insert partition metadata with composite key support
         let insert_result = self
             .metastore
             .execute_helper(ExecuteParams {
                 sql: r"
                 INSERT INTO cayenne_partition (
-                    table_id, partition_columns_json, partition_values_json, partition_key, path, path_is_relative, record_count, file_size_bytes
+                    partition_id, table_id, partition_columns_json, partition_values_json, partition_key, path, path_is_relative, record_count, file_size_bytes
                 ) VALUES (
-                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9
                 )",
                 params: vec![
-                    MetastoreValue::Integer(partition.table_id),
+                    MetastoreValue::Text(partition_id.clone()),
+                    MetastoreValue::Text(partition.table_id.clone()),
                     MetastoreValue::Text(columns_json.clone()),
                     MetastoreValue::Text(values_json.clone()),
                     MetastoreValue::Text(partition_key.clone()),
@@ -988,9 +978,8 @@ impl MetadataCatalog for CayenneCatalog {
             .await;
 
         match insert_result {
-            // Success or constraint violation (another concurrent operation inserted first)
-            // Either way, retrieve the partition ID by falling through
-            Ok(()) | Err(CatalogError::ConstraintViolation { .. }) => {}
+            Ok(()) => return Ok(partition_id),
+            Err(CatalogError::ConstraintViolation { .. }) => {}
             Err(e) => {
                 return Err(CatalogError::FailedToAddPartition {
                     source: Box::new(e),
@@ -998,28 +987,28 @@ impl MetadataCatalog for CayenneCatalog {
             }
         }
 
-        // Retrieve the assigned partition ID using composite key
-        let partition_id: i64 = self
+        // Another concurrent operation inserted first — retrieve existing partition ID
+        let existing_id: String = self
             .metastore
             .query_row_helper(
                 QueryRowParams {
                     sql: "SELECT partition_id FROM cayenne_partition WHERE table_id = ?1 AND partition_key = ?2",
                     params: vec![
-                        MetastoreValue::Integer(partition.table_id),
+                        MetastoreValue::Text(partition.table_id),
                         MetastoreValue::Text(partition_key),
                     ],
                 },
-                |row| row.get_i64(0),
+                |row| row.get_string(0),
             )
             .await
             .map_err(|e| CatalogError::FailedToAddPartition {
                 source: Box::new(e),
             })?;
 
-        Ok(partition_id)
+        Ok(existing_id)
     }
 
-    async fn get_partitions(&self, table_id: i64) -> CatalogResult<Vec<PartitionMetadata>> {
+    async fn get_partitions(&self, table_id: &str) -> CatalogResult<Vec<PartitionMetadata>> {
         self.metastore
             .query_helper(
                 QueryParams {
@@ -1029,7 +1018,7 @@ impl MetadataCatalog for CayenneCatalog {
                     WHERE table_id = ?1
                     ORDER BY partition_id
                 ",
-                    params: vec![MetastoreValue::Integer(table_id)],
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
                 },
                 |row| {
                     let columns_json = row.get_string(2)?;
@@ -1045,8 +1034,8 @@ impl MetadataCatalog for CayenneCatalog {
                         })?;
 
                     Ok(PartitionMetadata {
-                        partition_id: row.get_i64(0)?,
-                        table_id: row.get_i64(1)?,
+                        partition_id: row.get_string(0)?,
+                        table_id: row.get_string(1)?,
                         partition_columns,
                         partition_values,
                         path: row.get_string(4)?,
@@ -1064,14 +1053,14 @@ impl MetadataCatalog for CayenneCatalog {
 
     async fn drop_table(&self, table_name: &str) -> CatalogResult<bool> {
         // First check if the table exists and get its ID
-        let table_id: Option<i64> = self
+        let table_id: Option<String> = self
             .metastore
             .query_row_helper(
                 QueryRowParams {
                     sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
                     params: vec![MetastoreValue::Text(table_name.to_string())],
                 },
-                |row| row.get_i64(0),
+                |row| row.get_string(0),
             )
             .await
             .ok();
@@ -1085,7 +1074,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.clone())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -1097,7 +1086,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_snapshot_sequence WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.clone())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -1109,7 +1098,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_delete_file WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.clone())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -1121,7 +1110,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_partition WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id.clone())],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -1133,7 +1122,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_table WHERE table_id = ?1",
-                params: vec![MetastoreValue::Integer(table_id)],
+                params: vec![MetastoreValue::Text(table_id)],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -1317,8 +1306,8 @@ mod tests {
 
             let handle = tokio::spawn(async move {
                 let partition = PartitionMetadata {
-                    partition_id: 0, // Will be assigned by catalog
-                    table_id,
+                    partition_id: String::new(), // Will be assigned by catalog
+                    table_id: table_id.clone(),
                     partition_columns: vec!["date".to_string()],
                     partition_values: vec!["2024-01-01".to_string()],
                     path: "/tmp/cayenne_test_partition/partition_20240101".to_string(),
@@ -1380,34 +1369,23 @@ mod tests {
         // Initialize the catalog
         catalog.init().await.expect("Failed to initialize catalog");
 
-        let table_id = 1;
-
-        // Insert the required table entry for the foreign key constraint
-        catalog
-            .metastore
-            .execute_helper(ExecuteParams {
-                sql: r"
-                INSERT INTO cayenne_table (
-                    table_uuid, table_name, path, path_is_relative, schema_json, primary_key_json,
-                    current_snapshot_id, partition_column, vortex_config_json
-                ) VALUES (
-                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9
-                )
-            ",
-                params: vec![
-                    MetastoreValue::Text(uuid::Uuid::now_v7().to_string()),
-                    MetastoreValue::Text("test_table".to_string()),
-                    MetastoreValue::Text("/tmp/cayenne_test".to_string()),
-                    MetastoreValue::Bool(false), // path_is_relative
-                    MetastoreValue::Text("{}".to_string()), // empty schema
-                    MetastoreValue::Null,        // primary_key_json
-                    MetastoreValue::Text(uuid::Uuid::now_v7().to_string()), // current_snapshot_id
-                    MetastoreValue::Null,        // partition_column
-                    MetastoreValue::Text("{}".to_string()), // empty vortex_config_json
-                ],
-            })
+        // Create a table via the catalog API to get a valid table_id
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
+        ]));
+        let table_options = CreateTableOptions {
+            table_name: "test_table".to_string(),
+            schema,
+            primary_key: vec![],
+            on_conflict: None,
+            base_path: "/tmp/cayenne_test".to_string(),
+            partition_column: None,
+            vortex_config: crate::metadata::VortexConfig::default(),
+        };
+        let table_id = catalog
+            .create_table(table_options)
             .await
-            .expect("Failed to insert test table");
+            .expect("Failed to create table");
 
         // Spawn multiple tasks that all try to create delete files concurrently
         let mut handles = vec![];
@@ -1416,8 +1394,8 @@ mod tests {
 
             let handle = tokio::spawn(async move {
                 let delete_file = DeleteFile {
-                    delete_file_id: 0, // Will be assigned by catalog
-                    table_id,
+                    delete_file_id: String::new(), // Will be assigned by catalog
+                    table_id: table_id.clone(),
                     source_data_file_path: None,
                     path: format!("/tmp/delete_file_{i}.parquet"),
                     path_is_relative: false,
@@ -1456,7 +1434,7 @@ mod tests {
 
         // Verify all delete files were created
         let delete_files = catalog
-            .get_table_delete_files(table_id)
+            .get_table_delete_files(&table_id)
             .await
             .expect("Failed to get delete files");
 
@@ -1512,8 +1490,8 @@ mod tests {
 
             // Add a partition
             let partition = PartitionMetadata {
-                partition_id: 0,
-                table_id,
+                partition_id: String::new(),
+                table_id: table_id.clone(),
                 partition_columns: vec!["name".to_string()],
                 partition_values: vec!["test_value".to_string()],
                 path: format!("{base_path}/partition_test"),
@@ -1528,8 +1506,8 @@ mod tests {
 
             // Add a delete file
             let delete_file = DeleteFile {
-                delete_file_id: 0,
-                table_id,
+                delete_file_id: String::new(),
+                table_id: table_id.clone(),
                 source_data_file_path: None,
                 path: format!("{base_path}/delete_file.parquet"),
                 path_is_relative: false,
@@ -1546,7 +1524,7 @@ mod tests {
 
             // Increment sequence number
             let seq = catalog
-                .increment_sequence_number(table_id)
+                .increment_sequence_number(&table_id)
                 .await
                 .expect("Failed to increment sequence");
             assert_eq!(seq, 1);
@@ -1582,7 +1560,7 @@ mod tests {
 
             // Verify partition persisted
             let partitions = catalog
-                .get_partitions(table_id)
+                .get_partitions(&table_id)
                 .await
                 .expect("Failed to get partitions");
             assert_eq!(partitions.len(), 1);
@@ -1591,7 +1569,7 @@ mod tests {
 
             // Verify delete file persisted
             let delete_files = catalog
-                .get_table_delete_files(table_id)
+                .get_table_delete_files(&table_id)
                 .await
                 .expect("Failed to get delete files");
             assert_eq!(delete_files.len(), 1);
@@ -1600,7 +1578,7 @@ mod tests {
 
             // Verify sequence number persisted
             let seq = catalog
-                .get_sequence_number(table_id)
+                .get_sequence_number(&table_id)
                 .await
                 .expect("Failed to get sequence number");
             assert_eq!(seq, 1);
@@ -1660,8 +1638,8 @@ mod tests {
 
             for i in 0..5 {
                 let delete_file = DeleteFile {
-                    delete_file_id: 0,
-                    table_id,
+                    delete_file_id: String::new(),
+                    table_id: table_id.clone(),
                     source_data_file_path: None,
                     path: format!("{base_path}/delete_{i}.parquet"),
                     path_is_relative: false,
@@ -1686,7 +1664,7 @@ mod tests {
             catalog.init().await.expect("Failed to init");
 
             let delete_files = catalog
-                .get_table_delete_files(table_id)
+                .get_table_delete_files(&table_id)
                 .await
                 .expect("Failed to get delete files");
             assert_eq!(delete_files.len(), 5, "All 5 delete files should persist");
@@ -1694,7 +1672,7 @@ mod tests {
             // Increment sequence number multiple times
             for _ in 0..3 {
                 catalog
-                    .increment_sequence_number(table_id)
+                    .increment_sequence_number(&table_id)
                     .await
                     .expect("Failed to increment");
             }
@@ -1717,7 +1695,7 @@ mod tests {
             );
 
             let delete_files = catalog
-                .get_table_delete_files(table_id)
+                .get_table_delete_files(&table_id)
                 .await
                 .expect("Failed to get delete files");
             assert_eq!(delete_files.len(), 5);
@@ -1773,11 +1751,11 @@ mod tests {
 
             // Add some data
             catalog
-                .increment_sequence_number(table_id)
+                .increment_sequence_number(&table_id)
                 .await
                 .expect("Failed to increment");
             catalog
-                .increment_sequence_number(table_id)
+                .increment_sequence_number(&table_id)
                 .await
                 .expect("Failed to increment");
 
@@ -1844,18 +1822,18 @@ mod tests {
 
             // Add individual insert records
             catalog
-                .add_insert_record(table_id, vec![1, 2, 3, 4], 1)
+                .add_insert_record(&table_id, vec![1, 2, 3, 4], 1)
                 .await
                 .expect("Failed to add insert record");
             catalog
-                .add_insert_record(table_id, vec![5, 6, 7, 8], 2)
+                .add_insert_record(&table_id, vec![5, 6, 7, 8], 2)
                 .await
                 .expect("Failed to add insert record");
 
             // Add batch insert records
             catalog
                 .add_insert_records_batch(
-                    table_id,
+                    &table_id,
                     vec![vec![9, 10], vec![11, 12], vec![13, 14]],
                     3,
                 )
@@ -1871,7 +1849,7 @@ mod tests {
             catalog.init().await.expect("Failed to init");
 
             let records = catalog
-                .get_insert_records(table_id)
+                .get_insert_records(&table_id)
                 .await
                 .expect("Failed to get insert records");
 
@@ -1937,15 +1915,15 @@ mod tests {
                 .expect("Failed to create table");
 
             catalog
-                .set_snapshot_sequence(table_id, &snapshot_1, 10)
+                .set_snapshot_sequence(&table_id, &snapshot_1, 10)
                 .await
                 .expect("Failed to set snapshot seq");
             catalog
-                .set_snapshot_sequence(table_id, &snapshot_2, 20)
+                .set_snapshot_sequence(&table_id, &snapshot_2, 20)
                 .await
                 .expect("Failed to set snapshot seq");
             catalog
-                .set_snapshot_sequence(table_id, &snapshot_3, 30)
+                .set_snapshot_sequence(&table_id, &snapshot_3, 30)
                 .await
                 .expect("Failed to set snapshot seq");
 
@@ -1958,15 +1936,15 @@ mod tests {
             catalog.init().await.expect("Failed to init");
 
             let seq_1 = catalog
-                .get_snapshot_sequence(table_id, &snapshot_1)
+                .get_snapshot_sequence(&table_id, &snapshot_1)
                 .await
                 .expect("Failed to get seq");
             let seq_2 = catalog
-                .get_snapshot_sequence(table_id, &snapshot_2)
+                .get_snapshot_sequence(&table_id, &snapshot_2)
                 .await
                 .expect("Failed to get seq");
             let seq_3 = catalog
-                .get_snapshot_sequence(table_id, &snapshot_3)
+                .get_snapshot_sequence(&table_id, &snapshot_3)
                 .await
                 .expect("Failed to get seq");
 
@@ -1975,7 +1953,7 @@ mod tests {
             assert_eq!(seq_3, Some(30));
 
             let all_seqs = catalog
-                .get_all_snapshot_sequences(table_id)
+                .get_all_snapshot_sequences(&table_id)
                 .await
                 .expect("Failed to get all seqs");
             assert_eq!(all_seqs.len(), 3);

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -339,17 +339,30 @@ impl MetadataCatalog for CayenneCatalog {
         match insert_result {
             Ok(()) => {}
             Err(CatalogError::ConstraintViolation { .. }) => {
-                let existing_id: String = self
-                    .metastore
-                    .query_row_helper(
-                        QueryRowParams {
-                            sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?1",
-                            params: vec![MetastoreValue::Text(table_name.clone())],
-                        },
-                        |row| row.get_string(0),
-                    )
-                    .await?;
-                return Ok(existing_id);
+                // A concurrent create likely won the race. Load the stored metadata,
+                // verify that its configuration matches the requested options, and
+                // ensure the initial snapshot directory exists for local paths.
+                let existing_table = self.get_table(&table_name).await?;
+
+                if !configuration_matches(&existing_table, &options) {
+                    return Err(CatalogError::ChangedConfiguration {
+                        table_name: table_name.clone(),
+                    });
+                }
+
+                // For non-S3 paths, ensure the initial snapshot directory exists.
+                // create_dir_all is idempotent so this is safe even if the winner already created it.
+                if !existing_table.path.starts_with("s3://") {
+                    let snapshot_dir = std::path::PathBuf::from(&existing_table.path)
+                        .join(&existing_table.table_id)
+                        .join(&existing_table.current_snapshot_id);
+
+                    tokio::fs::create_dir_all(&snapshot_dir)
+                        .await
+                        .map_err(|e| CatalogError::Io { source: e })?;
+                }
+
+                return Ok(existing_table.table_id.clone());
             }
             Err(e) => return Err(e),
         }
@@ -537,38 +550,14 @@ impl MetadataCatalog for CayenneCatalog {
             })
             .await;
 
-        match insert_result {
-            Ok(()) => Ok(delete_file_id),
-            Err(CatalogError::ConstraintViolation { .. }) => {
-                // Another concurrent operation inserted first — retrieve the existing ID
-                let existing_id: String = self
-                    .metastore
-                    .query_row_helper(
-                        QueryRowParams {
-                            sql: r"
-                            SELECT delete_file_id
-                            FROM cayenne_delete_file
-                            WHERE table_id = ?1 AND path = ?2
-                            ORDER BY delete_file_id DESC
-                            LIMIT 1
-                        ",
-                            params: vec![
-                                MetastoreValue::Text(delete_file.table_id.clone()),
-                                MetastoreValue::Text(delete_file.path.clone()),
-                            ],
-                        },
-                        |row| row.get_string(0),
-                    )
-                    .await
-                    .map_err(|e| CatalogError::FailedToAddDeleteFile {
-                        source: Box::new(e),
-                    })?;
-                Ok(existing_id)
-            }
-            Err(e) => Err(CatalogError::FailedToAddDeleteFile {
-                source: Box::new(e),
-            }),
-        }
+        insert_result.map_or_else(
+            |e| {
+                Err(CatalogError::FailedToAddDeleteFile {
+                    source: Box::new(e),
+                })
+            },
+            |()| Ok(delete_file_id),
+        )
     }
 
     async fn get_table_delete_files(&self, table_id: &str) -> CatalogResult<Vec<DeleteFile>> {
@@ -891,6 +880,20 @@ impl MetadataCatalog for CayenneCatalog {
     }
 
     async fn commit_compaction(&self, table_id: &str, new_snapshot_id: &str) -> CatalogResult<()> {
+        // Validate that both IDs are valid UUIDs before interpolating into SQL.
+        // These are internally generated UUIDv7s, but we validate defensively
+        // since execute_batch_helper doesn't support parameterized queries.
+        let table_uuid = uuid::Uuid::parse_str(table_id).map_err(|_| {
+            CatalogError::InvalidOperationNoSource {
+                message: format!("Invalid table_id UUID: {table_id}"),
+            }
+        })?;
+        let snapshot_uuid = uuid::Uuid::parse_str(new_snapshot_id).map_err(|_| {
+            CatalogError::InvalidOperationNoSource {
+                message: format!("Invalid new_snapshot_id UUID: {new_snapshot_id}"),
+            }
+        })?;
+
         // Execute all operations atomically using a transaction batch.
         // SQLite's execute_batch runs all statements in a single transaction,
         // ensuring atomicity: either all succeed or none takes effect.
@@ -907,10 +910,10 @@ impl MetadataCatalog for CayenneCatalog {
         // but data is not corrupted).
         let batch_sql = format!(
             "BEGIN TRANSACTION; \
-             DELETE FROM cayenne_delete_file WHERE table_id = '{table_id}'; \
-             DELETE FROM cayenne_insert_record WHERE table_id = '{table_id}'; \
-             DELETE FROM cayenne_snapshot_sequence WHERE table_id = '{table_id}'; \
-             UPDATE cayenne_table SET current_snapshot_id = '{new_snapshot_id}' WHERE table_id = '{table_id}'; \
+             DELETE FROM cayenne_delete_file WHERE table_id = '{table_uuid}'; \
+             DELETE FROM cayenne_insert_record WHERE table_id = '{table_uuid}'; \
+             DELETE FROM cayenne_snapshot_sequence WHERE table_id = '{table_uuid}'; \
+             UPDATE cayenne_table SET current_snapshot_id = '{snapshot_uuid}' WHERE table_id = '{table_uuid}'; \
              COMMIT;"
         );
 

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -23,10 +23,8 @@ use serde::{Deserialize, Serialize};
 /// Metadata about a table in the catalog.
 #[derive(Debug, Clone)]
 pub struct TableMetadata {
-    /// Unique identifier for this table
-    pub table_id: i64,
-    /// UUID for this table (for external references)
-    pub table_uuid: String,
+    /// Unique identifier for this table (`UUIDv7`)
+    pub table_id: String,
     /// Name of the table
     pub table_name: String,
     /// Path to the table's data directory
@@ -69,10 +67,10 @@ pub struct TableMetadata {
 pub struct DataFile {
     /// Unique identifier for this data file
     pub data_file_id: i64,
-    /// Table this file belongs to
-    pub table_id: i64,
+    /// Table this file belongs to (`UUIDv7`)
+    pub table_id: String,
     /// Partition this file belongs to (None for non-partitioned tables)
-    pub partition_id: Option<i64>,
+    pub partition_id: Option<String>,
     /// Ordering of this file within the table
     pub file_order: i64,
     /// Path to the directory containing the `ListingTable`'s Vortex files
@@ -109,10 +107,10 @@ pub enum DeletionType {
 /// Represents a deletion vector file tracking deleted rows.
 #[derive(Debug, Clone)]
 pub struct DeleteFile {
-    /// Unique identifier for this delete file
-    pub delete_file_id: i64,
-    /// Table this delete file belongs to
-    pub table_id: i64,
+    /// Unique identifier for this delete file (`UUIDv7`)
+    pub delete_file_id: String,
+    /// Table this delete file belongs to (`UUIDv7`)
+    pub table_id: String,
     /// Path of the data file this deletion vector applies to (for position-based deletions).
     /// `None` for key-based deletions which apply to the entire table.
     /// For position-based deletions, row IDs are relative to this specific data file.
@@ -147,10 +145,10 @@ pub struct DeleteFile {
 /// corresponds to the i-th partition value.
 #[derive(Debug, Clone)]
 pub struct PartitionMetadata {
-    /// Unique identifier for this partition
-    pub partition_id: i64,
-    /// Table this partition belongs to
-    pub table_id: i64,
+    /// Unique identifier for this partition (`UUIDv7`)
+    pub partition_id: String,
+    /// Table this partition belongs to (`UUIDv7`)
+    pub table_id: String,
     /// Names of the partition columns (ordered).
     /// For a single partition column, this is a single-element vector.
     /// For composite partitions like `partition_by: [year, month]`, this contains
@@ -187,14 +185,14 @@ impl PartitionMetadata {
     /// Creates a new `PartitionMetadata` for a single partition column (legacy compatibility).
     #[must_use]
     pub fn new_single(
-        table_id: i64,
+        table_id: String,
         partition_column: String,
         partition_value: String,
         path: String,
         path_is_relative: bool,
     ) -> Self {
         Self {
-            partition_id: 0,
+            partition_id: String::new(),
             table_id,
             partition_columns: vec![partition_column],
             partition_values: vec![partition_value],
@@ -208,14 +206,14 @@ impl PartitionMetadata {
     /// Creates a new `PartitionMetadata` for composite partition columns.
     #[must_use]
     pub fn new_composite(
-        table_id: i64,
+        table_id: String,
         partition_columns: Vec<String>,
         partition_values: Vec<String>,
         path: String,
         path_is_relative: bool,
     ) -> Self {
         Self {
-            partition_id: 0,
+            partition_id: String::new(),
             table_id,
             partition_columns,
             partition_values,

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -53,7 +53,6 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         name: "cayenne_table",
         columns: &[
             "table_id",
-            "table_uuid",
             "table_name",
             "path",
             "path_is_relative",

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -169,6 +169,11 @@ impl SqliteMetastore {
         )
     ";
 
+    const TABLE_NAME_UNIQUE_INDEX_DDL: &'static str = r"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_cayenne_table_name_unique
+        ON cayenne_table(table_name)
+    ";
+
     /// Schema for the `cayenne_delete_file` table.
     const DELETE_FILE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_delete_file (
@@ -342,8 +347,9 @@ impl MetastoreBackend for SqliteMetastore {
         conn.call(|conn| {
             // Create tables in a transaction
             conn.execute_batch(&format!(
-                "{}; {}; {}; {}; {};",
+                "{}; {}; {}; {}; {}; {};",
                 Self::TABLE_TABLE_DDL,
+                Self::TABLE_NAME_UNIQUE_INDEX_DDL,
                 Self::DELETE_FILE_TABLE_DDL,
                 Self::PARTITION_TABLE_DDL,
                 Self::INSERT_RECORD_TABLE_DDL,
@@ -448,17 +454,18 @@ impl MetastoreBackend for SqliteMetastore {
                     .map(|v| v as &dyn rusqlite::ToSql)
                     .collect();
 
-                conn.prepare_cached(&sql)?.query_row(params_refs.as_slice(), |row| {
-                    let column_count = row.as_ref().column_count();
-                    let mut values = Vec::with_capacity(column_count);
+                conn.prepare_cached(&sql)?
+                    .query_row(params_refs.as_slice(), |row| {
+                        let column_count = row.as_ref().column_count();
+                        let mut values = Vec::with_capacity(column_count);
 
-                    for i in 0..column_count {
-                        let value = row.get_ref(i)?;
-                        values.push(convert_sqlite_value(value));
-                    }
+                        for i in 0..column_count {
+                            let value = row.get_ref(i)?;
+                            values.push(convert_sqlite_value(value));
+                        }
 
-                    Ok(values)
-                })
+                        Ok(values)
+                    })
             })
             .await
             .map_err(

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -153,12 +153,9 @@ impl SqliteMetastore {
     }
 
     /// Schema for the `cayenne_table` table.
-    /// Using INTEGER for AUTOINCREMENT is required
-    /// It is unlikely someone will have more than `9223372036854775807` tables (`SQLite` INTEGER max)
     const TABLE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_table (
-            table_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_uuid TEXT NOT NULL,
+            table_id TEXT PRIMARY KEY,
             table_name TEXT NOT NULL,
             path TEXT NOT NULL,
             path_is_relative BOOLEAN NOT NULL,
@@ -175,8 +172,8 @@ impl SqliteMetastore {
     /// Schema for the `cayenne_delete_file` table.
     const DELETE_FILE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_delete_file (
-            delete_file_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            delete_file_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             path TEXT NOT NULL,
             path_is_relative BOOLEAN NOT NULL,
             format TEXT NOT NULL,
@@ -195,8 +192,8 @@ impl SqliteMetastore {
     /// for efficient lookups and uniqueness constraints.
     const PARTITION_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_partition (
-            partition_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            partition_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             partition_columns_json TEXT NOT NULL,
             partition_values_json TEXT NOT NULL,
             partition_key TEXT NOT NULL,
@@ -218,8 +215,8 @@ impl SqliteMetastore {
     /// - If `delete_sequence` > `insert_sequence`, the row is filtered out
     const INSERT_RECORD_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_insert_record (
-            insert_record_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            insert_record_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             pk_bytes BLOB NOT NULL,
             sequence_number BIGINT NOT NULL,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
@@ -234,7 +231,7 @@ impl SqliteMetastore {
     /// <= the delete file's `sequence_number`.
     const SNAPSHOT_SEQUENCE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_snapshot_sequence (
-            table_id INTEGER NOT NULL,
+            table_id TEXT NOT NULL,
             snapshot_id TEXT NOT NULL,
             sequence_number BIGINT NOT NULL,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
@@ -451,7 +448,7 @@ impl MetastoreBackend for SqliteMetastore {
                     .map(|v| v as &dyn rusqlite::ToSql)
                     .collect();
 
-                conn.query_row(&sql, params_refs.as_slice(), |row| {
+                conn.prepare_cached(&sql)?.query_row(params_refs.as_slice(), |row| {
                     let column_count = row.as_ref().column_count();
                     let mut values = Vec::with_capacity(column_count);
 

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -148,6 +148,11 @@ impl TursoMetastore {
         )
     ";
 
+    const TABLE_NAME_UNIQUE_INDEX_DDL: &'static str = r"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_cayenne_table_name_unique
+        ON cayenne_table(table_name)
+    ";
+
     /// Schema for the `cayenne_delete_file` table.
     const DELETE_FILE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_delete_file (
@@ -331,8 +336,9 @@ impl MetastoreBackend for TursoMetastore {
 
         // Create tables
         let schema_sql = format!(
-            "{}; {}; {}; {}; {};",
+            "{}; {}; {}; {}; {}; {};",
             Self::TABLE_TABLE_DDL,
+            Self::TABLE_NAME_UNIQUE_INDEX_DDL,
             Self::DELETE_FILE_TABLE_DDL,
             Self::PARTITION_TABLE_DDL,
             Self::INSERT_RECORD_TABLE_DDL,
@@ -447,12 +453,12 @@ impl MetastoreBackend for TursoMetastore {
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
-        let mut stmt = conn
-            .prepare_cached(params.sql)
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to query row: {e}"),
-            })?;
+        let mut stmt =
+            conn.prepare_cached(params.sql)
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to query row: {e}"),
+                })?;
         let mut rows = stmt
             .query(turso_params)
             .await
@@ -490,12 +496,12 @@ impl MetastoreBackend for TursoMetastore {
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
-        let mut stmt = conn
-            .prepare_cached(params.sql)
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to query rows: {e}"),
-            })?;
+        let mut stmt =
+            conn.prepare_cached(params.sql)
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to query rows: {e}"),
+                })?;
         let mut rows = stmt
             .query(turso_params)
             .await

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -134,8 +134,7 @@ impl TursoMetastore {
     /// Schema for the `cayenne_table` table.
     const TABLE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_table (
-            table_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_uuid TEXT NOT NULL,
+            table_id TEXT PRIMARY KEY,
             table_name TEXT NOT NULL,
             path TEXT NOT NULL,
             path_is_relative BOOLEAN NOT NULL,
@@ -152,8 +151,8 @@ impl TursoMetastore {
     /// Schema for the `cayenne_delete_file` table.
     const DELETE_FILE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_delete_file (
-            delete_file_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            delete_file_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             path TEXT NOT NULL,
             path_is_relative BOOLEAN NOT NULL,
             format TEXT NOT NULL,
@@ -172,8 +171,8 @@ impl TursoMetastore {
     /// for efficient lookups and uniqueness constraints.
     const PARTITION_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_partition (
-            partition_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            partition_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             partition_columns_json TEXT NOT NULL,
             partition_values_json TEXT NOT NULL,
             partition_key TEXT NOT NULL,
@@ -195,8 +194,8 @@ impl TursoMetastore {
     /// - If `delete_sequence` > `insert_sequence`, the row is filtered out
     const INSERT_RECORD_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_insert_record (
-            insert_record_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            table_id INTEGER NOT NULL,
+            insert_record_id TEXT PRIMARY KEY,
+            table_id TEXT NOT NULL,
             pk_bytes BLOB NOT NULL,
             sequence_number BIGINT NOT NULL,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
@@ -211,7 +210,7 @@ impl TursoMetastore {
     /// <= the delete file's `sequence_number`.
     const SNAPSHOT_SEQUENCE_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_snapshot_sequence (
-            table_id INTEGER NOT NULL,
+            table_id TEXT NOT NULL,
             snapshot_id TEXT NOT NULL,
             sequence_number BIGINT NOT NULL,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -476,7 +476,7 @@ impl CayenneDeletionSink {
         } else {
             let sequence = self
                 .catalog
-                .increment_sequence_number(self.table_metadata.table_id)
+                .increment_sequence_number(&self.table_metadata.table_id)
                 .await?;
             *delete_sequence = Some(sequence);
             sequence
@@ -500,7 +500,7 @@ impl CayenneDeletionSink {
         } else {
             let sequence = self
                 .catalog
-                .increment_sequence_number(self.table_metadata.table_id)
+                .increment_sequence_number(&self.table_metadata.table_id)
                 .await?;
             *delete_sequence = Some(sequence);
             sequence
@@ -522,7 +522,7 @@ impl CayenneDeletionSink {
 
         let delete_sequence = self
             .catalog
-            .increment_sequence_number(self.table_metadata.table_id)
+            .increment_sequence_number(&self.table_metadata.table_id)
             .await?;
 
         self.persist_key_based_deletions_with_sequence(filtered_row_keys, delete_sequence)
@@ -640,7 +640,7 @@ impl CayenneDeletionSink {
 
         let delete_sequence = self
             .catalog
-            .increment_sequence_number(self.table_metadata.table_id)
+            .increment_sequence_number(&self.table_metadata.table_id)
             .await?;
 
         self.persist_int64_pk_deletions_with_sequence(filtered_pk_values, delete_sequence)

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -101,7 +101,7 @@ pub struct FileBasedDeletionSink {
     /// In-memory protected snapshots map (shared with `CayenneTableProvider`).
     protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
     /// Table ID for catalog operations.
-    table_id: i64,
+    table_id: String,
     /// Table base path for constructing snapshot directory paths.
     table_path: String,
     /// Shared runtime environment for cache invalidation after file deletion.
@@ -131,7 +131,7 @@ impl FileBasedDeletionSink {
         table_name: String,
         catalog: Arc<dyn MetadataCatalog>,
         protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
-        table_id: i64,
+        table_id: String,
         table_path: String,
         runtime_env: Arc<RuntimeEnv>,
     ) -> Self {
@@ -435,7 +435,7 @@ impl FileBasedDeletionSink {
             // 1. Remove snapshot sequence from catalog
             if let Err(e) = self
                 .catalog
-                .clear_snapshot_sequence(self.table_id, snapshot_id)
+                .clear_snapshot_sequence(&self.table_id, snapshot_id)
                 .await
             {
                 tracing::warn!(
@@ -458,7 +458,7 @@ impl FileBasedDeletionSink {
 
             // 3. Delete the empty snapshot directory
             let snapshot_dir = std::path::PathBuf::from(&self.table_path)
-                .join(self.table_id.to_string())
+                .join(&self.table_id)
                 .join(snapshot_id);
             match tokio::fs::remove_dir_all(&snapshot_dir).await {
                 Ok(()) => {}

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -503,8 +503,8 @@ fn build_delete_file(
     })?;
 
     Ok(DeleteFile {
-        delete_file_id: 0,
-        table_id: table.table_id,
+        delete_file_id: String::new(),
+        table_id: table.table_id.clone(),
         source_data_file_path,
         path: file_path.to_string_lossy().to_string(),
         path_is_relative: false,
@@ -555,8 +555,7 @@ mod tests {
 
     fn build_table_metadata(temp_dir: &TempDir) -> TableMetadata {
         TableMetadata {
-            table_id: 42,
-            table_uuid: Uuid::now_v7().to_string(),
+            table_id: "test-table-id".to_string(),
             table_name: "test_table".to_string(),
             path: temp_dir.path().to_string_lossy().to_string(),
             path_is_relative: false,

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -1015,9 +1015,9 @@ mod tests {
         .expect("to create upsert batch");
         insert_batch(&provider, batch2).await;
 
-        let table_id = provider.table_id();
+        let table_id = provider.table_id().to_string();
         let pre_restart_insert_records = catalog
-            .get_insert_records(table_id)
+            .get_insert_records(&table_id)
             .await
             .expect("Failed to read insert records before restart");
         assert!(
@@ -1041,7 +1041,7 @@ mod tests {
             Arc::clone(&catalog2) as Arc<dyn MetadataCatalog>;
 
         let persisted_insert_records = catalog2
-            .get_insert_records(table_id)
+            .get_insert_records(&table_id)
             .await
             .expect("Failed to read insert records after restart");
         assert!(

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -352,8 +352,8 @@ impl CayenneTableProvider {
 
     /// Returns the table ID from the catalog.
     #[must_use]
-    pub(crate) fn table_id(&self) -> i64 {
-        self.table_metadata.table_id
+    pub(crate) fn table_id(&self) -> &str {
+        &self.table_metadata.table_id
     }
 
     /// Returns a reference to the write lock for serializing insert operations.
@@ -373,7 +373,7 @@ impl CayenneTableProvider {
     pub(crate) fn snapshot_dir_path_for(&self, snapshot_id: &str) -> std::path::PathBuf {
         Self::snapshot_dir_path(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             snapshot_id,
         )
     }
@@ -383,7 +383,7 @@ impl CayenneTableProvider {
     /// This clears any existing delete files since overwrite replaces all data.
     pub(crate) async fn commit_overwrite(&self, new_snapshot_id: &str) -> CatalogResult<()> {
         self.catalog
-            .commit_compaction(self.table_metadata.table_id, new_snapshot_id)
+            .commit_compaction(&self.table_metadata.table_id, new_snapshot_id)
             .await
     }
 
@@ -393,7 +393,7 @@ impl CayenneTableProvider {
     pub(crate) fn update_listing_table_for_snapshot(&self, new_snapshot_id: &str) -> Result<()> {
         let snapshot_dir_url = Self::snapshot_dir_url(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             new_snapshot_id,
         );
 
@@ -439,17 +439,17 @@ impl CayenneTableProvider {
             {
                 tracing::warn!(
                     "Failed to cleanup old S3 snapshots for table {}: {err}",
-                    self.table_metadata.table_id
+                    &self.table_metadata.table_id
                 );
             }
         } else {
             let table_path = self.table_metadata.path.clone();
-            let table_id = self.table_metadata.table_id;
+            let table_id = self.table_metadata.table_id.clone();
             let current_snapshot = current_snapshot.to_string();
             tokio::task::spawn_blocking(move || {
                 if let Err(e) = Self::cleanup_old_snapshots_blocking(
                     &table_path,
-                    table_id,
+                    &table_id,
                     &current_snapshot,
                     &protected_snapshot_ids,
                 ) {
@@ -473,11 +473,11 @@ impl CayenneTableProvider {
     /// * `snapshot_id` - The snapshot identifier
     pub(super) fn snapshot_dir_path(
         table_path: &str,
-        table_id: i64,
+        table_id: &str,
         snapshot_id: &str,
     ) -> std::path::PathBuf {
         std::path::PathBuf::from(table_path)
-            .join(table_id.to_string())
+            .join(table_id)
             .join(snapshot_id)
     }
 
@@ -528,7 +528,7 @@ impl CayenneTableProvider {
 
         let snapshot_url = Self::snapshot_dir_url(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             snapshot_id,
         );
 
@@ -698,7 +698,7 @@ impl CayenneTableProvider {
     /// * `table_path` - The base path for the table (local path or S3 URL)
     /// * `table_id` - The unique identifier for the table
     /// * `snapshot_id` - The snapshot identifier
-    fn snapshot_dir_url(table_path: &str, table_id: i64, snapshot_id: &str) -> String {
+    fn snapshot_dir_url(table_path: &str, table_id: &str, snapshot_id: &str) -> String {
         if table_path.starts_with("s3://") {
             // S3 URL: join path components with /
             let base = table_path.trim_end_matches('/');
@@ -742,7 +742,7 @@ impl CayenneTableProvider {
             // Local FS: remove and recreate the directory
             let staging_dir = Self::snapshot_dir_path(
                 &self.table_metadata.path,
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 STAGING_DIR_NAME,
             );
             match tokio::fs::remove_dir_all(&staging_dir).await {
@@ -781,12 +781,12 @@ impl CayenneTableProvider {
     async fn move_staging_files_local(&self, current_snapshot: &str) -> Result<()> {
         let staging_dir = Self::snapshot_dir_path(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             STAGING_DIR_NAME,
         );
         let target_dir = Self::snapshot_dir_path(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             current_snapshot,
         );
 
@@ -977,11 +977,11 @@ impl CayenneTableProvider {
     /// It must be called from within `tokio::task::spawn_blocking`.
     fn cleanup_old_snapshots_blocking(
         table_path: &str,
-        table_id: i64,
+        table_id: &str,
         current_snapshot_id: &str,
         protected_snapshot_ids: &HashSet<String>,
     ) -> CatalogResult<()> {
-        let table_dir = std::path::PathBuf::from(table_path).join(table_id.to_string());
+        let table_dir = std::path::PathBuf::from(table_path).join(table_id);
 
         // Check if table directory exists
         if !table_dir.exists() {
@@ -1120,7 +1120,7 @@ impl CayenneTableProvider {
         // All tables have a snapshot ID (created on table initialization)
         let snapshot_dir_url = Self::snapshot_dir_url(
             &table_metadata.path,
-            table_metadata.table_id,
+            &table_metadata.table_id,
             &table_metadata.current_snapshot_id,
         );
 
@@ -1175,10 +1175,10 @@ impl CayenneTableProvider {
         // Load deletion vectors and insert records once at initialization
         // to avoid repeated SQLite queries on every scan.
         // Returns the fully constructed PkDeletionStrategy with embedded caches.
-        let table_id = table_metadata.table_id;
+        let table_id = table_metadata.table_id.clone();
         let catalog_for_load = Arc::clone(&catalog);
         let pk_deletion_strategy =
-            Self::load_deletion_vectors_all(table_id, catalog_for_load, pk_deletion_strategy_kind)
+            Self::load_deletion_vectors_all(&table_id, catalog_for_load, pk_deletion_strategy_kind)
                 .await?;
 
         let listing_table = Self::create_listing_table(
@@ -1192,7 +1192,7 @@ impl CayenneTableProvider {
         // Protected snapshots are those with sequence > max_delete_sequence.
         // They contain data written after deletions and should skip deletion filtering.
         let protected_snapshots =
-            Self::load_protected_snapshots(Arc::clone(&catalog), table_id, &pk_deletion_strategy)
+            Self::load_protected_snapshots(Arc::clone(&catalog), &table_id, &pk_deletion_strategy)
                 .await?;
 
         // Register the S3 object store in the shared RuntimeEnv once during
@@ -1311,7 +1311,7 @@ impl CayenneTableProvider {
         // Record the snapshot's sequence number in the catalog
         self.catalog
             .set_snapshot_sequence(
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 &new_snapshot_id,
                 sequence_number,
             )
@@ -1400,7 +1400,7 @@ impl CayenneTableProvider {
         // Construct snapshot directory URL
         let snapshot_dir_url = Self::snapshot_dir_url(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             snapshot_id,
         );
 
@@ -1822,7 +1822,7 @@ impl CayenneTableProvider {
         for (snapshot_id, max_delete_seq_at_creation) in &protected_snapshots {
             let snapshot_url = Self::snapshot_dir_url(
                 &self.table_metadata.path,
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 snapshot_id,
             );
 
@@ -2292,7 +2292,7 @@ impl CayenneTableProvider {
         // the next delete will be properly filtered.
         let delete_sequence = self
             .catalog
-            .increment_sequence_number(self.table_metadata.table_id)
+            .increment_sequence_number(&self.table_metadata.table_id)
             .await
             .map_err(|err| CatalogError::InvalidOperationNoSource {
                 message: format!("Failed to get delete sequence number: {err}"),
@@ -2370,7 +2370,7 @@ impl CayenneTableProvider {
         if !pk_bytes_list_for_insert_records.is_empty() {
             self.catalog
                 .add_insert_records_batch(
-                    self.table_metadata.table_id,
+                    &self.table_metadata.table_id,
                     pk_bytes_list_for_insert_records,
                     insert_sequence,
                 )
@@ -2620,7 +2620,7 @@ impl CayenneTableProvider {
             if is_s3 {
                 let snapshot_url = Self::snapshot_dir_url(
                     &self.table_metadata.path,
-                    self.table_metadata.table_id,
+                    &self.table_metadata.table_id,
                     &new_snapshot_id,
                 );
 
@@ -2721,7 +2721,7 @@ impl CayenneTableProvider {
         // the catalog yet, avoiding an inconsistent state.
         let snapshot_dir_url = Self::snapshot_dir_url(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             &new_snapshot_id,
         );
         let new_listing_table = Self::create_listing_table(
@@ -2869,7 +2869,7 @@ impl CayenneTableProvider {
     /// Returns an error if deletion vectors cannot be loaded from the catalog.
     async fn refresh_deletion_cache(&self) -> CatalogResult<()> {
         let fresh_strategy = Self::load_deletion_vectors_all(
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             Arc::clone(&self.catalog),
             self.pk_deletion_strategy.strategy(),
         )
@@ -3137,7 +3137,7 @@ impl CayenneTableProvider {
         let current_snapshot = self.get_current_snapshot_id()?;
         let snapshot_dir_url = Self::snapshot_dir_url(
             &self.table_metadata.path,
-            self.table_metadata.table_id,
+            &self.table_metadata.table_id,
             &current_snapshot,
         );
 
@@ -3215,7 +3215,7 @@ impl CayenneTableProvider {
     ///
     /// The fully constructed `PkDeletionStrategy` with all caches populated.
     async fn load_deletion_vectors_all(
-        table_id: i64,
+        table_id: &str,
         catalog: Arc<dyn MetadataCatalog>,
         strategy: PkDeletionStrategy,
     ) -> CatalogResult<PkDeletionStrategyWithCache> {
@@ -3394,7 +3394,7 @@ impl CayenneTableProvider {
     /// They contain data written after deletions and should skip deletion filtering.
     async fn load_protected_snapshots(
         catalog: Arc<dyn MetadataCatalog>,
-        table_id: i64,
+        table_id: &str,
         strategy: &PkDeletionStrategyWithCache,
     ) -> CatalogResult<HashMap<String, i64>> {
         // Only PK-based strategies support sequence-ordered snapshot protection.
@@ -3519,7 +3519,7 @@ impl CayenneTableProvider {
             // Create listing table for this snapshot
             let snapshot_url = Self::snapshot_dir_url(
                 &self.table_metadata.path,
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 &snapshot_id,
             );
 
@@ -4117,7 +4117,7 @@ impl TableProvider for CayenneTableProvider {
             })?;
             let snapshot_dir = Self::snapshot_dir_path(
                 &self.table_metadata.path,
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 &current_snapshot,
             );
             Self::ensure_snapshot_dir_exists(&snapshot_dir)
@@ -4195,7 +4195,7 @@ impl CayenneTableProvider {
                 self.table_metadata.table_name.clone(),
                 Arc::clone(&self.catalog),
                 Arc::clone(&self.protected_snapshots),
-                self.table_metadata.table_id,
+                self.table_metadata.table_id.clone(),
                 self.table_metadata.path.clone(),
                 Arc::clone(self.context.runtime_env()),
             )),
@@ -4250,7 +4250,7 @@ impl CayenneTableProvider {
         for (snapshot_id, _) in protected_snapshots {
             let snapshot_url = Self::snapshot_dir_url(
                 &self.table_metadata.path,
-                self.table_metadata.table_id,
+                &self.table_metadata.table_id,
                 &snapshot_id,
             );
 

--- a/crates/cayenne/tests/catalog_concurrency_test.rs
+++ b/crates/cayenne/tests/catalog_concurrency_test.rs
@@ -118,11 +118,12 @@ async fn test_concurrent_partition_creation_impl(fixture: TestFixture) -> TestRe
 
         for i in 0..num_calls {
             let catalog_clone = Arc::clone(&fixture.catalog);
+            let table_id = table_id.clone();
             let path = table_dir.join(format!("partition_20240101_{i}"));
 
             let handle = tokio::spawn(async move {
                 let mut partition = PartitionMetadata::new_single(
-                    table_id.clone(),
+                    table_id,
                     "partition_date".to_string(),
                     "2024-01-01".to_string(), // Same value for all
                     path.to_string_lossy().to_string(),

--- a/crates/cayenne/tests/catalog_concurrency_test.rs
+++ b/crates/cayenne/tests/catalog_concurrency_test.rs
@@ -68,7 +68,7 @@ async fn create_partitioned_table(
     catalog: &Arc<CayenneCatalog>,
     table_name: &str,
     base_path: &str,
-) -> TestResult<i64> {
+) -> TestResult<String> {
     let schema = create_test_schema();
 
     let table_options = CreateTableOptions {
@@ -122,7 +122,7 @@ async fn test_concurrent_partition_creation_impl(fixture: TestFixture) -> TestRe
 
             let handle = tokio::spawn(async move {
                 let mut partition = PartitionMetadata::new_single(
-                    table_id,
+                    table_id.clone(),
                     "partition_date".to_string(),
                     "2024-01-01".to_string(), // Same value for all
                     path.to_string_lossy().to_string(),
@@ -153,7 +153,7 @@ async fn test_concurrent_partition_creation_impl(fixture: TestFixture) -> TestRe
             let path = table_dir.join(format!("partition_20240101_{i}"));
 
             let mut partition = PartitionMetadata::new_single(
-                table_id,
+                table_id.clone(),
                 "partition_date".to_string(),
                 "2024-01-01".to_string(), // Same value for all
                 path.to_string_lossy().to_string(),
@@ -174,7 +174,7 @@ async fn test_concurrent_partition_creation_impl(fixture: TestFixture) -> TestRe
     );
 
     // Verify the partition exists and can be queried
-    let partitions = fixture.catalog.get_partitions(table_id).await?;
+    let partitions = fixture.catalog.get_partitions(&table_id).await?;
 
     assert_eq!(partitions.len(), 1, "Should have exactly one partition");
     assert_eq!(partitions[0].partition_id, partition_ids[0]);
@@ -205,7 +205,7 @@ async fn test_partition_roundtrip_impl(fixture: TestFixture) -> TestResult<()> {
 
     for value in partition_values {
         let mut partition = PartitionMetadata::new_single(
-            table_id,
+            table_id.clone(),
             "partition_date".to_string(),
             value.to_string(),
             table_dir
@@ -222,7 +222,7 @@ async fn test_partition_roundtrip_impl(fixture: TestFixture) -> TestResult<()> {
     }
 
     // Read back all partitions
-    let partitions = fixture.catalog.get_partitions(table_id).await?;
+    let partitions = fixture.catalog.get_partitions(&table_id).await?;
 
     assert_eq!(partitions.len(), 3, "Should have 3 partitions");
 
@@ -256,8 +256,8 @@ async fn test_delete_file_roundtrip_impl(fixture: TestFixture) -> TestResult<()>
 
     for i in 0..3 {
         let delete_file = DeleteFile {
-            delete_file_id: 0,
-            table_id,
+            delete_file_id: String::new(),
+            table_id: table_id.clone(),
             path: table_dir
                 .join(format!("delete_{i}.bin"))
                 .to_string_lossy()
@@ -276,7 +276,7 @@ async fn test_delete_file_roundtrip_impl(fixture: TestFixture) -> TestResult<()>
     }
 
     // Read back all delete files
-    let delete_files = fixture.catalog.get_table_delete_files(table_id).await?;
+    let delete_files = fixture.catalog.get_table_delete_files(&table_id).await?;
 
     assert_eq!(delete_files.len(), 3, "Should have 3 delete files");
 
@@ -362,7 +362,7 @@ async fn test_sequential_partition_stress_impl(fixture: TestFixture) -> TestResu
             .to_string();
 
         let mut partition = PartitionMetadata::new_single(
-            table_id,
+            table_id.clone(),
             "partition_date".to_string(),
             partition_value.clone(),
             path,
@@ -376,7 +376,7 @@ async fn test_sequential_partition_stress_impl(fixture: TestFixture) -> TestResu
     }
 
     // Verify we have exactly num_partitions unique partitions
-    let partitions = fixture.catalog.get_partitions(table_id).await?;
+    let partitions = fixture.catalog.get_partitions(&table_id).await?;
     assert_eq!(
         partitions.len(),
         num_partitions,
@@ -411,7 +411,7 @@ async fn test_duplicate_partition_returns_existing_impl(fixture: TestFixture) ->
 
     // Create first partition
     let mut partition1 = PartitionMetadata::new_single(
-        table_id,
+        table_id.clone(),
         "partition_date".to_string(),
         "2024-06-15".to_string(),
         table_dir.join("partition_v1").to_string_lossy().to_string(),
@@ -424,7 +424,7 @@ async fn test_duplicate_partition_returns_existing_impl(fixture: TestFixture) ->
 
     // Create second partition with same key but different path
     let mut partition2 = PartitionMetadata::new_single(
-        table_id,
+        table_id.clone(),
         "partition_date".to_string(),
         "2024-06-15".to_string(), // Same partition value
         table_dir.join("partition_v2").to_string_lossy().to_string(), // Different path
@@ -443,7 +443,7 @@ async fn test_duplicate_partition_returns_existing_impl(fixture: TestFixture) ->
 
     // Create third partition with same key
     let mut partition3 = PartitionMetadata::new_single(
-        table_id,
+        table_id.clone(),
         "partition_date".to_string(),
         "2024-06-15".to_string(), // Same partition value again
         table_dir.join("partition_v3").to_string_lossy().to_string(),
@@ -461,7 +461,7 @@ async fn test_duplicate_partition_returns_existing_impl(fixture: TestFixture) ->
     );
 
     // Verify only one partition exists in the catalog
-    let all_partitions = fixture.catalog.get_partitions(table_id).await?;
+    let all_partitions = fixture.catalog.get_partitions(&table_id).await?;
     assert_eq!(
         all_partitions.len(),
         1,
@@ -488,7 +488,7 @@ async fn test_constraint_violation_recovery_impl(fixture: TestFixture) -> TestRe
 
     // First, create a partition
     let mut partition1 = PartitionMetadata::new_single(
-        table_id,
+        table_id.clone(),
         "partition_date".to_string(),
         "2024-01-01".to_string(),
         table_dir.join("partition_1").to_string_lossy().to_string(),
@@ -501,7 +501,7 @@ async fn test_constraint_violation_recovery_impl(fixture: TestFixture) -> TestRe
 
     // Now try to create the same partition again (should return same ID)
     let mut partition2 = PartitionMetadata::new_single(
-        table_id,
+        table_id.clone(),
         "partition_date".to_string(),
         "2024-01-01".to_string(), // Same value
         table_dir.join("partition_2").to_string_lossy().to_string(), // Different path
@@ -519,7 +519,7 @@ async fn test_constraint_violation_recovery_impl(fixture: TestFixture) -> TestRe
     );
 
     // Verify only one partition exists
-    let all_partitions = fixture.catalog.get_partitions(table_id).await?;
+    let all_partitions = fixture.catalog.get_partitions(&table_id).await?;
     assert_eq!(all_partitions.len(), 1, "Should have exactly one partition");
 
     Ok(())

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -1224,10 +1224,8 @@ fn table_id_dir(
     table: &CayenneTableProvider,
     table_name: &str,
 ) -> std::path::PathBuf {
-    fixture
-        .data_path
-        .join(table_name)
-        .join(table.metadata().table_id.to_string())
+    let meta = table.metadata();
+    fixture.data_path.join(table_name).join(&meta.table_id)
 }
 
 /// Creates a dummy non-empty cache value. The cache rejects empty vecs internally.

--- a/crates/cayenne/tests/integration_test.rs
+++ b/crates/cayenne/tests/integration_test.rs
@@ -454,17 +454,16 @@ fn verify_sqlite_metadata(
         conn.query_row("SELECT COUNT(*) FROM cayenne_table", [], |row| row.get(0))?;
     assert_eq!(table_count, 1, "Expected 1 table in cayenne_table");
 
-    let (table_id, table_uuid, table_name, path, path_is_relative, schema_json): (
-        i64,
+    let (table_id, table_name, path, path_is_relative, schema_json): (
         String,
         String,
         String,
         bool,
         String,
     ) = conn.query_row(
-        "SELECT table_id, table_uuid, table_name, path, path_is_relative, schema_json FROM cayenne_table",
+        "SELECT table_id, table_name, path, path_is_relative, schema_json FROM cayenne_table",
         [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?)),
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
     )?;
 
     assert_eq!(
@@ -477,17 +476,13 @@ fn verify_sqlite_metadata(
         "Expected path to match data directory"
     );
     assert!(!path_is_relative, "Expected path_is_relative to be false");
-    assert!(table_id >= 1, "Expected table_id to be at least 1");
-    assert!(
-        !table_uuid.is_empty(),
-        "Expected table_uuid to be non-empty"
-    );
+    assert!(!table_id.is_empty(), "Expected table_id to be non-empty");
     assert!(
         !schema_json.is_empty(),
         "Expected schema_json to be non-empty"
     );
     println!(
-        "  • Table metadata verified: table_id={table_id}, uuid={table_uuid}, name={table_name}"
+        "  • Table metadata verified: table_id={table_id}, name={table_name}"
     );
 
     // 3. Verify schema_json is base64 encoded (it's stored in Arrow IPC format)

--- a/crates/cayenne/tests/integration_test.rs
+++ b/crates/cayenne/tests/integration_test.rs
@@ -463,7 +463,15 @@ fn verify_sqlite_metadata(
     ) = conn.query_row(
         "SELECT table_id, table_name, path, path_is_relative, schema_json FROM cayenne_table",
         [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
     )?;
 
     assert_eq!(
@@ -481,9 +489,7 @@ fn verify_sqlite_metadata(
         !schema_json.is_empty(),
         "Expected schema_json to be non-empty"
     );
-    println!(
-        "  • Table metadata verified: table_id={table_id}, name={table_name}"
-    );
+    println!("  • Table metadata verified: table_id={table_id}, name={table_name}");
 
     // 3. Verify schema_json is base64 encoded (it's stored in Arrow IPC format)
     // We don't fully deserialize it here to avoid complex IPC parsing issues,

--- a/crates/cayenne/tests/multi_partition_test.rs
+++ b/crates/cayenne/tests/multi_partition_test.rs
@@ -425,7 +425,7 @@ async fn test_composite_partition_metadata_impl(
 
     // Test creating composite partition metadata directly
     let composite_partition = PartitionMetadata::new_composite(
-        1, // table_id (not important for this test)
+        "test-table-id".to_string(), // table_id (not important for this test)
         vec!["year".to_string(), "month".to_string()],
         vec!["2025".to_string(), "10".to_string()],
         data_path
@@ -452,7 +452,7 @@ async fn test_composite_partition_metadata_impl(
 
     // Test single partition metadata (backward compatibility)
     let single_partition = PartitionMetadata::new_single(
-        1,
+        "test-table-id".to_string(),
         "region".to_string(),
         "us-east-1".to_string(),
         data_path

--- a/crates/cayenne/tests/overwrite_test.rs
+++ b/crates/cayenne/tests/overwrite_test.rs
@@ -73,6 +73,7 @@ async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
     let table =
         CayenneTableProvider::create_table(Arc::clone(&catalog), table_options, ctx.runtime_env())
             .await?;
+    let table_id = table.metadata().table_id.clone();
     println!("✓ Table created");
 
     // 3. Register with DataFusion context
@@ -101,7 +102,7 @@ async fn test_insert_overwrite() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check how many snapshot subdirectories exist before overwrite
     // Directory structure: [data_path]/[table_id]/[snapshot_id]/
-    let table_dir = data_path.join("1"); // table_id = 1
+    let table_dir = data_path.join(&table_id);
     let snapshots_before = snapshot_dirs(&table_dir);
     println!("✓ Snapshots before overwrite: {}", snapshots_before.len());
 
@@ -220,6 +221,7 @@ async fn test_insert_overwrite_cleanup_old_snapshots() -> Result<(), Box<dyn std
     let table =
         CayenneTableProvider::create_table(Arc::clone(&catalog), table_options, ctx.runtime_env())
             .await?;
+    let table_id = table.metadata().table_id.clone();
     println!("✓ Table created");
 
     // 3. Register with DataFusion context
@@ -234,7 +236,7 @@ async fn test_insert_overwrite_cleanup_old_snapshots() -> Result<(), Box<dyn std
     println!("✓ Initial data inserted (2 rows)");
 
     // 5. Get initial snapshot count
-    let table_dir = data_path.join("1"); // table_id = 1
+    let table_dir = data_path.join(&table_id);
     let snapshots_after_insert = snapshot_dirs(&table_dir);
     println!(
         "✓ Snapshots after initial insert: {}",

--- a/crates/cayenne/tests/read_time_filtering_test.rs
+++ b/crates/cayenne/tests/read_time_filtering_test.rs
@@ -209,7 +209,7 @@ async fn test_get_table_delete_files_works() -> TestResult<()> {
     // Verify no deletion files initially
     let delete_files = table_provider
         .catalog()
-        .get_table_delete_files(table_provider.metadata().table_id)
+        .get_table_delete_files(&table_provider.metadata().table_id)
         .await?;
     assert_eq!(
         delete_files.len(),
@@ -225,7 +225,7 @@ async fn test_get_table_delete_files_works() -> TestResult<()> {
     // Verify deletion file was registered
     let delete_files = table_provider
         .catalog()
-        .get_table_delete_files(table_provider.metadata().table_id)
+        .get_table_delete_files(&table_provider.metadata().table_id)
         .await?;
     assert_eq!(
         delete_files.len(),

--- a/crates/cayenne/tests/retention_test.rs
+++ b/crates/cayenne/tests/retention_test.rs
@@ -90,7 +90,7 @@ async fn test_retention_filters_apply_on_insert_impl(
     // Retention should have created a delete file containing row IDs 0 and 1.
     let delete_files = table_provider
         .catalog()
-        .get_table_delete_files(table_provider.metadata().table_id)
+        .get_table_delete_files(&table_provider.metadata().table_id)
         .await?;
     assert_eq!(
         delete_files.len(),
@@ -195,7 +195,7 @@ async fn test_retention_filters_skip_when_no_matches_impl(
     // No delete files should have been created.
     let delete_files = table_provider
         .catalog()
-        .get_table_delete_files(table_provider.metadata().table_id)
+        .get_table_delete_files(&table_provider.metadata().table_id)
         .await?;
     assert!(
         delete_files.is_empty(),

--- a/crates/cayenne/tests/staged_append_test.rs
+++ b/crates/cayenne/tests/staged_append_test.rs
@@ -379,7 +379,7 @@ async fn test_wal_persists_on_move_failure_impl(
     // has already been written.
     let meta = table.metadata();
     let snapshot_dir = PathBuf::from(&meta.path)
-        .join(meta.table_id.to_string())
+        .join(&meta.table_id)
         .join(&meta.current_snapshot_id);
     std::fs::remove_dir_all(&snapshot_dir)?;
     std::fs::write(&snapshot_dir, b"not a directory")?;
@@ -518,7 +518,7 @@ fn make_batch(ids: &[i64], names: &[&str]) -> RecordBatch {
 fn staging_dir(table: &CayenneTableProvider) -> PathBuf {
     let meta = table.metadata();
     PathBuf::from(&meta.path)
-        .join(meta.table_id.to_string())
+        .join(&meta.table_id)
         .join(STAGING_DIR_NAME)
 }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1332,7 +1332,7 @@ struct CayennePartitionCreator {
     partition_by: Vec<PartitionedBy>,
     schema: SchemaRef,
     catalog: Arc<dyn cayenne::MetadataCatalog>,
-    table_id: i64,
+    table_id: String,
     unsupported_type_action: UnsupportedTypeAction,
     retention_filters: Vec<Expr>,
     time_retention_filter_builder: Option<cayenne::TimeRetentionFilterBuilder>,
@@ -1376,7 +1376,7 @@ impl CayennePartitionCreator {
         partition_by: Vec<PartitionedBy>,
         schema: SchemaRef,
         catalog: Arc<dyn cayenne::MetadataCatalog>,
-        table_id: i64,
+        table_id: String,
         unsupported_type_action: UnsupportedTypeAction,
         retention_filters: Vec<Expr>,
         time_retention_filter_builder: Option<cayenne::TimeRetentionFilterBuilder>,
@@ -1510,7 +1510,7 @@ impl PartitionCreator for CayennePartitionCreator {
 
         // Create partition metadata with composite key support
         let partition_metadata = cayenne::PartitionMetadata::new_composite(
-            self.table_id,
+            self.table_id.clone(),
             partition_column_names,
             partition_value_strings.clone(),
             partition_path.clone(),
@@ -1568,7 +1568,7 @@ impl PartitionCreator for CayennePartitionCreator {
         // Query catalog for existing partitions
         let partitions = self
             .catalog
-            .get_partitions(self.table_id)
+            .get_partitions(&self.table_id)
             .await
             .boxed()
             .context(creator::InferringPartitionsSnafu)?;


### PR DESCRIPTION
## Summary
- switch Cayenne table, partition, snapshot, insert, and delete-file identifiers to UUIDv7 strings
- adapt trunk-era catalog and test code to the string-based IDs, including concurrent create-table handling
- add the schema invariant needed for concurrent table creation to return a single table id

## Testing
- cargo test -p cayenne
- make lint