### PR TITLE
style: Fix clippy equatable_if_let in builder.rs

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -343,9 +343,10 @@ impl DataFusionBuilder {
                 Arc::new(Box::new(track_bytes_processed)),
             )));
 
-        if let Some(ClusterRole::Scheduler) =
-            self.cluster_config.as_ref().and_then(|cfg| cfg.role())
-        {
+        if matches!(
+            self.cluster_config.as_ref().and_then(|cfg| cfg.role()),
+            Some(ClusterRole::Scheduler)
+        ) {
             state = state.with_physical_optimizer_rule(FlightSQLPartialAggregatePushdown::new());
         }
 


### PR DESCRIPTION
## Summary
- Fix `clippy::equatable_if_let` warning in `crates/runtime/src/datafusion/builder.rs`
- Replace `if let Some(ClusterRole::Scheduler) = expr` with `matches!(expr, Some(ClusterRole::Scheduler))`

This was introduced by #9882 and not caught by the follow-up lint fix commit.

## Test plan
- `make lint` passes with this fix