### PR TITLE
Add PVC block storage configuration for scheduler and executor in spidapter

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -80,6 +80,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use url::Url;
 use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
+use util::session_state::builder_from_existing;
 use x509_certificate::CapturedX509Certificate;
 const SCHEDULER_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SCHEDULER_BACKOFF_MAX: Duration = Duration::from_secs(5);
@@ -1587,7 +1588,7 @@ async fn create_scheduler_server(
                 .map(Arc::clone)
                 .collect();
 
-            Ok(SessionStateBuilder::new_from_existing(spice_state)
+            Ok(builder_from_existing(&spice_state)
                 .with_config(cfg)
                 .with_runtime_env(default_runtime_env(io_runtime.clone()))
                 .with_analyzer_rules(distributed_analyzer_rules)

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -30,7 +30,6 @@ use crate::{
     FailedToRegisterSchedulerSnafu, FailedToStartClusterExecutorSnafu,
     FailedToStartClusterSchedulerSnafu, LogErrors, Runtime, UnableToStartClusterServerSnafu,
 };
-use ::datafusion::execution::SessionStateBuilder;
 use ::datafusion::optimizer::AnalyzerRule;
 use ::datafusion::prelude::SessionConfig;
 use ::datafusion::sql::TableReference;

--- a/crates/runtime/src/cluster/partition/discovery.rs
+++ b/crates/runtime/src/cluster/partition/discovery.rs
@@ -28,9 +28,10 @@ use datafusion::sql::sqlparser::{
     dialect::GenericDialect,
     parser::Parser,
 };
-use datafusion::{execution::SessionStateBuilder, prelude::SessionContext, sql::TableReference};
+use datafusion::{prelude::SessionContext, sql::TableReference};
 use snafu::prelude::*;
 use spicepod::partitioning::PartitionedBy;
+use util::session_state::builder_from_existing;
 
 /// Query the source table provider for partition values for a given table.
 ///
@@ -145,9 +146,7 @@ async fn execute_partition_discovery_query(
         });
     };
 
-    let ctx = SessionContext::new_with_state(
-        SessionStateBuilder::new_from_existing(df.ctx.state()).build(),
-    );
+    let ctx = SessionContext::new_with_state(builder_from_existing(&df.ctx.state()).build());
 
     let provider = acc.table_provider().await;
     let schema = provider.schema();

--- a/crates/runtime/src/flight/session.rs
+++ b/crates/runtime/src/flight/session.rs
@@ -57,6 +57,7 @@ use moka::sync::Cache;
 use std::sync::Arc;
 use std::time::Duration;
 use tonic::metadata::MetadataMap;
+use util::session_state::builder_from_existing;
 use uuid::Uuid;
 
 /// Default session time-to-live in seconds (1 hour)
@@ -131,12 +132,10 @@ impl SessionStore {
         // This is critical for session isolation - each session needs its own session_id
         // so that prepared statements stored in SessionState.prepared_plans are isolated.
         //
-        // Note: We use new_from_existing() which copies all catalog/function registrations
-        // but sets session_id to None, allowing build() to generate a new unique ID.
-        let new_state =
-            datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                base_ctx.state(),
-            )
+        // Note: We clone the existing state into a new builder so catalog/function
+        // registrations and custom analyzer/optimizer rules are preserved, while
+        // `session_id` remains unset until we assign a unique one below.
+        let new_state = builder_from_existing(&base_ctx.state())
             .with_session_id(session_id.clone())
             .build();
         let session_ctx = Arc::new(SessionContext::new_with_state(new_state));
@@ -199,10 +198,7 @@ impl SessionStore {
             // Create new session with the provided ID (from auth token)
             // Use SessionStateBuilder to ensure the session has its own unique session_id
             // for proper prepared statement isolation
-            let new_state =
-                datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                    base_ctx.state(),
-                )
+            let new_state = builder_from_existing(&base_ctx.state())
                 .with_session_id(session_id.clone())
                 .build();
             let session_ctx = Arc::new(SessionContext::new_with_state(new_state));
@@ -244,10 +240,7 @@ impl SessionStore {
             // Create new session with the provided ID (from auth token)
             // Use SessionStateBuilder to ensure the session has its own unique session_id
             // for proper prepared statement isolation
-            let new_state =
-                datafusion::execution::session_state::SessionStateBuilder::new_from_existing(
-                    base_ctx.state(),
-                )
+            let new_state = builder_from_existing(&base_ctx.state())
                 .with_session_id(session_id.clone())
                 .build();
             let session_ctx = Arc::new(SessionContext::new_with_state(new_state));

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -29,7 +29,7 @@ use datafusion::{
     common::{Column, Constraints, JoinType},
     datasource::{DefaultTableSource, TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
-    execution::{SessionState, SessionStateBuilder},
+    execution::SessionState,
     logical_expr::{Expr, LogicalPlan},
     physical_plan::ExecutionPlan,
     sql::TableReference,
@@ -38,6 +38,7 @@ use datafusion_expr::{LogicalPlanBuilder, TableProviderFilterPushDown, ident};
 
 use datafusion_optimizer_rules::physical_plan::EmptyHashJoinExecPhysicalOptimization;
 use itertools::Itertools;
+use util::session_state::builder_from_existing;
 
 use crate::index::VectorIndex;
 
@@ -312,11 +313,9 @@ impl TableProvider for VectorScanTableProvider {
 /// Datafusion does not propagate [`SessionState::physical_optimizers`] into [`TableProvider::scan`].
 fn with_join_optimization(state: &dyn Session) -> Option<Arc<dyn Session>> {
     Some(Arc::new(
-        SessionStateBuilder::new_from_existing(
-            state.as_any().downcast_ref::<SessionState>()?.clone(),
-        )
-        .with_physical_optimizer_rule(Arc::new(EmptyHashJoinExecPhysicalOptimization {}))
-        .build(),
+        builder_from_existing(state.as_any().downcast_ref::<SessionState>()?)
+            .with_physical_optimizer_rule(Arc::new(EmptyHashJoinExecPhysicalOptimization {}))
+            .build(),
     ) as Arc<dyn Session>)
 }
 

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -57,6 +57,8 @@ pub struct AppExecutor {
     pub replicas: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_size_gb: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -71,6 +73,8 @@ pub struct AppConfig {
     pub executor: Option<AppExecutor>,
     pub region: Option<String>,
     pub node_group: Option<String>,
+    pub storage_size_gb: Option<f64>,
+    /// Deprecated: Use `storage_size_gb` instead.
     pub storage_claim_size_gb: Option<f64>,
 }
 
@@ -134,6 +138,8 @@ pub struct UpdateAppRequest {
     pub resources: Option<AppResources>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub executor: Option<AppExecutor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_size_gb: Option<f64>,
 }
 
 // ============================================================================

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -36,6 +36,8 @@ pub mod arrow;
 #[cfg(feature = "datafusion")]
 pub mod expr;
 #[cfg(feature = "datafusion")]
+pub mod session_state;
+#[cfg(feature = "datafusion")]
 pub mod stream_utils;
 pub mod time_format;
 #[cfg(feature = "datafusion")]

--- a/crates/util/src/session_state.rs
+++ b/crates/util/src/session_state.rs
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion::execution::{SessionState, SessionStateBuilder};
+
+/// Returns a [`SessionStateBuilder`] cloned from `existing` while preserving custom rules.
+#[must_use]
+pub fn builder_from_existing(existing: &SessionState) -> SessionStateBuilder {
+    SessionStateBuilder::new_from_existing(existing.clone())
+        .with_analyzer_rules(existing.analyzer().rules.iter().map(Arc::clone).collect())
+        .with_optimizer_rules(existing.optimizers().iter().map(Arc::clone).collect())
+        .with_physical_optimizer_rules(
+            existing
+                .physical_optimizers()
+                .iter()
+                .map(Arc::clone)
+                .collect(),
+        )
+}

--- a/tools/spidapter/src/args/mod.rs
+++ b/tools/spidapter/src/args/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,6 +102,14 @@ pub struct StdioArgs {
     /// Memory request for the Spice Cloud executor pod (e.g. `256Mi`).
     #[arg(long, env = "SPIDAPTER_EXECUTOR_MEMORY_REQUEST")]
     pub executor_memory_request: Option<String>,
+
+    /// PVC block storage size in GB for the Spice Cloud app (scheduler) pod (e.g. `10`).
+    #[arg(long, env = "SPIDAPTER_APP_STORAGE_SIZE_GB")]
+    pub app_storage_size_gb: Option<f64>,
+
+    /// PVC block storage size in GB for the Spice Cloud executor pod (e.g. `5`).
+    #[arg(long, env = "SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB")]
+    pub executor_storage_size_gb: Option<f64>,
 
     /// S3 URL prefix for the spiced scheduler state location (e.g. `s3://bucket/state`).
     #[arg(long, env = "SCHEDULER_STATE_LOCATION")]

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ pub(crate) struct AppCreateConfig {
     pub app_cpu_request: Option<String>,
     pub app_memory_request: Option<String>,
     pub app_replicas: Option<i32>,
+    pub app_storage_size_gb: Option<f64>,
     pub executor_replicas: i32,
     pub executor_memory_limit: Option<String>,
     pub executor_cpu_limit: Option<String>,
     pub executor_cpu_request: Option<String>,
     pub executor_memory_request: Option<String>,
+    pub executor_storage_size_gb: Option<f64>,
 }
 
 pub(crate) fn spice_cloud_base_url(api_url_override: Option<&str>) -> String {
@@ -167,6 +169,7 @@ pub(crate) async fn ensure_spice_cloud_app(
             config.executor_cpu_request.as_deref(),
             config.executor_memory_request.as_deref(),
         )),
+        storage_size_gb: config.executor_storage_size_gb,
     });
 
     let create_result = cloud
@@ -186,11 +189,15 @@ pub(crate) async fn ensure_spice_cloud_app(
         .await;
 
     match create_result {
-        Ok(app) => Ok(app.id),
+        Ok(app) => {
+            apply_storage_config(cloud, app.id, config).await?;
+            Ok(app.id)
+        }
         Err(spice_cloud_client::error::Error::Conflict { .. }) => {
             // Race condition — another caller created it; re-fetch
             let apps = cloud.list_apps().await?;
             if let Some(app) = apps.into_iter().find(|a| a.name == app_name) {
+                apply_storage_config(cloud, app.id, config).await?;
                 return Ok(app.id);
             }
             Err(anyhow::anyhow!(
@@ -201,6 +208,46 @@ pub(crate) async fn ensure_spice_cloud_app(
             "Failed to create Spice Cloud app '{app_name}': {e}"
         )),
     }
+}
+
+/// Apply storage configuration to an app via the update API if any storage
+/// sizes are configured.
+async fn apply_storage_config(
+    cloud: &CloudClient,
+    app_id: i64,
+    config: &AppCreateConfig,
+) -> anyhow::Result<()> {
+    let has_storage =
+        config.app_storage_size_gb.is_some() || config.executor_storage_size_gb.is_some();
+
+    if !has_storage {
+        return Ok(());
+    }
+
+    let executor = config.executor_storage_size_gb.map(|size| AppExecutor {
+        replicas: None,
+        resources: None,
+        storage_size_gb: Some(size),
+    });
+
+    cloud
+        .update_app(
+            app_id,
+            &UpdateAppRequest {
+                description: None,
+                visibility: None,
+                replicas: None,
+                image_tag: None,
+                region: None,
+                spicepod: None,
+                resources: None,
+                executor,
+                storage_size_gb: config.app_storage_size_gb,
+            },
+        )
+        .await?;
+
+    Ok(())
 }
 
 pub(crate) async fn resolve_default_cname(cloud: &CloudClient) -> anyhow::Result<String> {
@@ -259,6 +306,7 @@ pub(crate) async fn apply_spicepod_to_app(
                 spicepod: Some(spicepod_yaml.to_string()),
                 resources: None,
                 executor: None,
+                storage_size_gb: None,
             },
         )
         .await?;

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -599,11 +599,13 @@ async fn provision_spice_cloud_app(
         app_cpu_request: args.app_cpu_request.clone(),
         app_memory_request: args.app_memory_request.clone(),
         app_replicas: args.app_replicas,
+        app_storage_size_gb: args.app_storage_size_gb,
         executor_replicas: args.executor_replicas,
         executor_memory_limit: args.executor_memory_limit.clone(),
         executor_cpu_limit: args.executor_cpu_limit.clone(),
         executor_cpu_request: args.executor_cpu_request.clone(),
         executor_memory_request: args.executor_memory_request.clone(),
+        executor_storage_size_gb: args.executor_storage_size_gb,
     };
     let app_id = commands::ensure_spice_cloud_app(&cloud, &app_name, &app_create_config).await?;
 


### PR DESCRIPTION
Updates the Rust SDK client (spice-cloud-client) and spidapter tooling to support the new `storage_size_gb` API fields in SCP.

### Cloud API changes

 - PUT /v1/apps/<app_id> now accepts storage_size_gb (canonical replacement for the deprecated storage_claim_size_gb) and executor.storage_size_gb for executor-specific block storage.
 - GET /v1/apps/<app_id> response now includes both fields.

 ### tools/spidapter — CLI & provisioning
 - args/mod.rs: Add --app-storage-size-gb (SPIDAPTER_APP_STORAGE_SIZE_GB) and --executor-storage-size-gb (SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB) CLI flags

#### Usage

 ```shell
   spidapter stdio \
     --app-storage-size-gb 10 \
     --executor-storage-size-gb 5
 ```

 Or via environment variables:

 ```bash
   SPIDAPTER_APP_STORAGE_SIZE_GB=10 \
   SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB=5 \
   spidapter stdio
 ```