### PR TITLE
fix: Fix data correctness bugs in DynamoDB decimal conversion and GraphQL pagination

### DIFF
--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -664,7 +664,7 @@ impl TableProvider for DynamoDBTableProvider {
                 partition_key: self.table_schema.partition_key().to_string(),
                 sort_key: self.table_schema.sort_key().map(ToString::to_string),
                 time_format: self.table_schema.time_format(),
-                filters: filters,
+                filters,
                 parallelism: self.write_parallelism,
             },
         ))))

--- a/crates/data_components/src/dynamodb/utils.rs
+++ b/crates/data_components/src/dynamodb/utils.rs
@@ -80,14 +80,35 @@ pub fn scalar_to_attribute_value(
                 let divisor = 10_i128.pow(scale_u32);
                 let whole = v / divisor;
                 let frac = (v % divisor).unsigned_abs();
-                format!("{whole}.{frac:0>width$}", width = scale_u32 as usize)
+                // When the value is negative but |v| < divisor, whole is 0 and
+                // the sign would be lost. Emit an explicit "-" prefix.
+                let sign = if *v < 0 && whole == 0 { "-" } else { "" };
+                format!("{sign}{whole}.{frac:0>width$}", width = scale_u32 as usize)
             } else {
                 v.to_string()
             };
             Ok(AttributeValue::N(s))
         }
