### PR TITLE
fix: Prevent write-through stalls and preserve PartitionTableProvider during catalog refresh

### DIFF
--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -40,6 +40,7 @@ use crate::parameters::Parameters;
 use crate::spice_data_base_path;
 use data_components::RefreshableCatalogProvider;
 use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
+use runtime_table_partition::provider::PartitionTableProvider;
 
 use crate::catalogconnector::PartitionAwareCatalog;
 
@@ -502,19 +503,73 @@ impl CayenneSchemaProvider {
         existing_provider: &Arc<dyn TableProvider>,
         refreshed_provider: &Arc<dyn TableProvider>,
     ) -> bool {
-        let Some(existing_cayenne) = Self::cayenne_table_from_provider(existing_provider) else {
-            return false;
-        };
-        let Some(refreshed_cayenne) = Self::cayenne_table_from_provider(refreshed_provider) else {
-            return false;
-        };
+        // Case 1: Non-partitioned CayenneTableProvider — refresh in place from the
+        // freshly-loaded provider.
+        if let Some(existing_cayenne) = Self::cayenne_table_from_provider(existing_provider) {
+            let Some(refreshed_cayenne) = Self::cayenne_table_from_provider(refreshed_provider)
+            else {
+                return false;
+            };
 
-        if let Err(err) = existing_cayenne.refresh(refreshed_cayenne).await {
-            tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
-            return false;
+            if let Err(err) = existing_cayenne.refresh(refreshed_cayenne).await {
+                tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
+                return false;
+            }
+
+            return true;
         }
 
-        true
+        // Case 2: PartitionTableProvider (wrapped in DeletionTableProviderAdapter)
+        // — refresh each partition's inner CayenneTableProvider from itself (reloads
+        // deletion vectors, protected snapshots, snapshot ID, and listing table from
+        // the catalog).
+        let partition_provider = existing_provider
+            .as_any()
+            .downcast_ref::<DeletionTableProviderAdapter>()
+            .and_then(|adapter| {
+                adapter
+                    .source()
+                    .as_any()
+                    .downcast_ref::<PartitionTableProvider>()
+            });
+
+        if let Some(partition_provider) = partition_provider {
+            let providers = partition_provider.partition_table_providers().await;
+            for provider in &providers {
+                // Each partition's inner provider is a DeletionTableProviderAdapter
+                // wrapping a CayenneTableProvider.
+                let Some(cayenne) = provider
+                    .as_any()
+                    .downcast_ref::<DeletionTableProviderAdapter>()
+                    .and_then(|adapter| {
+                        adapter
+                            .source()
+                            .as_any()
+                            .downcast_ref::<CayenneTableProvider>()
+                    })
+                    .or_else(|| {
+                        provider.as_any().downcast_ref::<CayenneTableProvider>()
+                    })
+                else {
+                    tracing::warn!(
+                        "Partition sub-provider is not a CayenneTableProvider, skipping refresh"
+                    );
+                    continue;
+                };
+                if let Err(err) = cayenne.refresh(cayenne).await {
+                    tracing::warn!(
+                        "Failed to refresh partitioned Cayenne table in place: {err}"
+                    );
+                    // Fail safely: keep the existing partitioned provider rather than
+                    // signaling failure that would cause it to be replaced by a
+                    // non-partitioned provider.
+                    return true;
+                }
+            }
+            return true;
+        }
+
+        false
     }
 
     fn cayenne_table_from_provider(

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Forwards writes to each relevant executor based on their assigned partitions.
 //! This is used for partitioned tables that are written to via the coordinator.
 
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc, sync::atomic::{AtomicU64, Ordering}};
 
 use arrow::array::{Array, RecordBatch};
 use arrow_flight::{
@@ -407,9 +407,13 @@ async fn route_batch_and_assign_unseen(
     partition_manager: &Arc<PartitionManager>,
     path: &TableReference,
 ) -> Result<()> {
-    // Route matched rows to known executors.
-    let unmatched = route_matched_and_collect_unmatched(batch, executor_filters, senders).await?;
+    // Partition rows by executor filter, collecting (executor_id, batch) pairs
+    // without sending yet. All sends happen concurrently at the end to avoid
+    // head-of-line blocking when one executor's channel is full.
+    let (unmatched, mut pending_sends) =
+        partition_matched_rows(batch, executor_filters, senders)?;
     if unmatched.num_rows() == 0 {
+        send_all_concurrent(senders, pending_sends, path).await?;
         return Ok(());
     }
 
@@ -533,17 +537,19 @@ async fn route_batch_and_assign_unseen(
             }
         }
 
-        // Forward the rows.
-        let tx = senders
-            .get(&executor_id)
-            .ok_or_else(|| Error::NoSenderForExecutor {
+        // Queue the rows for concurrent send.
+        if !senders.contains_key(&executor_id) {
+            return Err(Error::NoSenderForExecutor {
                 executor_id: executor_id.clone(),
                 table: path.to_string(),
-            })?;
-        tx.send(sub_batch).await.map_err(|_| Error::SendBatch {
-            executor_id: executor_id.clone(),
-        })?;
+            });
+        }
+
+        pending_sends.push((executor_id.clone(), sub_batch));
     }
+
+    // Send all pending batches (matched + newly assigned) concurrently.
+    send_all_concurrent(senders, pending_sends, path).await?;
 
     Ok(())
 }
