### PR TITLE
ci: Split pr-develop into parallel check and build-and-test jobs

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -24,10 +24,11 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
-  pr-develop:
-    name: Lint, Build, and Test (Develop)
+  check-changes:
+    name: Check for code changes
     runs-on: spiceai-macos
-
+    outputs:
+      relevant_changes: ${{ steps.check.outputs.relevant_changes }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -37,65 +38,70 @@ jobs:
         id: check
         uses: ./.github/actions/check-code-changes
 
-      - name: Cache Cargo registry
-        if: steps.check.outputs.relevant_changes == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+  check:
+    name: Check (Develop)
+    needs: check-changes
+    if: needs.check-changes.outputs.relevant_changes == 'true'
+    runs-on: spiceai-macos
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Rust
-        if: steps.check.outputs.relevant_changes == 'true'
+        uses: ./.github/actions/setup-rust
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up cc
+        uses: ./.github/actions/setup-cc
+
+      - name: Run cargo check
+        run: cargo check --all-targets --features adbc,aws-secrets-manager,keyring-secret-store,models,release,mcp --workspace --exclude libnfs --locked
+
+      - name: Validate datafusion-table-providers commit
+        run: bash .github/scripts/validate_table_providers_commit.sh
+        env:
+          BRANCH: spiceai-52
+
+  build-and-test:
+    name: Build and Test (Develop)
+    needs: check-changes
+    if: needs.check-changes.outputs.relevant_changes == 'true'
+    runs-on: spiceai-macos
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
       - name: Set up Nextest
-        if: steps.check.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-nextest
 
       - name: Install Protoc
-        if: steps.check.outputs.relevant_changes == 'true'
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up make
-        if: steps.check.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-make
 
       - name: Set up cc
-        if: steps.check.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-cc
 
-      # Check
-      - name: Run cargo check
-        if: steps.check.outputs.relevant_changes == 'true'
-        run: cargo check --all-targets --features adbc,aws-secrets-manager,keyring-secret-store,models,release,mcp --workspace --exclude libnfs --locked
-
-      - name: Validate datafusion-table-providers commit
-        if: steps.check.outputs.relevant_changes == 'true'
-        run: bash .github/scripts/validate_table_providers_commit.sh
-        env:
-          BRANCH: spiceai-52
-
-      # Build and Test (exclude nfs and secret-dependent packages)
       - name: Build CLI and run nextest
-        if: steps.check.outputs.relevant_changes == 'true'
         run: make build-cli nextest
         env:
           RUST_PROFILE: ${{ env.RUST_PROFILE }}
           NEXTEST_FLAG: "--exclude libnfs --exclude connector-nfs -E 'not (package(aws-sdk-credential-bridge) | package(object_store_occ))'"
 
       - name: Build testoperator
-        if: steps.check.outputs.relevant_changes == 'true'
         run: cargo build -p testoperator --all-features --locked
 
       - name: Check if Cargo.lock is updated
-        if: steps.check.outputs.relevant_changes == 'true'
         run: |
           if git diff --exit-code Cargo.lock; then
             echo "Cargo.lock is up to date"

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -24,7 +24,7 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
-  check-changes:
+  check_changes:
     name: Check for code changes
     runs-on: spiceai-macos
     outputs:
@@ -40,8 +40,8 @@ jobs:
 
   check:
     name: Check (Develop)
-    needs: check-changes
-    if: needs.check-changes.outputs.relevant_changes == 'true'
+    needs: check_changes
+    if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
 
     steps:
@@ -68,8 +68,8 @@ jobs:
 
   build-and-test:
     name: Build and Test (Develop)
-    needs: check-changes
-    if: needs.check-changes.outputs.relevant_changes == 'true'
+    needs: check_changes
+    if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
 
     steps:


### PR DESCRIPTION
## Changes

- **Split single CI job into parallel jobs** for faster wall-clock time:
  - `check`: `cargo check` + datafusion-table-providers commit validation
  - `build-and-test`: CLI build, nextest, testoperator build, Cargo.lock check
- **Remove Cargo registry cache steps** — unnecessary overhead on self-hosted `spiceai-macos` runners (registry already persists on disk)
- **Add lightweight `check-changes` gate job** to skip both jobs when only docs/non-code files change