### PR TITLE
refactor: make CommitChange trait async, remove block_in_place from DynamoDB

### DIFF
--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -22,6 +22,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
 };
 use arrow_buffer::OffsetBuffer;
+use async_trait::async_trait;
 use futures::stream::BoxStream;
 use snafu::prelude::*;
 
@@ -79,12 +80,13 @@ impl std::fmt::Display for StreamError {
 }
 
 /// Allows to commit a change that has been processed.
+#[async_trait]
 pub trait CommitChange {
-    fn commit(&self) -> Result<(), CommitError>;
+    async fn commit(&self) -> Result<(), CommitError>;
 }
 
 pub struct ChangeEnvelope {
-    change_committer: Box<dyn CommitChange + Send>,
+    change_committer: Box<dyn CommitChange + Send + Sync>,
     pub change_batch: ChangeBatch,
     is_dataset_ready: bool,
 }
@@ -92,7 +94,7 @@ pub struct ChangeEnvelope {
 impl ChangeEnvelope {
     #[must_use]
     pub fn new(
-        change_committer: Box<dyn CommitChange + Send>,
+        change_committer: Box<dyn CommitChange + Send + Sync>,
         change_batch: ChangeBatch,
         is_dataset_ready: bool,
     ) -> Self {
@@ -103,12 +105,12 @@ impl ChangeEnvelope {
         }
     }
 
-    pub fn commit(self) -> Result<(), CommitError> {
-        self.change_committer.commit()
+    pub async fn commit(self) -> Result<(), CommitError> {
+        self.change_committer.commit().await
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (Box<dyn CommitChange + Send>, ChangeBatch, bool) {
+    pub fn into_parts(self) -> (Box<dyn CommitChange + Send + Sync>, ChangeBatch, bool) {
         (
             self.change_committer,
             self.change_batch,
@@ -118,7 +120,7 @@ impl ChangeEnvelope {
 
     #[must_use]
     pub fn from_parts(
-        change_committer: Box<dyn CommitChange + Send>,
+        change_committer: Box<dyn CommitChange + Send + Sync>,
         change_batch: ChangeBatch,
         is_dataset_ready: bool,
     ) -> Self {

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -498,8 +498,9 @@ impl<'a, K, V> KafkaMessage<'a, K, V> {
     }
 }
 
-impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
-    fn commit(&self) -> Result<(), CommitError> {
+#[async_trait]
+impl<K: Sync, V: Sync> CommitChange for KafkaMessage<'_, K, V> {
+    async fn commit(&self) -> Result<(), CommitError> {
         self.mark_processed()
             .boxed()
             .map_err(|e| cdc::CommitError::UnableToCommitChange { source: e })?;
@@ -540,8 +541,9 @@ impl MessageBatchCommitter {
     }
 }
 
+#[async_trait]
 impl CommitChange for MessageBatchCommitter {
-    fn commit(&self) -> Result<(), CommitError> {
+    async fn commit(&self) -> Result<(), CommitError> {
         for (topic, partition, offset) in &self.offsets {
             self.consumer
                 .store_offset(topic, *partition, *offset)

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -105,7 +105,7 @@ impl RefreshTask {
                                     .await;
                             }
 
-                            if let Err(e) = change_envelope.commit()
+                            if let Err(e) = change_envelope.commit().await
                                 && !self.runtime_status.is_shutdown()
                             {
                                 tracing::error!("Failed to commit CDC change envelope: {e}");

--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -82,8 +82,9 @@ mod tests {
 
     struct MockCommitChange;
 
+    #[async_trait]
     impl CommitChange for MockCommitChange {
-        fn commit(&self) -> Result<(), CommitError> {
+        async fn commit(&self) -> Result<(), CommitError> {
             Ok(())
         }
     }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -621,7 +621,7 @@ async fn create_bootstrap_stream(
 
                     let committer =
                         DynamoDBStreamCommitter::new(dynamodb_sys_cloned, checkpoint_cloned);
-                    if let Err(err) = committer.commit() {
+                    if let Err(err) = committer.commit().await {
                         tracing::error!(error = ?err, "Failed to commit initialization lag");
                     }
 
@@ -959,7 +959,7 @@ async fn do_rebootstrap(
 
     // 4. Commit the checkpoint
     let committer = DynamoDBStreamCommitter::new(Arc::clone(dynamodb_sys), new_checkpoint.clone());
-    if let Err(e) = committer.commit() {
+    if let Err(e) = committer.commit().await {
         tracing::error!(
             dataset = %dataset_name,
             error = ?e,
@@ -1106,8 +1106,9 @@ impl MetricsProvider for DynamoDBMetricsProvider {
 }
 
 struct NoOpCommitter;
+#[async_trait]
 impl CommitChange for NoOpCommitter {
-    fn commit(&self) -> Result<(), CommitError> {
+    async fn commit(&self) -> Result<(), CommitError> {
         Ok(())
     }
 }
@@ -1127,8 +1128,9 @@ impl DynamoDBStreamCommitter {
     }
 }
 
+#[async_trait]
 impl CommitChange for DynamoDBStreamCommitter {
-    fn commit(&self) -> Result<(), CommitError> {
+    async fn commit(&self) -> Result<(), CommitError> {
         tracing::trace!(checkpoint = ?self.checkpoint, "Committing DynamoDB lag");
 
         let checkpoint_json = serde_json::to_string(&self.checkpoint).map_err(|e| {
@@ -1143,14 +1145,10 @@ impl CommitChange for DynamoDBStreamCommitter {
         };
 
         match self.dynamodb_sys.as_ref() {
-            Some(dynamodb_sys) => tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    dynamodb_sys.upsert(&metadata).await.map_err(|e| {
-                        CommitError::UnableToCommitChange {
-                            source: Box::new(e),
-                        }
-                    })
-                })
+            Some(dynamodb_sys) => dynamodb_sys.upsert(&metadata).await.map_err(|e| {
+                CommitError::UnableToCommitChange {
+                    source: Box::new(e),
+                }
             }),
             None => Ok(()),
         }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -443,8 +443,9 @@ pub fn subscribe_to_append_stream(
 
 pub struct SpiceAIChangeCommiter {}
 
+#[async_trait]
 impl CommitChange for SpiceAIChangeCommiter {
-    fn commit(&self) -> Result<(), CommitError> {
+    async fn commit(&self) -> Result<(), CommitError> {
         // Noop
         Ok(())
     }


### PR DESCRIPTION
## Changes

Make the CommitChange trait async, removing block_in_place from DynamoDBStreamCommitter.

### Why

block_in_place is a workaround for bad architecture. The DynamoDBStreamCommitter was using block_in_place + Handle::block_on to call an async upsert from a sync trait method, even though all callers are in async contexts. Making the trait async removes this workaround.

### What changed

- crates/data_components/src/cdc.rs: Added async_trait to CommitChange trait, changed commit() to async. Updated ChangeEnvelope to use Send + Sync bounds.
- crates/data_components/src/kafka.rs: Updated KafkaMessage and MessageBatchCommitter impls to async.
- crates/runtime/src/dataconnector/dynamodb.rs: Removed block_in_place from DynamoDBStreamCommitter, now directly awaiting the async upsert. Updated NoOpCommitter. Added .await at two call sites.
- crates/runtime/src/dataconnector/spiceai.rs: Updated SpiceAIChangeCommiter to async.
- crates/runtime/src/accelerated_table/refresh_task/changes.rs: Added .await to commit() call.
- crates/runtime/src/changes/mod.rs: Updated MockCommitChange in tests.
