### PR TITLE
Route FlightSQL statement updates through QueryBuilder

### DIFF
--- a/crates/runtime/src/flight/flightsql/prepared_statement_update.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_update.rs
@@ -32,11 +32,8 @@ use tokio_stream::{StreamExt, adapters::Peekable};
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{
-    datafusion::{
-        request_context_extension::get_current_datafusion,
-        sql_validator::validate_sql_query_operations,
-    },
-    flight::{Service, metrics, to_tonic_err, util::set_flightsql_protocol},
+    datafusion::{query::QueryBuilder, request_context_extension::get_current_datafusion},
+    flight::{Service, handle_query_error, metrics, to_tonic_err, util::set_flightsql_protocol},
 };
 use runtime_request_context::{AsyncMarker, RequestContext};
 
@@ -111,38 +108,23 @@ pub(crate) async fn do_get(
 
     let parameters = decode_param_values(&parameters).map_err(error_to_status)?;
 
-    // Execute the update statement
-    // For UPDATE/INSERT/DELETE statements, we need to execute the full logical plan
-    let session = datafusion.ctx.state();
-    let plan = session
-        .create_logical_plan(&sql)
+    // Execute through the standard query path, which handles DELETE and UPDATE
+    // via the runtime's DML interception in Query::run().
+    let query_result = QueryBuilder::new(&sql, datafusion)
+        .parameters(parameters)
+        .build()
+        .run()
         .await
-        .map_err(|e| Status::internal(format!("Failed to create logical plan: {e}")))?;
+        .map_err(handle_query_error)?;
 
-    // Validate the plan to ensure only allowed operations are executed
-    // This prevents SQL injection attacks via prepared statement updates
-    if let Err(e) = validate_sql_query_operations(&plan, &datafusion) {
-        return Err(Status::permission_denied(format!(
-            "Operation not allowed: {e}"
-        )));
-    }
-
-    let plan = if let Some(params) = parameters {
-        plan.with_param_values(params)
-            .map_err(|e| Status::internal(format!("Failed to bind parameters: {e}")))?
-    } else {
-        plan
+    let results: Vec<RecordBatch> = {
+        use futures::TryStreamExt;
+        query_result
+            .data
+            .try_collect()
+            .await
+            .map_err(to_tonic_err)?
     };
-
-    let physical_plan = session
-        .create_physical_plan(&plan)
-        .await
-        .map_err(|e| Status::internal(format!("Failed to create physical plan: {e}")))?;
-
-    // Execute the plan and collect the result (which should be a count for DML statements)
-    let results = datafusion::physical_plan::collect(physical_plan, datafusion.ctx.task_ctx())
-        .await
-        .map_err(|e| Status::internal(format!("Failed to execute statement: {e}")))?;
 
     // Extract affected rows count from the result
     // DML statements typically return a single row with a count column

--- a/crates/runtime/src/flight/flightsql/statement_update.rs
+++ b/crates/runtime/src/flight/flightsql/statement_update.rs
@@ -22,20 +22,19 @@ use arrow::array::{Int64Array, RecordBatch};
 use arrow_flight::{
     PutResult,
     flight_service_server::FlightService,
-    sql::{CommandStatementUpdate, DoPutUpdateResult, ProstMessageExt},
+    sql::{CommandStatementUpdate, DoPutUpdateResult},
 };
+use futures::TryStreamExt;
 use prost::Message;
 use tonic::{Response, Status};
 
 use crate::{
     config::ClusterRole,
-    datafusion::request_context_extension::get_current_datafusion,
-    flight::{Service, metrics},
+    datafusion::{query::QueryBuilder, request_context_extension::get_current_datafusion},
+    flight::{Service, handle_query_error, metrics, to_tonic_err, util::set_flightsql_protocol},
 };
-use runtime_request_context::{AsyncMarker, RequestContext};
-
-use crate::datafusion::sql_validator::validate_sql_query_operations;
 use runtime_auth::AuthRequestContext;
+use runtime_request_context::{AsyncMarker, RequestContext};
 
 /// Execute a SQL DML statement received via `DoPut` with `CommandStatementUpdate`.
 ///
@@ -45,6 +44,7 @@ pub(crate) async fn do_put(
     cmd: CommandStatementUpdate,
 ) -> Result<Response<<Service as FlightService>::DoPutStream>, Status> {
     let _start = metrics::track_flight_request("do_put", Some("statement_update")).await;
+    set_flightsql_protocol().await;
 
     // Authenticate — this handler is dispatched before the generic DoPut auth
     // check, so we must verify credentials here.
@@ -79,28 +79,19 @@ pub(crate) async fn do_put(
     let sql = &cmd.query;
     tracing::trace!("do_put_statement_update: {sql}");
 
-    // Parse and validate
-    let session = datafusion.ctx.state();
-    let plan = session
-        .create_logical_plan(sql)
+    // Execute through the standard query path, which handles DELETE and UPDATE
+    // via the runtime's DML interception in Query::run().
+    let query_result = QueryBuilder::new(sql, datafusion)
+        .build()
+        .run()
         .await
-        .map_err(|e| Status::internal(format!("Failed to create logical plan: {e}")))?;
+        .map_err(handle_query_error)?;
 
-    if let Err(e) = validate_sql_query_operations(&plan, &datafusion) {
-        return Err(Status::permission_denied(format!(
-            "Operation not allowed: {e}"
-        )));
-    }
-
-    // Execute
-    let physical_plan = session
-        .create_physical_plan(&plan)
+    let results: Vec<RecordBatch> = query_result
+        .data
+        .try_collect()
         .await
-        .map_err(|e| Status::internal(format!("Failed to create physical plan: {e}")))?;
-
-    let results = datafusion::physical_plan::collect(physical_plan, datafusion.ctx.task_ctx())
-        .await
-        .map_err(|e| Status::internal(format!("Failed to execute statement: {e}")))?;
+        .map_err(to_tonic_err)?;
 
     // Extract affected rows count
     let affected_rows = extract_affected_rows(&results);
@@ -110,7 +101,7 @@ pub(crate) async fn do_put(
     };
 
     let output = futures::stream::iter(vec![Ok(PutResult {
-        app_metadata: result.as_any().encode_to_vec().into(),
+        app_metadata: result.encode_to_vec().into(),
     })]);
 
     Ok(Response::new(Box::pin(output)))

--- a/crates/runtime/tests/flight/mod.rs
+++ b/crates/runtime/tests/flight/mod.rs
@@ -50,6 +50,7 @@ const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 mod do_get;
 mod do_put;
 mod prepared_statements;
+mod statement_update;
 
 async fn start_spice_test_app(
     flight_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,

--- a/crates/runtime/tests/flight/statement_update.rs
+++ b/crates/runtime/tests/flight/statement_update.rs
@@ -1,0 +1,394 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Integration tests for `FlightSQL` `CommandStatementUpdate` (`DoPut`) handling of
+//! DML statements (DELETE, UPDATE).
+//!
+//! These tests use a Cayenne catalog so DELETE and UPDATE are fully supported
+//! end-to-end through the runtime's `Query::run()` DML interception path.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::array::RecordBatch;
+use arrow_flight::sql::client::FlightSqlServiceClient;
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
+use rand::Rng as _;
+use runtime::Runtime;
+use runtime::auth::EndpointAuth;
+use runtime::config::Config;
+use runtime_auth::FlightBasicAuth;
+use runtime_auth::api_key::ApiKeyAuth;
+use spicepod::component::access::AccessMode;
+use spicepod::component::catalog::Catalog;
+use spicepod::component::runtime::ApiKey;
+use spicepod::param::Params;
+use tokio::time::sleep;
+use tonic::transport::Channel;
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, runtime_ready_check, test_request_context, wait_until_true},
+};
+
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Creates a Cayenne catalog pointed at temp dirs with `read_write_create` access.
+fn make_cayenne_catalog(catalog_name: &str, data_dir: &str, metadata_dir: &str) -> Catalog {
+    let mut catalog = Catalog::new("cayenne".to_string(), catalog_name.to_string())
+        .with_access(AccessMode::ReadWriteCreate);
+    catalog.params = Some(Params::from_string_map(
+        vec![
+            ("cayenne_data_dir".to_string(), data_dir.to_string()),
+            ("cayenne_metadata_dir".to_string(), metadata_dir.to_string()),
+        ]
+        .into_iter()
+        .collect::<HashMap<String, String>>(),
+    ));
+    catalog
+}
+
+/// Run SQL against the runtime directly (for setup operations).
+async fn run_sql(rt: &Runtime, sql: &str) -> Result<Vec<RecordBatch>, String> {
+    let result = rt
+        .datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("query '{sql}' failed: {e}"))?;
+
+    result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("collecting results for '{sql}' failed: {e}"))
+}
+
+/// Start a test runtime with a Cayenne catalog and Flight/HTTP servers.
+/// Returns a connected Flight channel and the runtime for direct setup queries.
+async fn start_cayenne_flight_app(
+    catalog: Catalog,
+) -> Result<(Channel, Arc<Runtime>), anyhow::Error> {
+    let mut rng = rand::rng();
+    let http_port: u16 = rng.random_range(50000..60000);
+    let flight_port: u16 = http_port + 1;
+    let metrics_port: u16 = http_port + 2;
+
+    register_test_connectors().await;
+
+    let api_config = Config::new()
+        .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
+        .with_caching_disabled();
+
+    let registry = prometheus::Registry::new();
+
+    configure_test_datafusion();
+    let rt_builder =
+        Runtime::builder().with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry);
+
+    let app = app::AppBuilder::new("flightsql_statement_update_test")
+        .with_catalog(catalog)
+        .build();
+
+    let rt = Arc::new(
+        rt_builder
+            .with_app(app)
+            .with_runtime_config(api_config.clone())
+            .build()
+            .await,
+    );
+
+    let cloned_rt = Arc::clone(&rt);
+    tokio::select! {
+        () = tokio::time::sleep(Duration::from_secs(60)) => {
+            return Err(anyhow::anyhow!("Timed out waiting for components to load"));
+        }
+        () = cloned_rt.load_components() => {}
+    };
+
+    runtime_ready_check(&rt).await;
+
+    // Auth: API key with read-write access
+    let auth_provider = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("test-key:rw")]))
+        as Arc<dyn FlightBasicAuth + Send + Sync>;
+    let auth = EndpointAuth::default().with_flight_basic_auth(auth_provider);
+
+    // Start servers
+    let rt_for_server = Arc::clone(&rt);
+    tokio::spawn(async move {
+        let _ = Box::pin(rt_for_server.start_servers(api_config, None, auth)).await;
+    });
+
+    // Wait for HTTP readiness
+    wait_until_true(Duration::from_secs(10), || async {
+        reqwest::get(format!("http://localhost:{http_port}/health"))
+            .await
+            .is_ok()
+    })
+    .await;
+
+    // Connect Flight channel
+    let start_time = std::time::Instant::now();
+    let channel = loop {
+        if start_time.elapsed() > Duration::from_secs(30) {
+            return Err(anyhow::anyhow!("Flight server not ready within 30 seconds"));
+        }
+        match Channel::from_shared(format!("http://localhost:{flight_port}"))
+            .map_err(anyhow::Error::from)?
+            .connect()
+            .await
+        {
+            Ok(channel) => break channel,
+            Err(_) => sleep(Duration::from_millis(100)).await,
+        }
+    };
+
+    Ok((channel, rt))
+}
+
+/// Create an authenticated `FlightSqlServiceClient` via handshake.
+async fn create_flightsql_client(
+    channel: Channel,
+    api_key: &str,
+) -> Result<FlightSqlServiceClient<Channel>, anyhow::Error> {
+    let mut client = FlightSqlServiceClient::new(channel);
+    client.handshake("", api_key).await?;
+    Ok(client)
+}
+
+/// Execute a SELECT via `FlightSQL` (prepared statement → `DoGet`) and collect results.
+async fn flightsql_query(
+    client: &mut FlightSqlServiceClient<Channel>,
+    sql: &str,
+) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    let mut stmt = client.prepare(sql.to_string(), None).await?;
+    let flight_info = stmt.execute().await?;
+    let mut batches = Vec::new();
+    for endpoint in flight_info.endpoint {
+        if let Some(ticket) = endpoint.ticket {
+            let stream = client.do_get(ticket).await?;
+            let endpoint_batches: Vec<RecordBatch> = stream.try_collect().await?;
+            batches.extend(endpoint_batches);
+        }
+    }
+    Ok(batches)
+}
+
+/// Full lifecycle: setup table via runtime, then test INSERT, DELETE, UPDATE
+/// through `FlightSQL` `execute_update` (`CommandStatementUpdate` / `DoPut` path).
+#[tokio::test]
+async fn test_flightsql_execute_update_delete_and_update() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let data_dir = temp_dir.path().join("data");
+            let metadata_dir = temp_dir.path().join("metadata");
+
+            let catalog = make_cayenne_catalog(
+                "test_cat",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let (channel, rt) = start_cayenne_flight_app(catalog).await?;
+
+            // -----------------------------------------------------------------
+            // Setup: CREATE SCHEMA + TABLE + INSERT via runtime (not FlightSQL)
+            // to keep the test focused on testing DML via execute_update.
+            // -----------------------------------------------------------------
+            run_sql(&rt, "CREATE SCHEMA test_cat.myschema")
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+
+            run_sql(
+                &rt,
+                "CREATE TABLE test_cat.myschema.items (
+                    id BIGINT NOT NULL,
+                    name VARCHAR NOT NULL,
+                    price BIGINT NOT NULL
+                )",
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+            run_sql(
+                &rt,
+                "INSERT INTO test_cat.myschema.items VALUES
+                    (1, 'apple',  100),
+                    (2, 'banana', 200),
+                    (3, 'cherry', 300)",
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+            let mut client = create_flightsql_client(channel, "test-key").await?;
+
+            // Verify initial data via FlightSQL SELECT (DoGet path)
+            let batches = flightsql_query(
+                &mut client,
+                "SELECT id, name, price FROM test_cat.myschema.items ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-------+",
+                    "| id | name   | price |",
+                    "+----+--------+-------+",
+                    "| 1  | apple  | 100   |",
+                    "| 2  | banana | 200   |",
+                    "| 3  | cherry | 300   |",
+                    "+----+--------+-------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // DELETE via execute_update (the bug path: CommandStatementUpdate)
+            // Before the fix, this returned "Unsupported plan: Dml".
+            // -----------------------------------------------------------------
+            let affected = client
+                .execute_update(
+                    "DELETE FROM test_cat.myschema.items WHERE id = 2".to_string(),
+                    None,
+                )
+                .await?;
+            assert_eq!(affected, 1, "DELETE should report 1 affected row");
+
+            // Verify row is gone
+            let batches = flightsql_query(
+                &mut client,
+                "SELECT id, name, price FROM test_cat.myschema.items ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-------+",
+                    "| id | name   | price |",
+                    "+----+--------+-------+",
+                    "| 1  | apple  | 100   |",
+                    "| 3  | cherry | 300   |",
+                    "+----+--------+-------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // UPDATE via execute_update (the bug path: CommandStatementUpdate)
+            // Before the fix, this returned "Unsupported plan: Dml".
+            // -----------------------------------------------------------------
+            let affected = client
+                .execute_update(
+                    "UPDATE test_cat.myschema.items SET price = 999 WHERE id = 1".to_string(),
+                    None,
+                )
+                .await?;
+            assert_eq!(affected, 1, "UPDATE should report 1 affected row");
+
+            // Verify the update took effect
+            let batches = flightsql_query(
+                &mut client,
+                "SELECT id, name, price FROM test_cat.myschema.items ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-------+",
+                    "| id | name   | price |",
+                    "+----+--------+-------+",
+                    "| 1  | apple  | 999   |",
+                    "| 3  | cherry | 300   |",
+                    "+----+--------+-------+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // DELETE multiple rows
+            // -----------------------------------------------------------------
+            let affected = client
+                .execute_update(
+                    "DELETE FROM test_cat.myschema.items WHERE price < 500".to_string(),
+                    None,
+                )
+                .await?;
+            assert_eq!(affected, 1, "DELETE should report 1 affected row (cherry)");
+
+            let batches = flightsql_query(
+                &mut client,
+                "SELECT id, name, price FROM test_cat.myschema.items ORDER BY id",
+            )
+            .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+-------+",
+                    "| id | name  | price |",
+                    "+----+-------+-------+",
+                    "| 1  | apple | 999   |",
+                    "+----+-------+-------+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Verify that `execute_update` requires write-level authentication.
+#[tokio::test]
+async fn test_flightsql_execute_update_requires_auth() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let data_dir = temp_dir.path().join("data");
+            let metadata_dir = temp_dir.path().join("metadata");
+
+            let catalog = make_cayenne_catalog(
+                "test_cat",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let (channel, _rt) = start_cayenne_flight_app(catalog).await?;
+
+            // Client with NO auth — no handshake performed
+            let mut no_auth_client = FlightSqlServiceClient::new(channel.clone());
+            let result = no_auth_client
+                .execute_update("DELETE FROM test_cat.foo WHERE id = 1".to_string(), None)
+                .await;
+            let err = result
+                .expect_err("execute_update without auth should fail")
+                .to_string();
+            // The tonic Status is wrapped in ArrowError::IpcError(format!("{status:?}")),
+            // so we check for the gRPC status code name in the debug representation.
+            assert!(
+                err.contains("Unauthenticated"),
+                "Expected Unauthenticated gRPC status, got: {err}"
+            );
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
## Problem

The FlightSQL `CommandStatementUpdate` and `PreparedStatementUpdate` handlers called `session.create_physical_plan()` directly, bypassing the runtime's DELETE/UPDATE interception in `Query::run()`. This caused DML operations (DELETE, UPDATE) via FlightSQL `execute_update` to fail with:

```
This feature is not implemented: Unsupported plan: Dml(DmlStatement...)
```

while the same operations via the SQL/DoGet path produced the correct error or succeeded.

## Solution

Route both handlers through `QueryBuilder::new().build().run()`, which goes through the standard query execution path including `create_delete_physical_plan` and `create_update_physical_plan` interception.

This also removes duplicated `validate_sql_query_operations` calls from the handlers since `Query::run()` already performs this validation.

## Changes

- **`statement_update.rs`**: Replace manual `create_logical_plan` → `create_physical_plan` → `collect` with `QueryBuilder::new(sql, datafusion).build().run()`
- **`prepared_statement_update.rs`**: Replace manual plan creation with `QueryBuilder::new(&sql, datafusion).parameters(parameters).build().run()`

Fixes #9746