### PR TITLE
Add executor resource and replica support to cloud app config

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -138,7 +138,10 @@ impl CloudClient {
             visibility: visibility.to_string(),
             cname: None,
             tags: None,
+            replicas: None,
             resources: None,
+            executor_replicas: None,
+            executor_resources: None,
         };
         self.inner.create_app(&request).await.map_err(into_cli)
     }
@@ -161,6 +164,8 @@ impl CloudClient {
             region: region.map(String::from),
             spicepod: None,
             resources: None,
+            executor_replicas: None,
+            executor_resources: None,
         };
         self.inner
             .update_app(app.id, &request)

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -140,8 +140,7 @@ impl CloudClient {
             tags: None,
             replicas: None,
             resources: None,
-            executor_replicas: None,
-            executor_resources: None,
+            executor: None,
         };
         self.inner.create_app(&request).await.map_err(into_cli)
     }
@@ -164,8 +163,7 @@ impl CloudClient {
             region: region.map(String::from),
             spicepod: None,
             resources: None,
-            executor_replicas: None,
-            executor_resources: None,
+            executor: None,
         };
         self.inner
             .update_app(app.id, &request)

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -61,6 +61,8 @@ pub struct AppConfig {
     pub update_channel: Option<String>,
     pub replicas: Option<i32>,
     pub resources: Option<AppResources>,
+    pub executor_replicas: Option<i32>,
+    pub executor_resources: Option<AppResources>,
     pub region: Option<String>,
     pub node_group: Option<String>,
     pub storage_claim_size_gb: Option<f64>,
@@ -101,7 +103,13 @@ pub struct CreateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub replicas: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executor_replicas: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executor_resources: Option<AppResources>,
 }
 
 #[derive(Debug, Serialize)]
@@ -120,6 +128,10 @@ pub struct UpdateAppRequest {
     pub spicepod: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executor_replicas: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executor_resources: Option<AppResources>,
 }
 
 // ============================================================================

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -53,6 +53,14 @@ pub struct AppsResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AppExecutor {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replicas: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<AppResources>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
     pub spicepod: Option<serde_json::Value>,
     pub registry: Option<String>,
@@ -61,8 +69,7 @@ pub struct AppConfig {
     pub update_channel: Option<String>,
     pub replicas: Option<i32>,
     pub resources: Option<AppResources>,
-    pub executor_replicas: Option<i32>,
-    pub executor_resources: Option<AppResources>,
+    pub executor: Option<AppExecutor>,
     pub region: Option<String>,
     pub node_group: Option<String>,
     pub storage_claim_size_gb: Option<f64>,
@@ -107,9 +114,7 @@ pub struct CreateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub executor_replicas: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub executor_resources: Option<AppResources>,
+    pub executor: Option<AppExecutor>,
 }
 
 #[derive(Debug, Serialize)]
@@ -129,9 +134,7 @@ pub struct UpdateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub executor_replicas: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub executor_resources: Option<AppResources>,
+    pub executor: Option<AppExecutor>,
 }
 
 // ============================================================================

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -57,6 +57,66 @@ pub(crate) fn build_cloud_client(api_url_override: Option<&str>) -> anyhow::Resu
         .with_timeout(Duration::from_secs(600))?)
 }
 
