### PR TITLE
Lightweight object store pub/sub for cache invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12678,6 +12678,9 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid 1.21.0",
 ]
 
 [[package]]
@@ -19946,6 +19949,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/object_store_occ/Cargo.toml
+++ b/crates/object_store_occ/Cargo.toml
@@ -13,7 +13,10 @@ parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time", "rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/object_store_occ/src/lib.rs
+++ b/crates/object_store_occ/src/lib.rs
@@ -25,7 +25,7 @@ mod state;
 use snafu::Snafu;
 
 pub use local_conditional_put::LocalConditionalPut;
-pub use state::{InsertResult, ObjectState, UpdateResult, WriteResult};
+pub use state::{ChangeWatchHandle, InsertResult, ObjectState, UpdateResult, WriteResult};
 
 /// Errors that can occur during object state operations.
 #[derive(Debug, Snafu)]

--- a/crates/object_store_occ/src/state.rs
+++ b/crates/object_store_occ/src/state.rs
@@ -450,7 +450,7 @@ where
     ///
     /// [`conditional_refresh`]: Self::conditional_refresh
     pub fn spawn_change_watcher(self: &Arc<Self>, poll_interval: Duration) -> ChangeWatchHandle {
-        let signal_path = Path::from(format!("{}__signal.json", self.prefix));
+        let signal_path = Path::from(format!("{}__signal", self.prefix));
         // Enable signaling: subsequent writes will auto-publish to this path
         *self.signal_path.write() = Some(signal_path.clone());
 
@@ -892,7 +892,7 @@ mod tests {
             Arc::new(ObjectState::new(Arc::clone(&store)).with_prefix("test/"));
 
         // No signal file before watcher is spawned
-        let signal_path = Path::from("test/__signal.json");
+        let signal_path = Path::from("test/__signal");
         assert!(store.head(&signal_path).await.is_err());
 
         // Spawn watcher — this enables signaling

--- a/crates/object_store_occ/src/state.rs
+++ b/crates/object_store_occ/src/state.rs
@@ -17,13 +17,18 @@ limitations under the License.
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Duration;
 
 use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectStore, PutMode, PutOptions, UpdateVersion};
+use object_store::{
+    Error as ObjectStoreError, GetOptions, ObjectStore, PutMode, PutOptions, UpdateVersion,
+};
 use parking_lot::RwLock;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use snafu::ResultExt;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 
 use crate::{DeserializationSnafu, Error, ObjectStoreSnafu, Result, SerializationSnafu};
 
@@ -72,6 +77,9 @@ pub struct ObjectState<T> {
     prefix: String,
     cache: RwLock<HashMap<String, CachedEntry<T>>>,
     _marker: PhantomData<T>,
+    /// When set, successful writes auto-publish a change signal to this path.
+    /// Set by `spawn_change_watcher`.
+    signal_path: RwLock<Option<Path>>,
 }
 
 impl<T> std::fmt::Debug for ObjectState<T> {
@@ -86,7 +94,7 @@ impl<T> std::fmt::Debug for ObjectState<T> {
 
 impl<T> ObjectState<T>
 where
-    T: Serialize + DeserializeOwned + Clone + Send + Sync,
+    T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
 {
     /// Creates a new `ObjectState` with the given object store.
     #[must_use]
@@ -95,6 +103,7 @@ where
             store,
             prefix: String::new(),
             cache: RwLock::new(HashMap::new()),
+            signal_path: RwLock::new(None),
             _marker: PhantomData,
         }
     }
@@ -128,6 +137,7 @@ where
             Ok(result) => {
                 let version = UpdateVersion::from(result);
                 self.update_cache(key, value.clone(), version);
+                self.notify_change().await;
                 Ok(InsertResult::Ok)
             }
             Err(ObjectStoreError::AlreadyExists { .. }) => Ok(InsertResult::AlreadyExists),
@@ -173,6 +183,7 @@ where
             Ok(result) => {
                 let new_version = UpdateVersion::from(result);
                 self.update_cache(key, value.clone(), new_version);
+                self.notify_change().await;
                 Ok(UpdateResult::Ok)
             }
             Err(ObjectStoreError::Precondition { .. }) => {
@@ -334,6 +345,67 @@ where
         Ok(())
     }
 
+    /// Conditionally refresh the local cache using `If-None-Match`.
+    ///
+    /// For each key, sends a single `GET` with the cached `ETag`. The server returns
+    /// `304 Not Modified` (no body) if unchanged, or `200` with the new data if
+    /// changed — one round-trip per key either way.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if listing keys fails.
+    pub async fn conditional_refresh(&self) -> Result<()> {
+        let keys = self.list_keys().await?;
+
+        for key in keys {
+            // Ignore per-key errors — just skip failed entries
+            let _ = self.get_if_changed(&key).await;
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a key only if it has changed since the cached version.
+    ///
+    /// Uses a conditional GET with `If-None-Match`: if the remote `ETag` matches
+    /// the cached one, the server returns `304 Not Modified` (no body transfer).
+    /// Otherwise, the full object is returned and the cache is updated.
+    ///
+    /// Returns `true` if the entry was updated, `false` if unchanged.
+    async fn get_if_changed(&self, key: &str) -> Result<bool> {
+        let path = self.path(key);
+        let cached_etag = self.get_cached_version(key).and_then(|v| v.e_tag);
+
+        let opts = GetOptions {
+            if_none_match: cached_etag,
+            ..Default::default()
+        };
+
+        match self.store.get_opts(&path, opts).await {
+            Ok(result) => {
+                let version = UpdateVersion {
+                    e_tag: result.meta.e_tag.clone(),
+                    version: result.meta.version.clone(),
+                };
+                let bytes = result.bytes().await.context(ObjectStoreSnafu {
+                    key,
+                    operation: "get",
+                })?;
+                let value: T =
+                    serde_json::from_slice(&bytes).context(DeserializationSnafu { key })?;
+                self.update_cache(key, value, version);
+                Ok(true)
+            }
+            Err(ObjectStoreError::NotModified { .. }) => Ok(false),
+            Err(ObjectStoreError::NotFound { .. }) => Ok(false),
+            Err(source) => Err(Error::ObjectStore {
+                key: key.to_string(),
+                operation: "get",
+                source,
+            }),
+        }
+    }
+
     fn update_cache(&self, key: &str, value: T, version: UpdateVersion) {
         self.cache
             .write()
@@ -350,6 +422,160 @@ where
             .get(key)
             .map(|entry| entry.version.clone())
     }
+
+    /// Best-effort publish of a change signal when `signal_path` is configured.
+    async fn notify_change(&self) {
+        let path = self.signal_path.read().clone();
+        let Some(signal_path) = path else {
+            return;
+        };
+        if let Err(e) = publish_change_signal(&*self.store, &signal_path).await {
+            tracing::warn!(error = %e, "Failed to publish change signal");
+        }
+    }
+
+    /// Spawns a background task that polls a signal file and conditionally refreshes
+    /// the cache when the signal changes.
+    ///
+    /// The signal file is a lightweight change beacon: any write to it (by any
+    /// scheduler) changes its `ETag`. When the watcher detects an `ETag` change via a
+    /// `HEAD` request, it calls [`conditional_refresh`] to update only the entries
+    /// whose remote `ETag` differs from the cached version.
+    ///
+    /// Returns a [`ChangeWatchHandle`] that cancels the watcher when dropped.
+    ///
+    /// # Arguments
+    ///
+    /// * `poll_interval` — How often to poll the signal file.
+    ///
+    /// [`conditional_refresh`]: Self::conditional_refresh
+    pub fn spawn_change_watcher(self: &Arc<Self>, poll_interval: Duration) -> ChangeWatchHandle {
+        let signal_path = Path::from(format!("{}__signal.json", self.prefix));
+        // Enable signaling: subsequent writes will auto-publish to this path
+        *self.signal_path.write() = Some(signal_path.clone());
+
+        let cancel = CancellationToken::new();
+        let state = Arc::clone(self);
+        let cancel_clone = cancel.clone();
+        let join_handle = tokio::spawn(async move {
+            change_watch_loop(state, signal_path, poll_interval, cancel_clone).await;
+        });
+        ChangeWatchHandle {
+            cancel,
+            join_handle,
+        }
+    }
+}
+
+/// Handle returned by [`ObjectState::spawn_change_watcher`].
+///
+/// The watcher runs until the handle is dropped (which cancels the background task)
+/// or explicitly cancelled via [`cancel`](Self::cancel).
+pub struct ChangeWatchHandle {
+    cancel: CancellationToken,
+    join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl ChangeWatchHandle {
+    /// Cancel the watcher explicitly.
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Returns a reference to the cancellation token.
+    #[must_use]
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancel
+    }
+}
+
+impl Drop for ChangeWatchHandle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.join_handle.abort();
+    }
+}
+
+/// Internal watcher loop: HEAD the signal, on change call `conditional_refresh`.
+async fn change_watch_loop<T>(
+    state: Arc<ObjectState<T>>,
+    signal_path: Path,
+    poll_interval: Duration,
+    cancel: CancellationToken,
+) where
+    T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    let mut interval = tokio::time::interval(poll_interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut last_known_etag: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::info!("Change watcher shutting down");
+                break;
+            }
+            _ = interval.tick() => {
+                match check_signal_and_refresh(&state, &signal_path, &mut last_known_etag).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::debug!(error = %e, "Change watcher poll error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Single poll cycle: conditional GET on signal file, if changed trigger `conditional_refresh`.
+async fn check_signal_and_refresh<T>(
+    state: &Arc<ObjectState<T>>,
+    signal_path: &Path,
+    last_known_etag: &mut Option<String>,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    let opts = GetOptions {
+        if_none_match: last_known_etag.clone(),
+        ..Default::default()
+    };
+
+    match state.store.get_opts(signal_path, opts).await {
+        Ok(result) => {
+            // Signal changed — update ETag and conditionally refresh all entries
+            *last_known_etag = result.meta.e_tag.clone();
+            if let Err(e) = state.conditional_refresh().await {
+                tracing::debug!(error = %e, "Conditional refresh from change signal failed");
+            } else {
+                tracing::debug!("Refreshed cache from change signal");
+            }
+        }
+        Err(ObjectStoreError::NotModified { .. }) => {} // No change
+        Err(ObjectStoreError::NotFound { .. }) => {}    // No signal yet
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(())
+}
+
+/// Publish a change signal to the given path.
+///
+/// Writes a random UUID so the object's `ETag` changes on every write.
+/// Uses `PutMode::Overwrite` (last-writer-wins) to avoid OCC overhead.
+async fn publish_change_signal(
+    store: &dyn ObjectStore,
+    signal_path: &Path,
+) -> std::result::Result<(), object_store::Error> {
+    let payload = uuid::Uuid::new_v4().to_string();
+    store
+        .put_opts(
+            signal_path,
+            payload.into(),
+            PutOptions::from(PutMode::Overwrite),
+        )
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -569,5 +795,153 @@ mod tests {
         state.refresh().await.expect("refresh failed");
 
         assert_eq!(state.get_cached("external"), Some(data));
+    }
+
+    #[tokio::test]
+    async fn test_get_if_changed_returns_false_when_unchanged() {
+        let store = Arc::new(InMemory::new());
+        let state: ObjectState<TestData> = ObjectState::new(store).with_prefix("test/");
+
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+
+        state.insert("key1", &data).await.expect("insert failed");
+
+        // Nothing changed — should return false
+        let changed = state
+            .get_if_changed("key1")
+            .await
+            .expect("get_if_changed failed");
+        assert!(!changed);
+    }
+
+    #[tokio::test]
+    async fn test_get_if_changed_returns_true_when_modified() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let state: ObjectState<TestData> =
+            ObjectState::new(Arc::clone(&store)).with_prefix("test/");
+
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+
+        state.insert("key1", &data).await.expect("insert failed");
+
+        // Modify directly in store (simulating a peer scheduler write)
+        let updated = TestData {
+            name: "updated".to_string(),
+            value: 100,
+        };
+        let path = Path::from("test/key1.json");
+        let payload = serde_json::to_vec(&updated).expect("serialize failed");
+        store.put(&path, payload.into()).await.expect("put failed");
+
+        // Should detect change and update cache
+        let changed = state
+            .get_if_changed("key1")
+            .await
+            .expect("get_if_changed failed");
+        assert!(changed);
+        assert_eq!(state.get_cached("key1"), Some(updated));
+    }
+
+    #[tokio::test]
+    async fn test_conditional_refresh_only_updates_changed() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let state: ObjectState<TestData> =
+            ObjectState::new(Arc::clone(&store)).with_prefix("test/");
+
+        let data1 = TestData {
+            name: "a".to_string(),
+            value: 1,
+        };
+        let data2 = TestData {
+            name: "b".to_string(),
+            value: 2,
+        };
+
+        state.insert("key1", &data1).await.expect("insert failed");
+        state.insert("key2", &data2).await.expect("insert failed");
+
+        // Modify only key2 directly in store
+        let updated2 = TestData {
+            name: "b_updated".to_string(),
+            value: 20,
+        };
+        let path = Path::from("test/key2.json");
+        let payload = serde_json::to_vec(&updated2).expect("serialize failed");
+        store.put(&path, payload.into()).await.expect("put failed");
+
+        state
+            .conditional_refresh()
+            .await
+            .expect("conditional_refresh failed");
+
+        // key1 unchanged, key2 updated
+        assert_eq!(state.get_cached("key1"), Some(data1));
+        assert_eq!(state.get_cached("key2"), Some(updated2));
+    }
+
+    #[tokio::test]
+    async fn test_write_publishes_signal_when_watcher_active() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let state: Arc<ObjectState<TestData>> =
+            Arc::new(ObjectState::new(Arc::clone(&store)).with_prefix("test/"));
+
+        // No signal file before watcher is spawned
+        let signal_path = Path::from("test/__signal.json");
+        assert!(store.head(&signal_path).await.is_err());
+
+        // Spawn watcher — this enables signaling
+        let handle = state.spawn_change_watcher(Duration::from_secs(60));
+
+        // Insert should now publish a signal
+        let data = TestData {
+            name: "test".to_string(),
+            value: 1,
+        };
+        state.insert("key1", &data).await.expect("insert failed");
+
+        // Signal file should exist
+        assert!(store.head(&signal_path).await.is_ok());
+
+        handle.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_change_watcher_detects_cross_instance_update() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+        // Instance A — the writer
+        let state_a: Arc<ObjectState<TestData>> =
+            Arc::new(ObjectState::new(Arc::clone(&store)).with_prefix("test/"));
+        let _handle_a = state_a.spawn_change_watcher(Duration::from_secs(60));
+
+        // Instance B — the reader/watcher
+        let state_b: Arc<ObjectState<TestData>> =
+            Arc::new(ObjectState::new(Arc::clone(&store)).with_prefix("test/"));
+        let _handle_b = state_b.spawn_change_watcher(Duration::from_millis(50));
+
+        // A writes data
+        let data = TestData {
+            name: "from_a".to_string(),
+            value: 42,
+        };
+        state_a
+            .insert("shared_key", &data)
+            .await
+            .expect("insert failed");
+
+        // B doesn't see it in cache yet
+        assert!(state_b.get_cached("shared_key").is_none());
+
+        // Wait for B's watcher to detect the signal and refresh
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // B should now have the data in cache
+        assert_eq!(state_b.get_cached("shared_key"), Some(data));
     }
 }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -260,8 +260,10 @@ impl RuntimeBuilder {
                     .await
                     {
                         Ok(store) => {
-                            let partition_manager =
-                                Arc::new(PartitionManager::new(Arc::clone(&store)));
+                            let partition_manager = Arc::new(PartitionManager::new(
+                                Arc::clone(&store),
+                                "accelerations/partitions/",
+                            ));
 
                             Some(DistributedNode::Scheduler {
                                 peers: Arc::new(RwLock::new(HashMap::new())),
@@ -269,10 +271,10 @@ impl RuntimeBuilder {
                                 job_executor: Arc::new(RwLock::new(None)),
                                 executor_registry: Arc::new(ExecutorRegistry::new(
                                     Arc::clone(&partition_manager),
-                                    Arc::new(
-                                        PartitionManager::new(Arc::clone(&store))
-                                            .with_prefix("catalog/partitions/"),
-                                    ),
+                                    Arc::new(PartitionManager::new(
+                                        Arc::clone(&store),
+                                        "catalog/partitions/",
+                                    )),
                                 )),
                                 partition_manager,
                             })
@@ -290,16 +292,19 @@ impl RuntimeBuilder {
                     );
                     let store: Arc<dyn object_store::ObjectStore> =
                         Arc::new(object_store::memory::InMemory::new());
-                    let partition_manager = Arc::new(PartitionManager::new(Arc::clone(&store)));
+                    let partition_manager = Arc::new(PartitionManager::new(
+                        Arc::clone(&store),
+                        "accelerations/partitions/",
+                    ));
                     Some(DistributedNode::Scheduler {
                         peers: Arc::new(RwLock::new(HashMap::new())),
                         job_executor: Arc::new(RwLock::new(None)),
                         executor_registry: Arc::new(ExecutorRegistry::new(
                             Arc::clone(&partition_manager),
-                            Arc::new(
-                                PartitionManager::new(Arc::clone(&store))
-                                    .with_prefix("catalog/partitions/"),
-                            ),
+                            Arc::new(PartitionManager::new(
+                                Arc::clone(&store),
+                                "catalog/partitions/",
+                            )),
                         )),
                         partition_manager,
                     })

--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -528,8 +528,14 @@ mod tests {
     #[tokio::test]
     async fn test_register_unregister() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
         );
         let (tx, _rx) = mpsc::channel(1);
 
@@ -547,8 +553,14 @@ mod tests {
     #[tokio::test]
     async fn test_reconnect_replaces_connection() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
         );
         let (tx1, _rx1) = mpsc::channel(1);
         let (tx2, _rx2) = mpsc::channel(1);
@@ -563,8 +575,14 @@ mod tests {
     #[tokio::test]
     async fn test_request_metrics_empty_registry() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
         );
         let result = registry.request_metrics_from_all().await;
         assert!(result.is_ok());
@@ -574,8 +592,14 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_executors() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
         );
         let (tx1, _rx1) = mpsc::channel(1);
         let (tx2, _rx2) = mpsc::channel(1);
@@ -604,8 +628,14 @@ mod tests {
     #[tokio::test]
     async fn test_unregister_nonexistent() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
+            Arc::new(PartitionManager::new(
+                Arc::new(InMemory::new()),
+                "test/partitions/",
+            )),
         );
         let (tx, _rx) = mpsc::channel(1);
 

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -862,6 +862,8 @@ pub(crate) async fn initialize_cluster_scheduler_future(
             rt.status
                 .update_component_status("partition_metadata", ComponentStatus::Initializing);
 
+            let watch_interval = pm_config.change_watch_interval;
+
             let pm_task = PartitionManagementTask::new(
                 rt.app(),
                 rt.datafusion(),
@@ -891,11 +893,11 @@ pub(crate) async fn initialize_cluster_scheduler_future(
             // Start partition change watchers for fast cross-scheduler metadata propagation.
             // Polls lightweight signal files to detect partition changes made by peer schedulers.
             change_watch_handles
-                .push(partition_manager.spawn_change_watcher(Duration::from_secs(3)));
+                .push(partition_manager.spawn_change_watcher(watch_interval));
             change_watch_handles.push(
                 scheduler_executor_registry
                     .federated_partition_manager()
-                    .spawn_change_watcher(Duration::from_secs(3)),
+                    .spawn_change_watcher(watch_interval),
             );
         }
 

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -808,6 +808,9 @@ pub(crate) async fn initialize_cluster_scheduler_future(
                 .await,
         )];
 
+    // Handles for partition change watchers, kept alive in the returned future.
+    let mut change_watch_handles: Vec<object_store_occ::ChangeWatchHandle> = Vec::new();
+
     let Some(app) = rt.read_app().await else {
         tracing::warn!(
             "No app found in runtime during cluster scheduler initialization; skipping scheduler registry and partition manager setup"
@@ -884,6 +887,16 @@ pub(crate) async fn initialize_cluster_scheduler_future(
                     )
                     .await,
             ));
+
+            // Start partition change watchers for fast cross-scheduler metadata propagation.
+            // Polls lightweight signal files to detect partition changes made by peer schedulers.
+            change_watch_handles
+                .push(partition_manager.spawn_change_watcher(Duration::from_secs(3)));
+            change_watch_handles.push(
+                scheduler_executor_registry
+                    .federated_partition_manager()
+                    .spawn_change_watcher(Duration::from_secs(3)),
+            );
         }
 
         let registry_shutdown = CancellationToken::new();
@@ -907,6 +920,9 @@ pub(crate) async fn initialize_cluster_scheduler_future(
     }
 
     Ok(Some(Box::pin(async move {
+        // Keep change watchers alive until all futures complete or are cancelled.
+        // Dropping the handles cancels the watcher tasks.
+        let _watchers = change_watch_handles;
         try_join_all(futures).await.map(|_| ())
     })))
 }

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use std::{collections::HashMap, sync::Arc};
 
 use datafusion::sql::TableReference;
 use object_store::ObjectStore;
-use object_store_occ::{InsertResult, ObjectState, WriteResult};
+use object_store_occ::{ChangeWatchHandle, InsertResult, ObjectState, WriteResult};
 use snafu::prelude::*;
 
-use crate::cluster::partition::metadata::PartitionValue;
-
-use super::metadata::{PartitionMetadata, TablePartitionMetadata};
+use super::metadata::{PartitionMetadata, PartitionValue, TablePartitionMetadata};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -49,15 +47,13 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-static PARTITION_PREFIX: &str = "accelerations/partitions/";
-
 /// Manages partition metadata for accelerated tables in object storage.
 ///
 /// Uses optimistic concurrency control to safely coordinate partition assignments
 /// across multiple schedulers without locks.
 #[derive(Debug)]
 pub struct PartitionManager {
-    state: ObjectState<TablePartitionMetadata>,
+    state: Arc<ObjectState<TablePartitionMetadata>>,
 }
 
 #[derive(Debug, Clone)]
@@ -81,20 +77,23 @@ impl AllocationResult {
 }
 
 impl PartitionManager {
-    /// Creates a new partition manager with the given object store.
-    ///
-    /// All partition metadata will be stored under the "partitions/" prefix.
+    /// Creates a new partition manager with the given object store and key prefix.
     #[must_use]
-    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
+    pub fn new(store: Arc<dyn ObjectStore>, prefix: &str) -> Self {
         Self {
-            state: ObjectState::new(store).with_prefix(PARTITION_PREFIX),
+            state: Arc::new(ObjectState::new(store).with_prefix(prefix)),
         }
     }
 
-    #[must_use]
-    pub fn with_prefix(mut self, prefix: &str) -> Self {
-        self.state = self.state.with_prefix(prefix);
-        self
+    /// Spawns a background change watcher that polls a signal file and conditionally
+    /// refreshes the local cache when changes are detected by peer schedulers.
+    ///
+    /// This also **enables change signaling**: subsequent writes will auto-publish
+    /// a signal to `{prefix}__signal.json` so other watchers can detect the change.
+    ///
+    /// Returns a [`ChangeWatchHandle`] that cancels the watcher when dropped.
+    pub fn spawn_change_watcher(&self, poll_interval: Duration) -> ChangeWatchHandle {
+        self.state.spawn_change_watcher(poll_interval)
     }
 
     /// Get partition metadata for a table from object store.
@@ -310,6 +309,17 @@ impl PartitionManager {
         })
     }
 
+    /// Conditionally refresh the local cache: only fetch entries whose remote
+    /// ETag differs from the cached version (uses `HEAD` for change detection).
+    pub async fn conditional_refresh(&self) -> Result<()> {
+        self.state
+            .conditional_refresh()
+            .await
+            .context(MetadataAccessSnafu {
+                table: String::from("<conditional_refresh>"),
+            })
+    }
+
     /// Adds new partitions to a table's metadata and assigns each to its
     /// respective executor in a single OCC write. If a partition already exists,
     /// it is assigned (or left as-is if already assigned to the same executor).
@@ -378,6 +388,8 @@ impl PartitionManager {
     }
 
     /// Write metadata using `insert_or_update` with conflict handling.
+    ///
+    /// Change signals are published automatically by `ObjectState` on successful writes.
     pub(crate) async fn write_metadata(
         &self,
         key: &str,

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -109,6 +109,9 @@ pub struct PartitionManagementConfig {
 
     /// How long to wait for partition discovery before timing out
     pub discovery_timeout: Duration,
+
+    /// How often to poll the change signal file for cross-scheduler cache invalidation
+    pub change_watch_interval: Duration,
 }
 
 #[derive(Debug, Snafu)]
@@ -130,6 +133,17 @@ pub enum ConfigError {
 
     #[snafu(display("Partition management discovery timeout must be greater than zero"))]
     DiscoveryTimeoutIsZero,
+
+    #[snafu(display(
+        "Invalid partition management change watch interval '{interval}': {source}"
+    ))]
+    InvalidChangeWatchInterval {
+        interval: String,
+        source: fundu::ParseError,
+    },
+
+    #[snafu(display("Partition management change watch interval must be greater than zero"))]
+    ChangeWatchIntervalIsZero,
 }
 
 impl TryFrom<spicepod::component::runtime::PartitionManagement> for PartitionManagementConfig {
@@ -156,11 +170,23 @@ impl TryFrom<spicepod::component::runtime::PartitionManagement> for PartitionMan
             return Err(ConfigError::DiscoveryTimeoutIsZero);
         }
 
+        let change_watch_interval =
+            fundu::parse_duration(&config.change_watch_interval).context(
+                InvalidChangeWatchIntervalSnafu {
+                    interval: &config.change_watch_interval,
+                },
+            )?;
+
+        if change_watch_interval.is_zero() {
+            return Err(ConfigError::ChangeWatchIntervalIsZero);
+        }
+
         Ok(Self {
             interval,
             max_assignments_per_cycle: config.max_assignments_per_cycle,
             max_partitions_per_executor: config.max_partitions_per_executor,
             discovery_timeout,
+            change_watch_interval,
         })
     }
 }
