### PR TITLE
feat: Support PARTITION BY in Cayenne Catalog table creation

### DIFF
--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -88,7 +88,7 @@ pub fn encode_key(key: &ScalarValue) -> Result<String, Error> {
         ScalarValue::TimestampMillisecond(v, _) => v.map(|v| format!("{v}")),
         ScalarValue::TimestampMicrosecond(v, _) => v.map(|v| format!("{v}")),
         ScalarValue::TimestampNanosecond(v, _) => v.map(|v| format!("{v}")),
-        ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) => {
+        ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) | ScalarValue::Utf8View(v) => {
             v.as_ref().map(std::string::ToString::to_string)
         }
         value => {
@@ -293,6 +293,13 @@ pub fn parse_partition_value(
                 ScalarValue::Utf8(None)
             } else {
                 ScalarValue::Utf8(Some(value_str.to_string()))
+            }
+        }
+        DataType::Utf8View => {
+            if value_str == "none" || value_str == "NULL" {
+                ScalarValue::Utf8View(None)
+            } else {
+                ScalarValue::Utf8View(Some(value_str.to_string()))
             }
         }
         data_type => return Err(Error::UnsupportedType { data_type }),

--- a/crates/runtime-table-partition/src/expression.rs
+++ b/crates/runtime-table-partition/src/expression.rs
@@ -86,6 +86,17 @@ pub fn partition_by_expressions(
     Ok(partitioned_by)
 }
 
+/// Validates that a single [`Expr`] meets the partition expression criteria.
+///
+/// This is useful for DDL paths where the expression is already parsed as a
+/// DataFusion `Expr` (e.g. from a `PARTITION BY` clause).
+///
+/// # Errors
+/// Returns an error if the expression does not meet the partition criteria.
+pub fn validate_partition_expression(expr: &Expr, schema: &DFSchema) -> ValidationResult {
+    PartitionCriteria.validate(expr, schema)
+}
+
 /// Validates whether a [`ScalarValue`] can be produced by the given [`Expr`].
 ///
 /// # Errors
@@ -167,6 +178,7 @@ impl Criterion for DataTypeCriterion {
                 data_type,
                 DataType::Utf8
                     | DataType::LargeUtf8
+                    | DataType::Utf8View
                     | DataType::Int8
                     | DataType::Int16
                     | DataType::Int32

--- a/crates/runtime-table-partition/src/expression.rs
+++ b/crates/runtime-table-partition/src/expression.rs
@@ -89,7 +89,7 @@ pub fn partition_by_expressions(
 /// Validates that a single [`Expr`] meets the partition expression criteria.
 ///
 /// This is useful for DDL paths where the expression is already parsed as a
-/// DataFusion `Expr` (e.g. from a `PARTITION BY` clause).
+/// `DataFusion` `Expr` (e.g. from a `PARTITION BY` clause).
 ///
 /// # Errors
 /// Returns an error if the expression does not meet the partition criteria.

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -73,6 +73,7 @@ pub struct PartitionerExec {
     /// The table's data schema, used internally for evaluating partition expressions.
     data_schema: SchemaRef,
     properties: PlanProperties,
+    output_schema: SchemaRef,
 }
 
 impl PartitionerExec {
@@ -99,6 +100,7 @@ impl PartitionerExec {
             insert_op,
             data_schema,
             properties,
+            output_schema,
         }
     }
 }
@@ -130,7 +132,7 @@ impl ExecutionPlan for PartitionerExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(self.properties().schema())
+        Arc::clone(&self.output_schema)
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use datafusion::arrow::array::{Array, Int64Array, UInt64Array};
+use datafusion::arrow::array::{Array, UInt64Array};
 use datafusion::arrow::compute;
 use datafusion::common::DFSchema;
 use datafusion::execution::context::ExecutionProps;
@@ -51,6 +51,16 @@ use crate::creator::filename::encode_composite_key;
 use crate::expression::PartitionedBy;
 use crate::provider::CompositePartitionKey;
 
+/// Returns the schema that DataFusion expects from INSERT execution plans:
+/// a single non-null `count: UInt64` field.
+fn count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
 #[derive(Debug)]
 pub struct PartitionerExec {
     input: Arc<dyn ExecutionPlan>,
@@ -60,7 +70,8 @@ pub struct PartitionerExec {
     /// this contains multiple expressions in order.
     partition_by: Vec<PartitionedBy>,
     insert_op: InsertOp,
-    schema: SchemaRef,
+    /// The table's data schema, used internally for evaluating partition expressions.
+    data_schema: SchemaRef,
     properties: PlanProperties,
 }
 
@@ -71,10 +82,11 @@ impl PartitionerExec {
         creator: Arc<dyn PartitionCreator>,
         partitions: Arc<RwLock<HashMap<CompositePartitionKey, Partition>>>,
         insert_op: InsertOp,
-        schema: SchemaRef,
+        data_schema: SchemaRef,
     ) -> Self {
+        let output_schema = count_schema();
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(Arc::clone(&schema)),
+            EquivalenceProperties::new(Arc::clone(&output_schema)),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -85,7 +97,7 @@ impl PartitionerExec {
             partitions,
             partition_by,
             insert_op,
-            schema,
+            data_schema,
             properties,
         }
     }
@@ -118,7 +130,7 @@ impl ExecutionPlan for PartitionerExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
+        count_schema()
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -141,7 +153,7 @@ impl ExecutionPlan for PartitionerExec {
             Arc::clone(&self.creator),
             Arc::clone(&self.partitions),
             self.insert_op,
-            Arc::clone(&self.schema),
+            Arc::clone(&self.data_schema),
         )))
     }
 
@@ -156,15 +168,11 @@ impl ExecutionPlan for PartitionerExec {
             ));
         }
 
-        let row_count_schema = Arc::new(Schema::new(vec![Field::new(
-            "row_count",
-            DataType::Int64,
-            false,
-        )]));
+        let output_schema = count_schema();
 
         let row_count_stream = {
-            let schema = self.schema();
-            let row_count_schema = Arc::clone(&row_count_schema);
+            let schema = Arc::clone(&self.data_schema);
+            let output_schema = Arc::clone(&output_schema);
             let input = Arc::clone(&self.input);
             // Create physical expressions for all partition columns
             let physical_exprs: Vec<Arc<dyn PhysicalExpr>> = self
@@ -269,21 +277,18 @@ impl ExecutionPlan for PartitionerExec {
                 }
 
                 // Return the number of rows inserted
-                let row_count = i64::try_from(row_count).map_err(|e| {
+                let row_count = u64::try_from(row_count).map_err(|e| {
                     DataFusionError::Execution(format!(
-                        "Number of rows inserted exceeded i64::MAX: {e}"
+                        "Number of rows inserted exceeded u64::MAX: {e}"
                     ))
                 })?;
-                let array = Int64Array::from(vec![row_count]);
-                Ok(RecordBatch::try_new(
-                    row_count_schema,
-                    vec![Arc::new(array)],
-                )?)
+                let array = UInt64Array::from(vec![row_count]);
+                Ok(RecordBatch::try_new(output_schema, vec![Arc::new(array)])?)
             })
         };
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            row_count_schema,
+            output_schema,
             row_count_stream,
         )))
     }

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -130,7 +130,7 @@ impl ExecutionPlan for PartitionerExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        count_schema()
+        Arc::clone(self.properties().schema())
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -51,7 +51,7 @@ use crate::creator::filename::encode_composite_key;
 use crate::expression::PartitionedBy;
 use crate::provider::CompositePartitionKey;
 
