### PR TITLE
feat(spidapter): Support custom container image for SCP deployments

### DIFF
--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -129,7 +129,13 @@ pub struct UpdateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replicas: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image_tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_channel: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tools/spidapter/src/args/mod.rs
+++ b/tools/spidapter/src/args/mod.rs
@@ -50,6 +50,21 @@ pub struct StdioArgs {
     #[arg(long)]
     pub channel: Option<String>,
 
+    /// Custom container image registry (e.g. `ghcr.io/spiceai`).
+    /// When set, the app's image registry is updated before deploying.
+    #[arg(long, env = "SPIDAPTER_IMAGE_REGISTRY")]
+    pub image_registry: Option<String>,
+
+    /// Custom container image name (e.g. `spiceai-dev`).
+    /// When set, the app's image name is updated before deploying.
+    #[arg(long, env = "SPIDAPTER_IMAGE_NAME")]
+    pub image_name: Option<String>,
+
+    /// Custom container image tag (e.g. `spicebench-sf10`).
+    /// When set, the app's image tag is updated before deploying.
+    #[arg(long, env = "SPIDAPTER_IMAGE_TAG")]
+    pub image_tag: Option<String>,
+
     /// Spice Cloud API key for authentication.
     /// When not provided, falls back to `SPICEAI_API_KEY`, `SPICE_API_KEY`, `SPICE_SPICEAI_API_KEY`, or `SPICE_SPICEAI_TOKEN`.
     #[arg(long, env = "SPICEAI_API_KEY")]

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -242,15 +242,9 @@ async fn apply_storage_config(
         .update_app(
             app_id,
             &UpdateAppRequest {
-                description: None,
-                visibility: None,
-                replicas: None,
-                image_tag: None,
-                region: None,
-                spicepod: None,
-                resources: None,
                 executor,
                 storage_size_gb: config.app_storage_size_gb,
+                ..UpdateAppRequest::default()
             },
         )
         .await?;
@@ -306,15 +300,8 @@ pub(crate) async fn apply_spicepod_to_app(
         .update_app(
             app_id,
             &UpdateAppRequest {
-                description: None,
-                visibility: None,
-                replicas: None,
-                image_tag: None,
-                region: None,
                 spicepod: Some(spicepod_yaml.to_string()),
-                resources: None,
-                executor: None,
-                storage_size_gb: None,
+                ..UpdateAppRequest::default()
             },
         )
         .await?;

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -22,7 +22,7 @@ use tokio::process::{Child, Command as TokioCommand};
 
 use arrow::datatypes::DataType;
 use async_trait::async_trait;
-use spice_cloud_client::CloudClient;
+use spice_cloud_client::{CloudClient, types::UpdateAppRequest};
 use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
 use spicepod::component::ComponentOrReference;
 use spicepod::component::access::AccessMode;
@@ -639,6 +639,37 @@ async fn provision_spice_cloud_app(
     eprintln!("[stdio] Setting RUNNER secret...");
     commands::secrets::set_secret(&cloud, app_id, "RUNNER", "spidapter").await?;
     eprintln!("[stdio] RUNNER secret set");
+
+    // Apply custom image configuration if any image-related overrides are provided.
+    // This sets the app's registry/image/image_tag/update_channel before creating the deployment,
+    // so the deployment picks up the custom image instead of the default.
+    let has_custom_image = args.image_registry.is_some()
+        || args.image_name.is_some()
+        || args.image_tag.is_some()
+        || args.channel.is_some();
+
+    if has_custom_image {
+        eprintln!(
+            "[stdio] Applying custom image config: registry={:?}, image={:?}, tag={:?}, channel={:?}",
+            args.image_registry, args.image_name, args.image_tag, args.channel
+        );
+        cloud
+            .update_app(
+                app_id,
+                &UpdateAppRequest {
+                    registry: args.image_registry.clone(),
+                    image: args.image_name.clone(),
+                    image_tag: args.image_tag.clone(),
+                    update_channel: args.channel.clone(),
+                    ..UpdateAppRequest::default()
+                },
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to apply custom image config to app '{app_name}': {e}")
+            })?;
+        eprintln!("[stdio] Custom image config applied");
+    }
 
     eprintln!("[stdio] Creating deployment...");
     commands::create_deployment(&cloud, app_id, args.channel.as_deref()).await?;
@@ -1576,6 +1607,9 @@ mod tests {
             spice_cloud_api_url: "https://api.spice.ai".to_string(),
             ready_wait: 600,
             channel: None,
+            image_registry: None,
+            image_name: None,
+            image_tag: None,
             api_key: None,
             backend: BackendMode::Scp,
             flight_url: None,


### PR DESCRIPTION
Add `--image-registry`, `--image-name`, and `--image-tag` CLI args (and corresponding `SPIDAPTER_IMAGE_REGISTRY`/`SPIDAPTER_IMAGE_NAME`/`SPIDAPTER_IMAGE_TAG` env vars) to spidapter.

When any image override is provided, spidapter calls `update_app` to set the custom registry/image/image_tag/update_channel on the SCP app before creating the deployment. This allows deploying custom dev or benchmark images such as `ghcr.io/spiceai/spiceai-dev:spicebench-sf10` on the `internal` channel.

### Changes

**`crates/spice-cloud-client/src/types.rs`**
- Added `registry`, `image`, and `update_channel` fields to `UpdateAppRequest`

**`tools/spidapter/src/args/mod.rs`**
- Added `--image-registry` (`SPIDAPTER_IMAGE_REGISTRY`), `--image-name` (`SPIDAPTER_IMAGE_NAME`), `--image-tag` (`SPIDAPTER_IMAGE_TAG`) CLI args

**`tools/spidapter/src/stdio_server.rs`**
- Before deploying, calls `update_app` with custom image config when any image overrides are set

**`tools/spidapter/src/commands/mod.rs`**
- Simplified `UpdateAppRequest` usages with `..Default::default()`

### Depends on
- spicehq/cloud#4351 (merged) — adds `spiceai/spiceai-dev` to `INTERNAL_RUNTIME_IMAGES`