### PR TITLE
Block accelerated and Cayenne catalog table queries in async distributed API

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -875,6 +875,25 @@ impl DataFusion {
             .contains(table_reference)
     }
 
+    /// Returns `true` if the given table reference resolves to a Cayenne-backed catalog.
+    #[must_use]
+    pub fn is_cayenne_catalog(&self, table_reference: &TableReference) -> bool {
+        let catalog_name = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+
+        #[cfg(not(windows))]
+        {
+            self.ctx
+                .catalog(catalog_name)
+                .is_some_and(|catalog| cayenne_ddl::is_cayenne_catalog(catalog.as_ref()))
+        }
+
+        #[cfg(windows)]
+        {
+            let _ = catalog_name;
+            false
+        }
+    }
+
     /// Returns the partition expression string for a table by querying the catalog provider.
     ///
     /// Delegates to the catalog provider's [`PartitionAwareCatalog`] implementation,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -131,6 +131,18 @@ pub enum Error {
 
     #[snafu(display("Failed to submit job to distributed scheduler: {message}"))]
     JobSubmissionFailed { message: String },
+
+    #[snafu(display(
+        "Querying locally accelerated dataset '{table}' via async queries API is not currently supported. \
+        Use the synchronous query API (/v1/sql or Flight SQL) instead."
+    ))]
+    AcceleratedTableNotSupportedInDistributedQuery { table: String },
+
+    #[snafu(display(
+        "Querying Cayenne catalog table '{table}' via async queries API is not currently supported. \
+        Use the synchronous query API (/v1/sql or Flight SQL) instead."
+    ))]
+    CayenneCatalogTableNotSupportedInDistributedQuery { table: String },
 }
 
 impl Error {
@@ -381,20 +393,26 @@ impl Query {
             span.record("runtime_query", true);
         }
 
-        // If any of the input tables are accelerated, mark the query as accelerated
-        let mut is_accelerated = false;
+        // Distributed execution doesn't currently support querying accelerated datasets
+        // or Cayenne catalog tables
         for tr in &input_tables {
             if self.df.is_accelerated(tr).await {
-                is_accelerated = true;
-                break;
+                return Err(Error::AcceleratedTableNotSupportedInDistributedQuery {
+                    table: tr.to_string(),
+                });
+            }
+            if self.df.is_cayenne_catalog(tr) {
+                return Err(Error::CayenneCatalogTableNotSupportedInDistributedQuery {
+                    table: tr.to_string(),
+                });
             }
         }
-        if is_accelerated {
-            tracker = tracker.map(|mut t| {
-                t.is_accelerated = Some(true);
-                t
-            });
-        }
+
+        // All tables verified non-accelerated above
+        tracker = tracker.map(|mut t| {
+            t.is_accelerated = Some(false);
+            t
+        });
 
         let datasets = Arc::new(input_tables);
         let tracker = tracker.map(|t| t.datasets(Arc::clone(&datasets)));

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -117,19 +117,15 @@ pub fn validate_sql_query_operations(
                     );
                 }
 
-                let target_catalog = dml
-                    .table_name
-                    .catalog()
-                    .unwrap_or(super::SPICE_DEFAULT_CATALOG);
-
-                if !df.is_catalog_writable(target_catalog) {
+                if !df.is_path_catalog_writable(&dml.table_name) {
                     return plan_err!(
                         "UPDATE operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
                         dml.table_name
                     );
                 }
 
-                if !is_cayenne_catalog(df, target_catalog) {
+                if !df.is_cayenne_catalog(&dml.table_name) {
+                    let target_catalog = dml.table_name.catalog().unwrap_or(super::SPICE_DEFAULT_CATALOG);
                     return plan_err!(
                         "UPDATE operations are only supported on writable Cayenne catalog tables. Table '{}', catalog '{}' is not Cayenne-backed.",
                         dml.table_name,
@@ -155,22 +151,6 @@ pub fn validate_sql_query_operations(
         _ => Ok(TreeNodeRecursion::Continue),
     })?;
     Ok(())
-}
-
-fn is_cayenne_catalog(df: &Arc<DataFusion>, catalog_name: &str) -> bool {
-    #[cfg(not(windows))]
-    {
-        df.ctx
-            .catalog(catalog_name)
-            .is_some_and(|catalog| super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref()))
-    }
-
-    #[cfg(windows)]
-    {
-        let _ = df;
-        let _ = catalog_name;
-        false
-    }
 }
 
 /// Validates DDL operations. DDL is only allowed on catalogs with `access: read_write_create`.

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -298,7 +298,10 @@ impl JobExecutor {
             Error::SessionCreationFailed { .. } | Error::JobSubmissionFailed { .. } => {
                 JobErrorCode::SubmissionFailed
             }
-            Error::UnableToExecuteQuery { .. } | Error::TableAccessDisallowed { .. } => {
+            Error::UnableToExecuteQuery { .. }
+            | Error::TableAccessDisallowed { .. }
+            | Error::AcceleratedTableNotSupportedInDistributedQuery { .. }
+            | Error::CayenneCatalogTableNotSupportedInDistributedQuery { .. } => {
                 JobErrorCode::ExecutionFailed
             }
             Error::BindingParameters { .. } => JobErrorCode::ParameterBindingFailed,


### PR DESCRIPTION
## 📝 Summary

Queries against locally accelerated datasets and Cayenne catalog tables cannot be executed via the async distributed query API (`v1/queries`) because their physical plans are not serializable by Ballista and their data is local to the scheduler node.

This PR detects these unsupported queries before Ballista submission and returns clear errors directing users to the synchronous API (`/v1/sql` or Flight SQL).

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/9832

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
