### PR TITLE
fix: Address data correctness bugs found in audit

### DIFF
--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -195,14 +195,21 @@ pub(crate) async fn forward_federated_partitioned_write(
 
     // Decode the first message and build a streaming iterator that yields
     // each subsequent FlightData message as a RecordBatch without buffering.
-    let first_batch =
-        flight_data_to_arrow_batch(&first_message, Arc::clone(&schema), &dictionaries_by_id).ok();
+    let first_batch = flight_data_to_arrow_batch(
+        &first_message,
+        Arc::clone(&schema),
+        &dictionaries_by_id,
+    )
+    .context(DecodeBatchSnafu)?;
+    let first_batch = if first_batch.num_rows() > 0 {
+        Some(first_batch)
+    } else {
+        None
+    };
 
     let decode_schema = Arc::clone(&schema);
     let batch_stream = async_stream::try_stream! {
-        if let Some(batch) = first_batch
-            && batch.num_rows() > 0
-        {
+        if let Some(batch) = first_batch {
             yield batch;
         }
         while let Some(result) = streaming_flight.next().await {

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1322,23 +1322,26 @@ impl ExecutionPlan for DistributedCayenneUpdateExec {
         let result_schema = ddl_result_schema();
 
         let stream = futures::stream::once(async move {
-            if let Some(ref registry) = executor_registry {
-                if assignments_sql.is_empty() {
-                    return Err(DataFusionError::Execution(format!(
-                        "UPDATE on '{table_name}' has no SET assignments"
-                    )));
-                }
-                let set_clause = assignments_sql
-                    .iter()
-                    .map(|(col, val)| format!("\"{col}\" = {val}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let mut sql = format!("UPDATE {table_name} SET {set_clause}");
-                if let Some(ref filter) = filter_sql {
-                    let _ = write!(sql, " WHERE {filter}");
-                }
-                forward_dml_to_executors(registry, &sql).await?;
+            let Some(ref registry) = executor_registry else {
+                return Err(DataFusionError::Execution(format!(
+                    "UPDATE on '{table_name}' cannot be forwarded: no executor registry available"
+                )));
+            };
+            if assignments_sql.is_empty() {
+                return Err(DataFusionError::Execution(format!(
+                    "UPDATE on '{table_name}' has no SET assignments"
+                )));
             }
+            let set_clause = assignments_sql
+                .iter()
+                .map(|(col, val)| format!("\"{col}\" = {val}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let mut sql = format!("UPDATE {table_name} SET {set_clause}");
+            if let Some(ref filter) = filter_sql {
+                let _ = write!(sql, " WHERE {filter}");
+            }
+            forward_dml_to_executors(registry, &sql).await?;
 
             RecordBatch::try_new(
                 result_schema,

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::BTreeMap, collections::HashMap, fmt::Display};
 
 use arrow::error::ArrowError;
 use arrow_tools::format::to_markdown_documents;
@@ -124,15 +124,19 @@ pub async fn to_matches_sorted(result: VectorSearchResult, limit: usize) -> Resu
     }
 
     // Sort by score descending, then by dataset + primary key ascending for deterministic ordering on ties.
+    // Use BTreeMap for primary key serialization to ensure deterministic key ordering,
+    // since HashMap iteration order is non-deterministic due to hash randomization.
     matches.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| a.dataset.cmp(&b.dataset))
             .then_with(|| {
-                let a_pk = serde_json::to_string(&a.primary_key).unwrap_or_default();
-                let b_pk = serde_json::to_string(&b.primary_key).unwrap_or_default();
-                a_pk.cmp(&b_pk)
+                let a_pk: BTreeMap<_, _> = a.primary_key.iter().collect();
+                let b_pk: BTreeMap<_, _> = b.primary_key.iter().collect();
+                let a_str = serde_json::to_string(&a_pk).unwrap_or_default();
+                let b_str = serde_json::to_string(&b_pk).unwrap_or_default();
+                a_str.cmp(&b_str)
             })
     });
 
@@ -289,5 +293,72 @@ mod tests {
         );
 
         assert_json_snapshot!(sort_result(transpose_and_convert(column_format)));
+    }
+
+    /// Regression test: sorting matches with composite primary keys must produce
+    /// deterministic ordering regardless of HashMap iteration order.
+    #[test]
+    fn test_sort_matches_deterministic_composite_pk() {
+        let make_match = |score: f64, dataset: &str, pk: Vec<(&str, Value)>| Match {
+            score,
+            dataset: dataset.to_string(),
+            primary_key: pk.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+            matches: HashMap::new(),
+            data: HashMap::new(),
+            metadata: HashMap::new(),
+        };
+
+        // Two matches with the same score/dataset but different composite primary keys.
+        // The keys are "b" and "a" — HashMap might iterate them in any order,
+        // but BTreeMap-based serialization will always produce {"a":...,"b":...}.
+        let m1 = make_match(
+            0.9,
+            "ds",
+            vec![
+                ("b", Value::Number(2.into())),
+                ("a", Value::Number(1.into())),
+            ],
+        );
+        let m2 = make_match(
+            0.9,
+            "ds",
+            vec![
+                ("b", Value::Number(3.into())),
+                ("a", Value::Number(1.into())),
+            ],
+        );
+
+        let mut matches = vec![m2.clone(), m1.clone()];
+
+        // Sort multiple times to verify stability across runs
+        for _ in 0..10 {
+            matches.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.dataset.cmp(&b.dataset))
+                    .then_with(|| {
+                        let a_pk: BTreeMap<_, _> = a.primary_key.iter().collect();
+                        let b_pk: BTreeMap<_, _> = b.primary_key.iter().collect();
+                        let a_str = serde_json::to_string(&a_pk).unwrap_or_default();
+                        let b_str = serde_json::to_string(&b_pk).unwrap_or_default();
+                        a_str.cmp(&b_str)
+                    })
+            });
+
+            // m1 has a=1,b=2 and m2 has a=1,b=3.
+            // Serialized deterministically: {"a":1,"b":2} < {"a":1,"b":3}
+            // So m1 should always come first.
+            assert_eq!(
+                matches[0].primary_key.get("b"),
+                Some(&Value::Number(2.into())),
+                "First match should have b=2 (lower composite key)"
+            );
+            assert_eq!(
+                matches[1].primary_key.get("b"),
+                Some(&Value::Number(3.into())),
+                "Second match should have b=3 (higher composite key)"
+            );
+        }
     }
 }

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -568,7 +568,7 @@ impl TableProvider for SearchQueryProvider {
                 let mut sort_exprs = vec![SortExpr::new(
                     Expr::Column(Column::new_unqualified(SEARCH_SCORE_COLUMN_NAME)),
                     false, // descending
-                    true,  // nulls_first
+                    false, // nulls_last (null scores should rank lowest, consistent with other search sort sites)
                 )];
                 sort_exprs.extend(self.primary_key.iter().map(|pk| {
                     SortExpr::new(


### PR DESCRIPTION
## Summary

Fixes four data correctness bugs found during a systematic audit of recent trunk commits:

- **Non-deterministic search result ordering for composite primary keys**: `to_matches_sorted` in `types.rs` serialized `HashMap<String, Value>` primary keys using `serde_json::to_string`, but `HashMap` iteration order is non-deterministic due to hash randomization. For composite primary keys (2+ columns), this produced different JSON strings across runs (e.g., `{"a":1,"b":2}` vs `{"b":2,"a":1}`), making the tie-breaking sort non-deterministic — directly undermining the goal of commit `1f2468d48`. Fixed by collecting into `BTreeMap` before serialization to guarantee sorted key order.

- **`DistributedCayenneUpdateExec` silently dropping updates when `executor_registry` is `None`**: The UPDATE exec used `if let Some(ref registry) = executor_registry` which silently skipped forwarding and reported success when no registry was available. The DELETE and INSERT execs correctly use `let ... else` guards that return errors. Fixed to match the DELETE/INSERT pattern.

- **Silent data loss on first batch decode in distributed writes**: `write_through.rs` line 199 used `.ok()` to discard decode errors on the first `FlightData` message, silently dropping all rows in that batch. Subsequent batches correctly propagated errors via `.context(DecodeBatchSnafu)?`. Fixed to use proper error propagation.

- **Inconsistent `nulls_first` in search score sort**: `SearchQueryProvider` in `provider.rs` used `nulls_first=true` for the score descending sort, while `pipeline.rs` and `reciprocal_rank.rs` used `nulls_first=false`. This meant null scores would rank highest in one code path but lowest in others. Fixed to use `nulls_last` consistently.

## Test plan

- [x] Added regression test `test_sort_matches_deterministic_composite_pk` verifying deterministic ordering with composite primary keys
- [x] `cargo check -p runtime --lib` passes
- [x] `cargo check -p search --lib` passes
- [ ] CI passes