### PR TITLE
fix(spidapter): Add IF NOT EXISTS to setup table creation and fix test YAML kind casing

### DIFF
--- a/tools/spidapter/src/commands/secrets.rs
+++ b/tools/spidapter/src/commands/secrets.rs
@@ -126,13 +126,13 @@ mod tests {
     const BASIC_SPICEPOD_YAML: &str = "
 name: test
 version: v2
-kind: spicepod
+kind: Spicepod
 ";
 
     const SCHEDULER_SPICEPOD_YAML: &str = "
 name: test
 version: v2
-kind: spicepod
+kind: Spicepod
 runtime:
   scheduler:
     state_location: s3://bucket/path
@@ -141,7 +141,7 @@ runtime:
     const FILE_SCHEDULER_SPICEPOD_YAML: &str = "
 name: test
 version: v2
-kind: spicepod
+kind: Spicepod
 runtime:
     scheduler:
         state_location: file:///tmp/state

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -535,7 +535,7 @@ fn generate_adbc_create_table_statement(
     }
 
     Ok(format!(
-        "CREATE TABLE spicebench.bench.{quoted_dataset_name} ({})",
+        "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_dataset_name} ({})",
         table_elements.join(", ")
     ))
 }
@@ -1408,7 +1408,7 @@ mod tests {
         )
         .expect("statement should generate");
 
-        assert!(statement.contains("CREATE TABLE spicebench.bench.\"orders\""));
+        assert!(statement.contains("CREATE TABLE IF NOT EXISTS spicebench.bench.\"orders\""));
         assert!(statement.contains("\"id\" BIGINT NOT NULL"));
         assert!(statement.contains("\"name\" TEXT"));
         assert!(statement.contains("\"price\" DECIMAL(10, 2)"));


### PR DESCRIPTION
## Changes

- Add `IF NOT EXISTS` to the `CREATE TABLE` statement generated during setup, preventing errors when the table already exists.
- Fix test YAML constants in `secrets.rs` that used lowercase `kind: spicepod` instead of `kind: Spicepod` (PascalCase). The `SpicepodKind` enum requires PascalCase, so the YAML parsing was silently failing, causing two tests to always fail:
  - `includes_required_aws_secrets_when_scheduler_state_location_is_set`
  - `keeps_existing_store_mapping_for_required_secrets`

## Testing

All 13 spidapter tests pass:
```
cargo test -p spidapter
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```