### PR TITLE
Implement DML for DynamoDBTableProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5323,7 +5323,7 @@ dependencies = [
  "url",
  "util",
  "uuid 1.21.0",
- "zip 7.4.0",
+ "zip 8.3.0",
 ]
 
 [[package]]
@@ -6620,7 +6620,7 @@ dependencies = [
 [[package]]
 name = "docx-rs"
 version = "0.4.17"
-source = "git+https://github.com/spiceai/docx-rs?rev=508456cf36bbc1ae5f381d24b03f0a993703e3ee#508456cf36bbc1ae5f381d24b03f0a993703e3ee"
+source = "git+https://github.com/spiceai/docx-rs?rev=2a85dce57d0128e2cd7c369545516c347cb8c529#2a85dce57d0128e2cd7c369545516c347cb8c529"
 dependencies = [
  "base64 0.13.1",
  "image 0.24.9",
@@ -6628,7 +6628,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "xml-rs",
- "zip 7.4.0",
+ "zip 8.3.0",
 ]
 
 [[package]]
@@ -10953,6 +10953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+dependencies = [
  "sha2 0.10.9",
 ]
 
@@ -23474,7 +23483,34 @@ dependencies = [
  "getrandom 0.4.1",
  "hmac 0.12.1",
  "indexmap 2.13.0",
- "lzma-rust2",
+ "lzma-rust2 0.15.7",
+ "memchr",
+ "pbkdf2 0.12.2",
+ "ppmd-rust",
+ "sha1 0.10.6",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a243cfad17427fc077f529da5a95abe4e94fd2bfdb601611870a6557cc67657"
+dependencies = [
+ "aes 0.8.4",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.1",
+ "hmac 0.12.1",
+ "indexmap 2.13.0",
+ "lzma-rust2 0.16.2",
  "memchr",
  "pbkdf2 0.12.2",
  "ppmd-rust",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -104,7 +104,7 @@ twox-hash.workspace = true
 url.workspace = true
 util = { path = "../util", features = ["datafusion"] }
 uuid.workspace = true
-zip = "7.2.0"
+zip = "8.3.0"
 tokio-stream.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/data_components/src/dynamodb/dml/delete.rs
+++ b/crates/data_components/src/dynamodb/dml/delete.rs
@@ -1,0 +1,539 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::streaming_batch_write;
+use crate::delete::DeletionSink;
+use crate::dynamodb::utils::scalar_to_attribute_value;
+use arrow_array::Array;
+use async_trait::async_trait;
+use aws_sdk_dynamodb::Client as DbClient;
+use aws_sdk_dynamodb::types::{DeleteRequest, WriteRequest};
+use datafusion::common::ScalarValue;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::expr::InList;
+use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aws_sdk_dynamodb::types::AttributeValue;
+
+pub struct DynamoDBDeletionSink {
+    pub db_client: Arc<DbClient>,
+    pub table_name: String,
+    pub partition_key: String,
+    pub sort_key: Option<String>,
+    pub time_format: Arc<String>,
+    pub filters: Vec<Expr>,
+    pub parallelism: usize,
+}
+
+/// A single primary key to delete: (`partition_key_value`, optional `sort_key_value`).
+type KeyToDelete = (AttributeValue, Option<AttributeValue>);
+
+#[async_trait]
+impl DeletionSink for DynamoDBDeletionSink {
+    async fn delete_from(
+        &self,
+    ) -> std::result::Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let keys = extract_delete_keys(
+            &self.filters,
+            &self.partition_key,
+            self.sort_key.as_deref(),
+            &self.time_format,
+        )
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+
+        let mut write_requests: Vec<WriteRequest> = Vec::with_capacity(keys.len());
+        for (pk_val, sk_val) in &keys {
+            let mut key = HashMap::new();
+            key.insert(self.partition_key.clone(), pk_val.clone());
+            if let (Some(sk_name), Some(sk_val)) = (&self.sort_key, sk_val) {
+                key.insert(sk_name.clone(), sk_val.clone());
+            }
+
+            let delete_request = DeleteRequest::builder()
+                .set_key(Some(key))
+                .build()
+                .map_err(|e| {
+                    Box::new(DataFusionError::Execution(format!(
+                        "Failed to build DeleteRequest: {e}"
+                    ))) as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            write_requests.push(
+                WriteRequest::builder()
+                    .delete_request(delete_request)
+                    .build(),
+            );
+        }
+
+        let request_stream = futures::stream::iter(write_requests.into_iter().map(Ok));
+
+        streaming_batch_write(
+            &self.db_client,
+            &self.table_name,
+            Box::pin(request_stream),
+            self.parallelism,
+        )
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    }
+}
+
+/// Extract primary key values from DELETE filter expressions.
+///
+/// Supports:
+/// - `pk = <literal>` (single delete, no sort key)
+/// - `pk = <literal> AND sk = <literal>` (single delete with sort key)
+/// - `pk = <lit> OR pk = <lit> OR ...` (multiple deletes, no sort key)
+/// - `(pk = <lit> AND sk = <lit>) OR (pk = <lit> AND sk = <lit>) OR ...`
+///
+/// Rejects filters on non-primary-key columns.
+fn extract_delete_keys(
+    filters: &[Expr],
+    partition_key: &str,
+    sort_key: Option<&str>,
+    time_format: &str,
+) -> Result<Vec<KeyToDelete>, DataFusionError> {
+    if filters.is_empty() {
+        return Err(DataFusionError::Plan(
+            "DynamoDB DELETE requires a WHERE clause on the primary key".to_string(),
+        ));
+    }
+
+    let mut keys = Vec::new();
+    for filter in filters {
+        extract_keys_from_expr(filter, partition_key, sort_key, time_format, &mut keys)?;
+    }
+
+    if keys.is_empty() {
+        return Err(DataFusionError::Plan(
+            "DynamoDB DELETE: no primary key values found in WHERE clause".to_string(),
+        ));
+    }
+
+    Ok(keys)
+}
+
+fn extract_keys_from_expr(
+    expr: &Expr,
+    partition_key: &str,
+    sort_key: Option<&str>,
+    time_format: &str,
+    keys: &mut Vec<KeyToDelete>,
+) -> Result<(), DataFusionError> {
+    match expr {
+        // OR: each side is a separate key to delete
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::Or,
+            right,
+        }) => {
+            extract_keys_from_expr(left, partition_key, sort_key, time_format, keys)?;
+            extract_keys_from_expr(right, partition_key, sort_key, time_format, keys)?;
+        }
+        // AND: combine pk and sk from both sides into a single key
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        }) => {
+            let mut pk_val = None;
+            let mut sk_val = None;
+            collect_key_equalities(
+                left,
+                partition_key,
+                sort_key,
+                time_format,
+                &mut pk_val,
+                &mut sk_val,
+            )?;
+            collect_key_equalities(
+                right,
+                partition_key,
+                sort_key,
+                time_format,
+                &mut pk_val,
+                &mut sk_val,
+            )?;
+
+            let Some(pk) = pk_val else {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB DELETE: AND expression must include partition key '{partition_key}'"
+                )));
+            };
+            keys.push((pk, sk_val));
+        }
+        // Simple equality: pk = <literal>
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::Eq,
+            right,
+        }) => {
+            match (left.as_ref(), right.as_ref()) {
+                // Simple: column = literal
+                (Expr::Column(col), Expr::Literal(scalar, _))
+                | (Expr::Literal(scalar, _), Expr::Column(col)) => {
+                    let col = col.name();
+                    if col == partition_key {
+                        let attr = scalar_to_attribute_value(scalar, time_format)?;
+                        keys.push((attr, None));
+                    } else if sort_key.is_some_and(|sk| sk == col) {
+                        return Err(DataFusionError::Plan(
+                            "DynamoDB DELETE: sort key filter must be combined with partition key using AND".to_string(),
+                        ));
+                    } else {
+                        return Err(DataFusionError::Plan(format!(
+                            "DynamoDB DELETE only supports filters on primary key columns, got '{col}'"
+                        )));
+                    }
+                }
+                // Struct equality: struct(pk, sk) = struct(v1, v2)
+                // DataFusion rewrites single-element IN lists like (pk, sk) IN ((v1, v2))
+                // into struct(pk, sk) = struct(v1, v2)
+                (Expr::ScalarFunction(func), Expr::Literal(scalar, _))
+                | (Expr::Literal(scalar, _), Expr::ScalarFunction(func)) => {
+                    extract_keys_from_struct_eq(
+                        func,
+                        scalar,
+                        partition_key,
+                        sort_key,
+                        time_format,
+                        keys,
+                    )?;
+                }
+                _ => {
+                    return Err(DataFusionError::Plan(
+                        "DynamoDB DELETE only supports column = literal or struct = struct filters on primary key columns".to_string(),
+                    ));
+                }
+            }
+        }
+        // Simple IN list: pk IN (v1, v2, v3)
+        Expr::InList(InList {
+            expr: in_expr,
+            list,
+            negated,
+        }) => {
+            if *negated {
+                return Err(DataFusionError::Plan(
+                    "DynamoDB DELETE does not support NOT IN".to_string(),
+                ));
+            }
+            extract_keys_from_in_list(in_expr, list, partition_key, sort_key, time_format, keys)?;
+        }
+        _ => {
+            return Err(DataFusionError::Plan(format!(
+                "DynamoDB DELETE: unsupported filter expression: {expr}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Extract a single column = literal equality from an expression, matching it to pk or sk.
+fn collect_key_equalities(
+    expr: &Expr,
+    partition_key: &str,
+    sort_key: Option<&str>,
+    time_format: &str,
+    pk_val: &mut Option<AttributeValue>,
+    sk_val: &mut Option<AttributeValue>,
+) -> Result<(), DataFusionError> {
+    match expr {
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        }) => {
+            collect_key_equalities(left, partition_key, sort_key, time_format, pk_val, sk_val)?;
+            collect_key_equalities(right, partition_key, sort_key, time_format, pk_val, sk_val)?;
+        }
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::Eq,
+            right,
+        }) => {
+            let (col, scalar) = match (left.as_ref(), right.as_ref()) {
+                (Expr::Column(col), Expr::Literal(scalar, _))
+                | (Expr::Literal(scalar, _), Expr::Column(col)) => (col.name(), scalar),
+                _ => {
+                    return Err(DataFusionError::Plan(
+                        "DynamoDB DELETE only supports column = literal filters on primary key columns".to_string(),
+                    ));
+                }
+            };
+
+            let attr = scalar_to_attribute_value(scalar, time_format)?;
+            if col == partition_key {
+                *pk_val = Some(attr);
+            } else if sort_key.is_some_and(|sk| sk == col) {
+                *sk_val = Some(attr);
+            } else {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB DELETE only supports filters on primary key columns, got '{col}'"
+                )));
+            }
+        }
+        _ => {
+            return Err(DataFusionError::Plan(format!(
+                "DynamoDB DELETE: unsupported filter expression in AND clause: {expr}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Handle `pk IN (v1, v2, ...)` and `(pk, sk) IN ((v1, v2), (v3, v4), ...)`.
+fn extract_keys_from_in_list(
+    in_expr: &Expr,
+    list: &[Expr],
+    partition_key: &str,
+    sort_key: Option<&str>,
+    time_format: &str,
+    keys: &mut Vec<KeyToDelete>,
+) -> Result<(), DataFusionError> {
+    match in_expr {
+        // Simple: pk IN (v1, v2, v3)
+        Expr::Column(col) => {
+            if col.name() != partition_key {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB DELETE IN list only supports partition key column '{}', got '{}'",
+                    partition_key,
+                    col.name()
+                )));
+            }
+            for item in list {
+                let Expr::Literal(scalar, _) = item else {
+                    return Err(DataFusionError::Plan(format!(
+                        "DynamoDB DELETE IN list values must be literals, got: {item}"
+                    )));
+                };
+                let attr = scalar_to_attribute_value(scalar, time_format)?;
+                keys.push((attr, None));
+            }
+            Ok(())
+        }
+        // Tuple: (pk, sk) IN ((v1, v2), (v3, v4))
+        // DataFusion represents the tuple as a ScalarFunction (named_struct or struct)
+        // with Column args. The list items are struct literals.
+        Expr::ScalarFunction(func) => {
+            let columns: Vec<&str> = func
+                .args
+                .iter()
+                .map(|arg| match arg {
+                    Expr::Column(col) => Ok(col.name()),
+                    _ => Err(DataFusionError::Plan(
+                        "DynamoDB DELETE: tuple IN list expr must contain only columns".to_string(),
+                    )),
+                })
+                .collect::<Result<_, _>>()?;
+
+            let pk_idx = columns
+                .iter()
+                .position(|&c| c == partition_key)
+                .ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "DynamoDB DELETE: tuple IN list must include partition key '{partition_key}'"
+                    ))
+                })?;
+
+            let sk_idx = sort_key
+                .map(|sk| {
+                    columns.iter().position(|&c| c == sk).ok_or_else(|| {
+                        DataFusionError::Plan(
+                            "DynamoDB DELETE: tuple IN list includes non-primary-key columns"
+                                .to_string(),
+                        )
+                    })
+                })
+                .transpose()?;
+
+            let expected_len = if sort_key.is_some() { 2 } else { 1 };
+            if columns.len() != expected_len {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB DELETE: tuple IN list must contain only primary key columns, got {} columns",
+                    columns.len()
+                )));
+            }
+
+            for item in list {
+                let (pk_attr, sk_attr) = match item {
+                    // Optimized case: struct literal (e.g., after constant folding)
+                    Expr::Literal(ScalarValue::Struct(struct_array), _) => {
+                        if struct_array.len() != 1 {
+                            return Err(DataFusionError::Plan(
+                                "DynamoDB DELETE: expected single-row struct in IN list"
+                                    .to_string(),
+                            ));
+                        }
+                        let pk_scalar = ScalarValue::try_from_array(struct_array.column(pk_idx), 0)
+                            .map_err(|e| {
+                                DataFusionError::Plan(format!(
+                                    "Failed to extract pk from struct: {e}"
+                                ))
+                            })?;
+                        let pk_attr = scalar_to_attribute_value(&pk_scalar, time_format)?;
+                        let sk_attr = sk_idx
+                            .map(|idx| {
+                                let sk_scalar =
+                                    ScalarValue::try_from_array(struct_array.column(idx), 0)
+                                        .map_err(|e| {
+                                            DataFusionError::Plan(format!(
+                                                "Failed to extract sk from struct: {e}"
+                                            ))
+                                        })?;
+                                scalar_to_attribute_value(&sk_scalar, time_format)
+                            })
+                            .transpose()?;
+                        (pk_attr, sk_attr)
+                    }
+                    // Unfolded case: struct(Literal, Literal) — a ScalarFunction with literal args
+                    Expr::ScalarFunction(func) => {
+                        extract_key_pair_from_struct_func(func, pk_idx, sk_idx, time_format)?
+                    }
+                    _ => {
+                        return Err(DataFusionError::Plan(format!(
+                            "DynamoDB DELETE: tuple IN list values must be struct literals, got: {item}"
+                        )));
+                    }
+                };
+                keys.push((pk_attr, sk_attr));
+            }
+            Ok(())
+        }
+        _ => Err(DataFusionError::Plan(format!(
+            "DynamoDB DELETE: unsupported IN list expression: {in_expr}"
+        ))),
+    }
+}
+
+/// Handle `struct(pk, sk) = struct(v1, v2)` — produced when `DataFusion` optimizes
+/// a single-element tuple IN list: `(pk, sk) IN ((v1, v2))` → `struct(pk, sk) = struct(v1, v2)`.
+fn extract_keys_from_struct_eq(
+    func: &datafusion::logical_expr::expr::ScalarFunction,
+    scalar: &ScalarValue,
+    partition_key: &str,
+    sort_key: Option<&str>,
+    time_format: &str,
+    keys: &mut Vec<KeyToDelete>,
+) -> Result<(), DataFusionError> {
+    let columns: Vec<&str> = func
+        .args
+        .iter()
+        .map(|arg| match arg {
+            Expr::Column(col) => Ok(col.name()),
+            _ => Err(DataFusionError::Plan(
+                "DynamoDB DELETE: struct equality expr must contain only columns".to_string(),
+            )),
+        })
+        .collect::<Result<_, _>>()?;
+
+    let pk_idx = columns
+        .iter()
+        .position(|&c| c == partition_key)
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "DynamoDB DELETE: struct equality must include partition key '{partition_key}'"
+            ))
+        })?;
+
+    let sk_idx = sort_key
+        .map(|sk| {
+            columns.iter().position(|&c| c == sk).ok_or_else(|| {
+                DataFusionError::Plan(
+                    "DynamoDB DELETE: struct equality includes non-primary-key columns".to_string(),
+                )
+            })
+        })
+        .transpose()?;
+
+    let expected_len = if sort_key.is_some() { 2 } else { 1 };
+    if columns.len() != expected_len {
+        return Err(DataFusionError::Plan(format!(
+            "DynamoDB DELETE: struct equality must contain only primary key columns, got {} columns",
+            columns.len()
+        )));
+    }
+
+    let ScalarValue::Struct(struct_array) = scalar else {
+        return Err(DataFusionError::Plan(
+            "DynamoDB DELETE: struct equality right-hand side must be a struct literal".to_string(),
+        ));
+    };
+
+    if struct_array.len() != 1 {
+        return Err(DataFusionError::Plan(
+            "DynamoDB DELETE: expected single-row struct in equality".to_string(),
+        ));
+    }
+
+    let pk_scalar = ScalarValue::try_from_array(struct_array.column(pk_idx), 0)
+        .map_err(|e| DataFusionError::Plan(format!("Failed to extract pk from struct: {e}")))?;
+    let pk_attr = scalar_to_attribute_value(&pk_scalar, time_format)?;
+
+    let sk_attr = sk_idx
+        .map(|idx| {
+            let sk_scalar =
+                ScalarValue::try_from_array(struct_array.column(idx), 0).map_err(|e| {
+                    DataFusionError::Plan(format!("Failed to extract sk from struct: {e}"))
+                })?;
+            scalar_to_attribute_value(&sk_scalar, time_format)
+        })
+        .transpose()?;
+
+    keys.push((pk_attr, sk_attr));
+    Ok(())
+}
+
+/// Extract pk/sk values from a `struct(Literal, Literal)` `ScalarFunction` expression.
+/// This handles the case where `DataFusion` represents tuple values as struct constructor
+/// calls with literal arguments (e.g., `struct(Utf8("a"), Utf8("1"))`).
+fn extract_key_pair_from_struct_func(
+    func: &datafusion::logical_expr::expr::ScalarFunction,
+    pk_idx: usize,
+    sk_idx: Option<usize>,
+    time_format: &str,
+) -> Result<KeyToDelete, DataFusionError> {
+    let pk_arg = func.args.get(pk_idx).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "DynamoDB DELETE: struct has no argument at index {pk_idx}"
+        ))
+    })?;
+    let Expr::Literal(pk_scalar, _) = pk_arg else {
+        return Err(DataFusionError::Plan(format!(
+            "DynamoDB DELETE: struct argument at index {pk_idx} is not a literal: {pk_arg}"
+        )));
+    };
+    let pk_attr = scalar_to_attribute_value(pk_scalar, time_format)?;
+
+    let sk_attr = sk_idx
+        .map(|idx| {
+            let sk_arg = func.args.get(idx).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "DynamoDB DELETE: struct has no argument at index {idx}"
+                ))
+            })?;
+            let Expr::Literal(sk_scalar, _) = sk_arg else {
+                return Err(DataFusionError::Plan(format!(
+                    "DynamoDB DELETE: struct argument at index {idx} is not a literal: {sk_arg}"
+                )));
+            };
+            scalar_to_attribute_value(sk_scalar, time_format)
+        })
+        .transpose()?;
+
+    Ok((pk_attr, sk_attr))
+}

