### PR TITLE
Update model and search integration test snapshots

### DIFF
--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -972,6 +972,10 @@ fn get_responses_model_with_tools(
     model
         .params
         .insert("tools".into(), serde_json::Value::String("auto".into()));
+    model.params.insert(
+        "responses_api".into(),
+        serde_json::Value::String("enabled".into()),
+    );
     model
 }
 

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_filters.snap
@@ -1,27 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
 expression: resp?
-snapshot_kind: text
 ---
 [
   {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "0.66"
+    "_score": 0.668
   },
   {
     "id": 1279,
     "answer": "$\\boxed{\\text{Pyruvate}}$ is not an intermediate of the TCA cycle. It is converted to acetyl-CoA, which then enters the cycle.",
-    "_score": "0.66"
+    "_score": 0.667
   },
   {
     "id": 1289,
     "answer": "$\\boxed{\\text{(a) pressure}}$ (Intensive properties, like pressure, do not depend on the size or mass of the system.)",
-    "_score": "0.65"
+    "_score": 0.654
   },
   {
     "id": 446,
     "answer": "Infection is acquired by ingestion of the spores, which transmit the sporoplasm through the tubules into enterocytes.",
-    "_score": "0.64"
+    "_score": 0.647
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "0.66"
+    "_score": 0.668
   },
   {
     "id": 1279,
     "answer": "$\\boxed{\\text{Pyruvate}}$ is not an intermediate of the TCA cycle. It is converted to acetyl-CoA, which then enters the cycle.",
-    "_score": "0.66"
+    "_score": 0.667
   },
   {
     "id": 1289,
     "answer": "$\\boxed{\\text{(a) pressure}}$ (Intensive properties, like pressure, do not depend on the size or mass of the system.)",
-    "_score": "0.65"
+    "_score": 0.654
   },
   {
     "id": 446,
     "answer": "Infection is acquired by ingestion of the spores, which transmit the sporoplasm through the tubules into enterocytes.",
-    "_score": "0.64"
+    "_score": 0.647
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_keywords_response.snap
@@ -6,7 +6,7 @@ expression: normalize_search_response(resp)
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "5.05",
+      "_score": "5.06",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "7.52"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "6.33"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "6.19"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "7.52"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "6.33"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "6.19"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "7.52"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_no_score_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_no_score_explain.snap
@@ -10,7 +10,7 @@ description: "SELECT id, answer FROM text_search(qs, 'second') order by _score d
 |               |     Projection: text_search(qs, Utf8("second")).id, text_search(qs, Utf8("second")).answer, text_search(qs, Utf8("second"))._score              |
 |               |       TableScan: text_search(qs, Utf8("second")) projection=[_score, answer, id]                                                                |
 | physical_plan | ProjectionExec: expr=[id@0 as id, answer@2 as answer]                                                                                           |
-|               |   SortExec: TopK(fetch=4), expr=[_score@1 DESC], preserve_partitioning=[false]                                                                  |
+|               |   SortExec: TopK(fetch=4), expr=[_score@1 DESC, id@0 ASC], preserve_partitioning=[false]                                                        |
 |               |     HashJoinExec: mode=CollectLeft, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(id@0, id@1)], projection=[id@0, _score@1, answer@2] |
 |               |       CoalescePartitionsExec                                                                                                                    |
 |               |         CooperativeExec                                                                                                                         |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "6.33"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "6.19"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_random_explain.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_random_explain.snap
@@ -2,24 +2,24 @@
 source: crates/runtime/tests/models/search.rs
 description: "SELECT subject FROM text_search(qs, 'second') order by _score desc LIMIT 4"
 ---
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                                                       |
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Projection: text_search(qs, Utf8("second")).subject                                                                                        |
-|               |   Sort: text_search(qs, Utf8("second"))._score DESC NULLS FIRST, fetch=4                                                                   |
-|               |     Projection: text_search(qs, Utf8("second")).subject, text_search(qs, Utf8("second"))._score                                            |
-|               |       TableScan: text_search(qs, Utf8("second")) projection=[_score, subject]                                                              |
-| physical_plan | ProjectionExec: expr=[subject@1 as subject]                                                                                                |
-|               |   SortExec: TopK(fetch=4), expr=[_score@0 DESC], preserve_partitioning=[false]                                                             |
-|               |     HashJoinExec: mode=CollectLeft, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(id@0, id@0)], projection=[_score@1, subject@3] |
-|               |       CoalescePartitionsExec                                                                                                               |
-|               |         CooperativeExec                                                                                                                    |
-|               |           BytesProcessedExec                                                                                                               |
-|               |             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                           |
-|               |               CooperativeExec                                                                                                              |
-|               |                 FullTextSearchTableExec q=second                                                                                           |
-|               |       SchemaCastScanExec                                                                                                                   |
-|               |         BytesProcessedExec                                                                                                                 |
-|               |           DataSourceExec: partitions=1, partition_sizes=[2]                                                                                |
-|               |                                                                                                                                            |
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------+
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                             |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Projection: text_search(qs, Utf8("second")).subject                                                                                              |
+|               |   Sort: text_search(qs, Utf8("second"))._score DESC NULLS FIRST, fetch=4                                                                         |
+|               |     Projection: text_search(qs, Utf8("second")).subject, text_search(qs, Utf8("second"))._score                                                  |
+|               |       TableScan: text_search(qs, Utf8("second")) projection=[_score, subject]                                                                    |
+| physical_plan | ProjectionExec: expr=[subject@2 as subject]                                                                                                      |
+|               |   SortExec: TopK(fetch=4), expr=[_score@1 DESC, id@0 ASC], preserve_partitioning=[false]                                                         |
+|               |     HashJoinExec: mode=CollectLeft, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(id@0, id@0)], projection=[id@0, _score@1, subject@3] |
+|               |       CoalescePartitionsExec                                                                                                                     |
+|               |         CooperativeExec                                                                                                                          |
+|               |           BytesProcessedExec                                                                                                                     |
+|               |             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                 |
+|               |               CooperativeExec                                                                                                                    |
+|               |                 FullTextSearchTableExec q=second                                                                                                 |
+|               |       SchemaCastScanExec                                                                                                                         |
+|               |         BytesProcessedExec                                                                                                                       |
+|               |           DataSourceExec: partitions=1, partition_sizes=[2]                                                                                      |
+|               |                                                                                                                                                  |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/models/snapshots/integration_models__models__tools__mcp__mcp_spiced_list.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__tools__mcp__mcp_spiced_list.snap
@@ -20,8 +20,22 @@ expression: tools_list
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "last": {
-          "description": "Retrieve memories created in the 'last' interval. ISO 8601 Format, e.g: \"1h\", \"2m30s\".",
+          "description": "Retrieve memories created in the 'last' interval as a human-readable duration string, e.g. \"1h\", \"2m30s\".",
           "type": "string"
+        },
+        "limit": {
+          "default": 100,
+          "description": "Maximum number of memories to return.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "description": "Number of memories to skip for pagination.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
         }
       },
       "required": [
@@ -60,8 +74,22 @@ expression: tools_list
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "last": {
-          "description": "Retrieve memories created in the 'last' interval. ISO 8601 Format, e.g: \"1h\", \"2m30s\".",
+          "description": "Retrieve memories created in the 'last' interval as a human-readable duration string, e.g. \"1h\", \"2m30s\".",
           "type": "string"
+        },
+        "limit": {
+          "default": 100,
+          "description": "Maximum number of memories to return.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "description": "Number of memories to skip for pagination.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

- Update search integration test snapshots to reflect `_score` type change from string to native float with full precision
- Update query plan snapshots to reflect `SortExec` tiebreaker on `id` for deterministic ordering
- Update MCP memory tool snapshots to include new `limit`/`offset` pagination parameters
- Fix `openai_responses_api_tools` test by enabling `responses_api` param in `get_responses_model_with_tools`