-/// Returns the schema that DataFusion expects from INSERT execution plans:
+/// Returns the schema that `DataFusion` expects from INSERT execution plans:
 /// a single non-null `count: UInt64` field.
 fn count_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![Field::new(

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -280,13 +280,25 @@ impl CatalogProvider for CayenneCatalogProvider {
 
 #[async_trait]
 impl PartitionAwareCatalog for CayenneCatalogProvider {
-    async fn table_partition_expr(&self, schema_name: &str, table_name: &str) -> Option<String> {
+    async fn table_partition_expr(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+    ) -> crate::catalogconnector::Result<Option<String>> {
         let metadata_table_name = format!("{schema_name}/{table_name}");
-        self.catalog
+        let metadata = self
+            .catalog
             .get_table(&metadata_table_name)
             .await
-            .ok()?
-            .partition_column
+            .map_err(
+                |source| crate::catalogconnector::Error::PartitionMetadataRead {
+                    schema_name: schema_name.to_string(),
+                    table_name: table_name.to_string(),
+                    source: Box::new(source),
+                },
+            )?;
+
+        Ok(metadata.partition_column)
     }
 }
 

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -41,6 +41,8 @@ use crate::spice_data_base_path;
 use data_components::RefreshableCatalogProvider;
 use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
+use crate::catalogconnector::PartitionAwareCatalog;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to initialize Cayenne catalog: {source}"))]
@@ -273,6 +275,18 @@ impl CatalogProvider for CayenneCatalogProvider {
         schema: Arc<dyn SchemaProvider>,
     ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
         self.register_schema_provider(name, schema)
+    }
+}
+
+#[async_trait]
+impl PartitionAwareCatalog for CayenneCatalogProvider {
+    async fn table_partition_expr(&self, schema_name: &str, table_name: &str) -> Option<String> {
+        let metadata_table_name = format!("{schema_name}/{table_name}");
+        self.catalog
+            .get_table(&metadata_table_name)
+            .await
+            .ok()?
+            .partition_column
     }
 }
 

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -307,6 +307,19 @@ pub trait CatalogConnector: Send + Sync {
     }
 }
 
+/// Trait for catalog providers that can report partition expressions for their tables.
+///
+/// Implementations read partition metadata from the catalog's own persistent storage,
+/// ensuring partition information survives runtime restarts.
+#[async_trait]
+pub trait PartitionAwareCatalog: Send + Sync {
+    /// Returns the partition expression for a table, if one was defined at creation time.
+    ///
+    /// The returned string is the partition column name as stored in the catalog metadata
+    /// (e.g. `"region"` for `PARTITION BY region`).
+    async fn table_partition_expr(&self, schema_name: &str, table_name: &str) -> Option<String>;
+}
+
 pub async fn get_catalog_provider(
     connector: Arc<dyn CatalogConnector>,
     runtime: Arc<Runtime>,

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -81,6 +81,15 @@ pub enum Error {
 
     #[snafu(display("Failed to start a catalog refresh task. The task is already running."))]
     RefreshTaskAlreadyStarted {},
+
+    #[snafu(display(
+        "Failed to read partition metadata for table {schema_name}.{table_name}: {source}"
+    ))]
+    PartitionMetadataRead {
+        schema_name: String,
+        table_name: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -317,7 +326,13 @@ pub trait PartitionAwareCatalog: Send + Sync {
     ///
     /// The returned string is the partition column/label value as stored in catalog metadata
     /// (e.g. `"region"` for `PARTITION BY region`).
-    async fn table_partition_expr(&self, schema_name: &str, table_name: &str) -> Option<String>;
+    ///
+    /// Returns `Ok(None)` only when no partition metadata is present.
+    async fn table_partition_expr(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<Option<String>>;
 }
 
 pub async fn get_catalog_provider(

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -307,15 +307,15 @@ pub trait CatalogConnector: Send + Sync {
     }
 }
 
-/// Trait for catalog providers that can report partition expressions for their tables.
+/// Trait for catalog providers that can report partition metadata labels for their tables.
 ///
 /// Implementations read partition metadata from the catalog's own persistent storage,
 /// ensuring partition information survives runtime restarts.
 #[async_trait]
 pub trait PartitionAwareCatalog: Send + Sync {
-    /// Returns the partition expression for a table, if one was defined at creation time.
+    /// Returns the partition metadata label for a table, if one was defined at creation time.
     ///
-    /// The returned string is the partition column name as stored in the catalog metadata
+    /// The returned string is the partition column/label value as stored in catalog metadata
     /// (e.g. `"region"` for `PARTITION BY region`).
     async fn table_partition_expr(&self, schema_name: &str, table_name: &str) -> Option<String>;
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1321,7 +1321,7 @@ impl DataAccelerator for CayenneAccelerator {
 ///
 /// Supports single and composite partition keys (e.g., `partition_by: [year, month, day]`).
 /// For composite partitions, data is stored in nested Hive-style directories.
-struct CayennePartitionCreator {
+pub(crate) struct CayennePartitionCreator {
     table_name: String,
     base_path: PathBuf,
     /// Partition expressions. For hierarchical partitions like `partition_by: [year, month]`,
@@ -1367,7 +1367,7 @@ impl std::fmt::Debug for CayennePartitionCreator {
 
 impl CayennePartitionCreator {
     #[expect(clippy::too_many_arguments)]
-    fn new(
+    pub(crate) fn new(
         table_name: String,
         base_path: PathBuf,
         partition_by: Vec<PartitionedBy>,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -440,8 +440,10 @@ impl DataFusionBuilder {
         #[cfg(not(windows))]
         ctx.add_analyzer_rule(Arc::new(
             super::cayenne_ddl::analyzer_rule::CayenneDdlAnalyzerRule::new(
+                ctx.state_weak_ref(),
                 ctx.state().catalog_list(),
                 &ddl_enabled_catalogs,
+                Arc::clone(&ddl_extension_store),
             ),
         ));
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -282,10 +282,10 @@ fn parse_and_validate_partition_expression(
             ))
         })?;
 
-    // Reject boolean partition expressions (AND/OR) — not supported yet
+    // Reject boolean PARTITION BY expressions that use AND/OR at the top level — not supported yet
     if is_boolean_partition_expr(&partition_expr) {
         return Err(DataFusionError::Plan(format!(
-            "Boolean PARTITION BY expressions are not supported: '{partition_expr_sql}'. Use a single column or scalar function instead"
+            "Boolean PARTITION BY expressions using AND/OR are not supported: '{partition_expr_sql}'. Use a single column or scalar function instead"
         )));
     }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -371,7 +371,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("Boolean PARTITION BY expressions are not supported"),
+                .contains("Boolean PARTITION BY expressions using AND/OR are not supported"),
             "unexpected error: {err}"
         );
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -23,8 +23,8 @@ use std::fmt;
 use std::sync::{Arc, RwLock, Weak};
 
 use datafusion::catalog::CatalogProviderList;
-use datafusion::common::{DFSchema, ToDFSchema};
 use datafusion::common::Constraint;
+use datafusion::common::{DFSchema, ToDFSchema};
 use datafusion::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::session_state::SessionState;
@@ -315,7 +315,10 @@ mod tests {
     use datafusion::common::{Constraint, Constraints, ToDFSchema};
     use datafusion::execution::context::SessionContext;
 
-    use super::{extract_primary_key_columns, parse_and_validate_partition_expression, parse_qualified_schema_name};
+    use super::{
+        extract_primary_key_columns, parse_and_validate_partition_expression,
+        parse_qualified_schema_name,
+    };
     use crate::datafusion::SPICE_DEFAULT_CATALOG;
 
     #[test]

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::sync::{Arc, RwLock, Weak};
 
 use datafusion::catalog::CatalogProviderList;
-use datafusion::common::ToDFSchema;
+use datafusion::common::{DFSchema, ToDFSchema};
 use datafusion::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::session_state::SessionState;
@@ -137,7 +137,7 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                 let arrow_schema = Arc::new(create.input.schema().inner().as_ref().clone());
 
                 // Consume DDL extensions from the store (consumed on use)
-                let partition_expr = {
+                let (partition_expr, partition_expr_sql) = {
                     let mut store = self.ddl_options.write().map_err(|e| {
                         DataFusionError::Execution(format!(
                             "Failed to acquire DDL extension store lock: {e}"
@@ -146,66 +146,39 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     let ext = store.remove(&extension_key);
                     if let Some(ext) = ext {
                         if let Some(partition_by_expr) = ext.partition_by {
-                            // Convert the sqlparser expression to a DataFusion Expr and validate
                             let partition_expr_sql = partition_by_expr.to_string();
-                            let df_schema = arrow_schema.as_ref().clone().to_dfschema()?;
                             let state = self.session_state.upgrade().ok_or_else(|| {
                                 DataFusionError::Execution(
                                     "Session state is no longer available".to_string(),
                                 )
                             })?;
                             let state_guard = state.read();
-                            let partition_expr = state_guard
-                                .create_logical_expr(&partition_expr_sql, &df_schema)
-                                .map_err(|e| {
-                                    DataFusionError::Plan(format!(
-                                        "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
-                                    ))
-                                })?;
-
-                            // Reject boolean partition expressions (AND/OR) — not supported yet
-                            if is_boolean_partition_expr(&partition_expr) {
-                                return Err(DataFusionError::Plan(format!(
-                                    "Boolean PARTITION BY expressions are not supported: '{partition_expr_sql}'. Use a single column or scalar function instead"
-                                )));
-                            }
-
-                            validate_partition_expression(&partition_expr, &df_schema)
-                                .map_err(|e| {
-                                    DataFusionError::Plan(format!(
-                                        "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
-                                    ))
-                                })?;
-
-                            // Extract the single column name referenced by the expression
-                            let col_refs = partition_expr.column_refs();
-                            let col_name = col_refs
-                                .into_iter()
-                                .next()
-                                .map(|c| c.name().to_string())
-                                .ok_or_else(|| {
-                                    DataFusionError::Plan(format!(
-                                        "PARTITION BY expression '{partition_expr_sql}' must reference a column"
-                                    ))
-                                })?;
-                            Some(col_name)
+                            let df_schema = arrow_schema.as_ref().clone().to_dfschema()?;
+                            let partition_expr = parse_and_validate_partition_expression(
+                                &partition_expr_sql,
+                                &state_guard,
+                                &df_schema,
+                            )?;
+                            (Some(partition_expr), Some(partition_expr_sql))
                         } else {
-                            None
+                            (None, None)
                         }
                     } else {
-                        None
+                        (None, None)
                     }
                 };
 
-                let node = CayenneCreateTableNode::new(
+                let node = CayenneCreateTableNode::builder(
                     table_name,
                     arrow_schema,
-                    create.if_not_exists,
-                    create.or_replace,
                     catalog_name,
                     schema_name,
-                    partition_expr,
-                );
+                )
+                .if_not_exists(create.if_not_exists)
+                .or_replace(create.or_replace)
+                .partition_expr(partition_expr)
+                .partition_expr_sql(partition_expr_sql)
+                .build();
 
                 Ok(LogicalPlan::Extension(Extension {
                     node: Arc::new(node),
@@ -268,6 +241,35 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
     }
 }
 
+fn parse_and_validate_partition_expression(
+    partition_expr_sql: &str,
+    session_state: &SessionState,
+    df_schema: &DFSchema,
+) -> DFResult<Expr> {
+    let partition_expr = session_state
+        .create_logical_expr(partition_expr_sql, df_schema)
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
+            ))
+        })?;
+
+    // Reject boolean partition expressions (AND/OR) — not supported yet
+    if is_boolean_partition_expr(&partition_expr) {
+        return Err(DataFusionError::Plan(format!(
+            "Boolean PARTITION BY expressions are not supported: '{partition_expr_sql}'. Use a single column or scalar function instead"
+        )));
+    }
+
+    validate_partition_expression(&partition_expr, df_schema).map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
+        ))
+    })?;
+
+    Ok(partition_expr)
+}
+
 /// Returns `true` if the expression is a boolean combination (`AND`/`OR`) at the top level,
 /// which is not supported as a partition expression.
 fn is_boolean_partition_expr(expr: &Expr) -> bool {
@@ -279,6 +281,13 @@ fn is_boolean_partition_expr(expr: &Expr) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::ToDFSchema;
+    use datafusion::execution::context::SessionContext;
+
+    use super::parse_and_validate_partition_expression;
     use super::parse_qualified_schema_name;
     use crate::datafusion::SPICE_DEFAULT_CATALOG;
 
@@ -294,5 +303,76 @@ mod tests {
         let (catalog, schema) = parse_qualified_schema_name("bench");
         assert_eq!(catalog, SPICE_DEFAULT_CATALOG);
         assert_eq!(schema, "bench");
+    }
+
+    fn test_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("region", DataType::Utf8, true),
+        ])
+    }
+
+    #[test]
+    fn partition_by_accepts_single_column_expression() {
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let df_schema = Arc::new(test_schema())
+            .to_dfschema()
+            .expect("test schema should convert to DF schema");
+
+        let expr = parse_and_validate_partition_expression("region", &state, &df_schema)
+            .expect("single column partition expression should be valid");
+
+        assert_eq!(expr.to_string(), "region");
+    }
+
+    #[test]
+    fn partition_by_rejects_boolean_expression() {
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let df_schema = Arc::new(test_schema())
+            .to_dfschema()
+            .expect("test schema should convert to DF schema");
+
+        let err = parse_and_validate_partition_expression("id > 1 AND id < 10", &state, &df_schema)
+            .expect_err("boolean partition expressions should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("Boolean PARTITION BY expressions are not supported"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn partition_by_rejects_unsupported_expression() {
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let df_schema = Arc::new(test_schema())
+            .to_dfschema()
+            .expect("test schema should convert to DF schema");
+
+        let err = parse_and_validate_partition_expression("sum(id)", &state, &df_schema)
+            .expect_err("aggregate partition expressions should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid PARTITION BY expression"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn partition_by_preserves_scalar_function_expression() {
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let df_schema = Arc::new(test_schema())
+            .to_dfschema()
+            .expect("test schema should convert to DF schema");
+
+        let expr = parse_and_validate_partition_expression("abs(id)", &state, &df_schema)
+            .expect("scalar function partition expression should be valid");
+
+        assert!(expr.to_string().contains("abs"));
+        assert!(expr.to_string().contains("id"));
     }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -23,14 +23,19 @@ use std::fmt;
 use std::sync::{Arc, RwLock, Weak};
 
 use datafusion::catalog::CatalogProviderList;
+use datafusion::common::ToDFSchema;
 use datafusion::config::ConfigOptions;
-use datafusion::error::Result as DFResult;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::session_state::SessionState;
 use datafusion::logical_expr::DdlStatement;
-use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion::logical_expr::{Extension, LogicalPlan, Operator};
 use datafusion::optimizer::AnalyzerRule;
+use datafusion::prelude::Expr;
+use runtime_table_partition::expression::validate_partition_expression;
 
 use super::is_cayenne_catalog;
 use super::logical_nodes::{CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode};
+use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 
 fn parse_qualified_schema_name(name: &str) -> (String, String) {
@@ -43,12 +48,17 @@ fn parse_qualified_schema_name(name: &str) -> (String, String) {
 /// Analyzer rule that rewrites DDL targeting Cayenne catalogs into
 /// custom extension nodes for Cayenne catalog operations.
 ///
-/// Uses `Weak` references to avoid reference cycles.
+/// Uses `Weak` references to avoid reference cycles: the `SessionContext`
+/// owns the analyzer rules, so `Arc` refs back would create a cycle.
 pub struct CayenneDdlAnalyzerRule {
+    /// Weak reference to the session state for SQL expression parsing.
+    session_state: Weak<parking_lot::RwLock<SessionState>>,
     /// Weak reference to the catalog list for catalog resolution.
     catalog_list: Weak<dyn CatalogProviderList>,
     /// Weak reference to the set of DDL-enabled catalog names.
     ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
+    /// Shared store for DDL extensions extracted from `CREATE TABLE` statements.
+    ddl_options: SharedDdlExtensionStore,
 }
 
 impl fmt::Debug for CayenneDdlAnalyzerRule {
@@ -61,12 +71,16 @@ impl fmt::Debug for CayenneDdlAnalyzerRule {
 impl CayenneDdlAnalyzerRule {
     #[must_use]
     pub fn new(
+        session_state: Weak<parking_lot::RwLock<SessionState>>,
         catalog_list: &Arc<dyn CatalogProviderList>,
         ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
+        ddl_options: SharedDdlExtensionStore,
     ) -> Self {
         Self {
+            session_state,
             catalog_list: Arc::downgrade(catalog_list),
             ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
+            ddl_options,
         }
     }
 
@@ -117,9 +131,71 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     .unwrap_or(SPICE_DEFAULT_SCHEMA)
                     .to_string();
                 let table_name = create.name.table().to_string();
+                let extension_key = create.name.to_string();
 
                 // Extract the Arrow schema from the logical plan's input
                 let arrow_schema = Arc::new(create.input.schema().inner().as_ref().clone());
+
+                // Consume DDL extensions from the store (consumed on use)
+                let partition_expr = {
+                    let mut store = self.ddl_options.write().map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to acquire DDL extension store lock: {e}"
+                        ))
+                    })?;
+                    let ext = store.remove(&extension_key);
+                    if let Some(ext) = ext {
+                        if let Some(partition_by_expr) = ext.partition_by {
+                            // Convert the sqlparser expression to a DataFusion Expr and validate
+                            let partition_expr_sql = partition_by_expr.to_string();
+                            let df_schema = arrow_schema.as_ref().clone().to_dfschema()?;
+                            let state = self.session_state.upgrade().ok_or_else(|| {
+                                DataFusionError::Execution(
+                                    "Session state is no longer available".to_string(),
+                                )
+                            })?;
+                            let state_guard = state.read();
+                            let partition_expr = state_guard
+                                .create_logical_expr(&partition_expr_sql, &df_schema)
+                                .map_err(|e| {
+                                    DataFusionError::Plan(format!(
+                                        "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
+                                    ))
+                                })?;
+
+                            // Reject boolean partition expressions (AND/OR) — not supported yet
+                            if is_boolean_partition_expr(&partition_expr) {
+                                return Err(DataFusionError::Plan(format!(
+                                    "Boolean PARTITION BY expressions are not supported: '{partition_expr_sql}'. Use a single column or scalar function instead"
+                                )));
+                            }
+
+                            validate_partition_expression(&partition_expr, &df_schema)
+                                .map_err(|e| {
+                                    DataFusionError::Plan(format!(
+                                        "Invalid PARTITION BY expression '{partition_expr_sql}': {e}"
+                                    ))
+                                })?;
+
+                            // Extract the single column name referenced by the expression
+                            let col_refs = partition_expr.column_refs();
+                            let col_name = col_refs
+                                .into_iter()
+                                .next()
+                                .map(|c| c.name().to_string())
+                                .ok_or_else(|| {
+                                    DataFusionError::Plan(format!(
+                                        "PARTITION BY expression '{partition_expr_sql}' must reference a column"
+                                    ))
+                                })?;
+                            Some(col_name)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                };
 
                 let node = CayenneCreateTableNode::new(
                     table_name,
@@ -128,6 +204,7 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     create.or_replace,
                     catalog_name,
                     schema_name,
+                    partition_expr,
                 );
 
                 Ok(LogicalPlan::Extension(Extension {
@@ -189,6 +266,15 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
             _ => Ok(plan),
         }
     }
+}
+
+/// Returns `true` if the expression is a boolean combination (`AND`/`OR`) at the top level,
+/// which is not supported as a partition expression.
+fn is_boolean_partition_expr(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::BinaryExpr(bin) if matches!(bin.op, Operator::And | Operator::Or)
+    )
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -52,6 +52,8 @@ pub struct CayenneCreateTableNode {
     pub df_catalog_name: String,
     /// The `DataFusion` schema name (for registering the table provider).
     pub df_schema_name: String,
+    /// Optional partition expression for the new table (SQL string, e.g. `col_a` or `bucket(5, col_a)`).
+    pub partition_expr: Option<String>,
     /// Output schema (single "result" column).
     output_schema: DFSchemaRef,
 }
@@ -65,6 +67,7 @@ impl CayenneCreateTableNode {
         or_replace: bool,
         df_catalog_name: String,
         df_schema_name: String,
+        partition_expr: Option<String>,
     ) -> Self {
         Self {
             table_name,
@@ -73,6 +76,7 @@ impl CayenneCreateTableNode {
             or_replace,
             df_catalog_name,
             df_schema_name,
+            partition_expr,
             output_schema: ddl_output_schema(),
         }
     }
@@ -83,6 +87,7 @@ impl Hash for CayenneCreateTableNode {
         self.table_name.hash(state);
         self.df_catalog_name.hash(state);
         self.df_schema_name.hash(state);
+        self.partition_expr.hash(state);
     }
 }
 
@@ -91,6 +96,7 @@ impl PartialEq for CayenneCreateTableNode {
         self.table_name == other.table_name
             && self.df_catalog_name == other.df_catalog_name
             && self.df_schema_name == other.df_schema_name
+            && self.partition_expr == other.partition_expr
     }
 }
 
@@ -139,6 +145,7 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
             or_replace: self.or_replace,
             df_catalog_name: self.df_catalog_name.clone(),
             df_schema_name: self.df_schema_name.clone(),
+            partition_expr: self.partition_expr.clone(),
             output_schema: DFSchemaRef::clone(&self.output_schema),
         })
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -149,6 +149,7 @@ impl Hash for CayenneCreateTableNode {
         self.table_name.hash(state);
         self.df_catalog_name.hash(state);
         self.df_schema_name.hash(state);
+        self.partition_expr.hash(state);
         self.partition_expr_sql.hash(state);
         self.primary_key.hash(state);
     }
@@ -159,6 +160,7 @@ impl PartialEq for CayenneCreateTableNode {
         self.table_name == other.table_name
             && self.df_catalog_name == other.df_catalog_name
             && self.df_schema_name == other.df_schema_name
+            && self.partition_expr == other.partition_expr
             && self.partition_expr_sql == other.partition_expr_sql
             && self.primary_key == other.primary_key
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -52,31 +52,82 @@ pub struct CayenneCreateTableNode {
     pub df_catalog_name: String,
     /// The `DataFusion` schema name (for registering the table provider).
     pub df_schema_name: String,
-    /// Optional partition expression for the new table (SQL string, e.g. `col_a` or `bucket(5, col_a)`).
-    pub partition_expr: Option<String>,
+    /// Optional validated partition expression for the new table.
+    pub partition_expr: Option<Expr>,
+    /// Original SQL text for the partition expression, preserved for forwarding.
+    pub partition_expr_sql: Option<String>,
     /// Output schema (single "result" column).
     output_schema: DFSchemaRef,
 }
 
 impl CayenneCreateTableNode {
     #[must_use]
-    pub fn new(
+    pub fn builder(
         table_name: String,
         arrow_schema: Arc<Schema>,
-        if_not_exists: bool,
-        or_replace: bool,
         df_catalog_name: String,
         df_schema_name: String,
-        partition_expr: Option<String>,
-    ) -> Self {
-        Self {
+    ) -> CayenneCreateTableNodeBuilder {
+        CayenneCreateTableNodeBuilder {
             table_name,
             arrow_schema,
-            if_not_exists,
-            or_replace,
             df_catalog_name,
             df_schema_name,
-            partition_expr,
+            if_not_exists: false,
+            or_replace: false,
+            partition_expr: None,
+            partition_expr_sql: None,
+        }
+    }
+}
+
+pub struct CayenneCreateTableNodeBuilder {
+    table_name: String,
+    arrow_schema: Arc<Schema>,
+    if_not_exists: bool,
+    or_replace: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    partition_expr: Option<Expr>,
+    partition_expr_sql: Option<String>,
+}
+
+impl CayenneCreateTableNodeBuilder {
+    #[must_use]
+    pub fn if_not_exists(mut self, if_not_exists: bool) -> Self {
+        self.if_not_exists = if_not_exists;
+        self
+    }
+
+    #[must_use]
+    pub fn or_replace(mut self, or_replace: bool) -> Self {
+        self.or_replace = or_replace;
+        self
+    }
+
+    #[must_use]
+    pub fn partition_expr(mut self, partition_expr: Option<Expr>) -> Self {
+        self.partition_expr = partition_expr;
+        self
+    }
+
+    #[must_use]
+    pub fn partition_expr_sql(mut self, partition_expr_sql: Option<String>) -> Self {
+        self.partition_expr_sql = partition_expr_sql;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> CayenneCreateTableNode {
+        CayenneCreateTableNode {
+            table_name: self.table_name,
+            arrow_schema: self.arrow_schema,
+            if_not_exists: self.if_not_exists,
+            or_replace: self.or_replace,
+            df_catalog_name: self.df_catalog_name,
+            df_schema_name: self.df_schema_name,
+            partition_expr: self.partition_expr,
+            partition_expr_sql: self.partition_expr_sql,
             output_schema: ddl_output_schema(),
         }
     }
@@ -87,7 +138,7 @@ impl Hash for CayenneCreateTableNode {
         self.table_name.hash(state);
         self.df_catalog_name.hash(state);
         self.df_schema_name.hash(state);
-        self.partition_expr.hash(state);
+        self.partition_expr_sql.hash(state);
     }
 }
 
@@ -96,7 +147,7 @@ impl PartialEq for CayenneCreateTableNode {
         self.table_name == other.table_name
             && self.df_catalog_name == other.df_catalog_name
             && self.df_schema_name == other.df_schema_name
-            && self.partition_expr == other.partition_expr
+            && self.partition_expr_sql == other.partition_expr_sql
     }
 }
 
@@ -122,7 +173,7 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
     }
 
     fn expressions(&self) -> Vec<Expr> {
-        vec![]
+        self.partition_expr.iter().cloned().collect()
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -135,9 +186,19 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
 
     fn with_exprs_and_inputs(
         &self,
-        _exprs: Vec<Expr>,
+        exprs: Vec<Expr>,
         _inputs: Vec<LogicalPlan>,
     ) -> datafusion::error::Result<Self> {
+        let partition_expr = match exprs.as_slice() {
+            [] => None,
+            [expr] => Some(expr.clone()),
+            _ => {
+                return Err(datafusion::error::DataFusionError::Internal(
+                    "CayenneCreateTableNode expects at most one partition expression".to_string(),
+                ));
+            }
+        };
+
         Ok(Self {
             table_name: self.table_name.clone(),
             arrow_schema: Arc::clone(&self.arrow_schema),
@@ -145,7 +206,8 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
             or_replace: self.or_replace,
             df_catalog_name: self.df_catalog_name.clone(),
             df_schema_name: self.df_schema_name.clone(),
-            partition_expr: self.partition_expr.clone(),
+            partition_expr,
+            partition_expr_sql: self.partition_expr_sql.clone(),
             output_schema: DFSchemaRef::clone(&self.output_schema),
         })
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -67,9 +67,12 @@ pub fn get_cayenne_provider(provider: &dyn CatalogProvider) -> Option<&CayenneCa
     None
 }
 
-/// If the catalog provider implements [`PartitionAwareCatalog`], return a trait reference.
+/// If the catalog provider is Cayenne-backed and implements [`PartitionAwareCatalog`],
+/// return a trait reference.
 ///
-/// Handles both direct providers and `ComposedCatalogProvider` wrappers.
+/// Handles both direct [`CayenneCatalogProvider`] providers and
+/// [`ComposedCatalogProvider`] wrappers whose external provider is a
+/// [`CayenneCatalogProvider`].
 pub fn as_partition_aware(provider: &dyn CatalogProvider) -> Option<&dyn PartitionAwareCatalog> {
     if let Some(cayenne) = provider.as_any().downcast_ref::<CayenneCatalogProvider>() {
         return Some(cayenne);

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -28,6 +28,7 @@ pub mod planner;
 use datafusion::catalog::CatalogProvider;
 
 use super::composed_catalog::ComposedCatalogProvider;
+use crate::catalogconnector::PartitionAwareCatalog;
 use crate::catalogconnector::cayenne::provider::CayenneCatalogProvider;
 
 /// Check whether the given catalog provider is a Cayenne-backed catalog.
@@ -62,6 +63,25 @@ pub fn get_cayenne_provider(provider: &dyn CatalogProvider) -> Option<&CayenneCa
             .external()
             .as_any()
             .downcast_ref::<CayenneCatalogProvider>();
+    }
+    None
+}
+
+/// If the catalog provider implements [`PartitionAwareCatalog`], return a trait reference.
+///
+/// Handles both direct providers and `ComposedCatalogProvider` wrappers.
+pub fn as_partition_aware(provider: &dyn CatalogProvider) -> Option<&dyn PartitionAwareCatalog> {
+    if let Some(cayenne) = provider.as_any().downcast_ref::<CayenneCatalogProvider>() {
+        return Some(cayenne);
+    }
+    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>() {
+        if let Some(cayenne) = composed
+            .external()
+            .as_any()
+            .downcast_ref::<CayenneCatalogProvider>()
+        {
+            return Some(cayenne);
+        }
     }
     None
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -74,14 +74,13 @@ pub fn as_partition_aware(provider: &dyn CatalogProvider) -> Option<&dyn Partiti
     if let Some(cayenne) = provider.as_any().downcast_ref::<CayenneCatalogProvider>() {
         return Some(cayenne);
     }
-    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>() {
-        if let Some(cayenne) = composed
+    if let Some(composed) = provider.as_any().downcast_ref::<ComposedCatalogProvider>()
+        && let Some(cayenne) = composed
             .external()
             .as_any()
             .downcast_ref::<CayenneCatalogProvider>()
-        {
-            return Some(cayenne);
-        }
+    {
+        return Some(cayenne);
     }
     None
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -27,6 +27,7 @@ limitations under the License.
 
 use std::any::Any;
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::array::{RecordBatch, StringArray};
@@ -37,15 +38,19 @@ use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapte
 use datafusion::catalog::{CatalogProviderList, SchemaProvider};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
+use datafusion::logical_expr::col;
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_table_providers::UnsupportedTypeAction;
+use runtime_table_partition::expression::PartitionedBy;
+use runtime_table_partition::provider::PartitionTableProvider;
 
 use super::get_cayenne_provider;
 use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
 use crate::cluster::executor_registry::ExecutorRegistry;
+use crate::dataaccelerator::cayenne::CayennePartitionCreator;
 use crate::dataaccelerator::cayenne::transform_schema_for_vortex;
 
 /// Maps an Arrow [`DataType`] to a SQL type string suitable for DDL forwarding.
@@ -98,44 +103,58 @@ async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &st
         return Ok(());
     }
 
-    let mut success_count = 0usize;
-    for (executor_id, client) in clients.iter() {
-        let mut client = client.clone();
-        let result: Result<(), String> = async {
-            use futures::StreamExt;
+    let futures: Vec<_> = clients
+        .iter()
+        .map(|(executor_id, client)| {
+            let mut client = client.clone();
+            let sql = sql.to_string();
+            let executor_id = executor_id.clone();
+            async move {
+                use futures::StreamExt;
 
-            let flight_info = client
-                .execute(sql.to_string(), None)
-                .await
-                .map_err(|e| e.to_string())?;
+                let result: Result<(), String> = async {
+                    let flight_info = client
+                        .execute(sql.clone(), None)
+                        .await
+                        .map_err(|e| e.to_string())?;
 
-            for endpoint in flight_info.endpoint {
-                let Some(ticket) = endpoint.ticket else {
-                    continue;
-                };
+                    for endpoint in flight_info.endpoint {
+                        let Some(ticket) = endpoint.ticket else {
+                            continue;
+                        };
 
-                let mut stream = client.do_get(ticket).await.map_err(|e| e.to_string())?;
-                while let Some(batch) = stream.next().await {
-                    batch.map_err(|e| e.to_string())?;
+                        let mut stream =
+                            client.do_get(ticket).await.map_err(|e| e.to_string())?;
+                        while let Some(batch) = stream.next().await {
+                            batch.map_err(|e| e.to_string())?;
+                        }
+                    }
+
+                    Ok(())
                 }
-            }
+                .await;
 
-            Ok(())
-        }
-        .await;
+                match &result {
+                    Ok(()) => {
+                        tracing::debug!(executor_id, sql, "Forwarded Cayenne DDL to executor");
+                    }
+                    Err(e) => {
+                        tracing::warn!(executor_id, sql, error = %e, "Failed to forward Cayenne DDL to executor");
+                    }
+                }
 
-        match result {
-            Ok(()) => {
-                success_count += 1;
-                tracing::debug!(executor_id, sql, "Forwarded Cayenne DDL to executor");
+                result.is_ok()
             }
-            Err(e) => {
-                tracing::warn!(executor_id, sql, error = %e, "Failed to forward Cayenne DDL to executor");
-            }
-        }
-    }
+        })
+        .collect();
 
-    if success_count == 0 {
+    // Release the read lock before awaiting the futures.
+    drop(clients);
+
+    let results = futures::future::join_all(futures).await;
+    let success_count = results.iter().filter(|&&ok| ok).count();
+
+    if success_count == 0 && !results.is_empty() {
         return Err(DataFusionError::Execution(format!(
             "Failed to forward Cayenne DDL to any executor: {sql}"
         )));
@@ -171,6 +190,7 @@ pub struct CayenneCreateTableExec {
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
     executor_registry: Option<Arc<ExecutorRegistry>>,
+    partition_expr: Option<String>,
     properties: PlanProperties,
 }
 
@@ -195,6 +215,7 @@ impl CayenneCreateTableExec {
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
         executor_registry: Option<Arc<ExecutorRegistry>>,
+        partition_expr: Option<String>,
     ) -> Self {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -211,6 +232,7 @@ impl CayenneCreateTableExec {
             df_schema_name,
             catalog_list,
             executor_registry,
+            partition_expr,
             properties,
         }
     }
@@ -262,6 +284,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
         let df_schema_name = self.df_schema_name.clone();
         let catalog_list = Arc::clone(&self.catalog_list);
         let executor_registry = self.executor_registry.clone();
+        let partition_expr = self.partition_expr.clone();
         let result_schema = ddl_result_schema();
         let runtime_env = context.runtime_env();
 
@@ -358,33 +381,90 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 data_base_path.trim_end_matches('/').to_string() + "/"
             );
 
+            let vortex_schema = Arc::new(vortex_schema);
+
             // Create table options with namespace-prefixed name
             let create_options = CreateTableOptions {
                 table_name: metadata_table_name.clone(),
-                schema: Arc::new(vortex_schema),
+                schema: Arc::clone(&vortex_schema),
                 primary_key: Vec::new(),
                 on_conflict: None,
-                base_path: table_data_path,
-                partition_column: None,
-                vortex_config,
+                base_path: table_data_path.clone(),
+                partition_column: partition_expr.clone(),
+                vortex_config: vortex_config.clone(),
             };
 
-            // Create the table via Cayenne
-            let builder = CayenneTableProviderBuilder::new(
-                Arc::clone(&metadata_catalog),
-                Arc::clone(&runtime_env),
-            );
+            // Register the table in the Cayenne metadata catalog
+            let table_id = metadata_catalog
+                .create_table(create_options)
+                .await
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to create Cayenne table '{table_name}': {e}"
+                    ))
+                })?;
 
-            let provider = builder.create(create_options).await.map_err(|e| {
-                DataFusionError::Execution(format!(
-                    "Failed to create Cayenne table '{table_name}': {e}"
-                ))
-            })?;
-
-            let provider = Arc::new(provider);
-            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+            // Build the table provider: partitioned or non-partitioned
             let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
-                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
+                if let Some(ref partition_col) = partition_expr {
+                    // Resolve the partition column from the schema
+                    if vortex_schema.field_with_name(partition_col).is_err() {
+                        return Err(DataFusionError::Execution(format!(
+                            "Partition column '{partition_col}' not found in table schema"
+                        )));
+                    }
+
+                    let partition_by = vec![PartitionedBy {
+                        name: partition_col.clone(),
+                        expression: col(partition_col),
+                    }];
+
+                    let creator = Arc::new(CayennePartitionCreator::new(
+                        metadata_table_name.clone(),
+                        PathBuf::from(&table_data_path),
+                        partition_by.clone(),
+                        Arc::clone(&vortex_schema),
+                        Arc::clone(&metadata_catalog),
+                        table_id,
+                        UnsupportedTypeAction::Error,
+                        Vec::new(), // retention_filters
+                        None,       // time_retention_filter_builder
+                        vortex_config,
+                        None,       // object_store_config (local filesystem)
+                        Vec::new(), // primary_key
+                        None,       // on_conflict
+                        Arc::clone(&runtime_env),
+                    ));
+
+                    let partition_provider = PartitionTableProvider::new(
+                        creator,
+                        partition_by,
+                        Arc::clone(&arrow_schema),
+                    )
+                    .await
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to create partitioned table '{table_name}': {e}"
+                        ))
+                    })?;
+
+                    Arc::new(partition_provider) as Arc<dyn datafusion::catalog::TableProvider>
+                } else {
+                    // Non-partitioned: open the table we just created
+                    let builder = CayenneTableProviderBuilder::new(
+                        Arc::clone(&metadata_catalog),
+                        Arc::clone(&runtime_env),
+                    );
+                    let provider = builder.open(&metadata_table_name).await.map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to open Cayenne table '{table_name}': {e}"
+                        ))
+                    })?;
+                    let provider = Arc::new(provider);
+                    let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                        as Arc<dyn datafusion::catalog::TableProvider>
+                };
 
             // Ensure the schema exists, creating it on demand if needed
             let schema_provider = if let Some(s) = cayenne_provider.schema_provider(&df_schema_name)
@@ -416,8 +496,11 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         Ok(format!("\"{}\" {sql_type}{null_str}", f.name()))
                     })
                     .collect::<DFResult<Vec<_>>>()?;
+                let partition_clause = partition_expr
+                    .as_deref()
+                    .map_or(String::new(), |col| format!(" PARTITION BY (\"{col}\")"));
                 let ddl_sql = format!(
-                    "CREATE TABLE IF NOT EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\" ({})",
+                    "CREATE TABLE IF NOT EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\" ({}){partition_clause}",
                     columns_sql.join(", ")
                 );
                 forward_ddl_to_executors(registry, &ddl_sql).await?;

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -654,7 +654,6 @@ impl ExecutionPlan for CayenneCreateTableExec {
     }
 }
 