--- a/crates/data_components/src/dynamodb/dml/insert.rs
+++ b/crates/data_components/src/dynamodb/dml/insert.rs
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::streaming_batch_write;
+use crate::dynamodb::utils::scalar_to_attribute_value;
+use arrow::array::Array;
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use aws_sdk_dynamodb::{
+    Client as DbClient,
+    types::{AttributeValue, PutRequest, WriteRequest},
+};
+use datafusion::{
+    common::ScalarValue,
+    datasource::sink::DataSink,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{DisplayAs, DisplayFormatType, metrics::MetricsSet},
+};
+use futures::StreamExt;
+use std::{any::Any, collections::HashMap, fmt, sync::Arc};
+
+pub struct DynamoDBInsertSink {
+    pub db_client: Arc<DbClient>,
+    pub table_name: String,
+    pub schema: SchemaRef,
+    pub time_format: Arc<String>,
+    pub parallelism: usize,
+}
+
+impl std::fmt::Debug for DynamoDBInsertSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamoDBInsertSink")
+            .field("table_name", &self.table_name)
+            .field("parallelism", &self.parallelism)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for DynamoDBInsertSink {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DynamoDBInsertSink(table={})", self.table_name)
+    }
+}
+
+/// Convert a single row from a `RecordBatch` to a `DynamoDB` item.
+fn record_batch_row_to_dynamodb_item(
+    batch: &arrow::array::RecordBatch,
+    row_idx: usize,
+    schema: &SchemaRef,
+    time_format: &str,
+) -> DataFusionResult<HashMap<String, AttributeValue>> {
+    let mut item = HashMap::new();
+    for (col_idx, field) in schema.fields().iter().enumerate() {
+        let col = batch.column(col_idx);
+        if col.is_null(row_idx) {
+            continue;
+        }
+        let scalar = ScalarValue::try_from_array(col, row_idx)?;
+        if scalar.is_null() {
+            continue;
+        }
+        let attr_value = scalar_to_attribute_value(&scalar, time_format)?;
+        item.insert(field.name().clone(), attr_value);
+    }
+    Ok(item)
+}
+
+#[async_trait]
+impl DataSink for DynamoDBInsertSink {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    async fn write_all(
+        &self,
+        data: SendableRecordBatchStream,
+        _context: &Arc<TaskContext>,
+    ) -> DataFusionResult<u64> {
+        let schema = Arc::clone(&self.schema);
+        let time_format = Arc::clone(&self.time_format);
+
+        // Build a stream of WriteRequests from the RecordBatch stream
+        let request_stream = data.flat_map(move |batch_result| {
+            let schema = Arc::clone(&schema);
+            let time_format = Arc::clone(&time_format);
+            match batch_result {
+                Err(e) => futures::stream::iter(vec![Err(e)]).boxed(),
+                Ok(batch) => {
+                    let rows = batch.num_rows();
+                    futures::stream::iter((0..rows).map(move |row_idx| {
+                        let item = record_batch_row_to_dynamodb_item(
+                            &batch,
+                            row_idx,
+                            &schema,
+                            &time_format,
+                        )?;
+                        let put_request = PutRequest::builder()
+                            .set_item(Some(item))
+                            .build()
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to build PutRequest: {e}"
+                                ))
+                            })?;
+                        Ok(WriteRequest::builder().put_request(put_request).build())
+                    }))
+                    .boxed()
+                }
+            }
+        });
+
+        let request_stream = Box::pin(request_stream);
+
+        streaming_batch_write(
+            &self.db_client,
+            &self.table_name,
+            request_stream,
+            self.parallelism,
+        )
+        .await
+    }
+}

