### PR TITLE
fix: Normalize Arrow Dictionary types for DuckDB and SQLite acceleration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_adbc.yml
+++ b/.github/workflows/integration_adbc.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -9,6 +9,13 @@ on:
       - release/*
     paths:
       - 'crates/llms/**'
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+    paths:
+      - 'crates/llms/**'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -162,7 +162,7 @@ pub fn normalize_dictionary_types(schema: &Schema) -> Schema {
             if &new_type == field.data_type() {
                 field.as_ref().clone()
             } else {
-                Field::new(field.name(), new_type, field.is_nullable())
+                field.as_ref().clone().with_data_type(new_type)
             }
         })
         .collect();
@@ -170,19 +170,65 @@ pub fn normalize_dictionary_types(schema: &Schema) -> Schema {
     Schema::new_with_metadata(transformed_fields, schema.metadata().clone())
 }
 
-/// Returns `true` if `schema` contains any `Dictionary`-encoded fields.
+/// Returns `true` if `schema` contains any `Dictionary`-encoded fields,
+/// including inside nested container types (List, Struct, Map, etc.).
 #[must_use]
 pub fn has_dictionary_types(schema: &Schema) -> bool {
     schema
         .fields()
         .iter()
-        .any(|f| matches!(f.data_type(), DataType::Dictionary(_, _)))
+        .any(|f| data_type_contains_dictionary(f.data_type()))
 }
 
-/// Recursively replaces `Dictionary(_, value_type)` with `value_type`.
+/// Recursively checks whether a `DataType` contains any `Dictionary` encoding.
+fn data_type_contains_dictionary(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Dictionary(_, _) => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => data_type_contains_dictionary(field.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|f| data_type_contains_dictionary(f.data_type())),
+        _ => false,
+    }
+}
+
+/// Recursively replaces `Dictionary(_, value_type)` with `value_type`,
+/// descending into nested container types (List, Struct, Map, etc.).
 fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
     match data_type {
         DataType::Dictionary(_, value_type) => normalize_dictionary_data_type(value_type.as_ref()),
+        DataType::List(field) => {
+            let inner = normalize_dictionary_data_type(field.data_type());
+            DataType::List(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::LargeList(field) => {
+            let inner = normalize_dictionary_data_type(field.data_type());
+            DataType::LargeList(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::FixedSizeList(field, size) => {
+            let inner = normalize_dictionary_data_type(field.data_type());
+            DataType::FixedSizeList(Arc::new(field.as_ref().clone().with_data_type(inner)), *size)
+        }
+        DataType::Map(field, sorted) => {
+            let inner = normalize_dictionary_data_type(field.data_type());
+            DataType::Map(
+                Arc::new(field.as_ref().clone().with_data_type(inner)),
+                *sorted,
+            )
+        }
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields
+                .iter()
+                .map(|f| {
+                    let inner = normalize_dictionary_data_type(f.data_type());
+                    f.as_ref().clone().with_data_type(inner)
+                })
+                .collect();
+            DataType::Struct(new_fields.into())
+        }
         other => other.clone(),
     }
 }

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -235,16 +235,16 @@ fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
                 .collect();
             DataType::Struct(new_fields.into())
         }
-        DataType::Union(fields, mode) => {
-            let new_fields: Vec<(i8, Arc<Field>)> = fields
+        DataType::Union(fields, mode) => DataType::Union(
+            fields
                 .iter()
                 .map(|(type_id, f)| {
                     let inner = normalize_dictionary_data_type(f.data_type());
                     (type_id, Arc::new(f.as_ref().clone().with_data_type(inner)))
                 })
-                .collect();
-            DataType::Union(new_fields.into_iter().collect(), *mode)
-        }
+                .collect(),
+            *mode,
+        ),
         other => other.clone(),
     }
 }

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -146,7 +146,7 @@ pub fn expand_views_schema(schema: &Schema) -> Schema {
 
 /// Replaces Arrow `Dictionary`-encoded fields with the dictionary's value type.
 ///
-/// Data accelerators such as DuckDB and SQLite do not natively support Arrow
+/// Data accelerators such as `DuckDB` and `SQLite` do not natively support Arrow
 /// Dictionary types.  By unpacking the dictionary encoding at the schema level
 /// (and later casting the data via `arrow_cast::cast`), the downstream
 /// accelerator receives only primitive types it can handle.
@@ -210,7 +210,10 @@ fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
         }
         DataType::FixedSizeList(field, size) => {
             let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::FixedSizeList(Arc::new(field.as_ref().clone().with_data_type(inner)), *size)
+            DataType::FixedSizeList(
+                Arc::new(field.as_ref().clone().with_data_type(inner)),
+                *size,
+            )
         }
         DataType::Map(field, sorted) => {
             let inner = normalize_dictionary_data_type(field.data_type());

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -551,12 +551,14 @@ mod tests {
         field_metadata.insert("custom_key".to_string(), "custom_value".to_string());
 
         let schema = Schema::new_with_metadata(
-            vec![Field::new(
-                "col",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                false,
-            )
-            .with_metadata(field_metadata.clone())],
+            vec![
+                Field::new(
+                    "col",
+                    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                    false,
+                )
+                .with_metadata(field_metadata.clone()),
+            ],
             metadata.clone(),
         );
 

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -144,6 +144,49 @@ pub fn expand_views_schema(schema: &Schema) -> Schema {
     Schema::new(transformed_fields)
 }
 
+/// Replaces Arrow `Dictionary`-encoded fields with the dictionary's value type.
+///
+/// Data accelerators such as DuckDB and SQLite do not natively support Arrow
+/// Dictionary types.  By unpacking the dictionary encoding at the schema level
+/// (and later casting the data via `arrow_cast::cast`), the downstream
+/// accelerator receives only primitive types it can handle.
+///
+/// For example, `Dictionary(Int32, Utf8)` is normalised to `Utf8`.
+#[must_use]
+pub fn normalize_dictionary_types(schema: &Schema) -> Schema {
+    let transformed_fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let new_type = normalize_dictionary_data_type(field.data_type());
+            if &new_type == field.data_type() {
+                field.as_ref().clone()
+            } else {
+                Field::new(field.name(), new_type, field.is_nullable())
+            }
+        })
+        .collect();
+
+    Schema::new_with_metadata(transformed_fields, schema.metadata().clone())
+}
+
+/// Returns `true` if `schema` contains any `Dictionary`-encoded fields.
+#[must_use]
+pub fn has_dictionary_types(schema: &Schema) -> bool {
+    schema
+        .fields()
+        .iter()
+        .any(|f| matches!(f.data_type(), DataType::Dictionary(_, _)))
+}
+
+/// Recursively replaces `Dictionary(_, value_type)` with `value_type`.
+fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::Dictionary(_, value_type) => normalize_dictionary_data_type(value_type.as_ref()),
+        other => other.clone(),
+    }
+}
+
 pub fn set_computed_columns_meta<S: ::std::hash::BuildHasher>(
     schema: &mut Schema,
     computed_columns_meta: &HashMap<String, Vec<String>, S>,
@@ -391,5 +434,80 @@ mod tests {
 
         let diff = schema_difference(&schema, &schema);
         assert!(diff.is_none());
+    }
+
+    #[test]
+    fn test_normalize_dictionary_types() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "status",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ),
+            Field::new("name", DataType::Utf8, false),
+            Field::new(
+                "category",
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::LargeUtf8)),
+                false,
+            ),
+        ]);
+
+        let normalized = normalize_dictionary_types(&schema);
+
+        assert_eq!(normalized.field(0).data_type(), &DataType::Int64);
+        assert_eq!(normalized.field(1).data_type(), &DataType::Utf8);
+        assert!(normalized.field(1).is_nullable());
+        assert_eq!(normalized.field(2).data_type(), &DataType::Utf8);
+        assert_eq!(normalized.field(3).data_type(), &DataType::LargeUtf8);
+        assert!(!normalized.field(3).is_nullable());
+    }
+
+    #[test]
+    fn test_has_dictionary_types() {
+        let no_dict_schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+        assert!(!has_dictionary_types(&no_dict_schema));
+
+        let dict_schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "status",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ),
+        ]);
+        assert!(has_dictionary_types(&dict_schema));
+    }
+
+    #[test]
+    fn test_normalize_schema_without_dictionary_is_noop() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+
+        let normalized = normalize_dictionary_types(&schema);
+        assert_eq!(schema, normalized);
+    }
+
+    #[test]
+    fn test_normalize_preserves_metadata() {
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), "value".to_string());
+        let schema = Schema::new_with_metadata(
+            vec![Field::new(
+                "col",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                false,
+            )],
+            metadata.clone(),
+        );
+
+        let normalized = normalize_dictionary_types(&schema);
+        assert_eq!(normalized.metadata(), &metadata);
+        assert_eq!(normalized.field(0).data_type(), &DataType::Utf8);
     }
 }

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -546,17 +546,111 @@ mod tests {
     fn test_normalize_preserves_metadata() {
         let mut metadata = HashMap::new();
         metadata.insert("key".to_string(), "value".to_string());
+
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("custom_key".to_string(), "custom_value".to_string());
+
         let schema = Schema::new_with_metadata(
             vec![Field::new(
                 "col",
                 DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                 false,
-            )],
+            )
+            .with_metadata(field_metadata.clone())],
             metadata.clone(),
         );
 
         let normalized = normalize_dictionary_types(&schema);
         assert_eq!(normalized.metadata(), &metadata);
         assert_eq!(normalized.field(0).data_type(), &DataType::Utf8);
+        assert_eq!(
+            normalized.field(0).metadata(),
+            &field_metadata,
+            "field-level metadata must be preserved after normalization"
+        );
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_list() {
+        let schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ))),
+            false,
+        )]);
+
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_struct() {
+        let schema = Schema::new(vec![Field::new(
+            "record",
+            DataType::Struct(
+                vec![
+                    Field::new("id", DataType::Int64, false),
+                    Field::new(
+                        "status",
+                        DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                        true,
+                    ),
+                ]
+                .into(),
+            ),
+            false,
+        )]);
+
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::Struct(
+            vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("status", DataType::Utf8, true),
+            ]
+            .into(),
+        );
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_has_dictionary_types_nested() {
+        // Dictionary inside List
+        let list_dict_schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ))),
+            false,
+        )]);
+        assert!(has_dictionary_types(&list_dict_schema));
+
+        // Dictionary inside Struct
+        let struct_dict_schema = Schema::new(vec![Field::new(
+            "record",
+            DataType::Struct(
+                vec![Field::new(
+                    "status",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                    true,
+                )]
+                .into(),
+            ),
+            false,
+        )]);
+        assert!(has_dictionary_types(&struct_dict_schema));
+
+        // No dictionary in nested types
+        let no_dict_nested = Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        )]);
+        assert!(!has_dictionary_types(&no_dict_nested));
     }
 }

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -191,6 +191,9 @@ fn data_type_contains_dictionary(data_type: &DataType) -> bool {
         DataType::Struct(fields) => fields
             .iter()
             .any(|f| data_type_contains_dictionary(f.data_type())),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, f)| data_type_contains_dictionary(f.data_type())),
         _ => false,
     }
 }
@@ -231,6 +234,16 @@ fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
                 })
                 .collect();
             DataType::Struct(new_fields.into())
+        }
+        DataType::Union(fields, mode) => {
+            let new_fields: Vec<(i8, Arc<Field>)> = fields
+                .iter()
+                .map(|(type_id, f)| {
+                    let inner = normalize_dictionary_data_type(f.data_type());
+                    (type_id, Arc::new(f.as_ref().clone().with_data_type(inner)))
+                })
+                .collect();
+            DataType::Union(new_fields.into_iter().collect(), *mode)
         }
         other => other.clone(),
     }
@@ -654,5 +667,81 @@ mod tests {
             false,
         )]);
         assert!(!has_dictionary_types(&no_dict_nested));
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_union() {
+        use arrow_schema::{UnionFields, UnionMode};
+
+        let union_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new(
+                    "dict_val",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ],
+        )
+        .expect("union fields");
+        let schema = Schema::new(vec![Field::new(
+            "mixed",
+            DataType::Union(union_fields, UnionMode::Dense),
+            false,
+        )]);
+
+        let normalized = normalize_dictionary_types(&schema);
+        let expected_union = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new("dict_val", DataType::Utf8, true),
+            ],
+        )
+        .expect("expected union fields");
+        assert_eq!(
+            normalized.field(0).data_type(),
+            &DataType::Union(expected_union, UnionMode::Dense)
+        );
+    }
+
+    #[test]
+    fn test_has_dictionary_types_in_union() {
+        use arrow_schema::{UnionFields, UnionMode};
+
+        let union_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new(
+                    "dict_val",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ],
+        )
+        .expect("union fields");
+        let schema = Schema::new(vec![Field::new(
+            "mixed",
+            DataType::Union(union_fields, UnionMode::Dense),
+            false,
+        )]);
+        assert!(has_dictionary_types(&schema));
+
+        let no_dict_union = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new("str_val", DataType::Utf8, true),
+            ],
+        )
+        .expect("union fields");
+        let no_dict_schema = Schema::new(vec![Field::new(
+            "mixed",
+            DataType::Union(no_dict_union, UnionMode::Sparse),
+            false,
+        )]);
+        assert!(!has_dictionary_types(&no_dict_schema));
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -1671,7 +1671,7 @@ mod tests {
     /// Regression test for <https://github.com/spiceai/spiceai/issues/2889>.
     ///
     /// Arrow Dictionary-encoded columns (enums) must be transparently unpacked
-    /// to their value types before reaching the DuckDB accelerator.
+    /// to their value types before reaching the `DuckDB` accelerator.
     #[tokio::test]
     async fn test_duckdb_dictionary_type_round_trip() {
         use arrow::array::StringDictionaryBuilder;

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -1667,4 +1667,100 @@ mod tests {
         drop(table);
         drop(temp_dir);
     }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/2889>.
+    ///
+    /// Arrow Dictionary-encoded columns (enums) must be transparently unpacked
+    /// to their value types before reaching the DuckDB accelerator.
+    #[tokio::test]
+    async fn test_duckdb_dictionary_type_round_trip() {
+        use arrow::array::StringDictionaryBuilder;
+        use arrow::datatypes::Int32Type;
+
+        // Build a schema containing a Dictionary(Int32, Utf8) column.
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "status",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                false,
+            ),
+        ]));
+
+        // Normalize the schema (Dictionary -> Utf8).
+        let accel_schema =
+            Arc::new(arrow_tools::schema::normalize_dictionary_types(&source_schema));
+        assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);
+
+        let df_schema =
+            ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
+
+        let external_table = CreateExternalTable {
+            schema: df_schema,
+            name: TableReference::bare("dict_test"),
+            location: String::new(),
+            file_type: String::new(),
+            table_partition_cols: vec![],
+            if_not_exists: true,
+            or_replace: false,
+            definition: None,
+            order_exprs: vec![],
+            unbounded: false,
+            options: HashMap::new(),
+            constraints: Constraints::new_unverified(vec![]),
+            column_defaults: HashMap::default(),
+            temporary: false,
+        };
+
+        let duckdb_accelerator = DuckDBAccelerator::new();
+        let table = duckdb_accelerator
+            .create_external_table(external_table, None, vec![], None)
+            .await
+            .expect("DuckDB table with normalized Dictionary types should be created");
+
+        // Build a record batch with Dictionary-encoded data.
+        let ids = Int64Array::from(vec![1, 2, 3]);
+        let mut status_builder = StringDictionaryBuilder::<Int32Type>::new();
+        status_builder.append_value("active");
+        status_builder.append_value("inactive");
+        status_builder.append_value("active");
+        let statuses = status_builder.finish();
+
+        let data = RecordBatch::try_new(
+            Arc::clone(&source_schema),
+            vec![Arc::new(ids), Arc::new(statuses)],
+        )
+        .expect("record batch");
+
+        // Cast from Dictionary to the normalized schema before inserting.
+        let casted = arrow_tools::record_batch::try_cast_to(data, Arc::clone(&accel_schema))
+            .expect("cast Dictionary to Utf8");
+
+        let exec = MockExec::new(vec![Ok(casted)], accel_schema);
+        let ctx = SessionContext::new();
+
+        let insertion = table
+            .insert_into(&ctx.state(), Arc::new(exec), InsertOp::Append)
+            .await
+            .expect("insertion of Dictionary data into DuckDB should succeed");
+
+        let result = collect(insertion, ctx.task_ctx())
+            .await
+            .expect("insert should succeed");
+
+        assert!(!result.is_empty());
+
+        // Verify the data can be read back.
+        let scan = table
+            .scan(&ctx.state(), None, &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let batches = collect(scan, ctx.task_ctx())
+            .await
+            .expect("should read back data");
+
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, 3, "should have 3 rows");
+    }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -1688,12 +1688,12 @@ mod tests {
         ]));
 
         // Normalize the schema (Dictionary -> Utf8).
-        let accel_schema =
-            Arc::new(arrow_tools::schema::normalize_dictionary_types(&source_schema));
+        let accel_schema = Arc::new(arrow_tools::schema::normalize_dictionary_types(
+            &source_schema,
+        ));
         assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);
 
-        let df_schema =
-            ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
+        let df_schema = ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
 
         let external_table = CreateExternalTable {
             schema: df_schema,

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -227,9 +227,20 @@ impl AcceleratorEngineRegistry {
     ) -> Result<Arc<dyn TableProvider>> {
         let engine = acceleration_settings.engine;
 
-        // Normalize Dictionary-encoded types to their value types for accelerator
-        // engines that do not support Arrow Dictionary encoding (e.g. DuckDB, SQLite).
-        let schema = if arrow_tools::schema::has_dictionary_types(&schema) {
+        // Normalize Dictionary-encoded types to their value types only for
+        // accelerator engines that do not natively support Arrow Dictionary
+        // encoding (DuckDB, SQLite, Turso).  Other engines (Arrow, Cayenne,
+        // PostgreSQL) handle Dictionary types natively and benefit from the
+        // compact encoding.
+        let needs_dictionary_normalization = matches!(
+            engine.to_unpartitioned(),
+            acceleration::Engine::DuckDB
+                | acceleration::Engine::Sqlite
+                | acceleration::Engine::Turso
+        );
+        let schema = if needs_dictionary_normalization
+            && arrow_tools::schema::has_dictionary_types(&schema)
+        {
             let normalized = arrow_tools::schema::normalize_dictionary_types(&schema);
             tracing::debug!(
                 "Normalized Arrow Dictionary types in schema for {engine} acceleration"

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -227,6 +227,18 @@ impl AcceleratorEngineRegistry {
     ) -> Result<Arc<dyn TableProvider>> {
         let engine = acceleration_settings.engine;
 
+        // Normalize Dictionary-encoded types to their value types for accelerator
+        // engines that do not support Arrow Dictionary encoding (e.g. DuckDB, SQLite).
+        let schema = if arrow_tools::schema::has_dictionary_types(&schema) {
+            let normalized = arrow_tools::schema::normalize_dictionary_types(&schema);
+            tracing::debug!(
+                "Normalized Arrow Dictionary types in schema for {engine} acceleration"
+            );
+            Arc::new(normalized)
+        } else {
+            schema
+        };
+
         let accelerator = self
             .get_accelerator_engine(acceleration_settings.engine)
             .await

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -630,7 +630,9 @@ mod tests {
             .await
             .expect("insert should succeed");
 
-        assert!(!result.is_empty());
+        // Verify the insertion reports the expected number of inserted rows.
+        let inserted_rows: usize = result.iter().map(RecordBatch::num_rows).sum();
+        assert!(inserted_rows > 0, "insert result should contain row count");
 
         // Verify the data can be read back with the expected row count.
         let scan = table

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -547,4 +547,90 @@ mod tests {
         // cleanup
         std::fs::remove_file(&path).expect("file should be removed");
     }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/2891>.
+    ///
+    /// Arrow Dictionary-encoded columns (used for enums/categoricals) must be
+    /// transparently unpacked to their value types before reaching the SQLite
+    /// accelerator, which does not support Dictionary encoding.
+    #[tokio::test]
+    async fn test_sqlite_dictionary_type_round_trip() {
+        use arrow::array::StringDictionaryBuilder;
+        use arrow::datatypes::Int32Type;
+
+        // Build a schema with a Dictionary(Int32, Utf8) column -- the Arrow
+        // representation of an enum/categorical.
+        let source_schema = Arc::new(Schema::new(vec![
+            arrow::datatypes::Field::new("id", DataType::Int64, false),
+            arrow::datatypes::Field::new(
+                "status",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                false,
+            ),
+        ]));
+
+        // Normalize the schema so the accelerator sees plain Utf8 instead of Dictionary.
+        let accel_schema =
+            Arc::new(arrow_tools::schema::normalize_dictionary_types(&source_schema));
+        assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);
+
+        let df_schema =
+            ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
+
+        let external_table = CreateExternalTable {
+            schema: df_schema,
+            name: TableReference::bare("dict_test"),
+            location: String::new(),
+            file_type: String::new(),
+            table_partition_cols: vec![],
+            if_not_exists: true,
+            or_replace: false,
+            definition: None,
+            order_exprs: vec![],
+            unbounded: false,
+            options: HashMap::new(),
+            constraints: Constraints::new_unverified(vec![]),
+            column_defaults: HashMap::default(),
+            temporary: false,
+        };
+
+        let ctx = SessionContext::new();
+        let table = SqliteAccelerator::new()
+            .create_external_table(external_table, None, vec![], None)
+            .await
+            .expect("SQLite table with normalized Dictionary types should be created");
+
+        // Build a record batch with Dictionary-encoded data.
+        let ids = Int64Array::from(vec![1, 2, 3]);
+        let mut status_builder = StringDictionaryBuilder::<Int32Type>::new();
+        status_builder.append_value("active");
+        status_builder.append_value("inactive");
+        status_builder.append_value("active");
+        let statuses = status_builder.finish();
+
+        let data = RecordBatch::try_new(
+            Arc::clone(&source_schema),
+            vec![Arc::new(ids), Arc::new(statuses)],
+        )
+        .expect("record batch should be created");
+
+        // Cast to the accelerator schema (Dictionary -> Utf8) before inserting,
+        // mimicking what `SchemaCastScanExec` does at runtime.
+        let casted =
+            arrow_tools::record_batch::try_cast_to(data, Arc::clone(&accel_schema)).expect("cast");
+
+        let exec = MockExec::new(vec![Ok(casted)], accel_schema);
+
+        let insertion = table
+            .insert_into(&ctx.state(), Arc::new(exec), InsertOp::Append)
+            .await
+            .expect("insertion of Dictionary data into SQLite should succeed");
+
+        let result = collect(insertion, ctx.task_ctx())
+            .await
+            .expect("insert should succeed");
+
+        // Verify data was written (count row returns 1 batch with row count)
+        assert!(!result.is_empty());
+    }
 }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -551,7 +551,7 @@ mod tests {
     /// Regression test for <https://github.com/spiceai/spiceai/issues/2891>.
     ///
     /// Arrow Dictionary-encoded columns (used for enums/categoricals) must be
-    /// transparently unpacked to their value types before reaching the SQLite
+    /// transparently unpacked to their value types before reaching the `SQLite`
     /// accelerator, which does not support Dictionary encoding.
     #[tokio::test]
     async fn test_sqlite_dictionary_type_round_trip() {

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -630,7 +630,19 @@ mod tests {
             .await
             .expect("insert should succeed");
 
-        // Verify data was written (count row returns 1 batch with row count)
         assert!(!result.is_empty());
+
+        // Verify the data can be read back with the expected row count.
+        let scan = table
+            .scan(&ctx.state(), None, &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let batches = collect(scan, ctx.task_ctx())
+            .await
+            .expect("should read back data");
+
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, 3, "should have 3 rows");
     }
 }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -570,12 +570,12 @@ mod tests {
         ]));
 
         // Normalize the schema so the accelerator sees plain Utf8 instead of Dictionary.
-        let accel_schema =
-            Arc::new(arrow_tools::schema::normalize_dictionary_types(&source_schema));
+        let accel_schema = Arc::new(arrow_tools::schema::normalize_dictionary_types(
+            &source_schema,
+        ));
         assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);
 
-        let df_schema =
-            ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
+        let df_schema = ToDFSchema::to_dfschema_ref(Arc::clone(&accel_schema)).expect("df schema");
 
         let external_table = CreateExternalTable {
             schema: df_schema,


### PR DESCRIPTION
## Summary
- Arrow Dictionary-encoded columns (used for enums and categorical data) are not supported by the DuckDB and SQLite data accelerators, causing failures when accelerating datasets with those column types
- Added `normalize_dictionary_types()` in `arrow_tools::schema` to convert Dictionary fields to their underlying value types (e.g. `Dictionary(Int32, Utf8)` -> `Utf8`) before the schema reaches the accelerator engine
- The existing `SchemaCastScanExec` pipeline automatically casts the actual record batch data to match the normalized schema, so no additional data conversion code is needed

## Test plan
- [x] Unit tests for `normalize_dictionary_types()`, `has_dictionary_types()`, and metadata preservation
- [x] Round-trip test: create SQLite table with normalized Dictionary schema, insert cast data, verify success
- [x] Round-trip test: create DuckDB table with normalized Dictionary schema, insert cast data, read back and verify 3 rows

Fixes #2889
Fixes #2891

🤖 Generated with [Claude Code](https://claude.com/claude-code)