### PR TITLE
fix: add MetastoreTransaction to prevent concurrent SQLite transaction conflicts

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -29,8 +29,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use turso_shared::{
-    is_retryable_write_conflict_message, retry_backoff_delay, BEGIN_CONCURRENT_SQL,
-    BEGIN_TRANSACTION_SQL, COMMIT_SQL, DEFAULT_CONCURRENT_WRITE_MAX_ATTEMPTS,
+    is_retryable_write_conflict_message, retry_backoff_delay, DEFAULT_CONCURRENT_WRITE_MAX_ATTEMPTS,
 };
 
 struct ExistingDeleteFileRecord {
@@ -52,18 +51,6 @@ pub(crate) enum MetastoreImpl {
 }
 
 impl MetastoreImpl {
-    #[must_use]
-    pub(crate) fn is_turso(&self) -> bool {
-        #[cfg(feature = "turso")]
-        {
-            matches!(self, Self::Turso(_))
-        }
-        #[cfg(not(feature = "turso"))]
-        {
-            false
-        }
-    }
-
     /// Helper to query a single row from metastore, working with both `SQLite` and Turso
     pub(crate) async fn query_row_helper<F, T>(
         &self,
@@ -90,18 +77,6 @@ impl MetastoreImpl {
         }
     }
 
-    /// Helper to execute a batch of SQL statements.
-    ///
-    /// Callers that require atomicity must include explicit `BEGIN ... COMMIT`
-    /// statements in the SQL they pass to this helper.
-    pub(crate) async fn execute_batch_helper(&self, sql: &str) -> CatalogResult<()> {
-        match self {
-            MetastoreImpl::Sqlite(m) => m.execute_batch(sql).await,
-            #[cfg(feature = "turso")]
-            MetastoreImpl::Turso(m) => m.execute_batch(sql).await,
-        }
-    }
-
     /// Helper to query multiple rows from metastore, working with both `SQLite` and Turso
     pub(crate) async fn query_helper<F, T>(
         &self,
@@ -125,6 +100,21 @@ impl MetastoreImpl {
             MetastoreImpl::Sqlite(m) => m.shutdown().await,
             #[cfg(feature = "turso")]
             MetastoreImpl::Turso(m) => m.shutdown().await,
+        }
+    }
+
+    /// Begin a transaction on the underlying metastore.
+    ///
+    /// Each backend sends the appropriate BEGIN statement (e.g. `BEGIN TRANSACTION`
+    /// for `SQLite`, `BEGIN CONCURRENT` for Turso). The returned transaction object
+    /// holds exclusive access to the connection.
+    pub(crate) async fn begin_transaction(
+        &self,
+    ) -> CatalogResult<Box<dyn super::metastore::MetastoreTransaction>> {
+        match self {
+            MetastoreImpl::Sqlite(m) => m.begin_transaction().await,
+            #[cfg(feature = "turso")]
+            MetastoreImpl::Turso(m) => m.begin_transaction().await,
         }
     }
 }
@@ -239,6 +229,25 @@ impl CayenneCatalog {
         pk_bytes_list: Vec<Vec<u8>>,
         sequence_number: i64,
     ) -> CatalogResult<()> {
+        let (sql, params) =
+            Self::build_insert_records_chunk_sql(table_id, pk_bytes_list, sequence_number);
+
+        self.metastore
+            .execute_helper(ExecuteParams { sql: &sql, params })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to add insert record entries in batch".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(())
+    }
+
+    /// Build the SQL and parameters for a single chunk of insert records.
+    fn build_insert_records_chunk_sql(
+        table_id: &str,
+        pk_bytes_list: Vec<Vec<u8>>,
+        sequence_number: i64,
+    ) -> (String, Vec<MetastoreValue>) {
         let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
         let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
         let table_id = table_id.to_string();
@@ -264,14 +273,7 @@ impl CayenneCatalog {
             values_parts.join(", ")
         );
 
-        self.metastore
-            .execute_helper(ExecuteParams { sql: &sql, params })
-            .await
-            .map_err(|e| CatalogError::InvalidOperation {
-                message: "Failed to add insert record entries in batch".to_string(),
-                source: Box::new(e),
-            })?;
-        Ok(())
+        (sql, params)
     }
 }
 
@@ -847,40 +849,29 @@ impl MetadataCatalog for CayenneCatalog {
                 .await;
         }
 
