### PR TITLE
Fix JsonSchema derivation for Arc<str> fields in TaskHistory

### DIFF
--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -344,16 +344,22 @@ pub struct TaskHistory {
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default = "default_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub captured_output: Arc<str>,
     #[serde(default = "default_retention_period")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub retention_period: Arc<str>,
     #[serde(default = "default_retention_check_interval")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub retention_check_interval: Arc<str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub min_sql_duration: Option<Arc<str>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub captured_plan: Option<Arc<str>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub min_plan_duration: Option<Arc<str>>,
 }
 


### PR DESCRIPTION
## Summary
- The `schemars` crate does not implement `JsonSchema` for `str` (only `String`), so `Arc<str>` fields in `TaskHistory` fail to compile when the `schemars` feature is enabled (as used by the `spicepodschema` tool).
- Added `#[schemars(with = "String")]` and `#[schemars(with = "Option<String>")]` attributes to the six `Arc<str>` fields in `TaskHistory`, telling schemars to generate the JSON schema as if the fields were plain strings -- which is semantically correct.

## Test plan
- [x] `cargo check -p spicepod --features schemars` passes
- [x] `cargo check -p spicepod` passes (without schemars feature)
- [ ] `cargo check --manifest-path tools/spicepodschema/Cargo.toml` passes

Fixes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)