### PR TITLE
fix: update wait_timeout for Databricks SQL Statements API to 50s

### DIFF
--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -252,6 +252,8 @@ impl SqlWarehouseApi {
         let sql = format!(
             "SELECT column_name, full_data_type, is_nullable FROM information_schema.columns WHERE table_name = '{escaped_table}' AND table_schema = '{escaped_schema}' AND table_catalog = '{escaped_catalog}'"
         );
+        // Databricks SQL Statements API max wait_timeout is 50s.
+        // https://docs.databricks.com/api/workspace/statementexecution/executestatement
         Ok(json!({
             "warehouse_id": self.sql_warehouse_id,
             "catalog": table_catalog,
@@ -259,7 +261,7 @@ impl SqlWarehouseApi {
             "statement": sql,
             "format": "JSON_ARRAY",
             "disposition": "INLINE",
-            "wait_timeout": "5m",
+            "wait_timeout": "50s",
             "on_wait_timeout": "CONTINUE",
         }))
     }
@@ -651,7 +653,7 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
             "warehouse_id": self.api.sql_warehouse_id,
             "format": "ARROW_STREAM",
             "disposition": "EXTERNAL_LINKS",
-            "wait_timeout": "5m",
+            "wait_timeout": "50s",
             "on_wait_timeout": "CONTINUE",
             "statement": query,
         });
@@ -720,7 +722,7 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
             "warehouse_id": self.api.sql_warehouse_id,
             "format": "ARROW_STREAM",
             "disposition": "EXTERNAL_LINKS",
-            "wait_timeout": "5m",
+            "wait_timeout": "50s",
             "on_wait_timeout": "CONTINUE",
             "statement": sql,
         });
@@ -1073,7 +1075,7 @@ mod tests {
 
         assert_eq!(payload["format"], "JSON_ARRAY");
         assert_eq!(payload["disposition"], "INLINE");
-        assert_eq!(payload["wait_timeout"], "5m");
+        assert_eq!(payload["wait_timeout"], "50s");
         assert_eq!(payload["on_wait_timeout"], "CONTINUE");
         assert_eq!(payload["warehouse_id"], "warehouse-123");
         assert!(


### PR DESCRIPTION
This pull request updates the Databricks SQL Statements API integration to use the correct maximum wait timeout value. The timeout is reduced from 5 minutes to 50 seconds in all relevant API calls, aligning with Databricks documentation and ensuring proper request handling.

API timeout adjustment:

* Changed the `wait_timeout` parameter from `"5m"` to `"50s"` in the SQL statement payload construction within `SqlWarehouseApi` to comply with Databricks API limits.
* Updated the `wait_timeout` from `"5m"` to `"50s"` in two places within the `AsyncDbConnection` implementation for `SqlWarehouseC` to ensure consistent timeout behavior across query executions. [[1]](diffhunk://#diff-fb3288d03f83e2558ff91c1d17874f82e587f0045f0949743e60e06578b485a2L654-R656) [[2]](diffhunk://#diff-fb3288d03f83e2558ff91c1d17874f82e587f0045f0949743e60e06578b485a2L723-R725)

Test updates:

* Modified the test assertions to expect `"50s"` for the `wait_timeout` parameter, reflecting the new API limit.