### PR TITLE
fix(cayenne catalog): fix catalog refresh race condition causing duplicate primary keys in Cayenne

### DIFF
--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -71,6 +71,7 @@ use datafusion_expr::Expr;
 use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
 use futures::StreamExt;
 use std::sync::{Arc, RwLock};
+use tokio::sync::Mutex as TokioMutex;
 
 // Position-based deletion methods implemented in sink/position_based.rs
 mod position_based;
@@ -102,6 +103,10 @@ pub struct CayenneDeletionSink {
     protected_snapshot_tables: Vec<Arc<ListingTable>>,
     /// Shared `RuntimeEnv` for S3 object store access.
     runtime_env: Arc<RuntimeEnv>,
+    /// Shared write lock to prevent concurrent writes/refreshes from racing with deletions.
+    /// `None` when the caller already holds the write lock (e.g. retention filters applied
+    /// during `write_all_append`).
+    write_lock: Option<Arc<TokioMutex<()>>>,
 }
 
 impl CayenneDeletionSink {
@@ -118,6 +123,7 @@ impl CayenneDeletionSink {
         pk_column_indices: Vec<usize>,
         protected_snapshot_tables: Vec<Arc<ListingTable>>,
         runtime_env: Arc<RuntimeEnv>,
+        write_lock: Option<Arc<TokioMutex<()>>>,
     ) -> Self {
         Self {
             table_metadata,
@@ -130,6 +136,7 @@ impl CayenneDeletionSink {
             pk_column_indices,
             protected_snapshot_tables,
             runtime_env,
+            write_lock,
         }
     }
 
@@ -770,6 +777,14 @@ impl CayenneDeletionSink {
 #[async_trait]
 impl DeletionSink for CayenneDeletionSink {
     async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        // Acquire write lock (if provided) to prevent racing with concurrent inserts or catalog refreshes.
+        // When called from within write_all_append (e.g. retention filters), the caller already
+        // holds the lock, so write_lock is None to avoid deadlocking the non-reentrant mutex.
+        let _write_guard = match &self.write_lock {
+            Some(lock) => Some(lock.lock().await),
+            None => None,
+        };
+
         let ctx = SessionContext::new_with_config_rt(
             SessionConfig::default(),
             Arc::clone(&self.runtime_env),

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -48,6 +48,7 @@ use datafusion_expr::Expr;
 use object_store::{ObjectMeta, ObjectStore};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use tokio::sync::Mutex as TokioMutex;
 
 /// Result from file-based deletion, including metadata for post-delete cleanup.
 #[derive(Debug)]
@@ -106,6 +107,8 @@ pub struct FileBasedDeletionSink {
     table_path: String,
     /// Shared runtime environment for cache invalidation after file deletion.
     runtime_env: Arc<RuntimeEnv>,
+    /// Shared write lock to prevent concurrent writes/refreshes from racing with deletions.
+    write_lock: Arc<TokioMutex<()>>,
 }
 
 impl FileBasedDeletionSink {
@@ -134,6 +137,7 @@ impl FileBasedDeletionSink {
         table_id: String,
         table_path: String,
         runtime_env: Arc<RuntimeEnv>,
+        write_lock: Arc<TokioMutex<()>>,
     ) -> Self {
         Self {
             listing_table,
@@ -145,6 +149,7 @@ impl FileBasedDeletionSink {
             table_id,
             table_path,
             runtime_env,
+            write_lock,
         }
     }
 
@@ -402,6 +407,9 @@ impl FileBasedDeletionSink {
 #[async_trait]
 impl DeletionSink for FileBasedDeletionSink {
     async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        // Acquire write lock to prevent racing with concurrent inserts or catalog refreshes.
+        let _write_guard = self.write_lock.lock().await;
+
         let result = self.delete_from_internal().await?;
 
         // Invalidate the list-files cache for snapshot directories where

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2701,6 +2701,7 @@ impl CayenneTableProvider {
             self.pk_column_indices.clone(),
             Vec::new(), // Retention filters don't need to scan protected snapshots
             Arc::clone(self.context.runtime_env()),
+            None, // Already under write_lock from write_all_append
         );
 
         let deleted_count =
@@ -2937,16 +2938,23 @@ impl CayenneTableProvider {
         Ok(())
     }
 
-    /// Refresh in-memory query state from a freshly opened provider for the same table.
+    /// Refresh in-memory query state by reloading from the catalog (source of truth).
     ///
     /// This keeps existing `Arc<CayenneTableProvider>` handles usable after catalog refreshes
     /// by updating mutable state in place instead of swapping provider objects.
     ///
+    /// Acquires the write lock to prevent racing with in-progress writes/deletes. While holding
+    /// the lock, reloads deletion vectors, protected snapshots, and the listing table
+    /// directly from the catalog — NOT from the `source` provider, which may contain
+    /// stale state captured before the lock was acquired.
+    ///
+    /// The `source` parameter is used to validate that the table ID matches.
+    ///
     /// # Errors
     ///
     /// Returns an error if `source` refers to a different table (mismatched table IDs)
-    /// or if updating internal deletion/listing state fails.
-    pub fn refresh_from(&self, source: &Self) -> Result<()> {
+    /// or if reloading from the catalog fails.
+    pub async fn refresh(&self, source: &Self) -> Result<()> {
         if self.table_metadata.table_id != source.table_metadata.table_id {
             return Err(Error::Internal {
                 table: self.table_metadata.table_name.clone(),
@@ -2957,46 +2965,37 @@ impl CayenneTableProvider {
             });
         }
 
-        self.pk_deletion_strategy.refresh_from(
-            &source.pk_deletion_strategy,
-            &self.table_metadata.table_name,
-        )?;
+        // Acquire the write lock so no insert/delete is in-flight while we reload state.
+        let _write_guard = self.write_lock.lock().await;
 
-        let refreshed_listing_table = {
-            let guard = source
-                .listing_table
-                .read()
-                .map_err(|_| Error::LockPoisoned {
-                    table: self.table_metadata.table_name.clone(),
-                    lock: LISTING_TABLE_LOCK_POISONED,
-                })?;
-            Arc::clone(&guard)
-        };
+        // Reload deletion vectors from the catalog (SQLite) — the source of truth.
+        // This picks up any deletions committed by writes that completed after the
+        // source provider was opened.
+        let fresh_strategy = Self::load_deletion_vectors_all(
+            &self.table_metadata.table_id,
+            Arc::clone(&self.catalog),
+            self.pk_deletion_strategy.strategy(),
+        )
+        .await
+        .map_err(|e| Error::Internal {
+            table: self.table_metadata.table_name.clone(),
+            message: format!("Failed to reload deletion vectors during refresh: {e}"),
+        })?;
 
-        {
-            let mut guard = self
-                .listing_table
-                .write()
-                .map_err(|_| Error::LockPoisoned {
-                    table: self.table_metadata.table_name.clone(),
-                    lock: LISTING_TABLE_LOCK_POISONED,
-                })?;
-            *guard = refreshed_listing_table;
-        }
+        self.pk_deletion_strategy
+            .refresh_from(&fresh_strategy, &self.table_metadata.table_name)?;
 
-        let refreshed_snapshot_id = source.get_current_snapshot_id()?;
-        self.update_current_snapshot_id(&refreshed_snapshot_id)?;
-
-        let refreshed_protected_snapshots = {
-            let guard = source
-                .protected_snapshots
-                .read()
-                .map_err(|_| Error::LockPoisoned {
-                    table: self.table_metadata.table_name.clone(),
-                    lock: PROTECTED_SNAPSHOTS_LOCK_POISONED,
-                })?;
-            guard.clone()
-        };
+        // Reload protected snapshots from the catalog.
+        let fresh_protected_snapshots = Self::load_protected_snapshots(
+            Arc::clone(&self.catalog),
+            &self.table_metadata.table_id,
+            &self.pk_deletion_strategy,
+        )
+        .await
+        .map_err(|e| Error::Internal {
+            table: self.table_metadata.table_name.clone(),
+            message: format!("Failed to reload protected snapshots during refresh: {e}"),
+        })?;
 
         {
             let mut guard = self
@@ -3006,11 +3005,25 @@ impl CayenneTableProvider {
                     table: self.table_metadata.table_name.clone(),
                     lock: PROTECTED_SNAPSHOTS_LOCK_POISONED,
                 })?;
-            *guard = refreshed_protected_snapshots;
+            *guard = fresh_protected_snapshots;
         }
+
+        // Reload the current snapshot ID from the catalog.
+        let fresh_metadata = self
+            .catalog
+            .get_table(&self.table_metadata.table_name)
+            .await
+            .map_err(|e| Error::Internal {
+                table: self.table_metadata.table_name.clone(),
+                message: format!("Failed to reload table metadata during refresh: {e}"),
+            })?;
+        self.update_current_snapshot_id(&fresh_metadata.current_snapshot_id)?;
+
+        // Rebuild the listing table from the fresh snapshot ID on disk.
+        self.refresh_listing_table()?;
 
         tracing::debug!(
-            "Refreshed in-memory state for table {} from freshly opened provider",
+            "Refreshed in-memory state for table {} from catalog",
             self.table_metadata.table_name
         );
 
@@ -4140,6 +4153,7 @@ impl CayenneTableProvider {
                 self.table_metadata.table_id.clone(),
                 self.table_metadata.path.clone(),
                 Arc::clone(self.context.runtime_env()),
+                Arc::clone(&self.write_lock),
             )),
             &self.table_metadata.schema,
         )))
@@ -4168,6 +4182,7 @@ impl CayenneTableProvider {
                 self.pk_column_indices.clone(),
                 snapshot_tables,
                 Arc::clone(self.context.runtime_env()),
+                Some(Arc::clone(&self.write_lock)),
             )),
             &self.table_metadata.schema,
         )))

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -343,7 +343,9 @@ impl RefreshableCatalogProvider for CayenneCatalogProvider {
                     .as_any()
                     .downcast_ref::<CayenneSchemaProvider>()
             {
-                existing_cayenne_schema.refresh_from(&refreshed_schema);
+                existing_cayenne_schema
+                    .refresh_from(&refreshed_schema)
+                    .await;
                 new_schemas.insert(ns.clone(), Arc::clone(existing_schema));
             } else {
                 new_schemas.insert(ns.clone(), Arc::new(refreshed_schema));
@@ -471,7 +473,7 @@ impl CayenneSchemaProvider {
         }
     }
 
-    fn refresh_from(&self, source: &Self) {
+    async fn refresh_from(&self, source: &Self) {
         let existing_tables = self.tables_snapshot();
         let refreshed_tables = source.tables_snapshot();
         let mut merged_tables = HashMap::with_capacity(refreshed_tables.len());
@@ -479,7 +481,9 @@ impl CayenneSchemaProvider {
         for (table_name, refreshed_provider) in refreshed_tables {
             let provider_to_use = if let Some(existing_provider) = existing_tables.get(&table_name)
             {
-                if Self::refresh_table_provider_in_place(existing_provider, &refreshed_provider) {
+                if Self::refresh_table_provider_in_place(existing_provider, &refreshed_provider)
+                    .await
+                {
                     Arc::clone(existing_provider)
                 } else {
                     refreshed_provider
@@ -494,7 +498,7 @@ impl CayenneSchemaProvider {
         self.replace_tables(merged_tables);
     }
 
-    fn refresh_table_provider_in_place(
+    async fn refresh_table_provider_in_place(
         existing_provider: &Arc<dyn TableProvider>,
         refreshed_provider: &Arc<dyn TableProvider>,
     ) -> bool {
@@ -505,7 +509,7 @@ impl CayenneSchemaProvider {
             return false;
         };
 
-        if let Err(err) = existing_cayenne.refresh_from(refreshed_cayenne) {
+        if let Err(err) = existing_cayenne.refresh(refreshed_cayenne).await {
             tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
             return false;
         }


### PR DESCRIPTION
## 📝 Summary

Fixes a race condition where periodic catalog refresh overwrites in-memory state committed by concurrent writes, causing duplicate primary key rows.

## Root Cause

`refresh_from()` opened a fresh ephemeral provider *before* acquiring the write lock, then copied its state over the live provider. Writes completing between the ephemeral provider open and the state copy had their committed state (protected snapshots, deletion caches, listing table) silently overwritten — making newly inserted rows invisible to subsequent `on_conflict` deduplication checks.

## Fix

- **`CayenneTableProvider::refresh_from()` → `refresh()`**: Acquires the write lock *first*, then reloads all mutable state (deletion vectors, protected snapshots, snapshot ID, listing table) directly from the catalog (SQLite) — the source of truth — instead of copying from a potentially stale ephemeral provider.
- **Deletion sinks acquire write lock**: `CayenneDeletionSink` and `FileBasedDeletionSink` now accept and acquire the shared write lock to prevent racing with concurrent inserts or refreshes. When called from within `write_all_append` (retention filters), the lock is `None` to avoid deadlocking.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

```
T=25.037  Write A: acquires write_lock, starts write_all_append for bench/lineitem
T=25.371  Write A: load_existing_keyset → existing_keys=1,176,979
T=25.373  Write A: validate_on_conflict → on_conflict_deletions=0 (pure insert, 14,015 rows)

          ┌─────────────────────────────────────────────────────────────────┐
T=25.399  │ CONCURRENT: Refresh opens new ephemeral CayenneTableProvider   │
T=25.411  │ Ephemeral provider loads: 169,553 key-based DVs,              │
          │   110,228 insert-records, 100 protected snapshots             │
          │   (snapshot 5bd3 DOES NOT EXIST YET — Write A still in-flight)│
          └─────────────────────────────────────────────────────────────────┘

T=25.412  Write A: insert to NEW snapshot 5bd3 completes (14,015 rows persisted)
T=25.412  Write A: catalog.set_snapshot_sequence("5bd3") ← written to SQLite
T=25.412  Write A: self.protected_snapshots.insert("5bd3") ← in-memory on LIVE provider
T=25.417  Write A: refresh_listing_table, release write_lock ✓

T=25.428  ⚠️ refresh_from() OVERWRITES live provider with STALE ephemeral state:
            → snapshot_id reset to 019d1bc8-d97e…9d5f68964b0d (pre-Write-A)
            → protected_snapshots: 100 entries (5bd3 MISSING)
            → deletion caches: stale (from T=25.411)
            → listing_table: stale (doesn't include 5bd3's files)

T=25.783  Write B: acquires write_lock (using the NOW-STALE provider)
T=26.160  Write B: load_existing_keyset → existing_keys=1,176,979 ← SAME as Write A
          ⇒ Snapshot 5bd3's 14,015 rows are INVISIBLE → duplicates inserted

T=27.077  Write C: existing_keys=1,191,039 (recovery begins, but damage already done)
```

Raw logs from the same executor

```
2026-03-23T17:43:25.037117Z DEBUG runtime::flight::do_put: Starting writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:25.037222Z  INFO cayenne::provider::sink: write_all: started, acquiring write lock table=bench/lineitem operation="append"
2026-03-23T17:43:25.037233Z  INFO cayenne::provider::sink: write_all: write lock acquired table=bench/lineitem operation="append"
2026-03-23T17:43:25.037240Z  INFO cayenne::provider::sink: write_all_append: started table=bench/lineitem
2026-03-23T17:43:25.037367Z DEBUG cayenne::provider::sink: Table bench/lineitem has pending PK-based deletions, will write to new snapshot
2026-03-23T17:43:25.371791Z  INFO cayenne::provider::table: prepare_stream_for_insert: loaded existing keyset table=bench/lineitem existing_keys=1176979
2026-03-23T17:43:25.373967Z  INFO cayenne::provider::table: validate_on_conflict: completed table=bench/lineitem existing_keys=1176979 incoming_keys=14015 on_conflict_deletions=0 delete_specs_files=0
2026-03-23T17:43:25.394196Z DEBUG cayenne::provider::sink: write_all_append: delete_specs=0 files, deleted_pk_i64=0 keys, pending_deletions=true, on_conflict_deletions=false
2026-03-23T17:43:25.394205Z  INFO cayenne::provider::table: apply_on_conflict_deletions: started table=bench/lineitem delete_specs_files=0 deleted_pk_i64=0 deleted_row_keys=0 total_deletions=0


---- Refresh started
2026-03-23T17:43:25.399053Z DEBUG cayenne::provider::delete::vector_io: detect_deletion_type_and_read: processing 51 delete files
2026-03-23T17:43:25.399075Z DEBUG cayenne::provider::delete::vector_io: detect_deletion_type_and_read: reading file "/Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d5f68964b0d/deletions/delete_019d1bc8-f8c5-7572-8311-16ec80a7799f.arrow"
...
2026-03-23T17:43:25.411261Z DEBUG cayenne::provider::delete::vector_io: Loaded 0 position-based deletions across 0 files + 169553 key-based deleted rows from 51 deletion vector files
2026-03-23T17:43:25.411277Z DEBUG cayenne::provider::table: Cached deletion vectors for table_id 019d1bc8-d97e-7162-86f1-9d4b9877357d: 169553 key-based, 110228 key-insert
2026-03-23T17:43:25.411382Z DEBUG cayenne::provider::table: Loaded 100 protected snapshot(s) for table_id 019d1bc8-d97e-7162-86f1-9d4b9877357d
-- Replacement table load completed

-- New snapshot insert started for current table that will be replaced with above
2026-03-23T17:43:25.412363Z DEBUG cayenne::provider::table: Insert to new snapshot 019d1bcb-5bd3-7da1-aa88-c700222e9bbd completed, wrote 14015 rows to Vortex in 1 chunk(s)
2026-03-23T17:43:25.416756Z DEBUG cayenne::provider::table: Invalidated list-files cache for /Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d4b9877357d/019d1bc8-d97e-7162-86f1-9d5f68964b0d/

2026-03-23T17:43:25.416937Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:25.416960Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:25.416965Z  INFO cayenne::provider::sink: write_all_append: completed table=bench/lineitem total_rows=14015
2026-03-23T17:43:25.416969Z  INFO cayenne::provider::sink: write_all: completed successfully table=bench/lineitem operation="append" rows=14015
2026-03-23T17:43:25.416996Z DEBUG runtime::flight::do_put: Write operation completed successfully for dataset: spicebench.bench.lineitem
2026-03-23T17:43:25.417002Z DEBUG runtime::flight::do_put: Finished writing data into dataset: spicebench.bench.lineitem


2026-03-23T17:43:25.428826Z DEBUG cayenne::provider::table: Updated current snapshot ID for table bench/lineitem to 019d1bc8-d97e-7162-86f1-9d5f68964b0d
2026-03-23T17:43:25.428834Z DEBUG cayenne::provider::table: Refreshed in-memory state for table bench/lineitem from freshly opened provider

-- New DoPut (upsert)

2026-03-23T17:43:25.780743Z DEBUG runtime::flight::session: Flight SQL session lookup: ID=spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a, existing_sessions=1
2026-03-23T17:43:25.782836Z DEBUG runtime::flight::session: Using existing Flight SQL session: spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a
2026-03-23T17:43:25.782884Z DEBUG runtime::flight::do_put: Allowing unauthenticated DoPut on executor in mTLS scheduler-trusted mode
2026-03-23T17:43:25.782910Z DEBUG runtime::flight::do_put: Starting writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:25.783013Z  INFO cayenne::provider::sink: write_all: started, acquiring write lock table=bench/lineitem operation="append"
2026-03-23T17:43:25.783039Z  INFO cayenne::provider::sink: write_all: write lock acquired table=bench/lineitem operation="append"
2026-03-23T17:43:25.783046Z  INFO cayenne::provider::sink: write_all_append: started table=bench/lineitem
2026-03-23T17:43:25.783622Z DEBUG cayenne::provider::sink: Table bench/lineitem has pending PK-based deletions, will write to new snapshot
2026-03-23T17:43:26.160180Z  INFO cayenne::provider::table: prepare_stream_for_insert: loaded existing keyset table=bench/lineitem existing_keys=1176979
2026-03-23T17:43:26.166637Z  INFO cayenne::provider::table: validate_on_conflict: completed table=bench/lineitem existing_keys=1176979 incoming_keys=14060 on_conflict_deletions=0 delete_specs_files=0
2026-03-23T17:43:26.193786Z DEBUG cayenne::provider::sink: write_all_append: delete_specs=0 files, deleted_pk_i64=0 keys, pending_deletions=true, on_conflict_deletions=false
2026-03-23T17:43:26.193806Z  INFO cayenne::provider::table: apply_on_conflict_deletions: started table=bench/lineitem delete_specs_files=0 deleted_pk_i64=0 deleted_row_keys=0 total_deletions=0
2026-03-23T17:43:26.248360Z DEBUG cayenne::provider::table: Insert to new snapshot 019d1bcb-5ef1-7681-9bab-b5043829f168 completed, wrote 14060 rows to Vortex in 1 chunk(s)
2026-03-23T17:43:26.249829Z DEBUG cayenne::provider::table: Invalidated list-files cache for /Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d4b9877357d/019d1bc8-d97e-7162-86f1-9d5f68964b0d/
2026-03-23T17:43:26.249849Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:26.249868Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:26.249871Z  INFO cayenne::provider::sink: write_all_append: completed table=bench/lineitem total_rows=14060
2026-03-23T17:43:26.249875Z  INFO cayenne::provider::sink: write_all: completed successfully table=bench/lineitem operation="append" rows=14060
2026-03-23T17:43:26.249900Z DEBUG runtime::flight::do_put: Write operation completed successfully for dataset: spicebench.bench.lineitem
2026-03-23T17:43:26.249905Z DEBUG runtime::flight::do_put: Finished writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:27.077527Z DEBUG runtime::flight::session: Flight SQL session lookup: ID=spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a, existing_sessions=1
2026-03-23T17:43:27.077544Z DEBUG runtime::flight::session: Using existing Flight SQL session: spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a
2026-03-23T17:43:27.077565Z DEBUG runtime::flight::do_put: Allowing unauthenticated DoPut on executor in mTLS scheduler-trusted mode
2026-03-23T17:43:27.077585Z DEBUG runtime::flight::do_put: Starting writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:27.077633Z  INFO cayenne::provider::sink: write_all: started, acquiring write lock table=bench/lineitem operation="append"
2026-03-23T17:43:27.077638Z  INFO cayenne::provider::sink: write_all: write lock acquired table=bench/lineitem operation="append"
2026-03-23T17:43:27.077641Z  INFO cayenne::provider::sink: write_all_append: started table=bench/lineitem
2026-03-23T17:43:27.077900Z DEBUG cayenne::provider::sink: Table bench/lineitem has pending PK-based deletions, will write to new snapshot
2026-03-23T17:43:27.486306Z  INFO cayenne::provider::table: prepare_stream_for_insert: loaded existing keyset table=bench/lineitem existing_keys=1191039
2026-03-23T17:43:27.488396Z  INFO cayenne::provider::table: validate_on_conflict: completed table=bench/lineitem existing_keys=1191039 incoming_keys=14020 on_conflict_deletions=0 delete_specs_files=0
2026-03-23T17:43:27.512610Z DEBUG cayenne::provider::sink: write_all_append: delete_specs=0 files, deleted_pk_i64=0 keys, pending_deletions=true, on_conflict_deletions=false
2026-03-23T17:43:27.512626Z  INFO cayenne::provider::table: apply_on_conflict_deletions: started table=bench/lineitem delete_specs_files=0 deleted_pk_i64=0 deleted_row_keys=0 total_deletions=0
2026-03-23T17:43:27.540821Z DEBUG cayenne::provider::table: Insert to new snapshot 019d1bcb-6418-76f3-9b25-f320203c8f52 completed, wrote 14020 rows to Vortex in 1 chunk(s)
2026-03-23T17:43:27.541253Z DEBUG cayenne::provider::table: Invalidated list-files cache for /Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d4b9877357d/019d1bc8-d97e-7162-86f1-9d5f68964b0d/
2026-03-23T17:43:27.541310Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:27.541328Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:27.541332Z  INFO cayenne::provider::sink: write_all_append: completed table=bench/lineitem total_rows=14020
2026-03-23T17:43:27.541336Z  INFO cayenne::provider::sink: write_all: completed successfully table=bench/lineitem operation="append" rows=14020
2026-03-23T17:43:27.541359Z DEBUG runtime::flight::do_put: Write operation completed successfully for dataset: spicebench.bench.lineitem
2026-03-23T17:43:27.541365Z DEBUG runtime::flight::do_put: Finished writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:27.979897Z DEBUG runtime::flight::session: Flight SQL session lookup: ID=spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a, existing_sessions=1
2026-03-23T17:43:27.979914Z DEBUG runtime::flight::session: Using existing Flight SQL session: spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a
2026-03-23T17:43:27.979935Z DEBUG runtime::flight::do_put: Allowing unauthenticated DoPut on executor in mTLS scheduler-trusted mode
2026-03-23T17:43:27.979955Z DEBUG runtime::flight::do_put: Starting writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:27.980004Z  INFO cayenne::provider::sink: write_all: started, acquiring write lock table=bench/lineitem operation="append"
2026-03-23T17:43:27.980008Z  INFO cayenne::provider::sink: write_all: write lock acquired table=bench/lineitem operation="append"
2026-03-23T17:43:27.980011Z  INFO cayenne::provider::sink: write_all_append: started table=bench/lineitem
2026-03-23T17:43:27.980068Z DEBUG cayenne::provider::sink: Table bench/lineitem has pending PK-based deletions, will write to new snapshot
2026-03-23T17:43:28.270546Z  INFO cayenne::provider::table: prepare_stream_for_insert: loaded existing keyset table=bench/lineitem existing_keys=1205059
2026-03-23T17:43:28.270863Z  INFO cayenne::provider::table: validate_on_conflict: completed table=bench/lineitem existing_keys=1205059 incoming_keys=2336 on_conflict_deletions=0 delete_specs_files=0
2026-03-23T17:43:28.292870Z DEBUG cayenne::provider::sink: write_all_append: delete_specs=0 files, deleted_pk_i64=0 keys, pending_deletions=true, on_conflict_deletions=false
2026-03-23T17:43:28.292887Z  INFO cayenne::provider::table: apply_on_conflict_deletions: started table=bench/lineitem delete_specs_files=0 deleted_pk_i64=0 deleted_row_keys=0 total_deletions=0
2026-03-23T17:43:28.307527Z DEBUG cayenne::provider::table: Insert to new snapshot 019d1bcb-6724-79f0-8c5c-610942e29ec0 completed, wrote 2336 rows to Vortex in 1 chunk(s)
2026-03-23T17:43:28.307941Z DEBUG cayenne::provider::table: Invalidated list-files cache for /Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d4b9877357d/019d1bc8-d97e-7162-86f1-9d5f68964b0d/
2026-03-23T17:43:28.307961Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:28.307975Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:28.307978Z  INFO cayenne::provider::sink: write_all_append: completed table=bench/lineitem total_rows=2336
2026-03-23T17:43:28.307982Z  INFO cayenne::provider::sink: write_all: completed successfully table=bench/lineitem operation="append" rows=2336
2026-03-23T17:43:28.308009Z DEBUG runtime::flight::do_put: Write operation completed successfully for dataset: spicebench.bench.lineitem
2026-03-23T17:43:28.308014Z DEBUG runtime::flight::do_put: Finished writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:28.685909Z DEBUG runtime::flight::session: Flight SQL session lookup: ID=spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a, existing_sessions=1
2026-03-23T17:43:28.685927Z DEBUG runtime::flight::session: Using existing Flight SQL session: spidapter-local-13ff4aa6-475c-4bc2-bc06-69b6b1ae6d2a
2026-03-23T17:43:28.685951Z DEBUG runtime::flight::do_put: Allowing unauthenticated DoPut on executor in mTLS scheduler-trusted mode
2026-03-23T17:43:28.685974Z DEBUG runtime::flight::do_put: Starting writing data into dataset: spicebench.bench.lineitem
2026-03-23T17:43:28.686035Z  INFO cayenne::provider::sink: write_all: started, acquiring write lock table=bench/lineitem operation="append"
2026-03-23T17:43:28.686040Z  INFO cayenne::provider::sink: write_all: write lock acquired table=bench/lineitem operation="append"
2026-03-23T17:43:28.686044Z  INFO cayenne::provider::sink: write_all_append: started table=bench/lineitem
2026-03-23T17:43:28.686336Z DEBUG cayenne::provider::sink: Table bench/lineitem has pending PK-based deletions, will write to new snapshot
2026-03-23T17:43:28.991609Z  INFO cayenne::provider::table: prepare_stream_for_insert: loaded existing keyset table=bench/lineitem existing_keys=1207395
2026-03-23T17:43:28.996012Z  INFO cayenne::provider::table: validate_on_conflict: completed table=bench/lineitem existing_keys=1207395 incoming_keys=11559 on_conflict_deletions=11433 delete_specs_files=1
2026-03-23T17:43:29.018500Z DEBUG cayenne::provider::sink: write_all_append: delete_specs=1 files, deleted_pk_i64=0 keys, pending_deletions=true, on_conflict_deletions=true
2026-03-23T17:43:29.018517Z  INFO cayenne::provider::table: apply_on_conflict_deletions: started table=bench/lineitem delete_specs_files=1 deleted_pk_i64=0 deleted_row_keys=11433 total_deletions=11433
2026-03-23T17:43:29.105048Z DEBUG cayenne::provider::table: Updated RowConverter deletion cache with 179957 keys (seq=156) for table bench/lineitem
2026-03-23T17:43:29.109029Z DEBUG cayenne::provider::table: Updated RowConverter insert records cache with 120632 keys (seq=157) for table bench/lineitem
2026-03-23T17:43:29.122663Z DEBUG cayenne::provider::table: Insert to new snapshot 019d1bcb-6a55-7661-bbc3-7d8295294eeb completed, wrote 11559 rows to Vortex in 1 chunk(s)
2026-03-23T17:43:29.123744Z DEBUG cayenne::provider::table: Invalidated list-files cache for /Users/sg/spice/spicebench/spice-debug/executor-2/.spice/data/cayenne_cayenne/data/bench/lineitem/019d1bc8-d97e-7162-86f1-9d4b9877357d/019d1bc8-d97e-7162-86f1-9d5f68964b0d/
2026-03-23T17:43:29.123773Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:29.123788Z DEBUG cayenne::provider::table: Refreshed listing table for bench/lineitem to pick up new files and update statistics
2026-03-23T17:43:29.123792Z  INFO cayenne::provider::sink: write_all_append: completed table=bench/lineitem total_rows=11559
2026-03-23T17:43:29.123796Z  INFO cayenne::provider::sink: write_all: completed successfully table=bench/lineitem operation="append" rows=11559
2026-03-23T17:43:29.123822Z DEBUG runtime::flight::do_put: Write operation completed successfully for dataset: spicebench.bench.lineitem
2026-03-23T17:43:29.123827Z DEBUG runtime::flight::do_put: Finished writing data into dataset: spicebench.bench.lineitem
```
