### PR TITLE
fix: Ensure distributed Cayenne DML inserts are forwarded to executors

### DIFF
--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -135,6 +135,11 @@ pub enum Error {
 
     #[snafu(display("Failed to persist partition assignment: {source}"))]
     PersistAssignment { source: Box<super::manager::Error> },
+
+    #[snafu(display("Upstream execution error: {source}"))]
+    UpstreamExecution {
+        source: datafusion::error::DataFusionError,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Forwards writes to each relevant executor based on their assigned partitions.
 //! This is used for partitioned tables that are written to via the coordinator.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use arrow::array::RecordBatch;
 use arrow_flight::{
@@ -33,11 +33,11 @@ use datafusion::{
     sql::{ResolvedTableReference, TableReference},
 };
 use datafusion_expr::{Expr, execution_props::ExecutionProps, lit};
-use futures::TryStreamExt as _;
+use futures::{Stream, TryStreamExt as _};
 use runtime_request_context::{AsyncMarker, RequestContext};
 use snafu::{ResultExt, Snafu};
 use tokio::sync::mpsc::{self, Sender};
-use tokio_stream::{StreamExt as _, adapters::Peekable, wrappers::ReceiverStream};
+use tokio_stream::{StreamExt, adapters::Peekable, wrappers::ReceiverStream};
 use tonic::{Response, Streaming};
 
 use crate::{
@@ -158,6 +158,9 @@ type ExecutorFilter = (ExecutorId, Arc<dyn datafusion::physical_plan::PhysicalEx
 /// Rows with partition values not yet assigned to any executor are assigned
 /// to the least-loaded executor. The assignment is persisted to the partition
 /// metadata store before the rows are forwarded.
+///
+/// Batches are decoded and routed incrementally from the Flight stream to
+/// avoid materializing the full payload in memory.
 pub(crate) async fn forward_federated_partitioned_write(
     executor_registry: &ExecutorRegistry,
     ctx: Arc<datafusion::prelude::SessionContext>,
@@ -173,31 +176,30 @@ pub(crate) async fn forward_federated_partitioned_write(
 
     let dictionaries_by_id = Arc::new(HashMap::new());
 
-    // Decode FlightData into RecordBatches and feed them to the common routing logic.
+    // Decode the first message and build a streaming iterator that yields
+    // each subsequent FlightData message as a RecordBatch without buffering.
     let first_batch =
         flight_data_to_arrow_batch(&first_message, Arc::clone(&schema), &dictionaries_by_id).ok();
 
-    let batch_iter = async {
-        let mut batches: Vec<RecordBatch> = Vec::new();
+    let decode_schema = Arc::clone(&schema);
+    let batch_stream = async_stream::try_stream! {
         if let Some(batch) = first_batch {
             if batch.num_rows() > 0 {
-                batches.push(batch);
+                yield batch;
             }
         }
         while let Some(result) = streaming_flight.next().await {
             let batch = flight_data_to_arrow_batch(
                 &result.context(StreamReadSnafu)?,
-                Arc::clone(&schema),
+                Arc::clone(&decode_schema),
                 &dictionaries_by_id,
             )
             .context(DecodeBatchSnafu)?;
             if batch.num_rows() > 0 {
-                batches.push(batch);
+                yield batch;
             }
         }
-        Ok(batches)
     };
-    let batches = batch_iter.await?;
 
     forward_partitioned_batches(
         executor_registry,
@@ -205,7 +207,7 @@ pub(crate) async fn forward_federated_partitioned_write(
         io_runtime,
         path,
         &schema,
-        batches,
+        Box::pin(batch_stream),
         raw_partition_by,
     )
     .await?;
@@ -218,15 +220,15 @@ pub(crate) async fn forward_federated_partitioned_write(
 /// Core partition-aware batch routing logic shared by the Flight `DoPut` path
 /// and the SQL `INSERT INTO` path.
 ///
-/// Receives a pre-decoded list of [`RecordBatch`] and routes each batch to the
-/// correct executor based on partition assignments.
+/// Accepts an async stream of [`RecordBatch`] and routes each batch to the
+/// correct executor as it arrives, avoiding full materialization in memory.
 pub(crate) async fn forward_partitioned_batches(
     executor_registry: &ExecutorRegistry,
     ctx: Arc<datafusion::prelude::SessionContext>,
     io_runtime: tokio::runtime::Handle,
     path: &TableReference,
     schema: &SchemaRef,
-    batches: Vec<RecordBatch>,
+    mut batches: Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>,
     raw_partition_by: &[String],
 ) -> Result<()> {
     let partition_manager = executor_registry.federated_partition_manager();
@@ -298,7 +300,14 @@ pub(crate) async fn forward_partitioned_batches(
 
     // Route each batch through partition filters to the appropriate executor.
     let mut routing_error: Option<Error> = None;
-    for batch in batches {
+    while let Some(batch_result) = StreamExt::next(&mut batches).await {
+        let batch = match batch_result {
+            Ok(b) => b,
+            Err(e) => {
+                routing_error = Some(e);
+                break;
+            }
+        };
         if let Err(e) = route_batch_and_assign_unseen(
             &batch,
             &mut executor_filters,

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -167,6 +167,68 @@ pub(crate) async fn forward_federated_partitioned_write(
     mut streaming_flight: Peekable<Streaming<FlightData>>,
     raw_partition_by: &[String],
 ) -> Result<Response<<FlightSvc as FlightService>::DoPutStream>> {
+    let schema = Arc::new(
+        try_schema_from_flatbuffer_bytes(&first_message.data_header).context(DecodeSchemaSnafu)?,
+    );
+
+    let dictionaries_by_id = Arc::new(HashMap::new());
+
+    // Decode FlightData into RecordBatches and feed them to the common routing logic.
+    let first_batch =
+        flight_data_to_arrow_batch(&first_message, Arc::clone(&schema), &dictionaries_by_id).ok();
+
+    let batch_iter = async {
+        let mut batches: Vec<RecordBatch> = Vec::new();
+        if let Some(batch) = first_batch {
+            if batch.num_rows() > 0 {
+                batches.push(batch);
+            }
+        }
+        while let Some(result) = streaming_flight.next().await {
+            let batch = flight_data_to_arrow_batch(
+                &result.context(StreamReadSnafu)?,
+                Arc::clone(&schema),
+                &dictionaries_by_id,
+            )
+            .context(DecodeBatchSnafu)?;
+            if batch.num_rows() > 0 {
+                batches.push(batch);
+            }
+        }
+        Ok(batches)
+    };
+    let batches = batch_iter.await?;
+
+    forward_partitioned_batches(
+        executor_registry,
+        ctx,
+        io_runtime,
+        path,
+        &schema,
+        batches,
+        raw_partition_by,
+    )
+    .await?;
+
+    Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+        PutResult::default(),
+    )]))))
+}
+
+/// Core partition-aware batch routing logic shared by the Flight `DoPut` path
+/// and the SQL `INSERT INTO` path.
+///
+/// Receives a pre-decoded list of [`RecordBatch`] and routes each batch to the
+/// correct executor based on partition assignments.
+pub(crate) async fn forward_partitioned_batches(
+    executor_registry: &ExecutorRegistry,
+    ctx: Arc<datafusion::prelude::SessionContext>,
+    io_runtime: tokio::runtime::Handle,
+    path: &TableReference,
+    schema: &SchemaRef,
+    batches: Vec<RecordBatch>,
+    raw_partition_by: &[String],
+) -> Result<()> {
     let partition_manager = executor_registry.federated_partition_manager();
     let table_partitions = match partition_manager.get_table_metadata(path).await {
         Ok(Some(metadata)) => metadata,
@@ -207,14 +269,10 @@ pub(crate) async fn forward_federated_partitioned_write(
         .all_executor_partitions(&ctx, &target_schema)
         .context(ResolvePartitionsSnafu)?;
 
-    let schema = Arc::new(
-        try_schema_from_flatbuffer_bytes(&first_message.data_header).context(DecodeSchemaSnafu)?,
-    );
-
-    let mut executor_filters = build_executor_filters(&partitions_by_executor, &schema)?;
+    let mut executor_filters = build_executor_filters(&partitions_by_executor, schema)?;
 
     // Parse partition_by expressions into physical exprs for splitting unmatched rows.
-    let partition_phys_exprs = build_partition_physical_exprs(&partition_by, &schema)?;
+    let partition_phys_exprs = build_partition_physical_exprs(&partition_by, schema)?;
 
     let tbl = path
         .clone()
@@ -238,14 +296,10 @@ pub(crate) async fn forward_federated_partitioned_write(
 
     let partition_manager = executor_registry.federated_partition_manager();
 
-    // Decode and route the first message.
-    let dictionaries_by_id = Arc::new(HashMap::new());
+    // Route each batch through partition filters to the appropriate executor.
     let mut routing_error: Option<Error> = None;
-
-    if let Ok(batch) =
-        flight_data_to_arrow_batch(&first_message, Arc::clone(&schema), &dictionaries_by_id)
-        && batch.num_rows() > 0
-        && let Err(e) = route_batch_and_assign_unseen(
+    for batch in batches {
+        if let Err(e) = route_batch_and_assign_unseen(
             &batch,
             &mut executor_filters,
             &senders,
@@ -256,35 +310,9 @@ pub(crate) async fn forward_federated_partitioned_write(
             path,
         )
         .await
-    {
-        routing_error = Some(e);
-    }
-
-    // Decode and route the rest of the stream.
-    if routing_error.is_none() {
-        while let Some(result) = streaming_flight.next().await {
-            let batch = flight_data_to_arrow_batch(
-                &result.context(StreamReadSnafu)?,
-                Arc::clone(&schema),
-                &dictionaries_by_id,
-            )
-            .context(DecodeBatchSnafu)?;
-            if batch.num_rows() > 0
-                && let Err(e) = route_batch_and_assign_unseen(
-                    &batch,
-                    &mut executor_filters,
-                    &senders,
-                    &partition_phys_exprs,
-                    raw_partition_by,
-                    &mut partitions_by_executor,
-                    &partition_manager,
-                    path,
-                )
-                .await
-            {
-                routing_error = Some(e);
-                break;
-            }
+        {
+            routing_error = Some(e);
+            break;
         }
     }
 
@@ -319,9 +347,7 @@ pub(crate) async fn forward_federated_partitioned_write(
         return Err(route_err);
     }
 
-    Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
-        PutResult::default(),
-    )]))))
+    Ok(())
 }
 
 /// Routes a [`RecordBatch`] of data to one or more executors' [`Sender<RecordBatch>`], based on the executor filter

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -646,7 +646,12 @@ pub(crate) fn default_extension_planners(
         Arc::new(CacheInvalidationExtensionPlanner::new()),
         Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new(datafusion_ref)),
         #[cfg(not(windows))]
-        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new(executor_registry, Some(io_runtime))),
+        Arc::new(
+            super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new(
+                executor_registry,
+                Some(io_runtime),
+            ),
+        ),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -299,6 +299,7 @@ impl DataFusionBuilder {
                 ExtensionPlanQueryPlanner::from_extension_planners(default_extension_planners(
                     Arc::clone(&datafusion_ref),
                     self.executor_registry.clone(),
+                    self.io_runtime.clone(),
                 )),
             ))
             .with_runtime_env(runtime_env(
@@ -468,6 +469,9 @@ impl DataFusionBuilder {
                 self.cluster_config.as_ref().is_some_and(|cfg| {
                     matches!(cfg.effective_role(), Some(ClusterRole::Scheduler))
                 }),
+                self.cluster_config
+                    .as_ref()
+                    .is_some_and(|cfg| cfg.effective_role().is_some()),
             ),
         ));
 
@@ -634,6 +638,7 @@ pub(crate) fn runtime_env(
 pub(crate) fn default_extension_planners(
     datafusion_ref: super::iceberg_ddl::SharedDataFusionRef,
     executor_registry: Option<Arc<ExecutorRegistry>>,
+    io_runtime: tokio::runtime::Handle,
 ) -> Vec<Arc<dyn ExtensionPlanner + Send + Sync>> {
     vec![
         Arc::new(IndexTableScanExtensionPlanner::new()),
@@ -641,7 +646,7 @@ pub(crate) fn default_extension_planners(
         Arc::new(CacheInvalidationExtensionPlanner::new()),
         Arc::new(super::iceberg_ddl::planner::IcebergDdlExtensionPlanner::new(datafusion_ref)),
         #[cfg(not(windows))]
-        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new(executor_registry)),
+        Arc::new(super::cayenne_ddl::planner::CayenneDdlExtensionPlanner::new(executor_registry, Some(io_runtime))),
         #[cfg(feature = "duckdb")]
         DuckDBLogicalExtensionPlanner::new(),
     ]

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -41,7 +41,7 @@ use runtime_table_partition::expression::validate_partition_expression;
 use super::is_cayenne_catalog;
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
 };
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
@@ -92,7 +92,14 @@ pub struct CayenneDdlAnalyzerRule {
     ddl_enabled_catalogs: Weak<RwLock<HashSet<String>>>,
     /// Shared store for DDL extensions extracted from `CREATE TABLE` statements.
     ddl_options: SharedDdlExtensionStore,
+    /// When `true`, DML targeting Cayenne catalogs is rewritten into distributed
+    /// extension nodes that forward operations to executors. Only `true` for the
+    /// scheduler role.
     apply_distributed_nodes: bool,
+    /// When `true`, the runtime is running in some cluster role (Scheduler or
+    /// Executor). Cayenne catalogs require distributed mode — standalone
+    /// (non-distributed) Cayenne usage is not supported.
+    is_distributed: bool,
 }
 
 impl fmt::Debug for CayenneDdlAnalyzerRule {
@@ -110,6 +117,7 @@ impl CayenneDdlAnalyzerRule {
         ddl_enabled_catalogs: &Arc<RwLock<HashSet<String>>>,
         ddl_options: SharedDdlExtensionStore,
         apply_distributed_nodes: bool,
+        is_distributed: bool,
     ) -> Self {
         Self {
             session_state,
@@ -117,6 +125,7 @@ impl CayenneDdlAnalyzerRule {
             ddl_enabled_catalogs: Arc::downgrade(ddl_enabled_catalogs),
             ddl_options,
             apply_distributed_nodes,
+            is_distributed,
         }
     }
 
@@ -159,6 +168,12 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
 
                 if !self.is_cayenne_backed(&catalog_name) {
                     return Ok(plan);
+                }
+
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "CREATE TABLE on Cayenne catalog '{catalog_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
                 }
 
                 let schema_name = create
@@ -238,6 +253,12 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     return Ok(plan);
                 }
 
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "DROP TABLE on Cayenne catalog '{catalog_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
+                }
+
                 let schema_name = drop
                     .name
                     .schema()
@@ -263,16 +284,22 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                 output_schema,
                 ..
             }) => {
-                if !self.apply_distributed_nodes {
-                    return Ok(plan);
-                }
-
                 let catalog_name = table_name
                     .catalog()
                     .unwrap_or(SPICE_DEFAULT_CATALOG)
                     .to_string();
 
                 if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "DELETE on Cayenne catalog table '{table_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
+                }
+
+                if !self.apply_distributed_nodes {
                     return Ok(plan);
                 }
 
@@ -294,16 +321,22 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                 output_schema,
                 ..
             }) => {
-                if !self.apply_distributed_nodes {
-                    return Ok(plan);
-                }
-
                 let catalog_name = table_name
                     .catalog()
                     .unwrap_or(SPICE_DEFAULT_CATALOG)
                     .to_string();
 
                 if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "UPDATE on Cayenne catalog table '{table_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
+                }
+
+                if !self.apply_distributed_nodes {
                     return Ok(plan);
                 }
 
@@ -322,6 +355,40 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     node: Arc::new(node),
                 }))
             }
