### PR TITLE
Hash ADBC join-pushdown context to prevent credential leaks in EXPLAN plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16087,6 +16087,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "snafu",
  "snowflake-api",
  "spice-cloud",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -154,6 +154,7 @@ search = { path = "../search", default-features = false, features = [
 secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sha2 = { workspace = true, optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 spicepod = { path = "../spicepod" }
@@ -255,7 +256,7 @@ tracing-subscriber.workspace = true
 yaml = { path = "../yaml" }
 
 [features]
-adbc = ["dep:adbc_core", "dep:adbc_driver_manager", "data_components/adbc", "datafusion-table-providers/adbc-federation"]
+adbc = ["dep:adbc_core", "dep:adbc_driver_manager", "dep:sha2", "data_components/adbc", "datafusion-table-providers/adbc-federation"]
 aws-secrets-manager = ["dep:aws-sdk-sts", "runtime-secrets/aws-secrets-manager"]
 bedrock = []
 clickhouse = ["db_connection_pool/clickhouse", "data_components/clickhouse"]

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! and provides schema/table discovery using the ADBC metadata API.
 
 use super::{CatalogConnector, ConnectorComponent, ParameterSpec};
-use crate::dataconnector::adbc::{build_db_options, dialect_for_driver};
+use crate::dataconnector::adbc::{build_db_options, build_join_context, dialect_for_driver};
 use crate::{Runtime, component::catalog::Catalog, dataconnector::parameters::ConnectorParams};
 use adbc_core::options::AdbcVersion;
 use adbc_core::{Driver as _, LOAD_FLAG_DEFAULT};
@@ -213,6 +213,8 @@ async fn create_pool(params: &ConnectorParams) -> Result<(String, Arc<ADBCPool<M
     let driver_options = params.parameters.get("driver_options").expose().ok();
     let db_options = build_db_options(&uri_str, username, password, driver_options);
 
+    let join_context = build_join_context(&uri_str, username, None, None);
+
     let parse_pool_param = |name: &str| -> Result<Option<u32>> {
         match params.parameters.get(name).expose().ok() {
             Some(v) => {
@@ -265,7 +267,7 @@ async fn create_pool(params: &ConnectorParams) -> Result<(String, Arc<ADBCPool<M
         let pool = AdbcConnectionPoolBuilder::new(db)
             .with_max_size(pool_size)
             .with_min_idle(pool_min_idle)
-            .with_join_push_down(JoinPushDown::AllowedFor(uri_str.clone()))
+            .with_join_push_down(JoinPushDown::AllowedFor(join_context))
             .build()
             .context(UnableToCreateConnectionPoolSnafu {
                 driver_location,

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -26,9 +26,11 @@ use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
+use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -200,6 +202,9 @@ impl DataConnectorFactory for AdbcFactory {
 
             let conn_options = build_conn_options(catalog.as_deref(), schema.as_deref());
 
+            let join_context =
+                build_join_context(&uri_str, username, catalog.as_deref(), schema.as_deref());
+
             let federation_enabled =
                 is_query_federation_enabled(&params.parameters).map_err(|e| {
                     DataConnectorError::InvalidConfigurationNoSource {
@@ -279,7 +284,7 @@ impl DataConnectorFactory for AdbcFactory {
                 let mut pool_builder = AdbcConnectionPoolBuilder::new(db)
                     .with_max_size(pool_size)
                     .with_min_idle(pool_min_idle)
-                    .with_join_push_down(JoinPushDown::AllowedFor(uri_str.clone()));
+                    .with_join_push_down(JoinPushDown::AllowedFor(join_context));
 
                 if let Some(conn_opts) = conn_options {
                     pool_builder = pool_builder.with_conn_options(conn_opts);
@@ -392,6 +397,45 @@ fn build_conn_options(
 
     if opts.is_empty() { None } else { Some(opts) }
 }
+
+/// Builds a hashed join-pushdown context identifier for ADBC connections.
+///
+/// ADBC URIs are driver-vendor-specific and can mix sensitive credentials
+/// with critical identity information (e.g. `bigquery:///project?DatasetId=x`)
+/// in ways that cannot be reliably parsed. We hash all identity-relevant
+/// parts together (similar to the ODBC connector approach) so that:
+///
+/// - No secrets are ever exposed in `EXPLAIN` plans (`compute_context=...`)
+/// - Two connections to the same database instance produce the same hash,
+///   enabling federated join pushdown
+/// - Different usernames, catalogs, or schemas produce different hashes,
+///   preventing incorrect cross-credential pushdown
+pub(crate) fn build_join_context(
+    uri: &str,
+    username: Option<&str>,
+    catalog: Option<&str>,
+    schema: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(uri.as_bytes());
+    hasher.update(b"\0");
+    if let Some(u) = username {
+        hasher.update(u.as_bytes());
+    }
+    hasher.update(b"\0");
+    if let Some(c) = catalog {
+        hasher.update(c.as_bytes());
+    }
+    hasher.update(b"\0");
+    if let Some(s) = schema {
+        hasher.update(s.as_bytes());
+    }
+    hasher.finalize().iter().fold(String::new(), |mut hash, b| {
+        let _ = write!(hash, "{b:02x}");
+        hash
+    })
+}
+
 pub(crate) fn dialect_for_driver(driver_name: &str) -> Option<Arc<dyn Dialect + Send + Sync>> {
     match driver_name {
         "bigquery" => Some(Arc::new(BigQueryDialect::new())),
@@ -679,5 +723,66 @@ mod tests {
     fn test_query_federation_invalid_value() {
         let params = make_params(vec![("query_federation", "invalid")]);
         is_query_federation_enabled(&params).expect_err("should error on invalid value");
+    }
+
+    #[test]
+    fn test_build_join_context_no_secrets_in_output() {
+        let ctx = build_join_context(
+            "bigquery:///project?DatasetId=tpch_sf1&token=SECRET123",
+            Some("admin"),
+            Some("my_catalog"),
+            Some("my_schema"),
+        );
+        // Hash output must not contain any raw URI or credential fragments
+        assert!(
+            !ctx.contains("SECRET123"),
+            "context must not contain secrets from URI"
+        );
+        assert!(
+            !ctx.contains("bigquery:///"),
+            "context must not contain raw URI"
+        );
+        assert!(
+            !ctx.contains("admin"),
+            "context must not contain raw username"
+        );
+        assert!(
+            !ctx.contains("my_catalog"),
+            "context must not contain raw catalog"
+        );
+        // Must be a fixed-length hex string (SHA-256 = 64 hex chars)
+        assert_eq!(
+            ctx.len(),
+            64,
+            "context should be a 64-char SHA-256 hex digest"
+        );
+        assert!(
+            ctx.chars().all(|c| c.is_ascii_hexdigit()),
+            "context should be hex only"
+        );
+    }
+
+    #[test]
+    fn test_build_join_context_deterministic() {
+        let ctx1 = build_join_context("postgresql://host:5432/db", Some("user"), None, None);
+        let ctx2 = build_join_context("postgresql://host:5432/db", Some("user"), None, None);
+        assert_eq!(ctx1, ctx2, "same inputs must produce the same hash");
+    }
+
+    #[test]
+    fn test_build_join_context_differs_by_username() {
+        let ctx_a = build_join_context("postgresql://host/db", Some("alice"), None, None);
+        let ctx_b = build_join_context("postgresql://host/db", Some("bob"), None, None);
+        assert_ne!(
+            ctx_a, ctx_b,
+            "different usernames must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_build_join_context_differs_by_uri() {
+        let ctx_a = build_join_context("bigquery:///project-a?DatasetId=ds1", None, None, None);
+        let ctx_b = build_join_context("bigquery:///project-b?DatasetId=ds1", None, None, None);
+        assert_ne!(ctx_a, ctx_b, "different URIs must produce different hashes");
     }
 }


### PR DESCRIPTION
## 📝 Summary

Replace raw `uri_str.clone()` in `JoinPushDown::AllowedFor` for ADBC connectors with a SHA-256 hash of identity-relevant parts (URI, username, catalog, schema).

**Problem:** ADBC URIs are vendor-specific and can embed credentials alongside identity params (e.g. `bigquery:///project?DatasetId=tpch_sf1&token=SECRET`). The raw URI was surfaced in `EXPLAIN` plans via `compute_context=...`, leaking secrets. Using only the URI also missed username/catalog/schema differences, risking incorrect cross-credential join pushdown.

**Fix:** Hash all identity parts with SHA-256 (matching the ODBC connector pattern):
- `compute_context` is now a 64-char hex digest — no secrets exposed
- Same DB instance → same hash → correct federation
- Different user/catalog/schema → different hash → no cross-credential pushdown

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