-
 /// Physical plan for creating a Cayenne schema.
 pub struct CayenneCreateSchemaExec {
     schema_name: String,

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -61,6 +61,38 @@ use crate::cluster::executor_registry::ExecutorRegistry;
 use crate::dataaccelerator::cayenne::CayennePartitionCreator;
 use crate::dataaccelerator::cayenne::transform_schema_for_vortex;
 
+/// Builds a filesystem-safe partition label for persisted metadata and Hive-style paths.
+///
+/// Column expressions keep their column name when safe; non-column expressions use
+/// a stable generated label (`expr0`).
+fn partition_label_for_expr(partition_expr: &Expr) -> String {
+    let candidate = match partition_expr {
+        Expr::Column(col) => col.name.as_str(),
+        _ => "expr0",
+    };
+
+    let mut sanitized: String = candidate
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        return "expr0".to_string();
+    }
+
+    if sanitized.starts_with('.') {
+        sanitized.insert(0, '_');
+    }
+
+    sanitized
+}
+
 /// Maps an Arrow [`DataType`] to a SQL type string suitable for DDL forwarding.
 ///
 /// Returns a SQL type that `DataFusion`'s SQL parser can understand in a
@@ -350,6 +382,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
         let executor_registry = self.executor_registry.clone();
         let partition_expr = self.partition_expr.clone();
         let partition_expr_sql = self.partition_expr_sql.clone();