+/// Parse an optional non-negative integer from an environment variable.
+///
+/// Returns `Ok(None)` when the variable is unset, and an error when it is set
+/// but cannot be parsed as a non-negative integer.
+fn env_var_replicas(name: &str) -> anyhow::Result<Option<i32>> {
+    match std::env::var(name) {
+        Err(_) => Ok(None),
+        Ok(val) => val
+            .trim()
+            .parse::<i32>()
+            .map(Some)
+            .map_err(|_| anyhow::anyhow!("{name} must be a non-negative integer, got '{val}'")),
+    }
+}
+
+/// Default resource allocation shared by scheduler and executor when no env vars override them.
+fn default_resources() -> AppResources {
+    AppResources {
+        limits: AppResourceLimits {
+            cpu: None,
+            memory: "16Gi".to_string(),
+            ephemeral_storage: None,
+        },
+        requests: Some(AppResourceRequests {
+            cpu: Some("0.1".to_string()),
+            memory: Some("256Mi".to_string()),
+        }),
+    }
+}
+
+/// Build an [`AppResources`] from environment variables.
+///
+/// The memory limit variable is the anchor: if it is unset, `None` is returned.
+/// CPU limit/request and memory request are all optional on top of that.
+fn env_var_resources(
+    memory_limit_var: &str,
+    cpu_limit_var: &str,
+    cpu_request_var: &str,
+    memory_request_var: &str,
+) -> Option<AppResources> {
+    let memory_limit = std::env::var(memory_limit_var).ok()?;
+    let cpu_request = std::env::var(cpu_request_var).ok();
+    let memory_request = std::env::var(memory_request_var).ok();
+    Some(AppResources {
+        limits: AppResourceLimits {
+            cpu: std::env::var(cpu_limit_var).ok(),
+            memory: memory_limit,
+            ephemeral_storage: None,
+        },
+        requests: if cpu_request.is_some() || memory_request.is_some() {
+            Some(AppResourceRequests {
+                cpu: cpu_request,
+                memory: memory_request,
+            })
+        } else {
+            None
+        },
+    })
+}
+
 pub(crate) async fn ensure_spice_cloud_app(
     cloud: &CloudClient,
     app_name: &str,
@@ -68,8 +128,26 @@ pub(crate) async fn ensure_spice_cloud_app(
 
     let cname = resolve_default_cname(cloud).await?;
 
-    let memory_limit =
-        std::env::var("SPIDAPTER_APP_MEMORY_LIMIT").unwrap_or_else(|_| "16Gi".to_string());
+    // App (scheduler) resources — default to 16Gi memory / 0.1 cpu request when unset.
+    let resources = env_var_resources(
+        "SPIDAPTER_APP_MEMORY_LIMIT",
+        "SPIDAPTER_APP_CPU_LIMIT",
+        "SPIDAPTER_APP_CPU_REQUEST",
+        "SPIDAPTER_APP_MEMORY_REQUEST",
+    )
+    .unwrap_or_else(default_resources);
+
+    let replicas = env_var_replicas("SPIDAPTER_APP_REPLICAS")?;
+
+    // Executor resources — same defaults as scheduler; override via env vars.
+    let executor_resources = env_var_resources(
+        "SPIDAPTER_EXECUTOR_MEMORY_LIMIT",
+        "SPIDAPTER_EXECUTOR_CPU_LIMIT",
+        "SPIDAPTER_EXECUTOR_CPU_REQUEST",
+        "SPIDAPTER_EXECUTOR_MEMORY_REQUEST",
+    )
+    .unwrap_or_else(default_resources);
+    let executor_replicas = env_var_replicas("SPIDAPTER_EXECUTOR_REPLICAS")?.unwrap_or(1);
 
     let create_result = cloud
         .create_app(&CreateAppRequest {
@@ -81,17 +159,10 @@ pub(crate) async fn ensure_spice_cloud_app(
                 "kind".to_string(),
                 "cluster".to_string(),
             )])),
-            resources: Some(AppResources {
-                limits: AppResourceLimits {
-                    cpu: None,
-                    memory: memory_limit,
-                    ephemeral_storage: None,
-                },
-                requests: Some(AppResourceRequests {
-                    cpu: Some("0.1".to_string()),
-                    memory: Some("256Mi".to_string()),
-                }),
-            }),
+            replicas,
+            resources: Some(resources),
+            executor_replicas: Some(executor_replicas),
+            executor_resources: Some(executor_resources),
         })
         .await;
 
@@ -168,6 +239,8 @@ pub(crate) async fn apply_spicepod_to_app(
                 region: None,
                 spicepod: Some(spicepod_yaml.to_string()),
                 resources: None,
+                executor_replicas: None,
+                executor_resources: None,
             },
         )
         .await?;

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -20,7 +20,7 @@ use reqwest::Client;
 use spice_cloud_client::{
     CloudClient,
     types::{
-        AppResourceLimits, AppResourceRequests, AppResources, CreateAppRequest,
+        AppExecutor, AppResourceLimits, AppResourceRequests, AppResources, CreateAppRequest,
         CreateDeploymentRequest, UpdateAppRequest,
     },
 };
