### PR TITLE
Add Turso query overrides for TPC-H benchmarks

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -58,6 +58,7 @@ on:
           - 'postgres-catalog'
           - 'mysql-catalog'
           - 'mssql-catalog'
+          - 'turso'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -609,6 +609,7 @@ pub enum QueryOverrides {
     Spicecloud,
     DynamoDB,
     Arrow,
+    Turso,
 }
 
 impl QueryOverrides {
@@ -624,6 +625,7 @@ impl QueryOverrides {
             "duckdb" => Some(Self::DuckDB),
             "dynamodb" => Some(Self::DynamoDB),
             "arrow" => Some(Self::Arrow),
+            "turso" => Some(Self::Turso),
             _ => None,
         }
     }
@@ -896,6 +898,17 @@ pub fn get_tpch_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
             20, // Physical plan does not support logical expression ScalarSubquery(<subquery>); https://github.com/spiceai/spiceai/issues/8384
             21  // Binder Error; https://github.com/spiceai/spiceai/issues/8384
         ),
+        Some(QueryOverrides::Turso) => {
+            let mut queries: Vec<Query> = remove_tpch_query!(
+                queries,
+                2, // Correlated scalar subquery not supported; DF limitation, Turso tests are not cross-table federated
+                6, // Rewritten: explicit BETWEEN 0.05 AND 0.07 to avoid libSQL float arithmetic precision issue; https://github.com/spiceai/spiceai/issues/9872
+                17, // Correlated scalar subquery not supported
+                20  // Correlated scalar subquery not supported
+            );
+            queries.extend(generate_tpch_queries_override!("turso", q6));
+            queries
+        }
         _ => queries,
     }
 }

--- a/crates/test-framework/src/queries/tpch/turso/q6.sql
+++ b/crates/test-framework/src/queries/tpch/turso/q6.sql
@@ -1,0 +1,11 @@
+select
+    sum(l_extendedprice * l_discount) as revenue
+from
+    lineitem
+where
+        l_shipdate >= date '1994-01-01'
+  and l_shipdate < date '1995-01-01'
+  -- `between 0.06 - 0.01 and 0.06 + 0.01` rewritten as explicit values to avoid float arithmetic precision issue
+  -- https://github.com/spiceai/spiceai/issues/9872
+  and l_discount between 0.05 and 0.07
+  and l_quantity < 24;

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-cayenne[file]turso.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-cayenne[file]turso.yaml
@@ -2,14 +2,17 @@ tests:
   bench:
     spicepod_path: accelerated/file[parquet]-cayenne[file]turso.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     validate_results: true
   throughput:
     spicepod_path: accelerated/file[parquet]-cayenne[file]turso.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-large-runners
   load:
     spicepod_path: accelerated/file[parquet]-cayenne[file]turso.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-large-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[file].yaml
@@ -3,16 +3,19 @@ tests:
   # bench:
   #   spicepod_path: accelerated/file[parquet]-turso[file].yaml
   #   query_set: tpch
+  #   query_overrides: turso
   #   runner_type: spiceai-dev-runners
   #   ready_wait: 600
   #   validate_results: true
   throughput:
     spicepod_path: accelerated/file[parquet]-turso[file].yaml
+    query_overrides: turso
     query_set: tpch
     runner_type: spiceai-dev-runners
     ready_wait: 600
   load:
     spicepod_path: accelerated/file[parquet]-turso[file].yaml
+    query_overrides: turso
     query_set: tpch
     runner_type: spiceai-dev-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[memory].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[memory].yaml
@@ -3,17 +3,20 @@ tests:
   # bench:
   #   spicepod_path: accelerated/file[parquet]-turso[memory].yaml
   #   query_set: tpch
+  #   query_overrides: turso
   #   runner_type: spiceai-dev-runners
   #   ready_wait: 900
   #   validate_results: true
   throughput:
     spicepod_path: accelerated/file[parquet]-turso[memory].yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     ready_wait: 900
   load:
     spicepod_path: accelerated/file[parquet]-turso[memory].yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     duration: 28800
     ready_wait: 900

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-turso[file]-indexes.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-turso[file]-indexes.yaml
@@ -2,15 +2,18 @@ tests:
   bench:
     spicepod_path: accelerated/indexes/file[parquet]-turso[file]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     ready_wait: 600
     validate_results: true
   throughput:
     spicepod_path: accelerated/indexes/file[parquet]-turso[file]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
   load:
     spicepod_path: accelerated/indexes/file[parquet]-turso[file]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-turso[memory]-indexes.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-turso[memory]-indexes.yaml
@@ -2,15 +2,18 @@ tests:
   bench:
     spicepod_path: accelerated/indexes/file[parquet]-turso[memory]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     ready_wait: 600
     validate_results: true
   throughput:
     spicepod_path: accelerated/indexes/file[parquet]-turso[memory]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
   load:
     spicepod_path: accelerated/indexes/file[parquet]-turso[memory]-indexes.yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-turso[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-turso[file].yaml
@@ -2,17 +2,20 @@ tests:
   bench:
     spicepod_path: accelerated/s3[parquet]-turso[file].yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-runners
     validate_results: true
     ready_wait: 900
   throughput:
     spicepod_path: accelerated/s3[parquet]-turso[file].yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-large-runners
     ready_wait: 900
   load:
     spicepod_path: accelerated/s3[parquet]-turso[file].yaml
     query_set: tpch
+    query_overrides: turso
     runner_type: spiceai-dev-large-runners
     duration: 28800
     ready_wait: 900

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -173,6 +173,8 @@ pub enum QueryOverridesArg {
     DynamoDB,
     #[serde(rename = "arrow")]
     Arrow,
+    #[serde(rename = "turso")]
+    Turso,
 }
 
 impl From<QuerySetArg> for QuerySet {
@@ -285,6 +287,7 @@ impl From<QueryOverridesArg> for QueryOverrides {
             QueryOverridesArg::PostgresCatalog => QueryOverrides::PostgresCatalog,
             QueryOverridesArg::MysqlCatalog => QueryOverrides::MysqlCatalog,
             QueryOverridesArg::MsSqlCatalog => QueryOverrides::MSSqlCatalog,
+            QueryOverridesArg::Turso => QueryOverrides::Turso,
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

Adds `QueryOverrides::Turso` to the test framework and configures Turso TPC-H benchmark dispatches to use it.

### Changes

- Add `Turso` variant to `QueryOverrides` enum and `from_engine()` mapping
- Remove TPC-H queries unsupported by Turso: q2, q17, q20 (correlated scalar subqueries) and q6 (float precision)
- Add Turso-specific q6 override with explicit `BETWEEN 0.05 AND 0.07` to avoid libSQL float arithmetic precision issue (#9872)
- Add `turso` to `query_overrides` options in benchmark CI workflow
- Add `query_overrides: turso` to all Turso dispatch configs

## 🔗 Related

Part of 
- https://github.com/spiceai/spiceai/issues/8764

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
