### PR TITLE
chore: Change executor Flight API key auth log to debug level

### DIFF
--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -203,7 +203,7 @@ pub async fn start_executor_flight_server(
     }
 
     if !has_flight_auth {
-        tracing::warn!(
+        tracing::debug!(
             "Executor Flight API key auth is disabled; accepting scheduler-trusted DoPut requires cluster mTLS"
         );
     }


### PR DESCRIPTION
The 'Executor Flight API key auth is disabled; accepting scheduler-trusted DoPut requires cluster mTLS' warning is noisy in environments where cluster mTLS is the expected auth mechanism. Downgrade to debug level.