@@ -139,15 +139,19 @@ pub(crate) async fn ensure_spice_cloud_app(
 
     let replicas = env_var_replicas("SPIDAPTER_APP_REPLICAS")?;
 
-    // Executor resources — same defaults as scheduler; override via env vars.
-    let executor_resources = env_var_resources(
-        "SPIDAPTER_EXECUTOR_MEMORY_LIMIT",
-        "SPIDAPTER_EXECUTOR_CPU_LIMIT",
-        "SPIDAPTER_EXECUTOR_CPU_REQUEST",
-        "SPIDAPTER_EXECUTOR_MEMORY_REQUEST",
-    )
-    .unwrap_or_else(default_resources);
-    let executor_replicas = env_var_replicas("SPIDAPTER_EXECUTOR_REPLICAS")?.unwrap_or(1);
+    // Executor — same resource defaults as scheduler; override via env vars.
+    let executor = Some(AppExecutor {
+        replicas: Some(env_var_replicas("SPIDAPTER_EXECUTOR_REPLICAS")?.unwrap_or(1)),
+        resources: Some(
+            env_var_resources(
+                "SPIDAPTER_EXECUTOR_MEMORY_LIMIT",
+                "SPIDAPTER_EXECUTOR_CPU_LIMIT",
+                "SPIDAPTER_EXECUTOR_CPU_REQUEST",
+                "SPIDAPTER_EXECUTOR_MEMORY_REQUEST",
+            )
+            .unwrap_or_else(default_resources),
+        ),
+    });
 
     let create_result = cloud
         .create_app(&CreateAppRequest {
@@ -161,8 +165,7 @@ pub(crate) async fn ensure_spice_cloud_app(
             )])),
             replicas,
             resources: Some(resources),
-            executor_replicas: Some(executor_replicas),
-            executor_resources: Some(executor_resources),
+            executor,
         })
         .await;
 
@@ -239,8 +242,7 @@ pub(crate) async fn apply_spicepod_to_app(
                 region: None,
                 spicepod: Some(spicepod_yaml.to_string()),
                 resources: None,
-                executor_replicas: None,
-                executor_resources: None,
+                executor: None,
             },
         )
         .await?;

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -60,15 +60,23 @@ pub(crate) fn build_cloud_client(api_url_override: Option<&str>) -> anyhow::Resu
 /// Parse an optional non-negative integer from an environment variable.
 ///
 /// Returns `Ok(None)` when the variable is unset, and an error when it is set
-/// but cannot be parsed as a non-negative integer.
+/// but cannot be parsed as a non-negative integer, is negative, or contains
+/// invalid Unicode.
 fn env_var_replicas(name: &str) -> anyhow::Result<Option<i32>> {
     match std::env::var(name) {
-        Err(_) => Ok(None),
-        Ok(val) => val
-            .trim()
-            .parse::<i32>()
-            .map(Some)
-            .map_err(|_| anyhow::anyhow!("{name} must be a non-negative integer, got '{val}'")),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow::anyhow!(
+            "Environment variable {name} contains invalid Unicode; expected a non-negative integer"
+        )),
+        Ok(val) => {
+            let trimmed = val.trim();
+            match trimmed.parse::<i32>() {
+                Ok(n) if n >= 0 => Ok(Some(n)),
+                Ok(_) | Err(_) => Err(anyhow::anyhow!(
+                    "{name} must be a non-negative integer, got '{val}'"
+                )),
+            }
+        }
     }
 }
 
@@ -87,22 +95,42 @@ fn default_resources() -> AppResources {
     }
 }
 
-/// Build an [`AppResources`] from environment variables.
+/// Read a string environment variable, returning `None` when unset and an
+/// error when the value contains invalid Unicode.
+fn env_var_str(name: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(name) {
+        Ok(val) => Ok(Some(val)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow::anyhow!(
+            "Environment variable {name} contains invalid Unicode; expected a UTF-8 string"
+        )),
+    }
+}
+
+/// Build an [`AppResources`] by merging environment variable overrides on top
+/// of a set of base (default) resources.
 ///
