### PR TITLE
ci: run PR build-test job on spiceai-macos runners

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -1,15 +1,12 @@
 ---
-name: pr
+name: pr-develop
 
 on:
   merge_group:
     types: [checks_requested]
   pull_request:
     branches:
-      - trunk
-      - release-*
-      - release/*
-      - feature-*
+      - develop
   workflow_dispatch:
     inputs:
       profile_option:
@@ -31,7 +28,7 @@ on:
           - 'no'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'develop' && github.sha || 'any-sha' }}
   cancel-in-progress: true
 
 env:
@@ -43,16 +40,8 @@ env:
   CARGO_HTTP_TIMEOUT: 60
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
-  # Use fast linkers for PR builds (mold for x86_64, lld for aarch64)
-  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
-  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
-  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: clang
-  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
 
 jobs:
-  # `pr` is a required check for pull requests. Therefore we cannot skip the workflow via
-  # `on.pull_requests.paths-ignore`. Instead, we conditionally run the jobs (which report
-  # a success when skipped).
   check_changes:
     runs-on: spiceai-macos
     outputs:
@@ -60,14 +49,12 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          # Use fetch-depth 2 for PR change detection (dorny/paths-filter only needs base + head)
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
       - name: Check for code changes
         id: check
         uses: ./.github/actions/check-code-changes
 
-  # Run Rust linting
   lint-rust:
     name: Rust Lint
     runs-on: spiceai-macos
@@ -134,10 +121,9 @@ jobs:
         if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
 
-  # Build and test
   build-test:
     name: Build and Test
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
     needs: [check_changes]
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - develop
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,7 +137,7 @@ jobs:
   # Build and test
   build-test:
     name: Build and Test
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
     needs: [check_changes]
 
     steps:


### PR DESCRIPTION
Update the PR workflow to run the `build-test` job on `spiceai-macos` runners (macOS), matching the other jobs (`check_changes`, `lint-rust`) which already use `spiceai-macos`.