### PR TITLE
Add full query federation support for ADBC data connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=52eaec1a5c6ddf3017cc440cca27879ef79a8504#52eaec1a5c6ddf3017cc440cca27879ef79a8504"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d2968ed3413f426946cc9ba4afb8be0bc7259817#d2968ed3413f426946cc9ba4afb8be0bc7259817"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d3ae59a3efd87545d6fbfe96a7ff52445c1e7e29#d3ae59a3efd87545d6fbfe96a7ff52445c1e7e29"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=52eaec1a5c6ddf3017cc440cca27879ef79a8504#52eaec1a5c6ddf3017cc440cca27879ef79a8504"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -8226,7 +8226,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -13881,7 +13881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.16.1",
  "parking_lot 0.12.5",
  "rand 0.8.5",
 ]
@@ -14435,7 +14435,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -17911,7 +17911,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,7 +390,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "497da28eca941c9e9af3e2aa8a20b57e0561b265" }                    # spiceai-52
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "497da28eca941c9e9af3e2aa8a20b57e0561b265" }                # spiceai-52
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d3ae59a3efd87545d6fbfe96a7ff52445c1e7e29" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "52eaec1a5c6ddf3017cc440cca27879ef79a8504" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,7 +390,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "497da28eca941c9e9af3e2aa8a20b57e0561b265" }                    # spiceai-52
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "497da28eca941c9e9af3e2aa8a20b57e0561b265" }                # spiceai-52
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "52eaec1a5c6ddf3017cc440cca27879ef79a8504" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d2968ed3413f426946cc9ba4afb8be0bc7259817" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -112,7 +112,7 @@ rdkafka = { workspace = true, features = ["cmake-build"], optional = true }
 
 [features]
 bench = [] # Feature for benchmarking that exposes internal functions