+        let partition_label = partition_expr.as_ref().map(partition_label_for_expr);
         let result_schema = ddl_result_schema();
         let runtime_env = context.runtime_env();
 
@@ -462,10 +495,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 primary_key: primary_key.clone(),
                 on_conflict: on_conflict.clone(),
                 base_path: table_data_path.clone(),
-                partition_column: partition_expr
-                    .as_ref()
-                    .and_then(|expr| expr.column_refs().into_iter().next())
-                    .map(|col| col.name().to_string()),
+                partition_column: partition_label.clone(),
                 vortex_config: vortex_config.clone(),
             };
 
@@ -482,7 +512,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
             // Build the table provider: partitioned or non-partitioned
             let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
                 if let Some(ref partition_expr) = partition_expr {
-                    let df_schema = arrow_schema.as_ref().clone().to_dfschema()?;
+                    let df_schema = vortex_schema.as_ref().clone().to_dfschema()?;
                     let partition_expr_for_error = partition_expr_sql
                         .clone()
                         .unwrap_or_else(|| partition_expr.to_string());
@@ -492,9 +522,9 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         ))
                     })?;
 
-                    let partition_name = partition_expr_sql
+                    let partition_name = partition_label
                         .clone()
-                        .unwrap_or_else(|| partition_expr.to_string());
+                        .unwrap_or_else(|| partition_label_for_expr(partition_expr));
 
                     let partition_by = vec![PartitionedBy {
                         name: partition_name,
@@ -521,7 +551,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     let partition_provider = PartitionTableProvider::new(
                         creator,
                         partition_by,
-                        Arc::clone(&arrow_schema),
+                        Arc::clone(&vortex_schema),
                     )
                     .await
                     .map_err(|e| {
@@ -623,6 +653,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
         )))
     }
 }
