### PR TITLE
fix: Use GreedyMemoryPool, add spidapter query memory limit arg

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -1345,12 +1345,11 @@ impl RefreshTask {
             }
             match accelerated_field.data_type() {
                 DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {
-                    let arr = arrow::compute::cast(col_array, &DataType::Int64)
-                        .map_err(|e| super::Error::FailedToFindLatestTimestamp {
-                            reason: format!(
-                                "Failed to cast integer time column to Int64: {e}"
-                            ),
-                        })?;
+                    let arr = arrow::compute::cast(col_array, &DataType::Int64).map_err(|e| {
+                        super::Error::FailedToFindLatestTimestamp {
+                            reason: format!("Failed to cast integer time column to Int64: {e}"),
+                        }
+                    })?;
                     let arr = arr
                         .as_any()
                         .downcast_ref::<arrow::array::Int64Array>()
@@ -1371,18 +1370,20 @@ impl RefreshTask {
                     })?
                 }
                 DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
-                    let arr = arrow::compute::cast(col_array, &DataType::UInt64)
-                        .map_err(|e| super::Error::FailedToFindLatestTimestamp {
+                    let arr = arrow::compute::cast(col_array, &DataType::UInt64).map_err(|e| {
+                        super::Error::FailedToFindLatestTimestamp {
                             reason: format!(
                                 "Failed to cast unsigned integer time column to UInt64: {e}"
                             ),
-                        })?;
+                        }
+                    })?;
                     let arr = arr
                         .as_any()
                         .downcast_ref::<arrow::array::UInt64Array>()
                         .ok_or_else(|| super::Error::FailedToFindLatestTimestamp {
-                            reason: "Failed to downcast unsigned integer time column to UInt64Array."
-                                .to_string(),
+                            reason:
+                                "Failed to downcast unsigned integer time column to UInt64Array."
+                                    .to_string(),
                         })?;
                     if arr.is_null(0) {
                         return Ok(None);
@@ -1391,9 +1392,7 @@ impl RefreshTask {
                 }
                 other => {
                     return Err(super::Error::FailedToFindLatestTimestamp {
-                        reason: format!(
-                            "Unexpected data type {other} for integer time column."
-                        ),
+                        reason: format!("Unexpected data type {other} for integer time column."),
                     });
                 }
             }
@@ -2012,16 +2011,13 @@ mod tests {
     /// (e.g. `unix_seconds` / `unix_millis` time formats) without casting to a Timestamp type.
     #[tokio::test]
     async fn test_max_timestamp_df_integer_time_column() {
-        async fn run_test(
-            data_type: DataType,
-            array: Arc<dyn arrow::array::Array>,
-        ) -> RecordBatch {
+        async fn run_test(data_type: DataType, array: Arc<dyn arrow::array::Array>) -> RecordBatch {
             let schema = Arc::new(Schema::new(vec![Field::new("ts", data_type, false)]));
             let batch =
                 RecordBatch::try_new(Arc::clone(&schema), vec![array]).expect("batch created");
-            let mem_table = Arc::new(
-                MemTable::try_new(schema, vec![vec![batch]]).expect("mem table created"),
-            ) as Arc<dyn TableProvider>;
+            let mem_table =
+                Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("mem table created"))
+                    as Arc<dyn TableProvider>;
 
             let ctx = SessionContext::new();
             let df = max_timestamp_df(&mem_table, ctx.clone(), "ts").expect("df created");

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -34,7 +34,7 @@ use datafusion::{
     execution::{
         DiskManager, SessionStateBuilder,
         disk_manager::DiskManagerMode,
-        memory_pool::{FairSpillPool, MemoryPool, TrackConsumersPool, UnboundedMemoryPool},
+        memory_pool::{GreedyMemoryPool, MemoryPool, TrackConsumersPool, UnboundedMemoryPool},
         runtime_env::{RuntimeEnv, RuntimeEnvBuilder},
     },
     optimizer::{
@@ -617,7 +617,7 @@ pub(crate) fn runtime_env(
             unreachable!("Memory pool TopN must be greater than 0");
         };
 
-        Arc::new(TrackConsumersPool::new(FairSpillPool::new(limit), topn))
+        Arc::new(TrackConsumersPool::new(GreedyMemoryPool::new(limit), topn))
     } else {
         let Some(topn) = NonZeroUsize::new(5) else {
             unreachable!("Memory pool TopN must be greater than 0");

--- a/tools/spidapter/src/args/mod.rs
+++ b/tools/spidapter/src/args/mod.rs
@@ -150,4 +150,8 @@ pub struct StdioArgs {
     /// Spice Cloud organization tag to apply to created app
     #[arg(long, env = "SPIDAPTER_ORGANIZATION_TAG")]
     pub organization_tag: Option<String>,
+
+    /// Query memory limit to apply to `runtime.query.memory_limit` spicepod configuration (e.g. `150Gi`).
+    #[arg(long, env = "SPIDAPTER_QUERY_MEMORY_LIMIT")]
+    pub query_memory_limit: Option<String>,
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -29,7 +29,7 @@ use spicepod::component::access::AccessMode;
 use spicepod::component::catalog::Catalog;
 use spicepod::component::dataset::Dataset;
 use spicepod::component::runtime::{
-    ApiKey, ApiKeyAuth, Auth, Flight, Runtime, Scheduler, TelemetryConfig,
+    ApiKey, ApiKeyAuth, Auth, Flight, Query, Runtime, Scheduler, TelemetryConfig,
 };
 use spicepod::param::{ParamValue, Params};
 use spicepod::spec::SpicepodDefinition;
@@ -1508,6 +1508,13 @@ fn generate_adbc_spicepod(
             do_put_rate_limit_enabled: false,
             ..Flight::default()
         }),
+        query: Some(Query {
+            memory_limit: args
+                .query_memory_limit
+                .clone()
+                .or(Some("150Gi".to_string())),
+            ..Query::default()
+        }),
         ..Runtime::default()
     };
 
@@ -1631,6 +1638,7 @@ mod tests {
             cayenne_metadata_dir: None,
             ephemeral_storage_limit_gb: None,
             organization_tag: None,
+            query_memory_limit: None,
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Use `GreedyMemoryPool` instead of `FairSpillPool`, as it allows reservations to complete for high-concurrency queries with lots of partitions (= reservations)
* Updates spidapter to allow setting the `runtime.query.memory_limit` via an input arg or environment variable.