+            LogicalPlan::Dml(DmlStatement {
+                input,
+                table_name,
+                op: WriteOp::Insert(_),
+                output_schema,
+                ..
+            }) => {
+                let catalog_name = table_name
+                    .catalog()
+                    .unwrap_or(SPICE_DEFAULT_CATALOG)
+                    .to_string();
+
+                if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
+                    return Ok(plan);
+                }
+
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "INSERT on Cayenne catalog table '{table_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
+                }
+
+                if !self.apply_distributed_nodes {
+                    return Ok(plan);
+                }
+
+                Ok(LogicalPlan::Extension(Extension {
+                    node: Arc::new(DistributedCayenneInsertNode::new(
+                        table_name.clone(),
+                        Arc::clone(input),
+                        Arc::clone(output_schema),
+                    )),
+                }))
+            }
             LogicalPlan::Ddl(DdlStatement::CreateCatalogSchema(create)) => {
                 let (catalog_name, schema_name) =
                     parse_qualified_schema_name(create.schema_name.as_str());
@@ -332,6 +399,12 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
 
                 if !self.is_cayenne_backed(&catalog_name) {
                     return Ok(plan);
+                }
+
+                if !self.is_distributed {
+                    return Err(DataFusionError::Plan(format!(
+                        "CREATE SCHEMA on Cayenne catalog '{catalog_name}' requires distributed mode. Non-distributed Cayenne catalogs are not supported."
+                    )));
                 }
 
                 let node =

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -221,6 +221,12 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     }
                 };
 
