### PR TITLE
ci: Use spiceai-dev-runners for trunk PR workflow jobs

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   enforce-pull-with-spice:
-    runs-on: self-hosted
+    runs-on: spiceai-macos
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
   # `on.pull_requests.paths-ignore`. Instead, we conditionally run the jobs (which report
   # a success when skipped).
   check_changes:
-    runs-on: spiceai-macos
+    runs-on: spiceai-dev-runners
     outputs:
       relevant_changes: ${{ steps.check.outputs.relevant_changes }}
     steps:
@@ -68,7 +68,7 @@ jobs:
   # Run Rust linting
   lint-rust:
     name: Rust Lint
-    runs-on: spiceai-macos
+    runs-on: spiceai-dev-runners
     needs: check_changes
 
     steps:


### PR DESCRIPTION
Update `.github/workflows/pr.yml` to use `spiceai-dev-runners` for the `check_changes` and `lint-rust` jobs, matching the `build-test` job which already uses it.