### PR TITLE
ci: Replace full lint with lightweight cargo check in pr-develop

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -20,7 +20,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CARGO_NET_RETRY: 10
   CARGO_HTTP_TIMEOUT: 60
-  CARGO_INCREMENTAL: 0
+  CARGO_INCREMENTAL: 1
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
@@ -71,12 +71,10 @@ jobs:
         if: steps.check.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-cc
 
-      # Lint
-      - name: Run Rust lint
+      # Check
+      - name: Run cargo check
         if: steps.check.outputs.relevant_changes == 'true'
-        run: make lint-rust
-        env:
-          RUST_PROFILE: ${{ env.RUST_PROFILE }}
+        run: cargo check --all-targets --features adbc,aws-secrets-manager,keyring-secret-store,models,release,mcp --workspace --exclude libnfs --locked
 
       - name: Validate datafusion-table-providers commit
         if: steps.check.outputs.relevant_changes == 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ lto = "thin"              # Keep prod-like LTO (thin is fast + optimized)
 
 [profile.lint]
 debug = "line-tables-only"
-incremental = false
+incremental = true
 inherits = "dev"
 lto = "off"
 


### PR DESCRIPTION
## Changes

Replace the full `make lint-rust` step (cargo fmt + 2x cargo clippy passes) in `pr-develop.yml` with a lightweight `cargo check` for faster CI feedback.

### Details

- **Replace `make lint-rust` with `cargo check`**: The lint step ran `cargo fmt --check` and two full `cargo clippy` passes (lib/bins + tests). Replace with a single `cargo check --all-targets` that verifies compilation without the expensive analysis.
- **Remove `odbc` feature**: Excluded from the check features to reduce compilation scope.
- **Enable incremental compilation**: Since `spiceai-macos` is a self-hosted runner with a persistent `target/` directory:
  - Set `CARGO_INCREMENTAL: 1` (was `0`)
  - Set `incremental = true` in `[profile.lint]` (was `false`)

  This means only changed crates and their dependents are recompiled on subsequent runs.