### PR TITLE
Chunk metastore batch inserts to respect SQLite parameter limits

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -228,6 +228,49 @@ impl CayenneCatalog {
             }),
         }
     }
+
+    /// Execute a single parameterized `INSERT OR REPLACE` for a chunk of insert
+    /// records that fits within `SQLite`'s parameter limit.
+    async fn insert_records_chunk(
+        &self,
+        table_id: &str,
+        pk_bytes_list: Vec<Vec<u8>>,
+        sequence_number: i64,
+    ) -> CatalogResult<()> {
+        let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
+        let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
+        let table_id = table_id.to_string();
+
+        for (i, pk_bytes) in pk_bytes_list.into_iter().enumerate() {
+            let base = i * 4 + 1; // SQLite params are 1-indexed
+            values_parts.push(format!(
+                "(?{}, ?{}, ?{}, ?{})",
+                base,
+                base + 1,
+                base + 2,
+                base + 3
+            ));
+            params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
+            params.push(MetastoreValue::Text(table_id.clone()));
+            params.push(MetastoreValue::Blob(pk_bytes));
+            params.push(MetastoreValue::Integer(sequence_number));
+        }
+
+        let sql = format!(
+            "INSERT OR REPLACE INTO cayenne_insert_record \
+             (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
+            values_parts.join(", ")
+        );
+
+        self.metastore
+            .execute_helper(ExecuteParams { sql: &sql, params })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to add insert record entries in batch".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -762,43 +805,69 @@ impl MetadataCatalog for CayenneCatalog {
         pk_bytes_list: Vec<Vec<u8>>,
         sequence_number: i64,
     ) -> CatalogResult<()> {
+        // SQLite has a compile-time limit of SQLITE_MAX_VARIABLE_NUMBER (default
+        // 32 766) parameters per prepared statement.  Each row needs 4 params
+        // (insert_record_id, table_id, pk_bytes, sequence_number), so we chunk
+        // the list to stay within the limit.
+        //
+        // All chunks are wrapped in a single transaction so the operation is
+        // atomic: either every chunk is applied or none is.
+        const PARAMS_PER_ROW: usize = 4;
+        const MAX_PARAMS: usize = 32_000; // conservative cap below the 32 766 default
+        const MAX_ROWS_PER_CHUNK: usize = MAX_PARAMS / PARAMS_PER_ROW;
+
         if pk_bytes_list.is_empty() {
             return Ok(());
         }
 
-        // Build a batch insert with all PKs
-        // Using INSERT OR REPLACE to update sequence if PK already exists
-        let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
-        let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
-        let table_id = table_id.to_string();
-
-        for (i, pk_bytes) in pk_bytes_list.into_iter().enumerate() {
-            let base = i * 4 + 1; // SQLite params are 1-indexed
-            values_parts.push(format!(
-                "(?{}, ?{}, ?{}, ?{})",
-                base,
-                base + 1,
-                base + 2,
-                base + 3
-            ));
-            params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
-            params.push(MetastoreValue::Text(table_id.clone()));
-            params.push(MetastoreValue::Blob(pk_bytes));
-            params.push(MetastoreValue::Integer(sequence_number));
+        // Single chunk that fits within the parameter limit — no transaction
+        // overhead needed.
+        if pk_bytes_list.len() <= MAX_ROWS_PER_CHUNK {
+            return self
+                .insert_records_chunk(table_id, pk_bytes_list, sequence_number)
+                .await;
         }
 
-        let sql = format!(
-            "INSERT OR REPLACE INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
-            values_parts.join(", ")
-        );
-
+        // Multiple chunks required — wrap in a transaction for atomicity.
+        let begin = if self.metastore.is_turso() {
+            BEGIN_CONCURRENT_SQL
+        } else {
+            BEGIN_TRANSACTION_SQL
+        };
         self.metastore
-            .execute_helper(ExecuteParams { sql: &sql, params })
+            .execute_batch_helper(begin)
             .await
             .map_err(|e| CatalogError::InvalidOperation {
-                message: "Failed to add insert record entries in batch".to_string(),
+                message: "Failed to begin transaction for batch insert records".to_string(),
                 source: Box::new(e),
             })?;
+
+        for chunk in pk_bytes_list.chunks(MAX_ROWS_PER_CHUNK) {
+            if let Err(e) = self
+                .insert_records_chunk(table_id, chunk.to_vec(), sequence_number)
+                .await
+            {
+                // Best-effort rollback; if it fails, the connection will
+                // auto-rollback when the next statement runs.
+                let _ = self
+                    .metastore
+                    .execute_helper(ExecuteParams {
+                        sql: "ROLLBACK",
+                        params: vec![],
+                    })
+                    .await;
+                return Err(e);
+            }
+        }
+
+        self.metastore
+            .execute_batch_helper(COMMIT_SQL)
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to commit transaction for batch insert records".to_string(),
+                source: Box::new(e),
+            })?;
+
         Ok(())
     }
 

