### PR TITLE
fix: Add missing snafu::ensure import and fix rustfmt formatting

### DIFF
--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -35,7 +35,7 @@ use datafusion::{
 use datafusion_expr::{Expr, execution_props::ExecutionProps, lit};
 use futures::TryStreamExt as _;
 use runtime_request_context::{AsyncMarker, RequestContext};
-use snafu::{ResultExt, Snafu};
+use snafu::{ResultExt, Snafu, ensure};
 use tokio::sync::mpsc::{self, Sender};
 use tokio_stream::{StreamExt as _, adapters::Peekable, wrappers::ReceiverStream};
 use tonic::{Response, Streaming};

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -184,9 +184,7 @@ pub(crate) async fn ensure_spice_cloud_app(
             visibility: "private".to_string(),
             cname: Some(cname),
             tags: {
-                let mut tags = BTreeMap::from([
-                    ("kind".to_string(), "cluster".to_string()),
-                ]);
+                let mut tags = BTreeMap::from([("kind".to_string(), "cluster".to_string())]);
                 if let Some(org) = &config.organization_tag {
                     tags.insert("organization".to_string(), org.clone());
                 }


### PR DESCRIPTION
## Summary

- Add `ensure` to snafu imports in `write_through.rs` to fix compilation error introduced by #9934
- Fix `BTreeMap::from` formatting in spidapter to satisfy `rustfmt`, introduced by #9946

## Test plan

- CI lint and build checks should pass