### PR TITLE
Add support for DF native DML

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4093,6 +4093,23 @@ impl TableProvider for CayenneTableProvider {
 
         Ok(Arc::new(DataSinkExec::new(input, sink, None)))
     }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        if self.file_based_deletes_preferred(&filters) {
+            tracing::debug!(
+                "Table '{}': using file-based retention delete path",
+                self.table_metadata.table_name,
+            );
+            return self.delete_using_files(&filters);
+        }
+
+        // Default path: deletion vectors via CayenneDeletionSink
+        self.delete_using_deletion_vectors(&filters)
+    }
 }
 
 // Implement DeletionTableProvider for Cayenne
@@ -4100,19 +4117,10 @@ impl TableProvider for CayenneTableProvider {
 impl DeletionTableProvider for CayenneTableProvider {
     async fn delete_from(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         filters: &[Expr],
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        if self.file_based_deletes_preferred(filters) {
-            tracing::debug!(
-                "Table '{}': using file-based retention delete path",
-                self.table_metadata.table_name,
-            );
-            return self.delete_using_files(filters);
-        }
-
-        // Default path: deletion vectors via CayenneDeletionSink
-        self.delete_using_deletion_vectors(filters)
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/data_components/src/arrow/indexed.rs
+++ b/crates/data_components/src/arrow/indexed.rs
@@ -793,6 +793,14 @@ impl TableProvider for IndexedMemTable {
     fn get_column_default(&self, column: &str) -> Option<&Expr> {
         self.inner.get_column_default(column)
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.inner.delete_from(state, filters).await
+    }
 }
 
 #[async_trait]
@@ -968,9 +976,7 @@ impl crate::delete::DeletionTableProvider for IndexedMemTable {
         state: &dyn Session,
         filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Delegate deletion to inner MemTable
-        // Note: Index should be updated after deletion
-        crate::delete::DeletionTableProvider::delete_from(&self.inner, state, filters).await
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -344,6 +344,21 @@ impl TableProvider for MemTable {
     fn get_column_default(&self, column: &str) -> Option<&Expr> {
         self.column_defaults.get(column)
     }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(MemDeletionSink::new(
+                self.batches.clone(),
+                self.schema(),
+                &filters,
+            )),
+            &self.schema(),
+        )))
+    }
 }
 
 /// Implements for writing to a [`MemTable`]
@@ -1059,17 +1074,10 @@ impl DataSink for MemSink {
 impl DeletionTableProvider for MemTable {
     async fn delete_from(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(DeletionExec::new(
-            Arc::new(MemDeletionSink::new(
-                self.batches.clone(),
-                self.schema(),
-                filters,
-            )),
-            &self.schema(),
-        )))
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/data_components/src/iceberg/delete.rs
+++ b/crates/data_components/src/iceberg/delete.rs
@@ -446,11 +446,18 @@ impl datafusion::datasource::TableProvider for IcebergDeletionProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         self.inner.insert_into(state, input, overwrite).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<datafusion::logical_expr::Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.delete_from_impl(state, &filters).await
+    }
 }
 
-#[async_trait]
-impl crate::delete::DeletionTableProvider for IcebergDeletionProvider {
-    async fn delete_from(
+impl IcebergDeletionProvider {
+    async fn delete_from_impl(
         &self,
         state: &dyn Session,
         filters: &[datafusion::logical_expr::Expr],
@@ -572,5 +579,16 @@ impl crate::delete::DeletionTableProvider for IcebergDeletionProvider {
             coalesced,
             equality_ids,
         )))
+    }
+}
+
+#[async_trait]
+impl crate::delete::DeletionTableProvider for IcebergDeletionProvider {
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: &[datafusion::logical_expr::Expr],
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.delete_from_impl(state, filters).await
     }
 }

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -90,6 +90,7 @@ pub mod imap;
 pub mod index_maintenance;
 pub mod object;
 pub mod poly;
+pub mod update;
 
 #[async_trait]
 pub trait Read: Send + Sync {

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -172,4 +172,12 @@ impl TableProvider for PolyTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.write.insert_into(state, input, overwrite).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        DeletionTableProvider::delete_from(&*self.delete, state, &filters).await
+    }
 }