--- a/crates/cayenne/tests/large_upsert_test.rs
+++ b/crates/cayenne/tests/large_upsert_test.rs
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::clone_on_ref_ptr)]
+
+//! Regression test: upserting more than `SQLITE_MAX_VARIABLE_NUMBER` / 4 rows
+//! must not fail with a `SQLite` "too many SQL variables" error.
+//!
+//! `add_insert_records_batch` builds an INSERT with 4 params per row.
+//! `SQLite`'s default `SQLITE_MAX_VARIABLE_NUMBER` is 32 766, so batches with
+//! more than ~8 000 rows would exceed the limit without the inline-SQL
+//! fallback path.
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use cayenne::metadata::CreateTableOptions;
+use cayenne::{CayenneTableProvider, MetadataCatalog};
+
+use datafusion::prelude::SessionContext;
+
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+test_with_backends!(test_large_upsert_exceeds_sqlite_param_limit);
+
+async fn test_large_upsert_exceeds_sqlite_param_limit(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // 10 000 conflicting PKs → 40 000 SQL parameters in add_insert_records_batch.
+    // This exceeds SQLITE_MAX_VARIABLE_NUMBER (32 766) if the INSERT is unbatched.
+    const ROW_COUNT: usize = 10_000;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Utf8, false),
+    ]));
+
+    let table_options = CreateTableOptions {
+        table_name: "large_upsert".to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string()
+        ]))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog_arc: Arc<dyn MetadataCatalog> = fixture.catalog.clone();
+    let ctx = SessionContext::new();
+    let table =
+        CayenneTableProvider::create_table(catalog_arc, table_options, ctx.runtime_env()).await?;
+    let table = Arc::new(table);
+
+    ctx.register_table(
+        "large_upsert",
+        Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+    )?;
+
+    // Step 1: Insert ROW_COUNT rows (ids 0..ROW_COUNT).
+    let ids: Vec<i64> = (0..i64::try_from(ROW_COUNT).expect("ROW_COUNT fits in i64")).collect();
+    let values: Vec<String> = (0..ROW_COUNT).map(|i| format!("original_{i}")).collect();
+    let initial_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids.clone())),
+            Arc::new(StringArray::from(values)),
+        ],
+    )?;
+    common::insert_batch(&table, initial_batch).await?;
+
+    // Step 2: Upsert the same ROW_COUNT PKs with updated values.
+    // This triggers add_insert_records_batch with ROW_COUNT entries.
+    let updated_values: Vec<String> = (0..ROW_COUNT).map(|i| format!("updated_{i}")).collect();
+    let upsert_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(updated_values)),
+        ],
+    )?;
+    common::insert_batch(&table, upsert_batch).await?;
+
+    // Step 3: Verify all rows have updated values.
+    let results = ctx
+        .sql("SELECT id, value FROM large_upsert ORDER BY id")
+        .await?
+        .collect()
+        .await?;
+
+    let total_rows: usize = results.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(
+        total_rows, ROW_COUNT,
+        "Expected {ROW_COUNT} rows after upsert, got {total_rows}"
+    );
+
+    // Spot-check a few values.
+    let first_batch = &results[0];
+    let values_col = first_batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("value column");
+    assert_eq!(values_col.value(0), "updated_0");
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`add_insert_records_batch` builds a single `INSERT OR REPLACE` with **4 SQL parameters per row** (`insert_record_id`, `table_id`, `pk_bytes`, `sequence_number`). When a large upsert has more than ~8,000 conflicting primary keys, the total parameter count exceeds SQLite's compile-time `SQLITE_MAX_VARIABLE_NUMBER` limit (**32,766**), causing the prepared statement to fail.

For example, the spicebench TPC-H lineitem table upserts 23,400 rows, producing **93,600 parameters** — nearly 3× the limit. In Spice Cloud, this manifests as a server crash returning gRPC `UNAVAILABLE` to the client.

## Solution

Split large batches into chunks of **8,000 rows** (32,000 params), each executed as a separate parameterized `INSERT OR REPLACE`. When chunking is needed, all chunks are wrapped in an explicit `BEGIN`/`COMMIT` transaction so the operation remains atomic — either every chunk is applied or none is (with `ROLLBACK` on error).

Small batches (≤ 8,000 rows) take the existing single-statement path with no transaction overhead.

The chunk execution logic is extracted into a shared `insert_records_chunk` helper on `CayenneCatalog`.

## Changes

- **`crates/cayenne/src/cayenne_catalog.rs`**
  - Extract `insert_records_chunk` helper for a single parameterized INSERT OR REPLACE
  - Chunk `add_insert_records_batch` to stay within `SQLITE_MAX_VARIABLE_NUMBER`
  - Wrap multi-chunk execution in `BEGIN`/`COMMIT` with `ROLLBACK` on error
- **`crates/cayenne/tests/large_upsert_test.rs`** — regression test that upserts 10,000 rows (40,000 params), which fails without the fix:

```
variable number must be between ?1 and ?32766
```

## Testing

- New test `test_large_upsert_exceeds_sqlite_param_limit_sqlite` — **fails without fix, passes with fix**
- All existing cayenne tests pass