### PR TITLE
Fix Cayenne bulk upsert

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -766,39 +766,79 @@ impl MetadataCatalog for CayenneCatalog {
             return Ok(());
         }
 
-        // Build a batch insert with all PKs
-        // Using INSERT OR REPLACE to update sequence if PK already exists
-        let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
-        let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
-        let table_id = table_id.to_string();
+        // SQLite has a hard limit of 32,766 bind parameters per statement.
+        // Each row uses 4 params, so we chunk to stay within the limit.
+        const PARAMS_PER_ROW: usize = 4;
+        const SQLITE_MAX_VARIABLE_NUMBER: usize = 32_766;
+        const MAX_ROWS_PER_BATCH: usize = SQLITE_MAX_VARIABLE_NUMBER / PARAMS_PER_ROW;
 
-        for (i, pk_bytes) in pk_bytes_list.into_iter().enumerate() {
-            let base = i * 4 + 1; // SQLite params are 1-indexed
-            values_parts.push(format!(
-                "(?{}, ?{}, ?{}, ?{})",
-                base,
-                base + 1,
-                base + 2,
-                base + 3
-            ));
-            params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
-            params.push(MetastoreValue::Text(table_id.clone()));
-            params.push(MetastoreValue::Blob(pk_bytes));
-            params.push(MetastoreValue::Integer(sequence_number));
+        let table_id = table_id.to_string();
+        let needs_transaction = pk_bytes_list.len() > MAX_ROWS_PER_BATCH;
+
+        if needs_transaction {
+            let begin = if self.metastore.is_turso() {
+                BEGIN_CONCURRENT_SQL
+            } else {
+                BEGIN_TRANSACTION_SQL
+            };
+            self.metastore
+                .execute_batch_helper(begin)
+                .await
+                .map_err(|e| CatalogError::InvalidOperation {
+                    message: "Failed to begin transaction for insert records batch".to_string(),
+                    source: Box::new(e),
+                })?;
         }
 
-        let sql = format!(
-            "INSERT OR REPLACE INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
-            values_parts.join(", ")
-        );
+        for chunk in pk_bytes_list.chunks(MAX_ROWS_PER_BATCH) {
+            let mut values_parts = Vec::with_capacity(chunk.len());
+            let mut params = Vec::with_capacity(chunk.len() * PARAMS_PER_ROW);
 
-        self.metastore
-            .execute_helper(ExecuteParams { sql: &sql, params })
-            .await
-            .map_err(|e| CatalogError::InvalidOperation {
-                message: "Failed to add insert record entries in batch".to_string(),
-                source: Box::new(e),
-            })?;
+            for (i, pk_bytes) in chunk.iter().enumerate() {
+                let base = i * PARAMS_PER_ROW + 1; // SQLite params are 1-indexed
+                values_parts.push(format!(
+                    "(?{}, ?{}, ?{}, ?{})",
+                    base,
+                    base + 1,
+                    base + 2,
+                    base + 3
+                ));
+                params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
+                params.push(MetastoreValue::Text(table_id.clone()));
+                params.push(MetastoreValue::Blob(pk_bytes.clone()));
+                params.push(MetastoreValue::Integer(sequence_number));
+            }
+
+            let sql = format!(
+                "INSERT OR REPLACE INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
+                values_parts.join(", ")
+            );
+
+            if let Err(e) = self
+                .metastore
+                .execute_helper(ExecuteParams { sql: &sql, params })
+                .await
+            {
+                if needs_transaction {
+                    rollback_failed_compaction_transaction(&self.metastore).await;
+                }
+                return Err(CatalogError::InvalidOperation {
+                    message: "Failed to add insert record entries in batch".to_string(),
+                    source: Box::new(e),
+                });
+            }
+        }
+
+        if needs_transaction {
+            if let Err(e) = self.metastore.execute_batch_helper(COMMIT_SQL).await {
+                rollback_failed_compaction_transaction(&self.metastore).await;
+                return Err(CatalogError::InvalidOperation {
+                    message: "Failed to commit transaction for insert records batch".to_string(),
+                    source: Box::new(e),
+                });
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -1987,3 +1987,148 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
         })
         .await
 }
