### PR TITLE
chore: Update iceberg-rust fork to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "fundu",
  "iceberg",
+ "iceberg-storage-opendal",
  "object_store",
  "reqwest 0.12.24",
  "secrecy",
@@ -2833,6 +2834,16 @@ dependencies = [
  "rust-stemmers",
  "stop-words",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+dependencies = [
+ "serde",
+ "serde-big-array",
 ]
 
 [[package]]
@@ -7104,6 +7115,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7331,6 +7353,18 @@ dependencies = [
  "num-traits",
  "paste",
  "seq-macro",
+]
+
+[[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -8226,7 +8260,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -9389,8 +9423,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6dc788084d94bcd90e61d26c496fb7056ae7a9c4#6dc788084d94bcd90e61d26c496fb7056ae7a9c4"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -9412,23 +9446,20 @@ dependencies = [
  "chrono",
  "derive_builder",
  "expect-test",
+ "fastnum",
  "flate2",
  "fnv",
  "futures",
  "itertools 0.13.0",
  "moka",
  "murmur3",
- "num-bigint",
  "once_cell",
- "opendal",
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.8.5",
- "reqsign",
  "reqwest 0.12.24",
  "reqwest-middleware",
  "roaring",
- "rust_decimal",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -9438,6 +9469,7 @@ dependencies = [
  "strum 0.27.2",
  "tokio",
  "typed-builder 0.20.1",
+ "typetag",
  "url",
  "uuid 1.21.0",
  "zstd",
@@ -9445,14 +9477,15 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-glue"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6dc788084d94bcd90e61d26c496fb7056ae7a9c4#6dc788084d94bcd90e61d26c496fb7056ae7a9c4"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-glue",
  "iceberg",
+ "iceberg-storage-opendal",
  "serde_json",
  "tokio",
  "tracing",
@@ -9460,14 +9493,13 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6dc788084d94bcd90e61d26c496fb7056ae7a9c4#6dc788084d94bcd90e61d26c496fb7056ae7a9c4"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
  "aws-credential-types",
- "aws-sdk-sts",
  "aws-sigv4",
  "chrono",
  "http 1.4.0",
@@ -9486,11 +9518,12 @@ dependencies = [
 
 [[package]]
 name = "iceberg-datafusion"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6dc788084d94bcd90e61d26c496fb7056ae7a9c4#6dc788084d94bcd90e61d26c496fb7056ae7a9c4"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dashmap",
  "datafusion",
  "futures",
  "iceberg",
@@ -9500,11 +9533,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "iceberg_test_utils"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6dc788084d94bcd90e61d26c496fb7056ae7a9c4#6dc788084d94bcd90e61d26c496fb7056ae7a9c4"
+name = "iceberg-storage-opendal"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
 dependencies = [
- "tracing",
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "iceberg",
+ "opendal",
+ "reqsign",
+ "reqwest 0.12.24",
+ "serde",
+ "typetag",
+ "url",
+]
+
+[[package]]
+name = "iceberg_test_utils"
+version = "0.9.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=6c9b9709c572fe40484ec00aa969d1f62f2b0fe7#6c9b9709c572fe40484ec00aa969d1f62f2b0fe7"
+dependencies = [
+ "iceberg",
  "tracing-subscriber",
 ]
 
@@ -13881,7 +13932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.16.1",
  "parking_lot 0.12.5",
  "rand 0.8.5",
 ]
@@ -14435,7 +14486,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -15968,6 +16019,7 @@ dependencies = [
  "iceberg-catalog-glue",
  "iceberg-catalog-rest",
  "iceberg-datafusion",
+ "iceberg-storage-opendal",
  "indexmap 2.13.0",
  "insta",
  "itertools 0.14.0",
@@ -15984,6 +16036,7 @@ dependencies = [
  "ns_lookup",
  "object_store",
  "object_store_occ",
+ "opendal",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
@@ -17910,7 +17963,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -20735,6 +20788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3015e6ce46d5ad8751e4a772543a30c7511468070e98e64e20165f8f81155b64"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20788,6 +20847,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5297,6 +5297,7 @@ dependencies = [
  "iceberg",
  "iceberg-catalog-rest",
  "iceberg-datafusion",
+ "iceberg-storage-opendal",
  "iceberg_test_utils",
  "imap",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,11 +192,12 @@ hf-hub = { version = "0.4", features = ["tokio"] }
 http = "1.3.1"
 httpdate = "1.0"
 humantime = "2.1.0"
-iceberg = "0.8.0"
-iceberg-catalog-glue = "0.8.0"
-iceberg-catalog-rest = "0.8.0"
-iceberg-datafusion = "0.8.0"
-iceberg_test_utils = "0.8.0"
+iceberg = "0.9.0"
+iceberg-catalog-glue = "0.9.0"
+iceberg-catalog-rest = "0.9.0"
+iceberg-datafusion = "0.9.0"
+iceberg-storage-opendal = { version = "0.9.0", features = ["opendal-s3", "opendal-gcs", "opendal-fs"] }
+iceberg_test_utils = "0.9.0"
 imap = { git = "https://github.com/jonhoo/rust-imap", rev = "6fe22ed11a1ccffe1799a73f48e589366d8d100f" }
 indexmap = "2"
 insta = { version = "1.46.3", features = ["filters"] }
@@ -216,6 +217,7 @@ object_store = { version = "0.12.4", features = [
     "http",
 ] }
 odbc-api = { version = "20" }
+opendal = { version = "0.55", default-features = false, features = ["services-s3", "services-fs", "services-gcs", "services-memory"] }
 opentelemetry = { version = "0.31", default-features = false, features = [
     "metrics",
     "trace",
@@ -405,11 +407,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6dc788084d94bcd90e61d26c496fb7056ae7a9c4" }              # spiceai-52
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6dc788084d94bcd90e61d26c496fb7056ae7a9c4" } # spiceai-52
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6dc788084d94bcd90e61d26c496fb7056ae7a9c4" } # spiceai-52
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6dc788084d94bcd90e61d26c496fb7056ae7a9c4" }   # spiceai-52
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6dc788084d94bcd90e61d26c496fb7056ae7a9c4" }   # spiceai-52
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }              # spiceai-52
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }
 

--- a/crates/aws-sdk-credential-bridge/Cargo.toml
+++ b/crates/aws-sdk-credential-bridge/Cargo.toml
@@ -19,6 +19,7 @@ aws-smithy-runtime.workspace = true
 aws-smithy-runtime-api.workspace = true
 fundu.workspace = true
 iceberg.workspace = true
+iceberg-storage-opendal.workspace = true
 object_store.workspace = true
 reqwest.workspace = true
 secrecy.workspace = true

--- a/crates/aws-sdk-credential-bridge/src/credential_provider.rs
+++ b/crates/aws-sdk-credential-bridge/src/credential_provider.rs
@@ -35,7 +35,7 @@ use aws_smithy_runtime_api::client::{
     identity::SharedIdentityResolver,
     runtime_components::{RuntimeComponents, RuntimeComponentsBuilder},
 };
-use iceberg::io::{
+use iceberg_storage_opendal::{
     AwsCredential as IcebergAwsCredential, AwsCredentialLoad, CustomAwsCredentialLoader,
 };
 use object_store::{CredentialProvider, aws::AwsCredential as ObjectStoreAwsCredential};

--- a/crates/aws-sdk-credential-bridge/tests/credential_provider.rs
+++ b/crates/aws-sdk-credential-bridge/tests/credential_provider.rs
@@ -20,7 +20,7 @@ use aws_sdk_cognitoidentity as cognito_identity;
 use aws_sdk_cognitoidentityprovider as cognito_idp;
 use aws_sdk_cognitoidentityprovider::types::AuthFlowType;
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_or_init_sdk_config};
-use iceberg::io::AwsCredentialLoad;
+use iceberg_storage_opendal::AwsCredentialLoad;
 use object_store::CredentialProvider;
 use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -173,6 +173,7 @@ aws-smithy-types = { workspace = true }
 chrono = { workspace = true }
 criterion = { version = "0.7", features = ["async_tokio", "html_reports"] }
 ctor = "0.6.3"
+iceberg-storage-opendal.workspace = true
 iceberg_test_utils = { workspace = true, features = ["tests"] }
 insta.workspace = true
 object_store = { workspace = true }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -58,7 +58,7 @@ graphql-parser.workspace = true
 hash-index = { path = "../hash-index", features = ["metrics"] }
 http.workspace = true
 httpdate.workspace = true
-iceberg = { workspace = true, features = ["storage-gcs", "storage-s3"] }
+iceberg.workspace = true
 parquet = { workspace = true }
 iceberg-catalog-rest.workspace = true
 iceberg-datafusion.workspace = true
@@ -69,7 +69,7 @@ mysql_async = { workspace = true, optional = true }
 mailparse = { workspace = true, optional = true }
 num_cpus = "1.16"
 object_store = { workspace = true }
-opendal = "0.55"
+opendal.workspace = true
 oracle = { version = "0.6", optional = true }
 rand.workspace = true
 rdkafka = { workspace = true, features = ["ssl-vendored"], optional = true }

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::any::Any;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use iceberg::io::{Extensions, FileIO, InputFile};
+use iceberg::io::{FileIO, FileIOBuilder, InputFile, StorageFactory};
 use iceberg::spec::TableMetadata;
 use iceberg::table::Table;
 use iceberg::{
     Catalog, Error, ErrorKind, Namespace, NamespaceIdent, Result, TableCommit, TableCreation,
     TableIdent,
 };
-use opendal::{Entry, EntryMode};
+use opendal::{Entry, Operator};
 
 /// Specifies the mode for identifying metadata files in a Hadoop catalog
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -48,7 +48,8 @@ pub struct HadoopCatalogBuilder {
     file_io: Option<FileIO>,
     metadata_mode: MetadataMode,
     properties: HashMap<String, String>,
-    file_io_extensions: Extensions,
+    storage_factory: Option<Arc<dyn StorageFactory>>,
+    operator: Option<Operator>,
 }
 
 impl HadoopCatalogBuilder {
@@ -67,10 +68,17 @@ impl HadoopCatalogBuilder {
         self
     }
 
-    /// Sets the `FileIO` extensions for the Hadoop catalog.
+    /// Sets the `StorageFactory` for the Hadoop catalog.
     #[must_use]
-    pub fn with_file_io_extension<T: Any + Send + Sync>(mut self, extension: T) -> Self {
-        self.file_io_extensions.add(extension);
+    pub fn with_storage_factory(mut self, factory: Arc<dyn StorageFactory>) -> Self {
+        self.storage_factory = Some(factory);
+        self
+    }
+
+    /// Sets the opendal `Operator` for directory listing operations.
+    #[must_use]
+    pub fn with_operator(mut self, operator: Operator) -> Self {
+        self.operator = Some(operator);
         self
     }
 
@@ -108,24 +116,35 @@ impl HadoopCatalogBuilder {
 
             let file_io = if let Some(file_io) = self.file_io {
                 file_io
+            } else if let Some(factory) = &self.storage_factory {
+                FileIOBuilder::new(Arc::clone(factory))
+                    .with_props(self.properties.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+                    .build()
             } else {
-                FileIO::from_path(&warehouse_root)?
-                    .with_props(self.properties)
-                    .with_extensions(self.file_io_extensions)
-                    .build()?
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Either file_io or storage_factory must be provided",
+                ));
             };
 
+            let operator = self.operator.ok_or_else(|| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "An opendal Operator must be provided via with_operator()",
+                )
+            })?;
+
+            // Verify the warehouse root exists using the file_io (which handles full paths)
             let root_input = file_io.new_input(&warehouse_root).map_err(|e| {
                 Error::new(
                     ErrorKind::DataInvalid,
                     format!("Invalid warehouse root: {e}"),
                 )
             })?;
-
-            if !matches!(root_input.metadata().await?.mode, EntryMode::DIR) {
+            if !root_input.exists().await? {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
-                    "Warehouse root must be a directory",
+                    format!("Warehouse root '{warehouse_root}' does not exist"),
                 ));
             }
 
@@ -133,6 +152,7 @@ impl HadoopCatalogBuilder {
             let catalog = HadoopCatalog {
                 warehouse_root,
                 file_io,
+                operator,
                 metadata_mode: self.metadata_mode,
             };
 
@@ -200,6 +220,7 @@ impl HadoopCatalogBuilder {
 #[derive(Debug, Clone)]
 pub struct HadoopCatalog {
     file_io: FileIO,
+    operator: Operator,
     warehouse_root: String,
     metadata_mode: MetadataMode,
 }
@@ -446,10 +467,14 @@ impl Catalog for HadoopCatalog {
 impl HadoopCatalog {
     async fn get_directories(&self, root: &str) -> Result<Vec<Entry>> {
         let mut directories = Vec::new();
-        let mut lister = self.file_io.lister(root).await?;
+        let entries = self
+            .operator
+            .list(root)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list directory: {e}")))?;
 
-        while let Some(entry) = lister.try_next().await? {
-            if matches!(entry.metadata().mode(), EntryMode::DIR) && !root.ends_with(entry.path()) {
+        for entry in entries {
+            if entry.metadata().is_dir() && !root.ends_with(entry.path()) {
                 directories.push(entry);
             }
         }
@@ -463,20 +488,38 @@ impl HadoopCatalog {
         metadata_mode: MetadataMode,
     ) -> Result<bool> {
         let data_dir = format!("{path}/data/");
-        let input_data = self.file_io.new_input(&data_dir)?;
-        return Ok(input_data.exists().await?
-            && matches!(input_data.metadata().await?.mode, EntryMode::DIR)
-            && self.directory_has_metadata(path, metadata_mode).await?);
+        let exists = self
+            .operator
+            .exists(&data_dir)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
+        if !exists {
+            return Ok(false);
+        }
+        let stat = self
+            .operator
+            .stat(&data_dir)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to stat: {e}")))?;
+        Ok(stat.is_dir() && self.directory_has_metadata(path, metadata_mode).await?)
     }
 
     async fn directory_exists(&self, path: &str) -> Result<bool> {
-        let input = self.file_io.new_input(path)?;
-        if !input.exists().await? {
+        let exists = self
+            .operator
+            .exists(path)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
+        if !exists {
             return Ok(false);
         }
 
-        let metadata = input.metadata().await?;
-        Ok(matches!(metadata.mode, EntryMode::DIR))
+        let stat = self
+            .operator
+            .stat(path)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to stat: {e}")))?;
+        Ok(stat.is_dir())
     }
 
     async fn directory_has_metadata(
@@ -485,14 +528,22 @@ impl HadoopCatalog {
         metadata_mode: MetadataMode,
     ) -> Result<bool> {
         let metadata_directory = format!("{path}/metadata/");
-        let input = self.file_io.new_input(&metadata_directory)?;
-        if !input.exists().await? {
+        let exists = self
+            .operator
+            .exists(&metadata_directory)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
+        if !exists {
             return Ok(false);
         }
 
-        let mut lister = self.file_io.lister(&metadata_directory).await?;
-        while let Some(entry) = lister.try_next().await? {
-            if matches!(entry.metadata().mode(), EntryMode::FILE) {
+        let entries = self
+            .operator
+            .list(&metadata_directory)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list directory: {e}")))?;
+        for entry in entries {
+            if entry.metadata().is_file() {
                 let (metadata_file, fail_if_exact_missing) = match metadata_mode {
                     MetadataMode::Infer => (None, false),
                     MetadataMode::ExactOrInfer(ref metadata_file) => (Some(metadata_file), false),
@@ -576,10 +627,13 @@ impl HadoopCatalog {
                     table = table_identifier.name
                 );
 
-                let mut lister = self.file_io.lister(&metadata_directory).await?;
+                let mut lister = self.operator
+                    .lister(&metadata_directory)
+                    .await
+                    .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list metadata directory: {e}")))?;
                 let mut latest_metadata_file: Option<Entry> = None;
-                while let Some(entry) = lister.try_next().await? {
-                    if matches!(entry.metadata().mode(), EntryMode::FILE)
+                while let Some(entry) = lister.try_next().await.map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to read metadata entry: {e}")))? {
+                    if entry.metadata().is_file()
                         && entry.name().ends_with(".metadata.json")
                     {
                         if let Some(latest_file) = &latest_metadata_file {

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -465,16 +465,35 @@ impl Catalog for HadoopCatalog {
 }
 
 impl HadoopCatalog {
-    async fn get_directories(&self, root: &str) -> Result<Vec<Entry>> {
-        let mut directories = Vec::new();
-        let entries = self
-            .operator
-            .list(root)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list directory: {e}")))?;
+    /// Converts a full URL path (e.g., `s3://bucket/prefix/namespace/`) to a path
+    /// relative to the opendal operator root. The operator root is configured to match
+    /// the warehouse root path, so stripping the `warehouse_root` prefix yields the
+    /// correct operator-relative path.
+    fn to_operator_path(&self, full_path: &str) -> String {
+        match full_path.strip_prefix(&self.warehouse_root) {
+            Some("") => "/".to_string(),
+            Some(relative) => relative.to_string(),
+            None => full_path.to_string(),
+        }
+    }
 
-        for entry in entries {
-            if entry.metadata().is_dir() && !root.ends_with(entry.path()) {
+    async fn get_directories(&self, root: &str) -> Result<Vec<Entry>> {
+        let op_path = self.to_operator_path(root);
+        let mut directories = Vec::new();
+        let mut lister = self.operator.lister(&op_path).await.map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to list directory: {e}"),
+            )
+        })?;
+
+        while let Some(entry) = lister.try_next().await.map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to read directory entry: {e}"),
+            )
+        })? {
+            if entry.metadata().is_dir() {
                 directories.push(entry);
             }
         }
@@ -488,38 +507,33 @@ impl HadoopCatalog {
         metadata_mode: MetadataMode,
     ) -> Result<bool> {
         let data_dir = format!("{path}/data/");
-        let exists = self
-            .operator
-            .exists(&data_dir)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
-        if !exists {
+        let op_path = self.to_operator_path(&data_dir);
+        let is_data_dir = match self.operator.stat(&op_path).await {
+            Ok(m) => m.is_dir(),
+            Err(e) if e.kind() == opendal::ErrorKind::NotFound => return Ok(false),
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    format!("Failed to stat: {e}"),
+                ));
+            }
+        };
+        if !is_data_dir {
             return Ok(false);
         }
-        let stat = self
-            .operator
-            .stat(&data_dir)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to stat: {e}")))?;
-        Ok(stat.is_dir() && self.directory_has_metadata(path, metadata_mode).await?)
+        self.directory_has_metadata(path, metadata_mode).await
     }
 
     async fn directory_exists(&self, path: &str) -> Result<bool> {
-        let exists = self
-            .operator
-            .exists(path)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
-        if !exists {
-            return Ok(false);
+        let op_path = self.to_operator_path(path);
+        match self.operator.stat(&op_path).await {
+            Ok(m) => Ok(m.is_dir()),
+            Err(e) if e.kind() == opendal::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to stat: {e}"),
+            )),
         }
-
-        let stat = self
-            .operator
-            .stat(path)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to stat: {e}")))?;
-        Ok(stat.is_dir())
     }
 
     async fn directory_has_metadata(
@@ -528,38 +542,44 @@ impl HadoopCatalog {
         metadata_mode: MetadataMode,
     ) -> Result<bool> {
         let metadata_directory = format!("{path}/metadata/");
-        let exists = self
-            .operator
-            .exists(&metadata_directory)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to check existence: {e}")))?;
-        if !exists {
-            return Ok(false);
+        let op_path = self.to_operator_path(&metadata_directory);
+
+        // Check if the metadata directory exists
+        match self.operator.stat(&op_path).await {
+            Ok(m) if m.is_dir() => {}
+            Ok(_) | Err(_) => return Ok(false),
         }
 
-        let entries = self
-            .operator
-            .list(&metadata_directory)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list directory: {e}")))?;
-        for entry in entries {
-            if entry.metadata().is_file() {
-                let (metadata_file, fail_if_exact_missing) = match metadata_mode {
-                    MetadataMode::Infer => (None, false),
-                    MetadataMode::ExactOrInfer(ref metadata_file) => (Some(metadata_file), false),
-                    MetadataMode::Exact(ref metadata_file) => (Some(metadata_file), true),
-                };
+        let (metadata_file, fail_if_exact_missing) = match &metadata_mode {
+            MetadataMode::Infer => (None, false),
+            MetadataMode::ExactOrInfer(metadata_file) => (Some(metadata_file.as_str()), false),
+            MetadataMode::Exact(metadata_file) => (Some(metadata_file.as_str()), true),
+        };
 
-                if let Some(metadata_file) = metadata_file {
-                    if entry.name() == metadata_file {
+        let mut lister = self.operator.lister(&op_path).await.map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to list directory: {e}"),
+            )
+        })?;
+
+        while let Some(entry) = lister.try_next().await.map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to read metadata entry: {e}"),
+            )
+        })? {
+            if entry.metadata().is_file() {
+                if let Some(mf) = metadata_file {
+                    // Compare by filename — metadata_file may be a full path or just a name
+                    let mf_name = mf.rsplit('/').next().unwrap_or(mf);
+                    if entry.name() == mf_name {
                         return Ok(true);
-                    } else if fail_if_exact_missing {
-                        return Ok(false);
                     }
                 }
 
-                // Naive check if the file is a metadata file
-                if entry.name().ends_with(".metadata.json") {
+                // For non-Exact modes, any .metadata.json file qualifies
+                if !fail_if_exact_missing && entry.name().ends_with(".metadata.json") {
                     return Ok(true);
                 }
             }
@@ -627,15 +647,21 @@ impl HadoopCatalog {
                     table = table_identifier.name
                 );
 
-                let mut lister = self.operator
-                    .lister(&metadata_directory)
-                    .await
-                    .map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to list metadata directory: {e}")))?;
+                let op_path = self.to_operator_path(&metadata_directory);
+                let mut lister = self.operator.lister(&op_path).await.map_err(|e| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        format!("Failed to list metadata directory: {e}"),
+                    )
+                })?;
                 let mut latest_metadata_file: Option<Entry> = None;
-                while let Some(entry) = lister.try_next().await.map_err(|e| Error::new(ErrorKind::Unexpected, format!("Failed to read metadata entry: {e}")))? {
-                    if entry.metadata().is_file()
-                        && entry.name().ends_with(".metadata.json")
-                    {
+                while let Some(entry) = lister.try_next().await.map_err(|e| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        format!("Failed to read metadata entry: {e}"),
+                    )
+                })? {
+                    if entry.metadata().is_file() && entry.name().ends_with(".metadata.json") {
                         if let Some(latest_file) = &latest_metadata_file {
                             match (
                                 latest_file.metadata().last_modified(),

--- a/crates/data_components/src/iceberg/catalog/rest/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/rest/catalog.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use iceberg::{
     Catalog, Namespace, NamespaceIdent, Result as IcebergResult, TableCommit, TableCreation,
-    TableIdent, io::CustomAwsCredentialLoader, table::Table,
+    TableIdent, table::Table,
 };
 use iceberg_catalog_rest::RestCatalog as IcebergRestCatalog;
 
@@ -34,16 +34,6 @@ impl RestCatalog {
     #[must_use]
     pub fn new(inner: IcebergRestCatalog) -> Self {
         Self { inner }
-    }
-
-    #[must_use]
-    pub fn with_file_io_extension(
-        self,
-        custom_credential_loader: CustomAwsCredentialLoader,
-    ) -> Self {
-        Self {
-            inner: self.inner.with_file_io_extension(custom_credential_loader),
-        }
     }
 }
 

--- a/crates/data_components/src/iceberg/catalog/rest/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/rest/catalog.rs
@@ -139,6 +139,7 @@ mod tests {
     use iceberg::CatalogBuilder;
     use iceberg_catalog_rest::RestCatalogBuilder;
     use iceberg_datafusion::IcebergTableProvider;
+    use iceberg_storage_opendal::OpenDalStorageFactory;
     use std::sync::Arc;
 
     use super::*;
@@ -154,6 +155,10 @@ mod tests {
     async fn test_rest_catalog() {
         let catalog = RestCatalog::new(
             RestCatalogBuilder::default()
+                .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: "s3".to_string(),
+                    customized_credential_load: None,
+                }))
                 .load(
                     "rest",
                     HashMap::from([

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -27,10 +27,12 @@ use data_components::iceberg::catalog::hadoop::{HadoopCatalog, HadoopCatalogBuil
 use futures::TryStreamExt;
 use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY};
 use iceberg::{Catalog, NamespaceIdent};
+use iceberg_storage_opendal::OpenDalStorageFactory;
 #[cfg(feature = "test_hadoop_catalog_docker")]
 use iceberg_test_utils::docker::DockerCompose;
 #[cfg(feature = "test_hadoop_catalog_docker")]
 use iceberg_test_utils::normalize_test_name;
+use opendal::Configurator;
 
 #[cfg(feature = "test_hadoop_catalog_docker")]
 const MINIO_PORT: u16 = 9000;
@@ -39,8 +41,18 @@ const MINIO_PORT: u16 = 9000;
 static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
 
 #[cfg(feature = "test_hadoop_catalog_docker")]
+#[expect(clippy::expect_used)]
 fn get_file_hadoop_catalog() -> HadoopCatalogBuilder {
-    HadoopCatalogBuilder::default().with_warehouse_root("file:///tmp/hadoop_warehouse")
+    let mut fs_config = opendal::services::FsConfig::default();
+    fs_config.root = Some("/tmp/hadoop_warehouse".to_string());
+    let operator = opendal::Operator::new(fs_config.into_builder())
+        .expect("Should build FS operator")
+        .finish();
+
+    HadoopCatalogBuilder::default()
+        .with_warehouse_root("file:///tmp/hadoop_warehouse")
+        .with_storage_factory(Arc::new(iceberg::io::LocalFsStorageFactory))
+        .with_operator(operator)
 }
 
 #[expect(clippy::expect_used)]
@@ -63,8 +75,25 @@ fn get_s3a_hadoop_catalog() -> HadoopCatalogBuilder {
     let access_key = std::env::var("MINIO_ACCESS_KEY_ID").unwrap_or("admin".to_string());
     let secret_key = std::env::var("MINIO_SECRET_ACCESS_KEY").unwrap_or("password".to_string());
 
+    let mut s3_config = opendal::services::S3Config::default();
+    s3_config.bucket = "hadoop".to_string();
+    s3_config.root = Some("/".to_string());
+    s3_config.endpoint = Some(minio_endpoint.clone());
+    s3_config.region = Some("us-east-1".to_string());
+    s3_config.access_key_id = Some(access_key.clone());
+    s3_config.secret_access_key = Some(secret_key.clone());
+
+    let operator = opendal::Operator::new(s3_config.into_builder())
+        .expect("Should build S3 operator")
+        .finish();
+
     HadoopCatalogBuilder::default()
         .with_warehouse_root("s3a://hadoop/")
+        .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+            configured_scheme: "s3a".to_string(),
+            customized_credential_load: None,
+        }))
+        .with_operator(operator)
         .set_property(S3_REGION, "us-east-1")
         .set_property(S3_ENDPOINT, minio_endpoint)
         .set_property(S3_ACCESS_KEY_ID, access_key)

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -75,12 +75,14 @@ http-body-util = "0.1.3"
 humantime = { workspace = true, optional = true }
 hyper = "1.7.0"
 hyper-util = { version = "0.1.20", features = ["service"] }
-iceberg = { workspace = true, features = ["storage-gcs", "storage-s3"] }
+iceberg.workspace = true
 iceberg-catalog-glue.workspace = true
 iceberg-catalog-rest.workspace = true
 iceberg-datafusion.workspace = true
+iceberg-storage-opendal.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
+opendal.workspace = true
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 linkme.workspace = true
 llms = { path = "../llms", default-features = false }

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -638,6 +638,20 @@ pub fn parse_table_url(url: &str) -> Result<(String, HashMap<String, String>, Na
     }
 }
 
+/// Infers a default `StorageFactory` from the iceberg properties.
+///
+/// If any `gcs.*` property is present, returns a GCS factory; otherwise defaults to S3.
+fn default_storage_factory_from_props(props: &HashMap<String, String>) -> Arc<dyn StorageFactory> {
+    if props.keys().any(|k| k.starts_with("gcs.")) {
+        Arc::new(OpenDalStorageFactory::Gcs)
+    } else {
+        Arc::new(OpenDalStorageFactory::S3 {
+            configured_scheme: "s3".to_string(),
+            customized_credential_load: None,
+        })
+    }
+}
+
 /// Builds an `IcebergRestCatalog` from a base URI and properties.
 pub async fn get_rest_catalog(
     base_uri: String,
@@ -645,11 +659,9 @@ pub async fn get_rest_catalog(
     storage_factory: Option<Arc<dyn StorageFactory>>,
 ) -> Result<IcebergRestCatalog> {
     props.insert(REST_CATALOG_PROP_URI.to_string(), base_uri);
-    let mut builder = RestCatalogBuilder::default();
-    if let Some(factory) = storage_factory {
-        builder = builder.with_storage_factory(factory);
-    }
-    builder
+    let factory = storage_factory.unwrap_or_else(|| default_storage_factory_from_props(&props));
+    RestCatalogBuilder::default()
+        .with_storage_factory(factory)
         .load("rest", props)
         .await
         .context(UnableToBuildCatalogSnafu)

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -131,13 +131,14 @@ impl IcebergCatalog {
             }
         });
 
-        let operator = build_opendal_operator(catalog_id, &props)
-            .map_err(|e| super::Error::InvalidConfiguration {
+        let operator = build_opendal_operator(catalog_id, &props).map_err(|e| {
+            super::Error::InvalidConfiguration {
                 connector: "iceberg".into(),
                 message: format!("Failed to build opendal operator for Hadoop Catalog: {e}"),
                 connector_component: ConnectorComponent::from(catalog),
                 source: e,
-            })?;
+            }
+        })?;
 
         // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
         let catalog_builder = HadoopCatalogBuilder::default()
@@ -327,51 +328,52 @@ impl CatalogConnector for IcebergCatalog {
             }
         }
 
-        let storage_factory: Option<Arc<dyn StorageFactory>> = if let Some(endpoint) = props.get("s3.endpoint") {
-            verify_s3_endpoint(endpoint)
+        let storage_factory: Option<Arc<dyn StorageFactory>> =
+            if let Some(endpoint) = props.get("s3.endpoint") {
+                verify_s3_endpoint(endpoint).await.map_err(|e| {
+                    super::Error::InvalidConfiguration {
+                        connector: "iceberg".into(),
+                        message: e.to_string(),
+                        connector_component: ConnectorComponent::from(catalog),
+                        source: Box::new(e),
+                    }
+                })?;
+
+                let aws_sdk_config = initiate_config_with_credentials(
+                    "IcebergCatalogConnector",
+                    "s3_region",
+                    "s3_access_key_id",
+                    "s3_secret_access_key",
+                    "s3_session_token",
+                    &self.params,
+                    self.params.get("s3_iam_role_source").expose().ok(),
+                )
                 .await
                 .map_err(|e| super::Error::InvalidConfiguration {
                     connector: "iceberg".into(),
                     message: e.to_string(),
                     connector_component: ConnectorComponent::from(catalog),
                     source: Box::new(e),
-                })?;
-
-            let aws_sdk_config = initiate_config_with_credentials(
-                "IcebergCatalogConnector",
-                "s3_region",
-                "s3_access_key_id",
-                "s3_secret_access_key",
-                "s3_session_token",
-                &self.params,
-                self.params.get("s3_iam_role_source").expose().ok(),
-            )
-            .await
-            .map_err(|e| super::Error::InvalidConfiguration {
-                connector: "iceberg".into(),
-                message: e.to_string(),
-                connector_component: ConnectorComponent::from(catalog),
-                source: Box::new(e),
-            })?
-            .load()
-            .await;
-
-            let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
-                .map_err(|e| super::Error::InvalidConfiguration {
-                    connector: "iceberg".into(),
-                    message: e.to_string(),
-                    connector_component: ConnectorComponent::from(catalog),
-                    source: Box::new(e),
                 })?
-                .into_custom_loader();
+                .load()
+                .await;
 
-            Some(Arc::new(OpenDalStorageFactory::S3 {
-                configured_scheme: "s3".to_string(),
-                customized_credential_load: Some(custom_loader),
-            }) as Arc<dyn StorageFactory>)
-        } else {
-            None
-        };
+                let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
+                    .map_err(|e| super::Error::InvalidConfiguration {
+                        connector: "iceberg".into(),
+                        message: e.to_string(),
+                        connector_component: ConnectorComponent::from(catalog),
+                        source: Box::new(e),
+                    })?
+                    .into_custom_loader();
+
+                Some(Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: "s3".to_string(),
+                    customized_credential_load: Some(custom_loader),
+                }) as Arc<dyn StorageFactory>)
+            } else {
+                None
+            };
 
         if catalog_id.starts_with("file://")
             || catalog_id.starts_with("s3://")
@@ -777,6 +779,8 @@ pub(crate) fn build_opendal_operator(
     warehouse_url: &str,
     props: &HashMap<String, String>,
 ) -> std::result::Result<Operator, Box<dyn std::error::Error + Send + Sync>> {
+    use opendal::Configurator;
+
     if warehouse_url.starts_with("s3://") || warehouse_url.starts_with("s3a://") {
         let parsed = Url::parse(warehouse_url)?;
         let bucket = parsed
@@ -785,11 +789,15 @@ pub(crate) fn build_opendal_operator(
 
         let mut config = opendal::services::S3Config::default();
         config.bucket = bucket.to_string();
+        config.root = Some(parsed.path().to_string());
 
         if let Some(endpoint) = props.get("s3.endpoint") {
             config.endpoint = Some(endpoint.clone());
         }
-        if let Some(region) = props.get("s3.region").or_else(|| props.get("client.region")) {
+        if let Some(region) = props
+            .get("s3.region")
+            .or_else(|| props.get("client.region"))
+        {
             config.region = Some(region.clone());
         }
         if let Some(key_id) = props.get("s3.access-key-id") {
@@ -802,7 +810,6 @@ pub(crate) fn build_opendal_operator(
             config.session_token = Some(token.clone());
         }
 
-        use opendal::Configurator;
         let builder = config.into_builder();
         Ok(Operator::new(builder)?.finish())
     } else if warehouse_url.starts_with("gs://") || warehouse_url.starts_with("gcs://") {
@@ -812,18 +819,22 @@ pub(crate) fn build_opendal_operator(
             .host_str()
             .ok_or("GCS URL must have a bucket (host)")?
             .to_string();
+        config.root = Some(parsed.path().to_string());
 
         if let Some(cred) = props.get("gcs.credentials-json") {
             config.credential = Some(cred.clone());
         }
 
-        use opendal::Configurator;
         let builder = config.into_builder();
         Ok(Operator::new(builder)?.finish())
     } else if warehouse_url.starts_with("file://") || warehouse_url.starts_with('/') {
-        use opendal::Configurator;
         let mut config = opendal::services::FsConfig::default();
-        config.root = Some("/".to_string());
+        if let Ok(parsed) = Url::parse(warehouse_url) {
+            config.root = Some(parsed.path().to_string());
+        } else {
+            // Bare path like /data/warehouse
+            config.root = Some(warehouse_url.to_string());
+        }
         let builder = config.into_builder();
         Ok(Operator::new(builder)?.finish())
     } else {
@@ -1110,5 +1121,47 @@ mod tests {
         let parsed_url = Url::parse(url).expect("Failed to parse URL");
         let warehouse = get_warehouse(&parsed_url);
         assert_eq!(warehouse, None);
+    }
+
+    #[test]
+    fn test_build_opendal_operator_s3() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("s3://my-bucket/prefix/warehouse", &props);
+        assert!(op.is_ok(), "S3 operator should be created: {op:?}");
+    }
+
+    #[test]
+    fn test_build_opendal_operator_s3a() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("s3a://my-bucket/prefix/warehouse", &props);
+        assert!(op.is_ok(), "S3A operator should be created: {op:?}");
+    }
+
+    #[test]
+    fn test_build_opendal_operator_gcs() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("gs://my-bucket/prefix", &props);
+        assert!(op.is_ok(), "GCS operator should be created: {op:?}");
+    }
+
+    #[test]
+    fn test_build_opendal_operator_file_url() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("file:///tmp", &props);
+        assert!(op.is_ok(), "File operator should be created: {op:?}");
+    }
+
+    #[test]
+    fn test_build_opendal_operator_bare_path() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("/tmp", &props);
+        assert!(op.is_ok(), "Bare path operator should be created: {op:?}");
+    }
+
+    #[test]
+    fn test_build_opendal_operator_unsupported_scheme() {
+        let props = HashMap::new();
+        let op = build_opendal_operator("ftp://my-host/path", &props);
+        assert!(op.is_err(), "Unsupported scheme should fail");
     }
 }

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -33,11 +33,13 @@ use data_components::{
         provider::IcebergCatalogProvider,
     },
 };
-use iceberg::{CatalogBuilder, Namespace, NamespaceIdent, io::CustomAwsCredentialLoader};
+use iceberg::{CatalogBuilder, Namespace, NamespaceIdent, io::StorageFactory};
 use iceberg_catalog_rest::{
     REST_CATALOG_PROP_URI, RestCatalog as IcebergRestCatalog, RestCatalogBuilder,
 };
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use ns_lookup::verify_ns_lookup_and_tcp_connect;
+use opendal::Operator;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::fmt::Write;
@@ -110,19 +112,40 @@ impl IcebergCatalog {
 
     async fn load_hadoop_catalog(
         props: HashMap<String, String>,
-        custom_credential_loader: Option<CustomAwsCredentialLoader>,
+        storage_factory: Option<Arc<dyn StorageFactory>>,
         catalog: &Catalog,
         catalog_id: &str,
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
+        // Determine storage factory from scheme if not explicitly provided
+        let factory = storage_factory.unwrap_or_else(|| {
+            if catalog_id.starts_with("gs://") || catalog_id.starts_with("gcs://") {
+                Arc::new(OpenDalStorageFactory::Gcs)
+            } else if catalog_id.starts_with("s3://") || catalog_id.starts_with("s3a://") {
+                let scheme = catalog_id.split("://").next().unwrap_or("s3").to_string();
+                Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: scheme,
+                    customized_credential_load: None,
+                })
+            } else {
+                Arc::new(iceberg::io::LocalFsStorageFactory) as Arc<dyn StorageFactory>
+            }
+        });
+
+        let operator = build_opendal_operator(catalog_id, &props)
+            .map_err(|e| super::Error::InvalidConfiguration {
+                connector: "iceberg".into(),
+                message: format!("Failed to build opendal operator for Hadoop Catalog: {e}"),
+                connector_component: ConnectorComponent::from(catalog),
+                source: e,
+            })?;
+
         // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
-        let mut catalog_builder = HadoopCatalogBuilder::default()
+        let catalog_builder = HadoopCatalogBuilder::default()
             .with_warehouse_root(catalog_id)
             .with_metadata_mode(MetadataMode::Infer)
+            .with_storage_factory(factory)
+            .with_operator(operator)
             .with_properties(props);
-
-        if let Some(loader) = custom_credential_loader {
-            catalog_builder = catalog_builder.with_file_io_extension(loader);
-        }
 
         let hadoop_catalog =
             catalog_builder
@@ -304,7 +327,7 @@ impl CatalogConnector for IcebergCatalog {
             }
         }
 
-        let custom_credential_loader = if let Some(endpoint) = props.get("s3.endpoint") {
+        let storage_factory: Option<Arc<dyn StorageFactory>> = if let Some(endpoint) = props.get("s3.endpoint") {
             verify_s3_endpoint(endpoint)
                 .await
                 .map_err(|e| super::Error::InvalidConfiguration {
@@ -333,16 +356,19 @@ impl CatalogConnector for IcebergCatalog {
             .load()
             .await;
 
-            Some(
-                S3CredentialProvider::from_config(&aws_sdk_config)
-                    .map_err(|e| super::Error::InvalidConfiguration {
-                        connector: "iceberg".into(),
-                        message: e.to_string(),
-                        connector_component: ConnectorComponent::from(catalog),
-                        source: Box::new(e),
-                    })?
-                    .into_custom_loader(),
-            )
+            let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
+                .map_err(|e| super::Error::InvalidConfiguration {
+                    connector: "iceberg".into(),
+                    message: e.to_string(),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                })?
+                .into_custom_loader();
+
+            Some(Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: "s3".to_string(),
+                customized_credential_load: Some(custom_loader),
+            }) as Arc<dyn StorageFactory>)
         } else {
             None
         };
@@ -355,7 +381,7 @@ impl CatalogConnector for IcebergCatalog {
         {
             return IcebergCatalog::load_hadoop_catalog(
                 props,
-                custom_credential_loader,
+                storage_factory,
                 catalog,
                 &catalog_id,
             )
@@ -377,11 +403,8 @@ impl CatalogConnector for IcebergCatalog {
         };
 
         props.extend(new_props);
-        let catalog_config = get_rest_catalog(base_uri, props).await?;
-        let mut catalog_client = RestCatalog::new(catalog_config);
-        if let Some(loader) = custom_credential_loader {
-            catalog_client = catalog_client.with_file_io_extension(loader);
-        }
+        let catalog_config = get_rest_catalog(base_uri, props, storage_factory.clone()).await?;
+        let catalog_client = RestCatalog::new(catalog_config);
 
         let catalog_provider = IcebergCatalogProvider::try_new(
             Arc::new(catalog_client),
@@ -617,9 +640,14 @@ pub fn parse_table_url(url: &str) -> Result<(String, HashMap<String, String>, Na
 pub async fn get_rest_catalog(
     base_uri: String,
     mut props: HashMap<String, String, std::hash::RandomState>,
+    storage_factory: Option<Arc<dyn StorageFactory>>,
 ) -> Result<IcebergRestCatalog> {
     props.insert(REST_CATALOG_PROP_URI.to_string(), base_uri);
-    RestCatalogBuilder::default()
+    let mut builder = RestCatalogBuilder::default();
+    if let Some(factory) = storage_factory {
+        builder = builder.with_storage_factory(factory);
+    }
+    builder
         .load("rest", props)
         .await
         .context(UnableToBuildCatalogSnafu)
@@ -742,6 +770,65 @@ pub fn parse_hadoop_table_url(
     }
 
     Ok((base_uri, namespace, table_name.to_string()))
+}
+
+/// Builds an opendal `Operator` for directory listing operations from a warehouse URL and properties.
+pub(crate) fn build_opendal_operator(
+    warehouse_url: &str,
+    props: &HashMap<String, String>,
+) -> std::result::Result<Operator, Box<dyn std::error::Error + Send + Sync>> {
+    if warehouse_url.starts_with("s3://") || warehouse_url.starts_with("s3a://") {
+        let parsed = Url::parse(warehouse_url)?;
+        let bucket = parsed
+            .host_str()
+            .ok_or("S3 URL must have a bucket (host)")?;
+
+        let mut config = opendal::services::S3Config::default();
+        config.bucket = bucket.to_string();
+
+        if let Some(endpoint) = props.get("s3.endpoint") {
+            config.endpoint = Some(endpoint.clone());
+        }
+        if let Some(region) = props.get("s3.region").or_else(|| props.get("client.region")) {
+            config.region = Some(region.clone());
+        }
+        if let Some(key_id) = props.get("s3.access-key-id") {
+            config.access_key_id = Some(key_id.clone());
+        }
+        if let Some(secret) = props.get("s3.secret-access-key") {
+            config.secret_access_key = Some(secret.clone());
+        }
+        if let Some(token) = props.get("s3.session-token") {
+            config.session_token = Some(token.clone());
+        }
+
+        use opendal::Configurator;
+        let builder = config.into_builder();
+        Ok(Operator::new(builder)?.finish())
+    } else if warehouse_url.starts_with("gs://") || warehouse_url.starts_with("gcs://") {
+        let mut config = opendal::services::GcsConfig::default();
+        let parsed = Url::parse(warehouse_url)?;
+        config.bucket = parsed
+            .host_str()
+            .ok_or("GCS URL must have a bucket (host)")?
+            .to_string();
+
+        if let Some(cred) = props.get("gcs.credentials-json") {
+            config.credential = Some(cred.clone());
+        }
+
+        use opendal::Configurator;
+        let builder = config.into_builder();
+        Ok(Operator::new(builder)?.finish())
+    } else if warehouse_url.starts_with("file://") || warehouse_url.starts_with('/') {
+        use opendal::Configurator;
+        let mut config = opendal::services::FsConfig::default();
+        config.root = Some("/".to_string());
+        let builder = config.into_builder();
+        Ok(Operator::new(builder)?.finish())
+    } else {
+        Err(format!("Unsupported scheme in warehouse URL: {warehouse_url}").into())
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -36,6 +36,7 @@ use data_components::{
 };
 use iceberg::{CatalogBuilder, NamespaceIdent};
 use iceberg_catalog_rest::{REST_CATALOG_PROP_URI, RestCatalogBuilder};
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use snafu::prelude::*;
 use std::{any::Any, collections::HashMap, sync::Arc};
 use tonic::metadata::MetadataValue;
@@ -134,6 +135,10 @@ impl SpiceCloudPlatformCatalog {
         props.insert(REST_CATALOG_PROP_URI.to_string(), endpoint.to_string());
         let iceberg_rest_catalog = RestCatalogBuilder::default()
             .with_client(client)
+            .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: "s3".to_string(),
+                customized_credential_load: None,
+            }))
             .load("rest", props)
             .await
             .context(UnableToBuildCatalogSnafu)?;

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -29,6 +29,7 @@ use iceberg_catalog_glue::{
     GLUE_CATALOG_PROP_CATALOG_ID, GLUE_CATALOG_PROP_WAREHOUSE, GlueCatalogBuilder,
 };
 use iceberg_datafusion::IcebergTableProvider;
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::sync::LazyLock;
@@ -442,7 +443,23 @@ async fn create_iceberg_provider(
         props.insert(GLUE_CATALOG_PROP_CATALOG_ID.to_string(), catalog_id);
     }
 
+    // Derive the S3 scheme from the metadata location (e.g. "s3://" or "s3a://").
+    // The Glue catalog's default StorageFactory uses "s3a" as the configured scheme,
+    // but AWS Glue metadata locations typically use "s3://", causing a scheme mismatch.
+    let s3_scheme = metadata_location
+        .split("://")
+        .next()
+        .unwrap_or("s3")
+        .to_string();
+
+    let storage_factory: Arc<dyn iceberg::io::StorageFactory> =
+        Arc::new(OpenDalStorageFactory::S3 {
+            configured_scheme: s3_scheme,
+            customized_credential_load: None,
+        });
+
     let catalog = GlueCatalogBuilder::default()
+        .with_storage_factory(storage_factory)
         .load("glue", props)
         .await
         .map_err(|e| {

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -147,51 +147,52 @@ impl IcebergDataConnector {
             }
         }
 
-        let storage_factory: Option<Arc<dyn StorageFactory>> = if let Some(endpoint) = props.get("s3.endpoint") {
-            verify_s3_endpoint(endpoint)
+        let storage_factory: Option<Arc<dyn StorageFactory>> =
+            if let Some(endpoint) = props.get("s3.endpoint") {
+                verify_s3_endpoint(endpoint)
+                    .await
+                    .map_err(|e| Error::InvalidConfiguration {
+                        dataconnector: "iceberg".into(),
+                        message: e.to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: Box::new(e),
+                    })?;
+
+                let aws_sdk_config = initiate_config_with_credentials(
+                    "IcebergDataConnector",
+                    "s3_region",
+                    "s3_access_key_id",
+                    "s3_secret_access_key",
+                    "s3_session_token",
+                    &self.params,
+                    self.params.get("s3_iam_role_source").expose().ok(),
+                )
                 .await
                 .map_err(|e| Error::InvalidConfiguration {
                     dataconnector: "iceberg".into(),
                     message: e.to_string(),
                     connector_component: ConnectorComponent::from(dataset),
                     source: Box::new(e),
-                })?;
-
-            let aws_sdk_config = initiate_config_with_credentials(
-                "IcebergDataConnector",
-                "s3_region",
-                "s3_access_key_id",
-                "s3_secret_access_key",
-                "s3_session_token",
-                &self.params,
-                self.params.get("s3_iam_role_source").expose().ok(),
-            )
-            .await
-            .map_err(|e| Error::InvalidConfiguration {
-                dataconnector: "iceberg".into(),
-                message: e.to_string(),
-                connector_component: ConnectorComponent::from(dataset),
-                source: Box::new(e),
-            })?
-            .load()
-            .await;
-
-            let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
-                .map_err(|e| Error::InvalidConfiguration {
-                    dataconnector: "iceberg".into(),
-                    message: e.to_string(),
-                    connector_component: ConnectorComponent::from(dataset),
-                    source: Box::new(e),
                 })?
-                .into_custom_loader();
+                .load()
+                .await;
 
-            Some(Arc::new(OpenDalStorageFactory::S3 {
-                configured_scheme: "s3".to_string(),
-                customized_credential_load: Some(custom_loader),
-            }) as Arc<dyn StorageFactory>)
-        } else {
-            None
-        };
+                let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
+                    .map_err(|e| Error::InvalidConfiguration {
+                        dataconnector: "iceberg".into(),
+                        message: e.to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: Box::new(e),
+                    })?
+                    .into_custom_loader();
+
+                Some(Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: "s3".to_string(),
+                    customized_credential_load: Some(custom_loader),
+                }) as Arc<dyn StorageFactory>)
+            } else {
+                None
+            };
 
         if source.starts_with("file://")
             || source.starts_with("s3://")
@@ -238,13 +239,13 @@ impl IcebergDataConnector {
 
         props.extend(new_props);
 
-        let catalog_client = get_rest_catalog(base_uri, props, storage_factory.clone()).await.map_err(|e| {
-            Error::UnableToGetReadProvider {
+        let catalog_client = get_rest_catalog(base_uri, props, storage_factory.clone())
+            .await
+            .map_err(|e| Error::UnableToGetReadProvider {
                 dataconnector: "iceberg".into(),
                 connector_component: ConnectorComponent::from(dataset),
                 source: Box::new(e),
-            }
-        })?;
+            })?;
 
         let catalog_client: Arc<dyn Catalog> = Arc::new(catalog_client);
 
@@ -308,8 +309,8 @@ impl IcebergDataConnector {
             }
         });
 
-        // Build an opendal operator for directory listing
-        let operator = crate::catalogconnector::iceberg::build_opendal_operator(source, &props)
+        // Build an opendal operator for directory listing (scoped to the warehouse root, not the table URL)
+        let operator = crate::catalogconnector::iceberg::build_opendal_operator(&base_uri, &props)
             .map_err(|e| Error::UnableToGetReadProvider {
                 dataconnector: "iceberg".into(),
                 connector_component: ConnectorComponent::from(dataset),

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -23,8 +23,9 @@ use async_trait::async_trait;
 use aws_sdk_credential_bridge::S3CredentialProvider;
 use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
-use iceberg::{Catalog, NamespaceIdent, TableIdent, io::CustomAwsCredentialLoader};
+use iceberg::{Catalog, NamespaceIdent, TableIdent, io::StorageFactory};
 use iceberg_datafusion::IcebergTableProvider;
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use secrecy::ExposeSecret;
 use util::concat_arrays;
 
@@ -146,7 +147,7 @@ impl IcebergDataConnector {
             }
         }
 
-        let custom_credential_loader = if let Some(endpoint) = props.get("s3.endpoint") {
+        let storage_factory: Option<Arc<dyn StorageFactory>> = if let Some(endpoint) = props.get("s3.endpoint") {
             verify_s3_endpoint(endpoint)
                 .await
                 .map_err(|e| Error::InvalidConfiguration {
@@ -175,16 +176,19 @@ impl IcebergDataConnector {
             .load()
             .await;
 
-            Some(
-                S3CredentialProvider::from_config(&aws_sdk_config)
-                    .map_err(|e| Error::InvalidConfiguration {
-                        dataconnector: "iceberg".into(),
-                        message: e.to_string(),
-                        connector_component: ConnectorComponent::from(dataset),
-                        source: Box::new(e),
-                    })?
-                    .into_custom_loader(),
-            )
+            let custom_loader = S3CredentialProvider::from_config(&aws_sdk_config)
+                .map_err(|e| Error::InvalidConfiguration {
+                    dataconnector: "iceberg".into(),
+                    message: e.to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                })?
+                .into_custom_loader();
+
+            Some(Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: "s3".to_string(),
+                customized_credential_load: Some(custom_loader),
+            }) as Arc<dyn StorageFactory>)
         } else {
             None
         };
@@ -204,7 +208,7 @@ impl IcebergDataConnector {
 
             return IcebergDataConnector::load_hadoop_catalog(
                 props,
-                custom_credential_loader,
+                storage_factory,
                 dataset,
                 source,
                 metadata_mode,
@@ -234,16 +238,13 @@ impl IcebergDataConnector {
 
         props.extend(new_props);
 
-        let mut catalog_client = get_rest_catalog(base_uri, props).await.map_err(|e| {
+        let catalog_client = get_rest_catalog(base_uri, props, storage_factory.clone()).await.map_err(|e| {
             Error::UnableToGetReadProvider {
                 dataconnector: "iceberg".into(),
                 connector_component: ConnectorComponent::from(dataset),
                 source: Box::new(e),
             }
         })?;
-        if let Some(custom_loader) = custom_credential_loader {
-            catalog_client = catalog_client.with_file_io_extension(custom_loader);
-        }
 
         let catalog_client: Arc<dyn Catalog> = Arc::new(catalog_client);
 
@@ -274,7 +275,7 @@ impl IcebergDataConnector {
 
     async fn load_hadoop_catalog(
         props: HashMap<String, String>,
-        custom_credential_loader: Option<CustomAwsCredentialLoader>,
+        storage_factory: Option<Arc<dyn StorageFactory>>,
         dataset: &Dataset,
         source: &str,
         metadata_mode: MetadataMode,
@@ -292,14 +293,35 @@ impl IcebergDataConnector {
         let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 
-        let mut catalog_builder = HadoopCatalogBuilder::default()
+        // Determine storage factory from scheme if not explicitly provided
+        let factory = storage_factory.unwrap_or_else(|| {
+            if source.starts_with("gs://") || source.starts_with("gcs://") {
+                Arc::new(OpenDalStorageFactory::Gcs)
+            } else if source.starts_with("s3://") || source.starts_with("s3a://") {
+                let scheme = source.split("://").next().unwrap_or("s3").to_string();
+                Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: scheme,
+                    customized_credential_load: None,
+                })
+            } else {
+                Arc::new(iceberg::io::LocalFsStorageFactory) as Arc<dyn StorageFactory>
+            }
+        });
+
+        // Build an opendal operator for directory listing
+        let operator = crate::catalogconnector::iceberg::build_opendal_operator(source, &props)
+            .map_err(|e| Error::UnableToGetReadProvider {
+                dataconnector: "iceberg".into(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: e,
+            })?;
+
+        let catalog_builder = HadoopCatalogBuilder::default()
             .with_warehouse_root(base_uri)
             .with_metadata_mode(metadata_mode)
+            .with_storage_factory(factory)
+            .with_operator(operator)
             .with_properties(props);
-
-        if let Some(custom_loader) = custom_credential_loader {
-            catalog_builder = catalog_builder.with_file_io_extension(custom_loader);
-        }
 
         let catalog_client: Arc<dyn Catalog> =
             Arc::new(catalog_builder.build().await.map_err(|e| {


### PR DESCRIPTION
## Changes

Update spiceai/iceberg-rust dependency from v0.8.0 to v0.9.0 (commit 6c9b9709c572fe40484ec00aa969d1f62f2b0fe7 on branch spiceai-52).

### Key API migration changes

- **Storage model**: Replace Extensions/FileIO::from_path with StorageFactory/FileIOBuilder
- **Credential types**: Move AwsCredential, AwsCredentialLoad, CustomAwsCredentialLoader from iceberg::io to iceberg-storage-opendal
- **Directory listing**: Replace removed FileIO.lister() with opendal::Operator for HadoopCatalog directory listing
- **REST catalog**: Replace RestCatalog::with_file_io_extension with CatalogBuilder::with_storage_factory
- **Features**: Remove storage-gcs/storage-s3 features from iceberg crate (now provided by iceberg-storage-opendal)
- **Dependencies**: Add iceberg-storage-opendal and opendal as workspace dependencies

### Files changed

- Cargo.toml - Updated versions, added new workspace deps and patches
- crates/aws-sdk-credential-bridge/ - Updated imports for moved credential types
- crates/data_components/ - Rewrote HadoopCatalog to use StorageFactory + Operator; simplified RestCatalog wrapper
- crates/runtime/ - Updated data connector and catalog connector to use new StorageFactory API; added build_opendal_operator helper
