### PR TITLE
fix: require all executors to succeed for distributed DML (DELETE/UPDATE) forwarding

### DIFF
--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -141,19 +141,13 @@ fn arrow_datatype_to_sql(dt: &DataType) -> DFResult<String> {
 /// connected executor must succeed. Transient failures are retried up to
 /// `MAX_DML_RETRIES` times with an exponential back-off before the operation
 /// is considered failed.
-async fn forward_ddl_to_executors(
-    executor_registry: &ExecutorRegistry,
-    sql: &str,
-) -> DFResult<()> {
+async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
     forward_to_executors(executor_registry, sql, false).await
 }
 
 /// Forward a DML statement to all connected executors, requiring every
 /// executor to succeed (with retries for transient failures).
-async fn forward_dml_to_executors(
-    executor_registry: &ExecutorRegistry,
-    sql: &str,
-) -> DFResult<()> {
+async fn forward_dml_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
     forward_to_executors(executor_registry, sql, true).await
 }
 
@@ -180,7 +174,6 @@ async fn forward_to_executors(
             let client = client.clone();
             let sql = sql.to_string();
             let executor_id = executor_id.clone();
-            let require_all = require_all;
             async move {
                 let max_attempts = if require_all { MAX_DML_RETRIES + 1 } else { 1 };
                 let mut last_err: Option<String> = None;
@@ -274,7 +267,7 @@ async fn forward_to_executors(
     Ok(())
 }
 
-/// Send a single SQL statement to one executor via FlightSQL execute + do_get.
+/// Send a single SQL statement to one executor via `FlightSQL` execute + `do_get`.
 async fn forward_sql_to_executor(
     mut client: data_components::flightsql::FlightSqlClient,
     sql: &str,

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -125,28 +125,16 @@ fn arrow_datatype_to_sql(dt: &DataType) -> DFResult<String> {
     }
 }
 
-/// Forwards a DDL SQL statement to connected executor nodes.
+/// Forward a DDL statement (CREATE/DROP TABLE) to all connected executors.
 ///
-/// Iterates over [`ExecutorRegistry::flight_sql_clients`] and sends the SQL
-/// via `FlightSqlClient::execute`, then drains returned endpoints with `do_get`
-/// so the statement is actually executed on the remote executor.
-///
-/// Returns an error when at least one executor was targeted but all forwards failed.
-/// Forward a SQL statement to all connected executors.
-///
-/// When `require_all` is `false` (DDL operations like CREATE/DROP TABLE), the
-/// function succeeds as long as at least one executor processes the statement.
-///
-/// When `require_all` is `true` (DML operations like DELETE/UPDATE), **every**
-/// connected executor must succeed. Transient failures are retried up to
-/// `MAX_DML_RETRIES` times with an exponential back-off before the operation
-/// is considered failed.
+/// Succeeds as long as at least one executor processes the statement.
+/// DDL is idempotent and self-heals via periodic catalog refresh.
 async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
     forward_to_executors(executor_registry, sql, false).await
 }
 
-/// Forward a DML statement to all connected executors, requiring every
-/// executor to succeed (with retries for transient failures).
+/// Forward a DML statement (DELETE/UPDATE) to all connected executors,
+/// requiring every executor to succeed (with retries for transient failures).
 async fn forward_dml_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
     forward_to_executors(executor_registry, sql, true).await
 }
@@ -154,6 +142,12 @@ async fn forward_dml_to_executors(executor_registry: &ExecutorRegistry, sql: &st
 /// Maximum number of retry attempts for DML forwarding per executor.
 const MAX_DML_RETRIES: u32 = 3;
 
+/// Forward a SQL statement to all connected executors.
+///
+/// When `require_all` is `false`, succeeds if at least one executor processes
+/// the statement. When `true`, **every** executor must succeed; transient
+/// failures are retried up to [`MAX_DML_RETRIES`] times with exponential
+/// back-off.
 async fn forward_to_executors(
     executor_registry: &ExecutorRegistry,
     sql: &str,

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -132,7 +132,39 @@ fn arrow_datatype_to_sql(dt: &DataType) -> DFResult<String> {
 /// so the statement is actually executed on the remote executor.
 ///
 /// Returns an error when at least one executor was targeted but all forwards failed.
-async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &str) -> DFResult<()> {
+/// Forward a SQL statement to all connected executors.
+///
+/// When `require_all` is `false` (DDL operations like CREATE/DROP TABLE), the
+/// function succeeds as long as at least one executor processes the statement.
+///
+/// When `require_all` is `true` (DML operations like DELETE/UPDATE), **every**
+/// connected executor must succeed. Transient failures are retried up to
+/// `MAX_DML_RETRIES` times with an exponential back-off before the operation
+/// is considered failed.
+async fn forward_ddl_to_executors(
+    executor_registry: &ExecutorRegistry,
+    sql: &str,
+) -> DFResult<()> {
+    forward_to_executors(executor_registry, sql, false).await
+}
+
+/// Forward a DML statement to all connected executors, requiring every
+/// executor to succeed (with retries for transient failures).
+async fn forward_dml_to_executors(
+    executor_registry: &ExecutorRegistry,
+    sql: &str,
+) -> DFResult<()> {
+    forward_to_executors(executor_registry, sql, true).await
+}
+
+/// Maximum number of retry attempts for DML forwarding per executor.
+const MAX_DML_RETRIES: u32 = 3;
+
+async fn forward_to_executors(
+    executor_registry: &ExecutorRegistry,
+    sql: &str,
+    require_all: bool,
+) -> DFResult<()> {
     let clients = executor_registry.flight_sql_clients.read().await;
     if clients.is_empty() {
         tracing::debug!(
@@ -145,44 +177,61 @@ async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &st
     let futures: Vec<_> = clients
         .iter()
         .map(|(executor_id, client)| {
-            let mut client = client.clone();
+            let client = client.clone();
             let sql = sql.to_string();
             let executor_id = executor_id.clone();
+            let require_all = require_all;
             async move {
-                use futures::StreamExt;
+                let max_attempts = if require_all { MAX_DML_RETRIES + 1 } else { 1 };
+                let mut last_err: Option<String> = None;
 
-                let result: Result<(), String> = async {
-                    let flight_info = client
-                        .execute(sql.clone(), None)
-                        .await
-                        .map_err(|e| e.to_string())?;
+                for attempt in 0..max_attempts {
+                    if attempt > 0 {
+                        let backoff = std::time::Duration::from_millis(100 * 2u64.pow(attempt - 1));
+                        tracing::debug!(
+                            executor_id,
+                            attempt,
+                            backoff_ms = backoff.as_millis(),
+                            "Retrying DML forward to executor"
+                        );
+                        tokio::time::sleep(backoff).await;
+                    }
 
-                    for endpoint in flight_info.endpoint {
-                        let Some(ticket) = endpoint.ticket else {
-                            continue;
-                        };
-
-                        let mut stream =
-                            client.do_get(ticket).await.map_err(|e| e.to_string())?;
-                        while let Some(batch) = stream.next().await {
-                            batch.map_err(|e| e.to_string())?;
+                    let result = forward_sql_to_executor(client.clone(), &sql).await;
+                    match result {
+                        Ok(()) => {
+                            if attempt > 0 {
+                                tracing::info!(
+                                    executor_id,
+                                    attempt,
+                                    sql,
+                                    "DML forwarded to executor after retry"
+                                );
+                            } else {
+                                tracing::debug!(
+                                    executor_id,
+                                    sql,
+                                    "Forwarded Cayenne DDL/DML to executor"
+                                );
+                            }
+                            return (executor_id, Ok(()));
+                        }
+                        Err(e) => {
+                            last_err = Some(e);
                         }
                     }
-
-                    Ok(())
-                }
-                .await;
-
-                match &result {
-                    Ok(()) => {
-                        tracing::debug!(executor_id, sql, "Forwarded Cayenne DDL to executor");
-                    }
-                    Err(e) => {
-                        tracing::warn!(executor_id, sql, error = %e, "Failed to forward Cayenne DDL to executor");
-                    }
                 }
 
-                result.is_ok()
+                let err_msg = last_err.unwrap_or_else(|| "unknown error".to_string());
+                tracing::warn!(
+                    executor_id,
+                    sql,
+                    error = %err_msg,
+                    attempts = max_attempts,
+                    require_all,
+                    "Failed to forward Cayenne DDL/DML to executor"
+                );
+                (executor_id, Err(err_msg))
             }
         })
         .collect();
@@ -191,12 +240,61 @@ async fn forward_ddl_to_executors(executor_registry: &ExecutorRegistry, sql: &st
     drop(clients);
 
     let results = futures::future::join_all(futures).await;
-    let success_count = results.iter().filter(|&&ok| ok).count();
+    let total = results.len();
+    let mut failed_executors: Vec<(String, String)> = Vec::new();
+    let mut success_count = 0usize;
 
-    if success_count == 0 && !results.is_empty() {
+    for (executor_id, result) in results {
+        match result {
+            Ok(()) => success_count += 1,
+            Err(e) => failed_executors.push((executor_id, e)),
+        }
+    }
+
+    if require_all && !failed_executors.is_empty() {
+        let executor_errors: Vec<String> = failed_executors
+            .iter()
+            .map(|(id, e)| format!("{id}: {e}"))
+            .collect();
+        return Err(DataFusionError::Execution(format!(
+            "DML forwarding failed on {}/{} executor(s): [{}]. SQL: {}",
+            failed_executors.len(),
+            total,
+            executor_errors.join("; "),
+            sql
+        )));
+    }
+
+    if success_count == 0 && total > 0 {
         return Err(DataFusionError::Execution(format!(
             "Failed to forward Cayenne DDL to any executor: {sql}"
         )));
+    }
+
+    Ok(())
+}
+
+/// Send a single SQL statement to one executor via FlightSQL execute + do_get.
+async fn forward_sql_to_executor(
+    mut client: data_components::flightsql::FlightSqlClient,
+    sql: &str,
+) -> Result<(), String> {
+    use futures::StreamExt;
+
+    let flight_info = client
+        .execute(sql.to_string(), None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    for endpoint in flight_info.endpoint {
+        let Some(ticket) = endpoint.ticket else {
+            continue;
+        };
+
+        let mut stream = client.do_get(ticket).await.map_err(|e| e.to_string())?;
+        while let Some(batch) = stream.next().await {
+            batch.map_err(|e| e.to_string())?;
+        }
     }
 
     Ok(())
@@ -1111,7 +1209,7 @@ impl ExecutionPlan for DistributedCayenneDeleteExec {
             if let Some(ref filter) = filter_sql {
                 let _ = write!(sql, " WHERE {filter}");
             }
-            forward_ddl_to_executors(registry, &sql).await?;
+            forward_dml_to_executors(registry, &sql).await?;
 
             RecordBatch::try_new(
                 result_schema,
@@ -1247,7 +1345,7 @@ impl ExecutionPlan for DistributedCayenneUpdateExec {
                 if let Some(ref filter) = filter_sql {
                     let _ = write!(sql, " WHERE {filter}");
                 }
-                forward_ddl_to_executors(registry, &sql).await?;
+                forward_dml_to_executors(registry, &sql).await?;
             }
 
             RecordBatch::try_new(


### PR DESCRIPTION
## Problem

The `forward_ddl_to_executors` function was used for both DDL (CREATE/DROP TABLE) and DML (DELETE/UPDATE) operations in distributed Cayenne mode. Its error handling returned `Ok` as long as **at least one** executor succeeded:

```rust
if success_count == 0 && !results.is_empty() {
    return Err(...);
}
Ok(())
```

This is correct for DDL where any executor having the schema is sufficient, but **incorrect for DML** where every executor holds a partition of the data and all must execute the operation for correctness.

When an executor fails to process a forwarded DELETE or UPDATE (e.g., due to transient gRPC timeout under load), rows on that executor remain unmodified while the operation reports success. This causes silent data loss/corruption in distributed mutable workloads.

## Root Cause Verification

| Test | Executors | Result |
|------|-----------|--------|
| SF0.5, 50% updates + 50% deletes (before fix) | 4 | ❌ Checkpoint 0 timeout — customer +1,635 extra rows |
| SF0.5 (before fix) | 1 | ✅ Both checkpoints converge |
| SF0.5 (after fix) | 4 | ✅ Both checkpoints converge |

## Changes

- **`forward_dml_to_executors`** (new): Requires **all** executors to succeed, with up to 3 retries per executor using exponential backoff for transient failures
- **`forward_sql_to_executor`** (new): Extracted helper for sending SQL to a single executor via FlightSQL
- **`DistributedCayenneDeleteExec`**: Now uses `forward_dml_to_executors`
- **`DistributedCayenneUpdateExec`**: Now uses `forward_dml_to_executors`
- **`forward_ddl_to_executors`**: Unchanged — retains lenient any-executor-success behavior for CREATE/DROP TABLE

## Testing

Validated with SpiceBench mutable TPC-H benchmark:
- **SF0.5**, 50% update ratio, 50% delete ratio, 4 executors, `--validate-results`
- Both checkpoint 0 and checkpoint 1 converge successfully
- All 21 TPC-H queries pass
- Benchmark outcome: **success**