### PR TITLE
fix: Update S3 vectors search test snapshots for updated index data

### DIFF
--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_basic_response.snap
@@ -6,18 +6,6 @@ expression: normalize_search_response(resp)
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": 0.78,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          " is 2."
-        ]
-      },
-      "primary_key": {
-        "id": 349
-      }
-    },
-    {
       "_score": 0.55,
       "dataset": "qs",
       "matches": {
@@ -42,15 +30,27 @@ expression: normalize_search_response(resp)
       }
     },
     {
+      "_score": 0.53,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24"
+        ]
+      },
+      "primary_key": {
+        "id": 468
+      }
+    },
+    {
       "_score": 0.52,
       "dataset": "qs",
       "matches": {
         "answer": [
-          "\n\\( 232 \\times 0.14 = 32.48 \\)"
+          "4, 2))^3 \\times 40}\\)"
         ]
       },
       "primary_key": {
-        "id": 830
+        "id": 450
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_basic_response.snap
@@ -6,30 +6,6 @@ expression: normalize_search_response(resp)
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": 0.79,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "\n2"
-        ]
-      },
-      "primary_key": {
-        "id": 612
-      }
-    },
-    {
-      "_score": 0.78,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          " is 2."
-        ]
-      },
-      "primary_key": {
-        "id": 349
-      }
-    },
-    {
       "_score": 0.55,
       "dataset": "qs",
       "matches": {
@@ -51,6 +27,30 @@ expression: normalize_search_response(resp)
       },
       "primary_key": {
         "id": 1277
+      }
+    },
+    {
+      "_score": 0.53,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24"
+        ]
+      },
+      "primary_key": {
+        "id": 468
+      }
+    },
+    {
+      "_score": 0.51,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "\n_{14}P_{4} = 14 \\times 13 \\times 12 \\times 11 = \\boxed{24,\\!024"
+        ]
+      },
+      "primary_key": {
+        "id": 41
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_keywords_response.snap
@@ -18,39 +18,39 @@ expression: normalize_search_response(resp)
       }
     },
     {
+      "_score": 0.53,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          " divisors other than 1 and itself (e.g., 2, 3, 4, 6, 9, 12, 18)"
+        ]
+      },
+      "primary_key": {
+        "id": 484
+      }
+    },
+    {
+      "_score": 0.52,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "4, 2))^3 \\times 40}\\)"
+        ]
+      },
+      "primary_key": {
+        "id": 450
+      }
+    },
+    {
       "_score": 0.51,
       "dataset": "qs",
       "matches": {
         "answer": [
-          "Since there are 4 distinct letters, the number of arrangement"
+          "Since there are 50 equal numbers, each number is equal to \\("
         ]
       },
       "primary_key": {
-        "id": 362
-      }
-    },
-    {
-      "_score": 0.49,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "The number of such arrangements is \\(10! - 2 \\times 9! + 8"
-        ]
-      },
-      "primary_key": {
-        "id": 451
-      }
-    },
-    {
-      "_score": 0.49,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "Yes, because the last two digits (48) form a number that i"
-        ]
-      },
-      "primary_key": {
-        "id": 556
+        "id": 507
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_basic_response.snap
@@ -10,6 +10,21 @@ expression: normalize_search_response(resp)
       "dataset": "qs",
       "matches": {
         "answer": [
+          "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples."
+        ],
+        "question": [
+          "How many multiples of 4 are there between 1 and 30? List them and count the total."
+        ]
+      },
+      "primary_key": {
+        "id": 468
+      }
+    },
+    {
+      "_score": 0.03,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
           "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
         ],
         "question": [
@@ -25,6 +40,21 @@ expression: normalize_search_response(resp)
       "dataset": "qs",
       "matches": {
         "answer": [
+          "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
+        ],
+        "question": [
+          "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
+        ]
+      },
+      "primary_key": {
+        "id": 189
+      }
+    },
+    {
+      "_score": 0.03,
+      "dataset": "qs",
+      "matches": {
+        "answer": [
           "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
         ],
         "question": [
@@ -33,36 +63,6 @@ expression: normalize_search_response(resp)
       },
       "primary_key": {
         "id": 948
-      }
-    },
-    {
-      "_score": 0.03,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "To find how many groups of 2 are in 14, divide 14 by 2:  \n\\[ 14 \\div 2 = 7 \\]  \nThus, there are $\\boxed{7}$ groups of 2 in 14."
-        ],
-        "question": [
-          "How many groups of 2 are in 14?"
-        ]
-      },
-      "primary_key": {
-        "id": 462
-      }
-    },
-    {
-      "_score": 0.03,
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "The number of distinct permutations of 4 distinct letters is \\(4! = 4 \\times 3 \\times 2 \\times 1 = \\boxed{24}\\)."
-        ],
-        "question": [
-          "How many distinct permutations are there of the group of letters \\(\\{a, b, c, d\\}\\)?"
-        ]
-      },
-      "primary_key": {
-        "id": 458
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Updates 4 S3 vectors search test snapshot files to match current search index data
- Affected snapshots: `s3vectors_multiple_embeddings_basic_response`, `s3vectors_chunking_basic_response`, `s3vectors_chunking_metadata_keywords_response`, `s3vectors_chunking_metadata_basic_response`
- The S3 vectors test index was rebuilt/updated, causing the search integration tests to return different results

## Test plan
- [ ] Verify Test Search CI passes with updated snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)