### PR TITLE
fix: Use deterministic key ordering for search primary key tie-breaking

### DIFF
--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fmt::Display};
+use std::{cmp::Ordering, collections::HashMap, fmt::Display};
 
 use arrow::error::ArrowError;
 use arrow_tools::format::to_markdown_documents;
@@ -116,6 +116,34 @@ pub async fn to_pretty(agg: AggregationResult) -> Result<impl Display, ArrowErro
     Ok(doc_sets.join("\n"))
 }
 
+/// Compare two primary key maps deterministically by iterating keys in sorted order.
+/// `HashMap` iteration order is non-deterministic, so serializing via `serde_json::to_string`
+/// can produce different strings for identical maps across runs.
+fn compare_primary_keys(a: &HashMap<String, Value>, b: &HashMap<String, Value>) -> Ordering {
+    let mut a_keys: Vec<&String> = a.keys().collect();
+    let mut b_keys: Vec<&String> = b.keys().collect();
+    a_keys.sort();
+    b_keys.sort();
+
+    // First compare by sorted key lists
+    match a_keys.iter().cmp(b_keys.iter()) {
+        Ordering::Equal => {}
+        ord => return ord,
+    }
+
+    // Keys are identical — compare values in sorted key order
+    for key in a_keys {
+        let a_val = a.get(key).map(ToString::to_string).unwrap_or_default();
+        let b_val = b.get(key).map(ToString::to_string).unwrap_or_default();
+        match a_val.cmp(&b_val) {
+            Ordering::Equal => continue,
+            ord => return ord,
+        }
+    }
+
+    Ordering::Equal
+}
+
 pub async fn to_matches_sorted(result: VectorSearchResult, limit: usize) -> Result<Vec<Match>> {
     let mut matches: Vec<Match> = Vec::new();
     for (a, b) in result {
@@ -127,13 +155,9 @@ pub async fn to_matches_sorted(result: VectorSearchResult, limit: usize) -> Resu
     matches.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
             .then_with(|| a.dataset.cmp(&b.dataset))
-            .then_with(|| {
-                let a_pk = serde_json::to_string(&a.primary_key).unwrap_or_default();
-                let b_pk = serde_json::to_string(&b.primary_key).unwrap_or_default();
-                a_pk.cmp(&b_pk)
-            })
+            .then_with(|| compare_primary_keys(&a.primary_key, &b.primary_key))
     });
 
     matches.truncate(limit);

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -241,8 +241,113 @@ fn transpose_and_convert(
 mod tests {
     use super::*;
     use insta::assert_json_snapshot;
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use std::collections::HashMap;
+
+    // --- compare_primary_keys regression tests ---
+
+    fn make_pk(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn test_compare_pk_identical_single_key() {
+        let a = make_pk(&[("id", json!(42))]);
+        let b = make_pk(&[("id", json!(42))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_compare_pk_identical_multi_key() {
+        let a = make_pk(&[("id", json!(1)), ("name", json!("alice"))]);
+        let b = make_pk(&[("id", json!(1)), ("name", json!("alice"))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_compare_pk_different_values() {
+        let a = make_pk(&[("id", json!(1))]);
+        let b = make_pk(&[("id", json!(2))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Less);
+        assert_eq!(compare_primary_keys(&b, &a), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_pk_different_keys() {
+        let a = make_pk(&[("alpha", json!(1))]);
+        let b = make_pk(&[("beta", json!(1))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Less);
+        assert_eq!(compare_primary_keys(&b, &a), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_pk_different_key_count() {
+        let a = make_pk(&[("id", json!(1))]);
+        let b = make_pk(&[("id", json!(1)), ("name", json!("x"))]);
+        // a has fewer keys: ["id"] vs ["id", "name"] — "id" == "id", then a is shorter
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Less);
+        assert_eq!(compare_primary_keys(&b, &a), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_pk_empty_maps() {
+        let a: HashMap<String, Value> = HashMap::new();
+        let b: HashMap<String, Value> = HashMap::new();
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_compare_pk_one_empty() {
+        let a: HashMap<String, Value> = HashMap::new();
+        let b = make_pk(&[("id", json!(1))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Less);
+        assert_eq!(compare_primary_keys(&b, &a), Ordering::Greater);
+    }
+
+    /// Regression test: HashMap key ordering must not affect comparison.
+    /// Insert keys in different orders and verify identical maps always compare equal.
+    #[test]
+    fn test_compare_pk_insertion_order_independent() {
+        let mut a = HashMap::new();
+        a.insert("zebra".to_string(), json!(1));
+        a.insert("alpha".to_string(), json!(2));
+        a.insert("middle".to_string(), json!(3));
+
+        let mut b = HashMap::new();
+        b.insert("alpha".to_string(), json!(2));
+        b.insert("middle".to_string(), json!(3));
+        b.insert("zebra".to_string(), json!(1));
+
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Equal);
+    }
+
+    /// Regression test: the old serde_json::to_string approach was non-deterministic.
+    /// Verify that compare_primary_keys is deterministic over many iterations with
+    /// maps constructed fresh each time (which may have different internal hash state).
+    #[test]
+    fn test_compare_pk_deterministic_across_reconstructions() {
+        for _ in 0..100 {
+            let a = make_pk(&[("x", json!(1)), ("y", json!(2)), ("z", json!(3))]);
+            let b = make_pk(&[("x", json!(1)), ("y", json!(2)), ("z", json!(3))]);
+            assert_eq!(
+                compare_primary_keys(&a, &b),
+                Ordering::Equal,
+                "Identical maps must always compare equal"
+            );
+        }
+    }
+
+    /// Regression test: comparison on second key value when first key matches.
+    #[test]
+    fn test_compare_pk_multi_key_tiebreak_on_value() {
+        let a = make_pk(&[("id", json!(1)), ("version", json!(1))]);
+        let b = make_pk(&[("id", json!(1)), ("version", json!(2))]);
+        assert_eq!(compare_primary_keys(&a, &b), Ordering::Less);
+        assert_eq!(compare_primary_keys(&b, &a), Ordering::Greater);
+    }
 
     fn sort_result(v: Vec<HashMap<String, Vec<Value>>>) -> Vec<Vec<(String, Vec<Value>)>> {
         v.into_iter()


### PR DESCRIPTION
## Summary

- Fix non-deterministic search result ordering caused by `HashMap` serialization in primary key tie-breaking
- Replace `serde_json::to_string(&HashMap)` comparison with a `compare_primary_keys` function that sorts keys before comparing, ensuring stable ordering across process runs

## Problem

Commit `1f2468d48` added primary key tie-breaking to search result sorting for deterministic results. However, `serde_json::to_string` on `HashMap<String, Value>` does not guarantee key ordering — Rust's `HashMap` uses randomized hashing, so identical maps can serialize to different JSON strings across runs. This undermines the deterministic sort guarantee.

## Fix

Introduce `compare_primary_keys` which:
1. Collects and sorts both maps' keys
2. Compares key lists first (structural comparison)
3. Compares values in sorted key order (content comparison)

This ensures identical primary keys always compare as `Equal` and different primary keys always produce the same relative ordering.

## Test plan

- [x] `cargo check -p runtime` passes
- [ ] Existing search tests continue to pass