### PR TITLE
fix: Update Cayenne too many open files error

### DIFF
--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -138,6 +138,9 @@ pub enum Error {
     #[snafu(display("Internal error in table '{table}': {message}"))]
     Internal { table: String, message: String },
 
+    #[snafu(display("Unable to open Cayenne acceleration file ({file_path}). Too many Cayenne acceleration files are open. Try increasing your system's maximum open file count, or increase the size of generated Cayenne files with the parameter \"cayenne_target_file_size_mb\". For more details, visit: https://spiceai.org/docs/components/data-accelerators/cayenne#params"))]
+    TooManyOpenFiles { file_path: String },
+
     /// A previous write was interrupted, leaving the table in a potentially
     /// inconsistent state. The staging WAL file must be resolved before the
     /// table can be used.

--- a/crates/cayenne/src/provider/scan.rs
+++ b/crates/cayenne/src/provider/scan.rs
@@ -19,9 +19,12 @@ use std::{any::Any, sync::Arc};
 use arrow_schema::SchemaRef;
 use datafusion::config::ConfigOptions;
 use datafusion::error::Result;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_common::{DataFusionError, Statistics};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_physical_expr::{Distribution, OrderingRequirements, PhysicalExpr};
+use futures::TryStreamExt;
+
 use datafusion_physical_plan::{
     execution_plan::{check_default_invariants, CardinalityEffect, InvariantLevel},
     expressions::PhysicalSortExpr,
@@ -147,7 +150,30 @@ impl ExecutionPlan for CayenneAccelerationExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> datafusion::error::Result<SendableRecordBatchStream> {
-        self.inner.execute(partition, context)
+        let stream = self.inner.execute(partition, context)?;
+        let schema = stream.schema();
+        let mapped = stream.map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("Too many open files") {
+                // Extract the file path from messages like "Unable to open file /path/to/file.vortex: Too many ..."
+                let file_path = msg
+                    .find("Unable to open file ")
+                    .and_then(|start| {
+                        let after = &msg[start + "Unable to open file ".len()..];
+                        after.find(':').map(|end| &after[..end])
+                    })
+                    .unwrap_or("unknown");
+                DataFusionError::External(Box::new(super::Error::Internal {
+                    table: String::new(),
+                    message: format!(
+                        "Unable to open Cayenne acceleration file ({file_path}). Too many Cayenne acceleration files are open. Try increasing your system's maximum open file count, or increase the size of generated Cayenne files with the parameter \"cayenne_target_file_size_mb\". For more details, visit: https://spiceai.org/docs/components/data-accelerators/cayenne#params"
+                    ),
+                }))
+            } else {
+                e
+            }
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, mapped)))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/crates/cayenne/src/provider/scan.rs
+++ b/crates/cayenne/src/provider/scan.rs
@@ -163,11 +163,8 @@ impl ExecutionPlan for CayenneAccelerationExec {
                         after.find(':').map(|end| &after[..end])
                     })
                     .unwrap_or("unknown");
-                DataFusionError::External(Box::new(super::Error::Internal {
-                    table: String::new(),
-                    message: format!(
-                        "Unable to open Cayenne acceleration file ({file_path}). Too many Cayenne acceleration files are open. Try increasing your system's maximum open file count, or increase the size of generated Cayenne files with the parameter \"cayenne_target_file_size_mb\". For more details, visit: https://spiceai.org/docs/components/data-accelerators/cayenne#params"
-                    ),
+                DataFusionError::External(Box::new(super::Error::TooManyOpenFiles {
+                    file_path: file_path.to_string(),
                 }))
             } else {
                 e


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Wraps the errors from streams in Cayenne scans, and converts errors about too many open files into a more helpful error message about increasing system open file count limits or increasing the cayenne target file size parameter.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #8818
* Closes #8894

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
