### PR TITLE
Update autogenerated PR base branch to develop in GitHub workflows

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -25,7 +25,7 @@ jobs:
         id: check_pr
         run: |
           existing_pr=$(gh pr list \
-            --base trunk \
+            --base develop \
             --json title,headRefName \
             --jq '.[] | select(.title=="Update openapi.json")')
 

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -40,7 +40,7 @@ jobs:
             git add acknowledgements.md
             git commit -m "Update acknowledgements"
             git push origin acknowledgements/${GITHUB_RUN_ID}
-            gh pr create --title "Update acknowledgements" --body "Updated OSS acknowledgements" --base trunk --head acknowledgements/${GITHUB_RUN_ID}
+            gh pr create --title "Update acknowledgements" --body "Updated OSS acknowledgements" --base develop --head acknowledgements/${GITHUB_RUN_ID}
           else
             echo "No changes detected"
           fi

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -78,7 +78,7 @@ jobs:
             git add .schema/spicepod.schema.json
             git commit -m "Update spicepod.schema.json"
             git push origin schema/${GITHUB_RUN_ID}
-            gh pr create --title "Update spicepod.schema.json" --body "Updated Spicepod Schema" --base trunk --head schema/${GITHUB_RUN_ID}
+            gh pr create --title "Update spicepod.schema.json" --body "Updated Spicepod Schema" --base develop --head schema/${GITHUB_RUN_ID}
           else
             echo "No changes detected"
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_adbc.yml
+++ b/.github/workflows/integration_adbc.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -9,6 +9,13 @@ on:
       - release/*
     paths:
       - 'crates/llms/**'
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+    paths:
+      - 'crates/llms/**'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -496,7 +496,7 @@ jobs:
           **Profile:** \`${{ github.event.inputs.profile_option || 'release' }}\`
           EOF
           )
-              gh pr create --title "fix: Update ${{ github.event.inputs.query_set }} benchmark snapshots for ${{ github.event.inputs.spicepod_path }}" --body "${BODY}" --base trunk --head ${BRANCH_NAME} --label kind/bug
+              gh pr create --title "fix: Update ${{ github.event.inputs.query_set }} benchmark snapshots for ${{ github.event.inputs.spicepod_path }}" --body "${BODY}" --base develop --head ${BRANCH_NAME} --label kind/bug
               gh pr merge --squash --auto ${BRANCH_NAME}
             fi
           fi

--- a/.github/workflows/testoperator_run_schema.yml
+++ b/.github/workflows/testoperator_run_schema.yml
@@ -278,7 +278,7 @@ jobs:
               echo "PR already exists -> ${PR_URL}"
               exit 0
             else
-              gh pr create --title "fix: Update schema snapshots" --body "Updates schema snapshots" --base trunk --head ${BRANCH_NAME} --label kind/bug
+              gh pr create --title "fix: Update schema snapshots" --body "Updates schema snapshots" --base develop --head ${BRANCH_NAME} --label kind/bug
             fi
           fi
         env:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to change their default pull request base branch from `trunk` to `develop`. This standardizes the workflow automation to target the `develop` branch for automated updates and PRs, ensuring that generated and updated files are merged into the correct branch as part of the development process.

**Workflow base branch updates:**

* Changed the base branch from `trunk` to `develop` for PRs created by the OpenAPI generation workflow in `.github/workflows/generate-openapi.yml`.
* Updated the acknowledgements generation workflow to target `develop` instead of `trunk` when creating PRs in `.github/workflows/generate_acknowledgements.yml`.
* Modified the JSON schema generation workflow to create PRs against `develop` rather than `trunk` in `.github/workflows/generate_json_schema.yml`.
* Changed the benchmark snapshot update workflow to use `develop` as the PR base branch in `.github/workflows/testoperator_run_bench.yml`.
* Updated the schema snapshot update workflow to create PRs against `develop` instead of `trunk` in `.github/workflows/testoperator_run_schema.yml`.