### PR TITLE
chore: Update turso dependency from 0.5.0 to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ tracing = "0.1.43"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-turso = { version = "0.5.0", default-features = false }
+turso = { version = "0.5.1", default-features = false }
 turso-shared = { path = "crates/turso-shared" }
 twox-hash = "2.1.2"
 url = { version = "2.5", features = ["serde"] }


### PR DESCRIPTION
## Summary
- Bump the `turso` crate dependency from `0.5.0` to `0.5.1` (latest stable release)

## Test plan
- [ ] CI build and tests pass
- [ ] No breaking API changes in turso 0.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)