### PR TITLE
Re-enable Turso TPCH SF1 bench dispatch

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-turso[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-turso[file].yaml
@@ -1,11 +1,10 @@
 tests:
-  # bench:
-  #   https://github.com/spiceai/spiceai/issues/8764
-  #   spicepod_path: accelerated/s3[parquet]-turso[file].yaml
-  #   query_set: tpch
-  #   runner_type: spiceai-dev-runners
-  #   validate_results: true
-  #   ready_wait: 900
+  bench:
+    spicepod_path: accelerated/s3[parquet]-turso[file].yaml
+    query_set: tpch
+    runner_type: spiceai-dev-runners
+    validate_results: true
+    ready_wait: 900
   throughput:
     spicepod_path: accelerated/s3[parquet]-turso[file].yaml
     query_set: tpch


### PR DESCRIPTION
## Summary
- re-enable the TPCH SF-1 `s3[parquet]-turso[file]` bench dispatch entry
- keep throughput and load coverage unchanged

## Testing
- config-only change; no dedicated runtime test executed
- verified the dispatch diff restores the bench stanza for the existing spicepod path