### PR TITLE
Enable Turso TPCH benchmark (file[parquet]-turso[file]) in CI

### DIFF
--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -902,9 +902,14 @@ pub fn get_tpch_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
             let mut queries: Vec<Query> = remove_tpch_query!(
                 queries,
                 2, // Correlated scalar subquery not supported; DF limitation, Turso tests are not cross-table federated
+                4, // Federation fails for cross-provider subquery filters; https://github.com/spiceai/spiceai/issues/9879
                 6, // Rewritten: explicit BETWEEN 0.05 AND 0.07 to avoid libSQL float arithmetic precision issue; https://github.com/spiceai/spiceai/issues/9872
+                16, // Federation fails for cross-provider subquery filters; https://github.com/spiceai/spiceai/issues/9879
                 17, // Correlated scalar subquery not supported
-                20  // Correlated scalar subquery not supported
+                18, // Federation fails for cross-provider subquery filters; https://github.com/spiceai/spiceai/issues/9879
+                20, // Correlated scalar subquery not supported
+                21, // Federation fails for cross-provider subquery filters; https://github.com/spiceai/spiceai/issues/9879
+                22 // Federation fails for cross-provider subquery filters; https://github.com/spiceai/spiceai/issues/9879
             );
             queries.extend(generate_tpch_queries_override!("turso", q6));
             queries

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-turso[file].yaml
@@ -1,12 +1,11 @@
 tests:
-  # https://github.com/spiceai/spiceai/issues/8764
-  # bench:
-  #   spicepod_path: accelerated/file[parquet]-turso[file].yaml
-  #   query_set: tpch
-  #   query_overrides: turso
-  #   runner_type: spiceai-dev-runners
-  #   ready_wait: 600
-  #   validate_results: true
+  bench:
+    spicepod_path: accelerated/file[parquet]-turso[file].yaml
+    query_set: tpch
+    query_overrides: turso
+    runner_type: spiceai-dev-runners
+    ready_wait: 600
+    validate_results: true
   throughput:
     spicepod_path: accelerated/file[parquet]-turso[file].yaml
     query_overrides: turso


### PR DESCRIPTION
## 📝 Summary

Enables Turso accelerator TPCH benchmark tests in CI, excluding queries that depend on cross-provider subquery federation (q4, q16, q18, q21, q22) which is tracked in https://github.com/spiceai/spiceai/issues/9879.

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/8764

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
