### PR TITLE
Merge develop to trunk (2026-03-29)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_adbc.yml
+++ b/.github/workflows/integration_adbc.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -89,7 +89,7 @@ jobs:
 
   build:
     name: Build Test Binary
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -127,7 +127,7 @@ jobs:
           retention-days: 1
 
   test:
-    runs-on: spiceai-dev-runners
+    runs-on: ${{ matrix.target.runner }}
     needs: [build, setup-matrix]
     strategy:
       matrix:

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -9,6 +9,13 @@ on:
       - release/*
     paths:
       - 'crates/llms/**'
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+    paths:
+      - 'crates/llms/**'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -8,6 +8,7 @@ on:
       - release/*
   pull_request:
     branches:
+      - trunk
       - release-*
       - release/*
       - feature-*


### PR DESCRIPTION
## Summary
Merge `develop` to `trunk` (2026-03-29).

### Commits
- `02f2455` ci: Add `merge_group` trigger to integration test workflows
- `f700873` fix: Update runner type for build and test jobs to improve compatibility

### Changes
| File | Change |
|------|--------|
| `.github/workflows/integration.yml` | Add `trunk` to `pull_request.branches` |
| `.github/workflows/integration_adbc.yml` | Add `trunk` to `pull_request.branches` |
| `.github/workflows/integration_llms.yml` | Add `pull_request` trigger with `trunk` branch and `crates/llms/**` path filter; update runner types (`spiceai-macos` for build, matrix runner for test) |
| `.github/workflows/integration_models.yml` | Add `trunk` to `pull_request.branches` |

## Test plan
- [x] `make lint` passes locally
- CI workflows validate YAML syntax and run integration tests