### PR TITLE
Update datafusion-table-providers and datafusion-federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.4.2"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=09379a9#09379a9818b9e3fc10c0a52c7f6cb3fa99c1eaf8"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=7b37778211f37247823f0f17d929204cafe8c43c#7b37778211f37247823f0f17d929204cafe8c43c"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=fe0b78ff01a329448e3d533192967ba05a88cdd1#fe0b78ff01a329448e3d533192967ba05a88cdd1"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b2b9f54da35e9a4e0d9c0bd9f838066fc927bba6#b2b9f54da35e9a4e0d9c0bd9f838066fc927bba6"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ datafusion-common-runtime = "52.0.0"
 datafusion-datasource = "52.0.0"
 datafusion-execution = "52.0.0"
 datafusion-expr = "52.0.0"
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "09379a9", features = ["sql"] } # Must use short rev to match datafusion-table-providers
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7b37778211f37247823f0f17d929204cafe8c43c", features = ["sql"] } # Must use short rev to match datafusion-table-providers
 datafusion-functions = "52.0.0"
 datafusion-functions-json = "0.52"
 datafusion-physical-expr = "52.0.0"
@@ -392,7 +392,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "cdccd25339190aaae47740418f63f4e92c68fd8d" }                    # spiceai-52
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "cdccd25339190aaae47740418f63f4e92c68fd8d" }                # spiceai-52
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "fe0b78ff01a329448e3d533192967ba05a88cdd1" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b2b9f54da35e9a4e0d9c0bd9f838066fc927bba6" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52


### PR DESCRIPTION
Update `datafusion-federation` to point to https://github.com/spiceai/datafusion-federation/pull/66

Temporary solution until https://github.com/spiceai/datafusion-federation/pull/62 is finalized

Closes https://github.com/spiceai/spiceai/issues/8691