### PR TITLE
Add ADBC BigQuery to supported benchmark tests

### DIFF
--- a/.github/actions/setup-adbc-bigquery/action.yml
+++ b/.github/actions/setup-adbc-bigquery/action.yml
@@ -1,0 +1,43 @@
+name: Setup ADBC BigQuery Driver
+description: 'Build and install the ADBC BigQuery driver from source'
+
+inputs:
+  adbc_bigquery_commit:
+    description: 'Git commit hash to build the driver from'
+    required: false
+    default: 'fe83ac26d43bffeaf28844bcf5fef303b1bdf345'
+  go_version:
+    description: 'Go version to use for building'
+    required: false
+    default: '1.24.1'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      with:
+        go-version: ${{ inputs.go_version }}
+        cache: false
+
+    - name: Build ADBC BigQuery driver
+      shell: bash
+      run: |
+        set -eu
+        DRIVER_DIR="/etc/adbc/drivers"
+
+        git clone --depth=1 https://github.com/adbc-drivers/bigquery.git /tmp/adbc-bigquery
+        cd /tmp/adbc-bigquery
+        git fetch --depth=1 origin "${{ inputs.adbc_bigquery_commit }}"
+        git checkout "${{ inputs.adbc_bigquery_commit }}"
+        cd go
+        CGO_ENABLED=1 go build -tags driverlib -buildmode=c-shared \
+          -o /tmp/libadbc_driver_bigquery.so ./pkg/
+        rm -f /tmp/libadbc_driver_bigquery.h
+
+        sudo mkdir -p "${DRIVER_DIR}"
+        sudo cp /tmp/libadbc_driver_bigquery.so "${DRIVER_DIR}/"
+        printf '[Driver]\nshared = "%s/libadbc_driver_bigquery.so"\n' "${DRIVER_DIR}" | sudo tee "${DRIVER_DIR}/bigquery.toml"
+
+        echo "ADBC BigQuery driver installed to ${DRIVER_DIR}/libadbc_driver_bigquery.so"
+        rm -rf /tmp/adbc-bigquery /tmp/libadbc_driver_bigquery.so

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -200,6 +200,10 @@ jobs:
         if: ${{ contains(github.event.inputs.spicepod_path, 'oracle') }}
         uses: ./.github/actions/setup-oracle-odpi
 
+      - name: Install ADBC BigQuery Driver
+        if: ${{ contains(github.event.inputs.spicepod_path, 'adbc[bigquery]') }}
+        uses: ./.github/actions/setup-adbc-bigquery
+
       - name: Install PostgreSQL for DuckLake
         if: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') }}
         uses: ./.github/actions/install-postgres
@@ -332,6 +336,7 @@ jobs:
           AWS_DYNAMODB_SECRET_ACCESS_KEY: ${{ secrets.AWS_DYNAMODB_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'http://127.0.0.1:9000' || '' }}
           AWS_ALLOW_HTTP: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'true' || '' }}
+          BIGQUERY_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_SERVICE_ACCOUNT_JSON }}
           DUCKLAKE_CONNECTION_STRING: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'postgres:dbname=ducklake_catalog host=localhost user=postgres password=postgres' || '' }}
           GLUE_AWS_KEY: ${{ secrets.AWS_S3_ATHENA_ACCESS_KEY_ID }}
           GLUE_AWS_SECRET: ${{ secrets.AWS_S3_ATHENA_SECRET_ACCESS_KEY }}
@@ -402,6 +407,7 @@ jobs:
           AWS_DYNAMODB_SECRET_ACCESS_KEY: ${{ secrets.AWS_DYNAMODB_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'http://127.0.0.1:9000' || '' }}
           AWS_ALLOW_HTTP: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'true' || '' }}
+          BIGQUERY_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_SERVICE_ACCOUNT_JSON }}
           DUCKLAKE_CONNECTION_STRING: ${{ contains(github.event.inputs.spicepod_path, 'ducklake[postgres+s3]') && 'postgres:dbname=ducklake_catalog host=localhost user=postgres password=postgres' || '' }}
           GLUE_AWS_KEY: ${{ secrets.AWS_S3_ATHENA_ACCESS_KEY_ID }}
           GLUE_AWS_SECRET: ${{ secrets.AWS_S3_ATHENA_SECRET_ACCESS_KEY }}

--- a/test/spicepods/tpch/sf1/federated/adbc[bigquery].yaml
+++ b/test/spicepods/tpch/sf1/federated/adbc[bigquery].yaml
@@ -1,0 +1,31 @@
+version: v1
+kind: Spicepod
+name: adbc[bigquery]-federated
+datasets:
+  - from: adbc:customer
+    name: customer
+    params: &adbc_bigquery_params
+      adbc_driver: bigquery
+      adbc_driver_options: adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;adbc.bigquery.sql.auth_credentials=${secrets:BIGQUERY_SERVICE_ACCOUNT_JSON}
+      adbc_uri: bigquery:///spiceai-testing?DatasetId=tpch_sf1
+  - from: adbc:lineitem
+    name: lineitem
+    params: *adbc_bigquery_params
+  - from: adbc:nation
+    name: nation
+    params: *adbc_bigquery_params
+  - from: adbc:orders
+    name: orders
+    params: *adbc_bigquery_params
+  - from: adbc:part
+    name: part
+    params: *adbc_bigquery_params
+  - from: adbc:partsupp
+    name: partsupp
+    params: *adbc_bigquery_params
+  - from: adbc:region
+    name: region
+    params: *adbc_bigquery_params
+  - from: adbc:supplier
+    name: supplier
+    params: *adbc_bigquery_params


### PR DESCRIPTION
## 📝 Summary

PR adds ADBC BigQuery connector support to the benchmark test workflow:
- **`.github/actions/setup-adbc-bigquery/`** — New composite action that builds and installs the ADBC BigQuery driver from source (`adbc-drivers/bigquery`).
- **`test/spicepods/tpch/sf1/federated/adbc[bigquery].yaml`** — TPC-H SF1 federated benchmark spicepod using the ADBC connector against the `spiceai-testing` BigQuery project (`tpch_sf1` dataset).


Example run: https://github.com/spiceai/spiceai/actions/runs/23601811162/job/68733623948

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