@@ -563,17 +569,57 @@ fn scalar_to_sql_literal(scalar: &ScalarValue) -> String {
     }
 }
 
-/// Routes matched rows to known executors and returns the unmatched rows.
+/// Sends all pending `(executor_id, batch)` pairs concurrently so that one
+/// slow executor cannot block sends to the others (no head-of-line blocking).
+async fn send_all_concurrent(
+    senders: &HashMap<ExecutorId, Sender<RecordBatch>>,
+    pending: Vec<(ExecutorId, RecordBatch)>,
+    path: &TableReference,
+) -> Result<()> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let futures: Vec<_> = pending
+        .into_iter()
+        .map(|(executor_id, batch)| {
+            let tx = senders.get(&executor_id).cloned();
+            async move {
+                let Some(tx) = tx else {
+                    return Err(Error::NoSenderForExecutor {
+                        executor_id: executor_id.clone(),
+                        table: path.to_string(),
+                    });
+                };
+                tx.send(batch).await.map_err(|_| Error::SendBatch {
+                    executor_id: executor_id.clone(),
+                })?;
+                Ok(())
+            }
+        })
+        .collect();
+
+    let results = futures::future::join_all(futures).await;
+    for result in results {
+        result?;
+    }
+
+    Ok(())
+}
+
+/// Partitions rows by executor filter, returning `(unmatched_rows, pending_sends)`.
 ///
