### PR TITLE
fix: Improve error handling to avoid silencing errors on distributed writes

### DIFF
--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -378,6 +378,18 @@ async fn route_batch_and_assign_unseen(
         })
         .collect();
 
+    {
+        let total_partitioned: usize = entries.iter().map(|(_, _, b)| b.num_rows()).sum();
+        if total_partitioned != unmatched.num_rows() {
+            tracing::warn!(
+                table = %path,
+                unmatched_rows = unmatched.num_rows(),
+                partitioned_rows = total_partitioned,
+                "Row count mismatch after partitioning unmatched rows; some data may be lost"
+            );
+        }
+    }
+
     if entries.is_empty() {
         return Ok(());
     }
@@ -460,6 +472,13 @@ async fn route_batch_and_assign_unseen(
             tx.send(sub_batch).await.map_err(|_| Error::SendBatch {
                 executor_id: executor_id.clone(),
             })?;
+        } else {
+            tracing::warn!(
+                executor_id,
+                rows = sub_batch.num_rows(),
+                table = %path,
+                "No sender for assigned executor; rows will be lost"
+            );
         }
     }
 
@@ -525,13 +544,23 @@ async fn route_matched_and_collect_unmatched(
             continue;
         }
 
+        // If there is no active sender for this executor (e.g. it disconnected),
+        // leave the matched rows in `remaining` so they are treated as unmatched
+        // and re-assigned to a connected executor. This prevents silent data loss.
+        let Some(tx) = senders.get(executor_id) else {
+            tracing::warn!(
+                executor_id,
+                rows = matched_count,
+                "Skipping send to disconnected executor; rows will be re-assigned"
+            );
+            continue;
+        };
+
         let filtered =
             arrow::compute::filter_record_batch(&remaining, mask).context(FilterBatchSnafu)?;
-        if let Some(tx) = senders.get(executor_id) {
-            tx.send(filtered).await.map_err(|_| Error::SendBatch {
-                executor_id: executor_id.clone(),
-            })?;
-        }
+        tx.send(filtered).await.map_err(|_| Error::SendBatch {
+            executor_id: executor_id.clone(),
+        })?;
 
         // If every remaining row was matched, nothing left to process.
         if matched_count == remaining.num_rows() {
@@ -542,6 +571,14 @@ async fn route_matched_and_collect_unmatched(
         let negated = arrow::compute::not(mask).context(FilterBatchSnafu)?;
         remaining =
             arrow::compute::filter_record_batch(&remaining, &negated).context(FilterBatchSnafu)?;
+    }
+
+    if remaining.num_rows() > 0 {
+        tracing::debug!(
+            total_rows = batch.num_rows(),
+            unmatched_rows = remaining.num_rows(),
+            "Some rows did not match any executor filter; routing to new partition assignments"
+        );
     }
 
     Ok(remaining)

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -381,7 +381,7 @@ async fn route_batch_and_assign_unseen(
     {
         let total_partitioned: usize = entries.iter().map(|(_, _, b)| b.num_rows()).sum();
         if total_partitioned != unmatched.num_rows() {
-            tracing::warn!(
+            tracing::debug!(
                 table = %path,
                 unmatched_rows = unmatched.num_rows(),
                 partitioned_rows = total_partitioned,
@@ -473,7 +473,7 @@ async fn route_batch_and_assign_unseen(
                 executor_id: executor_id.clone(),
             })?;
         } else {
-            tracing::warn!(
+            tracing::debug!(
                 executor_id,
                 rows = sub_batch.num_rows(),
                 table = %path,

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -135,6 +135,18 @@ pub enum Error {
 
     #[snafu(display("Failed to persist partition assignment: {source}"))]
     PersistAssignment { source: Box<super::manager::Error> },
+
+    #[snafu(display(
+        "Row count mismatch after partitioning unmatched rows for table {table}: expected {expected} but got {actual}"
+    ))]
+    PartitionRowCountMismatch {
+        table: String,
+        expected: usize,
+        actual: usize,
+    },
+
+    #[snafu(display("No sender for assigned executor {executor_id} for table {table}"))]
+    NoSenderForExecutor { executor_id: String, table: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -380,14 +392,14 @@ async fn route_batch_and_assign_unseen(
 
     {
         let total_partitioned: usize = entries.iter().map(|(_, _, b)| b.num_rows()).sum();
-        if total_partitioned != unmatched.num_rows() {
-            tracing::debug!(
-                table = %path,
-                unmatched_rows = unmatched.num_rows(),
-                partitioned_rows = total_partitioned,
-                "Row count mismatch after partitioning unmatched rows; some data may be lost"
-            );
-        }
+        ensure!(
+            total_partitioned == unmatched.num_rows(),
+            PartitionRowCountMismatchSnafu {
+                table: path.to_string(),
+                expected: unmatched.num_rows(),
+                actual: total_partitioned,
+            }
+        );
     }
 
     if entries.is_empty() {
@@ -468,18 +480,15 @@ async fn route_batch_and_assign_unseen(
         }
 
         // Forward the rows.
-        if let Some(tx) = senders.get(&executor_id) {
-            tx.send(sub_batch).await.map_err(|_| Error::SendBatch {
+        let tx = senders
+            .get(&executor_id)
+            .ok_or_else(|| Error::NoSenderForExecutor {
                 executor_id: executor_id.clone(),
+                table: path.to_string(),
             })?;
-        } else {
-            tracing::debug!(
-                executor_id,
-                rows = sub_batch.num_rows(),
-                table = %path,
-                "No sender for assigned executor; rows will be lost"
-            );
-        }
+        tx.send(sub_batch).await.map_err(|_| Error::SendBatch {
+            executor_id: executor_id.clone(),
+        })?;
     }
 
     Ok(())

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -238,6 +238,19 @@ pub(crate) async fn handle(
         return response.map_err(Into::into);
     }
 
+    // In distributed mode, the scheduler must NEVER write data locally.
+    // Writes should always be forwarded to executors via the partitioned write path above.
+    // If we reached this point on the scheduler, the table is either not partitioned
+    // or partition resolution failed — reject the write to prevent silent data misrouting.
+    if matches!(
+        datafusion.cluster_config.effective_role(),
+        Some(ClusterRole::Scheduler)
+    ) {
+        return Err(Status::failed_precondition(format!(
+            "Cannot write data to table `{path}` on the scheduler. Ensure the table has a partition expression configured for distributed writes.",
+        )));
+    }
+
     let schema = try_schema_from_flatbuffer_bytes(&first_message.data_header)
         .map_err(|e| Status::internal(format!("Failed to get schema from data header: {e}")))?;
     let schema = Arc::new(schema);

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1141,11 +1141,13 @@ fn spawn_local_spiced(
         args.join(" ")
     );
 
+    let current_stderr = std::io::stderr();
+
     TokioCommand::new(spiced_path)
         .kill_on_drop(true)
         .args(args)
         .current_dir(current_dir)
-        .stdout(Stdio::null())
+        .stdout(Stdio::from(current_stderr))
         .stderr(Stdio::inherit())
         .spawn()
         .map_err(|error| anyhow::anyhow!("Failed to start local {process_name} process: {error}"))


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds some more debug logs for different distributed write failure scenarios
* Adds a check if the executor is connected before routing to it - if disconnected, do not route rows to it and return them as unmatched for assignment
* Redirects local spidapter spiced output to stderr so it can be seen in terminal instead of dropping it to a null stdout
