### PR TITLE
Defer executor anonymous telemetry until scheduler config is available

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -23,6 +23,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::sync::SetOnce;
+
 use app::spicepod::component::runtime::{Runtime as SpicepodRuntime, TelemetryConfig};
 use app::{App, AppBuilder};
 use clap::{ArgAction, Parser};
@@ -362,7 +364,26 @@ pub async fn run(args: Args) -> Result<()> {
     let app_name = app.as_ref().map(|app| app.name.clone());
     let spicepod_tls_config = runtime_config.and_then(|rt| rt.tls.clone());
     let tracing_config = runtime_config.and_then(|rt| rt.tracing.clone());
-    let telemetry_config = runtime_config.map(|rt| rt.telemetry.clone());
+
+    // Anonymous telemetry is a function of two inputs: the CLI flag and the
+    // spicepod `runtime.telemetry` config.  For schedulers and standalone
+    // instances the config is available immediately from the local spicepod.
+    // Executors don't have a spicepod — they fetch the app definition from the
+    // scheduler after joining the cluster — so the config is resolved later.
+    // A `SetOnce` lets `start_anonymous_telemetry` wait for the value.
+    let telemetry_config: Arc<SetOnce<TelemetryConfig>> = Arc::new(SetOnce::new());
+
+    let is_executor = matches!(args.runtime.cluster.role, Some(ClusterRole::Executor))
+        || (args.runtime.cluster.role.is_none()
+            && args.runtime.cluster.scheduler_address.is_some());
+
+    if !is_executor {
+        // Resolve immediately from the local spicepod (or use default).
+        let config = runtime_config
+            .map(|rt| rt.telemetry.clone())
+            .unwrap_or_default();
+        let _ = telemetry_config.set(config);
+    }
 
     // Configure Flight `DoPut` rate limits from spicepod runtime.flight settings
     let flight_config = runtime_config.and_then(|rt| rt.flight.clone());
@@ -437,6 +458,10 @@ pub async fn run(args: Args) -> Result<()> {
         builder = builder.with_metrics_reader(reader.clone());
     }
 
+    if is_executor {
+        builder = builder.with_telemetry_config(Arc::clone(&telemetry_config));
+    }
+
     if args.pods_watcher_enabled && args.spicepod.is_none() {
         let pods_watcher = PodsWatcher::new(spicepod_path.clone());
         builder = builder.with_pods_watcher(pods_watcher);
@@ -509,7 +534,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     if let Some(ref metrics_registry) = prometheus_registry {
         let otel_config = telemetry_config
-            .as_ref()
+            .get()
             .and_then(|c| c.otel_exporter.as_ref())
             .filter(|c| c.enabled);
 
@@ -531,12 +556,12 @@ pub async fn run(args: Args) -> Result<()> {
         .context(UnableToInitializeTlsSnafu)?;
 
     let telemetry_enabled = args.telemetry_enabled;
-    let telemetry_config_clone = telemetry_config.clone();
+    let telemetry_config_clone = Arc::clone(&telemetry_config);
     let app_name_clone = app_name.clone();
     tokio::spawn(async move {
         start_anonymous_telemetry(
             telemetry_enabled,
-            telemetry_config_clone.as_ref(),
+            telemetry_config_clone,
             app_name_clone.as_ref(),
         )
         .await;
@@ -709,7 +734,7 @@ fn create_otel_reader(
 
 async fn start_anonymous_telemetry(
     telemetry_enabled: Option<bool>,
-    spicepod_telemetry_config: Option<&TelemetryConfig>,
+    telemetry_config: Arc<SetOnce<TelemetryConfig>>,
     spicepod_name: Option<&String>,
 ) {
     // Always log hardware info at debug level regardless of telemetry settings
@@ -719,27 +744,32 @@ async fn start_anonymous_telemetry(
         .unwrap_or_else(|_| telemetry::hardware::HardwareInfo::detect());
     hardware_info.log_debug();
 
-    let explicitly_disabled =
-        telemetry_enabled == Some(false) || spicepod_telemetry_config.is_some_and(|c| !c.enabled);
-
-    let telemetry_properties = match spicepod_telemetry_config {
-        Some(config) => config
-            .properties
-            .clone()
-            .into_iter()
-            .map(|(k, v)| KeyValue::new(k, v))
-            .collect(),
-        None => Vec::new(),
-    };
-
-    if !explicitly_disabled {
-        #[cfg(feature = "anonymous_telemetry")]
-        telemetry::anonymous::start(
-            spicepod_name.map_or_else(|| "unknown", String::as_str),
-            telemetry_properties,
-        )
-        .await;
+    // CLI flag takes immediate priority.
+    if telemetry_enabled == Some(false) {
+        return;
     }
+
+    // Wait for the spicepod telemetry config to be resolved.  For schedulers
+    // and standalone instances this is already set; for executors it will be
+    // set once the app definition is fetched from the scheduler.
+    let config = telemetry_config.wait().await;
+
+    if telemetry_enabled != Some(true) && !config.enabled {
+        return;
+    }
+
+    let telemetry_properties: Vec<KeyValue> = config
+        .properties
+        .iter()
+        .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+        .collect();
+
+    #[cfg(feature = "anonymous_telemetry")]
+    telemetry::anonymous::start(
+        spicepod_name.map_or_else(|| "unknown", String::as_str),
+        telemetry_properties,
+    )
+    .await;
 }
 
 fn parse_set_string(s: &str) -> Result<(String, String), String> {

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -40,6 +40,7 @@ use crate::{
 use app::App;
 use spicepod::component::runtime::Runtime as SpicepodRuntime;
 use spicepod::component::runtime::RuntimeReadyState as SpicepodRuntimeReadyState;
+use spicepod::component::runtime::TelemetryConfig;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
 use tokio::runtime::Handle;
@@ -65,6 +66,7 @@ pub struct RuntimeBuilder {
     token_provider_registry: Arc<TokenProviderRegistry>,
     runtime_config: Arc<Config>,
     resolved_cluster_config: Option<ResolvedClusterConfig>,
+    telemetry_config: Option<Arc<tokio::sync::SetOnce<TelemetryConfig>>>,
 }
 
 impl RuntimeBuilder {
@@ -86,6 +88,7 @@ impl RuntimeBuilder {
             token_provider_registry: Arc::new(TokenProviderRegistry::new()),
             runtime_config: Arc::new(Config::default()),
             resolved_cluster_config: None,
+            telemetry_config: None,
         }
     }
 
@@ -163,6 +166,17 @@ impl RuntimeBuilder {
         resolved_cluster_config: ResolvedClusterConfig,
     ) -> Self {
         self.resolved_cluster_config = Some(resolved_cluster_config);
+        self
+    }
+
+    /// Sets a `SetOnce` handle that will be resolved with the spicepod
+    /// `TelemetryConfig` once it is available.  For executors, this is set
+    /// after the app definition is fetched from the scheduler.
+    pub fn with_telemetry_config(
+        mut self,
+        telemetry_config: Arc<tokio::sync::SetOnce<TelemetryConfig>>,
+    ) -> Self {
+        self.telemetry_config = Some(telemetry_config);
         self
     }
 
@@ -373,6 +387,7 @@ impl RuntimeBuilder {
             distributed,
             resource_monitor,
             config: Arc::clone(&self.runtime_config),
+            telemetry_config: self.telemetry_config,
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1015,6 +1015,12 @@ pub async fn initialize_cluster_executor(
         .boxed()
         .context(FailedToStartClusterExecutorSnafu)?;
 
+    // Resolve the telemetry config from the scheduler's app definition so that
+    // `start_anonymous_telemetry` (which is waiting on this value) can proceed.
+    if let Some(ref telemetry_config) = rt.telemetry_config {
+        let _ = telemetry_config.set(app_def.runtime.telemetry.clone());
+    }
+
     // Get shuffle_location from app params; if set to a path (not "memory"), use it as work_dir
     // Otherwise fall back to temp_directory from query config or system temp dir
     // Note: shuffle_memory_mode and object store config is set via the scheduler's override_session_builder

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,6 +20,7 @@ use ::tools::rename::with_name;
 use async_stream::stream;
 use datafusion_expr::Expr;
 use init::scheduler::ScheduleRegistry;
+use spicepod::component::runtime::TelemetryConfig;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::future::Future;
@@ -506,6 +507,12 @@ pub struct Runtime {
     resource_monitor: resource_monitor::ResourceMonitor,
 
     config: Arc<Config>,
+
+    /// Handle for resolving the spicepod `TelemetryConfig` for anonymous
+    /// telemetry.  For executors this is set after the app definition is
+    /// fetched from the scheduler; for all other modes it is set before
+    /// the runtime starts.
+    telemetry_config: Option<Arc<tokio::sync::SetOnce<TelemetryConfig>>>,
 }
 
 impl Debug for Runtime {


### PR DESCRIPTION
## Problem

Executors don't have a local spicepod — they fetch the app definition (including `runtime.telemetry` config) from the scheduler after joining the cluster. Previously, anonymous telemetry was started before this fetch using `App::default()` which has `telemetry.enabled=true`, so executors always emitted telemetry regardless of the scheduler's setting.

## Solution

Introduce a `SetOnce<TelemetryConfig>` that `start_anonymous_telemetry` waits on:

- **Schedulers and standalone instances**: resolved immediately from the local spicepod.
- **Executors**: resolved in `initialize_cluster_executor` after the app definition is fetched from the scheduler.
- **CLI `--telemetry_enabled` flag**: takes immediate priority in either direction without waiting.

## Changes

- `bin/spiced/src/lib.rs`: Create a `SetOnce<TelemetryConfig>`, resolve it immediately for non-executors, and pass it through to both the telemetry task and the runtime builder. Refactor `start_anonymous_telemetry` to wait on the promise.
- `crates/runtime/src/builder.rs`: Add `telemetry_config: Option<Arc<SetOnce<TelemetryConfig>>>` field and builder method.
- `crates/runtime/src/lib.rs`: Add the `telemetry_config` field to the `Runtime` struct.
- `crates/runtime/src/cluster/mod.rs`: After fetching the app definition from the scheduler in `initialize_cluster_executor`, set the telemetry config on the `SetOnce` so the waiting telemetry task can proceed.