### PR TITLE
Unassign partition from executors that are unregistered. 

### DIFF
--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -199,11 +199,25 @@ impl ExecutorRegistry {
     }
 
     /// Unregisters an executor connection.
-    pub async fn unregister(&self, executor_id: &str) {
+    pub async fn unregister(&self, executor_id: &str) -> Result<()> {
         let mut connections = self.connections.write().await;
         if connections.remove(executor_id).is_some() {
             tracing::debug!("Executor {executor_id} disconnected");
         }
+
+        // Optimisation: unassign partitions from this executor immediately on disconnect to free them up for reassignment. On failure, should be handled by partition manager's periodic reconciliation.
+        if let Err(e) = self
+            .partition_manager()
+            .unassign_all_from_executor(executor_id)
+            .await
+        {
+            tracing::warn!(
+                executor_id = %executor_id,
+                error = %e,
+                "Failed to unassign partitions from disconnected executor"
+            );
+        }
+        Ok(())
     }
 
     /// Returns the list of currently connected executor IDs.

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use datafusion::sql::TableReference;
 use object_store::ObjectStore;
-use object_store_occ::{InsertResult, ObjectState, WriteResult};
+use object_store_occ::{InsertResult, ObjectState, UpdateResult, WriteResult};
 use snafu::prelude::*;
 
 use crate::cluster::partition::metadata::PartitionValue;
@@ -117,6 +117,33 @@ impl PartitionManager {
     ) -> Option<TablePartitionMetadata> {
         let key = table.to_string();
         self.state.get_cached(&key)
+    }
+
+    /// Unassign all partitions from an executor across all tables.
+    ///
+    /// Attempt to update metadata for each table. Ignore `ConcurrentModification` errors. If an error occurs, will still attempt to unassign from all tables.
+    ///
+    /// This is a best effort to unassign the executor, but may not be perfect in the presence of concurrent updates.
+    pub async fn unassign_all_from_executor(&self, executor_id: &str) -> Result<()> {
+        let mut result: Result<()> = Ok(());
+        for tbl in self.list_tables().await? {
+            if let Some(mut partition) = self.state.get_cached(&tbl) {
+                partition.unassign_executor(executor_id);
+                match self.state.update(&tbl, &partition).await {
+                    Ok(UpdateResult::Ok | UpdateResult::NotFound) => (),
+                    Ok(UpdateResult::Conflict { .. }) => tracing::warn!(
+                        "Unassigning partitions for table {tbl} from {executor_id}, but concurrent modification detected. This may cause partitions to remain assigned to the executor until the next unassignment attempt.",
+                    ),
+                    Err(e) => {
+                        result = Err(Error::MetadataAccess {
+                            table: tbl.clone(),
+                            source: e,
+                        });
+                    }
+                }
+            }
+        }
+        result
     }
 
     /// Initialize a blank partition metadata file for a table.

--- a/crates/runtime/src/cluster/partition/metadata.rs
+++ b/crates/runtime/src/cluster/partition/metadata.rs
@@ -198,4 +198,10 @@ impl TablePartitionMetadata {
         }
         Ok(map)
     }
