### PR TITLE
fix: Use truncated scores for deterministic search snapshot ordering

### DIFF
--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -195,10 +195,14 @@ fn normalize_search_response(mut json: Value) -> String {
                 return Ordering::Less;
             };
 
-            // Opposite because we want to order descendingly
-            if score_a > score_b {
+            // Compare truncated scores (matching the display precision) to ensure
+            // deterministic ordering when displayed scores are the same, regardless
+            // of minor floating-point differences across different machines.
+            let truncated_a = (100.0 * score_a).trunc() / 100.0;
+            let truncated_b = (100.0 * score_b).trunc() / 100.0;
+            if truncated_a > truncated_b {
                 return Ordering::Less;
-            } else if score_a < score_b {
+            } else if truncated_a < truncated_b {
                 return Ordering::Greater;
             }
 

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
@@ -12,12 +12,12 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multiple_columns",
       "matches": {
-        "cp_department": [
-          "DEPARTMENT"
+        "cp_description": [
+          "Programmes receive just likely, key homes. Relevant,"
         ]
       },
       "primary_key": {
-        "cp_catalog_page_sk": 2
+        "cp_catalog_page_sk": 11
       }
     },
     {
@@ -27,12 +27,12 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multiple_columns",
       "matches": {
-        "cp_description": [
-          "Programmes receive just likely, key homes. Relevant,"
+        "cp_department": [
+          "DEPARTMENT"
         ]
       },
       "primary_key": {
-        "cp_catalog_page_sk": 11
+        "cp_catalog_page_sk": 1
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
@@ -9,24 +9,24 @@ expression: normalize_search_response(resp)
       "_score": "0.01",
       "dataset": "multiple_columns",
       "matches": {
-        "cp_department": [
-          "DEPARTMENT"
-        ]
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 2
-      }
-    },
-    {
-      "_score": "0.01",
-      "dataset": "multiple_columns",
-      "matches": {
         "cp_description": [
           "Programmes receive just likely, key homes. Relevant,"
         ]
       },
       "primary_key": {
         "cp_catalog_page_sk": 11
+      }
+    },
+    {
+      "_score": "0.01",
+      "dataset": "multiple_columns",
+      "matches": {
+        "cp_department": [
+          "DEPARTMENT"
+        ]
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Compare truncated (display-precision) scores in `normalize_search_response` instead of raw floating-point scores, preventing non-deterministic ordering when raw scores differ slightly across machines but display identically after truncation to 2 decimal places
- Update `multi_embedding_parent_child` snapshots to reflect the deterministic SQL-level tie-breaking (`ORDER BY score DESC, pk ASC`), which returns `pk=1` instead of `pk=2` for the department match

## Test plan
- [x] `make lint` passes locally
- [ ] CI checks pass on PR