### PR TITLE
Move scheduler_state_location from adapter metadata to env var

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -136,7 +136,6 @@ struct SetupConfig {
     region: Option<String>,
     endpoint: Option<String>,
     sink_type: Option<EtlSinkType>,
-    state_location: Option<String>,
 }
 
 impl SetupConfig {
@@ -145,7 +144,6 @@ impl SetupConfig {
             region: metadata_string(metadata, "etl_region"),
             endpoint: metadata_string(metadata, "etl_endpoint"),
             sink_type: None,
-            state_location: metadata_string(metadata, "scheduler_state_location"),
         }
     }
 
@@ -1293,15 +1291,18 @@ fn generate_initial_spicepod(
         _ => generate_hive_spicepod(run_id, setup_config, datasets),
     }?;
 
-    if let Some(ref loc) = setup_config.state_location {
-        spicepod.runtime.scheduler = Some(Scheduler {
-            state_location: loc.clone(),
-            params: Some(Params::from_string_map(HashMap::from([(
-                "s3_auth".to_string(),
-                "key".to_string(),
-            )]))),
-            partition_management: None,
-        });
+    if let Ok(loc) = std::env::var("SCHEDULER_STATE_LOCATION") {
+        let loc = loc.trim().to_string();
+        if !loc.is_empty() {
+            spicepod.runtime.scheduler = Some(Scheduler {
+                state_location: loc,
+                params: Some(Params::from_string_map(HashMap::from([(
+                    "s3_auth".to_string(),
+                    "key".to_string(),
+                )]))),
+                partition_management: None,
+            });
+        }
     }
 
     Ok(spicepod)
@@ -1315,23 +1316,13 @@ mod tests {
 
     #[test]
     fn setup_config_parses_metadata() {
-        let metadata = HashMap::from([
-            (
-                "etl_region".to_string(),
-                serde_json::Value::String("us-west-2".to_string()),
-            ),
-            (
-                "scheduler_state_location".to_string(),
-                serde_json::Value::String("s3://my-bucket/state".to_string()),
-            ),
-        ]);
+        let metadata = HashMap::from([(
+            "etl_region".to_string(),
+            serde_json::Value::String("us-west-2".to_string()),
+        )]);
 
         let config = SetupConfig::from_metadata(&metadata);
         assert_eq!(config.region.as_deref(), Some("us-west-2"));
-        assert_eq!(
-            config.state_location.as_deref(),
-            Some("s3://my-bucket/state")
-        );
     }
 
     #[test]
@@ -1363,7 +1354,6 @@ mod tests {
             region: Some("us-west-2".to_string()),
             endpoint: Some("http://localhost:9000".to_string()),
             sink_type: None,
-            state_location: Some("s3://bucket/state".to_string()),
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -1378,10 +1368,17 @@ mod tests {
             },
         )]);
 
+        // SAFETY: Test-only; no concurrent env reads in this single-threaded test.
+        unsafe { std::env::set_var("SCHEDULER_STATE_LOCATION", "s3://bucket/state") };
+
         let spicepod = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets, None)
             .expect("spicepod should generate");
         let spicepod_yaml =
             serialize_spicepod(&spicepod).expect("spicepod should serialize to YAML");
+
+        // Clean up env var.
+        // SAFETY: Test-only; no concurrent env reads in this single-threaded test.
+        unsafe { std::env::remove_var("SCHEDULER_STATE_LOCATION") };
 
         assert!(spicepod_yaml.contains("from: \"s3://bucket/path/my_table/\""));
         assert!(spicepod_yaml.contains("name: my_table"));
@@ -1403,7 +1400,6 @@ mod tests {
             region: None,
             endpoint: None,
             sink_type: None,
-            state_location: None,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));


### PR DESCRIPTION
The scheduler state location passed via setup metadata in the system adapter protocol is Spice-specific, not generic across all system adapters.

This moves it to an environment variable (`SCHEDULER_STATE_LOCATION`) that spidapter reads directly from its process environment instead of from the setup metadata.

**Changes:**
- Remove `state_location` field from `SetupConfig`
- Read `SCHEDULER_STATE_LOCATION` from `std::env::var()` in `generate_initial_spicepod`
- Update tests

Companion PR: https://github.com/spiceai/spicebench/pull/211