### PR TITLE
Ensure 'SessionStateBuilder::new_from_existing' adds optimizer/analyzer

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -80,6 +80,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use url::Url;
 use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
+use util::session_state::builder_from_existing;
 use x509_certificate::CapturedX509Certificate;
 const SCHEDULER_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SCHEDULER_BACKOFF_MAX: Duration = Duration::from_secs(5);
@@ -1587,7 +1588,7 @@ async fn create_scheduler_server(
                 .map(Arc::clone)
                 .collect();
 
-            Ok(SessionStateBuilder::new_from_existing(spice_state)
+            Ok(builder_from_existing(&spice_state)
                 .with_config(cfg)
                 .with_runtime_env(default_runtime_env(io_runtime.clone()))
                 .with_analyzer_rules(distributed_analyzer_rules)

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -30,7 +30,6 @@ use crate::{
     FailedToRegisterSchedulerSnafu, FailedToStartClusterExecutorSnafu,
     FailedToStartClusterSchedulerSnafu, LogErrors, Runtime, UnableToStartClusterServerSnafu,
 };
-use ::datafusion::execution::SessionStateBuilder;
 use ::datafusion::optimizer::AnalyzerRule;
 use ::datafusion::prelude::SessionConfig;
 use ::datafusion::sql::TableReference;

--- a/crates/runtime/src/cluster/partition/discovery.rs
+++ b/crates/runtime/src/cluster/partition/discovery.rs
@@ -28,9 +28,10 @@ use datafusion::sql::sqlparser::{
     dialect::GenericDialect,
     parser::Parser,
 };
-use datafusion::{execution::SessionStateBuilder, prelude::SessionContext, sql::TableReference};
+use datafusion::{prelude::SessionContext, sql::TableReference};
 use snafu::prelude::*;
 use spicepod::partitioning::PartitionedBy;
+use util::session_state::builder_from_existing;
 
 /// Query the source table provider for partition values for a given table.
 ///
@@ -145,9 +146,7 @@ async fn execute_partition_discovery_query(
         });
     };
 
-    let ctx = SessionContext::new_with_state(
-        SessionStateBuilder::new_from_existing(df.ctx.state()).build(),
-    );
+    let ctx = SessionContext::new_with_state(builder_from_existing(&df.ctx.state()).build());
 
     let provider = acc.table_provider().await;
     let schema = provider.schema();

--- a/crates/runtime/src/flight/session.rs
+++ b/crates/runtime/src/flight/session.rs
@@ -57,6 +57,7 @@ use moka::sync::Cache;
 use std::sync::Arc;
 use std::time::Duration;
 use tonic::metadata::MetadataMap;
+use util::session_state::builder_from_existing;
 use uuid::Uuid;
 
 /// Default session time-to-live in seconds (1 hour)
@@ -131,12 +132,10 @@ impl SessionStore {
         // This is critical for session isolation - each session needs its own session_id
         // so that prepared statements stored in SessionState.prepared_plans are isolated.
         //
-        // Note: We use new_from_existing() which copies all catalog/function registrations
-        // but sets session_id to None, allowing build() to generate a new unique ID.
-        let new_state =
-            datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                base_ctx.state(),
-            )
+        // Note: We clone the existing state into a new builder so catalog/function
+        // registrations and custom analyzer/optimizer rules are preserved, while
+        // `session_id` remains unset until we assign a unique one below.
+        let new_state = builder_from_existing(&base_ctx.state())
             .with_session_id(session_id.clone())
             .build();
         let session_ctx = Arc::new(SessionContext::new_with_state(new_state));
@@ -199,10 +198,7 @@ impl SessionStore {
             // Create new session with the provided ID (from auth token)
             // Use SessionStateBuilder to ensure the session has its own unique session_id
             // for proper prepared statement isolation
-            let new_state =
-                datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                    base_ctx.state(),
-                )
+            let new_state = builder_from_existing(&base_ctx.state())
                 .with_session_id(session_id.clone())
                 .build();
             let session_ctx = Arc::new(SessionContext::new_with_state(new_state));
@@ -244,10 +240,7 @@ impl SessionStore {
             // Create new session with the provided ID (from auth token)
             // Use SessionStateBuilder to ensure the session has its own unique session_id
             // for proper prepared statement isolation
-            let new_state =
-                datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                    base_ctx.state(),
-                )
+            let new_state = builder_from_existing(&base_ctx.state())
                 .with_session_id(session_id.clone())
                 .build();
             let session_ctx = Arc::new(SessionContext::new_with_state(new_state));

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -29,7 +29,7 @@ use datafusion::{
     common::{Column, Constraints, JoinType},
     datasource::{DefaultTableSource, TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
-    execution::{SessionState, SessionStateBuilder},
+    execution::SessionState,
     logical_expr::{Expr, LogicalPlan},
     physical_plan::ExecutionPlan,
     sql::TableReference,
@@ -38,6 +38,7 @@ use datafusion_expr::{LogicalPlanBuilder, TableProviderFilterPushDown, ident};
 
 use datafusion_optimizer_rules::physical_plan::EmptyHashJoinExecPhysicalOptimization;
 use itertools::Itertools;
+use util::session_state::builder_from_existing;
 
 use crate::index::VectorIndex;
 
@@ -312,11 +313,9 @@ impl TableProvider for VectorScanTableProvider {
 /// Datafusion does not propagate [`SessionState::physical_optimizers`] into [`TableProvider::scan`].
 fn with_join_optimization(state: &dyn Session) -> Option<Arc<dyn Session>> {
     Some(Arc::new(
-        SessionStateBuilder::new_from_existing(
-            state.as_any().downcast_ref::<SessionState>()?.clone(),
-        )
-        .with_physical_optimizer_rule(Arc::new(EmptyHashJoinExecPhysicalOptimization {}))
-        .build(),
+        builder_from_existing(state.as_any().downcast_ref::<SessionState>()?)
+            .with_physical_optimizer_rule(Arc::new(EmptyHashJoinExecPhysicalOptimization {}))
+            .build(),
     ) as Arc<dyn Session>)
 }
 

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -36,6 +36,8 @@ pub mod arrow;
 #[cfg(feature = "datafusion")]
 pub mod expr;
 #[cfg(feature = "datafusion")]
+pub mod session_state;
+#[cfg(feature = "datafusion")]
 pub mod stream_utils;
 pub mod time_format;
 #[cfg(feature = "datafusion")]

--- a/crates/util/src/session_state.rs
+++ b/crates/util/src/session_state.rs
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion::execution::{SessionState, SessionStateBuilder};
+
+/// Returns a [`SessionStateBuilder`] cloned from `existing` while preserving custom rules.
+#[must_use]
+pub fn builder_from_existing(existing: &SessionState) -> SessionStateBuilder {
+    SessionStateBuilder::new_from_existing(existing.clone())
+        .with_analyzer_rules(existing.analyzer().rules.iter().map(Arc::clone).collect())
+        .with_optimizer_rules(existing.optimizers().iter().map(Arc::clone).collect())
+        .with_physical_optimizer_rules(
+            existing
+                .physical_optimizers()
+                .iter()
+                .map(Arc::clone)
+                .collect(),
+        )
+}


### PR DESCRIPTION
## 📝 Summary
`SessionStateBuilder::new_from_existing` did not add `analyzer_rules`, `optimizer_rules` or physical_optimizer_rules`. 

```rust
pub fn new_from_existing(existing: SessionState) -> Self {
  // ... 

  Self {
    session_id: None,
    analyzer: Some(existing.analyzer),
    // .. 
    function_factory: existing.function_factory,
    cache_factory: existing.cache_factory,
    // fields to support convenience functions
    analyzer_rules: None,
    optimizer_rules: None,
    physical_optimizer_rules: None,
  }
}
```
Wrap usage of `SessionStateBuilder::new_from_existing` to include these fields. 