### PR TITLE
style: Fix formatting and clippy warnings on develop

### DIFF
--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -547,9 +547,7 @@ impl CayenneSchemaProvider {
                             .as_any()
                             .downcast_ref::<CayenneTableProvider>()
                     })
-                    .or_else(|| {
-                        provider.as_any().downcast_ref::<CayenneTableProvider>()
-                    })
+                    .or_else(|| provider.as_any().downcast_ref::<CayenneTableProvider>())
                 else {
                     tracing::warn!(
                         "Partition sub-provider is not a CayenneTableProvider, skipping refresh"
@@ -557,9 +555,7 @@ impl CayenneSchemaProvider {
                     continue;
                 };
                 if let Err(err) = cayenne.refresh(cayenne).await {
-                    tracing::warn!(
-                        "Failed to refresh partitioned Cayenne table in place: {err}"
-                    );
+                    tracing::warn!("Failed to refresh partitioned Cayenne table in place: {err}");
                     // Fail safely: keep the existing partitioned provider rather than
                     // signaling failure that would cause it to be replaced by a
                     // non-partitioned provider.

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -17,7 +17,12 @@ limitations under the License.
 //! Forwards writes to each relevant executor based on their assigned partitions.
 //! This is used for partitioned tables that are written to via the coordinator.
 
-use std::{collections::HashMap, pin::Pin, sync::Arc, sync::atomic::{AtomicU64, Ordering}};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use arrow::array::{Array, RecordBatch};
 use arrow_flight::{
@@ -196,7 +201,7 @@ pub(crate) async fn forward_federated_partitioned_write(
     // Decode the first message and build a streaming iterator that yields
     // each subsequent FlightData message as a RecordBatch without buffering.
     let first_batch =
-        maybe_read_first_batch(first_message, Arc::clone(&schema), &dictionaries_by_id)?;
+        maybe_read_first_batch(&first_message, Arc::clone(&schema), &dictionaries_by_id)?;
 
     let decode_schema = Arc::clone(&schema);
     let batch_stream = async_stream::try_stream! {
@@ -232,17 +237,17 @@ pub(crate) async fn forward_federated_partitioned_write(
     )]))))
 }
 