--- a/crates/data_components/src/dynamodb/dml/mod.rs
+++ b/crates/data_components/src/dynamodb/dml/mod.rs
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+pub mod delete;
+pub mod insert;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aws_sdk_dynamodb::{Client as DbClient, types::WriteRequest};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+
+/// Maximum number of items per `BatchWriteItem` request (`DynamoDB` limit).
+pub(crate) const DYNAMODB_BATCH_WRITE_MAX: usize = 25;
+
+/// Default number of concurrent `BatchWriteItem` requests.
+pub const DEFAULT_WRITE_PARALLELISM: usize = 5;
+
+/// Maximum number of retries for unprocessed items.
+const MAX_UNPROCESSED_RETRIES: usize = 8;
+
+/// Base delay for exponential backoff on unprocessed items.
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+
+/// Send a single `BatchWriteItem` request with retry logic for unprocessed items.
+///
+/// `DynamoDB` may return `UnprocessedItems` when throughput is exceeded.
+/// We retry with exponential backoff until all items are processed or max retries reached.
+async fn batch_write_with_retry(
+    client: &DbClient,
+    table_name: &str,
+    items: Vec<WriteRequest>,
+) -> DataFusionResult<()> {
+    let mut current_items = items;
+
+    for attempt in 0..=MAX_UNPROCESSED_RETRIES {
+        let response = client
+            .batch_write_item()
+            .request_items(table_name, current_items)
+            .send()
+            .await
+            .map_err(|e| {
+                DataFusionError::Execution(format!("DynamoDB BatchWriteItem failed: {e}"))
+            })?;
+
+        let unprocessed = response
+            .unprocessed_items
+            .as_ref()
+            .and_then(|m| m.get(table_name))
+            .cloned()
+            .unwrap_or_default();
+
+        if unprocessed.is_empty() {
+            return Ok(());
+        }
+
+        if attempt == MAX_UNPROCESSED_RETRIES {
+            return Err(DataFusionError::Execution(format!(
+                "DynamoDB BatchWriteItem: {} unprocessed items after {MAX_UNPROCESSED_RETRIES} retries",
+                unprocessed.len()
+            )));
+        }
+
+        let delay =
+            RETRY_BASE_DELAY * 2u32.saturating_pow(u32::try_from(attempt).unwrap_or(u32::MAX));
+        tokio::time::sleep(delay).await;
+        current_items = unprocessed;
+    }
+
+    Ok(())
+}
+
+/// Drain all remaining tasks from a `JoinSet`, returning the first error encountered.
+async fn drain_join_set(join_set: &mut JoinSet<DataFusionResult<()>>) -> DataFusionResult<()> {
+    let mut first_error: Option<DataFusionError> = None;
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok(Err(e)) => {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+            Err(e) if !e.is_cancelled() => {
+                if first_error.is_none() {
+                    first_error = Some(DataFusionError::Execution(format!("Task join error: {e}")));
+                }
+            }
+            Ok(Ok(())) | Err(_) => {} // success or cancelled tasks
+        }
+    }
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Consume a stream of `WriteRequest` items, batch them into groups of 25, and write
+/// to `DynamoDB` using a fixed pool of worker tasks. Cancels all workers on first error.
+///
+/// Returns the total number of items written.
+pub(crate) async fn streaming_batch_write(
+    client: &Arc<DbClient>,
+    table_name: &str,
+    mut requests: impl Stream<Item = DataFusionResult<WriteRequest>> + Send + Unpin,
+    parallelism: usize,
+) -> DataFusionResult<u64> {
+    let (tx, rx) = mpsc::channel::<Vec<WriteRequest>>(parallelism * 2);
+
+    // Spawn worker pool — each worker shares the receiver via a wrapper
+    // Since mpsc::Receiver is not Clone, we use a single receiver with a Mutex
+    let rx = Arc::new(tokio::sync::Mutex::new(rx));
+    let mut join_set = JoinSet::new();
+    for _ in 0..parallelism {
+        let client = Arc::clone(client);
+        let table_name = table_name.to_string();
+        let rx = Arc::clone(&rx);
+
+        join_set.spawn(async move {
+            loop {
+                let chunk = {
+                    let mut guard = rx.lock().await;
+                    guard.recv().await
+                };
+                match chunk {
+                    Some(items) => {
+                        batch_write_with_retry(&client, &table_name, items).await?;
+                    }
+                    None => return Ok(()), // channel closed
+                }
+            }
+        });
+    }
+
+    let mut pending: Vec<WriteRequest> = Vec::with_capacity(DYNAMODB_BATCH_WRITE_MAX);
+    let mut count: u64 = 0;
+
+    // Producer loop: read from stream, buffer into chunks, send to workers
+    let producer_result: DataFusionResult<()> = async {
+        while let Some(item) = requests.next().await {
+            let item = item?;
+            pending.push(item);
+            count += 1;
+
+            if pending.len() >= DYNAMODB_BATCH_WRITE_MAX {
+                // Check for worker errors before sending more work
+                if let Some(result) = join_set.try_join_next() {
+                    match result {
+                        Ok(Err(e)) => return Err(e),
+                        Err(e) if !e.is_cancelled() => {
+                            return Err(DataFusionError::Execution(format!(
+                                "Worker task error: {e}"
+                            )));
+                        }
+                        Ok(Ok(())) | Err(_) => {}
+                    }
+                }
+
+                let chunk =
+                    std::mem::replace(&mut pending, Vec::with_capacity(DYNAMODB_BATCH_WRITE_MAX));
+                tx.send(chunk).await.map_err(|_| {
+                    DataFusionError::Execution(
+                        "Failed to send chunk to worker: channel closed".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        // Flush remaining items
+        if !pending.is_empty() {
+            tx.send(pending).await.map_err(|_| {
+                DataFusionError::Execution(
+                    "Failed to send final chunk to worker: channel closed".to_string(),
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+    .await;
+
+    // Drop the sender so workers see channel closed and exit
+    drop(tx);
+
+    // If producer had an error, abort workers and drain
+    if let Err(e) = producer_result {
+        join_set.abort_all();
+        // Drain to ensure all tasks are stopped before returning
+        let _ = drain_join_set(&mut join_set).await;
+        return Err(e);
+    }
+
+    // Wait for all workers to finish
+    drain_join_set(&mut join_set).await?;
+
+    Ok(count)
+}

--- a/crates/data_components/src/dynamodb/mod.rs
+++ b/crates/data_components/src/dynamodb/mod.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use util::format_datafusion_error;
 
 mod arrow;
+pub mod dml;
 mod json_nest;
 pub mod provider;
 mod request_builder;

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -20,7 +20,10 @@ use super::{
     TableStatusIsNotActiveSnafu,
 };
 use crate::cdc::ChangeBatch;
+use crate::delete::DeletionExec;
 use crate::dynamodb::arrow::dynamodb_items_to_arrow;
+use crate::dynamodb::dml::delete::DynamoDBDeletionSink;
+use crate::dynamodb::dml::insert::DynamoDBInsertSink;
 use crate::dynamodb::json_nest::{JsonNesting, json_nest_except_fields};
 use crate::dynamodb::request_builder::DynamoDBRequestPlanBuilder;
 use crate::dynamodb::request_plan::{DynamoDBRequestPlan, QueryParams, ScanParams};
@@ -40,7 +43,10 @@ use aws_smithy_async::future::pagination_stream::TryFlatMap;
 use datafusion::common::{Constraint, Constraints, DFSchema};
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::DefaultTableSource;
-use datafusion::logical_expr::{LogicalPlanBuilder, TableProviderFilterPushDown, ident};
+use datafusion::datasource::sink::DataSinkExec;
+use datafusion::logical_expr::{
+    LogicalPlanBuilder, TableProviderFilterPushDown, dml::InsertOp, ident,
+};
 use datafusion::prelude::SessionContext;
 use datafusion::{
     catalog::{Session, TableProvider},
@@ -79,6 +85,7 @@ pub struct DynamoDBTableProvider {
     table_total_item_count: Option<i64>,
     pub ready_lag: Duration,
     json_nesting: Option<JsonNesting>,
+    write_parallelism: usize,
 }
 
 type DynamoDBItemStream =
@@ -104,6 +111,7 @@ impl DynamoDBTableProvider {
         ready_lag: Duration,
         metrics_collector: Arc<MetricsCollector>,
         json_nesting: Option<&JsonNesting>,
+        write_parallelism: usize,
     ) -> Result<Self, Error> {
         let db_client = Arc::new(DbClient::new(&sdk_config));
         let buffer_size = NonZeroUsize::new(1).unwrap_or_else(|| unreachable!("1 is safe"));
@@ -182,7 +190,121 @@ impl DynamoDBTableProvider {
             table_total_item_count,
             ready_lag,
             json_nesting: json_nesting.cloned(),
+            write_parallelism,
         })
+    }
+
+    /// Creates a new `DynamoDB` table provider with an explicit schema.
+    ///
+    /// Use this when the table schema is known upfront (e.g., from DDL) and
+    /// scan-based inference is not needed or possible (empty table).
+    /// Partition and sort keys are fetched from the `DynamoDB` table metadata.
+    #[expect(clippy::too_many_arguments)]
+    pub async fn try_new_with_schema(
+        sdk_config: SdkConfig,
+        table_name: Arc<str>,
+        schema: SchemaRef,
+        config_partitions: Option<usize>,
+        scan_interval: Duration,
+        time_format: String,
+        ready_lag: Duration,
+        metrics_collector: Arc<MetricsCollector>,
+        write_parallelism: usize,
+    ) -> Result<Self, Error> {
+        let db_client = Arc::new(DbClient::new(&sdk_config));
+
+        let (partition_key, sort_key) =
+            Self::fetch_table_keys(Arc::clone(&db_client), &table_name).await?;
+
+        let buffer_size = NonZeroUsize::new(1).unwrap_or_else(|| unreachable!("1 is safe"));
+        let streams_client = Arc::new(
+            StreamsClient::builder(sdk_config, table_name.to_string())
+                .interval(Some(scan_interval))
+                .buffer(buffer_size)
+                .metrics_collector(metrics_collector)
+                .build(),
+        );
+
+        let table_schema = DynamoDBTableSchema::new(
+            table_name,
+            schema,
+            partition_key,
+            sort_key,
+            HashSet::new(),
+            &time_format,
+        );
+
+        let Ok(df_schema) = DFSchema::try_from(Arc::clone(table_schema.schema())) else {
+            unreachable!("DFSchema::try_from is infallible as of DataFusion 38")
+        };
+
+        let pk_indices: Vec<usize> = table_schema
+            .primary_keys()
+            .iter()
+            .filter_map(|pk| df_schema.index_of_column_by_name(None, pk))
+            .collect();
+
+        let constraints = if pk_indices.is_empty() {
+            None
+        } else {
+            Some(Constraints::new_unverified(vec![Constraint::PrimaryKey(
+                pk_indices,
+            )]))
+        };
+
+        Ok(Self {
+            db_client,
+            streams_client,
+            table_schema: table_schema.clone(),
+            constraints,
+            request_plan_builder: Arc::new(DynamoDBRequestPlanBuilder::new(table_schema)),
+            unnest_depth: None,
+            config_partitions,
+            table_total_item_count: None,
+            ready_lag,
+            json_nesting: None,
+            write_parallelism,
+        })
+    }
+
+    /// Fetch partition key and sort key from `DynamoDB` table metadata.
+    async fn fetch_table_keys(
+        db_client: Arc<DbClient>,
+        table_name: &str,
+    ) -> Result<(String, Option<String>)> {
+        let response = db_client
+            .describe_table()
+            .table_name(table_name)
+            .send()
+            .await
+            .map_err(map_sdk_error)
+            .context(DescribeTableSnafu)?;
+
+        let Some(table) = response.table() else {
+            return TableDoesNotExistSnafu { table_name }.fail();
+        };
+
+        let key_schema = table.key_schema();
+        let mut partition_key = None;
+        let mut sort_key = None;
+
+        for key in key_schema {
+            match key.key_type() {
+                KeyType::Hash => {
+                    partition_key = Some(key.attribute_name().to_string());
+                }
+                KeyType::Range => {
+                    sort_key = Some(key.attribute_name().to_string());
+                }
+                _ => {}
+            }
+        }
+
+        let Some(partition_key) = partition_key else {
+            return Err(Error::MissingPartitionKey);
+        };
+
+        Ok((partition_key, sort_key))
     }
 
     async fn fetch_table_metadata(
@@ -402,6 +524,11 @@ impl DynamoDBTableProvider {
     pub fn stream_metrics(&self) -> Metrics {
         self.streams_client.metrics()
     }
+
+    #[must_use]
+    pub fn time_format(&self) -> Arc<String> {
+        self.table_schema.time_format()
+    }
 }
 
 #[async_trait]
@@ -507,6 +634,40 @@ impl TableProvider for DynamoDBTableProvider {
         );
 
         result
+    }
+
+    async fn insert_into(
+        &self,
+        _state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        _overwrite: InsertOp,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let sink = Arc::new(DynamoDBInsertSink {
+            db_client: Arc::clone(&self.db_client),
+            table_name: self.table_schema.table_name().to_string(),
+            schema: Arc::clone(self.table_schema.schema()),
+            time_format: self.table_schema.time_format(),
+            parallelism: self.write_parallelism,
+        });
+        Ok(Arc::new(DataSinkExec::new(input, sink, None)))
+    }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(Arc::new(
+            DynamoDBDeletionSink {
+                db_client: Arc::clone(&self.db_client),
+                table_name: self.table_schema.table_name().to_string(),
+                partition_key: self.table_schema.partition_key().to_string(),
+                sort_key: self.table_schema.sort_key().map(ToString::to_string),
+                time_format: self.table_schema.time_format(),
+                filters: filters,
+                parallelism: self.write_parallelism,
+            },
+        ))))
     }
 }
 

--- a/crates/data_components/src/dynamodb/table_schema.rs
+++ b/crates/data_components/src/dynamodb/table_schema.rs
@@ -103,7 +103,8 @@ impl DynamoDBTableSchema {
             .iter()
             .map(|&expr| {
                 if self.is_filter_supported(expr, false) {
-                    TableProviderFilterPushDown::Exact
+                    // Should be Exact once we switch to DF53
+                    TableProviderFilterPushDown::Inexact
                 } else {
                     TableProviderFilterPushDown::Unsupported
                 }
@@ -396,7 +397,7 @@ mod tests {
         let result = schema.supports_filters_pushdown(&filters);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], TableProviderFilterPushDown::Exact);
+        assert_eq!(result[0], TableProviderFilterPushDown::Inexact);
     }
 
     #[test]
@@ -420,8 +421,8 @@ mod tests {
         let result = schema.supports_filters_pushdown(&filters);
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], TableProviderFilterPushDown::Exact);
-        assert_eq!(result[1], TableProviderFilterPushDown::Exact);
+        assert_eq!(result[0], TableProviderFilterPushDown::Inexact);
+        assert_eq!(result[1], TableProviderFilterPushDown::Inexact);
     }
 
     #[test]
@@ -435,7 +436,7 @@ mod tests {
         let filters = vec![&f1];
         let result = schema.supports_filters_pushdown(&filters);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], TableProviderFilterPushDown::Exact);
+        assert_eq!(result[0], TableProviderFilterPushDown::Inexact);
 
         let f2 = lit(ScalarValue::TimestampMillisecond(
             Some(1_725_366_896_155),
@@ -445,7 +446,7 @@ mod tests {
         let filters = vec![&f2];
         let result = schema.supports_filters_pushdown(&filters);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], TableProviderFilterPushDown::Exact);
+        assert_eq!(result[0], TableProviderFilterPushDown::Inexact);
     }
 
     #[test]
@@ -462,7 +463,7 @@ mod tests {
         let filters = vec![&f2, &f3];
         let result = schema.supports_filters_pushdown(&filters);
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], TableProviderFilterPushDown::Exact);
-        assert_eq!(result[1], TableProviderFilterPushDown::Exact);
+        assert_eq!(result[0], TableProviderFilterPushDown::Inexact);
+        assert_eq!(result[1], TableProviderFilterPushDown::Inexact);
     }
 }

--- a/crates/data_components/src/dynamodb/utils.rs
+++ b/crates/data_components/src/dynamodb/utils.rs
@@ -15,56 +15,124 @@ limitations under the License.
 */
 use crate::dynamodb::table_schema::DynamoDBTableSchema;
 use aws_sdk_dynamodb::types::AttributeValue;
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, FixedOffset, NaiveDate};
 use datafusion::common::tree_node::{TreeNodeRecursion, TreeNodeVisitor};
 use datafusion::common::{DataFusionError, ScalarValue};
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use util::time_format::format_datetime;
+
+fn timestamp_to_attribute(
+    millis: i64,
+    tz_opt: Option<&Arc<str>>,
+    time_format: &str,
+) -> datafusion::error::Result<AttributeValue> {
+    let Some(dt_utc) = DateTime::from_timestamp_millis(millis) else {
+        return Err(DataFusionError::Internal(format!(
+            "Failed to convert timestamp in millis to DateTime: {millis}"
+        )));
+    };
+
+    let dt: DateTime<FixedOffset> = match tz_opt {
+        Some(tz_str) => {
+            let tz = FixedOffset::from_str(tz_str).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to parse TimeZone \"{tz_str}\": {e}"))
+            })?;
+            dt_utc.with_timezone(&tz)
+        }
+        None => dt_utc.fixed_offset(),
+    };
+
+    let Some(formatted) = format_datetime(dt, time_format) else {
+        return Err(DataFusionError::Internal(format!(
+            "Failed to parse timestamp. Verify format is valid: \"{time_format}\""
+        )));
+    };
+
+    Ok(AttributeValue::S(formatted))
+}
 
 pub fn scalar_to_attribute_value(
     scalar: &ScalarValue,
     time_format: &str,
 ) -> datafusion::error::Result<AttributeValue> {
     match scalar {
-        ScalarValue::Utf8(Some(s)) => Ok(AttributeValue::S(s.clone())),
-        ScalarValue::Int64(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => {
+            Ok(AttributeValue::S(s.clone()))
+        }
+        ScalarValue::Utf8View(Some(s)) => Ok(AttributeValue::S(s.clone())),
+        ScalarValue::Int8(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::Int16(Some(i)) => Ok(AttributeValue::N(i.to_string())),
         ScalarValue::Int32(Some(i)) => Ok(AttributeValue::N(i.to_string())),
-        ScalarValue::Float64(Some(f)) => Ok(AttributeValue::N(f.to_string())),
+        ScalarValue::Int64(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::UInt8(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::UInt16(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::UInt32(Some(i)) => Ok(AttributeValue::N(i.to_string())),
+        ScalarValue::UInt64(Some(i)) => Ok(AttributeValue::N(i.to_string())),
         ScalarValue::Float32(Some(f)) => Ok(AttributeValue::N(f.to_string())),
+        ScalarValue::Float64(Some(f)) => Ok(AttributeValue::N(f.to_string())),
+        ScalarValue::Decimal128(Some(v), _precision, scale) => {
+            let scale = *scale;
+            let s = if scale > 0 {
+                let scale_u32 = u32::try_from(scale).unwrap_or(0);
+                let divisor = 10_i128.pow(scale_u32);
+                let whole = v / divisor;
+                let frac = (v % divisor).unsigned_abs();
+                format!("{whole}.{frac:0>width$}", width = scale_u32 as usize)
+            } else {
+                v.to_string()
+            };
+            Ok(AttributeValue::N(s))
+        }
+        ScalarValue::Decimal256(Some(v), _precision, _scale) => {
+            Ok(AttributeValue::N(format!("{v}")))
+        }
         ScalarValue::Boolean(Some(b)) => Ok(AttributeValue::Bool(*b)),
-        ScalarValue::TimestampMillisecond(Some(timestamp_in_millis), tz_opt) => {
-            let Some(dt_utc) = DateTime::from_timestamp_millis(*timestamp_in_millis) else {
-                return Err(DataFusionError::Internal(format!(
-                    "Failed to convert timestamp in millis to DateTime: {timestamp_in_millis}"
-                )));
-            };
-
-            let dt: DateTime<FixedOffset> = match tz_opt {
-                Some(tz_str) => {
-                    let tz = FixedOffset::from_str(tz_str).map_err(|e| {
-                        DataFusionError::Internal(format!(
-                            "Failed to parse TimeZone \"{tz_str}\": {e}"
-                        ))
-                    })?;
-                    dt_utc.with_timezone(&tz)
-                }
-                None => dt_utc.fixed_offset(),
-            };
-
-            let Some(formatted) = format_datetime(dt, time_format) else {
-                return Err(DataFusionError::Internal(format!(
-                    "Failed to parse timestamp. Verify format is valid: \"{time_format}\""
-                )));
-            };
-
-            Ok(AttributeValue::S(formatted))
+        ScalarValue::Date32(Some(days)) => {
+            match NaiveDate::from_ymd_opt(1970, 1, 1)
+                .and_then(|d| d.checked_add_signed(chrono::Duration::days(i64::from(*days))))
+            {
+                Some(date) => Ok(AttributeValue::S(date.format("%Y-%m-%d").to_string())),
+                None => Err(DataFusionError::Execution(format!(
+                    "Invalid Date32 value: {days}"
+                ))),
+            }
+        }
+        // Date64: ms since 1970-01-01
+        ScalarValue::Date64(Some(ms)) => {
+            let days = *ms / 86_400_000;
+            match NaiveDate::from_ymd_opt(1970, 1, 1)
+                .and_then(|d| d.checked_add_signed(chrono::Duration::days(days)))
+            {
+                Some(date) => Ok(AttributeValue::S(date.format("%Y-%m-%d").to_string())),
+                None => Err(DataFusionError::Execution(format!(
+                    "Invalid Date64 value: {ms}"
+                ))),
+            }
+        }
+        ScalarValue::Binary(Some(b)) | ScalarValue::LargeBinary(Some(b)) => Ok(AttributeValue::B(
+            aws_sdk_dynamodb::primitives::Blob::new(b.clone()),
+        )),
+        ScalarValue::TimestampSecond(Some(s), tz_opt) => {
+            timestamp_to_attribute(*s * 1_000, tz_opt.as_ref(), time_format)
+        }
+        ScalarValue::TimestampMillisecond(Some(ms), tz_opt) => {
+            timestamp_to_attribute(*ms, tz_opt.as_ref(), time_format)
+        }
+        ScalarValue::TimestampMicrosecond(Some(us), tz_opt) => {
+            timestamp_to_attribute(*us / 1_000, tz_opt.as_ref(), time_format)
+        }
+        ScalarValue::TimestampNanosecond(Some(ns), tz_opt) => {
+            timestamp_to_attribute(*ns / 1_000_000, tz_opt.as_ref(), time_format)
         }
         ScalarValue::Null => Ok(AttributeValue::Null(true)),
-        _ => Err(DataFusionError::NotImplemented(
-            "ScalarValue type not supported".to_string(),
-        )),
+        t => Err(DataFusionError::NotImplemented(format!(
+            "ScalarValue type not supported: type={}, value={}",
+            t.data_type(),
+            t
+        ))),
     }
 }
 

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="508456cf36bbc1ae5f381d24b03f0a993703e3ee"}
+docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="2a85dce57d0128e2cd7c369545516c347cb8c529"}
 pdf-extract = { git = "https://github.com/spiceai/pdf-extract", rev = "3ca5e2c904cdf5897f3d671e3b2c4b62b1612b0c" }
 snafu.workspace = true
 bytes.workspace = true

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -149,6 +149,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("lag_exceeds_shard_retention_behavior")
         .description("Behavior when stream lag exceeds shard retention (24h). 'error' marks dataset as Error, 'ready_before_load' marks Ready then re-bootstraps, 'ready_after_load' re-bootstraps then marks Ready")
         .default("error"),
+    ParameterSpec::runtime("write_parallelism")
+        .description("Number of parallel operations for writing and deleting data to DynamoDB")
+        .default("10"),
 ];
 
 impl DataConnectorFactory for DynamoDBFactory {
@@ -249,6 +252,13 @@ fn parse_json_nesting_static_fields(
 impl DataConnector for DynamoDB {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    async fn read_write_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> Option<Result<Arc<dyn TableProvider>, DataConnectorError>> {
+        Some(self.read_provider(dataset).await)
     }
 
     async fn read_provider(
@@ -371,6 +381,14 @@ impl DataConnector for DynamoDB {
             .and_then(|v| fundu::parse_duration(v).ok())
             .unwrap_or(Duration::from_secs(2));
 
+        let write_parallelism = self
+            .params
+            .get("write_parallelism")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(data_components::dynamodb::dml::DEFAULT_WRITE_PARALLELISM);
+
         let provider = DynamoDBTableProvider::try_new(
             config,
             Arc::from(table_name),
@@ -382,6 +400,7 @@ impl DataConnector for DynamoDB {
             ready_lag,
             Arc::clone(&self.metrics_collector),
             parse_json_nesting_static_fields(dataset)?.as_ref(),
+            write_parallelism,
         )
         .await
         .map_err(|e| DataConnectorError::UnableToGetReadProvider {

--- a/crates/runtime/tests/dynamodb/dml.rs
+++ b/crates/runtime/tests/dynamodb/dml.rs
@@ -1,0 +1,499 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+
+use super::streams::{make_dynamodb_dataset, start_dynamodb_docker_container};
+use crate::utils::{runtime_ready_check, test_request_context};
+use crate::{configure_test_datafusion, init_tracing};
+use app::AppBuilder;
+use async_graphql::futures_util::TryStreamExt;
+use aws_config::{BehaviorVersion, Region, SdkConfig, retry::RetryConfig};
+use aws_credential_types::{Credentials, provider::SharedCredentialsProvider};
+use aws_sdk_dynamodb::{
+    Client,
+    types::{
+        AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+        ScalarAttributeType,
+    },
+};
+use runtime::Runtime;
+use spicepod::component::access::AccessMode;
+use spicepod::component::caching::SQLResultsCacheConfig;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+const PORT_DML_INSERT: u16 = 8010;
+const PORT_DML_DELETE: u16 = 8011;
+const PORT_DML_INSERT_DELETE: u16 = 8012;
+const PORT_DML_TYPES: u16 = 8013;
+const PORT_DML_COMPOSITE_DELETE: u16 = 8014;
+
+fn get_client(port: u16, access_key: &str, secret_key: &str) -> Client {
+    let config = SdkConfig::builder()
+        .endpoint_url(format!("http://localhost:{port}"))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::from_keys(
+            access_key, secret_key, None,
+        )))
+        .retry_config(RetryConfig::standard().with_max_attempts(5))
+        .behavior_version(BehaviorVersion::latest())
+        .region(Some(Region::from_static("us-east-1")))
+        .build();
+    Client::new(&config)
+}
+
+async fn create_table(client: &Client, table_name: &str) {
+    client
+        .create_table()
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .expect("Attribute definition created"),
+        )
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .expect("Key schema element created"),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect("Table created");
+}
+
+async fn create_composite_key_table(client: &Client, table_name: &str) {
+    client
+        .create_table()
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .expect("pk attribute definition"),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .expect("sk attribute definition"),
+        )
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .expect("pk key schema"),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .expect("sk key schema"),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect("Composite key table created");
+}
+
+async fn run_query(rt: &Runtime, query: &str) -> Result<String, anyhow::Error> {
+    let query_result = rt
+        .datafusion()
+        .query_builder(query)
+        .build()
+        .run()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    let data = query_result.data.try_collect::<Vec<_>>().await?;
+    let formatted = arrow::util::pretty::pretty_format_batches(&data)
+        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+    Ok(formatted.to_string())
+}
+
+async fn setup_runtime(table_name: &str, port: u16) -> Result<Runtime, anyhow::Error> {
+    let mut dataset = make_dynamodb_dataset(table_name, port, "foo", "bar", false);
+    dataset.access = AccessMode::ReadWrite;
+
+    let app = AppBuilder::new("dynamodb_dml_test")
+        .with_dataset(dataset)
+        .with_sql_cache(SQLResultsCacheConfig {
+            enabled: false,
+            ..Default::default()
+        })
+        .build();
+
+    configure_test_datafusion();
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    let cloned_rt = Arc::new(rt.clone());
+    tokio::select! {
+        () = tokio::time::sleep(Duration::from_secs(60)) => {
+            return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+        }
+        () = cloned_rt.load_components() => {}
+    }
+
+    runtime_ready_check(&rt).await;
+    Ok(rt)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_dml_insert() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,info",
+    ));
+
+    let table_name = "dml_insert_test";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT_DML_INSERT).await?;
+            let client = get_client(PORT_DML_INSERT, "foo", "bar");
+
+            create_table(&client, table_name).await;
+
+            // Seed one row so schema inference works
+            client
+                .put_item()
+                .table_name(table_name)
+                .item("id", AttributeValue::S("seed".to_string()))
+                .item("name", AttributeValue::S("Seed Item".to_string()))
+                .send()
+                .await?;
+
+            let rt = setup_runtime(table_name, PORT_DML_INSERT).await?;
+
+            // Verify seed data
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(result.contains("seed"), "Should contain seed row");
+
+            // Insert via SQL
+            run_query(
+                &rt,
+                &format!(
+                    "INSERT INTO {table_name} (id, name) VALUES ('1', 'Item 1'), ('2', 'Item 2')"
+                ),
+            )
+            .await?;
+
+            // Verify the inserted rows are visible via DynamoDB scan
+            sleep(Duration::from_millis(500)).await;
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(result.contains("Item 1"), "Should contain inserted Item 1");
+            assert!(result.contains("Item 2"), "Should contain inserted Item 2");
+            assert!(result.contains("seed"), "Should still contain seed row");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_dml_delete() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,info",
+    ));
+
+    let table_name = "dml_delete_test";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT_DML_DELETE).await?;
+            let client = get_client(PORT_DML_DELETE, "foo", "bar");
+
+            create_table(&client, table_name).await;
+
+            // Seed rows
+            for i in 1..=4 {
+                client
+                    .put_item()
+                    .table_name(table_name)
+                    .item("id", AttributeValue::S(format!("{i}")))
+                    .item("name", AttributeValue::S(format!("Item {i}")))
+                    .send()
+                    .await?;
+            }
+
+            let rt = setup_runtime(table_name, PORT_DML_DELETE).await?;
+
+            // Verify all 4 rows exist
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(result.contains("Item 1"));
+            assert!(result.contains("Item 4"));
+
+            // Delete specific rows via SQL
+            run_query(
+                &rt,
+                &format!("DELETE FROM {table_name} WHERE id IN ('1', '2')"),
+            )
+            .await?;
+
+            // Verify deletion
+            sleep(Duration::from_millis(500)).await;
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(!result.contains("Item 1"), "Item 1 should be deleted");
+            assert!(!result.contains("Item 2"), "Item 2 should be deleted");
+            assert!(result.contains("Item 3"), "Item 3 should remain");
+            assert!(result.contains("Item 4"), "Item 4 should remain");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_dml_insert_then_delete() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,info",
+    ));
+
+    let table_name = "dml_insert_delete_test";
+
+    test_request_context()
+        .scope(async {
+            let running_container =
+                start_dynamodb_docker_container(PORT_DML_INSERT_DELETE).await?;
+            let client = get_client(PORT_DML_INSERT_DELETE, "foo", "bar");
+
+            create_table(&client, table_name).await;
+
+            // Seed one row
+            client
+                .put_item()
+                .table_name(table_name)
+                .item("id", AttributeValue::S("seed".to_string()))
+                .item("name", AttributeValue::S("Seed".to_string()))
+                .send()
+                .await?;
+
+            let rt = setup_runtime(table_name, PORT_DML_INSERT_DELETE).await?;
+
+            // Insert rows via SQL
+            run_query(
+                &rt,
+                &format!(
+                    "INSERT INTO {table_name} (id, name) VALUES ('a', 'Alpha'), ('b', 'Beta'), ('c', 'Charlie')"
+                ),
+            )
+            .await?;
+
+            sleep(Duration::from_millis(500)).await;
+            let result =
+                run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(result.contains("Alpha"));
+            assert!(result.contains("Beta"));
+            assert!(result.contains("Charlie"));
+            assert!(result.contains("Seed"));
+
+            // Delete two of the inserted rows
+            run_query(
+                &rt,
+                &format!("DELETE FROM {table_name} WHERE id = 'a' OR id = 'b'"),
+            )
+            .await?;
+
+            sleep(Duration::from_millis(500)).await;
+            let result =
+                run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(!result.contains("Alpha"), "Alpha should be deleted");
+            assert!(!result.contains("Beta"), "Beta should be deleted");
+            assert!(result.contains("Charlie"), "Charlie should remain");
+            assert!(result.contains("Seed"), "Seed should remain");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_dml_insert_multiple_types() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,info",
+    ));
+
+    let table_name = "dml_types_test";
+
+    test_request_context()
+        .scope(async {
+            let running_container = start_dynamodb_docker_container(PORT_DML_TYPES).await?;
+            let client = get_client(PORT_DML_TYPES, "foo", "bar");
+
+            create_table(&client, table_name).await;
+
+            // Seed a row with multiple types so schema inference picks them up
+            client
+                .put_item()
+                .table_name(table_name)
+                .item("id", AttributeValue::S("seed".to_string()))
+                .item("int_val", AttributeValue::N("100".to_string()))
+                .item("float_val", AttributeValue::N("1.5".to_string()))
+                .item("bool_val", AttributeValue::Bool(false))
+                .item("name", AttributeValue::S("Seed Row".to_string()))
+                .send()
+                .await?;
+
+            let rt = setup_runtime(table_name, PORT_DML_TYPES).await?;
+
+            // Verify seed data
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+            assert!(result.contains("seed"), "Should contain seed row");
+
+            // Insert row with multiple types via SQL
+            run_query(
+                &rt,
+                &format!(
+                    "INSERT INTO {table_name} (id, int_val, float_val, bool_val, name) \
+                     VALUES ('new', 42, 3.14, true, 'Test Row')"
+                ),
+            )
+            .await?;
+
+            // Verify roundtrip
+            sleep(Duration::from_millis(500)).await;
+            let result = run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY id")).await?;
+
+            assert!(result.contains("new"), "Should contain new row");
+            assert!(result.contains("42"), "Should contain int_val 42");
+            assert!(result.contains("3.14"), "Should contain float_val 3.14");
+            assert!(result.contains("true"), "Should contain bool_val true");
+            assert!(result.contains("Test Row"), "Should contain name");
+            assert!(result.contains("seed"), "Should still contain seed row");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamodb_dml_delete_composite_key_tuple_in() -> anyhow::Result<()> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,data_components=debug,info",
+    ));
+
+    let table_name = "dml_composite_delete_test";
+
+    test_request_context()
+        .scope(async {
+            let running_container =
+                start_dynamodb_docker_container(PORT_DML_COMPOSITE_DELETE).await?;
+            let client = get_client(PORT_DML_COMPOSITE_DELETE, "foo", "bar");
+
+            create_composite_key_table(&client, table_name).await;
+
+            // Seed 4 rows with composite keys
+            for (pk, sk, val) in [
+                ("a", "1", "alpha-one"),
+                ("a", "2", "alpha-two"),
+                ("b", "1", "beta-one"),
+                ("b", "2", "beta-two"),
+            ] {
+                client
+                    .put_item()
+                    .table_name(table_name)
+                    .item("pk", AttributeValue::S(pk.to_string()))
+                    .item("sk", AttributeValue::S(sk.to_string()))
+                    .item("val", AttributeValue::S(val.to_string()))
+                    .send()
+                    .await?;
+            }
+
+            let rt = setup_runtime(table_name, PORT_DML_COMPOSITE_DELETE).await?;
+
+            // Verify all 4 rows exist
+            let result =
+                run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY pk, sk")).await?;
+            assert!(result.contains("alpha-one"));
+            assert!(result.contains("alpha-two"));
+            assert!(result.contains("beta-one"));
+            assert!(result.contains("beta-two"));
+
+            // Delete 1 row using single-tuple IN list (DataFusion optimizes this to struct = struct)
+            run_query(
+                &rt,
+                &format!("DELETE FROM {table_name} WHERE (pk, sk) IN (('a', '1'))"),
+            )
+            .await?;
+
+            sleep(Duration::from_millis(500)).await;
+            let result =
+                run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY pk, sk")).await?;
+            assert!(
+                !result.contains("alpha-one"),
+                "alpha-one should be deleted by single-tuple IN"
+            );
+            assert!(result.contains("alpha-two"), "alpha-two should remain");
+            assert!(result.contains("beta-one"), "beta-one should remain");
+            assert!(result.contains("beta-two"), "beta-two should remain");
+
+            // Delete 2 rows using multi-tuple IN list on composite key
+            run_query(
+                &rt,
+                &format!("DELETE FROM {table_name} WHERE (pk, sk) IN (('a', '2'), ('b', '1'))"),
+            )
+            .await?;
+
+            sleep(Duration::from_millis(500)).await;
+            let result =
+                run_query(&rt, &format!("SELECT * FROM {table_name} ORDER BY pk, sk")).await?;
+            assert!(
+                !result.contains("alpha-two"),
+                "alpha-two should be deleted by multi-tuple IN"
+            );
+            assert!(
+                !result.contains("beta-one"),
+                "beta-one should be deleted by multi-tuple IN"
+            );
+            assert!(result.contains("beta-two"), "beta-two should remain");
+
+            running_container.remove().await.map_err(|e| {
+                tracing::error!("running_container.remove: {e}");
+                anyhow::Error::msg(e.to_string())
+            })?;
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/dynamodb/mod.rs
+++ b/crates/runtime/tests/dynamodb/mod.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 #![allow(dead_code, clippy::allow_attributes)]
 
-mod streams;
+mod dml;
+pub(super) mod streams;
 
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
## 📝 Summary

* Add support for `delete_from` and `update` to `DynamoDBTableProvider`.

* Add configurable parallelism (added `write_parallelism` configuration parameter)

* Temporarily add custom handling for `DynamoDBTableProvider` in `get_deletion_provider` until we get rid of `DeletionTableProvider` in favor of DF's native support of `delete_from`

* Tests

Needed for DynamoDB ADBC driver.
Also: bump `docx-rs` version since `zip 7.4.0` version was yanked (using yanked versions is not allowed for new projects such as DynamoDB ADBC driver)