+
 
 /// Physical plan for creating a Cayenne schema.
 pub struct CayenneCreateSchemaExec {
@@ -942,5 +973,30 @@ impl ExecutionPlan for CayenneDropTableExec {
             ddl_result_schema(),
             stream,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::logical_expr::col;
+
+    use super::partition_label_for_expr;
+
+    #[test]
+    fn partition_label_for_expr_uses_column_name_when_safe() {
+        let expr = col("order_date");
+        assert_eq!(partition_label_for_expr(&expr), "order_date");
+    }
+
+    #[test]
+    fn partition_label_for_expr_uses_generated_label_for_non_column_expr() {
+        let expr = col("id").eq(datafusion::logical_expr::lit(1_i64));
+        assert_eq!(partition_label_for_expr(&expr), "expr0");
+    }
+
+    #[test]
+    fn partition_label_for_expr_sanitizes_unsafe_column_names() {
+        let expr = col("tenant/../id");
+        assert_eq!(partition_label_for_expr(&expr), "tenant____id");
     }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -16,14 +16,19 @@ limitations under the License.
 
 //! Physical execution plans for Cayenne DDL operations.
 //!
-//! `CayenneCreateTableExec` creates a new table in the Cayenne metadata catalog
-//! with data stored in S3 Express One Zone via Vortex columnar format.
+//! `CayenneCreateTableExec` registers a new table definition in the Cayenne
+//! metadata catalog via `metadata_catalog.create_table(...)`, then opens and
+//! registers the corresponding `TableProvider` in the `DataFusion` catalog.
+//! Depending on the presence of a `PARTITION BY` expression, it constructs
+//! either a partitioned `PartitionTableProvider` wrapped in
+//! `DeletionTableProviderAdapter` or a non-partitioned provider, with data
+//! stored in Vortex columnar format (typically in S3 Express One Zone).
 //!
-//! `CayenneCreateSchemaExec` registers a schema namespace in the `DataFusion` catalog
-//! for Cayenne-backed DDL catalogs.
+//! `CayenneCreateSchemaExec` registers a schema namespace in the `DataFusion`
+//! catalog for Cayenne-backed DDL catalogs.
 //!
-//! `CayenneDropTableExec` removes a table from both the Cayenne metadata catalog
-//! and the `DataFusion` catalog.
+//! `CayenneDropTableExec` removes a table from both the Cayenne metadata
+//! catalog and the `DataFusion` catalog.
 
 use std::any::Any;
 use std::fmt;

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -82,12 +82,8 @@ fn partition_label_for_expr(partition_expr: &Expr) -> String {
         })
         .collect();
 
-    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+    if sanitized.is_empty() {
         return "expr0".to_string();
-    }
-
-    if sanitized.starts_with('.') {
-        sanitized.insert(0, '_');
     }
 
     sanitized

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -71,7 +71,7 @@ fn partition_label_for_expr(partition_expr: &Expr) -> String {
         _ => "expr0",
     };
 
-    let mut sanitized: String = candidate
+    let sanitized: String = candidate
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || matches!(c, '_' | '-') {

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -507,7 +507,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         Vec::new(), // retention_filters
                         None,       // time_retention_filter_builder
                         vortex_config.clone(),
-                        None,       // object_store_config (local filesystem)
+                        None, // object_store_config (local filesystem)
                         primary_key.clone(),
                         on_conflict.clone(),
                         Arc::clone(&runtime_env),

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -36,9 +36,10 @@ use cayenne::CayenneTableProviderBuilder;
 use cayenne::metadata::CreateTableOptions;
 use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use datafusion::catalog::{CatalogProviderList, SchemaProvider};
+use datafusion::common::ToDFSchema;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
-use datafusion::logical_expr::col;
+use datafusion::logical_expr::{Expr, ExprSchemable};
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -190,7 +191,8 @@ pub struct CayenneCreateTableExec {
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
     executor_registry: Option<Arc<ExecutorRegistry>>,
-    partition_expr: Option<String>,
+    partition_expr: Option<Expr>,
+    partition_expr_sql: Option<String>,
     properties: PlanProperties,
 }
 
@@ -213,7 +215,8 @@ pub struct CayenneCreateTableExecBuilder {
     df_schema_name: String,
     catalog_list: Arc<dyn CatalogProviderList>,
     executor_registry: Option<Arc<ExecutorRegistry>>,
-    partition_expr: Option<String>,
+    partition_expr: Option<Expr>,
+    partition_expr_sql: Option<String>,
 }
 
 impl CayenneCreateTableExecBuilder {
@@ -233,6 +236,7 @@ impl CayenneCreateTableExecBuilder {
             catalog_list,
             executor_registry: None,
             partition_expr: None,
+            partition_expr_sql: None,
         }
     }
 
@@ -249,8 +253,14 @@ impl CayenneCreateTableExecBuilder {
     }
 
     #[must_use]
-    pub fn partition_expr(mut self, partition_expr: Option<String>) -> Self {
+    pub fn partition_expr(mut self, partition_expr: Option<Expr>) -> Self {
         self.partition_expr = partition_expr;
+        self
+    }
+
+    #[must_use]
+    pub fn partition_expr_sql(mut self, partition_expr_sql: Option<String>) -> Self {
+        self.partition_expr_sql = partition_expr_sql;
         self
     }
 
@@ -272,6 +282,7 @@ impl CayenneCreateTableExecBuilder {
             catalog_list: self.catalog_list,
             executor_registry: self.executor_registry,
             partition_expr: self.partition_expr,
+            partition_expr_sql: self.partition_expr_sql,
             properties,
         }
     }
@@ -324,6 +335,7 @@ impl ExecutionPlan for CayenneCreateTableExec {
         let catalog_list = Arc::clone(&self.catalog_list);
         let executor_registry = self.executor_registry.clone();
         let partition_expr = self.partition_expr.clone();
+        let partition_expr_sql = self.partition_expr_sql.clone();
         let result_schema = ddl_result_schema();
         let runtime_env = context.runtime_env();
 
@@ -429,7 +441,10 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 primary_key: Vec::new(),
                 on_conflict: None,
                 base_path: table_data_path.clone(),
-                partition_column: partition_expr.clone(),
+                partition_column: partition_expr
+                    .as_ref()
+                    .and_then(|expr| expr.column_refs().into_iter().next())
+                    .map(|col| col.name().to_string()),
                 vortex_config: vortex_config.clone(),
             };
 
@@ -445,17 +460,24 @@ impl ExecutionPlan for CayenneCreateTableExec {
 
             // Build the table provider: partitioned or non-partitioned
             let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
-                if let Some(ref partition_col) = partition_expr {
-                    // Resolve the partition column from the schema
-                    if vortex_schema.field_with_name(partition_col).is_err() {
-                        return Err(DataFusionError::Execution(format!(
-                            "Partition column '{partition_col}' not found in table schema"
-                        )));
-                    }
+                if let Some(ref partition_expr) = partition_expr {
+                    let df_schema = arrow_schema.as_ref().clone().to_dfschema()?;
+                    let partition_expr_for_error = partition_expr_sql
+                        .clone()
+                        .unwrap_or_else(|| partition_expr.to_string());
+                    partition_expr.to_field(&df_schema).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Invalid PARTITION BY expression '{partition_expr_for_error}': {e}",
+                        ))
+                    })?;
+
+                    let partition_name = partition_expr_sql
+                        .clone()
+                        .unwrap_or_else(|| partition_expr.to_string());
 
                     let partition_by = vec![PartitionedBy {
-                        name: partition_col.clone(),
-                        expression: col(partition_col),
+                        name: partition_name,
+                        expression: partition_expr.clone(),
                     }];
 
                     let creator = Arc::new(CayennePartitionCreator::new(
@@ -487,7 +509,10 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         ))
                     })?;
 