+                if partition_expr.is_none() {
+                    return Err(DataFusionError::Plan(format!(
+                        "CREATE TABLE on Cayenne catalog '{catalog_name}' requires a PARTITION BY clause. Example: CREATE TABLE {catalog_name}.{schema_name}.{table_name} (...) PARTITION BY column_name"
+                    )));
+                }
+
                 let node = CayenneCreateTableNode::builder(
                     table_name,
                     arrow_schema,

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -609,3 +609,93 @@ impl UserDefinedLogicalNodeCore for DistributedCayenneUpdateNode {
         })
     }
 }
+
+/// Logical plan node to forward `INSERT` DML operations to a Cayenne table
+/// across relevant executors in distributed mode, using partition-aware routing.
+#[derive(Debug)]
+pub struct DistributedCayenneInsertNode {
+    /// Fully qualified table reference.
+    pub table_name: TableReference,
+    /// The input plan producing the rows to insert.
+    pub input: Arc<LogicalPlan>,
+    /// Output schema from the original DML statement.
+    pub output_schema: DFSchemaRef,
+}
+
+impl DistributedCayenneInsertNode {
+    #[must_use]
+    pub fn new(
+        table_name: TableReference,
+        input: Arc<LogicalPlan>,
+        output_schema: DFSchemaRef,
+    ) -> Self {
+        Self {
+            table_name,
+            input,
+            output_schema,
+        }
+    }
+}
+
+impl Hash for DistributedCayenneInsertNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_name.hash(state);
+        self.input.hash(state);
+        self.output_schema.hash(state);
+    }
+}
+
+impl PartialEq for DistributedCayenneInsertNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.table_name == other.table_name && self.input == other.input
+    }
+}
+
+impl Eq for DistributedCayenneInsertNode {}
+
+impl PartialOrd for DistributedCayenneInsertNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.table_name
+            .to_string()
+            .partial_cmp(&other.table_name.to_string())
+    }
+}
+
+impl UserDefinedLogicalNodeCore for DistributedCayenneInsertNode {
+    fn name(&self) -> &'static str {
+        "CayenneInsert"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CayenneInsert: {}", self.table_name)
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        let input = inputs.into_iter().next().ok_or_else(|| {
+            datafusion::error::DataFusionError::Internal(
+                "CayenneInsertNode requires exactly one input".to_string(),
+            )
+        })?;
+        Ok(Self {
+            table_name: self.table_name.clone(),
+            input: Arc::new(input),
+            output_schema: DFSchemaRef::clone(&self.output_schema),
+        })
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -555,7 +555,11 @@ impl Hash for DistributedCayenneUpdateNode {
 
 impl PartialEq for DistributedCayenneUpdateNode {
     fn eq(&self, other: &Self) -> bool {
-        self.table_name == other.table_name && self.input == other.input
+        self.table_name == other.table_name
+            && self.input == other.input
+            && self.output_schema == other.output_schema
+            && self.filter_sql == other.filter_sql
+            && self.assignments_sql == other.assignments_sql
     }
 }
 
@@ -647,7 +651,9 @@ impl Hash for DistributedCayenneInsertNode {
 
 impl PartialEq for DistributedCayenneInsertNode {
     fn eq(&self, other: &Self) -> bool {
-        self.table_name == other.table_name && self.input == other.input
+        self.table_name == other.table_name
+            && self.input == other.input
+            && self.output_schema == other.output_schema
     }
 }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1520,8 +1520,8 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
                             }
                             Ok(_) => None,
                             Err(e) => Some(Err(
-                                crate::cluster::partition::write_through::Error::DecodeBatch {
-                                    source: arrow_schema::ArrowError::ExternalError(Box::new(e)),
+                                crate::cluster::partition::write_through::Error::UpstreamExecution {
+                                    source: e,
                                 },
                             )),
                         }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1351,6 +1351,203 @@ impl ExecutionPlan for DistributedCayenneUpdateExec {
     }
 }
 
+/// Physical plan to forward `INSERT` DML operations to a Cayenne table across
+/// relevant executors in distributed mode, using partition-aware batch routing.
+///
+/// Materializes the input source plan into [`RecordBatch`]es and routes them
+/// to executors via the same partition write-through path used by Flight `DoPut`.
+pub struct DistributedCayenneInsertExec {
+    table_name: datafusion::sql::TableReference,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
+    ctx: Arc<datafusion::prelude::SessionContext>,
+    io_runtime: tokio::runtime::Handle,
+    /// The child physical plan producing the rows to insert.
+    input: Arc<dyn ExecutionPlan>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for DistributedCayenneInsertExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CayenneInsertExec")
+            .field("table_name", &self.table_name.to_string())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DistributedCayenneInsertExec {
+    #[must_use]
+    pub fn new(
+        table_name: datafusion::sql::TableReference,
+        executor_registry: Option<Arc<ExecutorRegistry>>,
+        ctx: Arc<datafusion::prelude::SessionContext>,
+        io_runtime: tokio::runtime::Handle,
+        input: Arc<dyn ExecutionPlan>,
+    ) -> Self {
+        let schema = dml_count_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            table_name,
+            executor_registry,
+            ctx,
+            io_runtime,
+            input,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for DistributedCayenneInsertExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CayenneInsertExec: {}", self.table_name)
+    }
+}
+
+impl ExecutionPlan for DistributedCayenneInsertExec {
+    fn name(&self) -> &'static str {
+        "CayenneInsertExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let input = children.into_iter().next().ok_or_else(|| {
+            DataFusionError::Internal("CayenneInsertExec requires exactly one child".to_string())
+        })?;
+        Ok(Arc::new(Self::new(
+            self.table_name.clone(),
+            self.executor_registry.clone(),
+            Arc::clone(&self.ctx),
+            self.io_runtime.clone(),
+            input,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let table_name = self.table_name.clone();
+        let executor_registry = self.executor_registry.clone();
+        let ctx = Arc::clone(&self.ctx);
+        let io_runtime = self.io_runtime.clone();
+        let input = Arc::clone(&self.input);
+        let result_schema = dml_count_schema();
+        let task_ctx = context;
+
+        let stream = futures::stream::once(async move {
+            let Some(ref registry) = executor_registry else {
+                return Err(DataFusionError::Execution(format!(
+                    "INSERT on '{table_name}' cannot be forwarded: no executor registry available"
+                )));
+            };
+
+            if registry.flight_sql_clients.read().await.is_empty() {
+                return Err(DataFusionError::Execution(format!(
+                    "INSERT on '{table_name}' cannot be forwarded: no executors are currently connected"
+                )));
+            }
+
+            // Resolve the partition expression for this table.
+            let partition_expr =
+                crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+                    &ctx, registry, &table_name,
+                )
+                .await
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to resolve partition expression for table '{table_name}': {e}"
+                    ))
+                })?;
+
+            let Some(partition_expr) = partition_expr else {
+                return Err(DataFusionError::Execution(format!(
+                    "INSERT on '{table_name}' cannot be forwarded: table has no partition expression. Cayenne tables require PARTITION BY for distributed writes."
+                )));
+            };
+
+            // Materialize the INSERT source plan into record batches.
+            let mut stream = input.execute(partition, task_ctx)?;
+            let mut batches: Vec<RecordBatch> = Vec::new();
+            let mut total_rows: u64 = 0;
+
+            while let Some(result) = futures::StreamExt::next(&mut stream).await {
+                let batch = result?;
+                total_rows += batch.num_rows() as u64;
+                if batch.num_rows() > 0 {
+                    batches.push(batch);
+                }
+            }
+
+            if batches.is_empty() {
+                return RecordBatch::try_new(
+                    result_schema,
+                    vec![Arc::new(arrow::array::UInt64Array::from(vec![0_u64]))],
+                )
+                .map_err(Into::into);
+            }
+
+            let schema = batches[0].schema();
+
+            // Route batches through the partition write-through path.
+            crate::cluster::partition::write_through::forward_partitioned_batches(
+                registry,
+                Arc::clone(&ctx),
+                io_runtime,
+                &table_name,
+                &schema,
+                batches,
+                &[partition_expr],
+            )
+            .await
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Failed to forward INSERT batches for table '{table_name}': {e}"
+                ))
+            })?;
+
+            RecordBatch::try_new(
+                result_schema,
+                vec![Arc::new(arrow::array::UInt64Array::from(vec![total_rows]))],
+            )
+            .map_err(Into::into)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            dml_count_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Schema for DML count results — single `count` column with UInt64 type,
+/// matching DataFusion's standard DML output format.
+fn dml_count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
 #[cfg(test)]
 mod tests {
     use datafusion::logical_expr::col;

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -741,6 +741,11 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     "CREATE TABLE IF NOT EXISTS \"{df_catalog_name}\".\"{df_schema_name}\".\"{table_name}\" ({})",
                     table_elements.join(", ")
                 );