-adbc = ["datafusion-table-providers/adbc"]
+adbc = ["datafusion-table-providers/adbc-federation"]
 clickhouse = ["dep:clickhouse-rs", "datafusion-table-providers/federation"]
 databricks = [
     "delta_lake",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -253,7 +253,7 @@ tracing-subscriber.workspace = true
 yaml = { path = "../yaml" }
 
 [features]
-adbc = ["dep:adbc_core", "dep:adbc_driver_manager", "data_components/adbc", "datafusion-table-providers/adbc"]
+adbc = ["dep:adbc_core", "dep:adbc_driver_manager", "data_components/adbc", "datafusion-table-providers/adbc-federation"]
 aws-secrets-manager = ["dep:aws-sdk-sts", "runtime-secrets/aws-secrets-manager"]
 bedrock = []
 clickhouse = ["db_connection_pool/clickhouse", "data_components/clickhouse"]
@@ -264,6 +264,7 @@ default = [
     "keyring-secret-store",
     "aws-secrets-manager",
     "sharepoint",
+    "delta_lake",
     "bedrock",
 ]
 delta_lake = ["data_components/delta_lake"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -264,7 +264,6 @@ default = [
     "keyring-secret-store",
     "aws-secrets-manager",
     "sharepoint",
-    "delta_lake",
     "bedrock",
 ]
 delta_lake = ["data_components/delta_lake"]

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -32,6 +32,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DFResult;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::adbc::AdbcTableFactory;
+use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
@@ -264,6 +265,7 @@ async fn create_pool(params: &ConnectorParams) -> Result<(String, Arc<ADBCPool<M
         let pool = AdbcConnectionPoolBuilder::new(db)
             .with_max_size(pool_size)
             .with_min_idle(pool_min_idle)
+            .with_join_push_down(JoinPushDown::AllowedFor(uri_str.clone()))
             .build()
             .context(UnableToCreateConnectionPoolSnafu {
                 driver_location,

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::unparser::dialect::{BigQueryDialect, Dialect};
 use datafusion_table_providers::adbc::AdbcTableFactory;
+use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
@@ -36,6 +37,7 @@ use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     ParameterSpec,
 };
+use crate::parameters::Parameters;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -73,6 +75,11 @@ pub enum Error {
         uri: String,
         source: datafusion_table_providers::sql::db_connection_pool::Error,
     },
+
+    #[snafu(display(
+        "Invalid 'query_federation' value '{value}'. Expected 'enabled' or 'disabled'."
+    ))]
+    InvalidQueryFederation { value: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -128,6 +135,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("connection_pool_min_idle")
         .description("The minimum number of idle connections to keep open in the pool.")
         .default("1"),
+    ParameterSpec::runtime("query_federation")
+        .description("Enable or disable query federation for this connector. Valid values: 'enabled' (default), 'disabled'.")
+        .default("enabled"),
 ];
 
 impl DataConnectorFactory for AdbcFactory {
@@ -189,6 +199,15 @@ impl DataConnectorFactory for AdbcFactory {
                 .map(String::from);
 
             let conn_options = build_conn_options(catalog.as_deref(), schema.as_deref());
+
+            let federation_enabled =
+                is_query_federation_enabled(&params.parameters).map_err(|e| {
+                    DataConnectorError::UnableToConnectInternal {
+                        dataconnector: "adbc".to_string(),
+                        connector_component: params.component.clone(),
+                        source: Box::new(e),
+                    }
+                })?;
 
             let parse_pool_param = |name: &str| -> std::result::Result<Option<u32>, Error> {
                 match params.parameters.get(name).expose().ok() {
@@ -259,7 +278,8 @@ impl DataConnectorFactory for AdbcFactory {
 
                 let mut pool_builder = AdbcConnectionPoolBuilder::new(db)
                     .with_max_size(pool_size)
-                    .with_min_idle(pool_min_idle);
+                    .with_min_idle(pool_min_idle)
+                    .with_join_push_down(JoinPushDown::AllowedFor(uri_str.clone()));
 
                 if let Some(conn_opts) = conn_options {
                     pool_builder = pool_builder.with_conn_options(conn_opts);
@@ -286,7 +306,8 @@ impl DataConnectorFactory for AdbcFactory {
                 source: Box::new(e),
             })?;
 
-            let adbc_factory = AdbcTableFactory::new(pool);
+            let adbc_factory =
+                AdbcTableFactory::new(pool).with_federation_enabled(federation_enabled);
 
             Ok(Arc::new(Adbc {
                 adbc_factory,
@@ -419,6 +440,19 @@ impl DataConnector for Adbc {
                     source: e,
                 }),
         )
+    }
+}
+
+/// Returns whether query federation is enabled based on the `query_federation` parameter.
+/// Defaults to `true` (enabled) when the parameter is absent.
+fn is_query_federation_enabled(params: &Parameters) -> Result<bool> {
+    match params.get("query_federation").expose().ok() {
+        None | Some("enabled") => Ok(true),
+        Some("disabled") => Ok(false),
+        Some(other) => InvalidQueryFederationSnafu {
+            value: other.to_string(),
+        }
+        .fail(),
     }
 }
 
@@ -609,5 +643,41 @@ mod tests {
             opts.get("adbc.connection.catalog"),
             Some(&"cat".to_string())
         );
+    }
+
+    fn make_params(pairs: Vec<(&str, &str)>) -> Parameters {
+        use secrecy::SecretString;
+        Parameters::new(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), SecretString::from(v.to_string())))
+                .collect(),
+            "adbc",
+            PARAMETERS,
+        )
+    }
+
+    #[test]
+    fn test_query_federation_enabled() {
+        let params = make_params(vec![("query_federation", "enabled")]);
+        assert!(is_query_federation_enabled(&params).expect("to parse"));
+    }
+
+    #[test]
+    fn test_query_federation_disabled() {
+        let params = make_params(vec![("query_federation", "disabled")]);
+        assert!(!is_query_federation_enabled(&params).expect("to parse"));
+    }
+
+    #[test]
+    fn test_query_federation_missing_defaults_enabled() {
+        let params = make_params(vec![]);
+        assert!(is_query_federation_enabled(&params).expect("to parse"));
+    }
+
+    #[test]
+    fn test_query_federation_invalid_value() {
+        let params = make_params(vec![("query_federation", "invalid")]);
+        is_query_federation_enabled(&params).expect_err("should error on invalid value");
     }
 }

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -202,10 +202,10 @@ impl DataConnectorFactory for AdbcFactory {
 
             let federation_enabled =
                 is_query_federation_enabled(&params.parameters).map_err(|e| {
-                    DataConnectorError::UnableToConnectInternal {
+                    DataConnectorError::InvalidConfigurationNoSource {
                         dataconnector: "adbc".to_string(),
                         connector_component: params.component.clone(),
-                        source: Box::new(e),
+                        message: e.to_string(),
                     }
                 })?;
 


### PR DESCRIPTION
## 📝 Summary

Enable full SQL query federation for the ADBC data connector so that queries like `SELECT count(*) FROM my_table` are converted to SQL and fully pushed directly to the remote database

Note: full federation is enabled by default and can be disabled using `query_federation` parameter to preserve non-federated behavior: projections, filters, and limits are still pushed down, but aggregations and other computations are performed locally.

```yaml
datasets:
  - from: adbc:schedules
    name: my_table
    params:
      query_federation: disabled
      adbc_driver: bigquery
      adbc_uri: bigquery:///...
```

## 🔗 Related

Resolves #9952

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I also manually run TPC-H SF1 queries and created the following item to address failed. Full automated benchmark run for ADBC / BigQuery is coming as well.
 - https://github.com/spiceai/spiceai/issues/9954


```
sql> explain select
    l_returnflag,
    l_linestatus,
    sum(l_quantity) as sum_qty,
    sum(l_extendedprice) as sum_base_price,
    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
    avg(l_quantity) as avg_qty,
    avg(l_extendedprice) as avg_price,
    avg(l_discount) as avg_disc,
    count(*) as count_order
from
    lineitem
where
        l_shipdate <= date '1998-09-02'
group by
    l_returnflag,
    l_linestatus
order by
    l_returnflag,
    l_linestatus;
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|   plan_type   |                                                                                                                                                                                                                                                                                                                                                                                                                                                plan                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|    varchar    |                                                                                                                                                                                                                                                                                                                                                                                                                                              varchar                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Federated                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|               |  Sort: lineitem.l_returnflag ASC NULLS LAST, lineitem.l_linestatus ASC NULLS LAST                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|               |   Projection: lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity) AS sum_qty, sum(lineitem.l_extendedprice) AS sum_base_price, sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount) AS sum_disc_price, sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount * Int64(1) + lineitem.l_tax) AS sum_charge, avg(lineitem.l_quantity) AS avg_qty, avg(lineitem.l_extendedprice) AS avg_price, avg(lineitem.l_discount) AS avg_disc, count(Int64(1)) AS count_order                                                                                                                                                                                                                                                                                                                                                                                               |
|               |     Aggregate: groupBy=[[lineitem.l_returnflag, lineitem.l_linestatus]], aggr=[[sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum(lineitem.l_extendedprice * (Int64(1) - lineitem.l_discount)), sum(lineitem.l_extendedprice * (Int64(1) - lineitem.l_discount) * (Int64(1) + lineitem.l_tax)), avg(lineitem.l_quantity), avg(lineitem.l_extendedprice), avg(lineitem.l_discount), count(Int64(1))]]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|               |       Filter: lineitem.l_shipdate <= CAST(Utf8("1998-09-02") AS Date32)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|               |         TableScan: lineitem projection=[l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| physical_plan | SchemaCastScanExec                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|               |   CooperativeExec                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|               |     BytesProcessedExec                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|               |       VirtualExecutionPlan name=adbc compute_context=bigquery:///spiceai-testing?DatasetId=tpch_sf1 base_sql=SELECT `lineitem`.`l_returnflag`, `lineitem`.`l_linestatus`, sum(`lineitem`.`l_quantity`) AS `sum_qty`, sum(`lineitem`.`l_extendedprice`) AS `sum_base_price`, sum((`lineitem`.`l_extendedprice` * (1 - `lineitem`.`l_discount`))) AS `sum_disc_price`, sum(((`lineitem`.`l_extendedprice` * (1 - `lineitem`.`l_discount`)) * (1 + `lineitem`.`l_tax`))) AS `sum_charge`, avg(`lineitem`.`l_quantity`) AS `avg_qty`, avg(`lineitem`.`l_extendedprice`) AS `avg_price`, avg(`lineitem`.`l_discount`) AS `avg_disc`, count(1) AS `count_order` FROM `lineitem` WHERE (`lineitem`.`l_shipdate` <= CAST('1998-09-02' AS DATE)) GROUP BY `lineitem`.`l_returnflag`, `lineitem`.`l_linestatus` ORDER BY `lineitem`.`l_returnflag` ASC NULLS LAST, `lineitem`.`l_linestatus` ASC NULLS LAST |
|               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 0.052946583 seconds. 2 rows.
```