+
+/// Test that upserting >8191 rows doesn't hit the SQLite bind parameter limit.
+///
+/// SQLite has a hard limit of 32,766 bind parameters per statement.
+/// `add_insert_records_batch` uses 4 params per row, so >8191 rows
+/// (8192 × 4 = 32,768 > 32,766) will fail without chunking.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_cayenne_large_upsert_batch_sqlite_bind_limit() -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use cayenne::metadata::CreateTableOptions;
+    use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+    use datafusion_table_providers::util::{
+        column_reference::ColumnReference, on_conflict::OnConflict,
+    };
+
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = tempfile::tempdir()?;
+            let cayenne_dir = temp_dir.path().join("cayenne_bind_limit");
+            let metadata_db = temp_dir.path().join("metadata_bind_limit.db");
+            std::fs::create_dir_all(&cayenne_dir)?;
+
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("value", DataType::Utf8, false),
+            ]));
+
+            let table_options = CreateTableOptions {
+                table_name: "bind_limit_test".to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec!["id".to_string()],
+                on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                    "id".to_string(),
+                ]))),
+                base_path: cayenne_dir.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            };
+
+            let connection_string = format!("sqlite://{}", metadata_db.to_string_lossy());
+            let catalog = Arc::new(CayenneCatalog::new(connection_string)?);
+            catalog.init().await?;
+            let catalog_arc: Arc<dyn MetadataCatalog> = catalog;
+
+            let ctx = SessionContext::new();
+            let table =
+                CayenneTableProvider::create_table(catalog_arc, table_options, ctx.runtime_env())
+                    .await?;
+            let table = Arc::new(table);
+
+            ctx.register_table(
+                "bind_limit_test",
+                Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+            )?;
+
+            let num_rows: i64 = 10_000;
+
+            // Insert initial rows in batches of 1000 (to avoid huge SQL strings)
+            for batch_start in (1..=num_rows).step_by(1000) {
+                let batch_end = (batch_start + 999).min(num_rows);
+                let mut values = String::new();
+                for id in batch_start..=batch_end {
+                    if id > batch_start {
+                        values.push_str(", ");
+                    }
+                    let _ = write!(values, "({id}, 'original_{id}')");
+                }
+                ctx.sql(&format!(
+                    "INSERT INTO bind_limit_test (id, value) VALUES {values}"
+                ))
+                .await?
+                .collect()
+                .await?;
+            }
+
+            // Verify initial count
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM bind_limit_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+-------+",
+                "| cnt   |",
+                "+-------+",
+                "| 10000 |",
+                "+-------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Upsert all 10,000 rows in a SINGLE write operation to trigger
+            // add_insert_records_batch with 10,000 PKs × 4 params = 40,000 bind params
+            // (exceeds SQLite's 32,766 limit). We build one large SQL INSERT so all
+            // conflicting PKs are collected in a single write_all_append call.
+            let mut values = String::new();
+            for id in 1..=num_rows {
+                if id > 1 {
+                    values.push_str(", ");
+                }
+                let _ = write!(values, "({id}, 'updated_{id}')");
+            }
+            ctx.sql(&format!(
+                "INSERT INTO bind_limit_test (id, value) VALUES {values}"
+            ))
+            .await?
+            .collect()
+            .await?;
+
+            // Verify count is still 10,000 (upsert, not duplicate insert)
+            let result = ctx
+                .sql("SELECT COUNT(*) as cnt FROM bind_limit_test")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+-------+",
+                "| cnt   |",
+                "+-------+",
+                "| 10000 |",
+                "+-------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Verify values were actually updated
+            let result = ctx
+                .sql("SELECT value FROM bind_limit_test WHERE id = 1")
+                .await?
+                .collect()
+                .await?;
+            let expected = [
+                "+-----------+",
+                "| value     |",
+                "+-----------+",
+                "| updated_1 |",
+                "+-----------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
## 📝 Summary

SQLite has a hard limit of `32,766` bind parameters per statement.

When performing upsert, each `cayenne_insert_record` row uses 4 parameters - which means we can only process 8191 records. 

This PR adds logic to:
* Split rows into batches of `32,766 / 4` rows
* Wrap these operations into a transaction
* Integration test