-                    Arc::new(partition_provider) as Arc<dyn datafusion::catalog::TableProvider>
+                    let partition_provider = Arc::new(partition_provider);
+                    let deletion_provider: Arc<dyn DeletionTableProvider> = partition_provider;
+                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                        as Arc<dyn datafusion::catalog::TableProvider>
                 } else {
                     // Non-partitioned: open the table we just created
                     let builder = CayenneTableProviderBuilder::new(
@@ -536,8 +561,14 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     })
                     .collect::<DFResult<Vec<_>>>()?;
                 let partition_clause = partition_expr
-                    .as_deref()
-                    .map_or(String::new(), |col| format!(" PARTITION BY (\"{col}\")"));
+                    .as_ref()
+                    .map(|expr| {
+                        let partition_sql = partition_expr_sql
+                            .clone()
+                            .unwrap_or_else(|| expr.to_string());
+                        format!(" PARTITION BY ({partition_sql})")
+                    })
+                    .unwrap_or_default();
                 let ddl_sql = format!(
                     "CREATE TABLE IF NOT EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\" ({}){partition_clause}",
                     columns_sql.join(", ")

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -22,7 +22,9 @@ limitations under the License.
 //! Depending on the presence of a `PARTITION BY` expression, it constructs
 //! either a partitioned `PartitionTableProvider` wrapped in
 //! `DeletionTableProviderAdapter` or a non-partitioned provider, with data
-//! stored in Vortex columnar format (typically in S3 Express One Zone).
+//! stored in Vortex columnar format on local filesystem paths managed by the
+//! Cayenne catalog provider. S3 Express One Zone applies to the Cayenne
+//! accelerator path, not Cayenne DDL catalog storage.
 //!
 //! `CayenneCreateSchemaExec` registers a schema namespace in the `DataFusion`
 //! catalog for Cayenne-backed DDL catalogs.

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -205,18 +205,57 @@ impl fmt::Debug for CayenneCreateTableExec {
     }
 }
 
