### PR TITLE
Implement RefreshDataset for distributed control stream

### DIFF
--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -114,6 +114,7 @@ message SchedulerControlMessage {
         PollNowCommand poll_now = 2;
         UpdatePartitions update_partitions = 3;
         CancelTasksCommand cancel_tasks = 4;
+        RefreshDatasetCommand refresh_dataset = 5;
     }
 }
 
@@ -160,6 +161,14 @@ message TaskCancelInfo {
     string job_id = 2;
     uint32 stage_id = 3;
     uint32 partition_id = 4;
+}
+
+// Command sent from scheduler to executor to refresh a specific dataset.
+message RefreshDatasetCommand {
+    // The dataset name (as a TableReference string, e.g. "taxi_trips").
+    string dataset_name = 1;
+    // Optional JSON-serialized RefreshOverrides.
+    optional string overrides_json = 2;
 }
 
 // Heartbeat message sent by executor to scheduler.

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -761,14 +761,23 @@ impl Builder {
 
         refresher.with_s3_express_acceleration(self.is_s3_express_acceleration);
 
-        let refresh_handle = if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {
-            // Accelerated tables aren't accelerated on scheduler. Immediately ready.
-            self.runtime_status
-                .update_dataset(&self.dataset_name, status::ComponentStatus::Ready);
-            None
-        } else {
-            refresher.start(acceleration_refresh_mode).await?
-        };
+        let (refresh_handle, refresh_trigger) =
+            if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {
+                // Accelerated tables aren't accelerated on scheduler. Immediately ready.
+                // Set refresh_trigger to None because the receiver will be dropped
+                // (refresher.start() is not called), making the channel dead.
+                self.runtime_status
+                    .update_dataset(&self.dataset_name, status::ComponentStatus::Ready);
+                // Notify immediately so schedule creation doesn't block waiting for
+                // a refresh that will never happen locally on the scheduler.
+                on_complete_notification.notify_waiters();
+                (None, None)
+            } else {
+                (
+                    refresher.start(acceleration_refresh_mode).await?,
+                    refresh_trigger,
+                )
+            };
         let refresher = Arc::new(refresher);
 
         let mut handlers = vec![];

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -66,9 +66,8 @@ pub type PartitionUpdateHandler = Arc<
 /// The handler takes two arguments:
 /// 1. `dataset_name`: The dataset name to refresh.
 /// 2. `overrides_json`: Optional JSON-serialized `RefreshOverrides`.
-pub type RefreshDatasetHandler = Arc<
-    dyn Fn(String, Option<String>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
->;
+pub type RefreshDatasetHandler =
+    Arc<dyn Fn(String, Option<String>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 /// Handle for a single control stream connection to a scheduler.
 struct ControlStreamHandle {
@@ -446,9 +445,7 @@ async fn handle_scheduler_message(
             if let Some(handler) = refresh_dataset_handler {
                 handler(cmd.dataset_name, cmd.overrides_json).await;
             } else {
-                tracing::warn!(
-                    "Received RefreshDataset command but no handler is registered"
-                );
+                tracing::warn!("Received RefreshDataset command but no handler is registered");
             }
         }
     }

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -61,6 +61,15 @@ pub type PartitionUpdateHandler = Arc<
         + Sync,
 >;
 
+/// Callback type for when an executor receives a dataset refresh command from the scheduler.
+///
+/// The handler takes two arguments:
+/// 1. `dataset_name`: The dataset name to refresh.
+/// 2. `overrides_json`: Optional JSON-serialized `RefreshOverrides`.
+pub type RefreshDatasetHandler = Arc<
+    dyn Fn(String, Option<String>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+>;
+
 /// Handle for a single control stream connection to a scheduler.
 struct ControlStreamHandle {
     cancel: CancellationToken,
@@ -86,11 +95,13 @@ fn spawn_control_stream(
     poll_now_notify: Arc<Notify>,
     outbound_tx_state: Arc<RwLock<Option<mpsc::Sender<ExecutorControlMessage>>>>,
     partition_update_handler: Option<&PartitionUpdateHandler>,
+    refresh_dataset_handler: Option<&RefreshDatasetHandler>,
 ) -> ControlStreamHandle {
     let cancel = CancellationToken::new();
     let token = cancel.clone();
     let outbound_tx_state_for_task = Arc::clone(&outbound_tx_state);
     let partition_update_handler = partition_update_handler.cloned();
+    let refresh_dataset_handler = refresh_dataset_handler.cloned();
 
     let task = tokio::spawn(async move {
         let tls_enabled = client_tls_config.is_some();
@@ -271,6 +282,7 @@ fn spawn_control_stream(
                                         executor.as_deref(),
                                         &poll_now_notify,
                                         partition_update_handler.as_ref(),
+                                        refresh_dataset_handler.as_ref(),
                                     )
                                     .await;
                                 }
@@ -326,6 +338,7 @@ async fn handle_scheduler_message(
     executor: Option<&Executor>,
     poll_now_notify: &Notify,
     partition_update_handler: Option<&PartitionUpdateHandler>,
+    refresh_dataset_handler: Option<&RefreshDatasetHandler>,
 ) {
     match message {
         SchedulerMessage::RequestMetrics(request) => {
@@ -424,6 +437,20 @@ async fn handle_scheduler_message(
                 }
             }
         }
+        SchedulerMessage::RefreshDataset(cmd) => {
+            tracing::info!(
+                dataset = %cmd.dataset_name,
+                "Received RefreshDataset from scheduler {scheduler_address}"
+            );
+
+            if let Some(handler) = refresh_dataset_handler {
+                handler(cmd.dataset_name, cmd.overrides_json).await;
+            } else {
+                tracing::warn!(
+                    "Received RefreshDataset command but no handler is registered"
+                );
+            }
+        }
     }
 }
 
@@ -454,6 +481,8 @@ pub struct ControlStreamManager {
     poll_now_notify: Arc<Notify>,
     /// Callback handler for partition updates.
     partition_update_handler: Option<PartitionUpdateHandler>,
+    /// Callback handler for dataset refresh commands.
+    refresh_dataset_handler: Option<RefreshDatasetHandler>,
 }
 
 impl ControlStreamManager {
@@ -466,6 +495,7 @@ impl ControlStreamManager {
         metrics_reader: Option<MetricsReader>,
         partition_update_handler: Option<PartitionUpdateHandler>,
         executor: Option<Arc<Executor>>,
+        refresh_dataset_handler: Option<RefreshDatasetHandler>,
     ) -> Self {
         Self {
             executor_id,
@@ -477,6 +507,7 @@ impl ControlStreamManager {
             known_schedulers: HashSet::new(),
             poll_now_notify: Arc::new(Notify::new()),
             partition_update_handler,
+            refresh_dataset_handler,
         }
     }
 
@@ -559,6 +590,7 @@ impl ControlStreamManager {
                 Arc::clone(&self.poll_now_notify),
                 Arc::clone(&outbound_tx_state),
                 self.partition_update_handler.as_ref(),
+                self.refresh_dataset_handler.as_ref(),
             );
             self.streams.insert(address, handle);
         }
@@ -641,6 +673,7 @@ mod tests {
             None, // no metrics reader
             None,
             None,
+            None,
         );
         assert!(manager.known_schedulers.is_empty());
         assert!(manager.streams.is_empty());
@@ -657,6 +690,7 @@ mod tests {
             Some(reader),
             None,
             None,
+            None,
         );
         assert!(manager.metrics_reader.is_some());
     }
@@ -666,6 +700,7 @@ mod tests {
         let mut manager = ControlStreamManager::new(
             "executor-1".to_string(),
             "executor-1".to_string(),
+            None,
             None,
             None,
             None,
@@ -681,6 +716,7 @@ mod tests {
         let mut manager = ControlStreamManager::new(
             "executor-1".to_string(),
             "executor-1".to_string(),
+            None,
             None,
             None,
             None,

--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -232,7 +232,9 @@ impl ExecutorRegistry {
             })?;
             Ok(())
         } else {
-            tracing::error!("Failed to send command to executor: missing executor '{executor_id}' in registry");
+            tracing::error!(
+                "Failed to send command to executor: missing executor '{executor_id}' in registry"
+            );
             Err(Error::SendFailed {
                 executor_id: executor_id.to_string(),
             })

--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -224,11 +224,15 @@ impl ExecutorRegistry {
             let tx = connection.request_tx.clone();
             drop(connections);
 
-            tx.send(command).await.map_err(|_| Error::SendFailed {
-                executor_id: executor_id.to_string(),
+            tx.send(command).await.map_err(|e| {
+                tracing::error!("Failed to send command to executor {executor_id}: {e}");
+                Error::SendFailed {
+                    executor_id: executor_id.to_string(),
+                }
             })?;
             Ok(())
         } else {
+            tracing::error!("Failed to send command to executor: missing executor '{executor_id}' in registry");
             Err(Error::SendFailed {
                 executor_id: executor_id.to_string(),
             })

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1232,6 +1232,40 @@ pub async fn initialize_cluster_executor(
         })
     }));
 
+    let refresh_dataset_handler_rt = Arc::clone(&rt);
+    let refresh_dataset_handler: Option<
+        crate::cluster::control_stream_client::RefreshDatasetHandler,
+    > = Some(Arc::new(move |dataset_name, overrides_json| {
+        let rt = Arc::clone(&refresh_dataset_handler_rt);
+        Box::pin(async move {
+            let dataset_ref =
+                ::datafusion::sql::TableReference::parse_str(&dataset_name);
+            let overrides = overrides_json.and_then(|json| {
+                serde_json::from_str(&json)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "Failed to deserialize refresh overrides for {dataset_name}: {e}"
+                        );
+                        e
+                    })
+                    .ok()
+            });
+
+            match rt.datafusion().refresh_table(&dataset_ref, overrides).await {
+                Ok(_) => {
+                    tracing::info!(
+                        "Successfully triggered refresh for dataset '{dataset_name}'"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to refresh dataset '{dataset_name}': {e}"
+                    );
+                }
+            }
+        })
+    }));
+
     // Thread to handle:
     //  - periodic refresh of scheduler membership
     //  - spawning/stopping scheduler poll loops as membership changes
@@ -1248,6 +1282,7 @@ pub async fn initialize_cluster_executor(
             control_stream_metrics_reader,
             partition_update_handler,
             Some(Arc::clone(&executor_for_manager)),
+            refresh_dataset_handler,
         );
 
         // Get the shared poll_now notify handle from the control stream manager.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1238,8 +1238,7 @@ pub async fn initialize_cluster_executor(
     > = Some(Arc::new(move |dataset_name, overrides_json| {
         let rt = Arc::clone(&refresh_dataset_handler_rt);
         Box::pin(async move {
-            let dataset_ref =
-                ::datafusion::sql::TableReference::parse_str(&dataset_name);
+            let dataset_ref = ::datafusion::sql::TableReference::parse_str(&dataset_name);
             let overrides = overrides_json.and_then(|json| {
                 serde_json::from_str(&json)
                     .map_err(|e| {
@@ -1253,14 +1252,10 @@ pub async fn initialize_cluster_executor(
 
             match rt.datafusion().refresh_table(&dataset_ref, overrides).await {
                 Ok(_) => {
-                    tracing::info!(
-                        "Successfully triggered refresh for dataset '{dataset_name}'"
-                    );
+                    tracing::info!("Successfully triggered refresh for dataset '{dataset_name}'");
                 }
                 Err(e) => {
-                    tracing::error!(
-                        "Failed to refresh dataset '{dataset_name}': {e}"
-                    );
+                    tracing::error!("Failed to refresh dataset '{dataset_name}': {e}");
                 }
             }
         })

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1949,14 +1949,16 @@ impl DataFusion {
         overrides: &Option<RefreshOverrides>,
     ) -> Result<Option<Arc<Notify>>> {
         let overrides_json = match overrides {
-            Some(o) => Some(serde_json::to_string(o).map_err(|_| {
-                Error::UnableToTriggerRefresh {
-                    dataset_name: dataset_name.to_string(),
-                    source: crate::accelerated_table::Error::FailedToTriggerRefresh {
-                        source: tokio::sync::mpsc::error::SendError(None),
-                    },
-                }
-            })?),
+            Some(o) => {
+                Some(
+                    serde_json::to_string(o).map_err(|_| Error::UnableToTriggerRefresh {
+                        dataset_name: dataset_name.to_string(),
+                        source: crate::accelerated_table::Error::FailedToTriggerRefresh {
+                            source: tokio::sync::mpsc::error::SendError(None),
+                        },
+                    })?,
+                )
+            }
             None => None,
         };
 
@@ -1985,9 +1987,7 @@ impl DataFusion {
                 .send_command(executor_id, command.clone())
                 .await
             {
-                tracing::warn!(
-                    "Failed to send refresh command to executor {executor_id}: {e}"
-                );
+                tracing::warn!("Failed to send refresh command to executor {executor_id}: {e}");
                 failures.push(executor_id.clone());
             }
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1908,6 +1908,19 @@ impl DataFusion {
         dataset_name: &TableReference,
         overrides: Option<RefreshOverrides>,
     ) -> Result<Option<Arc<Notify>>> {
+        // If we're a scheduler with an executor registry, forward refresh to executors
+        // instead of trying to refresh locally (the scheduler doesn't run refresh workers).
+        if matches!(
+            self.cluster_config.effective_role(),
+            Some(crate::config::ClusterRole::Scheduler)
+        ) {
+            if let Some(executor_registry) = &self.executor_registry {
+                return self
+                    .forward_refresh_to_executors(executor_registry, dataset_name, &overrides)
+                    .await;
+            }
+        }
+
         let table = self
             .get_accelerated_table_provider(dataset_name.to_string().as_str())
             .await?;
@@ -1925,6 +1938,74 @@ impl DataFusion {
             table_name: dataset_name.to_string(),
         }
         .fail()?
+    }
+
+    /// Forwards a dataset refresh command to all connected executors via the control stream.
+    /// Returns `Ok(None)` because the scheduler does not have a local notifier for executor refreshes.
+    async fn forward_refresh_to_executors(
+        &self,
+        executor_registry: &ExecutorRegistry,
+        dataset_name: &TableReference,
+        overrides: &Option<RefreshOverrides>,
+    ) -> Result<Option<Arc<Notify>>> {
+        let overrides_json = match overrides {
+            Some(o) => Some(serde_json::to_string(o).map_err(|_| {
+                Error::UnableToTriggerRefresh {
+                    dataset_name: dataset_name.to_string(),
+                    source: crate::accelerated_table::Error::FailedToTriggerRefresh {
+                        source: tokio::sync::mpsc::error::SendError(None),
+                    },
+                }
+            })?),
+            None => None,
+        };
+
+        let command = runtime_proto::SchedulerControlMessage {
+            message: Some(
+                runtime_proto::scheduler_control_message::Message::RefreshDataset(
+                    runtime_proto::RefreshDatasetCommand {
+                        dataset_name: dataset_name.to_string(),
+                        overrides_json,
+                    },
+                ),
+            ),
+        };
+
+        let executor_ids = executor_registry.connected_executors().await;
+        if executor_ids.is_empty() {
+            tracing::warn!(
+                "No executors connected to forward refresh for dataset '{dataset_name}'"
+            );
+            return Ok(None);
+        }
+
+        let mut failures = Vec::new();
+        for executor_id in &executor_ids {
+            if let Err(e) = executor_registry
+                .send_command(executor_id, command.clone())
+                .await
+            {
+                tracing::warn!(
+                    "Failed to send refresh command to executor {executor_id}: {e}"
+                );
+                failures.push(executor_id.clone());
+            }
+        }
+
+        if failures.is_empty() {
+            tracing::info!(
+                "Forwarded refresh for dataset '{dataset_name}' to {} executor(s)",
+                executor_ids.len()
+            );
+        } else {
+            tracing::warn!(
+                "Refresh for '{dataset_name}' failed for {}/{} executor(s)",
+                failures.len(),
+                executor_ids.len()
+            );
+        }
+
+        Ok(None)
     }
 
     pub async fn update_refresh_sql(

--- a/crates/runtime/tests/cluster/distributed_acceleration.rs
+++ b/crates/runtime/tests/cluster/distributed_acceleration.rs
@@ -662,6 +662,96 @@ async fn test_distributed_acceleration_join_two_partitioned_tables() -> Result<(
         .await
 }
 
+/// Test that `refresh_table()` on the scheduler forwards the refresh command to executors
+/// via the `RefreshDataset` control stream message, rather than failing with a
+/// "channel closed" error.
+///
+/// Verifies:
+/// - The scheduler detects it is in scheduler mode and forwards to executors
+/// - Executors receive the `RefreshDataset` command and trigger a local refresh
+/// - Data remains correct after the distributed refresh
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn test_distributed_refresh_forwarding() -> Result<(), anyhow::Error> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new("runtime=debug,info"))
+        .with_ansi(true)
+        .try_init();
+
+    for env_var in ["AWS_S3_VECTORS_KEY", "AWS_S3_VECTORS_SECRET"] {
+        verify_env_secret_exists(env_var)
+            .await
+            .map_err(anyhow::Error::msg)?;
+    }
+
+    let csv_tempdir = tempfile::tempdir().expect("csv tempdir");
+    let csv_path = csv_tempdir.path().join("test_data.csv");
+    tokio::fs::write(&csv_path, TEST_DATA_CSV)
+        .await
+        .expect("write test data");
+
+    test_request_context()
+        .scope(async {
+            configure_test_datafusion();
+            let app = AppBuilder::new("test_refresh_forwarding")
+                .with_dataset(make_memory_accelerated_dataset(
+                    format!("file:{}", csv_path.display()),
+                    "test_data",
+                    3,
+                    "id",
+                ))
+                .with_runtime(SpicepodRuntime {
+                    scheduler: Some(make_named_scheduler_config(
+                        "test_distributed_refresh_forwarding",
+                    )),
+                    ..SpicepodRuntime::default()
+                })
+                .build();
+
+            let harness = ClusterHarness::builder()
+                .scheduler(app)
+                .executors(1)
+                .start()
+                .await?;
+
+            harness.wait_for_executors(Duration::from_secs(15)).await?;
+            wait_for_row_count(&harness, "test_data", 10, Duration::from_secs(60)).await?;
+
+            // Trigger refresh from the scheduler. Previously this would fail with
+            // "the refresh worker is no longer running. channel closed" because the
+            // scheduler doesn't run local refresh workers. Now it forwards to executors.
+            let table_ref = datafusion::sql::TableReference::parse_str("test_data");
+            harness
+                .scheduler
+                .datafusion()
+                .refresh_table(&table_ref, None)
+                .await
+                .expect("refresh_table on scheduler should forward to executors");
+
+            // Allow time for the executor to process the refresh command.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+
+            // Verify data is still correct after refresh.
+            wait_for_row_count(&harness, "test_data", 10, Duration::from_secs(30)).await?;
+
+            let rows = harness
+                .query("SELECT COUNT(*) as cnt FROM test_data")
+                .await?;
+            let rows_fmt = arrow::util::pretty::pretty_format_batches(&rows).expect("format rows");
+            insta::assert_snapshot!(rows_fmt, @r"
+            +-----+
+            | cnt |
+            +-----+
+            | 10  |
+            +-----+
+            ");
+
+            harness.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📝 Summary

In distributed mode, calling `spice refresh <dataset>` on the scheduler failed with `the refresh worker is no longer running. channel closed` because the scheduler doesn't run local refresh workers but still held a dead channel sender.                                                  
                                                                                                                                                 
This PR:                                                                                                                                       
  - Adds a `RefreshDatasetCommand` to the `scheduler-executor` control stream proto                                                                  
  - Fixes the dead channel on the scheduler by setting `refresh_trigger = None` and immediately notifying the completion notifier (unblocking cron schedule creation)                                                                                                                            
  - Forwards refresh requests from the scheduler to all connected executors via the control stream                                               
  - Handles `RefreshDataset` on the executor side by triggering a local refresh

Closes https://github.com/spiceai/spiceai/issues/9597