### PR TITLE
fix: Set default S3 region for opendal operator and fix cayenne nextest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 .PHONY: nextest
 nextest:
 	@cargo nextest run --all --lib $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
-	@cargo nextest run -p cayenne --tests $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
+	@cargo nextest run -p cayenne --tests $(NEXTEST_CARGO_PROFILE)
 
 # Also update .github/workflows/integration.yml with changes to this target
 .PHONY: test-integration

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -806,12 +806,13 @@ pub(crate) fn build_opendal_operator(
         if let Some(endpoint) = props.get("s3.endpoint") {
             config.endpoint = Some(endpoint.clone());
         }
-        if let Some(region) = props
-            .get("s3.region")
-            .or_else(|| props.get("client.region"))
-        {
-            config.region = Some(region.clone());
-        }
+        config.region = Some(
+            props
+                .get("s3.region")
+                .or_else(|| props.get("client.region"))
+                .cloned()
+                .unwrap_or_else(|| "us-east-1".to_string()),
+        );
         if let Some(key_id) = props.get("s3.access-key-id") {
             config.access_key_id = Some(key_id.clone());
         }


### PR DESCRIPTION
## Summary

Two CI fixes:

### 1. S3 region default for opendal operator
The opendal S3 builder (updated via iceberg-rust v0.9 in #9917) now requires a `region` to be set. The `build_opendal_operator` function used for Hadoop catalog directory listing didn't set a default region, causing `test_build_opendal_operator_s3` and `test_build_opendal_operator_s3a` to fail with:

```
ConfigInvalid (permanent) at Builder::build => region is missing.
Please find it by S3::detect_region() or set them in env.
```

When no region is provided via `s3.region` or `client.region` properties, this now defaults to `us-east-1`.

### 2. Remove NEXTEST_FLAG from cayenne-specific nextest command
The cayenne nextest command (`cargo nextest run -p cayenne --tests`) was receiving `$(NEXTEST_FLAG)` which contains `--exclude` flags. `--exclude` is only valid with `--workspace`, not with `-p` (single package), causing:

```
error: --exclude can only be used together with --workspace
```

The excludes (libnfs, connector-nfs, etc.) are unnecessary when running a specific package.

## Test plan

- [x] `test_build_opendal_operator_s3` passes
- [x] `test_build_opendal_operator_s3a` passes
- [x] `make nextest` with NEXTEST_FLAG containing --exclude no longer errors on cayenne step