-impl CayenneCreateTableExec {
-    #[must_use]
+pub struct CayenneCreateTableExecBuilder {
+    table_name: String,
+    arrow_schema: Arc<Schema>,
+    if_not_exists: bool,
+    df_catalog_name: String,
+    df_schema_name: String,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
+    partition_expr: Option<String>,
+}
+
+impl CayenneCreateTableExecBuilder {
     pub fn new(
         table_name: String,
         arrow_schema: Arc<Schema>,
-        if_not_exists: bool,
         df_catalog_name: String,
         df_schema_name: String,
         catalog_list: Arc<dyn CatalogProviderList>,
-        executor_registry: Option<Arc<ExecutorRegistry>>,
-        partition_expr: Option<String>,
     ) -> Self {
+        Self {
+            table_name,
+            arrow_schema,
+            if_not_exists: false,
+            df_catalog_name,
+            df_schema_name,
+            catalog_list,
+            executor_registry: None,
+            partition_expr: None,
+        }
+    }
+
+    #[must_use]
+    pub fn if_not_exists(mut self, if_not_exists: bool) -> Self {
+        self.if_not_exists = if_not_exists;
+        self
+    }
+
+    #[must_use]
+    pub fn executor_registry(mut self, executor_registry: Option<Arc<ExecutorRegistry>>) -> Self {
+        self.executor_registry = executor_registry;
+        self
+    }
+
+    #[must_use]
+    pub fn partition_expr(mut self, partition_expr: Option<String>) -> Self {
+        self.partition_expr = partition_expr;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> CayenneCreateTableExec {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&schema)),
@@ -224,15 +263,15 @@ impl CayenneCreateTableExec {
             EmissionType::Final,
             Boundedness::Bounded,
         );
-        Self {
-            table_name,
-            arrow_schema,
-            if_not_exists,
-            df_catalog_name,
-            df_schema_name,
-            catalog_list,
-            executor_registry,
-            partition_expr,
+        CayenneCreateTableExec {
+            table_name: self.table_name,
+            arrow_schema: self.arrow_schema,
+            if_not_exists: self.if_not_exists,
+            df_catalog_name: self.df_catalog_name,
+            df_schema_name: self.df_schema_name,
+            catalog_list: self.catalog_list,
+            executor_registry: self.executor_registry,
+            partition_expr: self.partition_expr,
             properties,
         }
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -28,7 +28,7 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use super::logical_nodes::{CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode};
 use super::physical_plans::{
-    CayenneCreateSchemaExec, CayenneCreateTableExec, CayenneDropTableExec,
+    CayenneCreateSchemaExec, CayenneCreateTableExecBuilder, CayenneDropTableExec,
 };
 use crate::cluster::executor_registry::ExecutorRegistry;
 
@@ -67,16 +67,19 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
         let catalog_list = Arc::<dyn CatalogProviderList>::clone(session_state.catalog_list());
 
         if let Some(create) = node.as_any().downcast_ref::<CayenneCreateTableNode>() {
-            return Ok(Some(Arc::new(CayenneCreateTableExec::new(
-                create.table_name.clone(),
-                Arc::clone(&create.arrow_schema),
-                create.if_not_exists,
-                create.df_catalog_name.clone(),
-                create.df_schema_name.clone(),
-                catalog_list,
-                self.executor_registry.clone(),
-                create.partition_expr.clone(),
-            ))));
+            return Ok(Some(Arc::new(
+                CayenneCreateTableExecBuilder::new(
+                    create.table_name.clone(),
+                    Arc::clone(&create.arrow_schema),
+                    create.df_catalog_name.clone(),
+                    create.df_schema_name.clone(),
+                    catalog_list,
+                )
+                .if_not_exists(create.if_not_exists)
+                .executor_registry(self.executor_registry.clone())
+                .partition_expr(create.partition_expr.clone())
+                .build(),
+            )));
         }
 
         if let Some(create_schema) = node.as_any().downcast_ref::<CayenneCreateSchemaNode>() {

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -75,6 +75,7 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 create.df_schema_name.clone(),
                 catalog_list,
                 self.executor_registry.clone(),
+                create.partition_expr.clone(),
             ))));
         }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -78,6 +78,7 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 .if_not_exists(create.if_not_exists)
                 .executor_registry(self.executor_registry.clone())
                 .partition_expr(create.partition_expr.clone())
