### PR TITLE
ci: switch integration_models from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - trunk
       - release/*
-  pull_request_target:
+  pull_request:
     branches:
       - trunk
       - release-*
@@ -72,7 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1 # Shallow clone for faster checkout
 
       - name: Set up Rust
@@ -120,8 +119,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -173,8 +170,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -265,8 +260,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -314,8 +307,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -359,8 +350,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -394,8 +383,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -436,7 +423,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1 # Shallow clone for faster checkout
 
       - name: Set up Rust
@@ -481,8 +467,6 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
## Changes

Switch `integration_models.yml` from `pull_request_target` to `pull_request` and remove the explicit `ref: ${{ github.event.pull_request.head.sha }}` from all checkout steps.

### Why

`pull_request_target` runs in the context of the base branch with full secrets access and is designed for workflows that need write permissions (e.g. labeling, commenting). This workflow only builds and runs tests — it doesn't need elevated privileges.

The previous setup checked out untrusted PR code (`ref: head.sha`) in a privileged `pull_request_target` context on self-hosted runners, which is a known attack vector for CI secret exfiltration and runner compromise. With `pull_request`, fork PRs cannot access repo secrets, and the checkout defaults to the correct merge ref.

This also provides defense in depth alongside the org-level fork PR approval setting.

### What changed

- `pull_request_target` → `pull_request`
- Removed `ref: ${{ github.event.pull_request.head.sha }}` from all 9 checkout steps (unnecessary with `pull_request`, which checks out the merge ref by default)
