### PR TITLE
Skip ClickBench zero-row queries in row count validation (partial data is used)

### DIFF
--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -524,7 +524,21 @@ impl QuerySet {
                     "tpcds_q76",
                 ]
             }
-            QuerySet::Clickbench | QuerySet::Scenario { .. } => vec![],
+            QuerySet::Clickbench => {
+                // ClickBench queries that currently return 0 rows and should skip row count validation
+                // https://github.com/spiceai/spiceai/issues/8802
+                vec![
+                    "clickbench_q20",
+                    "clickbench_q37",
+                    "clickbench_q38",
+                    "clickbench_q39",
+                    "clickbench_q40",
+                    "clickbench_q41",
+                    "clickbench_q42",
+                    "clickbench_q43",
+                ]
+            }
+            QuerySet::Scenario { .. } => vec![],
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

Skip ClickBench zero-row queries in row count validation

Adds queries that legitimately return 0 rows (q20, q37–q43) to the row count validation skip list for ClickBench.

Failures are due to several datasets include only subset of data (see below). Note: refresh_sql is currently used for Postgres, SQLite and Arrow, but here is not dedicated Override for Arrow yet so we temporary apply the same override for all queries. 

```
acceleration:
      enabled: true
      engine: arrow
      refresh_sql: "SELECT * FROM hits LIMIT 50000000" # dev-runners do not have enough memory for full clickbench in-memory
```

```
acceleration:
      refresh_sql: "SELECT * FROM hits LIMIT 5000000"
```

See #8802 for details

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
