### PR TITLE
Properly handle `EXPLAIN ANALYZE`

### DIFF
--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -64,6 +64,12 @@ impl FederationProvider for AcceleratedTableFederationProvider {
         if !self.enabled {
             return None;
         }
+        // Analyze plans (EXPLAIN ANALYZE) cannot be converted to SQL by the
+        // Unparser and must not be federated as a whole. Returning `Unable`
+        // causes the federation rule to federate only the inner query instead.
+        if matches!(plan, LogicalPlan::Analyze(_)) {
+            return Some(FederationAnalyzerForLogicalPlan::Unable);
+        }
         self.federation_provider()?.analyzer(plan)
     }
 }


### PR DESCRIPTION
## 📝 Summary

Closes https://github.com/spiceai/spiceai/issues/8691

Fix `EXPLAIN ANALYZE` failing on federated queries by preventing the federation analyzer from wrapping the Analyze plan node, so only the inner query is federated.