### PR TITLE
Fix partial aggregation deduplication on string checking

### DIFF
--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
@@ -638,6 +638,95 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test: column names containing "count" or "sum" as a
+    /// substring (e.g. `l_dis`**`count`**) must not confuse the AVG state
+    /// field classification. Both `COUNT` and `SUM` must appear in the
+    /// pushed-down SQL.
+    #[tokio::test]
+    async fn test_pushdown_avg_column_name_contains_count() -> Result<()> {
+        let schema = lineitem_schema();
+        let union_input = make_union(vec![
+            make_flight_exec(&schema, "foo.foo.lineitem", &[]),
+            make_flight_exec(&schema, "foo.foo.lineitem", &[]),
+        ]);
+
+        // l_discount is at index 2 in lineitem_schema — its name contains "count"
+        let avg_expr =
+            AggregateExprBuilder::new(avg_udaf(), vec![Arc::new(Column::new("l_discount", 2))])
+                .schema(Arc::clone(&schema))
+                .alias("avg(l_discount)")
+                .build()?;
+
+        let plan = full_aggregate(
+            union_input,
+            &[(3, "l_returnflag")],
+            vec![Arc::new(avg_expr)],
+        )?;
+
+        let optimized = optimize(plan)?;
+        // Must produce both COUNT and SUM, not two COUNTs
+        insta::assert_snapshot!(plan_display(&optimized), @r#"
+        AggregateExec: mode=Final, gby=[l_returnflag@0 as l_returnflag], aggr=[avg(l_discount)]
+          CoalescePartitionsExec
+            UnionExec
+              PartialAggregationFlightSqlExec sql=SELECT "l_returnflag", COUNT("l_discount") AS "__agg_0", SUM("l_discount") AS "__agg_1" FROM foo.foo.lineitem GROUP BY "l_returnflag"
+              PartialAggregationFlightSqlExec sql=SELECT "l_returnflag", COUNT("l_discount") AS "__agg_0", SUM("l_discount") AS "__agg_1" FROM foo.foo.lineitem GROUP BY "l_returnflag"
+        "#);
+
+        Ok(())
+    }
+
+    /// Regression test: end-to-end correctness for `avg(l_discount)` where
+    /// the column name contains "count" as a substring. Verifies the Final
+    /// aggregate computes `SUM / COUNT`, not `COUNT / COUNT`.
+    #[tokio::test]
+    async fn test_result_avg_column_name_contains_count() -> Result<()> {
+        let schema = lineitem_schema();
+        let union_input = make_union(vec![
+            make_flight_exec(&schema, "foo.foo.lineitem", &[]),
+            make_flight_exec(&schema, "foo.foo.lineitem", &[]),
+        ]);
+
+        // l_discount at index 2
+        let avg_expr =
+            AggregateExprBuilder::new(avg_udaf(), vec![Arc::new(Column::new("l_discount", 2))])
+                .schema(Arc::clone(&schema))
+                .alias("avg(l_discount)")
+                .build()?;
+
+        let plan = full_aggregate(union_input, &[], vec![Arc::new(avg_expr)])?;
+        let optimized = optimize(plan)?;
+
+        let partial_schema = optimized.children()[0].children()[0].schema();
+        assert_eq!(
+            partial_schema.fields().len(),
+            2,
+            "AVG partial state must have exactly 2 fields (count, sum), got schema: {partial_schema}"
+        );
+
+        // Partition 1: [0.04, 0.06, 0.10] → COUNT=3, SUM=0.20 (20 in cents)
+        // Partition 2: [0.08, 0.02]        → COUNT=2, SUM=0.10 (10 in cents)
+        // Correct AVG = 0.30 / 5 = 0.06
+        // Wrong   AVG = COUNT/COUNT = 1.0  (if SUM field got COUNT value)
+        let mut data = vec![
+            vec![make_scalar_partial_batch(&partial_schema, 3, 0, 0.0, 20)?],
+            vec![make_scalar_partial_batch(&partial_schema, 2, 0, 0.0, 10)?],
+        ]
+        .into_iter();
+        let executable = replace_pushdown_with_memory(optimized, &mut data)?;
+        let result = execute_plan(executable).await?;
+
+        insta::assert_snapshot!(pretty(&result), @r"
+        +-----------------+
+        | avg(l_discount) |
+        +-----------------+
+        | 0.060000        |
+        +-----------------+
+        ");
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_pushdown_single_partition_no_union() -> Result<()> {
         let schema = lineitem_schema();

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/exec.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/exec.rs
@@ -437,13 +437,14 @@ fn build_aggregate_sql(
 
             for field in &state_fields {
                 let name_lower = field.name().to_lowercase();
-                if name_lower.contains("count") {
+                // Match on the `[count]` / `[sum]` suffix produced by `format_state_name`.
+                if name_lower.ends_with("[count]") {
                     all_fragments.push(SqlFragment {
                         sql: format!("COUNT({arg_sql})"),
                         dedup_key: format!("COUNT({stripped})"),
                         needs_alias: true,
                     });
-                } else if name_lower.contains("sum") {
+                } else if name_lower.ends_with("[sum]") {
                     // Use SUM(col) (no CAST) as the dedup key so it merges with an
                     // existing explicit SUM(col). The local side casts the Decimal
                     // result to Float64 via remap_batch.
@@ -454,7 +455,7 @@ fn build_aggregate_sql(
                     });
                 } else {
                     return Err(DataFusionError::Internal(format!(
-                        "Unrecognized AVG state field '{}' — expected name containing 'count' or 'sum'",
+                        "Unrecognized AVG state field '{}' — expected name ending with '[count]' or '[sum]'",
                         field.name()
                     )));
                 }


### PR DESCRIPTION
The root cause is in exec.rs lines 438-458, in the AVG decomposition logic within `build_aggregate_sql`:

 ```rust
 for field in &state_fields {
     let name_lower = field.name().to_lowercase();
     if name_lower.contains("count") {
         // emit COUNT fragment
     } else if name_lower.contains("sum") {
         // emit SUM fragment
     } else {
         return Err(...);
     }
 }
 ```

 DataFusion's AVG accumulator produces state field names using `.format_state_name(`, which embeds the full aggregate expression name including the column name. For `avg(l_discount)`, the state fields are named something like:
 - `avg(l_discount)[count]`
 - `avg(l_discount)[sum]`

 The code does `name_lower.contains("count")` to distinguish them. But the column name l_discount contains "count" as a substring: l_discount.

 This means both state fields match the contains("count") branch:
 1. `avg(l_discount)[count]` → contains "count" ✓ → emits COUNT("l_discount") ✓
 2. `avg(l_discount)[sum]` → contains "count" (from "discount") ✓ → emits COUNT("l_discount") instead of SUM("l_discount") ✗

Both fragments now have the same dedup key (`COUNT("l_discount")`), so the deduplication in Phase 2 collapses them into a single `COUNT("l_discount")` column. The SUM is never emitted.