+                let ddl_sql = if let Some(ref partition_sql) = partition_expr_sql {
+                    format!("{ddl_sql} PARTITION BY {partition_sql}")
+                } else {
+                    ddl_sql
+                };
                 forward_ddl_to_executors(registry, &ddl_sql).await?;
             }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1485,28 +1485,44 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
                 )));
             };
 
-            // Materialize the INSERT source plan into record batches.
-            let mut stream = input.execute(partition, task_ctx)?;
-            let mut batches: Vec<RecordBatch> = Vec::new();
-            let mut total_rows: u64 = 0;
-
-            while let Some(result) = futures::StreamExt::next(&mut stream).await {
-                let batch = result?;
-                total_rows += batch.num_rows() as u64;
-                if batch.num_rows() > 0 {
-                    batches.push(batch);
-                }
-            }
-
-            if batches.is_empty() {
-                return RecordBatch::try_new(
-                    result_schema,
-                    vec![Arc::new(arrow::array::UInt64Array::from(vec![0_u64]))],
-                )
-                .map_err(Into::into);
-            }
-
-            let schema = batches[0].schema();
+            // Stream batches from the INSERT source plan directly through
+            // the partition write-through path, counting rows as they flow.
+            let input_schema = input.schema();
+            let child_stream = input.execute(partition, task_ctx)?;
+            let row_count = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+            let row_counter = Arc::clone(&row_count);
+            let counting_stream: std::pin::Pin<
+                Box<
+                    dyn futures::Stream<
+                            Item = std::result::Result<
+                                RecordBatch,
+                                crate::cluster::partition::write_through::Error,
+                            >,
+                        > + Send,
+                >,
+            > = Box::pin(futures::StreamExt::filter_map(
+                child_stream,
+                move |result| {
+                    let counter = Arc::clone(&row_counter);
+                    async move {
+                        match result {
+                            Ok(batch) if batch.num_rows() > 0 => {
+                                counter.fetch_add(
+                                    batch.num_rows() as u64,
+                                    std::sync::atomic::Ordering::Relaxed,
+                                );
+                                Some(Ok(batch))
+                            }
+                            Ok(_) => None,
+                            Err(e) => Some(Err(
+                                crate::cluster::partition::write_through::Error::DecodeBatch {
+                                    source: arrow_schema::ArrowError::ExternalError(Box::new(e)),
+                                },
+                            )),
+                        }
+                    }
+                },
+            ));
 
             // Route batches through the partition write-through path.
             crate::cluster::partition::write_through::forward_partitioned_batches(
@@ -1514,8 +1530,8 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
                 Arc::clone(&ctx),
                 io_runtime,
                 &table_name,
-                &schema,
-                batches,
+                &input_schema,
+                counting_stream,
                 &[partition_expr],
             )
             .await
