### PR TITLE
Fix snapshot test score precision mismatch

### DIFF
--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -215,8 +215,8 @@ fn normalize_search_response(mut json: Value) -> String {
                 && let Some(Value::Number(n)) = obj.get("_score")
                 && let Some(score) = n.as_f64()
                 && let Some(truncated_score) =
-                    serde_json::Number::from_f64((10000.0 * score).trunc() / 10000.0)
-            // Keep 4 decimals
+                    serde_json::Number::from_f64((100.0 * score).trunc() / 100.0)
+            // Keep 2 decimals
             {
                 obj.insert("_score".to_string(), Value::Number(truncated_score));
             }


### PR DESCRIPTION
## Summary
- Fix `normalize_search_response` in `models/search.rs` to use 2-decimal truncation (`100.0`) instead of 4-decimal (`10000.0`), matching all existing snapshot files and aligning with `search/mod.rs`
- This resolves 26+ snapshot test failures in "Test Search" and "Test OpenAI Models" CI jobs on the develop→trunk PR #9961

## Test plan
- [ ] CI "Test Search" and "Test OpenAI Models" jobs pass
- [ ] All other existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)