+                .partition_expr_sql(create.partition_expr_sql.clone())
                 .build(),
             )));
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -867,7 +867,7 @@ impl DataFusion {
     /// Returns the partition expression for a table by querying the catalog provider.
     ///
     /// Delegates to the catalog provider's [`PartitionAwareCatalog`] implementation,
-    /// which reads from the catalog's persistent metadata store (e.g. Cayenne's SQLite).
+    /// which reads from the catalog's persistent metadata store (e.g. Cayenne's `SQLite`).
     pub async fn get_table_partition_expr(
         &self,
         table_reference: &TableReference,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -864,6 +864,24 @@ impl DataFusion {
             .contains(table_reference)
     }
 
+    /// Returns the partition expression for a table by querying the catalog provider.
+    ///
+    /// Delegates to the catalog provider's [`PartitionAwareCatalog`] implementation,
+    /// which reads from the catalog's persistent metadata store (e.g. Cayenne's SQLite).
+    pub async fn get_table_partition_expr(
+        &self,
+        table_reference: &TableReference,
+    ) -> Option<String> {
+        let catalog_name = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+        let catalog = self.ctx.catalog(catalog_name)?;
+        let partition_aware = cayenne_ddl::as_partition_aware(catalog.as_ref())?;
+        let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
+        let table_name = table_reference.table();
+        partition_aware
+            .table_partition_expr(schema_name, table_name)
+            .await
+    }
+
     pub fn set_cpu_runtime(&self, handle: ManagedTokioRuntime) {
         if self.cpu_runtime.set(handle).is_err() {
             // Failure to set means this was already set - that shouldn't happen.

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -267,6 +267,19 @@ pub enum Error {
     #[snafu(display("The schema {schema} is not registered."))]
     SchemaMissing { schema: String },
 
+    #[snafu(display("The catalog {catalog} does not support partition metadata lookups."))]
+    CatalogNotPartitionAware { catalog: String },
+
+    #[snafu(display(
+        "Failed to read partition metadata for table {catalog}.{schema}.{table}: {source}"
+    ))]
+    UnableToReadPartitionMetadata {
+        catalog: String,
+        schema: String,
+        table: String,
+        source: Box<crate::catalogconnector::Error>,
+    },
+
     #[snafu(display("Unable to get {schema} schema: {}", format_datafusion_error(source)))]
     UnableToGetSchema {
         schema: String,
@@ -871,18 +884,35 @@ impl DataFusion {
     ///
     /// Note: this returns the catalog metadata label (historically named as an expression API),
     /// not a guaranteed round-trippable SQL expression.
+    ///
+    /// Returns `Ok(None)` only when no partition metadata is present.
     pub async fn get_table_partition_expr(
         &self,
         table_reference: &TableReference,
-    ) -> Option<String> {
+    ) -> Result<Option<String>> {
         let catalog_name = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
-        let catalog = self.ctx.catalog(catalog_name)?;
-        let partition_aware = cayenne_ddl::as_partition_aware(catalog.as_ref())?;
+        let catalog = self
+            .ctx
+            .catalog(catalog_name)
+            .context(CatalogMissingSnafu {
+                catalog: catalog_name.to_string(),
+            })?;
+        let partition_aware = cayenne_ddl::as_partition_aware(catalog.as_ref()).context(
+            CatalogNotPartitionAwareSnafu {
+                catalog: catalog_name.to_string(),
+            },
+        )?;
         let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
         let table_name = table_reference.table();
         partition_aware
             .table_partition_expr(schema_name, table_name)
             .await
+            .map_err(|source| Error::UnableToReadPartitionMetadata {
+                catalog: catalog_name.to_string(),
+                schema: schema_name.to_string(),
+                table: table_name.to_string(),
+                source: Box::new(source),
+            })
     }
 
     pub fn set_cpu_runtime(&self, handle: ManagedTokioRuntime) {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -864,10 +864,13 @@ impl DataFusion {
             .contains(table_reference)
     }
 
-    /// Returns the partition expression for a table by querying the catalog provider.
+    /// Returns the partition column label for a table by querying the catalog provider.
     ///
     /// Delegates to the catalog provider's [`PartitionAwareCatalog`] implementation,
     /// which reads from the catalog's persistent metadata store (e.g. Cayenne's `SQLite`).
+    ///
+    /// Note: this returns the catalog metadata label (historically named as an expression API),
+    /// not a guaranteed round-trippable SQL expression.
     pub async fn get_table_partition_expr(
         &self,
         table_reference: &TableReference,


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Introduced `PartitionAwareCatalog` trait so catalogs can report partition expressions for their tables; implemented for `CayenneCatalogProvider`
* Added `get_table_partition_expr` on `DataFusion` to query partition metadata from catalog providers
* Extended Cayenne DDL logical/physical plan nodes to carry and propagate an optional `partition_expr`
* Added `PARTITION BY` expression parsing and validation in the DDL analyzer rule, rejecting unsupported boolean expressions - boolean partition expressions (multi-expression partitioning) can be added later
* Partitioned table creation in `CayenneCreateTableExec`: builds `CayennePartitionCreator` + `PartitionTableProvider` when a partition column is specified
* Forwarded `PARTITION BY` clause when distributing `CREATE TABLE` DDL to cluster executors
* Added `Utf8View` support in `runtime-table-partition` (key encoding, value parsing, type validation)
* Fixed `PartitionerExec` output schema to use `count: UInt64` matching DataFusion's expected INSERT schema
* Refactored `forward_ddl_to_executors` to run concurrently via `join_all` and release the read lock before awaiting

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #9725