@@ -1525,6 +1541,7 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
                 ))
             })?;
 
+            let total_rows = row_count.load(std::sync::atomic::Ordering::Relaxed);
             RecordBatch::try_new(
                 result_schema,
                 vec![Arc::new(arrow::array::UInt64Array::from(vec![total_rows]))],

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1467,16 +1467,17 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
             }
 
             // Resolve the partition expression for this table.
-            let partition_expr =
-                crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
-                    &ctx, registry, &table_name,
-                )
-                .await
-                .map_err(|e| {
-                    DataFusionError::Execution(format!(
-                        "Failed to resolve partition expression for table '{table_name}': {e}"
-                    ))
-                })?;
+            let partition_expr = crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+                &ctx,
+                registry,
+                &table_name,
+            )
+            .await
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Failed to resolve partition expression for table '{table_name}': {e}"
+                ))
+            })?;
 
             let Some(partition_expr) = partition_expr else {
                 return Err(DataFusionError::Execution(format!(

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -28,11 +28,11 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
 };
 use super::physical_plans::{
     CayenneCreateSchemaExec, CayenneCreateTableExecBuilder, CayenneDropTableExec,
-    DistributedCayenneDeleteExec, DistributedCayenneUpdateExec,
+    DistributedCayenneDeleteExec, DistributedCayenneInsertExec, DistributedCayenneUpdateExec,
 };
 use crate::cluster::executor_registry::ExecutorRegistry;
 
@@ -43,18 +43,25 @@ use crate::cluster::executor_registry::ExecutorRegistry;
 #[derive(Debug)]
 pub struct CayenneDdlExtensionPlanner {
     executor_registry: Option<Arc<ExecutorRegistry>>,
+    io_runtime: Option<tokio::runtime::Handle>,
 }
 
 impl CayenneDdlExtensionPlanner {
     #[must_use]
-    pub fn new(executor_registry: Option<Arc<ExecutorRegistry>>) -> Self {
-        Self { executor_registry }
+    pub fn new(
+        executor_registry: Option<Arc<ExecutorRegistry>>,
+        io_runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self {
+            executor_registry,
+            io_runtime,
+        }
     }
 }
 
 impl Default for CayenneDdlExtensionPlanner {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(None, None)
     }
 }
 
@@ -133,6 +140,29 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 self.executor_registry.clone(),
                 update.filter_sql.clone(),
                 update.assignments_sql.clone(),
+                Arc::clone(input),
+            ))));
+        }
+
+        if let Some(insert) = node.as_any().downcast_ref::<DistributedCayenneInsertNode>() {
+            let input = _physical_inputs.first().ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(
+                    "DistributedCayenneInsertNode requires exactly one physical input".to_string(),
+                )
+            })?;
+            let io_runtime = self.io_runtime.clone().ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(
+                    "DistributedCayenneInsertExec requires an IO runtime handle".to_string(),
+                )
+            })?;
+            let ctx = Arc::new(datafusion::prelude::SessionContext::new_with_state(
+                session_state.clone(),
+            ));
+            return Ok(Some(Arc::new(DistributedCayenneInsertExec::new(
+                insert.table_name.clone(),
+                self.executor_registry.clone(),
+                ctx,
+                io_runtime,
                 Arc::clone(input),
             ))));
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1006,6 +1006,57 @@ impl DataFusion {
         Ok(metadata.partition_expressions.get(idx).cloned())
     }
 
