### PR TITLE
spidapter - set allow_http param when S3 endpoint uses http scheme

### DIFF
--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1228,6 +1228,9 @@ fn generate_hive_spicepod(
         ]);
         if let Some(endpoint) = &setup_config.endpoint {
             param_map.insert("s3_endpoint".to_string(), endpoint.clone());
+            if endpoint.starts_with("http://") {
+                param_map.insert("allow_http".to_string(), "true".to_string());
+            }
         }
 
         let mut dataset = Dataset::new(from, dataset_name.as_str());
@@ -1386,6 +1389,7 @@ mod tests {
         assert!(spicepod_yaml.contains("file_format: parquet"));
         assert!(spicepod_yaml.contains("s3_region: us-west-2"));
         assert!(spicepod_yaml.contains("s3_endpoint: \"http://localhost:9000\""));
+        assert!(spicepod_yaml.contains("allow_http: \"true\""));
         assert!(spicepod_yaml.contains("engine: cayenne"));
         assert!(spicepod_yaml.contains("mode: file"));
         assert!(spicepod_yaml.contains("refresh_mode: full"));


### PR DESCRIPTION
This pull request updates the `generate_hive_spicepod` function to improve support for HTTP S3 endpoints. Now, when the S3 endpoint uses the `http://` scheme, an additional configuration parameter is set to explicitly allow HTTP connections. The corresponding test is also updated to verify this new behavior.

Enhancements for S3 endpoint configuration:

* Updated `generate_hive_spicepod` in `stdio_server.rs` to insert an `allow_http` parameter with value `"true"` into the configuration map when the S3 endpoint starts with `http://`.

Test coverage improvements:

* Added a test assertion to ensure the generated configuration includes `allow_http: "true"` when the S3 endpoint uses HTTP.