--- a/crates/data_components/src/turso.rs
+++ b/crates/data_components/src/turso.rs
@@ -1199,23 +1199,31 @@ impl TableProvider for TursoTableProvider {
         // Wrap in DataSinkExec to execute the insertion
         Ok(Arc::new(DataSinkExec::new(input, sink, None)))
     }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(TursoDeletionSink::new(
+                Arc::clone(&self.pool),
+                self.table_name.clone(),
+                &filters,
+            )),
+            &self.schema(),
+        )))
+    }
 }
 
 #[async_trait]
 impl DeletionTableProvider for TursoTableProvider {
     async fn delete_from(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(DeletionExec::new(
-            Arc::new(TursoDeletionSink::new(
-                Arc::clone(&self.pool),
-                self.table_name.clone(),
-                filters,
-            )),
-            &self.schema(),
-        )))
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/data_components/src/update.rs
+++ b/crates/data_components/src/update.rs
@@ -23,6 +23,8 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use datafusion::execution::SessionState;
+use datafusion::physical_plan::execute_stream;
 use datafusion::{
     datasource::TableProvider,
     error::DataFusionError,
@@ -35,8 +37,6 @@ use datafusion::{
         stream::RecordBatchStreamAdapter,
     },
 };
-use datafusion::execution::SessionState;
-use datafusion::physical_plan::execute_stream;
 use datafusion_datasource::memory::MemorySourceConfig;
 
 /// An execution plan that implements UPDATE as delete + insert.
@@ -87,11 +87,7 @@ impl std::fmt::Debug for UpdateExec {
 }
 
 impl DisplayAs for UpdateExec {
-    fn fmt_as(
-        &self,
-        _t: DisplayFormatType,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "UpdateExec")
     }
 }