+    /// Returns the partition expression string for a table using only a `SessionContext`
+    /// and `ExecutorRegistry`, without requiring a full `DataFusion` reference.
+    ///
+    /// This is used by `DistributedCayenneInsertExec` which is constructed from the
+    /// extension planner and only has access to the session context.
+    pub async fn get_table_partition_expr_from_ctx(
+        ctx: &datafusion::prelude::SessionContext,
+        executor_registry: &ExecutorRegistry,
+        table_reference: &TableReference,
+    ) -> Result<Option<String>, DataFusionError> {
+        let catalog_name = match table_reference {
+            TableReference::Bare { .. } | TableReference::Partial { .. } => SPICE_DEFAULT_CATALOG,
+            TableReference::Full { catalog, .. } => catalog,
+        };
+        let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
+
+        let Some(catalog) = ctx.catalog(catalog_name) else {
+            return Ok(None);
+        };
+
+        let Some(aware) = cayenne_ddl::as_partition_aware(catalog.as_ref()) else {
+            return Ok(None);
+        };
+
+        let Some(expr_string) = aware
+            .table_partition_expr(schema_name, table_reference.table())
+            .await
+            .boxed()
+            .map_err(DataFusionError::External)?
+        else {
+            return Ok(None);
+        };
+
+        // Resolve auto-generated labels from partition manager metadata.
+        if let Some(Ok(idx)) = expr_string.strip_prefix("expr").map(str::parse::<usize>) {
+            if let Ok(Some(metadata)) = executor_registry
+                .federated_partition_manager()
+                .get_table_metadata(table_reference)
+                .await
+                .boxed()
+                .map_err(DataFusionError::External)
+            {
+                if let Some(original) = metadata.partition_expressions.get(idx) {
+                    return Ok(Some(original.clone()));
+                }
+            }
+        }
+
+        Ok(Some(expr_string))
+    }
+
     /// Parses a SQL expression string into a `DataFusion` `Expr`, using the schema of the given table reference for resolution.
     pub async fn sql_expr(
         &self,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -962,48 +962,13 @@ impl DataFusion {
         &self,
         table_reference: &TableReference,
     ) -> Result<Option<String>, DataFusionError> {
-        let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
-        if let Some(catalog) = self.resolve_catalog_provider(table_reference)
-            && let Some(aware) = cayenne_ddl::as_partition_aware(catalog.as_ref())
-            && let Some(expr_string) = aware
-                .table_partition_expr(schema_name, table_reference.table())
-                .await
-                .boxed()
-                .map_err(DataFusionError::External)?
-        {
-            let resolved = self
-                .resolve_partition_label(&expr_string, table_reference)
-                .await?
-                .unwrap_or(expr_string);
-            return Ok(Some(resolved));
-        }
-        Ok(None)
-    }
-
-    /// If `label` is an auto-generated partition label like `"expr0"`, resolve it to
-    /// the original SQL expression string from the partition manager metadata.
-    async fn resolve_partition_label(
-        &self,
-        label: &str,
-        table_reference: &TableReference,
-    ) -> Result<Option<String>, DataFusionError> {
-        let Some(Ok(idx)) = label.strip_prefix("expr").map(str::parse::<usize>) else {
-            return Ok(None);
-        };
-        let Some(ref executor_registry) = self.executor_registry else {
-            return Ok(None);
-        };
-
-        let Some(metadata) = executor_registry
-            .federated_partition_manager()
-            .get_table_metadata(table_reference)
-            .await
-            .boxed()
-            .map_err(DataFusionError::External)?
-        else {
-            return Ok(None);
-        };
-        Ok(metadata.partition_expressions.get(idx).cloned())
+        let catalog = self.resolve_catalog_provider(table_reference);
+        resolve_table_partition_expr(
+            catalog.as_deref(),
+            self.executor_registry.as_deref(),
+            table_reference,
+        )
+        .await
     }
 
     /// Returns the partition expression string for a table using only a `SessionContext`
@@ -1016,45 +981,10 @@ impl DataFusion {
         executor_registry: &ExecutorRegistry,
         table_reference: &TableReference,
     ) -> Result<Option<String>, DataFusionError> {
-        let catalog_name = match table_reference {
-            TableReference::Bare { .. } | TableReference::Partial { .. } => SPICE_DEFAULT_CATALOG,
-            TableReference::Full { catalog, .. } => catalog,
-        };
-        let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
-
-        let Some(catalog) = ctx.catalog(catalog_name) else {
-            return Ok(None);
-        };
-
-        let Some(aware) = cayenne_ddl::as_partition_aware(catalog.as_ref()) else {
-            return Ok(None);
-        };
-
-        let Some(expr_string) = aware
-            .table_partition_expr(schema_name, table_reference.table())
+        let catalog_name = table_reference.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+        let catalog = ctx.catalog(catalog_name);
+        resolve_table_partition_expr(catalog.as_deref(), Some(executor_registry), table_reference)
             .await
-            .boxed()
-            .map_err(DataFusionError::External)?
-        else {
-            return Ok(None);
-        };
-
-        // Resolve auto-generated labels from partition manager metadata.
-        if let Some(Ok(idx)) = expr_string.strip_prefix("expr").map(str::parse::<usize>) {
-            if let Ok(Some(metadata)) = executor_registry
-                .federated_partition_manager()
-                .get_table_metadata(table_reference)
-                .await
-                .boxed()
-                .map_err(DataFusionError::External)
-            {
-                if let Some(original) = metadata.partition_expressions.get(idx) {
-                    return Ok(Some(original.clone()));
-                }
-            }
-        }
-
-        Ok(Some(expr_string))
     }
 
     /// Parses a SQL expression string into a `DataFusion` `Expr`, using the schema of the given table reference for resolution.
@@ -2648,6 +2578,56 @@ impl DataFusion {
         self.ctx
             .parse_sql_expr(expr, &tbl_provider.schema().to_dfschema()?)
     }
+}
+
+/// Shared implementation for resolving a table's partition expression from its catalog
+/// provider and optional [`ExecutorRegistry`] metadata.
+///
+/// When the catalog returns an auto-generated label like `"expr0"` (used for function
+/// partition expressions such as `bucket(3, c_nationkey)`), the original SQL expression
+/// string is resolved from [`TablePartitionMetadata`] stored in the partition manager.
+async fn resolve_table_partition_expr(
+    catalog: Option<&dyn CatalogProvider>,
+    executor_registry: Option<&ExecutorRegistry>,
+    table_reference: &TableReference,
+) -> Result<Option<String>, DataFusionError> {
+    let schema_name = table_reference.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
+
+    let Some(catalog) = catalog else {
+        return Ok(None);
+    };
+
+    let Some(aware) = cayenne_ddl::as_partition_aware(catalog) else {
+        return Ok(None);
+    };
+
+    let Some(expr_string) = aware
+        .table_partition_expr(schema_name, table_reference.table())
+        .await
+        .boxed()
+        .map_err(DataFusionError::External)?
+    else {
+        return Ok(None);
+    };
+
+    // Resolve auto-generated labels (e.g. "expr0") from partition manager metadata.
+    if let Some(Ok(idx)) = expr_string.strip_prefix("expr").map(str::parse::<usize>)
+        && let Some(executor_registry) = executor_registry
+    {
+        if let Some(metadata) = executor_registry
+            .federated_partition_manager()
+            .get_table_metadata(table_reference)
+            .await
+            .boxed()
+            .map_err(DataFusionError::External)?
+        {
+            if let Some(original) = metadata.partition_expressions.get(idx) {
+                return Ok(Some(original.clone()));
+            }
+        }
+    }
+
+    Ok(Some(expr_string))
 }
 
 #[must_use]


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensures that Distributed Cayenne DML `INSERT` operations are forwarded to executors, similar to `UPDATE`/`DELETE` nodes
* Adds better error handling and identification around running Cayenne Catalog in non-distributed mode. Non-distributed Cayenne Catalog is not supported until https://github.com/spiceai/spiceai/issues/9942 is implemented

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #9733