-        ScalarValue::Decimal256(Some(v), _precision, _scale) => {
-            Ok(AttributeValue::N(format!("{v}")))
+        ScalarValue::Decimal256(Some(v), _precision, scale) => {
+            let scale = *scale;
+            let s = if scale > 0 {
+                let scale_u32 = u32::try_from(scale).unwrap_or(0);
+                let divisor = arrow::datatypes::i256::from_i128(10_i128.pow(scale_u32));
+                let whole = v.wrapping_div(divisor);
+                let frac = v.wrapping_rem(divisor).wrapping_abs();
+                // Same sign-loss fix as Decimal128.
+                let sign = if v.is_negative() && whole == arrow::datatypes::i256::ZERO {
+                    "-"
+                } else {
+                    ""
+                };
+                // i256::Display does not forward fill/width, so convert first.
+                let frac_str = format!("{frac}");
+                format!("{sign}{whole}.{frac_str:0>width$}", width = scale_u32 as usize)
+            } else {
+                format!("{v}")
+            };
+            Ok(AttributeValue::N(s))
         }
         ScalarValue::Boolean(Some(b)) => Ok(AttributeValue::Bool(*b)),
         ScalarValue::Date32(Some(days)) => {
@@ -248,5 +269,113 @@ impl<'n> TreeNodeVisitor<'n> for FilterStringVisitor<'_> {
                 Ok(TreeNodeRecursion::Stop)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_dynamodb::types::AttributeValue;
+
+    fn assert_number(scalar: &ScalarValue, expected: &str) {
+        let result = scalar_to_attribute_value(scalar, "%Y-%m-%dT%H:%M:%S%z").unwrap();
+        match result {
+            AttributeValue::N(n) => assert_eq!(n, expected, "for scalar {scalar:?}"),
+            other => panic!("Expected AttributeValue::N, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal128 regression tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decimal128_positive_whole_and_fraction() {
+        // 12345 with scale 2 → 123.45
+        let scalar = ScalarValue::Decimal128(Some(12345), 10, 2);
+        assert_number(&scalar, "123.45");
+    }
+
+    #[test]
+    fn decimal128_negative_whole_and_fraction() {
+        // -12345 with scale 2 → -123.45
+        let scalar = ScalarValue::Decimal128(Some(-12345), 10, 2);
+        assert_number(&scalar, "-123.45");
+    }
+
+    #[test]
+    fn decimal128_negative_fraction_only() {
+        // Regression: -5 with scale 1 → -0.5 (sign must not be lost)
+        let scalar = ScalarValue::Decimal128(Some(-5), 10, 1);
+        assert_number(&scalar, "-0.5");
+    }
+
+    #[test]
+    fn decimal128_negative_small_fraction() {
+        // -1 with scale 2 → -0.01
+        let scalar = ScalarValue::Decimal128(Some(-1), 10, 2);
+        assert_number(&scalar, "-0.01");
+    }
+
+    #[test]
+    fn decimal128_positive_fraction_only() {
+        // 5 with scale 1 → 0.5
+        let scalar = ScalarValue::Decimal128(Some(5), 10, 1);
+        assert_number(&scalar, "0.5");
+    }
+
+    #[test]
+    fn decimal128_zero() {
+        let scalar = ScalarValue::Decimal128(Some(0), 10, 2);
+        assert_number(&scalar, "0.00");
+    }
+
+    #[test]
+    fn decimal128_no_scale() {
+        let scalar = ScalarValue::Decimal128(Some(42), 10, 0);
+        assert_number(&scalar, "42");
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal256 regression tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decimal256_positive_with_scale() {
+        // 12345 with scale 2 → 123.45
+        let v = arrow::datatypes::i256::from_i128(12345);
+        let scalar = ScalarValue::Decimal256(Some(v), 20, 2);
+        assert_number(&scalar, "123.45");
+    }
+
+    #[test]
+    fn decimal256_negative_with_scale() {
+        // -12345 with scale 2 → -123.45
+        let v = arrow::datatypes::i256::from_i128(-12345);
+        let scalar = ScalarValue::Decimal256(Some(v), 20, 2);
+        assert_number(&scalar, "-123.45");
+    }
+
+    #[test]
+    fn decimal256_negative_fraction_only() {
+        // -5 with scale 1 → -0.5
+        let v = arrow::datatypes::i256::from_i128(-5);
+        let scalar = ScalarValue::Decimal256(Some(v), 20, 1);
+        assert_number(&scalar, "-0.5");
+    }
+
+    #[test]
+    fn decimal256_no_scale() {
+        // No scale → raw integer
+        let v = arrow::datatypes::i256::from_i128(42);
+        let scalar = ScalarValue::Decimal256(Some(v), 20, 0);
+        assert_number(&scalar, "42");
+    }
+
+    #[test]
+    fn decimal256_zero_with_scale() {
+        let v = arrow::datatypes::i256::from_i128(0);
+        let scalar = ScalarValue::Decimal256(Some(v), 20, 3);
+        assert_number(&scalar, "0.000");
     }
 }

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -416,7 +416,12 @@ impl PaginationParameters {
                 }
                 graphql_parser::query::Selection::Field(field) => {
                     let field_name = field.name.as_ref();
-                    let new_path = format!("{current_path}/{field_name}");
+                    // Use alias when present — the JSON response uses aliases as keys.
+                    let response_key = field
+                        .alias
+                        .as_ref()
+                        .map_or_else(|| field_name, |a| a.as_ref());
+                    let new_path = format!("{current_path}/{response_key}");
 
                     // End of recursion, `pageInfo` field found
                     if field_name == "pageInfo" {
@@ -444,8 +449,13 @@ impl PaginationParameters {
                             );
                         }
 
-                        let json_pointer =
-                            data_field.map(|f| format!("/data{current_path}/{}", f.name.as_ref()));
+                        let json_pointer = data_field.map(|f| {
+                            let key = f
+                                .alias
+                                .as_ref()
+                                .map_or_else(|| f.name.as_ref(), |a| a.as_ref());
+                            format!("/data{current_path}/{key}")
+                        });
 
                         let pagination_argument =
                             match TryInto::<PaginationArgument>::try_into(parent_field) {
@@ -1662,6 +1672,42 @@ mod tests {
                         ],
                     }),
                     Some("/data/paginatedUsers/users".into()),
+                ),
+            },
+            TestPaginationParseCase {
+                name: "Aliased field with pageInfo uses alias in path",
+                query: r#"
+                    query {
+                        repository(owner: "org", name: "repo") {
+                            selected_ref: defaultBranchRef {
+                                target {
+                                    ... on Commit {
+                                        history(first: 100) {
+                                            pageInfo {
+                                                hasNextPage
+                                                endCursor
+                                            }
+                                            nodes {
+                                                oid
+                                                message
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                "#,
+                expected: (
+                    Some(PaginationParameters {
+                        resource_name: "history".to_owned(),
+                        pagination_argument: super::PaginationArgument::First(100),
+                        page_info_path: Some(
+                            "/repository/selected_ref/target/history/pageInfo".to_owned(),
+                        ),
+                        other_arguments: vec![],
+                    }),
+                    Some("/data/repository/selected_ref/target/history/nodes".into()),
                 ),
             },
         ];


### PR DESCRIPTION
## Summary

Fixes three data correctness bugs found during automated audit of commits from the last 24 hours:

- **DynamoDB `Decimal128` sign loss** (#9915): Negative values in the range `(-1, 0)` (e.g., `-0.5`) were stored with incorrect sign. Integer division truncated the whole part to `0`, losing the negative prefix. For example, `Decimal128(-5, 10, 1)` produced `"0.5"` instead of `"-0.5"`.

- **DynamoDB `Decimal256` scale ignored** (#9915): The `scale` parameter was completely ignored for `Decimal256` values, causing them to be stored as raw unscaled integers. For example, a value of `12345` with `scale=2` (representing `123.45`) was stored as `"12345"`.

- **GraphQL pagination with aliased fields** (#10023): `PaginationParameters::find_in_selection_set` built the `page_info_path` using GraphQL field names instead of aliases. For the GitHub commits query which uses `selected_ref: defaultBranchRef`, the cursor lookup searched for `/defaultBranchRef/` but the JSON response uses `/selected_ref/`, causing pagination to silently stop after the first page (max 100 commits returned).

Also fixes a pre-existing clippy lint (`redundant_field_names`) in `provider.rs`.

## Test plan

- [x] Added 12 regression tests for `scalar_to_attribute_value` covering `Decimal128` and `Decimal256` edge cases (positive, negative, fraction-only, zero, no-scale)
- [x] Added regression test for aliased field pagination path resolution
- [x] All existing `data_components` tests pass (`cargo test -p data_components --features dynamodb`)
- [x] Clippy passes with `-D warnings`