### PR TITLE
Fix Dockerfile: add `libclang-dev`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:${RUST_VERSION}-slim-bookworm as build
 USER root
 
 RUN apt update \
-    && apt install --yes pkg-config libssl-dev build-essential libsqlite3-dev cmake protobuf-compiler unixodbc-dev \
+    && apt install --yes pkg-config libssl-dev build-essential libsqlite3-dev cmake protobuf-compiler unixodbc-dev libclang-dev \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 COPY . /build


### PR DESCRIPTION
## 📝 Summary

Adds `libclang-dev` (needed by `custom-labels` crate)