### PR TITLE
fix: bump datafusion-ballista to fix BatchCoalescer schema mismatch panic in distributed queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2329,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1153d7b5df15f7c7be12160fd4be1e10e33537d#e1153d7b5df15f7c7be12160fd4be1e10e33537d"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,9 +387,9 @@ datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "cc38905a6ff37c1156ee528b5dc15c18c8ae9776" } # spiceai-52
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" }      # spiceai-52
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" } # spiceai-52
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1153d7b5df15f7c7be12160fd4be1e10e33537d" } # spiceai-52
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "9d26fb3662d2edb8f382d4d0f7899c303549f0d0" } # spiceai-0.18.2
 


### PR DESCRIPTION
## Summary

Bumps `datafusion-ballista` from `e1153d7b` to `ad88031f` ([spiceai/datafusion-ballista#24](https://github.com/spiceai/datafusion-ballista/pull/24)).

## Problem

Distributed (Ballista) queries with `GROUP BY` on string columns panic with `Internal("\"primitive array\"")`. The `BatchCoalescer` inside `CoalescedShuffleReaderStream` was eagerly initialized with the declared plan schema, but the actual IPC shuffle data can have different Arrow types (e.g., `Utf8` from a CSV reader vs `LargeUtf8` declared in the plan). The type mismatch causes `InProgressPrimitiveArray<T>::copy_rows()` to panic on downcast.

## Fix

Lazily initialize the `BatchCoalescer` from the first actual batch's schema — the same pattern applied to `RepartitionExec` in [spiceai/datafusion#135](https://github.com/spiceai/datafusion/pull/135).

## Reproduction

With S3 taxi trip + CSV zone lookup datasets in a scheduler+executor cluster:

```sql
SELECT z.Borough, COUNT(*) AS total_trips, AVG(t.total_amount) AS avg_fare, MAX(t.total_amount) AS max_fare
FROM taxi_trips t
JOIN taxi_zone_lookup z ON t.PULocationID = z.LocationID
WHERE z.Borough != 'N/A'
GROUP BY z.Borough
ORDER BY total_trips DESC;
```

**Before**: panics in Stage 4 with `Internal("\"primitive array\"")`
**After**: returns correct results

## Changes

- `Cargo.toml`: bump ballista rev to `ad88031f`
- `Cargo.lock`: updated accordingly