-/// Partitions are non-overlapping, so each row matches at most one executor.
-/// We progressively shrink the remaining batch as rows get matched, avoiding
-/// redundant filter evaluations and data copies on already-routed rows.
-async fn route_matched_and_collect_unmatched(
+/// Evaluates each executor's filter predicate against the batch and collects
+/// matched rows into `pending_sends` without sending them. This is a pure
+/// compute step — all sends happen concurrently afterwards in
+/// [`send_all_concurrent`] to avoid head-of-line blocking.
+fn partition_matched_rows(
     batch: &RecordBatch,
     executor_filters: &[ExecutorFilter],
     senders: &HashMap<ExecutorId, Sender<RecordBatch>>,
-) -> Result<RecordBatch> {
+) -> Result<(RecordBatch, Vec<(ExecutorId, RecordBatch)>)> {
     let mut remaining = batch.clone();
+    let mut pending_sends: Vec<(ExecutorId, RecordBatch)> = Vec::new();
 
     for (executor_id, filter_expr) in executor_filters {
         if remaining.num_rows() == 0 {
@@ -610,7 +656,7 @@ async fn route_matched_and_collect_unmatched(
         // If there is no active sender for this executor (e.g. it disconnected),
         // leave the matched rows in `remaining` so they are treated as unmatched
         // and re-assigned to a connected executor. This prevents silent data loss.
-        let Some(tx) = senders.get(executor_id) else {
+        if !senders.contains_key(executor_id) {
             tracing::warn!(
                 executor_id,
                 rows = matched_count,
@@ -621,13 +667,12 @@ async fn route_matched_and_collect_unmatched(
 
         let filtered =
             arrow::compute::filter_record_batch(&remaining, mask).context(FilterBatchSnafu)?;
-        tx.send(filtered).await.map_err(|_| Error::SendBatch {
-            executor_id: executor_id.clone(),
-        })?;
+
+        pending_sends.push((executor_id.clone(), filtered));
 
         // If every remaining row was matched, nothing left to process.
         if matched_count == remaining.num_rows() {
-            return Ok(RecordBatch::new_empty(batch.schema()));
+            return Ok((RecordBatch::new_empty(batch.schema()), pending_sends));
         }
 
         // Shrink remaining to only unmatched rows for subsequent executors.
@@ -636,15 +681,7 @@ async fn route_matched_and_collect_unmatched(
             arrow::compute::filter_record_batch(&remaining, &negated).context(FilterBatchSnafu)?;
     }
 
-    if remaining.num_rows() > 0 {
-        tracing::debug!(
-            total_rows = batch.num_rows(),
-            unmatched_rows = remaining.num_rows(),
-            "Some rows did not match any executor filter; routing to new partition assignments"
-        );
-    }
-
-    Ok(remaining)
+    Ok((remaining, pending_sends))
 }
 
 /// Parses partition-by SQL expression strings into logical + physical expression pairs.
@@ -771,7 +808,7 @@ async fn spawn_executor_forwarding_tasks(
 
     for (executor_id, client) in executor_clients {
         let (tx, rx) = mpsc::channel::<RecordBatch>(64);
-        senders.insert(executor_id, tx);
+        senders.insert(executor_id.clone(), tx);
 
         join_handles.push(io_runtime.spawn(forward_batches_to_executor(
             client,
@@ -780,6 +817,7 @@ async fn spawn_executor_forwarding_tasks(
             tbl.clone(),
             auth_header.clone(),
             io_runtime.clone(),
+            executor_id,
         )));
     }
 
@@ -907,14 +945,34 @@ async fn forward_batches_to_executor(
     tbl: ResolvedTableReference,
     auth_header: Option<String>,
     io_runtime: tokio::runtime::Handle,
+    executor_id: String,
 ) -> Result<()> {
+    let forward_start = std::time::Instant::now();
+    let batches_forwarded = Arc::new(AtomicU64::new(0));
+    let keepalives_sent = Arc::new(AtomicU64::new(0));
+    let table_label = tbl.to_string();
+    tracing::info!(
+        executor = %executor_id,
+        table = %table_label,
+        "Executor forwarding task started",
+    );
     let (tx, flight_rx) = mpsc::channel::<arrow_flight::FlightData>(64);
     let (encode_result_tx, encode_result_rx) =
         tokio::sync::oneshot::channel::<std::result::Result<(), String>>();
 
     let encoder_schema = Arc::clone(&schema);
     let adapt_schema = Arc::clone(&schema);
-    io_runtime.spawn(async move {
+
+    // Keepalive interval: send a heartbeat at 1/3 of the executor idle timeout
+    // so the executor never reaches its deadline while a write-through is active.
+    // Clamp to a minimum non-zero duration to avoid a tight loop when the
+    // idle timeout is very small (e.g. in tests with 1-2s timeouts).
+    let keepalive_interval =
+        (crate::flight::do_put_idle_timeout() / 3).max(std::time::Duration::from_millis(100));
+
+    let encoder_batches = Arc::clone(&batches_forwarded);
+    let encoder_keepalives = Arc::clone(&keepalives_sent);
+    let encoder_handle = io_runtime.spawn(async move {
         let mut flight_data_encoder = Box::pin(
             arrow_flight::encode::FlightDataEncoderBuilder::new()
                 .with_schema(encoder_schema)
@@ -936,25 +994,59 @@ async fn forward_batches_to_executor(
             tbl.schema.to_string(),
             tbl.table.to_string(),
         ]);
+
+        let keepalive_sleep = tokio::time::sleep(keepalive_interval);
+        tokio::pin!(keepalive_sleep);
+
         loop {
-            match flight_data_encoder.next().await {
-                Some(Ok(mut fdata)) => {
+            tokio::select! {
+                biased;
+                data = flight_data_encoder.next() => {
+                    match data {
+                        Some(Ok(mut fdata)) => {
+                            if is_first {
+                                fdata.flight_descriptor = Some(fd.clone());
+                                is_first = false;
+                            }
+                            // Reset keepalive timer after each real message.
+                            keepalive_sleep.as_mut().reset(tokio::time::Instant::now() + keepalive_interval);
+                            if tx.send(fdata).await.is_err() {
+                                let _ = encode_result_tx.send(Ok(()));
+                                return;
+                            }
+                            encoder_batches.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Some(Err(e)) => {
+                            let _ = encode_result_tx.send(Err(e.to_string()));
+                            return;
+                        }
+                        None => {
+                            let _ = encode_result_tx.send(Ok(()));
+                            return;
+                        }
+                    }
+                }
+                () = &mut keepalive_sleep => {
+                    // Only send keepalives after the first real FlightData
+                    // (which carries the schema/descriptor) has been sent.
+                    // Sending a keepalive before the schema would confuse
+                    // the executor's DoPut handler.
                     if is_first {
-                        fdata.flight_descriptor = Some(fd.clone());
-                        is_first = false;
+                        keepalive_sleep.as_mut().reset(tokio::time::Instant::now() + keepalive_interval);
+                        continue;
                     }
-                    if tx.send(fdata).await.is_err() {
+                    // No data for a while — send a keepalive to prevent the
+                    // executor's DoPut idle timeout from firing.
+                    let keepalive = arrow_flight::FlightData {
+                        app_metadata: bytes::Bytes::from_static(crate::flight::KEEPALIVE_APP_METADATA),
+                        ..Default::default()
+                    };
+                    if tx.send(keepalive).await.is_err() {
                         let _ = encode_result_tx.send(Ok(()));
-                        break;
+                        return;
                     }
-                }
-                Some(Err(e)) => {
-                    let _ = encode_result_tx.send(Err(e.to_string()));
-                    break;
-                }
-                None => {
-                    let _ = encode_result_tx.send(Ok(()));
-                    break;
+                    encoder_keepalives.fetch_add(1, Ordering::Relaxed);
+                    keepalive_sleep.as_mut().reset(tokio::time::Instant::now() + keepalive_interval);
                 }
             }
         }
@@ -971,15 +1063,45 @@ async fn forward_batches_to_executor(
     let response = match inner_client.do_put(request).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!("DoPut to executor failed: {e}");
+            // Abort the encoder task so its `rx` is dropped promptly.
+            // This prevents the routing loop from queuing data into a dead
+            // channel and eventually stalling.
+            encoder_handle.abort();
+            tracing::error!(
+                executor = %executor_id,
+                table = %table_label,
+                elapsed_ms = forward_start.elapsed().as_millis() as u64,
+                batches = batches_forwarded.load(Ordering::Relaxed),
+                keepalives = keepalives_sent.load(Ordering::Relaxed),
+                error = %e,
+                "`DoPut` to executor failed",
+            );
             return Err(Error::DoPut { source: e });
         }
     };
 
     if let Err(e) = response.into_inner().try_collect::<Vec<_>>().await {
-        tracing::error!("Executor DoPut acknowledgement failed: {e}");
+        encoder_handle.abort();
+        tracing::error!(
+            executor = %executor_id,
+            table = %table_label,
+            elapsed_ms = forward_start.elapsed().as_millis() as u64,
+            batches = batches_forwarded.load(Ordering::Relaxed),
+            keepalives = keepalives_sent.load(Ordering::Relaxed),
+            error = %e,
+            "Executor `DoPut` acknowledgement failed",
+        );
         return Err(Error::DoPutAck { source: e });
     }
+
+    tracing::info!(
+        executor = %executor_id,
+        table = %table_label,
+        elapsed_ms = forward_start.elapsed().as_millis() as u64,
+        batches = batches_forwarded.load(Ordering::Relaxed),
+        keepalives = keepalives_sent.load(Ordering::Relaxed),
+        "Executor forwarding task completed successfully",
+    );
 
     match encode_result_rx.await {
         Ok(Ok(())) | Err(_) => Ok(()),

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -392,15 +392,22 @@ fn create_response_stream(
 
         // Use a single pinned Sleep future that is reset on each received message,
         // rather than creating a new timer allocation on every loop iteration.
-        let idle_timeout = Duration::from_secs(120);
+        let idle_timeout = crate::flight::do_put_idle_timeout();
         let deadline = tokio::time::sleep(idle_timeout);
         tokio::pin!(deadline);
 
         loop {
             tokio::select! {
                 () = &mut deadline => {
-                    tracing::error!("Timeout: no record batch received within 120 seconds");
-                    yield Err(Status::deadline_exceeded("Timeout: no record batch received within 120 seconds"));
+                    tracing::error!(
+                        dataset = %path,
+                        "Timeout: no record batch received within {} seconds",
+                        idle_timeout.as_secs()
+                    );
+                    yield Err(Status::deadline_exceeded(format!(
+                        "Timeout: no record batch received within {} seconds",
+                        idle_timeout.as_secs()
+                    )));
                     break;
                 }
                 // Poll the writing task to check if it has completed with an error while processing the data
@@ -432,6 +439,12 @@ fn create_response_stream(
                         Some(Ok(message)) => {
                             // Reset the idle timeout on each received message
                             deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
+
+                            // Skip keepalive messages — these are heartbeats from
+                            // write-through forwarding to prevent the idle timeout.
+                            if message.app_metadata.as_ref() == crate::flight::KEEPALIVE_APP_METADATA {
+                                continue;
+                            }
 
                             let new_batch = match flight_data_to_arrow_batch(
                                 &message,

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -77,6 +77,21 @@ mod util;
 
 pub use session::SessionStore;
 
+/// Sentinel value in [`FlightData::app_metadata`] that marks a message as a
+/// keepalive heartbeat. Write-through forwarding tasks send these periodically
+/// to prevent the executor's DoPut idle timeout from firing on streams that
+/// receive data in bursts with long idle gaps between them.
+pub const KEEPALIVE_APP_METADATA: &[u8] = b"spice-keepalive";
+
+/// Returns the DoPut idle timeout.  Override with the
+/// `SPICE_DO_PUT_IDLE_TIMEOUT_SECS` env-var (useful for tests).
+pub fn do_put_idle_timeout() -> std::time::Duration {
+    std::env::var("SPICE_DO_PUT_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(std::time::Duration::from_secs(120), std::time::Duration::from_secs)
+}
+
 pub struct Service {
     channel_map: Arc<RwLock<HashMap<TableReference, Arc<Sender<DataUpdate>>>>>,
     basic_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,

--- a/crates/runtime/tests/cluster/harness.rs
+++ b/crates/runtime/tests/cluster/harness.rs
@@ -137,6 +137,8 @@ pub struct ClusterHarness {
     /// Background server handles — aborted on drop.
     handles: Vec<JoinHandle<RuntimeResult<()>>>,
     executor_manager: ExecutorManager,
+    /// The scheduler's Flight bind address (for external DoPut tests).
+    scheduler_flight_addr: SocketAddr,
 }
 
 impl Drop for ClusterHarness {
@@ -153,6 +155,10 @@ impl ClusterHarness {
         ClusterHarnessBuilder::new()
     }
 
+    /// Returns the scheduler's Flight address for direct client connections.
+    pub fn scheduler_flight_addr(&self) -> SocketAddr {
+        self.scheduler_flight_addr
+    }
     /// Block until exactly `n` executors have registered with the scheduler,
     /// or return an error after `timeout`.
     pub async fn wait_for_executors(&self, timeout: Duration) -> Result<(), anyhow::Error> {
@@ -429,6 +435,7 @@ impl ClusterHarnessBuilder {
             executors: executor_rts,
             handles,
             executor_manager,
+            scheduler_flight_addr: scheduler_ports.flight_addr(),
         })
     }
 }

--- a/crates/runtime/tests/cluster/mod.rs
+++ b/crates/runtime/tests/cluster/mod.rs
@@ -20,3 +20,4 @@ pub mod harness;
 mod in_memory_shuffle;
 mod job_store;
 mod simple;
+mod write_through_idle_timeout;

--- a/crates/runtime/tests/cluster/write_through_idle_timeout.rs
+++ b/crates/runtime/tests/cluster/write_through_idle_timeout.rs
@@ -1,0 +1,385 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Regression test for write-through `DoPut` idle timeout keepalive.
+//!
+//! Verifies that keepalive FlightData messages (app_metadata = "spice-keepalive")
+//! prevent the executor's `DoPut` idle timeout from firing.
+//!
+//! Uses a minimal Flight server stub that mirrors the idle-timeout behavior
+//! from `create_response_stream` in `do_put.rs`, so no full Spice runtime is needed.
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use arrow_flight::encode::FlightDataEncoderBuilder;
+    use arrow_flight::flight_service_client::FlightServiceClient;
+    use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+    use arrow_flight::{
+        Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+        HandshakeRequest, HandshakeResponse, PollInfo, PutResult, SchemaResult, Ticket,
+    };
+    use futures::{Stream, StreamExt};
+    use runtime::flight::KEEPALIVE_APP_METADATA;
+
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use tokio_stream::wrappers::ReceiverStream;
+    use tonic::{IntoStreamingRequest, Request, Response, Status, Streaming};
+
+    /// Minimal Flight service that accepts `DoPut` with an idle timeout.
+    /// Mirrors the timeout behavior from `create_response_stream` in `do_put.rs`.
+    #[derive(Clone)]
+    struct IdleTimeoutFlightService {
+        idle_timeout: Duration,
+    }
+
+    #[tonic::async_trait]
+    impl FlightService for IdleTimeoutFlightService {
+        type HandshakeStream =
+            Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>;
+        type ListFlightsStream = Pin<Box<dyn Stream<Item = Result<FlightInfo, Status>> + Send>>;
+        type DoGetStream = Pin<Box<dyn Stream<Item = Result<FlightData, Status>> + Send>>;
+        type DoPutStream = Pin<Box<dyn Stream<Item = Result<PutResult, Status>> + Send>>;
+        type DoActionStream =
+            Pin<Box<dyn Stream<Item = Result<arrow_flight::Result, Status>> + Send>>;
+        type ListActionsStream = Pin<Box<dyn Stream<Item = Result<ActionType, Status>> + Send>>;
+        type DoExchangeStream = Pin<Box<dyn Stream<Item = Result<FlightData, Status>> + Send>>;
+
+        async fn handshake(
+            &self,
+            _: Request<Streaming<HandshakeRequest>>,
+        ) -> Result<Response<Self::HandshakeStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn list_flights(
+            &self,
+            _: Request<Criteria>,
+        ) -> Result<Response<Self::ListFlightsStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn get_flight_info(
+            &self,
+            _: Request<FlightDescriptor>,
+        ) -> Result<Response<FlightInfo>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn get_schema(
+            &self,
+            _: Request<FlightDescriptor>,
+        ) -> Result<Response<SchemaResult>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn do_get(&self, _: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn do_put(
+            &self,
+            request: Request<Streaming<FlightData>>,
+        ) -> Result<Response<Self::DoPutStream>, Status> {
+            let mut stream = request.into_inner();
+            let idle_timeout = self.idle_timeout;
+
+            let output = async_stream::stream! {
+                let deadline = tokio::time::sleep(idle_timeout);
+                tokio::pin!(deadline);
+
+                loop {
+                    tokio::select! {
+                        () = &mut deadline => {
+                            let secs = idle_timeout.as_secs();
+                            yield Err(Status::deadline_exceeded(
+                                format!("Timeout: no record batch received within {secs} seconds"),
+                            ));
+                            break;
+                        }
+                        message = stream.next() => {
+                            match message {
+                                Some(Ok(msg)) => {
+                                    // Reset idle timer on every message.
+                                    deadline.as_mut().reset(
+                                        tokio::time::Instant::now() + idle_timeout,
+                                    );
+
+                                    // Skip keepalive messages.
+                                    if msg.app_metadata.as_ref() == KEEPALIVE_APP_METADATA {
+                                        continue;
+                                    }
+
+                                    // Accept the data.
+                                    yield Ok(PutResult::default());
+                                }
+                                Some(Err(e)) => {
+                                    yield Err(Status::internal(format!("Stream error: {e}")));
+                                    break;
+                                }
+                                None => {
+                                    // Stream ended normally.
+                                    yield Ok(PutResult::default());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Ok(Response::new(Box::pin(output)))
+        }
+
+        async fn do_action(
+            &self,
+            _: Request<Action>,
+        ) -> Result<Response<Self::DoActionStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn list_actions(
+            &self,
+            _: Request<Empty>,
+        ) -> Result<Response<Self::ListActionsStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn do_exchange(
+            &self,
+            _: Request<Streaming<FlightData>>,
+        ) -> Result<Response<Self::DoExchangeStream>, Status> {
+            Err(Status::unimplemented(""))
+        }
+
+        async fn poll_flight_info(
+            &self,
+            _: Request<FlightDescriptor>,
+        ) -> Result<Response<PollInfo>, Status> {
+            Err(Status::unimplemented(""))
+        }
+    }
+
+    /// Start the stub Flight server, return the port.
+    async fn start_server(idle_timeout: Duration) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+
+        let svc = IdleTimeoutFlightService { idle_timeout };
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(FlightServiceServer::new(svc))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .expect("server");
+        });
+
+        // Wait for server to be ready.
+        let start = std::time::Instant::now();
+        let addr = format!("127.0.0.1:{port}");
+        let timeout = Duration::from_secs(5);
+        loop {
+            if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+                break;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "Flight server did not become ready within {timeout:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        port
+    }
+
+    fn test_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["Alice", "Bob"])),
+            ],
+        )
+        .expect("batch")
+    }
+
+    /// Verify that an idle `DoPut` stream times out when no data or keepalives
+    /// are sent within the idle timeout period.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_do_put_idle_timeout_fires() {
+        let port = start_server(Duration::from_secs(2)).await;
+
+        let url = format!("http://127.0.0.1:{port}");
+        let channel = tonic::transport::Channel::from_shared(url)
+            .expect("setup")
+            .connect()
+            .await
+            .expect("setup");
+        let mut client = FlightServiceClient::new(channel);
+
+        let batch = test_batch();
+        let descriptor = FlightDescriptor::new_path(vec!["test".to_string()]);
+        let flight_data: Vec<FlightData> = FlightDataEncoderBuilder::new()
+            .with_flight_descriptor(Some(descriptor))
+            .build(futures::stream::iter(vec![Ok(batch)]))
+            .map(|r| r.expect("encode"))
+            .collect()
+            .await;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<FlightData>(16);
+
+        // Send initial flight data.
+        for fd in flight_data {
+            tx.send(fd).await.expect("setup");
+        }
+
+        let request = ReceiverStream::new(rx).into_streaming_request();
+        let response = client.do_put(request).await.expect("setup");
+        let mut stream = response.into_inner();
+
+        // First batch should succeed.
+        let first = stream.next().await.expect("first result");
+        assert!(first.is_ok(), "first batch should succeed");
+
+        // Idle for longer than the 2-second timeout.
+        tokio::time::sleep(Duration::from_secs(4)).await;
+
+        // Collect remaining results — expect DEADLINE_EXCEEDED.
+        let mut got_timeout = false;
+        while let Some(result) = stream.next().await {
+            if let Err(status) = result {
+                assert!(
+                    status.code() == tonic::Code::DeadlineExceeded
+                        || status.message().contains("Timeout"),
+                    "Expected deadline exceeded, got: {status}"
+                );
+                got_timeout = true;
+                break;
+            }
+        }
+
+        assert!(
+            got_timeout,
+            "Expected idle timeout error but stream ended normally"
+        );
+        drop(tx);
+    }
+
+    /// Verify that keepalive messages prevent the idle timeout from firing.
+    ///
+    /// This is the core regression test for the write-through fix.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_do_put_keepalive_prevents_timeout() {
+        let port = start_server(Duration::from_secs(2)).await;
+
+        let url = format!("http://127.0.0.1:{port}");
+        let channel = tonic::transport::Channel::from_shared(url)
+            .expect("setup")
+            .connect()
+            .await
+            .expect("setup");
+        let mut client = FlightServiceClient::new(channel);
+
+        let batch1 = test_batch();
+        let batch2 = test_batch();
+
+        let descriptor = FlightDescriptor::new_path(vec!["test".to_string()]);
+        let fd1: Vec<FlightData> = FlightDataEncoderBuilder::new()
+            .with_flight_descriptor(Some(descriptor))
+            .build(futures::stream::iter(vec![Ok(batch1)]))
+            .map(|r| r.expect("encode"))
+            .collect()
+            .await;
+
+        let fd2: Vec<FlightData> = FlightDataEncoderBuilder::new()
+            .build(futures::stream::iter(vec![Ok(batch2)]))
+            .map(|r| r.expect("encode"))
+            .collect()
+            .await;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<FlightData>(32);
+
+        // Send batch1.
+        for fd in &fd1 {
+            tx.send(fd.clone()).await.expect("setup");
+        }
+
+        let request = ReceiverStream::new(rx).into_streaming_request();
+        let response = client.do_put(request).await.expect("setup");
+        let mut stream = response.into_inner();
+
+        // First batch should succeed.
+        let first = stream.next().await.expect("first");
+        first.expect("first batch ok");
+
+        // Send keepalives for 4 seconds — well beyond the 2s timeout.
+        let keepalive_tx = tx.clone();
+        let keepalive_task = tokio::spawn(async move {
+            for _ in 0..8 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                let keepalive = FlightData {
+                    app_metadata: bytes::Bytes::from_static(KEEPALIVE_APP_METADATA),
+                    ..Default::default()
+                };
+                if keepalive_tx.send(keepalive).await.is_err() {
+                    break;
+                }
+            }
+        });
+        keepalive_task.await.expect("setup");
+
+        // After keepalives, send batch2.
+        for fd in &fd2 {
+            tx.send(fd.clone()).await.expect("send batch2");
+        }
+        drop(tx); // End stream.
+
+        // Collect results — should NOT get a timeout.
+        let mut got_timeout = false;
+        let mut success_count = 0;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(_) => success_count += 1,
+                Err(status) => {
+                    if status.code() == tonic::Code::DeadlineExceeded {
+                        got_timeout = true;
+                    }
+                    break;
+                }
+            }
+        }
+
+        assert!(
+            !got_timeout,
+            "Keepalives should have prevented the idle timeout"
+        );
+        assert!(
+            success_count >= 1,
+            "Expected at least one success for batch2, got {success_count}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Three issues causing permanent ETL stalls and data loss in partitioned write-through mode during SpiceBench TPC-H benchmarks:

### 1. DoPut idle timeout (original bug)
The executor's hardcoded 120s idle timeout fired on write-through partition streams receiving sparse data. With partitioned tables (e.g. `PARTITION BY (bucket(10, l_linenumber))`), some executors receive data in bursts with long idle gaps. When the timeout fired, it closed the DoPut stream, but the scheduler's encoder task was orphaned (detached spawn), keeping the RecordBatch channel alive. The routing loop continued queuing data for the dead executor, eventually filling the channel (capacity 64) and blocking all other executors.

### 2. Head-of-line blocking
The routing loop sent batches to each executor's channel sequentially. When one slow executor's channel filled (64/64), the loop blocked, preventing ALL executors from receiving data — a permanent stall with no errors logged.

### 3. Partition visibility (data loss)
Catalog refresh (`CayenneSchemaProvider::refresh_from`) replaced `PartitionTableProvider` with plain `CayenneTableProvider` because `refresh_table_provider_in_place` couldn't downcast `PartitionTableProvider`. This meant any data written to partition subdirectories by the first DoPut (which grabbed an Arc to the old provider before refresh) was orphaned — physically on disk but invisible to queries.

## Fix

1. **Keepalive messages**: The encoder task now sends periodic keepalive FlightData messages (`app_metadata=b"spice-keepalive"`) at 1/3 of the idle timeout interval. The executor's DoPut handler recognizes and skips keepalives. Idle timeout is configurable via `SPICE_DO_PUT_IDLE_TIMEOUT_SECS`.

2. **Concurrent sends**: Refactored the routing into `partition_matched_rows()` (pure compute) + `send_all_concurrent()` (`futures::join_all`), so sends to executor channels happen concurrently. One slow executor only blocks its own send. Also aborts the encoder task on DoPut/ack errors so the channel is dropped promptly.

3. **PartitionTableProvider refresh**: `refresh_table_provider_in_place` now handles `PartitionTableProvider` (wrapped in `DeletionTableProviderAdapter`) by iterating `partition_table_providers()` and refreshing each inner `CayenneTableProvider` in place via self-refresh (`cayenne.refresh(cayenne)`).

## Testing

- Regression test for keepalive mechanism using a minimal Flight server stub
- Verified at SF1 scale: checkpoint 0 validation passes with the partition visibility fix
- All existing cluster tests pass