@@ -169,9 +165,7 @@ impl ExecutionPlan for UpdateExec {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(DataFusionError::from)?;
 
-            let delete_plan = table_provider
-                .delete_from(&session_state, filters)
-                .await?;
+            let delete_plan = table_provider.delete_from(&session_state, filters).await?;
             let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
             let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
 

--- a/crates/data_components/src/update.rs
+++ b/crates/data_components/src/update.rs
@@ -1,0 +1,213 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Shared `UpdateExec` execution plan for implementing UPDATE-as-delete+insert.
+//!
+//! Providers that implement `TableProvider::update` can return this plan from their
+//! `update()` method. The plan materializes the updated rows from a source plan,
+//! deletes the matching rows, then inserts the updated rows back.
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use datafusion::{
+    datasource::TableProvider,
+    error::DataFusionError,
+    execution::{SendableRecordBatchStream, TaskContext},
+    logical_expr::{Expr, dml::InsertOp},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+        execution_plan::{Boundedness, EmissionType},
+        stream::RecordBatchStreamAdapter,
+    },
+};
+use datafusion::execution::SessionState;
+use datafusion::physical_plan::execute_stream;
+use datafusion_datasource::memory::MemorySourceConfig;
+
+/// An execution plan that implements UPDATE as delete + insert.
+///
+/// 1. Materializes the updated rows from the source plan.
+/// 2. Normalizes output to match the target table schema.
+/// 3. Deletes matching rows via `TableProvider::delete_from`.
+/// 4. Inserts updated rows via `TableProvider::insert_into`.
+/// 5. Returns a single-row batch with the count of affected rows.
+pub struct UpdateExec {
+    source_plan: Arc<dyn ExecutionPlan>,
+    table_provider: Arc<dyn TableProvider>,
+    session_state: SessionState,
+    filters: Vec<Expr>,
+    properties: PlanProperties,
+}
+
+impl UpdateExec {
+    pub fn new(
+        source_plan: Arc<dyn ExecutionPlan>,
+        table_provider: Arc<dyn TableProvider>,
+        session_state: SessionState,
+        filters: Vec<Expr>,
+    ) -> Self {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            source_plan,
+            table_provider,
+            session_state,
+            filters,
+            properties,
+        }
+    }
+}
+
+impl std::fmt::Debug for UpdateExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpdateExec").finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for UpdateExec {
+    fn fmt_as(
+        &self,
+        _t: DisplayFormatType,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "UpdateExec")
+    }
+}
+
+impl ExecutionPlan for UpdateExec {
+    fn name(&self) -> &'static str {
+        "UpdateExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.source_plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "UpdateExec requires exactly one child, got {}",
+                children.len()
+            )));
+        }
+
+        Ok(Arc::new(Self::new(
+            Arc::clone(&children[0]),
+            Arc::clone(&self.table_provider),
+            self.session_state.clone(),
+            self.filters.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(format!(
+                "UpdateExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let source_plan = Arc::clone(&self.source_plan);
+        let table_provider = Arc::clone(&self.table_provider);
+        let session_state = self.session_state.clone();
+        let filters = self.filters.clone();
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
+        ]));
+
+        let stream = futures::stream::once(async move {
+            use futures::TryStreamExt;
+
+            let source_stream = execute_stream(Arc::clone(&source_plan), Arc::clone(&context))?;
+            let updated_batches: Vec<RecordBatch> = source_stream.try_collect().await?;
+
+            // Normalize update output to match the target table schema (including nullability)
+            // before performing any destructive operation.
+            let target_schema = table_provider.schema();
+            let normalized_batches = updated_batches
+                .into_iter()
+                .map(|batch| {
+                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(DataFusionError::from)?;
+
+            let delete_plan = table_provider
+                .delete_from(&session_state, filters)
+                .await?;
+            let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
+            let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
+
+            let deleted_count = delete_batches
+                .iter()
+                .flat_map(RecordBatch::columns)
+                .find_map(|arr| {
+                    arr.as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .and_then(|counts| counts.values().first().copied())
+                })
+                .unwrap_or(0);
+
+            if !normalized_batches.is_empty() {
+                let input_exec = MemorySourceConfig::try_new_exec(
+                    &[normalized_batches],
+                    Arc::clone(&target_schema),
+                    None,
+                )?;
+                let insert_plan = table_provider
+                    .insert_into(&session_state, input_exec, InsertOp::Append)
+                    .await?;
+                let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
+                let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
+            }
+
+            let result = RecordBatch::try_from_iter_with_nullable(vec![(
+                "count",
+                Arc::new(UInt64Array::from(vec![deleted_count])) as ArrayRef,
+                false,
+            )])
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+            Ok(result)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -391,6 +391,26 @@ impl TableProvider for PartitionTableProvider {
             .execute_insert(input, insert_op, &ctx)
             .await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // Collect all partitions that need deletion
+        let partitions = self.partitions.read().await;
+        let partition_list: Vec<_> = partitions.values().cloned().collect();
+        drop(partitions);
+
+        // Create a deletion sink that will iterate over all partitions
+        let deletion_sink = Arc::new(PartitionedDeletionSink::new(
+            partition_list,
+            filters,
+            state.task_ctx(),
+        ));
+
+        Ok(Arc::new(DeletionExec::new(deletion_sink, &self.schema)))
+    }
 }
 
 /// Implement `DeletionTableProvider` to support retention checks and delete operations
@@ -402,19 +422,7 @@ impl DeletionTableProvider for PartitionTableProvider {
         state: &dyn Session,
         filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        // Collect all partitions that need deletion
-        let partitions = self.partitions.read().await;
-        let partition_list: Vec<_> = partitions.values().cloned().collect();
-        drop(partitions);
-
-        // Create a deletion sink that will iterate over all partitions
-        let deletion_sink = Arc::new(PartitionedDeletionSink::new(
-            partition_list,
-            filters.to_vec(),
-            state.task_ctx(),
-        ));
-
-        Ok(Arc::new(DeletionExec::new(deletion_sink, &self.schema)))
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/runtime/src/dataaccelerator/upsert_dedup.rs
+++ b/crates/runtime/src/dataaccelerator/upsert_dedup.rs
@@ -167,6 +167,14 @@ impl TableProvider for UpsertDedupTableProvider {
 
         self.inner.insert_into(state, dedup_exec, op).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        DeletionTableProvider::delete_from(self.deletion_provider.as_ref(), state, &filters).await
+    }
 }
 
 #[async_trait]
@@ -176,7 +184,7 @@ impl DeletionTableProvider for UpsertDedupTableProvider {
         state: &dyn Session,
         filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        DeletionTableProvider::delete_from(self.deletion_provider.as_ref(), state, filters).await
+        TableProvider::delete_from(self, state, filters.to_vec()).await
     }
 }
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -21,17 +21,14 @@ use ::cache::{
     key::CacheKey,
     result::{CacheStatus, query::QueryResult},
 };
-use arrow::array::UInt64Array;
 use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
     common::ParamValues,
-    datasource::memory::MemorySourceConfig,
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
-    logical_expr::dml::InsertOp,
     logical_expr::{Expr, LogicalPlan},
     physical_plan::{
         ExecutionPlan, ExecutionPlanProperties, execute_stream, repartition::RepartitionExec,
@@ -1529,198 +1526,15 @@ async fn create_update_physical_plan(
         ))
     })?;
 
-    let deletion_provider =
-        get_deletion_provider(Arc::clone(&table_provider)).ok_or_else(|| {
-            DataFusionError::Plan(format!(
-                "Table '{}' does not support UPDATE operations",
-                dml.table_name
-            ))
-        })?;
-
     let source_plan = session_state.create_physical_plan(&dml.input).await?;
     let filters = extract_dml_filters(&dml.input);
 
-    Ok(Arc::new(UpdateExec::new(
+    Ok(Arc::new(data_components::update::UpdateExec::new(
         source_plan,
         table_provider,
-        deletion_provider,
         session_state.clone(),
         filters,
     )))
-}
-
-struct UpdateExec {
-    source_plan: Arc<dyn ExecutionPlan>,
-    table_provider: Arc<dyn datafusion::datasource::TableProvider>,
-    deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
-    session_state: SessionState,
-    filters: Vec<Expr>,
-    properties: datafusion::physical_plan::PlanProperties,
-}
-
-impl UpdateExec {
-    fn new(
-        source_plan: Arc<dyn ExecutionPlan>,
-        table_provider: Arc<dyn datafusion::datasource::TableProvider>,
-        deletion_provider: Arc<dyn data_components::delete::DeletionTableProvider>,
-        session_state: SessionState,
-        filters: Vec<Expr>,
-    ) -> Self {
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
-            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
-        ]));
-        let properties = datafusion::physical_plan::PlanProperties::new(
-            datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
-            datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
-            datafusion::physical_plan::execution_plan::EmissionType::Incremental,
-            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
-        Self {
-            source_plan,
-            table_provider,
-            deletion_provider,
-            session_state,
-            filters,
-            properties,
-        }
-    }
-}
-
-impl std::fmt::Debug for UpdateExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UpdateExec").finish_non_exhaustive()
-    }
-}
-
-impl datafusion::physical_plan::DisplayAs for UpdateExec {
-    fn fmt_as(
-        &self,
-        _t: datafusion::physical_plan::DisplayFormatType,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "UpdateExec")
-    }
-}
-
-impl ExecutionPlan for UpdateExec {
-    fn name(&self) -> &'static str {
-        "UpdateExec"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.source_plan]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        if children.len() != 1 {
-            return Err(DataFusionError::Internal(format!(
-                "UpdateExec requires exactly one child, got {}",
-                children.len()
-            )));
-        }
-
-        Ok(Arc::new(Self::new(
-            Arc::clone(&children[0]),
-            Arc::clone(&self.table_provider),
-            Arc::clone(&self.deletion_provider),
-            self.session_state.clone(),
-            self.filters.clone(),
-        )))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> std::result::Result<SendableRecordBatchStream, DataFusionError> {
-        if partition != 0 {
-            return Err(DataFusionError::Execution(format!(
-                "UpdateExec only supports partition 0, got {partition}"
-            )));
-        }
-
-        let source_plan = Arc::clone(&self.source_plan);
-        let table_provider = Arc::clone(&self.table_provider);
-        let deletion_provider = Arc::clone(&self.deletion_provider);
-        let session_state = self.session_state.clone();
-        let filters = self.filters.clone();
-
-        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
-            arrow::datatypes::Field::new("count", arrow::datatypes::DataType::UInt64, false),
-        ]));
-
-        let stream = futures::stream::once(async move {
-            use futures::TryStreamExt;
-
-            let source_stream = execute_stream(Arc::clone(&source_plan), Arc::clone(&context))?;
-            let updated_batches: Vec<RecordBatch> = source_stream.try_collect().await?;
-
-            // Normalize update output to match the target table schema (including nullability)
-            // before performing any destructive operation.
-            let target_schema = table_provider.schema();
-            let normalized_batches = updated_batches
-                .into_iter()
-                .map(|batch| {
-                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
-                })
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(DataFusionError::from)?;
-
-            let delete_plan = DeletionTableProvider::delete_from(
-                deletion_provider.as_ref(),
-                &session_state,
-                &filters,
-            )
-            .await?;
-            let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
-            let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
-
-            let deleted_count = delete_batches
-                .iter()
-                .flat_map(RecordBatch::columns)
-                .find_map(|arr| {
-                    arr.as_any()
-                        .downcast_ref::<UInt64Array>()
-                        .and_then(|counts| counts.values().first().copied())
-                })
-                .unwrap_or(0);
-
-            if !normalized_batches.is_empty() {
-                let input_exec = MemorySourceConfig::try_new_exec(
-                    &[normalized_batches],
-                    Arc::clone(&target_schema),
-                    None,
-                )?;
-                let insert_plan = table_provider
-                    .insert_into(&session_state, input_exec, InsertOp::Append)
-                    .await?;
-                let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
-                let _insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
-            }
-
-            let result = RecordBatch::try_from_iter_with_nullable(vec![(
-                "count",
-                Arc::new(UInt64Array::from(vec![deleted_count])) as arrow::array::ArrayRef,
-                false,
-            )])
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-
-            Ok(result)
-        });
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 📝 Summary

Add support for DF native `update` and `delete_from` for table providers that need to implement them.

Next steps: Remove custom `DeletionTableProvider` and cleanup.