### PR TITLE
Fix Cayenne DoPut upsert returning stale data after 3+ writes

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2937,6 +2937,86 @@ impl CayenneTableProvider {
         Ok(())
     }
 
+    /// Refresh in-memory query state from a freshly opened provider for the same table.
+    ///
+    /// This keeps existing `Arc<CayenneTableProvider>` handles usable after catalog refreshes
+    /// by updating mutable state in place instead of swapping provider objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `source` refers to a different table (mismatched table IDs)
+    /// or if updating internal deletion/listing state fails.
+    pub fn refresh_from(&self, source: &Self) -> Result<()> {
+        if self.table_metadata.table_id != source.table_metadata.table_id {
+            return Err(Error::Internal {
+                table: self.table_metadata.table_name.clone(),
+                message: format!(
+                    "Cannot refresh table {} from different table {}",
+                    self.table_metadata.table_id, source.table_metadata.table_id,
+                ),
+            });
+        }
+
+        self.pk_deletion_strategy.refresh_from(
+            &source.pk_deletion_strategy,
+            &self.table_metadata.table_name,
+        )?;
+
+        let refreshed_listing_table = {
+            let guard = source
+                .listing_table
+                .read()
+                .map_err(|_| Error::LockPoisoned {
+                    table: self.table_metadata.table_name.clone(),
+                    lock: LISTING_TABLE_LOCK_POISONED,
+                })?;
+            Arc::clone(&guard)
+        };
+
+        {
+            let mut guard = self
+                .listing_table
+                .write()
+                .map_err(|_| Error::LockPoisoned {
+                    table: self.table_metadata.table_name.clone(),
+                    lock: LISTING_TABLE_LOCK_POISONED,
+                })?;
+            *guard = refreshed_listing_table;
+        }
+
+        let refreshed_snapshot_id = source.get_current_snapshot_id()?;
+        self.update_current_snapshot_id(&refreshed_snapshot_id)?;
+
+        let refreshed_protected_snapshots = {
+            let guard = source
+                .protected_snapshots
+                .read()
+                .map_err(|_| Error::LockPoisoned {
+                    table: self.table_metadata.table_name.clone(),
+                    lock: PROTECTED_SNAPSHOTS_LOCK_POISONED,
+                })?;
+            guard.clone()
+        };
+
+        {
+            let mut guard = self
+                .protected_snapshots
+                .write()
+                .map_err(|_| Error::LockPoisoned {
+                    table: self.table_metadata.table_name.clone(),
+                    lock: PROTECTED_SNAPSHOTS_LOCK_POISONED,
+                })?;
+            *guard = refreshed_protected_snapshots;
+        }
+
+        tracing::debug!(
+            "Refreshed in-memory state for table {} from freshly opened provider",
+            self.table_metadata.table_name
+        );
+
+        Ok(())
+    }
+
     /// Delete rows matching the given primary key values.
     ///
     /// # Errors