-/// The memory limit variable is the anchor: if it is unset, `None` is returned.
-/// CPU limit/request and memory request are all optional on top of that.
-fn env_var_resources(
+/// Each field is overridden independently: only the env vars that are actually
+/// set replace the corresponding field in `base`. This means callers can
+/// override, e.g., only the memory limit without losing the CPU request
+/// default.
+fn env_var_resources_over(
+    base: AppResources,
     memory_limit_var: &str,
     cpu_limit_var: &str,
     cpu_request_var: &str,
     memory_request_var: &str,
-) -> Option<AppResources> {
-    let memory_limit = std::env::var(memory_limit_var).ok()?;
-    let cpu_request = std::env::var(cpu_request_var).ok();
-    let memory_request = std::env::var(memory_request_var).ok();
-    Some(AppResources {
+) -> anyhow::Result<AppResources> {
+    let memory_limit = env_var_str(memory_limit_var)?.unwrap_or(base.limits.memory);
+    let cpu_limit = env_var_str(cpu_limit_var)?.or(base.limits.cpu);
+    let cpu_request =
+        env_var_str(cpu_request_var)?.or(base.requests.as_ref().and_then(|r| r.cpu.clone()));
+    let memory_request =
+        env_var_str(memory_request_var)?.or(base.requests.as_ref().and_then(|r| r.memory.clone()));
+
+    Ok(AppResources {
         limits: AppResourceLimits {
-            cpu: std::env::var(cpu_limit_var).ok(),
+            cpu: cpu_limit,
             memory: memory_limit,
             ephemeral_storage: None,
         },
@@ -128,29 +156,27 @@ pub(crate) async fn ensure_spice_cloud_app(
 
     let cname = resolve_default_cname(cloud).await?;
 
-    // App (scheduler) resources — default to 16Gi memory / 0.1 cpu request when unset.
-    let resources = env_var_resources(
+    // App (scheduler) resources — start from defaults, then apply any env var overrides.
+    let resources = env_var_resources_over(
+        default_resources(),
         "SPIDAPTER_APP_MEMORY_LIMIT",
         "SPIDAPTER_APP_CPU_LIMIT",
         "SPIDAPTER_APP_CPU_REQUEST",
         "SPIDAPTER_APP_MEMORY_REQUEST",
-    )
-    .unwrap_or_else(default_resources);
+    )?;
 
     let replicas = env_var_replicas("SPIDAPTER_APP_REPLICAS")?;
 
-    // Executor — same resource defaults as scheduler; override via env vars.
+    // Executor — same resource defaults as scheduler; each field overridable independently.
     let executor = Some(AppExecutor {
         replicas: Some(env_var_replicas("SPIDAPTER_EXECUTOR_REPLICAS")?.unwrap_or(1)),
-        resources: Some(
-            env_var_resources(
-                "SPIDAPTER_EXECUTOR_MEMORY_LIMIT",
-                "SPIDAPTER_EXECUTOR_CPU_LIMIT",
-                "SPIDAPTER_EXECUTOR_CPU_REQUEST",
-                "SPIDAPTER_EXECUTOR_MEMORY_REQUEST",
-            )
-            .unwrap_or_else(default_resources),
-        ),
+        resources: Some(env_var_resources_over(
+            default_resources(),
+            "SPIDAPTER_EXECUTOR_MEMORY_LIMIT",
+            "SPIDAPTER_EXECUTOR_CPU_LIMIT",
+            "SPIDAPTER_EXECUTOR_CPU_REQUEST",
+            "SPIDAPTER_EXECUTOR_MEMORY_REQUEST",
+        )?),
     });
 
     let create_result = cloud


### PR DESCRIPTION
This pull request introduces support for configuring an app's executor (including its resources and replicas) independently from the main app (scheduler) in the Spice Cloud client and the `spidapter` tool. It adds a new `AppExecutor` struct, updates API request types to include executor settings, and enhances environment variable parsing for flexible resource configuration.

**API and Data Model Enhancements:**
- Added a new `AppExecutor` struct to represent executor-specific resource and replica settings, and integrated it into `AppConfig`, `CreateAppRequest`, and `UpdateAppRequest` to allow clients to specify executor configuration separately from the main app. [[1]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR55-R62) [[2]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR72) [[3]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR113-R117) [[4]](diffhunk://#diff-2800e1e132e30abba117a5144e0acd591dec1660dcdd8439944c9287351438beR136-R137)

**Environment Variable and Resource Configuration:**
- Implemented helper functions in `spidapter` for parsing environment variables for resource and replica overrides, with robust error handling and default values, enabling independent configuration for both scheduler and executor via environment variables.
- Refactored resource allocation logic in `ensure_spice_cloud_app` to use these helpers, supporting granular overrides for both scheduler and executor resource fields and replica counts. [[1]](diffhunk://#diff-0a17a9dac1f1b17bfc8c2809eaedb97804d63f55195136ed4b76460ac6411b74L71-R180) [[2]](diffhunk://#diff-0a17a9dac1f1b17bfc8c2809eaedb97804d63f55195136ed4b76460ac6411b74L84-R194)

**Codebase Maintenance:**
- Updated imports in `spidapter` to include the new `AppExecutor` type.
- Ensured that `apply_spicepod_to_app` sets the new `executor` field to `None` when updating app configuration, maintaining backward compatibility.