### PR TITLE
Add PVC block storage configuration for scheduler and executor in spidapter

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -161,9 +161,7 @@ impl CloudClient {
             replicas,
             image_tag: image_tag.map(String::from),
             region: region.map(String::from),
-            spicepod: None,
-            resources: None,
-            executor: None,
+            ..Default::default()
         };
         self.inner
             .update_app(app.id, &request)

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -57,6 +57,8 @@ pub struct AppExecutor {
     pub replicas: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<AppResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_size_gb: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -71,6 +73,8 @@ pub struct AppConfig {
     pub executor: Option<AppExecutor>,
     pub region: Option<String>,
     pub node_group: Option<String>,
+    pub storage_size_gb: Option<f64>,
+    /// Deprecated: Use `storage_size_gb` instead.
     pub storage_claim_size_gb: Option<f64>,
 }
 
@@ -134,6 +138,8 @@ pub struct UpdateAppRequest {
     pub resources: Option<AppResources>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub executor: Option<AppExecutor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_size_gb: Option<f64>,
 }
 
 // ============================================================================

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -120,7 +120,7 @@ pub struct CreateAppRequest {
     pub executor: Option<AppExecutor>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 pub struct UpdateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,

--- a/tools/spidapter/src/args/mod.rs
+++ b/tools/spidapter/src/args/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,6 +102,14 @@ pub struct StdioArgs {
     /// Memory request for the Spice Cloud executor pod (e.g. `256Mi`).
     #[arg(long, env = "SPIDAPTER_EXECUTOR_MEMORY_REQUEST")]
     pub executor_memory_request: Option<String>,
+
+    /// PVC block storage size in GB for the Spice Cloud app (scheduler) pod (e.g. `10`).
+    #[arg(long, env = "SPIDAPTER_APP_STORAGE_SIZE_GB")]
+    pub app_storage_size_gb: Option<f64>,
+
+    /// PVC block storage size in GB for the Spice Cloud executor pod (e.g. `5`).
+    #[arg(long, env = "SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB")]
+    pub executor_storage_size_gb: Option<f64>,
 
     /// S3 URL prefix for the spiced scheduler state location (e.g. `s3://bucket/state`).
     #[arg(long, env = "SCHEDULER_STATE_LOCATION")]

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ pub(crate) struct AppCreateConfig {
     pub app_cpu_request: Option<String>,
     pub app_memory_request: Option<String>,
     pub app_replicas: Option<i32>,
+    pub app_storage_size_gb: Option<f64>,
     pub executor_replicas: i32,
     pub executor_memory_limit: Option<String>,
     pub executor_cpu_limit: Option<String>,
     pub executor_cpu_request: Option<String>,
     pub executor_memory_request: Option<String>,
+    pub executor_storage_size_gb: Option<f64>,
 }
 
 pub(crate) fn spice_cloud_base_url(api_url_override: Option<&str>) -> String {
@@ -167,6 +169,7 @@ pub(crate) async fn ensure_spice_cloud_app(
             config.executor_cpu_request.as_deref(),
             config.executor_memory_request.as_deref(),
         )),
+        storage_size_gb: config.executor_storage_size_gb,
     });
 
     let create_result = cloud
@@ -186,11 +189,15 @@ pub(crate) async fn ensure_spice_cloud_app(
         .await;
 
     match create_result {
-        Ok(app) => Ok(app.id),
+        Ok(app) => {
+            apply_storage_config(cloud, app.id, config).await?;
+            Ok(app.id)
+        }
         Err(spice_cloud_client::error::Error::Conflict { .. }) => {
             // Race condition — another caller created it; re-fetch
             let apps = cloud.list_apps().await?;
             if let Some(app) = apps.into_iter().find(|a| a.name == app_name) {
+                apply_storage_config(cloud, app.id, config).await?;
                 return Ok(app.id);
             }
             Err(anyhow::anyhow!(
@@ -201,6 +208,46 @@ pub(crate) async fn ensure_spice_cloud_app(
             "Failed to create Spice Cloud app '{app_name}': {e}"
         )),
     }
+}
+
+/// Apply storage configuration to an app via the update API if any storage
+/// sizes are configured.
+async fn apply_storage_config(
+    cloud: &CloudClient,
+    app_id: i64,
+    config: &AppCreateConfig,
+) -> anyhow::Result<()> {
+    let has_storage =
+        config.app_storage_size_gb.is_some() || config.executor_storage_size_gb.is_some();
+
+    if !has_storage {
+        return Ok(());
+    }
+
+    let executor = config.executor_storage_size_gb.map(|size| AppExecutor {
+        replicas: None,
+        resources: None,
+        storage_size_gb: Some(size),
+    });
+
+    cloud
+        .update_app(
+            app_id,
+            &UpdateAppRequest {
+                description: None,
+                visibility: None,
+                replicas: None,
+                image_tag: None,
+                region: None,
+                spicepod: None,
+                resources: None,
+                executor,
+                storage_size_gb: config.app_storage_size_gb,
+            },
+        )
+        .await?;
+
+    Ok(())
 }
 
 pub(crate) async fn resolve_default_cname(cloud: &CloudClient) -> anyhow::Result<String> {
@@ -259,6 +306,7 @@ pub(crate) async fn apply_spicepod_to_app(
                 spicepod: Some(spicepod_yaml.to_string()),
                 resources: None,
                 executor: None,
+                storage_size_gb: None,
             },
         )
         .await?;

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1585,6 +1585,8 @@ mod tests {
             executor_cpu_limit: None,
             executor_cpu_request: None,
             executor_memory_request: None,
+            app_storage_size_gb: None,
+            executor_storage_size_gb: None,
             scheduler_state_location: Some("s3://bucket/state".to_string()),
             aws_region: None,
             cayenne_data_dir: None,

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -599,11 +599,13 @@ async fn provision_spice_cloud_app(
         app_cpu_request: args.app_cpu_request.clone(),
         app_memory_request: args.app_memory_request.clone(),
         app_replicas: args.app_replicas,
+        app_storage_size_gb: args.app_storage_size_gb,
         executor_replicas: args.executor_replicas,
         executor_memory_limit: args.executor_memory_limit.clone(),
         executor_cpu_limit: args.executor_cpu_limit.clone(),
         executor_cpu_request: args.executor_cpu_request.clone(),
         executor_memory_request: args.executor_memory_request.clone(),
+        executor_storage_size_gb: args.executor_storage_size_gb,
     };
     let app_id = commands::ensure_spice_cloud_app(&cloud, &app_name, &app_create_config).await?;
 


### PR DESCRIPTION
Updates the Rust SDK client (spice-cloud-client) and spidapter tooling to support the new `storage_size_gb` API fields in SCP.

### Cloud API changes

 - PUT /v1/apps/<app_id> now accepts storage_size_gb (canonical replacement for the deprecated storage_claim_size_gb) and executor.storage_size_gb for executor-specific block storage.
 - GET /v1/apps/<app_id> response now includes both fields.

 ### tools/spidapter — CLI & provisioning
 - args/mod.rs: Add --app-storage-size-gb (SPIDAPTER_APP_STORAGE_SIZE_GB) and --executor-storage-size-gb (SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB) CLI flags

#### Usage

 ```shell
   spidapter stdio \
     --app-storage-size-gb 10 \
     --executor-storage-size-gb 5
 ```

 Or via environment variables:

 ```bash
   SPIDAPTER_APP_STORAGE_SIZE_GB=10 \
   SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB=5 \
   spidapter stdio
 ```