### PR TITLE
feat: emit `scheduler_active_executors_count` and use it in spidapter

### DIFF
--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -474,6 +474,7 @@ impl ClusterService for ClusterServiceImpl {
         let executor_registry = Arc::clone(&self.executor_registry);
         let datafusion = Arc::clone(&self.datafusion);
         let outbound_tx_for_registry = outbound_tx.clone();
+        let metrics_node_id = self.advertise_address.clone();
         let inbound_task = tokio::spawn(async move {
             let executor_id = match inbound.next().await {
                 Some(Ok(msg)) => {
@@ -504,6 +505,10 @@ impl ClusterService for ClusterServiceImpl {
             let pending_requests = executor_registry
                 .register(executor_id.clone(), outbound_tx_for_registry)
                 .await;
+
+            // Update active executor count metric.
+            let count = executor_registry.connected_executors().await.len();
+            crate::metrics::cluster::set_active_executor_count(&metrics_node_id, count as u64);
 
             // Register the executor stream for PollNow broadcasts.
             executor_streams.register(&executor_id, registration_tx);
@@ -554,6 +559,10 @@ impl ClusterService for ClusterServiceImpl {
 
             // Unregister the executor when the stream ends.
             executor_registry.unregister(&executor_id).await;
+
+            // Update active executor count metric.
+            let count = executor_registry.connected_executors().await.len();
+            crate::metrics::cluster::set_active_executor_count(&metrics_node_id, count as u64);
 
             // Unregister the executor stream.
             executor_streams.unregister(&executor_id);

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -312,11 +312,18 @@ pub struct IngestionMetrics {
     pub bytes_ingested: Option<u64>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClusterMetrics {
+    pub active_executors_count: Option<u64>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MetricsResponse {
     pub metrics: BTreeMap<String, PodMetrics>,
     #[serde(default)]
     pub ingestion: Option<IngestionMetrics>,
+    #[serde(default)]
+    pub cluster: Option<ClusterMetrics>,
 }
 
 // ============================================================================

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -681,18 +681,21 @@ async fn provision_spice_cloud_app(
     )
     .await?;
 
-    // after the deployment is reported "ready", wait for another 10 seconds (or SPIDAPTER_DEPLOYMENT_READY_WAIT seconds if set)
-    // not all executors may be connected yet. executors should know to create missing tables when they join: https://github.com/spiceai/spiceai/issues/9848
-    let deployment_ready_wait = std::env::var("SPIDAPTER_DEPLOYMENT_READY_WAIT")
+    // Wait for executors to connect before declaring the deployment ready.
+    // Executors should know to create missing tables when they join: https://github.com/spiceai/spiceai/issues/9848
+    let expected_executors: u64 = std::env::var("SPIDAPTER_NUM_EXECUTORS")
         .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(10);
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
 
-    eprintln!(
-        "[stdio] Deployment is ready, waiting an additional {deployment_ready_wait}s for executors to connect..."
+    let executor_wait_timeout = Duration::from_secs(
+        std::env::var("SPIDAPTER_DEPLOYMENT_READY_WAIT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(120),
     );
 
-    tokio::time::sleep(Duration::from_secs(deployment_ready_wait)).await;
+    wait_for_scp_executor_count(&cloud, app_id, expected_executors, executor_wait_timeout).await;
 
     eprintln!("[stdio] Spice Cloud deployment ready for app '{app_name}' at {flight_url}");
 
@@ -1232,6 +1235,49 @@ async fn wait_for_local_sql_ready(
             Ok(response) if response.status().is_success() => return Ok(()),
             Ok(_) | Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
         }
+    }
+}
+
+/// Polls the Spice Cloud metrics API until the expected number of executors have connected,
+/// or the timeout expires. On timeout, logs a warning and returns (non-fatal).
+async fn wait_for_scp_executor_count(
+    cloud: &CloudClient,
+    app_id: i64,
+    expected_count: u64,
+    timeout: Duration,
+) {
+    eprintln!(
+        "[stdio] Deployment is ready, waiting up to {}s for {expected_count} executor(s) to connect...",
+        timeout.as_secs(),
+    );
+
+    let started = tokio::time::Instant::now();
+
+    loop {
+        if started.elapsed() > timeout {
+            eprintln!(
+                "[stdio] Timed out after {}s waiting for {expected_count} executor(s); proceeding anyway",
+                timeout.as_secs(),
+            );
+            return;
+        }
+
+        match cloud.get_app_metrics(app_id, None).await {
+            Ok(metrics) => {
+                if let Some(cluster) = &metrics.cluster
+                    && let Some(count) = cluster.active_executors_count
+                    && count >= expected_count
+                {
+                    eprintln!("[stdio] {count}/{expected_count} executor(s) connected");
+                    return;
+                }
+            }
+            Err(e) => {
+                eprintln!("[stdio] Metrics poll error (retrying): {e}");
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
     }
 }
 

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -683,19 +683,23 @@ async fn provision_spice_cloud_app(
 
     // Wait for executors to connect before declaring the deployment ready.
     // Executors should know to create missing tables when they join: https://github.com/spiceai/spiceai/issues/9848
-    let expected_executors: u64 = std::env::var("SPIDAPTER_NUM_EXECUTORS")
+    let _expected_executors: u64 = std::env::var("SPIDAPTER_NUM_EXECUTORS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1);
 
-    let executor_wait_timeout = Duration::from_secs(
-        std::env::var("SPIDAPTER_DEPLOYMENT_READY_WAIT")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(120),
-    );
+    let executor_wait_timeout = std::env::var("SPIDAPTER_DEPLOYMENT_READY_WAIT")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(120);
 
-    wait_for_scp_executor_count(&cloud, app_id, expected_executors, executor_wait_timeout).await;
+    // after the deployment is reported "ready", wait for another 10 seconds (or SPIDAPTER_DEPLOYMENT_READY_WAIT seconds if set)
+    // not all executors may be connected yet. executors should know to create missing tables when they join: https://github.com/spiceai/spiceai/issues/9848
+    eprintln!(
+        "[stdio] Deployment is ready, waiting an additional {executor_wait_timeout}s for executors to connect..."
+    );
+    tokio::time::sleep(Duration::from_secs(executor_wait_timeout)).await;
+    // wait_for_scp_executor_count(&cloud, app_id, expected_executors, Duration::from_secs(executor_wait_timeout)).await;
 
     eprintln!("[stdio] Spice Cloud deployment ready for app '{app_name}' at {flight_url}");
 
@@ -1240,6 +1244,7 @@ async fn wait_for_local_sql_ready(
 
 /// Polls the Spice Cloud metrics API until the expected number of executors have connected,
 /// or the timeout expires. On timeout, logs a warning and returns (non-fatal).
+#[expect(dead_code)]
 async fn wait_for_scp_executor_count(
     cloud: &CloudClient,
     app_id: i64,


### PR DESCRIPTION
## Summary
- Properly emit `scheduler_active_executors_count` from the scheduler.
- In spidapter, wait for `scheduler_active_executors_count`  to be correct after deployment.