-/// If the first FlightData message contains a non-empty body, decode it as the first RecordBatch to be forwarded.
-/// The first FlightData message could be schema-only with an empty body, or it could contain both schema and data - we support both cases.
+/// If the first `FlightData` message contains a non-empty body, decode it as the first `RecordBatch` to be forwarded.
+/// The first `FlightData` message could be schema-only with an empty body, or it could contain both schema and data - we support both cases.
 fn maybe_read_first_batch(
-    first_message: FlightData,
+    first_message: &FlightData,
     schema: SchemaRef,
     dictionaries_by_id: &Arc<HashMap<i64, Arc<dyn Array>>>,
 ) -> Result<Option<RecordBatch>> {
     if first_message.data_body.is_empty() {
         Ok(None)
     } else {
-        let batch = flight_data_to_arrow_batch(&first_message, schema, dictionaries_by_id)
+        let batch = flight_data_to_arrow_batch(first_message, schema, dictionaries_by_id)
             .context(DecodeBatchSnafu)?;
         Ok(Some(batch))
     }
@@ -410,8 +415,7 @@ async fn route_batch_and_assign_unseen(
     // Partition rows by executor filter, collecting (executor_id, batch) pairs
     // without sending yet. All sends happen concurrently at the end to avoid
     // head-of-line blocking when one executor's channel is full.
-    let (unmatched, mut pending_sends) =
-        partition_matched_rows(batch, executor_filters, senders)?;
+    let (unmatched, mut pending_sends) = partition_matched_rows(batch, executor_filters, senders)?;
     if unmatched.num_rows() == 0 {
         send_all_concurrent(senders, pending_sends, path).await?;
         return Ok(());
@@ -540,7 +544,7 @@ async fn route_batch_and_assign_unseen(
         // Queue the rows for concurrent send.
         if !senders.contains_key(&executor_id) {
             return Err(Error::NoSenderForExecutor {
-                executor_id: executor_id.clone(),
+                executor_id,
                 table: path.to_string(),
             });
         }
@@ -663,7 +667,7 @@ fn partition_matched_rows(
                 "Skipping send to disconnected executor; rows will be re-assigned"
             );
             continue;
-        };
+        }
 
         let filtered =
             arrow::compute::filter_record_batch(&remaining, mask).context(FilterBatchSnafu)?;
@@ -826,118 +830,6 @@ async fn spawn_executor_forwarding_tasks(
 
 /// Encodes `RecordBatch`es from `rx` as `FlightData` and sends them via `DoPut`
 /// to a specific executor.
-#[cfg(test)]
-#[expect(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-    use arrow::array::Int32Array;
-    use arrow::datatypes::{Field, Schema};
-    use arrow_flight::utils::batches_to_flight_data;
-
-    fn test_schema() -> SchemaRef {
-        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
-    }
-
-    fn encode_batch_to_flight_data(schema: &SchemaRef, batch: &RecordBatch) -> Vec<FlightData> {
-        let flight_data =
-            batches_to_flight_data(schema, vec![batch.clone()]).expect("encode flight data");
-        flight_data
-    }
-
-    #[test]
-    fn test_maybe_read_first_batch_empty_body_returns_none() {
-        let schema = test_schema();
-        let dictionaries_by_id = Arc::new(HashMap::new());
-
-        // Build a FlightData with schema header but empty body (schema-only message).
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-        )
-        .expect("should create batch");
-        let flight_data = encode_batch_to_flight_data(&schema, &batch);
-
-        // The schema-only message should have an empty data_body.
-        assert!(
-            flight_data[0].data_body.is_empty(),
-            "schema message should have empty body"
-        );
-
-        let result = maybe_read_first_batch(
-            flight_data[0].clone(),
-            Arc::clone(&schema),
-            &dictionaries_by_id,
-        )
-        .expect("should succeed");
-        assert!(result.is_none(), "empty body should return None");
-    }
-
-    #[test]
-    fn test_maybe_read_first_batch_with_data_returns_some() {
-        let schema = test_schema();
-        let dictionaries_by_id = Arc::new(HashMap::new());
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![10, 20, 30]))],
-        )
-        .expect("should create batch");
-
-        let flight_data = encode_batch_to_flight_data(&schema, &batch);
-        assert!(
-            !flight_data.is_empty(),
-            "should have at least one data message"
-        );
-
-        let data_fd = flight_data
-            .into_iter()
-            .nth(1)
-            .expect("should have data message");
-        assert!(
-            !data_fd.data_body.is_empty(),
-            "data message should have non-empty body"
-        );
-
-        let result = maybe_read_first_batch(data_fd, Arc::clone(&schema), &dictionaries_by_id)
-            .expect("should succeed");
-
-        let decoded = result.expect("non-empty body should return Some");
-        assert_eq!(decoded.num_rows(), 3);
-        assert_eq!(decoded.num_columns(), 1);
-
-        let col = decoded
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .expect("column should be Int32Array");
-        assert_eq!(col.values().as_ref(), &[10, 20, 30]);
-    }
-
-    #[test]
-    fn test_maybe_read_first_batch_single_row() {
-        let schema = test_schema();
-        let dictionaries_by_id = Arc::new(HashMap::new());
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![42]))],
-        )
-        .expect("should create batch");
-
-        let flight_data = encode_batch_to_flight_data(&schema, &batch);
-        let data_fd = flight_data
-            .into_iter()
-            .nth(1)
-            .expect("should have data message");
-
-        let result = maybe_read_first_batch(data_fd, Arc::clone(&schema), &dictionaries_by_id)
-            .expect("should succeed");
-
-        let decoded = result.expect("should return Some for single row");
-        assert_eq!(decoded.num_rows(), 1);
-    }
-}
-
 async fn forward_batches_to_executor(
     client: data_components::flightsql::FlightSqlClient,
     rx: mpsc::Receiver<RecordBatch>,
@@ -1070,7 +962,7 @@ async fn forward_batches_to_executor(
             tracing::error!(
                 executor = %executor_id,
                 table = %table_label,
-                elapsed_ms = forward_start.elapsed().as_millis() as u64,
+                elapsed_ms = u64::try_from(forward_start.elapsed().as_millis()).unwrap_or(u64::MAX),
                 batches = batches_forwarded.load(Ordering::Relaxed),
                 keepalives = keepalives_sent.load(Ordering::Relaxed),
                 error = %e,
@@ -1085,7 +977,7 @@ async fn forward_batches_to_executor(
         tracing::error!(
             executor = %executor_id,
             table = %table_label,
-            elapsed_ms = forward_start.elapsed().as_millis() as u64,
+            elapsed_ms = u64::try_from(forward_start.elapsed().as_millis()).unwrap_or(u64::MAX),
             batches = batches_forwarded.load(Ordering::Relaxed),
             keepalives = keepalives_sent.load(Ordering::Relaxed),
             error = %e,
@@ -1097,7 +989,7 @@ async fn forward_batches_to_executor(
     tracing::info!(
         executor = %executor_id,
         table = %table_label,
-        elapsed_ms = forward_start.elapsed().as_millis() as u64,
+        elapsed_ms = u64::try_from(forward_start.elapsed().as_millis()).unwrap_or(u64::MAX),
         batches = batches_forwarded.load(Ordering::Relaxed),
         keepalives = keepalives_sent.load(Ordering::Relaxed),
         "Executor forwarding task completed successfully",
@@ -1106,5 +998,112 @@ async fn forward_batches_to_executor(
     match encode_result_rx.await {
         Ok(Ok(())) | Err(_) => Ok(()),
         Ok(Err(message)) => Err(Error::Encode { message }),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{Field, Schema};
+    use arrow_flight::utils::batches_to_flight_data;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn encode_batch_to_flight_data(schema: &SchemaRef, batch: &RecordBatch) -> Vec<FlightData> {
+        batches_to_flight_data(schema, vec![batch.clone()]).expect("encode flight data")
+    }
+
+    #[test]
+    fn test_maybe_read_first_batch_empty_body_returns_none() {
+        let schema = test_schema();
+        let dictionaries_by_id = Arc::new(HashMap::new());
+
+        // Build a FlightData with schema header but empty body (schema-only message).
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .expect("should create batch");
+        let flight_data = encode_batch_to_flight_data(&schema, &batch);
+
+        // The schema-only message should have an empty data_body.
+        assert!(
+            flight_data[0].data_body.is_empty(),
+            "schema message should have empty body"
+        );
+
+        let result =
+            maybe_read_first_batch(&flight_data[0], Arc::clone(&schema), &dictionaries_by_id)
+                .expect("should succeed");
+        assert!(result.is_none(), "empty body should return None");
+    }
+
+    #[test]
+    fn test_maybe_read_first_batch_with_data_returns_some() {
+        let schema = test_schema();
+        let dictionaries_by_id = Arc::new(HashMap::new());
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![10, 20, 30]))],
+        )
+        .expect("should create batch");
+
+        let flight_data = encode_batch_to_flight_data(&schema, &batch);
+        assert!(
+            !flight_data.is_empty(),
+            "should have at least one data message"
+        );
+
+        let data_fd = flight_data
+            .into_iter()
+            .nth(1)
+            .expect("should have data message");
+        assert!(
+            !data_fd.data_body.is_empty(),
+            "data message should have non-empty body"
+        );
+
+        let result = maybe_read_first_batch(&data_fd, Arc::clone(&schema), &dictionaries_by_id)
+            .expect("should succeed");
+
+        let decoded = result.expect("non-empty body should return Some");
+        assert_eq!(decoded.num_rows(), 3);
+        assert_eq!(decoded.num_columns(), 1);
+
+        let col = decoded
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("column should be Int32Array");
+        assert_eq!(col.values().as_ref(), &[10, 20, 30]);
+    }
+
+    #[test]
+    fn test_maybe_read_first_batch_single_row() {
+        let schema = test_schema();
+        let dictionaries_by_id = Arc::new(HashMap::new());
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![42]))],
+        )
+        .expect("should create batch");
+
+        let flight_data = encode_batch_to_flight_data(&schema, &batch);
+        let data_fd = flight_data
+            .into_iter()
+            .nth(1)
+            .expect("should have data message");
+
+        let result = maybe_read_first_batch(&data_fd, Arc::clone(&schema), &dictionaries_by_id)
+            .expect("should succeed");
+
+        let decoded = result.expect("should return Some for single row");
+        assert_eq!(decoded.num_rows(), 1);
     }
 }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
 use arrow::array::RecordBatch;
 use arrow_flight::{

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -79,17 +79,20 @@ pub use session::SessionStore;
 
 /// Sentinel value in [`FlightData::app_metadata`] that marks a message as a
 /// keepalive heartbeat. Write-through forwarding tasks send these periodically
-/// to prevent the executor's DoPut idle timeout from firing on streams that
+/// to prevent the executor's `DoPut` idle timeout from firing on streams that
 /// receive data in bursts with long idle gaps between them.
 pub const KEEPALIVE_APP_METADATA: &[u8] = b"spice-keepalive";
 
-/// Returns the DoPut idle timeout.  Override with the
+/// Returns the `DoPut` idle timeout.  Override with the
 /// `SPICE_DO_PUT_IDLE_TIMEOUT_SECS` env-var (useful for tests).
 pub fn do_put_idle_timeout() -> std::time::Duration {
     std::env::var("SPICE_DO_PUT_IDLE_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .map_or(std::time::Duration::from_secs(120), std::time::Duration::from_secs)
+        .map_or(
+            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs,
+        )
 }
 
 pub struct Service {

--- a/crates/runtime/tests/cluster/harness.rs
+++ b/crates/runtime/tests/cluster/harness.rs
@@ -137,7 +137,7 @@ pub struct ClusterHarness {
     /// Background server handles — aborted on drop.
     handles: Vec<JoinHandle<RuntimeResult<()>>>,
     executor_manager: ExecutorManager,
-    /// The scheduler's Flight bind address (for external DoPut tests).
+    /// The scheduler's Flight bind address (for external `DoPut` tests).
     scheduler_flight_addr: SocketAddr,
 }
 
@@ -156,6 +156,7 @@ impl ClusterHarness {
     }
 
     /// Returns the scheduler's Flight address for direct client connections.
+    #[expect(dead_code)]
     pub fn scheduler_flight_addr(&self) -> SocketAddr {
         self.scheduler_flight_addr
     }

--- a/crates/runtime/tests/cluster/write_through_idle_timeout.rs
+++ b/crates/runtime/tests/cluster/write_through_idle_timeout.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! Regression test for write-through `DoPut` idle timeout keepalive.
 //!
-//! Verifies that keepalive FlightData messages (app_metadata = "spice-keepalive")
+//! Verifies that keepalive `FlightData` messages (`app_metadata` = "spice-keepalive")
 //! prevent the executor's `DoPut` idle timeout from firing.
 //!
 //! Uses a minimal Flight server stub that mirrors the idle-timeout behavior


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` formatting issues in `write_through.rs`, `provider.rs`, and `flight/mod.rs`
- Fix clippy pedantic warnings: `doc_markdown`, `needless_pass_by_value`, `redundant_clone`, `unnecessary_semicolon`, `cast_possible_truncation`, `let_and_return`, `items_after_test_module`
- Remove unused import (`time::Duration` in `do_put.rs`)
- Fix dead code warning in test harness with `#[expect(dead_code)]`

## Test plan
- `make lint` passes locally