### PR TITLE
Improve sccache setup in CI workflows

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -3,7 +3,7 @@ description: 'composite action'
 
 inputs:
   minio_endpoint:
-    description: 'MinIO endpoint (used for Linux and Windows)'
+    description: 'MinIO endpoint (used for Linux and self-hosted macOS)'
     required: false
 
 runs:
@@ -43,25 +43,23 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        set -euo pipefail
-
-        cache_dir="${SCCACHE_DIR:-$HOME/.cache/sccache}"
-
-        # Use the runner-local cache directory instead of an S3-backed config.
         if ! command -v sccache &> /dev/null; then
           echo "Error: sccache is not installed on this macOS runner"
           exit 1
         fi
         sccache --version
 
-        mkdir -p "$cache_dir"
-        probe_file="$cache_dir/.sccache-probe-$$"
-        touch "$probe_file"
-        rm -f "$probe_file"
-
-        rm -f ~/.config/sccache/config
-
-        echo "SCCACHE_DIR=$cache_dir" >> $GITHUB_ENV
+        rm -rf ~/.config/sccache/config
+        mkdir -p ~/.config/sccache
+        cat <<EOF > ~/.config/sccache/config
+        [cache.s3]
+        bucket = "sccache"
+        endpoint = "http://localhost:9000"
+        use_ssl = false
+        server_side_encryption = false
+        no_credentials = false
+        region = "us-east-1"
+        EOF
 
     - name: Set up sccache (Windows)
       if: runner.os == 'Windows' && inputs.minio_endpoint != ''

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -3,15 +3,14 @@ description: 'composite action'
 
 inputs:
   minio_endpoint:
-    description: 'MinIO endpoint (used for Linux and self-hosted macOS)'
+    description: 'MinIO endpoint (used for Linux and Windows)'
     required: false
-    type: string
 
 runs:
   using: 'composite'
   steps:
     - name: Set sccache environment variables
-      if: inputs.minio_endpoint != ''
+      if: runner.os == 'macOS' || inputs.minio_endpoint != ''
       shell: bash
       run: |
         echo "SCCACHE_CACHE_SIZE=200G" >> $GITHUB_ENV
@@ -40,31 +39,29 @@ runs:
         region = "us-east-1"
         EOF
 
-    - name: Set up sccache (macOS - self-hosted only)
-      if: runner.os == 'macOS' && inputs.minio_endpoint != ''
+    - name: Set up sccache (macOS)
+      if: runner.os == 'macOS'
       shell: bash
       run: |
-        # Only self-hosted macOS runners use sccache (with localhost MinIO)
-        # GitHub-hosted macOS runners use actions cache instead
+        set -euo pipefail
 
-        # Verify sccache is installed
+        cache_dir="${SCCACHE_DIR:-$HOME/.cache/sccache}"
+
+        # Use the runner-local cache directory instead of an S3-backed config.
         if ! command -v sccache &> /dev/null; then
           echo "Error: sccache is not installed on this macOS runner"
           exit 1
         fi
         sccache --version
 
-        rm -rf ~/.config/sccache/config
-        mkdir -p ~/.config/sccache
-        cat <<EOF > ~/.config/sccache/config
-        [cache.s3]
-        bucket = "sccache"
-        endpoint = "http://localhost:9000"
-        use_ssl = false
-        server_side_encryption = false
-        no_credentials = false
-        region = "us-east-1"
-        EOF
+        mkdir -p "$cache_dir"
+        probe_file="$cache_dir/.sccache-probe-$$"
+        touch "$probe_file"
+        rm -f "$probe_file"
+
+        rm -f ~/.config/sccache/config
+
+        echo "SCCACHE_DIR=$cache_dir" >> $GITHUB_ENV
 
     - name: Set up sccache (Windows)
       if: runner.os == 'Windows' && inputs.minio_endpoint != ''

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
@@ -57,12 +60,17 @@ jobs:
         uses: ./.github/actions/setup-cc
 
       - name: Run cargo check
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
         run: cargo check --all-targets --features adbc,aws-secrets-manager,keyring-secret-store,models,release,mcp --workspace --exclude libnfs --locked
 
       - name: Validate datafusion-table-providers commit
         run: bash .github/scripts/validate_table_providers_commit.sh
         env:
           BRANCH: spiceai-52
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
   build-and-test:
     name: Build and Test (Develop)
@@ -75,6 +83,9 @@ jobs:
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
+
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -93,11 +104,17 @@ jobs:
       - name: Build CLI and run nextest
         run: make build-cli nextest
         env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           RUST_PROFILE: ${{ env.RUST_PROFILE }}
           NEXTEST_FLAG: "--exclude libnfs --exclude connector-nfs -E 'not (package(aws-sdk-credential-bridge) | package(object_store_occ))'"
 
       - name: Build testoperator
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
         run: cargo build -p testoperator --all-features --locked
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Check if Cargo.lock is updated
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -225,6 +225,10 @@ jobs:
 
       - name: Build testoperator
         if: needs.check_changes.outputs.relevant_changes == 'true'
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
         run: cargo build -p testoperator --all-features --locked
 
       - name: Show sccache stats


### PR DESCRIPTION
## Summary
- add sccache setup and stats reporting to the macOS jobs in pr-develop
- ensure the pr.yml testoperator build uses the configured sccache wrapper and credentials
- update the shared setup-sccache action so macOS runners use a local cache directory instead of the localhost S3-style config

## Testing
- not run (workflow-only changes)