--- a/crates/cayenne/tests/mutation_model_test.rs
+++ b/crates/cayenne/tests/mutation_model_test.rs
@@ -1,0 +1,640 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Model-based mutation tests for Cayenne.
+//!
+//! These tests complement the existing targeted regression coverage with bounded,
+//! exhaustive state-machine checks over compact operation domains. They validate
+//! that small but adversarial histories of inserts/upserts/deletes always match a
+//! simple in-memory model both:
+//!
+//! 1. immediately after each operation, and
+//! 2. after reopening the table provider from catalog metadata.
+//!
+//! This gives strong coverage for protected-snapshot ordering, deletion cache
+//! reloads, insert-record persistence, and mixed single-row / batch mutation
+//! histories.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::{
+    metadata::CreateTableOptions, CayenneTableProvider, CayenneTableProviderBuilder,
+    MetadataCatalog,
+};
+use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionContext;
+use datafusion::prelude::{col, lit, Expr};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+type Int64Model = BTreeMap<i64, i64>;
+type CompositeKey = (String, i64);
+type CompositeModel = BTreeMap<CompositeKey, i64>;
+
+#[derive(Clone, Debug)]
+enum Int64MutationOp {
+    Upsert { key: i64, value: i64 },
+    Delete { key: i64 },
+    DeleteAll,
+}
+
+#[derive(Clone, Debug)]
+enum Int64BatchMutationOp {
+    BatchUpsert { value_1: i64, value_2: i64 },
+    Delete { key: i64 },
+    DeleteAll,
+}
+
+#[derive(Clone, Debug)]
+enum CompositeMutationOp {
+    Upsert {
+        region: &'static str,
+        id: i64,
+        value: i64,
+    },
+    Delete {
+        region: &'static str,
+        id: i64,
+    },
+    DeleteAll,
+}
+
+fn create_int64_upsert_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+fn create_composite_upsert_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("region", DataType::Utf8, false),
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+async fn setup_int64_upsert_table(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<(Arc<CayenneTableProvider>, SessionContext, Arc<Schema>)> {
+    let schema = create_int64_upsert_schema();
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string()
+        ]))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(catalog, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    Ok((table, ctx, schema))
+}
+
+async fn setup_composite_upsert_table(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<(Arc<CayenneTableProvider>, SessionContext, Arc<Schema>)> {
+    let schema = create_composite_upsert_schema();
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["region".to_string(), "id".to_string()],
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "region".to_string(),
+            "id".to_string(),
+        ]))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(catalog, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    Ok((table, ctx, schema))
+}
+
+async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> TestResult<u64> {
+    common::insert_batch(table.as_ref(), batch)
+        .await
+        .map_err(Into::into)
+}
+
+async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
+    let ctx = SessionContext::new();
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
+    let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
+}
+
+async fn read_int64_rows(ctx: &SessionContext, table_name: &str) -> TestResult<Vec<(i64, i64)>> {
+    let df = ctx
+        .sql(&format!("SELECT id, value FROM {table_name} ORDER BY id"))
+        .await?;
+    let results = df.collect().await?;
+
+    let mut rows = Vec::new();
+    for batch in &results {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("id column should be Int64");
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("value column should be Int64");
+
+        for idx in 0..batch.num_rows() {
+            rows.push((ids.value(idx), values.value(idx)));
+        }
+    }
+
+    Ok(rows)
+}
+
+async fn read_composite_rows(
+    ctx: &SessionContext,
+    table_name: &str,
+) -> TestResult<Vec<(String, i64, i64)>> {
+    let df = ctx
+        .sql(&format!(
+            "SELECT region, id, value FROM {table_name} ORDER BY region, id"
+        ))
+        .await?;
+    let results = df.collect().await?;
+
+    let mut rows = Vec::new();
+    for batch in &results {
+        let regions = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("region column should be Utf8");
+        let ids = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("id column should be Int64");
+        let values = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("value column should be Int64");
+
+        for idx in 0..batch.num_rows() {
+            rows.push((
+                regions.value(idx).to_string(),
+                ids.value(idx),
+                values.value(idx),
+            ));
+        }
+    }
+
+    Ok(rows)
+}
+
+async fn reopen_and_read_int64_rows(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<Vec<(i64, i64)>> {
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let provider = CayenneTableProviderBuilder::new(catalog, ctx.runtime_env())
+        .open(table_name)
+        .await?;
+    ctx.register_table(table_name, Arc::new(provider) as Arc<dyn TableProvider>)?;
+    read_int64_rows(&ctx, table_name).await
+}
+
+async fn reopen_and_read_composite_rows(
+    fixture: &TestFixture,
+    table_name: &str,
+) -> TestResult<Vec<(String, i64, i64)>> {
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let provider = CayenneTableProviderBuilder::new(catalog, ctx.runtime_env())
+        .open(table_name)
+        .await?;
+    ctx.register_table(table_name, Arc::new(provider) as Arc<dyn TableProvider>)?;
+    read_composite_rows(&ctx, table_name).await
+}
+
+fn expected_int64_rows(model: &Int64Model) -> Vec<(i64, i64)> {
+    model.iter().map(|(&key, &value)| (key, value)).collect()
+}
+
+fn expected_composite_rows(model: &CompositeModel) -> Vec<(String, i64, i64)> {
+    model
+        .iter()
+        .map(|((region, id), value)| (region.clone(), *id, *value))
+        .collect()
+}
+
+fn enumerate_sequences<T: Clone>(ops: &[T], depth: usize) -> Vec<Vec<T>> {
+    if depth == 0 {
+        return vec![Vec::new()];
+    }
+
+    let shorter = enumerate_sequences(ops, depth - 1);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "depth is always small in tests"
+    )]
+    let mut sequences = Vec::with_capacity(ops.len().pow(depth as u32));
+    for prefix in shorter {
+        for op in ops {
+            let mut sequence = prefix.clone();
+            sequence.push(op.clone());
+            sequences.push(sequence);
+        }
+    }
+    sequences
+}
+
+fn int64_single_row_ops() -> Vec<Int64MutationOp> {
+    vec![
+        Int64MutationOp::Upsert { key: 1, value: 10 },
+        Int64MutationOp::Upsert { key: 1, value: 20 },
+        Int64MutationOp::Upsert { key: 2, value: 10 },
+        Int64MutationOp::Upsert { key: 2, value: 20 },
+        Int64MutationOp::Delete { key: 1 },
+        Int64MutationOp::Delete { key: 2 },
+        Int64MutationOp::DeleteAll,
+    ]
+}
+
+fn int64_batch_ops() -> Vec<Int64BatchMutationOp> {
+    vec![
+        Int64BatchMutationOp::BatchUpsert {
+            value_1: 10,
+            value_2: 10,
+        },
+        Int64BatchMutationOp::BatchUpsert {
+            value_1: 10,
+            value_2: 20,
+        },
+        Int64BatchMutationOp::BatchUpsert {
+            value_1: 20,
+            value_2: 10,
+        },
+        Int64BatchMutationOp::BatchUpsert {
+            value_1: 20,
+            value_2: 20,
+        },
+        Int64BatchMutationOp::Delete { key: 1 },
+        Int64BatchMutationOp::Delete { key: 2 },
+        Int64BatchMutationOp::DeleteAll,
+    ]
+}
+
+fn composite_single_row_ops() -> Vec<CompositeMutationOp> {
+    vec![
+        CompositeMutationOp::Upsert {
+            region: "east",
+            id: 1,
+            value: 10,
+        },
+        CompositeMutationOp::Upsert {
+            region: "east",
+            id: 1,
+            value: 20,
+        },
+        CompositeMutationOp::Upsert {
+            region: "west",
+            id: 1,
+            value: 10,
+        },
+        CompositeMutationOp::Upsert {
+            region: "west",
+            id: 1,
+            value: 20,
+        },
+        CompositeMutationOp::Delete {
+            region: "east",
+            id: 1,
+        },
+        CompositeMutationOp::Delete {
+            region: "west",
+            id: 1,
+        },
+        CompositeMutationOp::DeleteAll,
+    ]
+}
+
+async fn apply_int64_mutation(
+    table: &Arc<CayenneTableProvider>,
+    schema: &Arc<Schema>,
+    op: &Int64MutationOp,
+) -> TestResult<()> {
+    match op {
+        Int64MutationOp::Upsert { key, value } => {
+            let batch = RecordBatch::try_new(
+                Arc::clone(schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![*key])),
+                    Arc::new(Int64Array::from(vec![*value])),
+                ],
+            )?;
+            let _ = insert_batch(table, batch).await?;
+        }
+        Int64MutationOp::Delete { key } => {
+            let _ = delete_records(table, col("id").eq(lit(*key))).await?;
+        }
+        Int64MutationOp::DeleteAll => {
+            let _ = delete_records(table, lit(true)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn apply_int64_batch_mutation(
+    table: &Arc<CayenneTableProvider>,
+    schema: &Arc<Schema>,
+    op: &Int64BatchMutationOp,
+) -> TestResult<()> {
+    match op {
+        Int64BatchMutationOp::BatchUpsert { value_1, value_2 } => {
+            let batch = RecordBatch::try_new(
+                Arc::clone(schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![1_i64, 2_i64])),
+                    Arc::new(Int64Array::from(vec![*value_1, *value_2])),
+                ],
+            )?;
+            let _ = insert_batch(table, batch).await?;
+        }
+        Int64BatchMutationOp::Delete { key } => {
+            let _ = delete_records(table, col("id").eq(lit(*key))).await?;
+        }
+        Int64BatchMutationOp::DeleteAll => {
+            let _ = delete_records(table, lit(true)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn apply_composite_mutation(
+    table: &Arc<CayenneTableProvider>,
+    schema: &Arc<Schema>,
+    op: &CompositeMutationOp,
+) -> TestResult<()> {
+    match op {
+        CompositeMutationOp::Upsert { region, id, value } => {
+            let batch = RecordBatch::try_new(
+                Arc::clone(schema),
+                vec![
+                    Arc::new(StringArray::from(vec![*region])),
+                    Arc::new(Int64Array::from(vec![*id])),
+                    Arc::new(Int64Array::from(vec![*value])),
+                ],
+            )?;
+            let _ = insert_batch(table, batch).await?;
+        }
+        CompositeMutationOp::Delete { region, id } => {
+            let _ = delete_records(
+                table,
+                col("region").eq(lit(*region)).and(col("id").eq(lit(*id))),
+            )
+            .await?;
+        }
+        CompositeMutationOp::DeleteAll => {
+            let _ = delete_records(table, lit(true)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_int64_model(model: &mut Int64Model, op: &Int64MutationOp) {
+    match op {
+        Int64MutationOp::Upsert { key, value } => {
+            model.insert(*key, *value);
+        }
+        Int64MutationOp::Delete { key } => {
+            model.remove(key);
+        }
+        Int64MutationOp::DeleteAll => {
+            model.clear();
+        }
+    }
+}
+
+fn apply_int64_batch_model(model: &mut Int64Model, op: &Int64BatchMutationOp) {
+    match op {
+        Int64BatchMutationOp::BatchUpsert { value_1, value_2 } => {
+            model.insert(1, *value_1);
+            model.insert(2, *value_2);
+        }
+        Int64BatchMutationOp::Delete { key } => {
+            model.remove(key);
+        }
+        Int64BatchMutationOp::DeleteAll => {
+            model.clear();
+        }
+    }
+}
+
+fn apply_composite_model(model: &mut CompositeModel, op: &CompositeMutationOp) {
+    match op {
+        CompositeMutationOp::Upsert { region, id, value } => {
+            model.insert(((*region).to_string(), *id), *value);
+        }
+        CompositeMutationOp::Delete { region, id } => {
+            model.remove(&(((*region).to_string()), *id));
+        }
+        CompositeMutationOp::DeleteAll => {
+            model.clear();
+        }
+    }
+}
+
+async fn assert_int64_state(
+    fixture: &TestFixture,
+    ctx: &SessionContext,
+    table_name: &str,
+    expected: &Int64Model,
+    sequence_index: usize,
+    step_index: usize,
+) -> TestResult<()> {
+    let expected_rows = expected_int64_rows(expected);
+    let live_rows = read_int64_rows(ctx, table_name).await?;
+    assert_eq!(
+        live_rows, expected_rows,
+        "live state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
+    );
+
+    let reopened_rows = reopen_and_read_int64_rows(fixture, table_name).await?;
+    assert_eq!(
+        reopened_rows, expected_rows,
+        "reopened state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
+    );
+
+    Ok(())
+}
+
+async fn assert_composite_state(
+    fixture: &TestFixture,
+    ctx: &SessionContext,
+    table_name: &str,
+    expected: &CompositeModel,
+    sequence_index: usize,
+    step_index: usize,
+) -> TestResult<()> {
+    let expected_rows = expected_composite_rows(expected);
+    let live_rows = read_composite_rows(ctx, table_name).await?;
+    assert_eq!(
+        live_rows, expected_rows,
+        "live state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
+    );
+
+    let reopened_rows = reopen_and_read_composite_rows(fixture, table_name).await?;
+    assert_eq!(
+        reopened_rows, expected_rows,
+        "reopened state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
+    );
+
+    Ok(())
+}
+
+async fn test_exhaustive_int64_single_row_sequences_impl(fixture: TestFixture) -> TestResult<()> {
+    let sequences = enumerate_sequences(&int64_single_row_ops(), 3);
+
+    for (sequence_index, sequence) in sequences.iter().enumerate() {
+        let table_name = format!("int64_single_model_{sequence_index}");
+        let (table, ctx, schema) = setup_int64_upsert_table(&fixture, &table_name).await?;
+        let mut expected = Int64Model::new();
+
+        for (step_index, op) in sequence.iter().enumerate() {
+            apply_int64_mutation(&table, &schema, op).await?;
+            apply_int64_model(&mut expected, op);
+            assert_int64_state(
+                &fixture,
+                &ctx,
+                &table_name,
+                &expected,
+                sequence_index,
+                step_index,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+test_with_backends!(test_exhaustive_int64_single_row_sequences_impl);
+
+async fn test_exhaustive_int64_batch_sequences_impl(fixture: TestFixture) -> TestResult<()> {
+    let sequences = enumerate_sequences(&int64_batch_ops(), 3);
+
+    for (sequence_index, sequence) in sequences.iter().enumerate() {
+        let table_name = format!("int64_batch_model_{sequence_index}");
+        let (table, ctx, schema) = setup_int64_upsert_table(&fixture, &table_name).await?;
+        let mut expected = Int64Model::new();
+
+        for (step_index, op) in sequence.iter().enumerate() {
+            apply_int64_batch_mutation(&table, &schema, op).await?;
+            apply_int64_batch_model(&mut expected, op);
+            assert_int64_state(
+                &fixture,
+                &ctx,
+                &table_name,
+                &expected,
+                sequence_index,
+                step_index,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+test_with_backends!(test_exhaustive_int64_batch_sequences_impl);
+
+async fn test_exhaustive_composite_single_row_sequences_impl(
+    fixture: TestFixture,
+) -> TestResult<()> {
+    let sequences = enumerate_sequences(&composite_single_row_ops(), 3);
+
+    for (sequence_index, sequence) in sequences.iter().enumerate() {
+        let table_name = format!("composite_model_{sequence_index}");
+        let (table, ctx, schema) = setup_composite_upsert_table(&fixture, &table_name).await?;
+        let mut expected = CompositeModel::new();
+
+        for (step_index, op) in sequence.iter().enumerate() {
+            apply_composite_mutation(&table, &schema, op).await?;
+            apply_composite_model(&mut expected, op);
+            assert_composite_state(
+                &fixture,
+                &ctx,
+                &table_name,
+                &expected,
+                sequence_index,
+                step_index,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+test_with_backends!(test_exhaustive_composite_single_row_sequences_impl);

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use cayenne::metadata::VortexConfig;
-use cayenne::{CayenneCatalog, CayenneTableProviderBuilder, MetadataCatalog};
+use cayenne::{CayenneCatalog, CayenneTableProvider, CayenneTableProviderBuilder, MetadataCatalog};
 use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
 use datafusion::error::Result as DFResult;
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -323,16 +323,44 @@ impl RefreshableCatalogProvider for CayenneCatalogProvider {
             }
         }
 
+        let existing_schemas = match self.schemas.read() {
+            Ok(schemas) => schemas.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        };
+
         let mut new_schemas: HashMap<String, Arc<dyn SchemaProvider>> = HashMap::new();
         for (ns, full_names) in &grouped {
-            let schema_provider = CayenneSchemaProvider::try_new(
+            let refreshed_schema = CayenneSchemaProvider::try_new(
                 Arc::clone(&self.catalog),
                 ns,
                 full_names,
                 Arc::clone(&self.runtime_env),
             )
             .await?;
-            new_schemas.insert(ns.clone(), Arc::new(schema_provider));
+
+            if let Some(existing_schema) = existing_schemas.get(ns)
+                && let Some(existing_cayenne_schema) = existing_schema
+                    .as_any()
+                    .downcast_ref::<CayenneSchemaProvider>()
+            {
+                existing_cayenne_schema.refresh_from(&refreshed_schema);
+                new_schemas.insert(ns.clone(), Arc::clone(existing_schema));
+            } else {
+                new_schemas.insert(ns.clone(), Arc::new(refreshed_schema));
+            }
+        }
+
+        for (ns, existing_schema) in &existing_schemas {
+            if grouped.contains_key(ns) {
+                continue;
+            }
+
+            if let Some(existing_cayenne_schema) = existing_schema
+                .as_any()
+                .downcast_ref::<CayenneSchemaProvider>()
+            {
+                existing_cayenne_schema.clear_tables();
+            }
         }
 
         if !new_schemas.is_empty() {
@@ -427,6 +455,78 @@ impl CayenneSchemaProvider {
             runtime_env,
             tables: RwLock::new(HashMap::new()),
         }
+    }
+
+    fn tables_snapshot(&self) -> HashMap<String, Arc<dyn TableProvider>> {
+        match self.tables.read() {
+            Ok(tables) => tables.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn replace_tables(&self, tables: HashMap<String, Arc<dyn TableProvider>>) {
+        match self.tables.write() {
+            Ok(mut existing_tables) => *existing_tables = tables,
+            Err(poisoned) => *poisoned.into_inner() = tables,
+        }
+    }
+
+    fn refresh_from(&self, source: &Self) {
+        let existing_tables = self.tables_snapshot();
+        let refreshed_tables = source.tables_snapshot();
+        let mut merged_tables = HashMap::with_capacity(refreshed_tables.len());
+
+        for (table_name, refreshed_provider) in refreshed_tables {
+            let provider_to_use = if let Some(existing_provider) = existing_tables.get(&table_name)
+            {
+                if Self::refresh_table_provider_in_place(existing_provider, &refreshed_provider) {
+                    Arc::clone(existing_provider)
+                } else {
+                    refreshed_provider
+                }
+            } else {
+                refreshed_provider
+            };
+
+            merged_tables.insert(table_name, provider_to_use);
+        }
+
+        self.replace_tables(merged_tables);
+    }
+
+    fn refresh_table_provider_in_place(
+        existing_provider: &Arc<dyn TableProvider>,
+        refreshed_provider: &Arc<dyn TableProvider>,
+    ) -> bool {
+        let Some(existing_cayenne) = Self::cayenne_table_from_provider(existing_provider) else {
+            return false;
+        };
+        let Some(refreshed_cayenne) = Self::cayenne_table_from_provider(refreshed_provider) else {
+            return false;
+        };
+
+        if let Err(err) = existing_cayenne.refresh_from(refreshed_cayenne) {
+            tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
+            return false;
+        }
+
+        true
+    }
+
+    fn cayenne_table_from_provider(
+        provider: &Arc<dyn TableProvider>,
+    ) -> Option<&CayenneTableProvider> {
+        let adapter = provider
+            .as_any()
+            .downcast_ref::<DeletionTableProviderAdapter>()?;
+        adapter
+            .source()
+            .as_any()
+            .downcast_ref::<CayenneTableProvider>()
+    }
+
+    fn clear_tables(&self) {
+        self.replace_tables(HashMap::new());
     }
 
     /// Returns a reference to the underlying Cayenne metadata catalog.

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1147,6 +1147,19 @@ impl DataFusion {
                 table_name: table_reference.to_string(),
             })?;
 
+        // Invalidate any cached logical plans that reference this table.
+        // Cached plans hold stale `Arc<dyn TableProvider>` references; after a
+        // write the underlying provider's in-memory state (e.g. Cayenne's
+        // protected snapshots and deletion caches) has changed, so plans must be
+        // re-resolved to pick up the new state.
+        if let Some(cache) = self.plans_cache_provider() {
+            if let Err(e) = cache.invalidate_for_table(table_reference.clone()) {
+                tracing::warn!(
+                    "Failed to invalidate plans cache for table {table_reference} after write: {e}"
+                );
+            }
+        }
+
         self.runtime_status
             .update_dataset(table_reference, status::ComponentStatus::Ready);
 
@@ -1199,6 +1212,19 @@ impl DataFusion {
             .context(UnableToExecuteTableInsertSnafu {
                 table_name: table_reference.to_string(),
             })?;
+
+        // Invalidate any cached logical plans that reference this table.
+        // Cached plans hold stale `Arc<dyn TableProvider>` references; after a
+        // write the underlying provider's in-memory state (e.g. Cayenne's
+        // protected snapshots and deletion caches) has changed, so plans must be
+        // re-resolved to pick up the new state.
+        if let Some(cache) = self.plans_cache_provider() {
+            if let Err(e) = cache.invalidate_for_table(table_reference.clone()) {
+                tracing::warn!(
+                    "Failed to invalidate plans cache for table {table_reference} after streaming write: {e}"
+                );
+            }
+        }
 
         Ok(())
     }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1152,12 +1152,12 @@ impl DataFusion {
         // write the underlying provider's in-memory state (e.g. Cayenne's
         // protected snapshots and deletion caches) has changed, so plans must be
         // re-resolved to pick up the new state.
-        if let Some(cache) = self.plans_cache_provider() {
-            if let Err(e) = cache.invalidate_for_table(table_reference.clone()) {
-                tracing::warn!(
-                    "Failed to invalidate plans cache for table {table_reference} after write: {e}"
-                );
-            }
+        if let Some(cache) = self.plans_cache_provider()
+            && let Err(e) = cache.invalidate_for_table(table_reference.clone())
+        {
+            tracing::warn!(
+                "Failed to invalidate plans cache for table {table_reference} after write: {e}"
+            );
         }
 
         self.runtime_status
@@ -1218,12 +1218,12 @@ impl DataFusion {
         // write the underlying provider's in-memory state (e.g. Cayenne's
         // protected snapshots and deletion caches) has changed, so plans must be
         // re-resolved to pick up the new state.
-        if let Some(cache) = self.plans_cache_provider() {
-            if let Err(e) = cache.invalidate_for_table(table_reference.clone()) {
-                tracing::warn!(
-                    "Failed to invalidate plans cache for table {table_reference} after streaming write: {e}"
-                );
-            }
+        if let Some(cache) = self.plans_cache_provider()
+            && let Err(e) = cache.invalidate_for_table(table_reference.clone())
+        {
+            tracing::warn!(
+                "Failed to invalidate plans cache for table {table_reference} after streaming write: {e}"
+            );
         }
 
         Ok(())

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -596,15 +596,14 @@ impl Query {
             // `Arc<dyn TableProvider>` references that won't reflect the upcoming
             // data changes, so subsequent queries must re-resolve through the
             // catalog.
-            if let LogicalPlan::Dml(dml) = &*plan {
-                if let Some(cache) = ctx.df.plans_cache_provider() {
-                    if let Err(e) = cache.invalidate_for_table(dml.table_name.clone()) {
-                        tracing::warn!(
-                            "Failed to invalidate plans cache for table {} before DML: {e}",
-                            dml.table_name
-                        );
-                    }
-                }
+            if let LogicalPlan::Dml(dml) = &*plan
+                && let Some(cache) = ctx.df.plans_cache_provider()
+                && let Err(e) = cache.invalidate_for_table(dml.table_name.clone())
+            {
+                tracing::warn!(
+                    "Failed to invalidate plans cache for table {} before DML: {e}",
+                    dml.table_name
+                );
             }
 
             let input_tables = get_logical_plan_input_tables(&plan);

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -591,6 +591,22 @@ impl Query {
                 )
             }
 
+            // Proactively invalidate plans cache for tables affected by DML
+            // mutations (INSERT, DELETE, UPDATE). Cached logical plans hold stale
+            // `Arc<dyn TableProvider>` references that won't reflect the upcoming
+            // data changes, so subsequent queries must re-resolve through the
+            // catalog.
+            if let LogicalPlan::Dml(dml) = &*plan {
+                if let Some(cache) = ctx.df.plans_cache_provider() {
+                    if let Err(e) = cache.invalidate_for_table(dml.table_name.clone()) {
+                        tracing::warn!(
+                            "Failed to invalidate plans cache for table {} before DML: {e}",
+                            dml.table_name
+                        );
+                    }
+                }
+            }
+
             let input_tables = get_logical_plan_input_tables(&plan);
             if input_tables
                 .iter()

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -34,26 +34,26 @@ use data_components::RefreshableCatalogProvider;
 use datafusion::assert_batches_eq;
 use datafusion::sql::TableReference;
 use futures::{StreamExt, TryStreamExt};
+use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
 use rand::Rng as _;
 use runtime::auth::EndpointAuth;
 use runtime::catalogconnector::cayenne::provider::CayenneCatalogProvider;
 use runtime::config::Config;
-use runtime_auth::FlightBasicAuth;
-use runtime_auth::api_key::ApiKeyAuth;
-use spicepod::component::catalog::Catalog;
-use spicepod::component::runtime::ApiKey;
-use tokio::time::sleep;
-use tonic::transport::Channel;
-use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
 use runtime::dataaccelerator::cayenne::s3::generate_bucket_name;
 use runtime::dataupdate::{DataUpdate, UpdateType};
 use runtime::{Runtime, accelerated_table::AcceleratedTable};
+use runtime_auth::FlightBasicAuth;
+use runtime_auth::api_key::ApiKeyAuth;
 use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode};
 use spicepod::component::access::AccessMode;
+use spicepod::component::catalog::Catalog;
 use spicepod::component::dataset::Dataset;
+use spicepod::component::runtime::ApiKey;
 use spicepod::param::Params;
 use spicepod::partitioning::PartitionedBy;
 use test_framework::queries::QuerySet;
+use tokio::time::sleep;
+use tonic::transport::Channel;
 
 /// Append a single row to a Cayenne-accelerated table through the Runtime write path.
 ///
@@ -738,14 +738,18 @@ async fn exec(rt: &Runtime, sql: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Send record batches to a Cayenne table via Flight DoPut.
+/// Send record batches to a Cayenne table via Flight `DoPut`.
 async fn doput_to_table(
     client: &mut FlightClient,
     table_path: &[&str],
     batch: RecordBatch,
 ) -> Result<(), String> {
-    let flight_descriptor =
-        FlightDescriptor::new_path(table_path.iter().map(|s| s.to_string()).collect());
+    let flight_descriptor = FlightDescriptor::new_path(
+        table_path
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
+    );
 
     #[expect(clippy::needless_collect)]
     let flight_data_stream = FlightDataEncoderBuilder::new()
@@ -765,7 +769,7 @@ async fn doput_to_table(
     Ok(())
 }
 
-/// Build a RecordBatch with (id: Int64, name: Utf8View) columns.
+/// Build a `RecordBatch` with (id: Int64, name: `Utf8View`) columns.
 fn make_batch(ids: &[i64], names: &[&str]) -> Result<RecordBatch, String> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
@@ -781,7 +785,7 @@ fn make_batch(ids: &[i64], names: &[&str]) -> Result<RecordBatch, String> {
     .map_err(|e| format!("failed to create RecordBatch: {e}"))
 }
 
-/// Helper: DoPut data, refresh catalog, query, and assert expected output.
+/// Helper: `DoPut` data, refresh catalog, query, and assert expected output.
 async fn doput_refresh_and_assert(
     client: &mut FlightClient,
     table_path: &[&str],
@@ -801,8 +805,14 @@ async fn doput_refresh_and_assert(
 
     let batches = run_query(rt, "SELECT id, name FROM stlcyc.ns.items ORDER BY id").await?;
 
-    let expected_vec: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-    let expected_refs: Vec<&str> = expected_vec.iter().map(|s| s.as_str()).collect();
+    let expected_vec: Vec<String> = expected
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+    let expected_refs: Vec<&str> = expected_vec
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
     assert_batches_eq!(&expected_refs, &batches);
 
     Ok(())
@@ -988,7 +998,7 @@ async fn test_cayenne_doput_upsert_cycle_stale() -> Result<(), String> {
         .await
 }
 
-/// Helper struct that bundles everything needed to run Cayenne DoPut + SQL
+/// Helper struct that bundles everything needed to run Cayenne `DoPut` + SQL
 /// operations against a local catalog backed runtime.
 struct CayenneTestHarness {
     rt: Arc<Runtime>,
@@ -1003,7 +1013,10 @@ unsafe impl Send for CayenneTestHarness {}
 
 impl CayenneTestHarness {
     /// Spin up a Cayenne-backed runtime with HTTP + Flight servers.
-    async fn new(data_dir: &std::path::Path, metadata_dir: &std::path::Path) -> Result<Self, String> {
+    async fn new(
+        data_dir: &std::path::Path,
+        metadata_dir: &std::path::Path,
+    ) -> Result<Self, String> {
         let catalog = make_cayenne_catalog(
             "cyc",
             &data_dir.to_string_lossy(),
@@ -1091,10 +1104,7 @@ impl CayenneTestHarness {
         exec(&rt, "CREATE SCHEMA cyc.ns").await?;
 
         let df = rt.datafusion();
-        let catalog_provider = df
-            .ctx
-            .catalog("cyc")
-            .ok_or("catalog 'cyc' not found")?;
+        let catalog_provider = df.ctx.catalog("cyc").ok_or("catalog 'cyc' not found")?;
         let cayenne_provider = catalog_provider
             .as_any()
             .downcast_ref::<CayenneCatalogProvider>()
@@ -1102,7 +1112,7 @@ impl CayenneTestHarness {
 
         Ok(Self {
             rt,
-            cayenne_provider: cayenne_provider as *const _,
+            cayenne_provider: std::ptr::from_ref(cayenne_provider),
             client,
         })
     }
@@ -1127,7 +1137,7 @@ impl CayenneTestHarness {
         .await
     }
 
-    /// DoPut a batch, refresh the catalog, then SELECT and assert.
+    /// `DoPut` a batch, refresh the catalog, then SELECT and assert.
     async fn doput_and_assert(
         &mut self,
         table_name: &str,
@@ -1165,19 +1175,21 @@ impl CayenneTestHarness {
     }
 
     /// SELECT all rows ordered by id and assert.
-    async fn assert_query(
-        &self,
-        table_name: &str,
-        expected: &[&str],
-    ) -> Result<(), String> {
+    async fn assert_query(&self, table_name: &str, expected: &[&str]) -> Result<(), String> {
         let batches = run_query(
             &self.rt,
             &format!("SELECT id, name FROM cyc.ns.{table_name} ORDER BY id"),
         )
         .await?;
 
-        let expected_vec: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-        let expected_refs: Vec<&str> = expected_vec.iter().map(|s| s.as_str()).collect();
+        let expected_vec: Vec<String> = expected
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        let expected_refs: Vec<&str> = expected_vec
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
         assert_batches_eq!(&expected_refs, &batches);
         Ok(())
     }
@@ -1187,7 +1199,7 @@ impl CayenneTestHarness {
 // Comprehensive DoPut / DELETE / UPDATE edge-case test
 // ---------------------------------------------------------------------------
 
-/// Exercises every combination of INSERT (DoPut), SQL DELETE, and SQL UPDATE
+/// Exercises every combination of INSERT (`DoPut`), SQL DELETE, and SQL UPDATE
 /// against Cayenne tables with a PRIMARY KEY.
 ///
 /// Each scenario uses its own table so failures are independent.
@@ -1251,137 +1263,347 @@ async fn test_cayenne_dml_comprehensive() -> Result<(), String> {
             // S3  Upsert with partial PK overlap (some new, some existing)
             // ---------------------------------------------------------------
             h.create_table("s3").await?;
-            h.doput_and_assert("s3", &[1, 2], &["Alice", "Bob"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s3",
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
             // Upsert ids 2,3 - id 2 updated, id 3 inserted
-            h.doput_and_assert("s3", &[2, 3], &["Bob2", "Carol"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob2  |", "| 3  | Carol |", "+----+-------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s3",
+                &[2, 3],
+                &["Bob2", "Carol"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob2  |",
+                    "| 3  | Carol |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
             // Upsert ids 1,3,4 - ids 1,3 updated, id 4 inserted
-            h.doput_and_assert("s3", &[1, 3, 4], &["Ax", "Cx", "Dave"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | Ax   |", "| 2  | Bob2 |", "| 3  | Cx   |", "| 4  | Dave |",
-                "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s3",
+                &[1, 3, 4],
+                &["Ax", "Cx", "Dave"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | Ax   |",
+                    "| 2  | Bob2 |",
+                    "| 3  | Cx   |",
+                    "| 4  | Dave |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S4  Insert then DELETE one specific row
             // ---------------------------------------------------------------
             h.create_table("s4").await?;
-            h.doput_and_assert("s4", &[1, 2, 3], &["Alice", "Bob", "Carol"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob   |", "| 3  | Carol |", "+----+-------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s4 WHERE id = 2", "s4", &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 3  | Carol |", "+----+-------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s4",
+                &[1, 2, 3],
+                &["Alice", "Bob", "Carol"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "| 3  | Carol |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s4 WHERE id = 2",
+                "s4",
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 3  | Carol |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S5  Insert then DELETE all rows
             // ---------------------------------------------------------------
             h.create_table("s5").await?;
-            h.doput_and_assert("s5", &[1, 2], &["Alice", "Bob"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s5", "s5", &[
-                "++", "++",
-            ]).await?;
+            h.doput_and_assert(
+                "s5",
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s5", "s5", &["++", "++"])
+                .await?;
 
             // ---------------------------------------------------------------
             // S6  Insert -> DELETE one row -> re-insert same PK with new value
             // ---------------------------------------------------------------
             h.create_table("s6").await?;
-            h.doput_and_assert("s6", &[1, 2], &["Alice", "Bob"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s6 WHERE id = 1", "s6", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 2  | Bob  |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s6",
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s6 WHERE id = 1",
+                "s6",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 2  | Bob  |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             // Re-insert id=1 with different value
-            h.doput_and_assert("s6", &[1], &["Alice2"], &[
-                "+----+--------+", "| id | name   |", "+----+--------+",
-                "| 1  | Alice2 |", "| 2  | Bob    |", "+----+--------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s6",
+                &[1],
+                &["Alice2"],
+                &[
+                    "+----+--------+",
+                    "| id | name   |",
+                    "+----+--------+",
+                    "| 1  | Alice2 |",
+                    "| 2  | Bob    |",
+                    "+----+--------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S7  Insert -> SQL UPDATE one row
             // ---------------------------------------------------------------
             h.create_table("s7").await?;
-            h.doput_and_assert("s7", &[1, 2], &["Alice", "Bob"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s7",
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
             h.sql_mutate_and_assert(
-                "UPDATE cyc.ns.s7 SET name = 'Alice2' WHERE id = 1", "s7", &[
-                "+----+--------+", "| id | name   |", "+----+--------+",
-                "| 1  | Alice2 |", "| 2  | Bob    |", "+----+--------+",
-            ]).await?;
+                "UPDATE cyc.ns.s7 SET name = 'Alice2' WHERE id = 1",
+                "s7",
+                &[
+                    "+----+--------+",
+                    "| id | name   |",
+                    "+----+--------+",
+                    "| 1  | Alice2 |",
+                    "| 2  | Bob    |",
+                    "+----+--------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S8  Insert -> UPDATE -> UPDATE again (chained updates)
             // ---------------------------------------------------------------
             h.create_table("s8").await?;
-            h.doput_and_assert("s8", &[1, 2], &["A", "B"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'X' WHERE id = 1", "s8", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | X    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'Y' WHERE id = 1", "s8", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | Y    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'Z'", "s8", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | Z    |", "| 2  | Z    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s8",
+                &[1, 2],
+                &["A", "B"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s8 SET name = 'X' WHERE id = 1",
+                "s8",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | X    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s8 SET name = 'Y' WHERE id = 1",
+                "s8",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | Y    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s8 SET name = 'Z'",
+                "s8",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | Z    |",
+                    "| 2  | Z    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S9  Insert -> Upsert -> DELETE -> verify deletion post-upsert
             // ---------------------------------------------------------------
             h.create_table("s9").await?;
-            h.doput_and_assert("s9", &[1, 2], &["A", "B"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.doput_and_assert("s9", &[1, 2], &["A2", "B2"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A2   |", "| 2  | B2   |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s9 WHERE id = 1", "s9", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 2  | B2   |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s9",
+                &[1, 2],
+                &["A", "B"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.doput_and_assert(
+                "s9",
+                &[1, 2],
+                &["A2", "B2"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A2   |",
+                    "| 2  | B2   |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s9 WHERE id = 1",
+                "s9",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 2  | B2   |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S10  Interleaved: Insert 1,2 -> Upsert 1 -> Delete 2 -> Insert 3
             // ---------------------------------------------------------------
             h.create_table("s10").await?;
-            h.doput_and_assert("s10", &[1, 2], &["A", "B"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.doput_and_assert("s10", &[1], &["A2"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A2   |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s10 WHERE id = 2", "s10", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A2   |", "+----+------+",
-            ]).await?;
-            h.doput_and_assert("s10", &[3], &["C"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A2   |", "| 3  | C    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s10",
+                &[1, 2],
+                &["A", "B"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.doput_and_assert(
+                "s10",
+                &[1],
+                &["A2"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A2   |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s10 WHERE id = 2",
+                "s10",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A2   |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.doput_and_assert(
+                "s10",
+                &[3],
+                &["C"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A2   |",
+                    "| 3  | C    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S11  Upsert with NULL -> non-NULL -> back to NULL
@@ -1392,70 +1614,154 @@ async fn test_cayenne_dml_comprehensive() -> Result<(), String> {
                     Field::new("id", DataType::Int64, false),
                     Field::new("name", DataType::Utf8View, true),
                 ]));
-                let batch = RecordBatch::try_new(schema, vec![
-                    Arc::new(Int64Array::from(vec![1])),
-                    Arc::new(StringViewArray::from(vec![None::<&str>])),
-                ]).map_err(|e| format!("batch: {e}"))?;
+                let batch = RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(Int64Array::from(vec![1])),
+                        Arc::new(StringViewArray::from(vec![None::<&str>])),
+                    ],
+                )
+                .map_err(|e| format!("batch: {e}"))?;
                 doput_to_table(&mut h.client, &["cyc", "ns", "s11"], batch).await?;
-                h.cayenne_provider().refresh().await.map_err(|e| e.to_string())?;
+                h.cayenne_provider()
+                    .refresh()
+                    .await
+                    .map_err(|e| e.to_string())?;
             }
-            h.assert_query("s11", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  |      |", "+----+------+",
-            ]).await?;
-            h.doput_and_assert("s11", &[1], &["Alice"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | Alice |", "+----+-------+",
-            ]).await?;
+            h.assert_query(
+                "s11",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  |      |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.doput_and_assert(
+                "s11",
+                &[1],
+                &["Alice"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
             {
                 let schema = Arc::new(Schema::new(vec![
                     Field::new("id", DataType::Int64, false),
                     Field::new("name", DataType::Utf8View, true),
                 ]));
-                let batch = RecordBatch::try_new(schema, vec![
-                    Arc::new(Int64Array::from(vec![1])),
-                    Arc::new(StringViewArray::from(vec![None::<&str>])),
-                ]).map_err(|e| format!("batch: {e}"))?;
+                let batch = RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(Int64Array::from(vec![1])),
+                        Arc::new(StringViewArray::from(vec![None::<&str>])),
+                    ],
+                )
+                .map_err(|e| format!("batch: {e}"))?;
                 doput_to_table(&mut h.client, &["cyc", "ns", "s11"], batch).await?;
-                h.cayenne_provider().refresh().await.map_err(|e| e.to_string())?;
+                h.cayenne_provider()
+                    .refresh()
+                    .await
+                    .map_err(|e| e.to_string())?;
             }
-            h.assert_query("s11", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  |      |", "+----+------+",
-            ]).await?;
+            h.assert_query(
+                "s11",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  |      |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S12  DELETE -> Upsert deleted PK -> verify re-appears
             // ---------------------------------------------------------------
             h.create_table("s12").await?;
-            h.doput_and_assert("s12", &[1, 2], &["A", "B"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s12 WHERE id = 1", "s12", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.doput_and_assert("s12", &[1], &["A_new"], &[
-                "+----+-------+", "| id | name  |", "+----+-------+",
-                "| 1  | A_new |", "| 2  | B     |", "+----+-------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s12",
+                &[1, 2],
+                &["A", "B"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s12 WHERE id = 1",
+                "s12",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.doput_and_assert(
+                "s12",
+                &[1],
+                &["A_new"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | A_new |",
+                    "| 2  | B     |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S13  DELETE all -> Insert -> verify
             // ---------------------------------------------------------------
             h.create_table("s13").await?;
-            h.doput_and_assert("s13", &[1, 2], &["A", "B"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s13", "s13", &[
-                "++", "++",
-            ]).await?;
-            h.doput_and_assert("s13", &[10, 20], &["X", "Y"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 10 | X    |", "| 20 | Y    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s13",
+                &[1, 2],
+                &["A", "B"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s13", "s13", &["++", "++"])
+                .await?;
+            h.doput_and_assert(
+                "s13",
+                &[10, 20],
+                &["X", "Y"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 10 | X    |",
+                    "| 20 | Y    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S14  Single-row table - multiple upserts (8 rounds)
@@ -1463,79 +1769,194 @@ async fn test_cayenne_dml_comprehensive() -> Result<(), String> {
             h.create_table("s14").await?;
             for round in 1..=8u32 {
                 let name = format!("v{round}");
-                h.doput_and_assert("s14", &[1], &[&name], &[
-                    "+----+------+", "| id | name |", "+----+------+",
-                    &format!("| 1  | {name:<4} |"), "+----+------+",
-                ]).await.map_err(|e| format!("S14 round {round}: {e}"))?;
+                h.doput_and_assert(
+                    "s14",
+                    &[1],
+                    &[&name],
+                    &[
+                        "+----+------+",
+                        "| id | name |",
+                        "+----+------+",
+                        &format!("| 1  | {name:<4} |"),
+                        "+----+------+",
+                    ],
+                )
+                .await
+                .map_err(|e| format!("S14 round {round}: {e}"))?;
             }
 
             // ---------------------------------------------------------------
             // S15  Insert -> UPDATE -> DELETE updated row -> verify others
             // ---------------------------------------------------------------
             h.create_table("s15").await?;
-            h.doput_and_assert("s15", &[1, 2, 3], &["A", "B", "C"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "| 3  | C    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("UPDATE cyc.ns.s15 SET name = 'B2' WHERE id = 2", "s15", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B2   |", "| 3  | C    |", "+----+------+",
-            ]).await?;
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s15 WHERE id = 2", "s15", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 3  | C    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s15",
+                &[1, 2, 3],
+                &["A", "B", "C"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "| 3  | C    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s15 SET name = 'B2' WHERE id = 2",
+                "s15",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B2   |",
+                    "| 3  | C    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s15 WHERE id = 2",
+                "s15",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 3  | C    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             // ---------------------------------------------------------------
             // S16  Rapid back-to-back upserts (10 rounds, no sleep)
             // ---------------------------------------------------------------
             h.create_table("s16").await?;
-            h.doput_and_assert("s16", &[1], &["v0"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | v0   |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s16",
+                &[1],
+                &["v0"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | v0   |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             for round in 1..=10u32 {
                 let name = format!("v{round}");
-                h.doput_and_assert("s16", &[1], &[&name], &[
-                    "+----+------+", "| id | name |", "+----+------+",
-                    &format!("| 1  | {name:<4} |"), "+----+------+",
-                ]).await.map_err(|e| format!("S16 round {round}: {e}"))?;
+                h.doput_and_assert(
+                    "s16",
+                    &[1],
+                    &[&name],
+                    &[
+                        "+----+------+",
+                        "| id | name |",
+                        "+----+------+",
+                        &format!("| 1  | {name:<4} |"),
+                        "+----+------+",
+                    ],
+                )
+                .await
+                .map_err(|e| format!("S16 round {round}: {e}"))?;
             }
 
             // ---------------------------------------------------------------
             // S17  Mix: DoPut inserts + DoPut upsert + SQL DELETE + SQL UPDATE
             // ---------------------------------------------------------------
             h.create_table("s17").await?;
-            h.doput_and_assert("s17", &[1, 2, 3, 4, 5], &["A", "B", "C", "D", "E"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B    |", "| 3  | C    |",
-                "| 4  | D    |", "| 5  | E    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s17",
+                &[1, 2, 3, 4, 5],
+                &["A", "B", "C", "D", "E"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B    |",
+                    "| 3  | C    |",
+                    "| 4  | D    |",
+                    "| 5  | E    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             // Upsert ids 2,4 (overlap) + insert id 6 (new)
-            h.doput_and_assert("s17", &[2, 4, 6], &["B2", "D2", "F"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B2   |", "| 3  | C    |",
-                "| 4  | D2   |", "| 5  | E    |", "| 6  | F    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s17",
+                &[2, 4, 6],
+                &["B2", "D2", "F"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B2   |",
+                    "| 3  | C    |",
+                    "| 4  | D2   |",
+                    "| 5  | E    |",
+                    "| 6  | F    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             // Delete ids 3,5
-            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s17 WHERE id IN (3, 5)", "s17", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A    |", "| 2  | B2   |", "| 4  | D2   |",
-                "| 6  | F    |", "+----+------+",
-            ]).await?;
+            h.sql_mutate_and_assert(
+                "DELETE FROM cyc.ns.s17 WHERE id IN (3, 5)",
+                "s17",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A    |",
+                    "| 2  | B2   |",
+                    "| 4  | D2   |",
+                    "| 6  | F    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             // Update remaining: set name = name || '!'
             h.sql_mutate_and_assert(
-                "UPDATE cyc.ns.s17 SET name = concat(name, '!')", "s17", &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | A!   |", "| 2  | B2!  |", "| 4  | D2!  |",
-                "| 6  | F!   |", "+----+------+",
-            ]).await?;
+                "UPDATE cyc.ns.s17 SET name = name || '!'",
+                "s17",
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | A!   |",
+                    "| 2  | B2!  |",
+                    "| 4  | D2!  |",
+                    "| 6  | F!   |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
             // DoPut upsert + new: ids 1 (existing) and 7 (new)
-            h.doput_and_assert("s17", &[1, 7], &["AX", "G"], &[
-                "+----+------+", "| id | name |", "+----+------+",
-                "| 1  | AX   |", "| 2  | B2!  |", "| 4  | D2!  |",
-                "| 6  | F!   |", "| 7  | G    |", "+----+------+",
-            ]).await?;
+            h.doput_and_assert(
+                "s17",
+                &[1, 7],
+                &["AX", "G"],
+                &[
+                    "+----+------+",
+                    "| id | name |",
+                    "+----+------+",
+                    "| 1  | AX   |",
+                    "| 2  | B2!  |",
+                    "| 4  | D2!  |",
+                    "| 6  | F!   |",
+                    "| 7  | G    |",
+                    "+----+------+",
+                ],
+            )
+            .await?;
 
             Ok(())
         })

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use std::collections::{BTreeMap, HashMap};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -22,12 +23,27 @@ use crate::configure_test_datafusion;
 use crate::utils::runtime_ready_check_with_timeout;
 use crate::{
     RecordBatch, init_tracing,
-    utils::{register_test_connectors, test_request_context},
+    utils::{register_test_connectors, test_request_context, wait_until_true},
 };
 use app::AppBuilder;
+use arrow::array::{Int64Array, StringViewArray};
+use arrow_flight::{FlightClient, FlightDescriptor, encode::FlightDataEncoderBuilder};
+use arrow_schema::{DataType, Field, Schema};
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_or_init_sdk_config};
+use data_components::RefreshableCatalogProvider;
+use datafusion::assert_batches_eq;
 use datafusion::sql::TableReference;
 use futures::{StreamExt, TryStreamExt};
+use rand::Rng as _;
+use runtime::auth::EndpointAuth;
+use runtime::catalogconnector::cayenne::provider::CayenneCatalogProvider;
+use runtime::config::Config;
+use runtime_auth::FlightBasicAuth;
+use runtime_auth::api_key::ApiKeyAuth;
+use spicepod::component::catalog::Catalog;
+use spicepod::component::runtime::ApiKey;
+use tokio::time::sleep;
+use tonic::transport::Channel;
 use object_store::{ClientOptions, ObjectStore, aws::AmazonS3Builder, path::Path as ObjectPath};
 use runtime::dataaccelerator::cayenne::s3::generate_bucket_name;
 use runtime::dataupdate::{DataUpdate, UpdateType};
@@ -682,4 +698,846 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
 
         Ok(())
     }).await
+}
+
+/// Creates a Cayenne `Catalog` component with `read_write_create` access.
+fn make_cayenne_catalog(catalog_name: &str, data_dir: &str, metadata_dir: &str) -> Catalog {
+    let mut catalog = Catalog::new("cayenne".to_string(), catalog_name.to_string())
+        .with_access(AccessMode::ReadWriteCreate);
+    catalog.params = Some(Params::from_string_map(
+        vec![
+            ("cayenne_data_dir".to_string(), data_dir.to_string()),
+            ("cayenne_metadata_dir".to_string(), metadata_dir.to_string()),
+        ]
+        .into_iter()
+        .collect::<HashMap<String, String>>(),
+    ));
+    catalog
+}
+
+/// Run a SQL query and collect all result batches.
+async fn run_query(rt: &Runtime, sql: &str) -> Result<Vec<RecordBatch>, String> {
+    let result = rt
+        .datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("query '{sql}' failed: {e}"))?;
+
+    result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("collecting results for '{sql}' failed: {e}"))
+}
+
+/// Run a SQL statement (DDL/DML) and discard results.
+async fn exec(rt: &Runtime, sql: &str) -> Result<(), String> {
+    run_query(rt, sql).await?;
+    Ok(())
+}
+
+/// Send record batches to a Cayenne table via Flight DoPut.
+async fn doput_to_table(
+    client: &mut FlightClient,
+    table_path: &[&str],
+    batch: RecordBatch,
+) -> Result<(), String> {
+    let flight_descriptor =
+        FlightDescriptor::new_path(table_path.iter().map(|s| s.to_string()).collect());
+
+    #[expect(clippy::needless_collect)]
+    let flight_data_stream = FlightDataEncoderBuilder::new()
+        .with_flight_descriptor(Some(flight_descriptor))
+        .build(futures::stream::iter(
+            vec![Ok(batch)].into_iter().collect::<Vec<_>>(),
+        ));
+
+    let _response: Vec<_> = client
+        .do_put(flight_data_stream)
+        .await
+        .map_err(|e| format!("do_put failed: {e}"))?
+        .try_collect()
+        .await
+        .map_err(|e| format!("do_put response stream failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Build a RecordBatch with (id: Int64, name: Utf8View) columns.
+fn make_batch(ids: &[i64], names: &[&str]) -> Result<RecordBatch, String> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8View, true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())),
+            Arc::new(StringViewArray::from(names.to_vec())),
+        ],
+    )
+    .map_err(|e| format!("failed to create RecordBatch: {e}"))
+}
+
+/// Helper: DoPut data, refresh catalog, query, and assert expected output.
+async fn doput_refresh_and_assert(
+    client: &mut FlightClient,
+    table_path: &[&str],
+    rt: &Runtime,
+    cayenne_provider: &CayenneCatalogProvider,
+    ids: &[i64],
+    names: &[&str],
+    expected: &[&str],
+) -> Result<(), String> {
+    let batch = make_batch(ids, names)?;
+    doput_to_table(client, table_path, batch).await?;
+
+    cayenne_provider
+        .refresh()
+        .await
+        .map_err(|e| format!("catalog refresh failed: {e}"))?;
+
+    let batches = run_query(rt, "SELECT id, name FROM stlcyc.ns.items ORDER BY id").await?;
+
+    let expected_vec: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+    let expected_refs: Vec<&str> = expected_vec.iter().map(|s| s.as_str()).collect();
+    assert_batches_eq!(&expected_refs, &batches);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cayenne_doput_upsert_cycle_stale() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "stlcyc",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let metrics_port: u16 = http_port + 2;
+
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), http_port))
+                .with_flight_bind_address(SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    flight_port,
+                ));
+
+            let app = AppBuilder::new("cayenne_doput_upsert_cycle_stale_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let registry = prometheus::Registry::new();
+            let rt = Arc::new(
+                Runtime::builder()
+                    .with_metrics_server(
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), metrics_port),
+                        registry,
+                    )
+                    .with_app(app)
+                    .with_runtime_config(Config::default().with_caching_disabled())
+                    .build()
+                    .await,
+            );
+
+            let cloned_rt = Arc::clone(&rt);
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("testkey:rw")]))
+                as Arc<dyn FlightBasicAuth + Send + Sync>;
+            let endpoint_auth = EndpointAuth::default().with_flight_basic_auth(auth);
+
+            let server_rt = Arc::clone(&rt);
+            tokio::spawn(async move {
+                Box::pin(server_rt.start_servers(api_config, None, endpoint_auth)).await
+            });
+
+            wait_until_true(Duration::from_secs(10), || async {
+                reqwest::get(format!("http://localhost:{http_port}/health"))
+                    .await
+                    .is_ok()
+            })
+            .await;
+
+            let channel = {
+                let start = std::time::Instant::now();
+                loop {
+                    if start.elapsed() > Duration::from_secs(30) {
+                        return Err("Flight server not ready within 30s".to_string());
+                    }
+                    match Channel::from_shared(format!("http://localhost:{flight_port}"))
+                        .map_err(|e| format!("invalid URI: {e}"))?
+                        .connect()
+                        .await
+                    {
+                        Ok(ch) => break ch,
+                        Err(_) => sleep(Duration::from_millis(100)).await,
+                    }
+                }
+            };
+
+            let mut client = FlightClient::new(channel);
+            client
+                .add_header("authorization", "Bearer testkey")
+                .map_err(|e| format!("failed to add auth header: {e}"))?;
+
+            exec(&rt, "CREATE SCHEMA stlcyc.ns").await?;
+            exec(
+                &rt,
+                "CREATE TABLE stlcyc.ns.items (
+                    id BIGINT NOT NULL,
+                    name VARCHAR,
+                    PRIMARY KEY (id)
+                )",
+            )
+            .await?;
+
+            let table_path = &["stlcyc", "ns", "items"];
+
+            let df = rt.datafusion();
+            let catalog_provider = df
+                .ctx
+                .catalog("stlcyc")
+                .ok_or("catalog 'stlcyc' not found")?;
+            let cayenne_provider = catalog_provider
+                .as_any()
+                .downcast_ref::<CayenneCatalogProvider>()
+                .ok_or("failed to downcast to CayenneCatalogProvider")?;
+
+            doput_refresh_and_assert(
+                &mut client,
+                table_path,
+                &rt,
+                cayenne_provider,
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+
+            doput_refresh_and_assert(
+                &mut client,
+                table_path,
+                &rt,
+                cayenne_provider,
+                &[1, 2],
+                &["Alice2", "Bob2"],
+                &[
+                    "+----+--------+",
+                    "| id | name   |",
+                    "+----+--------+",
+                    "| 1  | Alice2 |",
+                    "| 2  | Bob2   |",
+                    "+----+--------+",
+                ],
+            )
+            .await?;
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+
+            doput_refresh_and_assert(
+                &mut client,
+                table_path,
+                &rt,
+                cayenne_provider,
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+
+            Ok(())
+        })
+        .await
+}
+
+/// Helper struct that bundles everything needed to run Cayenne DoPut + SQL
+/// operations against a local catalog backed runtime.
+struct CayenneTestHarness {
+    rt: Arc<Runtime>,
+    cayenne_provider: *const CayenneCatalogProvider,
+    client: FlightClient,
+}
+
+// Safety: The CayenneCatalogProvider pointer is derived from an Arc held by the
+// runtime which outlives the harness. We only use it behind &self borrows and
+// never send it across threads independently.
+unsafe impl Send for CayenneTestHarness {}
+
+impl CayenneTestHarness {
+    /// Spin up a Cayenne-backed runtime with HTTP + Flight servers.
+    async fn new(data_dir: &std::path::Path, metadata_dir: &std::path::Path) -> Result<Self, String> {
+        let catalog = make_cayenne_catalog(
+            "cyc",
+            &data_dir.to_string_lossy(),
+            &metadata_dir.to_string_lossy(),
+        );
+
+        let mut rng = rand::rng();
+        let http_port: u16 = rng.random_range(50000..60000);
+        let flight_port: u16 = http_port + 1;
+        let metrics_port: u16 = http_port + 2;
+
+        let api_config = Config::new()
+            .with_http_bind_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), http_port))
+            .with_flight_bind_address(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                flight_port,
+            ));
+
+        let app = AppBuilder::new("cayenne_comprehensive_test")
+            .with_catalog(catalog)
+            .build();
+
+        configure_test_datafusion();
+        let registry = prometheus::Registry::new();
+        let rt = Arc::new(
+            Runtime::builder()
+                .with_metrics_server(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), metrics_port),
+                    registry,
+                )
+                .with_app(app)
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await,
+        );
+
+        let cloned_rt = Arc::clone(&rt);
+        tokio::select! {
+            () = tokio::time::sleep(Duration::from_secs(30)) => {
+                return Err("Timeout waiting for components to load".to_string());
+            }
+            () = cloned_rt.load_components() => {}
+        }
+        runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+        let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("testkey:rw")]))
+            as Arc<dyn FlightBasicAuth + Send + Sync>;
+        let endpoint_auth = EndpointAuth::default().with_flight_basic_auth(auth);
+
+        let server_rt = Arc::clone(&rt);
+        tokio::spawn(async move {
+            Box::pin(server_rt.start_servers(api_config, None, endpoint_auth)).await
+        });
+
+        wait_until_true(Duration::from_secs(10), || async {
+            reqwest::get(format!("http://localhost:{http_port}/health"))
+                .await
+                .is_ok()
+        })
+        .await;
+
+        let channel = {
+            let start = std::time::Instant::now();
+            loop {
+                if start.elapsed() > Duration::from_secs(30) {
+                    return Err("Flight server not ready within 30s".to_string());
+                }
+                match Channel::from_shared(format!("http://localhost:{flight_port}"))
+                    .map_err(|e| format!("invalid URI: {e}"))?
+                    .connect()
+                    .await
+                {
+                    Ok(ch) => break ch,
+                    Err(_) => sleep(Duration::from_millis(100)).await,
+                }
+            }
+        };
+
+        let mut client = FlightClient::new(channel);
+        client
+            .add_header("authorization", "Bearer testkey")
+            .map_err(|e| format!("failed to add auth header: {e}"))?;
+
+        // Create the schema once
+        exec(&rt, "CREATE SCHEMA cyc.ns").await?;
+
+        let df = rt.datafusion();
+        let catalog_provider = df
+            .ctx
+            .catalog("cyc")
+            .ok_or("catalog 'cyc' not found")?;
+        let cayenne_provider = catalog_provider
+            .as_any()
+            .downcast_ref::<CayenneCatalogProvider>()
+            .ok_or("failed to downcast to CayenneCatalogProvider")?;
+
+        Ok(Self {
+            rt,
+            cayenne_provider: cayenne_provider as *const _,
+            client,
+        })
+    }
+
+    fn cayenne_provider(&self) -> &CayenneCatalogProvider {
+        // Safety: pointer is valid for the lifetime of `self.rt`
+        unsafe { &*self.cayenne_provider }
+    }
+
+    /// Create a fresh table with `(id BIGINT PK, name VARCHAR)`.
+    async fn create_table(&self, table_name: &str) -> Result<(), String> {
+        exec(
+            &self.rt,
+            &format!(
+                "CREATE TABLE cyc.ns.{table_name} (
+                    id BIGINT NOT NULL,
+                    name VARCHAR,
+                    PRIMARY KEY (id)
+                )"
+            ),
+        )
+        .await
+    }
+
+    /// DoPut a batch, refresh the catalog, then SELECT and assert.
+    async fn doput_and_assert(
+        &mut self,
+        table_name: &str,
+        ids: &[i64],
+        names: &[&str],
+        expected: &[&str],
+    ) -> Result<(), String> {
+        let batch = make_batch(ids, names)?;
+        let table_path: Vec<&str> = vec!["cyc", "ns", table_name];
+        doput_to_table(&mut self.client, &table_path, batch).await?;
+
+        self.cayenne_provider()
+            .refresh()
+            .await
+            .map_err(|e| format!("catalog refresh failed: {e}"))?;
+
+        self.assert_query(table_name, expected).await
+    }
+
+    /// Run a SQL mutation (DELETE / UPDATE / INSERT INTO), refresh, and assert.
+    async fn sql_mutate_and_assert(
+        &self,
+        sql: &str,
+        table_name: &str,
+        expected: &[&str],
+    ) -> Result<(), String> {
+        exec(&self.rt, sql).await?;
+
+        self.cayenne_provider()
+            .refresh()
+            .await
+            .map_err(|e| format!("catalog refresh failed: {e}"))?;
+
+        self.assert_query(table_name, expected).await
+    }
+
+    /// SELECT all rows ordered by id and assert.
+    async fn assert_query(
+        &self,
+        table_name: &str,
+        expected: &[&str],
+    ) -> Result<(), String> {
+        let batches = run_query(
+            &self.rt,
+            &format!("SELECT id, name FROM cyc.ns.{table_name} ORDER BY id"),
+        )
+        .await?;
+
+        let expected_vec: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+        let expected_refs: Vec<&str> = expected_vec.iter().map(|s| s.as_str()).collect();
+        assert_batches_eq!(&expected_refs, &batches);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Comprehensive DoPut / DELETE / UPDATE edge-case test
+// ---------------------------------------------------------------------------
+
+/// Exercises every combination of INSERT (DoPut), SQL DELETE, and SQL UPDATE
+/// against Cayenne tables with a PRIMARY KEY.
+///
+/// Each scenario uses its own table so failures are independent.
+#[tokio::test]
+async fn test_cayenne_dml_comprehensive() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let mut h = CayenneTestHarness::new(&data_dir, &metadata_dir).await?;
+
+            // ---------------------------------------------------------------
+            // S1  Basic insert – two rows
+            // ---------------------------------------------------------------
+            h.create_table("s1").await?;
+            h.doput_and_assert(
+                "s1",
+                &[1, 2],
+                &["Alice", "Bob"],
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 1  | Alice |",
+                    "| 2  | Bob   |",
+                    "+----+-------+",
+                ],
+            )
+            .await?;
+
+            // ---------------------------------------------------------------
+            // S2  Upsert same PKs five times (extended cycle)
+            // ---------------------------------------------------------------
+            h.create_table("s2").await?;
+            for round in 1..=5u32 {
+                let name_a = format!("A{round}");
+                let name_b = format!("B{round}");
+                h.doput_and_assert(
+                    "s2",
+                    &[1, 2],
+                    &[&name_a, &name_b],
+                    &[
+                        "+----+------+",
+                        "| id | name |",
+                        "+----+------+",
+                        &format!("| 1  | {name_a:<4} |"),
+                        &format!("| 2  | {name_b:<4} |"),
+                        "+----+------+",
+                    ],
+                )
+                .await
+                .map_err(|e| format!("S2 round {round}: {e}"))?;
+            }
+
+            // ---------------------------------------------------------------
+            // S3  Upsert with partial PK overlap (some new, some existing)
+            // ---------------------------------------------------------------
+            h.create_table("s3").await?;
+            h.doput_and_assert("s3", &[1, 2], &["Alice", "Bob"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
+            ]).await?;
+            // Upsert ids 2,3 - id 2 updated, id 3 inserted
+            h.doput_and_assert("s3", &[2, 3], &["Bob2", "Carol"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob2  |", "| 3  | Carol |", "+----+-------+",
+            ]).await?;
+            // Upsert ids 1,3,4 - ids 1,3 updated, id 4 inserted
+            h.doput_and_assert("s3", &[1, 3, 4], &["Ax", "Cx", "Dave"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | Ax   |", "| 2  | Bob2 |", "| 3  | Cx   |", "| 4  | Dave |",
+                "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S4  Insert then DELETE one specific row
+            // ---------------------------------------------------------------
+            h.create_table("s4").await?;
+            h.doput_and_assert("s4", &[1, 2, 3], &["Alice", "Bob", "Carol"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob   |", "| 3  | Carol |", "+----+-------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s4 WHERE id = 2", "s4", &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 3  | Carol |", "+----+-------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S5  Insert then DELETE all rows
+            // ---------------------------------------------------------------
+            h.create_table("s5").await?;
+            h.doput_and_assert("s5", &[1, 2], &["Alice", "Bob"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s5", "s5", &[
+                "++", "++",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S6  Insert -> DELETE one row -> re-insert same PK with new value
+            // ---------------------------------------------------------------
+            h.create_table("s6").await?;
+            h.doput_and_assert("s6", &[1, 2], &["Alice", "Bob"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s6 WHERE id = 1", "s6", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 2  | Bob  |", "+----+------+",
+            ]).await?;
+            // Re-insert id=1 with different value
+            h.doput_and_assert("s6", &[1], &["Alice2"], &[
+                "+----+--------+", "| id | name   |", "+----+--------+",
+                "| 1  | Alice2 |", "| 2  | Bob    |", "+----+--------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S7  Insert -> SQL UPDATE one row
+            // ---------------------------------------------------------------
+            h.create_table("s7").await?;
+            h.doput_and_assert("s7", &[1, 2], &["Alice", "Bob"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "| 2  | Bob   |", "+----+-------+",
+            ]).await?;
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s7 SET name = 'Alice2' WHERE id = 1", "s7", &[
+                "+----+--------+", "| id | name   |", "+----+--------+",
+                "| 1  | Alice2 |", "| 2  | Bob    |", "+----+--------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S8  Insert -> UPDATE -> UPDATE again (chained updates)
+            // ---------------------------------------------------------------
+            h.create_table("s8").await?;
+            h.doput_and_assert("s8", &[1, 2], &["A", "B"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'X' WHERE id = 1", "s8", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | X    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'Y' WHERE id = 1", "s8", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | Y    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("UPDATE cyc.ns.s8 SET name = 'Z'", "s8", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | Z    |", "| 2  | Z    |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S9  Insert -> Upsert -> DELETE -> verify deletion post-upsert
+            // ---------------------------------------------------------------
+            h.create_table("s9").await?;
+            h.doput_and_assert("s9", &[1, 2], &["A", "B"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.doput_and_assert("s9", &[1, 2], &["A2", "B2"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A2   |", "| 2  | B2   |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s9 WHERE id = 1", "s9", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 2  | B2   |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S10  Interleaved: Insert 1,2 -> Upsert 1 -> Delete 2 -> Insert 3
+            // ---------------------------------------------------------------
+            h.create_table("s10").await?;
+            h.doput_and_assert("s10", &[1, 2], &["A", "B"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.doput_and_assert("s10", &[1], &["A2"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A2   |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s10 WHERE id = 2", "s10", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A2   |", "+----+------+",
+            ]).await?;
+            h.doput_and_assert("s10", &[3], &["C"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A2   |", "| 3  | C    |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S11  Upsert with NULL -> non-NULL -> back to NULL
+            // ---------------------------------------------------------------
+            h.create_table("s11").await?;
+            {
+                let schema = Arc::new(Schema::new(vec![
+                    Field::new("id", DataType::Int64, false),
+                    Field::new("name", DataType::Utf8View, true),
+                ]));
+                let batch = RecordBatch::try_new(schema, vec![
+                    Arc::new(Int64Array::from(vec![1])),
+                    Arc::new(StringViewArray::from(vec![None::<&str>])),
+                ]).map_err(|e| format!("batch: {e}"))?;
+                doput_to_table(&mut h.client, &["cyc", "ns", "s11"], batch).await?;
+                h.cayenne_provider().refresh().await.map_err(|e| e.to_string())?;
+            }
+            h.assert_query("s11", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  |      |", "+----+------+",
+            ]).await?;
+            h.doput_and_assert("s11", &[1], &["Alice"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | Alice |", "+----+-------+",
+            ]).await?;
+            {
+                let schema = Arc::new(Schema::new(vec![
+                    Field::new("id", DataType::Int64, false),
+                    Field::new("name", DataType::Utf8View, true),
+                ]));
+                let batch = RecordBatch::try_new(schema, vec![
+                    Arc::new(Int64Array::from(vec![1])),
+                    Arc::new(StringViewArray::from(vec![None::<&str>])),
+                ]).map_err(|e| format!("batch: {e}"))?;
+                doput_to_table(&mut h.client, &["cyc", "ns", "s11"], batch).await?;
+                h.cayenne_provider().refresh().await.map_err(|e| e.to_string())?;
+            }
+            h.assert_query("s11", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  |      |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S12  DELETE -> Upsert deleted PK -> verify re-appears
+            // ---------------------------------------------------------------
+            h.create_table("s12").await?;
+            h.doput_and_assert("s12", &[1, 2], &["A", "B"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s12 WHERE id = 1", "s12", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.doput_and_assert("s12", &[1], &["A_new"], &[
+                "+----+-------+", "| id | name  |", "+----+-------+",
+                "| 1  | A_new |", "| 2  | B     |", "+----+-------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S13  DELETE all -> Insert -> verify
+            // ---------------------------------------------------------------
+            h.create_table("s13").await?;
+            h.doput_and_assert("s13", &[1, 2], &["A", "B"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s13", "s13", &[
+                "++", "++",
+            ]).await?;
+            h.doput_and_assert("s13", &[10, 20], &["X", "Y"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 10 | X    |", "| 20 | Y    |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S14  Single-row table - multiple upserts (8 rounds)
+            // ---------------------------------------------------------------
+            h.create_table("s14").await?;
+            for round in 1..=8u32 {
+                let name = format!("v{round}");
+                h.doput_and_assert("s14", &[1], &[&name], &[
+                    "+----+------+", "| id | name |", "+----+------+",
+                    &format!("| 1  | {name:<4} |"), "+----+------+",
+                ]).await.map_err(|e| format!("S14 round {round}: {e}"))?;
+            }
+
+            // ---------------------------------------------------------------
+            // S15  Insert -> UPDATE -> DELETE updated row -> verify others
+            // ---------------------------------------------------------------
+            h.create_table("s15").await?;
+            h.doput_and_assert("s15", &[1, 2, 3], &["A", "B", "C"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "| 3  | C    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("UPDATE cyc.ns.s15 SET name = 'B2' WHERE id = 2", "s15", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B2   |", "| 3  | C    |", "+----+------+",
+            ]).await?;
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s15 WHERE id = 2", "s15", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 3  | C    |", "+----+------+",
+            ]).await?;
+
+            // ---------------------------------------------------------------
+            // S16  Rapid back-to-back upserts (10 rounds, no sleep)
+            // ---------------------------------------------------------------
+            h.create_table("s16").await?;
+            h.doput_and_assert("s16", &[1], &["v0"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | v0   |", "+----+------+",
+            ]).await?;
+            for round in 1..=10u32 {
+                let name = format!("v{round}");
+                h.doput_and_assert("s16", &[1], &[&name], &[
+                    "+----+------+", "| id | name |", "+----+------+",
+                    &format!("| 1  | {name:<4} |"), "+----+------+",
+                ]).await.map_err(|e| format!("S16 round {round}: {e}"))?;
+            }
+
+            // ---------------------------------------------------------------
+            // S17  Mix: DoPut inserts + DoPut upsert + SQL DELETE + SQL UPDATE
+            // ---------------------------------------------------------------
+            h.create_table("s17").await?;
+            h.doput_and_assert("s17", &[1, 2, 3, 4, 5], &["A", "B", "C", "D", "E"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B    |", "| 3  | C    |",
+                "| 4  | D    |", "| 5  | E    |", "+----+------+",
+            ]).await?;
+            // Upsert ids 2,4 (overlap) + insert id 6 (new)
+            h.doput_and_assert("s17", &[2, 4, 6], &["B2", "D2", "F"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B2   |", "| 3  | C    |",
+                "| 4  | D2   |", "| 5  | E    |", "| 6  | F    |", "+----+------+",
+            ]).await?;
+            // Delete ids 3,5
+            h.sql_mutate_and_assert("DELETE FROM cyc.ns.s17 WHERE id IN (3, 5)", "s17", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A    |", "| 2  | B2   |", "| 4  | D2   |",
+                "| 6  | F    |", "+----+------+",
+            ]).await?;
+            // Update remaining: set name = name || '!'
+            h.sql_mutate_and_assert(
+                "UPDATE cyc.ns.s17 SET name = concat(name, '!')", "s17", &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | A!   |", "| 2  | B2!  |", "| 4  | D2!  |",
+                "| 6  | F!   |", "+----+------+",
+            ]).await?;
+            // DoPut upsert + new: ids 1 (existing) and 7 (new)
+            h.doput_and_assert("s17", &[1, 7], &["AX", "G"], &[
+                "+----+------+", "| id | name |", "+----+------+",
+                "| 1  | AX   |", "| 2  | B2!  |", "| 4  | D2!  |",
+                "| 6  | F!   |", "| 7  | G    |", "+----+------+",
+            ]).await?;
+
+            Ok(())
+        })
+        .await
 }


### PR DESCRIPTION
## Summary

Fixes a bug where Cayenne tables with a `PRIMARY KEY` correctly handle the first DoPut upsert for a given key, but subsequent writes are silently lost — the table retains stale values from the previous write.

Fixes #9804

## Root Cause

Two contributing causes, both related to stale `CayenneTableProvider` references being used for queries after writes:

### 1. Plans cache holds stale provider references after writes

After a DoPut write modifies a Cayenne table's in-memory state (protected snapshots, deletion caches), the cached `LogicalPlan` entries in the plans cache still hold stale `Arc<dyn TableProvider>` references to the old provider state. Subsequent queries that hit the cache bypass catalog resolution entirely and use the stale provider, returning outdated data even though the underlying table was correctly mutated.

### 2. Catalog reload creates new providers that discard in-memory mutation state

When the Cayenne catalog is refreshed/reloaded (e.g. after a DoPut triggers a catalog refresh), new `CayenneTableProvider` instances are created from scratch from catalog metadata. The existing providers — which have accumulated up-to-date in-memory mutation state (protected snapshot ordering, deletion caches) from prior writes — are discarded and replaced. The newly created providers only reflect what is persisted in catalog metadata, so queries against them return stale data.

## Fix

### Plans cache invalidation

Invalidate plans cache entries for the affected table in all mutation paths:

1. **`write_data()` and `write_streaming_data()`** (DoPut path): invalidate after the insert completes
2. **SQL DML statements** (`INSERT INTO`, `DELETE FROM`, `UPDATE`): proactively invalidate when a DML logical plan is detected, before the physical plan executes

### In-place provider refresh on catalog reload

When refreshing the Cayenne catalog, instead of replacing providers wholesale, refresh existing `CayenneTableProvider` instances in place via a new `refresh_from()` method. This copies the freshly opened provider's listing table, snapshot ID, and protected snapshots into the existing provider's mutable state, preserving `Arc` identity so that any outstanding references (in cached plans, registered `SessionContext` tables, etc.) see the updated state. Schemas removed during a refresh have their tables cleared rather than leaked.

## Changes

### Commit 1: Invalidate plans cache after writes

- `crates/runtime/src/datafusion/mod.rs`: Plans cache invalidation after `write_data()` and `write_streaming_data()`
- `crates/runtime/src/datafusion/query.rs`: Proactive plans cache invalidation for SQL DML (`INSERT`/`DELETE`/`UPDATE`)
- `crates/runtime/tests/cayenne/mod.rs`: Regression tests (`test_cayenne_doput_upsert_cycle_stale`, `test_cayenne_dml_comprehensive`)

### Commit 2: Refresh provider state after catalog reload

- `crates/cayenne/src/provider/table.rs`: New `refresh_from()` method on `CayenneTableProvider` to update mutable state (listing table, snapshot ID, protected snapshots, deletion strategy) from a freshly opened provider
- `crates/runtime/src/catalogconnector/cayenne/provider.rs`: `CayenneCatalogProvider` and `CayenneSchemaProvider` refresh existing providers in place during catalog reload instead of replacing them; adds `clear_tables()` for removed schemas
- `crates/cayenne/tests/mutation_model_test.rs`: Model-based exhaustive mutation tests — bounded state-machine checks over all 3-step sequences of inserts/upserts/deletes for single-column PK, batch upserts, and composite PK tables, validating both live queries and reopened providers
- `crates/runtime/tests/cayenne/mod.rs`: Clippy/pedantic lint fixes

## Testing

- `test_cayenne_doput_upsert_cycle_stale` ✅ (previously failed on trunk)
- `test_cayenne_dml_comprehensive` (17 scenarios) ✅
- `test_exhaustive_int64_single_row_sequences` ✅ (343 sequences)
- `test_exhaustive_int64_batch_sequences` ✅ (343 sequences)
- `test_exhaustive_composite_single_row_sequences` ✅ (343 sequences)
- `test_cayenne_with_partitioned_tpch` ✅ (existing test, still passes)
- `make lint-rust` ✅