### PR TITLE
ci: pin spiceio setup action to v0.2.0

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@c6f862c24430ea058b464815437cd9e47c32d280 # trunk
+        uses: spiceai/spiceio/.github/actions/setup@f964d0fc0c7c60f1463c35971636493b8186a7e2 # v0.2.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@c6f862c24430ea058b464815437cd9e47c32d280 # trunk
+        uses: spiceai/spiceio/.github/actions/setup@f964d0fc0c7c60f1463c35971636493b8186a7e2 # v0.2.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}


### PR DESCRIPTION
## 📝 Summary

- Pin the spiceio setup action in the develop PR workflow to the v0.2.0 release commit.
- Stop tracking the trunk SHA for this CI dependency.

## 🔗 Related

- https://github.com/spiceai/spiceio/releases/tag/v0.2.0

## 📚 Docs

- None.