### PR TITLE
Fetch API keys from dedicated endpoint instead of apps response

### DIFF
--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -939,7 +939,10 @@ async fn execute_create(cmd: &CreateCommands) -> Result<()> {
                 return write_json(&app);
             }
             println!("\x1b[32m✓ Created app {}\x1b[0m", app.full_name());
-            if let Some(api_key) = app.api_key {
+            let org_app = app.full_name();
+            if let Ok(api_keys) = client.get_api_keys(&org_app).await
+                && let Some(api_key) = api_keys.api_key
+            {
                 println!("\nAPI Key: {api_key}");
                 println!("\nSave this key - it won't be shown again.");
             }

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -35,7 +35,6 @@ pub struct App {
     pub created_at: Option<String>,
     pub region: Option<String>,
     pub production_branch: Option<String>,
-    pub api_key: Option<String>,
     #[serde(default)]
     pub config: Option<AppConfig>,
 }

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -148,10 +148,10 @@ fn env_var_resources_over(
 pub(crate) async fn ensure_spice_cloud_app(
     cloud: &CloudClient,
     app_name: &str,
-) -> anyhow::Result<(i64, Option<String>)> {
+) -> anyhow::Result<i64> {
     let apps = cloud.list_apps().await?;
     if let Some(app) = apps.into_iter().find(|a| a.name == app_name) {
-        return Ok((app.id, app.api_key));
+        return Ok(app.id);
     }
 
     let cname = resolve_default_cname(cloud).await?;
@@ -196,12 +196,12 @@ pub(crate) async fn ensure_spice_cloud_app(
         .await;
 
     match create_result {
-        Ok(app) => Ok((app.id, app.api_key)),
+        Ok(app) => Ok(app.id),
         Err(spice_cloud_client::error::Error::Conflict { .. }) => {
             // Race condition — another caller created it; re-fetch
             let apps = cloud.list_apps().await?;
             if let Some(app) = apps.into_iter().find(|a| a.name == app_name) {
-                return Ok((app.id, app.api_key));
+                return Ok(app.id);
             }
             Err(anyhow::anyhow!(
                 "App '{app_name}' not found after conflict on create"

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -649,9 +649,15 @@ async fn provision_spice_cloud_app(
     eprintln!("[stdio] Flight endpoint: {flight_url}");
     eprintln!("[stdio] App name: {app_name}");
 
-    let (app_id, app_api_key) = commands::ensure_spice_cloud_app(&cloud, &app_name).await?;
+    let app_id = commands::ensure_spice_cloud_app(&cloud, &app_name).await?;
 
-    let api_key = app_api_key.ok_or_else(|| {
+    // Fetch API key from the dedicated api-keys endpoint
+    let api_keys = cloud
+        .get_api_keys(app_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to fetch API keys for app '{app_name}': {e}"))?;
+
+    let api_key = api_keys.api_key.ok_or_else(|| {
         anyhow::anyhow!("Spice Cloud did not return an API key for app '{app_name}'")
     })?;
 


### PR DESCRIPTION
The cloud API no longer returns `api_key` in the apps response. This updates spidapter and the Spice CLI to call `GET /v1/apps/{appId}/api-keys` to retrieve API keys separately.

## Changes

- **`crates/spice-cloud-client/src/types.rs`**: Remove `api_key` field from `App` struct
- **`tools/spidapter/src/commands/mod.rs`**: Change `ensure_spice_cloud_app` to return only the app ID (no longer extracts `api_key` from app response)
- **`tools/spidapter/src/stdio_server.rs`**: Add `cloud.get_api_keys(app_id)` call to fetch the API key from the dedicated endpoint after ensuring the app exists
- **`bin/spice/src/commands/cloud/mod.rs`**: Update CLI `create app` command to fetch API key via the dedicated endpoint after app creation