### PR TITLE
fix(cayenne): Skip retention filter for metadata-only scans to avoid full table scan on `count(*)`

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3789,12 +3789,28 @@ impl TableProvider for CayenneTableProvider {
             };
 
         // Time-based retention: build a keep filter at scan time.
+        // Retention deletes run concurrently with queries and may physically remove
+        // data files at any moment. The keep filter (`time_col >= cutoff`) ensures
+        // the scan never attempts to open a file that the retention task has already
+        // deleted, preventing I/O errors from concurrent file removal.
+        //
         // Prefer the builder (produces correctly-typed timestamps matching the
         // column's timezone) over the legacy Expr+simplify path.
         // Injected at two layers:
         // 1. Appended to scan filters for file-level statistics pruning (Vortex should_prune)
         // 2. Wrapped as a physical FilterExec for row-level filtering
-        let retention_keep_filter = if let Some(ref builder) = self.time_retention_filter_builder {
+        //
+        // Skip the retention filter when the projection is empty (e.g. `count(*)`).
+        // An empty projection means no column data is needed — only row counts from
+        // file-level statistics. Injecting the retention filter would force reading
+        // the time column for every row, turning a cheap metadata-only operation into
+        // a full table scan. This is safe because `count(*)` is resolved from cached
+        // ListingTable statistics via DataFusion's AggregateStatistics optimization
+        // (PlaceholderRowExec), without opening individual data files.
+        let is_metadata_only_scan = projection.is_some_and(Vec::is_empty);
+        let retention_keep_filter = if is_metadata_only_scan {
+            None
+        } else if let Some(ref builder) = self.time_retention_filter_builder {
             let filter = builder.keep_filter();
             let filter = util::expr::simplify_expr(filter, &self.table_metadata.schema)?;
             Some(filter)

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -69,6 +69,9 @@ test_with_backends!(test_pk_file_based_retention_multiple_protected_snapshots_im
 test_with_backends!(test_cache_invalidated_after_append_impl);
 test_with_backends!(test_file_based_retention_targeted_cache_invalidation_impl);
 
+// Query plan optimization tests
+test_with_backends!(test_count_star_uses_placeholder_with_retention_impl);
+
 /// Test: File-based retention physically deletes files that are fully expired.
 ///
 /// Setup (3-second retention, position-based / no PK):
@@ -932,6 +935,54 @@ async fn test_pk_file_based_retention_multiple_protected_snapshots_impl(
         "Expired rows removed, fresh rows preserved across snapshots",
     )
     .await?;
+
+    Ok(())
+}
+
+/// Test: `count(*)` resolves via `PlaceholderRowExec` (`AggregateStatistics`
+/// optimization) even when time-based retention is configured.
+///
+/// Without the metadata-only scan optimization, injecting the time-based retention
+/// filter forces the time column into the projection, which defeats
+/// `AggregateStatistics` and causes a full table scan.
+///
+/// Setup (60-second retention, position-based / no PK):
+///   - 3 files inserted with fresh timestamps (all within retention).
+///
+/// Verify: the physical plan for `SELECT count(*)` contains
+/// `PlaceholderRowExec` and does NOT contain `DataSourceExec`.
+async fn test_count_star_uses_placeholder_with_retention_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 60;
+    let table_name = "count_star_plan";
+    let ctx = SessionContext::new();
+    let table =
+        create_retention_table(&fixture, table_name, retention_seconds, ctx.runtime_env()).await?;
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?;
+    insert_row(&table, 2, now_us - 1_000_000).await?;
+    insert_row(&table, 3, now_us - 2_000_000).await?;
+
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    let df = ctx
+        .sql(&format!("SELECT count(*) FROM {table_name}"))
+        .await?;
+    let physical_plan = df.clone().create_physical_plan().await?;
+    let explain_plan = datafusion::physical_plan::displayable(physical_plan.as_ref())
+        .indent(true)
+        .to_string();
+
+    insta::assert_snapshot!("count_star_with_retention", explain_plan);
+
+    // Verify correctness: count should equal the number of inserted rows.
+    let batches = df.collect().await?;
+    let count = batches
+        .first()
+        .and_then(|b| b.column(0).as_any().downcast_ref::<Int64Array>())
+        .and_then(|a| a.values().first().copied())
+        .unwrap_or(0);
+    assert_eq!(count, 3, "count(*) should return 3");
 
     Ok(())
 }

--- a/crates/cayenne/tests/snapshots/file_based_retention_delete_test__count_star_with_retention.snap
+++ b/crates/cayenne/tests/snapshots/file_based_retention_delete_test__count_star_with_retention.snap
@@ -1,0 +1,6 @@
+---
+source: crates/cayenne/tests/file_based_retention_delete_test.rs
+expression: explain_plan
+---
+ProjectionExec: expr=[3 as count(*)]
+  PlaceholderRowExec


### PR DESCRIPTION
## 📝 Summary

When a cayenne table has time-based retention configured, `count(*)` triggers a full table scan instead of resolving from cached statistics.

**Root cause:** The retention keep filter (`time_col >= cutoff`) is injected for every scan. `extend_projection_for_retention_filter` then adds the time column to the projection, turning an empty projection (metadata-only) into a non-empty one. This defeats DataFusion's `AggregateStatistics` optimization, which requires an empty projection to replace the aggregate with `PlaceholderRowExec`.

**Fix:** Skip the retention filter when the projection is empty (`projection.is_some_and(|p| p.is_empty())`). This is safe because `count(*)` is resolved from cached `ListingTable` statistics via `AggregateStatistics` → `PlaceholderRowExec`, without opening any data files.

**Before:** `count(*)` scans all rows through `DataSourceExec` + `FilterExec`
**After:** `count(*)` resolves instantly via `PlaceholderRowExec`

## 🔗 Related

Fixes #9771

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

With this change, `count(*)` will include expired but not yet deleted records, which is fine for periodic time-based retention and we should prioritize performance here IMO.