+
+    pub fn unassign_executor(&mut self, executor_id: &str) {
+        for partition in &mut self.partitions {
+            partition.unassign_from(executor_id);
+        }
+    }
 }

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -181,6 +181,7 @@ impl Default for PartitionManagementConfig {
 /// 2. Adding new partitions to the partition metadata (initially unassigned).
 /// 3. Removing partitions that no longer exist in the source and notifying executors to unload them.
 /// 4. Assigning unassigned partitions to executors.
+/// 5. Unassigning partitions from executors that are no longer in the registry (so they can be reassigned).
 pub struct PartitionManagementTask {
     app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
@@ -345,6 +346,8 @@ impl PartitionManagementTask {
             self.remove_stale_partitions(discovery_result.removed_partitions)
                 .await?;
         }
+
+        self.unassign_stale_executors(&state).await?;
 
         let unassigned = self.find_unassigned_partitions(&state);
         tracing::debug!(
@@ -1132,6 +1135,56 @@ impl PartitionManagementTask {
                 failure_count,
                 "Notified executors of partition assignments"
             );
+        }
+
+        Ok(())
+    }
+
+    /// Unassign partitions from executors that are no longer in the executor registry.
+    ///
+    /// When an executor disconnects, its assigned partitions remain in the metadata as assigned.
+    /// This method detects those stale assignments and clears them so the partitions become
+    /// unassigned and eligible for reassignment to live executors in the same cycle.
+    async fn unassign_stale_executors(&self, state: &CycleState) -> Result<()> {
+        let live_executors: HashSet<&String> = state.executor_ids.iter().collect();
+
+        // Collect executor IDs that appear in partition assignments but are no longer live.
+        let mut stale_executors: HashSet<String> = HashSet::new();
+        for table_name in &state.tables {
+            let table_ref = TableReference::parse_str(table_name);
+            if let Some(metadata) = self.partition_manager.get_cached_table_metadata(&table_ref) {
+                for partition in &metadata.partitions {
+                    for executor_id in &partition.assigned_executors {
+                        if !live_executors.contains(executor_id) {
+                            stale_executors.insert(executor_id.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if stale_executors.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            stale_executor_count = stale_executors.len(),
+            "Detected stale executor assignments; unassigning partitions"
+        );
+
+        for executor_id in &stale_executors {
+            tracing::debug!(executor_id = %executor_id, "Unassigning all partitions from stale executor");
+            if let Err(e) = self
+                .partition_manager
+                .unassign_all_from_executor(executor_id)
+                .await
+            {
+                tracing::warn!(
+                    executor_id = %executor_id,
+                    error = %e,
+                    "Failed to unassign partitions from stale executor"
+                );
+            }
         }
 
         Ok(())

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -38,7 +38,7 @@ use super::{PartitionManager, Result};
 use crate::{
     cluster::partition::{
         MissingPartitionKeysSnafu, ObjectStoreBuildSnafu, PartitionAllocationRequestSnafu,
-        PartitionExpressionDeserializationSnafu, discovery,
+        PartitionExpressionDeserializationSnafu, PartitionMetadataInitSnafu, discovery,
     },
     datafusion::DataFusion,
 };
@@ -153,10 +153,11 @@ pub async fn initialize_partition_metadata(
 /// key configured, which is required for cluster partition management.
 pub fn validate_partition_keys(app: &App) -> Result<()> {
     for ds in &app.datasets {
-        if ds
-            .acceleration
-            .as_ref()
-            .is_some_and(|acc| acc.partition_by.is_empty())
+        if ds.is_accelerated()
+            && ds
+                .acceleration
+                .as_ref()
+                .is_some_and(|acc| acc.partition_by.is_empty())
         {
             return MissingPartitionKeysSnafu {
                 component_type: "dataset",
@@ -166,10 +167,11 @@ pub fn validate_partition_keys(app: &App) -> Result<()> {
         }
     }
     for view in &app.views {
-        if view
-            .acceleration
-            .as_ref()
-            .is_some_and(|acc| acc.partition_by.is_empty())
+        if view.is_accelerated()
+            && view
+                .acceleration
+                .as_ref()
+                .is_some_and(|acc| acc.partition_by.is_empty())
         {
             return MissingPartitionKeysSnafu {
                 component_type: "view",

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -38,7 +38,7 @@ use super::{PartitionManager, Result};
 use crate::{
     cluster::partition::{
         MissingPartitionKeysSnafu, ObjectStoreBuildSnafu, PartitionAllocationRequestSnafu,
-        PartitionExpressionDeserializationSnafu, PartitionMetadataInitSnafu, discovery,
+        PartitionExpressionDeserializationSnafu, discovery,
     },
     datafusion::DataFusion,
 };

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -153,11 +153,10 @@ pub async fn initialize_partition_metadata(
 /// key configured, which is required for cluster partition management.
 pub fn validate_partition_keys(app: &App) -> Result<()> {
     for ds in &app.datasets {
-        if ds.is_accelerated()
-            && ds
-                .acceleration
-                .as_ref()
-                .is_some_and(|acc| acc.partition_by.is_empty())
+        if ds
+            .acceleration
+            .as_ref()
+            .is_some_and(|acc| acc.partition_by.is_empty())
         {
             return MissingPartitionKeysSnafu {
                 component_type: "dataset",
@@ -167,11 +166,10 @@ pub fn validate_partition_keys(app: &App) -> Result<()> {
         }
     }
     for view in &app.views {
-        if view.is_accelerated()
-            && view
-                .acceleration
-                .as_ref()
-                .is_some_and(|acc| acc.partition_by.is_empty())
+        if view
+            .acceleration
+            .as_ref()
+            .is_some_and(|acc| acc.partition_by.is_empty())
         {
             return MissingPartitionKeysSnafu {
                 component_type: "view",

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -558,7 +558,9 @@ impl ClusterService for ClusterServiceImpl {
             }
 
             // Unregister the executor when the stream ends.
-            executor_registry.unregister(&executor_id).await;
+            if let Err(e) = executor_registry.unregister(&executor_id).await {
+                tracing::warn!("Failed to unregister executor {executor_id}: {e}");
+            }
 
             // Update active executor count metric.
             let count = executor_registry.connected_executors().await.len();

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -14,19 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use app::AppBuilder;
-use datafusion::assert_batches_eq;
-use futures::StreamExt;
-use futures::TryStreamExt;
-
-use runtime::Runtime;
-use spicepod::{component::dataset::Dataset, param::Params};
-
-use crate::{
-    init_tracing,
-    utils::{register_test_connectors, test_request_context},
-};
-
 #[cfg(feature = "postgres-accel")]
 #[tokio::test]
 async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## 📝 Summary
For Distributed query, when an executor disconnects, we should unassign its acceleration partitions. We remove them in two places:
 1. After the control stream has disconnected (the scheduler has its connection to executor disconnect).
 2. On the periodic partition management task. Any executor not in the registry will be removed.
 
 TODO: need to handle > 1 scheduler.