-        // Multiple chunks required — wrap in a transaction for atomicity.
-        let begin = if self.metastore.is_turso() {
-            BEGIN_CONCURRENT_SQL
-        } else {
-            BEGIN_TRANSACTION_SQL
-        };
-        self.metastore
-            .execute_batch_helper(begin)
-            .await
-            .map_err(|e| CatalogError::InvalidOperation {
+        // Multiple chunks required — use a proper transaction for atomicity.
+        // The transaction holds exclusive access to the connection, preventing
+        // concurrent operations from interleaving BEGIN/COMMIT boundaries.
+        let tx = self.metastore.begin_transaction().await.map_err(|e| {
+            CatalogError::InvalidOperation {
                 message: "Failed to begin transaction for batch insert records".to_string(),
                 source: Box::new(e),
-            })?;
+            }
+        })?;
 
         for chunk in pk_bytes_list.chunks(MAX_ROWS_PER_CHUNK) {
-            if let Err(e) = self
-                .insert_records_chunk(table_id, chunk.to_vec(), sequence_number)
-                .await
-            {
-                // Best-effort rollback; if it fails, the connection will
-                // auto-rollback when the next statement runs.
-                let _ = self
-                    .metastore
-                    .execute_helper(ExecuteParams {
-                        sql: "ROLLBACK",
-                        params: vec![],
-                    })
-                    .await;
-                return Err(e);
+            let (sql, params) =
+                Self::build_insert_records_chunk_sql(table_id, chunk.to_vec(), sequence_number);
+            if let Err(e) = tx.execute(ExecuteParams { sql: &sql, params }).await {
+                // Transaction auto-rolls-back on drop.
+                return Err(CatalogError::InvalidOperation {
+                    message: "Failed to add insert record entries in batch".to_string(),
+                    source: Box::new(e),
+                });
             }
         }
 
-        self.metastore
-            .execute_batch_helper(COMMIT_SQL)
+        tx.commit()
             .await
             .map_err(|e| CatalogError::InvalidOperation {
                 message: "Failed to commit transaction for batch insert records".to_string(),
@@ -1040,9 +1031,7 @@ impl MetadataCatalog for CayenneCatalog {
             }
         }
 
-        // Execute all operations atomically using a transaction batch.
-        // Atomicity is provided by explicit BEGIN ... COMMIT statements in `batch_sql`,
-        // ensuring either all statements succeed or none takes effect.
+        // Execute all operations atomically using a proper transaction.
         //
         // Order matters for crash safety:
         // 1. Clear delete files first - they reference the old snapshot's data
@@ -1054,30 +1043,19 @@ impl MetadataCatalog for CayenneCatalog {
         // If interrupted between these, the old snapshot remains active with
         // no delete files, which is safe (just loses the pending deletions,
         // but data is not corrupted).
-        let begin_transaction = if self.metastore.is_turso() {
-            BEGIN_CONCURRENT_SQL
-        } else {
-            BEGIN_TRANSACTION_SQL
-        };
-
         let table_id_literal = sql_text_literal(table_id);
         let new_snapshot_id_literal = sql_text_literal(new_snapshot_id);
         let batch_sql = format!(
-            "{begin_transaction}; \
-             DELETE FROM cayenne_delete_file WHERE table_id = {table_id_literal}; \
+            "DELETE FROM cayenne_delete_file WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_insert_record WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_snapshot_sequence WHERE table_id = {table_id_literal}; \
-             UPDATE cayenne_table SET current_snapshot_id = {new_snapshot_id_literal} WHERE table_id = {table_id_literal}; \
-             {COMMIT_SQL};"
+             UPDATE cayenne_table SET current_snapshot_id = {new_snapshot_id_literal} WHERE table_id = {table_id_literal};"
         );
 
-        // BEGIN CONCURRENT may fail with SQLITE_BUSY/SQLITE_LOCKED conflicts at commit time.
-        // Retry a few times with backoff to improve throughput under concurrent writers.
-        let max_attempts = if self.metastore.is_turso() {
-            DEFAULT_CONCURRENT_WRITE_MAX_ATTEMPTS
-        } else {
-            1
-        };
+        // The transaction may fail with SQLITE_BUSY/SQLITE_LOCKED conflicts at
+        // commit time (especially with Turso's BEGIN CONCURRENT). Retry a few
+        // times with backoff.
+        let max_attempts = DEFAULT_CONCURRENT_WRITE_MAX_ATTEMPTS;
         if max_attempts == 0 {
             return Err(CatalogError::InvalidOperationNoSource {
                 message: "commit_compaction requires at least one attempt".to_string(),
@@ -1085,25 +1063,33 @@ impl MetadataCatalog for CayenneCatalog {
         }
 
         for attempt in 1..=max_attempts {
-            match self.metastore.execute_batch_helper(&batch_sql).await {
-                Ok(()) => return Ok(()),
-                Err(e)
-                    if self.metastore.is_turso()
-                        && attempt < max_attempts
-                        && is_retryable_turso_write_conflict(&e) =>
-                {
-                    rollback_failed_compaction_transaction(&self.metastore).await;
-                    let delay = retry_backoff_delay(attempt);
-                    tracing::debug!(
-                        attempt,
-                        max_attempts,
-                        ?delay,
-                        "Retrying Turso BEGIN CONCURRENT compaction transaction after conflict"
-                    );
-                    tokio::time::sleep(delay).await;
+            let tx = self.metastore.begin_transaction().await.map_err(|e| {
+                CatalogError::FailedToSetCurrentSnapshot {
+                    source: Box::new(e),
                 }
+            })?;
+
+            match tx.execute_batch(&batch_sql).await {
+                Ok(()) => match tx.commit().await {
+                    Ok(()) => return Ok(()),
+                    Err(e) if attempt < max_attempts && is_retryable_write_conflict(&e) => {
+                        let delay = retry_backoff_delay(attempt);
+                        tracing::debug!(
+                            attempt,
+                            max_attempts,
+                            ?delay,
+                            "Retrying compaction transaction after commit conflict"
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                    Err(e) => {
+                        return Err(CatalogError::FailedToSetCurrentSnapshot {
+                            source: Box::new(e),
+                        });
+                    }
+                },
                 Err(e) => {
-                    rollback_failed_compaction_transaction(&self.metastore).await;
+                    // Transaction auto-rolls-back on drop.
                     return Err(CatalogError::FailedToSetCurrentSnapshot {
                         source: Box::new(e),
                     });
@@ -1358,7 +1344,7 @@ impl MetadataCatalog for CayenneCatalog {
     }
 }
 
-fn is_retryable_turso_write_conflict(error: &CatalogError) -> bool {
+fn is_retryable_write_conflict(error: &CatalogError) -> bool {
     match error {
         CatalogError::Database { message } => is_retryable_write_conflict_message(message),
         _ => false,
@@ -1440,27 +1426,6 @@ async fn ensure_snapshot_directory_exists(table: &TableMetadata) -> CatalogResul
     tokio::fs::create_dir_all(&snapshot_dir)
         .await
         .map_err(|e| CatalogError::Io { source: e })
-}
-
-async fn rollback_failed_compaction_transaction(metastore: &MetastoreImpl) {
-    if let Err(error) = metastore
-        .execute_helper(ExecuteParams {
-            sql: "ROLLBACK",
-            params: vec![],
-        })
-        .await
-    {
-        let backend = if metastore.is_turso() {
-            "Turso"
-        } else {
-            "SQLite"
-        };
-        tracing::debug!(
-            backend,
-            ?error,
-            "Failed to rollback compaction transaction after batch error"
-        );
-    }
 }
 
 /// Checks if the existing stored configuration matches the new [`CreateTableOptions`].
@@ -2904,37 +2869,6 @@ mod tests {
         for message in messages {
             assert!(!is_partition_unique_constraint_violation_message(message));
         }
-    }
-
-    #[tokio::test]
-    async fn test_rollback_failed_compaction_transaction_cleans_up_sqlite_batch_error() {
-        let test_db = format!(
-            "sqlite://./.test_compaction_rollback_{}.db",
-            uuid::Uuid::now_v7()
-        );
-        let catalog = CayenneCatalog::new(&test_db).expect("Failed to create catalog");
-        catalog.init().await.expect("Failed to initialize catalog");
-
-        let batch_result = catalog
-            .metastore
-            .execute_batch_helper(
-                "BEGIN TRANSACTION; INSERT INTO missing_table VALUES (1); COMMIT;",
-            )
-            .await;
-        assert!(batch_result.is_err(), "Expected batch execution to fail");
-
-        rollback_failed_compaction_transaction(&catalog.metastore).await;
-
-        catalog
-            .metastore
-            .execute_batch_helper("BEGIN TRANSACTION; COMMIT;")
-            .await
-            .expect("Expected rollback helper to clear the failed SQLite transaction");
-
-        let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_file(format!("{db_path}-shm"));
-        let _ = std::fs::remove_file(format!("{db_path}-wal"));
     }
 
     /// Helper to create a [`TableMetadata`] for unit tests.

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -365,21 +365,13 @@ impl<T: MetastoreGetValue> MetastoreGetValue for Option<T> {
     }
 }
 
-// Transaction support is backend-specific and cannot be expressed as a trait object
-// due to generic methods. Each backend should provide its own concrete transaction type.
-//
-// For example:
-// - SqliteMetastore provides SqliteTransaction
-// - TursoMetastore provides TursoTransaction
-//
-// These concrete types should follow the RAII pattern:
-// - Automatically rollback on drop unless explicitly committed
-// - Provide execute(), query_row(), query() methods matching the MetastoreBackend API
-// - Provide commit() and rollback() methods
+/// A metastore transaction that provides exclusive access to the underlying
+/// connection for the duration of its lifetime.
+///
 /// The transaction must be explicitly committed via `commit()`, otherwise it will
 /// automatically rollback when dropped.
 #[async_trait]
-pub trait MetastoreTransaction: Send + Sync {
+pub trait MetastoreTransaction: Send {
     /// Execute a SQL statement that modifies data within the transaction.
     ///
     /// # Errors
@@ -387,25 +379,12 @@ pub trait MetastoreTransaction: Send + Sync {
     /// Returns an error if the statement cannot be executed.
     async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()>;
 
-    /// Query a single row from the database within the transaction.
+    /// Execute a batch of SQL statements within the transaction.
     ///
     /// # Errors
     ///
-    /// Returns an error if the query fails or returns no rows.
-    async fn query_row<F, T>(&self, params: QueryRowParams<'_>, f: F) -> CatalogResult<T>
-    where
-        F: FnOnce(&dyn MetastoreRow) -> CatalogResult<T> + Send + 'static,
-        T: Send + 'static;
-
-    /// Query multiple rows from the database within the transaction.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the query fails.
-    async fn query<F, T>(&self, params: QueryParams<'_>, f: F) -> CatalogResult<Vec<T>>
-    where
-        F: Fn(&dyn MetastoreRow) -> CatalogResult<T> + Send + 'static,
-        T: Send + 'static;
+    /// Returns an error if any statement in the batch fails.
+    async fn execute_batch(&self, sql: &str) -> CatalogResult<()>;
 
     /// Commit the transaction.
     ///
@@ -414,7 +393,7 @@ pub trait MetastoreTransaction: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the transaction cannot be committed.
-    async fn commit(self) -> CatalogResult<()>;
+    async fn commit(self: Box<Self>) -> CatalogResult<()>;
 
     /// Explicitly rollback the transaction.
     ///
@@ -423,7 +402,7 @@ pub trait MetastoreTransaction: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the transaction cannot be rolled back.
-    async fn rollback(self) -> CatalogResult<()>;
+    async fn rollback(self: Box<Self>) -> CatalogResult<()>;
 }
 
 /// Trait for metastore backend implementations.
@@ -472,6 +451,21 @@ pub trait MetastoreBackend: Send + Sync {
     where
         F: Fn(&dyn MetastoreRow) -> CatalogResult<T> + Send + 'static,
         T: Send + 'static;
+
+    /// Begin a new transaction, acquiring exclusive access to the connection.
+    ///
+    /// The returned transaction holds a lock on the underlying connection,
+    /// preventing other operations from interleaving. This ensures that
+    /// multi-statement transactions (BEGIN...COMMIT) are atomic even when
+    /// multiple tasks share the same metastore.
+    ///
+    /// The backend-specific BEGIN statement is sent automatically
+    /// (e.g. `BEGIN TRANSACTION` for `SQLite`, `BEGIN CONCURRENT` for Turso).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction cannot be started.
+    async fn begin_transaction(&self) -> CatalogResult<Box<dyn MetastoreTransaction>>;
 
     /// Shutdown the metastore, performing any necessary cleanup.
     ///

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -21,12 +21,13 @@ limitations under the License.
 
 use super::{
     duplicate_delete_file_index_error_message, ExecuteParams, MetastoreBackend, MetastoreGetValue,
-    MetastoreRow, MetastoreValue, QueryParams, QueryRowParams,
+    MetastoreRow, MetastoreTransaction, MetastoreValue, QueryParams, QueryRowParams,
 };
 use crate::catalog::{CatalogError, CatalogResult};
 use async_trait::async_trait;
 use std::path::Path;
-use tokio::sync::OnceCell;
+use std::sync::Arc;
+use tokio::sync::{Mutex, OnceCell, OwnedMutexGuard};
 
 const DELETE_FILE_TABLE_UNIQUE_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXISTS idx_cayenne_delete_file_table_path ON cayenne_delete_file(table_id, path)";
 
@@ -36,9 +37,16 @@ const DELETE_FILE_TABLE_UNIQUE_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXI
 /// eliminating the overhead of opening/closing connections for each operation.
 pub struct SqliteMetastore {
     connection_string: String,
-    /// Cached connection - lazily initialized on first use via `OnceCell`
-    /// ensuring exactly one connection is created even under concurrent access.
-    conn: OnceCell<tokio_rusqlite::Connection>,
+    /// Cached connection behind a mutex.
+    ///
+    /// The [`Mutex`] ensures exclusive access to the underlying
+    /// `tokio_rusqlite::Connection`. Every operation acquires the mutex,
+    /// which prevents interleaving of multi-statement transactions
+    /// (e.g. `BEGIN ... INSERT ... COMMIT`) when multiple tasks share the
+    /// same metastore.
+    ///
+    /// Lazily initialized on first use via [`OnceCell`].
+    conn: OnceCell<Arc<Mutex<tokio_rusqlite::Connection>>>,
 }
 
 /// Convert a `tokio_rusqlite::Error` to a `CatalogError`, distinguishing constraint violations.
@@ -86,7 +94,7 @@ impl SqliteMetastore {
             .unwrap_or(&self.connection_string)
     }
 
-    /// Get or create the persistent connection.
+    /// Get or create the persistent connection (mutex-guarded).
     ///
     /// The connection is configured with performance optimizations:
     /// - WAL mode for non-blocking reads/writes
@@ -97,7 +105,9 @@ impl SqliteMetastore {
     ///
     /// Uses `OnceCell` to ensure the connection is created exactly once,
     /// even when multiple tasks call this method concurrently.
-    async fn get_conn(&self) -> CatalogResult<tokio_rusqlite::Connection> {
+    /// Returns an `Arc<Mutex<..>>` so callers acquire the mutex before
+    /// using the connection.
+    async fn get_conn(&self) -> CatalogResult<Arc<Mutex<tokio_rusqlite::Connection>>> {
         self.conn
             .get_or_try_init(|| async {
                 // Create parent directory if it doesn't exist
@@ -148,10 +158,10 @@ impl SqliteMetastore {
                     },
                 )?;
 
-                Ok(conn)
+                Ok(Arc::new(Mutex::new(conn)))
             })
             .await
-            .cloned()
+            .map(Arc::clone)
     }
 
     /// Schema for the `cayenne_table` table.
@@ -345,53 +355,59 @@ fn to_sqlite_value(value: &MetastoreValue) -> rusqlite::types::Value {
 impl MetastoreBackend for SqliteMetastore {
     async fn init_schema(&self) -> CatalogResult<()> {
         let conn = self.get_conn().await?;
+        let guard = conn.lock().await;
 
-        conn.call(|conn| {
-            // Create tables in a transaction
-            conn.execute_batch(&format!(
-                "{}; {}; {}; {}; {}; {};",
-                Self::TABLE_TABLE_DDL,
-                Self::TABLE_NAME_UNIQUE_INDEX_DDL,
-                Self::DELETE_FILE_TABLE_DDL,
-                Self::PARTITION_TABLE_DDL,
-                Self::INSERT_RECORD_TABLE_DDL,
-                Self::SNAPSHOT_SEQUENCE_TABLE_DDL
-            ))?;
+        guard
+            .call(|conn| {
+                // Create tables in a transaction
+                conn.execute_batch(&format!(
+                    "{}; {}; {}; {}; {}; {};",
+                    Self::TABLE_TABLE_DDL,
+                    Self::TABLE_NAME_UNIQUE_INDEX_DDL,
+                    Self::DELETE_FILE_TABLE_DDL,
+                    Self::PARTITION_TABLE_DDL,
+                    Self::INSERT_RECORD_TABLE_DDL,
+                    Self::SNAPSHOT_SEQUENCE_TABLE_DDL
+                ))?;
 
-            // Backfill new columns for existing deployments (SQLite doesn't support IF NOT EXISTS for ALTER TABLE until v3.35)
-            // Ignore errors when the column already exists to keep init idempotent.
-            let _ = conn.execute(
-                "ALTER TABLE cayenne_table ADD COLUMN on_conflict_json TEXT",
-                [],
-            );
+                // Backfill new columns for existing deployments (SQLite doesn't support IF NOT EXISTS for ALTER TABLE until v3.35)
+                // Ignore errors when the column already exists to keep init idempotent.
+                let _ = conn.execute(
+                    "ALTER TABLE cayenne_table ADD COLUMN on_conflict_json TEXT",
+                    [],
+                );
 
-            Ok::<_, rusqlite::Error>(())
-        })
-        .await
-        .map_err(
-            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
-                message: format!("Failed to initialize schema: {e}"),
-            },
-        )?;
+                Ok::<_, rusqlite::Error>(())
+            })
+            .await
+            .map_err(
+                |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                    message: format!("Failed to initialize schema: {e}"),
+                },
+            )?;
 
-        conn.call(|conn| {
-            conn.execute(DELETE_FILE_TABLE_UNIQUE_INDEX_DDL, [])?;
-            Ok::<_, rusqlite::Error>(())
-        })
-        .await
-        .map_err(
-            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
-                message: duplicate_delete_file_index_error_message("SQLite", e),
-            },
-        )?;
+        guard
+            .call(|conn| {
+                conn.execute(DELETE_FILE_TABLE_UNIQUE_INDEX_DDL, [])?;
+                Ok::<_, rusqlite::Error>(())
+            })
+            .await
+            .map_err(
+                |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                    message: duplicate_delete_file_index_error_message("SQLite", e),
+                },
+            )?;
 
         // Validate that existing tables match the expected schema.
         // This catches incompatible metadata databases from previous versions.
+        // Drop the guard before validation — the callback acquires it per-table.
+        drop(guard);
         let validate_conn = self.get_conn().await?;
         super::validate_existing_schema(|table_name| {
-            let conn = validate_conn.clone();
+            let conn = Arc::clone(&validate_conn);
             async move {
-                conn.call(move |conn| {
+                let g = conn.lock().await;
+                g.call(move |conn| {
                     let mut stmt = conn.prepare(&format!("PRAGMA table_info('{table_name}')"))?;
                     let columns: Vec<String> = stmt
                         .query_map([], |row| row.get::<_, String>(1))?
@@ -413,38 +429,42 @@ impl MetastoreBackend for SqliteMetastore {
 
     async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()> {
         let conn = self.get_conn().await?;
+        let guard = conn.lock().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
             params.params.iter().map(to_sqlite_value).collect();
 
-        conn.call(move |conn| {
-            let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
-                .iter()
-                .map(|v| v as &dyn rusqlite::ToSql)
-                .collect();
-            conn.prepare_cached(&sql)?.execute(params_refs.as_slice())?;
-            Ok::<_, rusqlite::Error>(())
-        })
-        .await
-        .map_err(|e| convert_tokio_rusqlite_error(e, "Failed to execute statement"))?;
+        guard
+            .call(move |conn| {
+                let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
+                    .iter()
+                    .map(|v| v as &dyn rusqlite::ToSql)
+                    .collect();
+                conn.prepare_cached(&sql)?.execute(params_refs.as_slice())?;
+                Ok::<_, rusqlite::Error>(())
+            })
+            .await
+            .map_err(|e| convert_tokio_rusqlite_error(e, "Failed to execute statement"))?;
 
         Ok(())
     }
 
     async fn execute_batch(&self, sql: &str) -> CatalogResult<()> {
         let conn = self.get_conn().await?;
+        let guard = conn.lock().await;
         let sql_owned = sql.to_string();
 
-        conn.call(move |conn| {
-            conn.execute_batch(&sql_owned)?;
-            Ok::<_, rusqlite::Error>(())
-        })
-        .await
-        .map_err(
-            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
-                message: format!("Failed to execute batch: {e}"),
-            },
-        )?;
+        guard
+            .call(move |conn| {
+                conn.execute_batch(&sql_owned)?;
+                Ok::<_, rusqlite::Error>(())
+            })
+            .await
+            .map_err(
+                |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                    message: format!("Failed to execute batch: {e}"),
+                },
+            )?;
 
         Ok(())
     }
@@ -455,12 +475,13 @@ impl MetastoreBackend for SqliteMetastore {
         T: Send + 'static,
     {
         let conn = self.get_conn().await?;
+        let guard = conn.lock().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
             params.params.iter().map(to_sqlite_value).collect();
 
         // Execute query and extract row values inside the closure
-        let row_values = conn
+        let row_values = guard
             .call(move |conn| {
                 let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
                     .iter()
@@ -498,12 +519,13 @@ impl MetastoreBackend for SqliteMetastore {
         T: Send + 'static,
     {
         let conn = self.get_conn().await?;
+        let guard = conn.lock().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
             params.params.iter().map(to_sqlite_value).collect();
 
         // Execute query and collect all row values inside the closure
-        let all_row_values = conn
+        let all_row_values = guard
             .call(move |conn| {
                 let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
                     .iter()
@@ -547,39 +569,60 @@ impl MetastoreBackend for SqliteMetastore {
         Ok(results)
     }
 
-    async fn shutdown(&self) -> CatalogResult<()> {
-        // Get the existing connection if it was initialized
-        if let Some(conn) = self.conn.get() {
-            conn.call(|conn| {
-                // Check if WAL mode is enabled
-                let journal_mode: String =
-                    conn.query_row("PRAGMA journal_mode", [], |row| row.get(0))?;
+    async fn begin_transaction(&self) -> CatalogResult<Box<dyn MetastoreTransaction>> {
+        let conn = self.get_conn().await?;
+        let guard = conn.lock_owned().await;
 
-                if journal_mode.eq_ignore_ascii_case("wal") {
-                    tracing::info!("Truncating Cayenne catalog WAL log");
-                    // Truncate the WAL log to persist changes and reduce file size
-                    // wal_checkpoint returns results (busy, log, checkpointed), so we use query_row
-                    let _: (i32, i32, i32) =
-                        conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
-                            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                        })?;
-                }
-
-                // Run optimize to improve query performance for future connections
-                // PRAGMA optimize may return rows indicating what was optimized
-                tracing::info!("Running optimize on Cayenne catalog");
-                let mut stmt = conn.prepare("PRAGMA optimize")?;
-                let mut rows = stmt.query([])?;
-                while rows.next()?.is_some() {} // Consume all results to ensure PRAGMA completes
-
+        guard
+            .call(|conn| {
+                conn.execute_batch("BEGIN TRANSACTION")?;
                 Ok::<_, rusqlite::Error>(())
             })
             .await
             .map_err(
                 |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
-                    message: format!("Failed to shutdown catalog: {e}"),
+                    message: format!("Failed to begin transaction: {e}"),
                 },
             )?;
+
+        Ok(Box::new(SqliteTransaction { conn: Some(guard) }))
+    }
+
+    async fn shutdown(&self) -> CatalogResult<()> {
+        // Get the existing connection if it was initialized
+        if let Some(conn) = self.conn.get() {
+            let guard = conn.lock().await;
+            guard
+                .call(|conn| {
+                    // Check if WAL mode is enabled
+                    let journal_mode: String =
+                        conn.query_row("PRAGMA journal_mode", [], |row| row.get(0))?;
+
+                    if journal_mode.eq_ignore_ascii_case("wal") {
+                        tracing::info!("Truncating Cayenne catalog WAL log");
+                        // Truncate the WAL log to persist changes and reduce file size
+                        // wal_checkpoint returns results (busy, log, checkpointed), so we use query_row
+                        let _: (i32, i32, i32) =
+                            conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                            })?;
+                    }
+
+                    // Run optimize to improve query performance for future connections
+                    // PRAGMA optimize may return rows indicating what was optimized
+                    tracing::info!("Running optimize on Cayenne catalog");
+                    let mut stmt = conn.prepare("PRAGMA optimize")?;
+                    let mut rows = stmt.query([])?;
+                    while rows.next()?.is_some() {} // Consume all results to ensure PRAGMA completes
+
+                    Ok::<_, rusqlite::Error>(())
+                })
+                .await
+                .map_err(
+                    |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                        message: format!("Failed to shutdown catalog: {e}"),
+                    },
+                )?;
 
             // Note: We intentionally do not explicitly close the connection here.
             // Closing a cloned handle would leave a closed connection stored in the
@@ -587,6 +630,135 @@ impl MetastoreBackend for SqliteMetastore {
             // connection and fail. Instead, we rely on normal drop semantics to
             // clean up the background connection when the metastore is dropped.
         }
+
+        Ok(())
+    }
+}
+
+/// A transaction on a `SQLite` metastore connection.
+///
+/// Holds an [`OwnedMutexGuard`] on the underlying connection, ensuring
+/// exclusive access for the lifetime of the transaction. The guard is
+/// released when the transaction is committed, rolled back, or dropped.
+///
+/// If neither [`commit`](MetastoreTransaction::commit) nor
+/// [`rollback`](MetastoreTransaction::rollback) is called, the transaction
+/// is automatically rolled back on drop via a best-effort `ROLLBACK`.
+pub struct SqliteTransaction {
+    /// Exclusive lock on the connection. `None` after commit/rollback.
+    conn: Option<OwnedMutexGuard<tokio_rusqlite::Connection>>,
+}
+
+impl Drop for SqliteTransaction {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            // Best-effort rollback — fire and forget since we're in drop.
+            // tokio_rusqlite::Connection::call sends a closure to the bg
+            // thread; it will execute even after this Drop returns.
+            // We spawn a task to await the future properly.
+            tokio::spawn(async move {
+                let _ = conn
+                    .call(|conn| {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        Ok::<_, rusqlite::Error>(())
+                    })
+                    .await;
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl MetastoreTransaction for SqliteTransaction {
+    async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()> {
+        let conn = self.conn.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let sql = params.sql.to_string();
+        let param_values: Vec<rusqlite::types::Value> =
+            params.params.iter().map(to_sqlite_value).collect();
+
+        conn.call(move |conn| {
+            let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
+                .iter()
+                .map(|v| v as &dyn rusqlite::ToSql)
+                .collect();
+            conn.prepare_cached(&sql)?.execute(params_refs.as_slice())?;
+            Ok::<_, rusqlite::Error>(())
+        })
+        .await
+        .map_err(|e| {
+            convert_tokio_rusqlite_error(e, "Failed to execute statement in transaction")
+        })?;
+
+        Ok(())
+    }
+
+    async fn execute_batch(&self, sql: &str) -> CatalogResult<()> {
+        let conn = self.conn.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let sql_owned = sql.to_string();
+
+        conn.call(move |conn| {
+            conn.execute_batch(&sql_owned)?;
+            Ok::<_, rusqlite::Error>(())
+        })
+        .await
+        .map_err(
+            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                message: format!("Failed to execute batch in transaction: {e}"),
+            },
+        )?;
+
+        Ok(())
+    }
+
+    async fn commit(mut self: Box<Self>) -> CatalogResult<()> {
+        let conn = self.conn.take().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+
+        let commit_result = conn
+            .call(|conn| {
+                conn.execute_batch("COMMIT")?;
+                Ok::<_, rusqlite::Error>(())
+            })
+            .await;
+
+        match commit_result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Best-effort rollback to leave the connection in a clean state.
+                let _ = conn
+                    .call(|conn| {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        Ok::<_, rusqlite::Error>(())
+                    })
+                    .await;
+
+                Err(CatalogError::Database {
+                    message: format!("Failed to commit transaction: {e}"),
+                })
+            }
+        }
+    }
+
+    async fn rollback(mut self: Box<Self>) -> CatalogResult<()> {
+        let conn = self.conn.take().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+
+        conn.call(|conn| {
+            conn.execute_batch("ROLLBACK")?;
+            Ok::<_, rusqlite::Error>(())
+        })
+        .await
+        .map_err(
+            |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                message: format!("Failed to rollback transaction: {e}"),
+            },
+        )?;
 
         Ok(())
     }

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -18,21 +18,23 @@ limitations under the License.
 
 use super::{
     duplicate_delete_file_index_error_message, ExecuteParams, MetastoreBackend, MetastoreGetValue,
-    MetastoreRow, MetastoreValue, QueryParams, QueryRowParams,
+    MetastoreRow, MetastoreTransaction, MetastoreValue, QueryParams, QueryRowParams,
 };
 use crate::catalog::{CatalogError, CatalogResult};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::{fmt::Debug, path::Path};
-use tokio::sync::Mutex;
-use turso::{Builder, Connection, Database, Value as TursoValue};
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use turso::{Builder, Connection, Value as TursoValue};
 use turso_shared::JOURNAL_MODE_SQL_LITERAL;
 
 const DELETE_FILE_TABLE_UNIQUE_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXISTS idx_cayenne_delete_file_table_path ON cayenne_delete_file(table_id, path)";
 
 /// Turso-based metastore backend.
+///
+/// The connection is behind a [`Mutex`] to ensure exclusive access during
+/// multi-statement transactions, matching the `SQLite` metastore design.
 pub struct TursoMetastore {
-    db: Arc<Mutex<Option<Database>>>,
     conn: Arc<Mutex<Option<Connection>>>,
     connection_string: String,
 }
@@ -49,7 +51,6 @@ impl TursoMetastore {
     /// Create a new Turso metastore.
     pub fn new(connection_string: impl Into<String>) -> Self {
         Self {
-            db: Arc::new(Mutex::new(None)),
             conn: Arc::new(Mutex::new(None)),
             connection_string: connection_string.into(),
         }
@@ -62,89 +63,75 @@ impl TursoMetastore {
             .unwrap_or(&self.connection_string)
     }
 
-    /// Get or create the database connection.
-    async fn get_db(&self) -> CatalogResult<Database> {
-        let mut db_guard = self.db.lock().await;
+    /// Get or create the database connection, returning the mutex-guarded wrapper.
+    ///
+    /// Callers acquire the lock before using the connection.
+    async fn get_conn(&self) -> CatalogResult<Arc<Mutex<Option<Connection>>>> {
+        // Initialize connection if needed
+        {
+            let mut conn_guard = self.conn.lock().await;
+            if conn_guard.is_none() {
+                let db_path = self.db_path();
 
-        if let Some(db) = db_guard.as_ref() {
-            return Ok(db.clone());
-        }
-
-        // Create the database
-        let db_path = self.db_path();
-
-        // Create parent directory if it doesn't exist
-        let db_dir =
-            Path::new(db_path)
-                .parent()
-                .ok_or_else(|| CatalogError::InvalidDatabasePath {
-                    path: db_path.to_string(),
+                // Create parent directory if it doesn't exist
+                let db_dir = Path::new(db_path).parent().ok_or_else(|| {
+                    CatalogError::InvalidDatabasePath {
+                        path: db_path.to_string(),
+                    }
                 })?;
 
-        if !db_dir.exists() {
-            tokio::fs::create_dir_all(db_dir).await?;
+                if !db_dir.exists() {
+                    tokio::fs::create_dir_all(db_dir).await?;
+                }
+
+                let db = Builder::new_local(db_path).build().await.map_err(|e| {
+                    CatalogError::Database {
+                        message: format!("Failed to open Turso database: {e}"),
+                    }
+                })?;
+
+                let conn = db.connect().map_err(|e| CatalogError::Database {
+                    message: format!("Failed to connect to Turso database: {e}"),
+                })?;
+
+                // Set busy timeout to wait for locks instead of immediately returning SQLITE_BUSY.
+                conn.busy_timeout(std::time::Duration::from_secs(5))
+                    .map_err(|e| CatalogError::Database {
+                        message: format!("Failed to set busy timeout: {e}"),
+                    })?;
+
+                // BEGIN CONCURRENT requires MVCC journal mode for concurrent writers.
+                conn.pragma_update("journal_mode", JOURNAL_MODE_SQL_LITERAL)
+                    .await
+                    .map_err(|e| CatalogError::Database {
+                        message: format!("Failed to set journal mode: {e}"),
+                    })?;
+
+                conn.execute("PRAGMA foreign_keys = ON", ())
+                    .await
+                    .map_err(|e| CatalogError::Database {
+                        message: format!("Failed to enable foreign keys: {e}"),
+                    })?;
+
+                // NORMAL synchronous mode: safe with MVCC, more performant than FULL
+                conn.execute("PRAGMA synchronous = NORMAL", ())
+                    .await
+                    .map_err(|e| CatalogError::Database {
+                        message: format!("Failed to set synchronous mode: {e}"),
+                    })?;
+
+                // 32MB cache size (negative value = kilobytes in SQLite/libSQL)
+                conn.execute("PRAGMA cache_size = -32768", ())
+                    .await
+                    .map_err(|e| CatalogError::Database {
+                        message: format!("Failed to set cache size: {e}"),
+                    })?;
+
+                *conn_guard = Some(conn);
+            }
         }
 
-        let db = Builder::new_local(db_path)
-            .build()
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to open Turso database: {e}"),
-            })?;
-
-        *db_guard = Some(db.clone());
-        Ok(db)
-    }
-
-    /// Get or create a cached connection from the database.
-    async fn get_conn(&self) -> CatalogResult<Connection> {
-        let mut conn_guard = self.conn.lock().await;
-
-        if let Some(conn) = conn_guard.as_ref() {
-            return Ok(conn.clone());
-        }
-
-        let db = self.get_db().await?;
-        let conn = db.connect().map_err(|e| CatalogError::Database {
-            message: format!("Failed to connect to Turso database: {e}"),
-        })?;
-
-        // Set busy timeout to wait for locks instead of immediately returning SQLITE_BUSY.
-        // This fixes issue #8826 where concurrent transactions to the same database fail.
-        conn.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set busy timeout: {e}"),
-            })?;
-
-        // BEGIN CONCURRENT requires MVCC journal mode for concurrent writers.
-        conn.pragma_update("journal_mode", JOURNAL_MODE_SQL_LITERAL)
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set journal mode: {e}"),
-            })?;
-
-        conn.execute("PRAGMA foreign_keys = ON", ())
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to enable foreign keys: {e}"),
-            })?;
-
-        // NORMAL synchronous mode: safe with MVCC, more performant than FULL
-        conn.execute("PRAGMA synchronous = NORMAL", ())
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set synchronous mode: {e}"),
-            })?;
-
-        // 32MB cache size (negative value = kilobytes in SQLite/libSQL)
-        conn.execute("PRAGMA cache_size = -32768", ())
-            .await
-            .map_err(|e| CatalogError::Database {
-                message: format!("Failed to set cache size: {e}"),
-            })?;
-
-        *conn_guard = Some(conn.clone());
-        Ok(conn)
+        Ok(Arc::clone(&self.conn))
     }
 
     /// Schema for the `cayenne_table` table.
@@ -348,7 +335,11 @@ fn convert_turso_error(e: turso::Error) -> CatalogError {
 #[async_trait]
 impl MetastoreBackend for TursoMetastore {
     async fn init_schema(&self) -> CatalogResult<()> {
-        let conn = self.get_conn().await?;
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock().await;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
 
         // Create tables
         let schema_sql = format!(
@@ -384,11 +375,8 @@ impl MetastoreBackend for TursoMetastore {
 
         // Validate that existing tables match the expected schema.
         // This catches incompatible metadata databases from previous versions.
-        // We query table_info for each expected table using a fresh connection per table
-        // since turso::Connection is not Clone.
         for expected in super::EXPECTED_TABLES {
-            let table_conn = self.get_conn().await?;
-            let mut rows = table_conn
+            let mut rows = conn
                 .query(&format!("PRAGMA table_info('{}')", expected.name), ())
                 .await
                 .map_err(|e| CatalogError::Database {
@@ -439,7 +427,11 @@ impl MetastoreBackend for TursoMetastore {
     }
 
     async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()> {
-        let conn = self.get_conn().await?;
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock().await;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
@@ -455,7 +447,11 @@ impl MetastoreBackend for TursoMetastore {
     }
 
     async fn execute_batch(&self, sql: &str) -> CatalogResult<()> {
-        let conn = self.get_conn().await?;
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock().await;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
 
         conn.execute_batch(sql)
             .await
@@ -471,7 +467,11 @@ impl MetastoreBackend for TursoMetastore {
         F: FnOnce(&dyn MetastoreRow) -> CatalogResult<T> + Send + 'static,
         T: Send + 'static,
     {
-        let conn = self.get_conn().await?;
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock().await;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
@@ -514,7 +514,11 @@ impl MetastoreBackend for TursoMetastore {
         F: Fn(&dyn MetastoreRow) -> CatalogResult<T> + Send + 'static,
         T: Send + 'static,
     {
-        let conn = self.get_conn().await?;
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock().await;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
 
         let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
 
@@ -560,9 +564,139 @@ impl MetastoreBackend for TursoMetastore {
         Ok(results)
     }
 
+    async fn begin_transaction(&self) -> CatalogResult<Box<dyn MetastoreTransaction>> {
+        let conn_arc = self.get_conn().await?;
+        let guard = conn_arc.lock_owned().await;
+
+        {
+            let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+                message: "Turso connection not initialized".to_string(),
+            })?;
+            conn.execute("BEGIN CONCURRENT", ())
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to begin concurrent transaction: {e}"),
+                })?;
+        }
+
+        Ok(Box::new(TursoTransaction { conn: Some(guard) }))
+    }
+
     async fn shutdown(&self) -> CatalogResult<()> {
         // Turso handles cleanup automatically
         tracing::info!("Shutting down Turso metastore");
+        Ok(())
+    }
+}
+
+/// A transaction on a Turso metastore connection.
+///
+/// Holds an [`OwnedMutexGuard`] on the underlying connection, ensuring
+/// exclusive access for the lifetime of the transaction.
+///
+/// If neither [`commit`](MetastoreTransaction::commit) nor
+/// [`rollback`](MetastoreTransaction::rollback) is called, the transaction
+/// is automatically rolled back on drop via a best-effort `ROLLBACK`.
+pub struct TursoTransaction {
+    /// Exclusive lock on the connection. `None` after commit/rollback.
+    conn: Option<OwnedMutexGuard<Option<Connection>>>,
+}
+
+impl Drop for TursoTransaction {
+    fn drop(&mut self) {
+        if let Some(guard) = self.conn.take() {
+            // Spawn a best-effort async rollback while holding the owned guard.
+            // The guard (and its mutex lock) is moved into the spawned task and
+            // released after the ROLLBACK completes or fails.
+            tokio::spawn(async move {
+                tracing::debug!(
+                    "TursoTransaction dropped without explicit commit or rollback; \
+                     attempting auto-rollback"
+                );
+                if let Some(conn) = guard.as_ref() {
+                    if let Err(err) = conn.execute("ROLLBACK", ()).await {
+                        tracing::error!("Failed to auto-rollback TursoTransaction on drop: {err}");
+                    }
+                }
+                // `guard` is dropped here, releasing the connection lock.
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl MetastoreTransaction for TursoTransaction {
+    async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()> {
+        let guard = self.conn.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
+
+        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+
+        let mut stmt = conn
+            .prepare_cached(params.sql)
+            .await
+            .map_err(convert_turso_error)?;
+        stmt.execute(turso_params)
+            .await
+            .map_err(convert_turso_error)?;
+
+        Ok(())
+    }
+
+    async fn execute_batch(&self, sql: &str) -> CatalogResult<()> {
+        let guard = self.conn.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
+
+        conn.execute_batch(sql)
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to execute batch in transaction: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    async fn commit(mut self: Box<Self>) -> CatalogResult<()> {
+        let guard = self.conn.take().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
+
+        if let Err(e) = conn.execute("COMMIT", ()).await {
+            // Best-effort rollback to leave the connection in a clean state.
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(CatalogError::Database {
+                message: format!("Failed to commit transaction: {e}"),
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn rollback(mut self: Box<Self>) -> CatalogResult<()> {
+        let guard = self.conn.take().ok_or_else(|| CatalogError::Database {
+            message: "Transaction already completed".to_string(),
+        })?;
+        let conn = guard.as_ref().ok_or_else(|| CatalogError::Database {
+            message: "Turso connection not initialized".to_string(),
+        })?;
+
+        conn.execute("ROLLBACK", ())
+            .await
+            .map_err(|e| CatalogError::Database {
+                message: format!("Failed to rollback transaction: {e}"),
+            })?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Problem

When multiple partitions of a partitioned Cayenne table write concurrently (via `PartitionTableProvider::insert_into`), they share the same `SqliteMetastore` with a single `tokio_rusqlite::Connection`. If two partitions simultaneously need multi-chunk `add_insert_records_batch` (>8000 upserted PKs), both send separate `BEGIN TRANSACTION` SQL statements through the connection, causing:

```
cannot start a transaction within a transaction
```

This manifests at SF10 scale where `lineitem` has enough rows per batch to exceed the `MAX_ROWS_PER_CHUNK` (8000) limit, triggering the multi-chunk transaction path.

## Root Cause

`add_insert_records_batch` and `commit_compaction` used raw `BEGIN`/`COMMIT` SQL statements sent as separate `conn.call()` invocations. Since `tokio_rusqlite` processes closures sequentially on a background thread but different async tasks can interleave their `call()` submissions, two concurrent callers could both send `BEGIN` before either sends `COMMIT`.

## Solution

1. **Add `Mutex` around the connection** in both `SqliteMetastore` and `TursoMetastore`. Every operation acquires the mutex, preventing interleaving of multi-statement transactions.

2. **Implement `MetastoreTransaction` trait** with `execute`, `execute_batch`, `commit`, and `rollback` methods. The transaction object holds an `OwnedMutexGuard`, ensuring exclusive connection access for its lifetime.

3. **Add `begin_transaction()` to `MetastoreBackend` trait** — each backend sends the appropriate BEGIN statement (`BEGIN TRANSACTION` for SQLite, `BEGIN CONCURRENT` for Turso), encapsulating the backend-specific logic.

4. **Refactor callers** (`add_insert_records_batch`, `commit_compaction`) to use the transaction API instead of raw SQL BEGIN/COMMIT. Transactions auto-rollback on drop if not committed.

5. **Remove `is_turso()` checks** from catalog code — the backend-specific transaction type is now handled by the trait implementation.

## Changes

- `crates/cayenne/src/metastore.rs` — `MetastoreTransaction` trait; `begin_transaction()` added to `MetastoreBackend`
- `crates/cayenne/src/metastore/sqlite.rs` — `SqliteMetastore` connection wrapped in `Arc<Mutex<..>>`; `SqliteTransaction` with `OwnedMutexGuard`
- `crates/cayenne/src/metastore/turso.rs` — `TursoMetastore` updated to use mutex-guarded connection; `TursoTransaction` with `OwnedMutexGuard`
- `crates/cayenne/src/cayenne_catalog.rs` — `add_insert_records_batch` and `commit_compaction` use `begin_transaction()` instead of raw SQL; removed dead code