@@ -172,6 +198,7 @@ impl Default for PartitionManagementConfig {
             max_assignments_per_cycle: 100,
             max_partitions_per_executor: 1000,
             discovery_timeout: Duration::from_secs(60),
+            change_watch_interval: Duration::from_secs(3),
         }
     }
 }

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -168,7 +168,7 @@ impl TryFrom<spicepod::component::runtime::PartitionManagement> for PartitionMan
 impl Default for PartitionManagementConfig {
     fn default() -> Self {
         Self {
-            interval: Duration::from_secs(30),
+            interval: Duration::from_secs(10),
             max_assignments_per_cycle: 100,
             max_partitions_per_executor: 1000,
             discovery_timeout: Duration::from_secs(60),

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -743,7 +743,7 @@ pub struct PartitionManagement {
 }
 
 fn default_partition_management_interval() -> String {
-    "30s".to_string()
+    "10s".to_string()
 }
 
 fn default_max_assignments_per_cycle() -> usize {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -740,10 +740,14 @@ pub struct PartitionManagement {
 
     #[serde(default = "default_discovery_timeout")]
     pub discovery_timeout: String,
+
+    /// How often to poll the change signal file for cross-scheduler cache invalidation.
+    #[serde(default = "default_change_watch_interval")]
+    pub change_watch_interval: String,
 }
 
 fn default_partition_management_interval() -> String {
-    "10s".to_string()
+    "30s".to_string()
 }
 
 fn default_max_assignments_per_cycle() -> usize {
@@ -758,6 +762,10 @@ fn default_discovery_timeout() -> String {
     "60s".to_string()
 }
 
+fn default_change_watch_interval() -> String {
+    "3s".to_string()
+}
+
 impl Default for PartitionManagement {
     fn default() -> Self {
         Self {
@@ -765,6 +773,7 @@ impl Default for PartitionManagement {
             max_assignments_per_cycle: default_max_assignments_per_cycle(),
             max_partitions_per_executor: default_max_partitions_per_executor(),
             discovery_timeout: default_discovery_timeout(),
+            change_watch_interval: default_change_watch_interval(),
         }
     }
 }

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -880,6 +880,7 @@ mod version_tests {
         assert_eq!(pm.max_assignments_per_cycle, 100);
         assert_eq!(pm.max_partitions_per_executor, 1000);
         assert_eq!(pm.discovery_timeout, "60s");
+        assert_eq!(pm.change_watch_interval, "3s");
     }
 
     /// `read_write_create` access mode deserializes.


### PR DESCRIPTION
## 📝 Summary

In multi-scheduler deployments, partition-to-executor assignment caches could be stale for up to 30s, causing queries to fail with `MissingPartitions`, route to wrong executors, or return incomplete results. 

This PR adds a change signaling mechanism to `ObjectState` where writes auto-publish a signal file (a random UUID written with `PutMode::Overwrite`). A background watcher polls the signal file using conditional GET (`If-None-Match`) every 3s (configurable). When the signal's ETag changes — indicating a peer scheduler wrote new partition metadata — the watcher performs a conditional refresh of all table partition metadata entries, fetching only those whose ETag differs from the local cache.

Spicepod configuration:
```yaml
runtime:
  scheduler:
    partition_management:
      change_watch_interval: 2s  # default: 3s
```

Closes https://github.com/spiceai/spiceai/issues/9653