### PR TITLE
refactor: Introduce unified statement planner with DELETE migration

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -2476,11 +2476,8 @@ mod tests {
 
         // Case 1: stored refresh_sql matches current → no forced refresh (should wait or be disabled)
         let stored_sql = refresh_sql.to_sql();
-        let checkpoint_matching = MockCheckpointer::new_arc_with_refresh_sql(
-            true,
-            Some(now),
-            Some(stored_sql.clone()),
-        );
+        let checkpoint_matching =
+            MockCheckpointer::new_arc_with_refresh_sql(true, Some(now), Some(stored_sql.clone()));
         let mut refresh_with_matching_sql = Refresh::new(RefreshMode::Full);
         refresh_with_matching_sql = refresh_with_matching_sql.refresh_sql(refresh_sql.clone());
         let result = refresh_with_matching_sql
@@ -2508,11 +2505,8 @@ mod tests {
         );
 
         // Case 3: stored refresh_sql is Some, current is None → forced refresh
-        let checkpoint_had_sql = MockCheckpointer::new_arc_with_refresh_sql(
-            true,
-            Some(now),
-            Some(stored_sql),
-        );
+        let checkpoint_had_sql =
+            MockCheckpointer::new_arc_with_refresh_sql(true, Some(now), Some(stored_sql));
         let refresh_no_sql = Refresh::new(RefreshMode::Full);
         let result = refresh_no_sql
             .startup_next_refresh(RefreshOnStartup::Auto, Some(checkpoint_had_sql))
@@ -2523,8 +2517,7 @@ mod tests {
         );
 
         // Case 4: stored refresh_sql is None, current is Some → forced refresh
-        let checkpoint_no_sql =
-            MockCheckpointer::new_arc_with_refresh_sql(true, Some(now), None);
+        let checkpoint_no_sql = MockCheckpointer::new_arc_with_refresh_sql(true, Some(now), None);
         let mut refresh_with_sql = Refresh::new(RefreshMode::Full);
         refresh_with_sql = refresh_with_sql.refresh_sql(refresh_sql);
         let result = refresh_with_sql

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -448,7 +448,10 @@ mod tests {
 
         // Update to a different refresh_sql
         checkpoint
-            .checkpoint(&schema_ref, Some("SELECT id FROM source_table WHERE id > 10"))
+            .checkpoint(
+                &schema_ref,
+                Some("SELECT id FROM source_table WHERE id > 10"),
+            )
             .await
             .expect("Failed to update refresh_sql");
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
@@ -513,7 +513,10 @@ mod tests {
 
         // Update to a different refresh_sql
         checkpoint
-            .checkpoint(&schema_ref, Some("SELECT id FROM source_table WHERE id > 10"))
+            .checkpoint(
+                &schema_ref,
+                Some("SELECT id FROM source_table WHERE id > 10"),
+            )
             .await
             .expect("Failed to update refresh_sql");
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -41,7 +41,7 @@ use runtime_table_partition::expression::validate_partition_expression;
 use super::is_cayenne_catalog;
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
+    DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
 };
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
@@ -257,37 +257,6 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
 
                 Ok(LogicalPlan::Extension(Extension {
                     node: Arc::new(node),
-                }))
-            }
-            LogicalPlan::Dml(DmlStatement {
-                input,
-                table_name,
-                op: WriteOp::Delete,
-                output_schema,
-                ..
-            }) => {
-                let catalog_name = table_name
-                    .catalog()
-                    .unwrap_or(SPICE_DEFAULT_CATALOG)
-                    .to_string();
-
-                if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
-                    return Ok(plan);
-                }
-
-                if !self.apply_distributed_nodes {
-                    return Ok(plan);
-                }
-
-                let filter_sql = extract_filter_sql(input)?;
-
-                Ok(LogicalPlan::Extension(Extension {
-                    node: Arc::new(DistributedCayenneDeleteNode::new(
-                        table_name.clone(),
-                        Arc::clone(input),
-                        Arc::clone(output_schema),
-                        filter_sql,
-                    )),
                 }))
             }
             LogicalPlan::Dml(DmlStatement {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -126,6 +126,8 @@ pub mod iceberg_ddl;
 pub mod job_executor_context_extension;
 pub mod managed_runtime;
 pub mod param_utils;
+#[cfg(not(windows))]
+pub mod planner;
 pub mod refresh_sql;
 pub mod request_context_extension;
 pub mod retention_sql;
@@ -924,6 +926,26 @@ impl DataFusion {
             .read()
             .await
             .contains(table_reference)
+    }
+
+    /// Returns `true` if any DDL-enabled catalog is Cayenne-backed.
+    #[cfg(not(windows))]
+    fn has_cayenne_catalog(&self) -> bool {
+        match self.ddl_enabled_catalogs.read() {
+            Ok(cats) => cats.iter().any(|name| {
+                self.ctx
+                    .catalog(name)
+                    .is_some_and(|c| cayenne_ddl::is_cayenne_catalog(c.as_ref()))
+            }),
+            Err(err) => {
+                tracing::error!(
+                    "Failed to acquire read lock for ddl_enabled_catalogs; \
+                     assuming Cayenne-backed catalogs are present to avoid \
+                     silently disabling distributed DELETE planning: {err}"
+                );
+                true
+            }
+        }
     }
 
     /// Returns `true` if the given table reference resolves to a Cayenne-backed catalog.
@@ -2578,7 +2600,7 @@ impl DataFusion {
             ddl::preprocess::PreprocessResult::Unchanged => (sql, None),
         };
 
-        let plan = match session.create_logical_plan(effective_sql).await {
+        let plan = match self.create_logical_plan(session, effective_sql).await {
             Ok(plan) => plan,
             Err(e) => {
                 if let Some(store_key) = store_key {
@@ -2599,6 +2621,37 @@ impl DataFusion {
         }
 
         Ok(plan)
+    }
+
+    /// Route SQL through the planner, which intercepts Cayenne DML
+    /// at the statement level, or falls back to DataFusion's standard planner.
+    #[cfg(not(windows))]
+    async fn create_logical_plan(
+        &self,
+        session: &SessionState,
+        sql: &str,
+    ) -> Result<LogicalPlan, DataFusionError> {
+        let ctx = planner::PlannerContext {
+            catalog_mode: if self.has_cayenne_catalog() {
+                planner::CatalogMode::Cayenne
+            } else {
+                planner::CatalogMode::Standard
+            },
+            cluster_role: self.cluster_config.effective_role(),
+        };
+
+        planner::create_logical_plan(sql, session, &ctx).await
+    }
+
+    /// On Windows the `planner` module is not available, so delegate
+    /// directly to DataFusion's standard logical planner.
+    #[cfg(windows)]
+    async fn create_logical_plan(
+        &self,
+        session: &SessionState,
+        sql: &str,
+    ) -> Result<LogicalPlan, DataFusionError> {
+        session.create_logical_plan(sql).await
     }
 
     pub(crate) async fn clear_cached_plans(&self) {

--- a/crates/runtime/src/datafusion/planner/delete.rs
+++ b/crates/runtime/src/datafusion/planner/delete.rs
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! DELETE planning for the unified Spice planner.
+//!
+//! In distributed (scheduler) mode, produces a [`DistributedCayenneDeleteNode`]
+//! that forwards the DELETE to executor nodes.
+//!
+//! In local mode, DELETE is handled by Cayenne's `TableProvider` implementation
+//! through DataFusion's standard physical planning — no interception needed.
+
+use std::sync::Arc;
+
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion_expr::DmlStatement;
+
+use crate::datafusion::cayenne_ddl::analyzer_rule::extract_filter_sql;
+use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneDeleteNode;
+
+/// Wrap a DataFusion `DmlStatement` (DELETE) into a distributed Cayenne
+/// extension node for forwarding to executor nodes.
+///
+/// This is only called in distributed (scheduler) mode. In local mode,
+/// the standard DataFusion plan is returned unchanged by the caller.
+pub(super) fn plan_distributed_delete(dml: &DmlStatement) -> DFResult<LogicalPlan> {
+    let filter_sql = extract_filter_sql(&dml.input)?;
+
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(DistributedCayenneDeleteNode::new(
+            dml.table_name.clone(),
+            Arc::clone(&dml.input),
+            Arc::clone(&dml.output_schema),
+            filter_sql,
+        )),
+    }))
+}

--- a/crates/runtime/src/datafusion/planner/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/planner/logical_nodes.rs
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Logical plan nodes for Cayenne DML operations produced by the Spice planner.
+//!
+//! Currently empty — local DELETE is handled by Cayenne's `TableProvider`
+//! implementation through DataFusion's standard physical planning, and
+//! distributed DELETE reuses `DistributedCayenneDeleteNode` from `cayenne_ddl`.
+//!
+//! Future DML operations (UPDATE, MERGE) will add nodes here.

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Unified SQL statement planner.
+//!
+//! All DML statements (DELETE, UPDATE, INSERT) targeting Cayenne catalog tables
+//! are intercepted at the statement level and converted into
+//! [`LogicalPlan::Extension`] nodes directly, instead of relying on
+//! DataFusion's DML planning followed by post-hoc interception.
+//!
+//! For everything else, the planner delegates to DataFusion's standard
+//! `session.statement_to_plan()` path.
+
+mod delete;
+pub mod logical_nodes;
+pub mod physical_execs;
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::SessionState;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::sql::parser::Statement;
+use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
+
+use crate::config::ClusterRole;
+
+use super::SPICE_DEFAULT_CATALOG;
+
+/// The type of catalog backing the planner's DML interception.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CatalogMode {
+    /// At least one DDL-enabled catalog is Cayenne-backed.
+    /// DML targeting Cayenne tables is intercepted at the statement level.
+    Cayenne,
+    /// No Cayenne catalogs are registered. All statements are delegated
+    /// to DataFusion's standard planner.
+    Standard,
+}
+
+/// Context for the statement planner, carrying catalog and cluster information.
+pub struct PlannerContext {
+    /// The catalog mode determines whether DML interception is active.
+    pub catalog_mode: CatalogMode,
+
+    /// The cluster role, if any. When `Some(ClusterRole::Scheduler)`, Cayenne
+    /// DML is rewritten into distributed extension nodes that forward operations
+    /// to executor nodes.
+    pub cluster_role: Option<ClusterRole>,
+}
+
+/// Create a [`LogicalPlan`] from SQL, intercepting Cayenne DML at the statement level.
+pub async fn create_logical_plan(
+    sql: &str,
+    session: &SessionState,
+    ctx: &PlannerContext,
+) -> DFResult<LogicalPlan> {
+    // Fast path: if Cayenne is not active, skip statement-level parsing and
+    // delegate entirely to DataFusion.
+    if ctx.catalog_mode != CatalogMode::Cayenne {
+        return session.create_logical_plan(sql).await;
+    }
+
+    // Step 1: Parse SQL into a DataFusion Statement (wraps sqlparser AST)
+    let dialect = session.config().options().sql_parser.dialect;
+    let statement = session.sql_to_statement(sql, &dialect)?;
+
+    // Step 2: Check if this is a DML statement we should intercept
+    if let Statement::Statement(ref sql_stmt) = statement {
+        match sql_stmt.as_ref() {
+            SQLStatement::Delete(_) => {
+                return plan_cayenne_delete(statement, session, ctx).await;
+            }
+            // Future: SQLStatement::Update { .. }, SQLStatement::Merge { .. }
+            _ => {}
+        }
+    }
+
+    // Step 3: Everything else goes through DataFusion's standard planner
+    session.statement_to_plan(statement).await
+}
+
+/// Plan a DELETE statement, producing either a local or distributed Cayenne
+/// extension node.
+///
+/// For local mode, returns the standard DataFusion plan unchanged — Cayenne's
+/// `TableProvider` implementation handles DELETE natively via `DeletionExec`.
+///
+/// For distributed (scheduler) mode, wraps the plan into a
+/// `DistributedCayenneDeleteNode` that forwards the operation to executors.
+async fn plan_cayenne_delete(
+    statement: Statement,
+    session: &SessionState,
+    ctx: &PlannerContext,
+) -> DFResult<LogicalPlan> {
+    // Let DataFusion plan the DELETE to get the validated DmlStatement
+    let df_plan = session.statement_to_plan(statement).await?;
+
+    // If not in distributed mode, Cayenne's TableProvider handles DELETE
+    // natively through DataFusion's standard physical planning. Return as-is.
+    if !matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
+        return Ok(df_plan);
+    }
+
+    let LogicalPlan::Dml(dml) = &df_plan else {
+        return Err(DataFusionError::Internal(
+            "Expected LogicalPlan::Dml for DELETE statement".to_string(),
+        ));
+    };
+
+    if !matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+        return Err(DataFusionError::Internal(format!(
+            "Expected WriteOp::Delete, got {:?}",
+            dml.op
+        )));
+    }
+
+    // Check if the target table is in a Cayenne catalog
+    let catalog_name = dml.table_name.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+
+    let is_cayenne = {
+        let catalog_list = session.catalog_list();
+        if let Some(catalog) = catalog_list.catalog(catalog_name) {
+            super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref())
+        } else {
+            false
+        }
+    };
+
+    // If not a Cayenne table, return the standard DF plan unchanged
+    if !is_cayenne {
+        return Ok(df_plan);
+    }
+
+    delete::plan_distributed_delete(dml)
+}

--- a/crates/runtime/src/datafusion/planner/physical_execs.rs
+++ b/crates/runtime/src/datafusion/planner/physical_execs.rs
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Physical execution plans for Cayenne DML operations.
+//!
+//! Currently empty — local DELETE is handled by Cayenne's `TableProvider`
+//! implementation through DataFusion's standard physical planning, and
+//! distributed DELETE reuses `DistributedCayenneDeleteExec` from `cayenne_ddl`.
+//!
+//! Future DML operations (UPDATE, MERGE) will add execution plans here.

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -34,6 +34,7 @@ use datafusion::{
         ExecutionPlan, ExecutionPlanProperties, execute_stream, repartition::RepartitionExec,
         sorts::sort_preserving_merge::SortPreservingMergeExec, stream::RecordBatchStreamAdapter,
     },
+    sql::TableReference,
 };
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
@@ -504,164 +505,164 @@ impl Query {
 
         let inner_span = span.clone();
 
-        let query_result = async {
-            let mut session = self.get_session_state(&request_context);
+        let query_result =
+            async {
+                let mut session = self.get_session_state(&request_context);
 
-            let ctx = self;
-            let tracker = ctx.tracker;
+                let ctx = self;
+                let tracker = ctx.tracker;
 
-            // Sets the request context as an extension on DataFusion, to allow recovering it to track telemetry
-            session
-                .config_mut()
-                .set_extension(Arc::clone(&request_context));
+                // Sets the request context as an extension on DataFusion, to allow recovering it to track telemetry
+                session
+                    .config_mut()
+                    .set_extension(Arc::clone(&request_context));
 
-            // Get the `LogicalPlan` or cached results
-            let (plan, mut tracker, cache_manager) = match &ctx.sql {
-                QueryMethod::Text {
-                    sql,
-                    parameters,
-                    table_allowlist: Some(allowlist),
-                } => {
-                    let raw_cache_key = CacheKey::Query(sql, parameters.as_ref())
-                        .as_raw_key(Query::plan_hasher(&ctx.df));
-                    let plan = match Self::get_plan(
-                        &ctx.df,
-                        &session,
+                // Get the `LogicalPlan` or cached results
+                let (plan, mut tracker, cache_manager) = match &ctx.sql {
+                    QueryMethod::Text {
                         sql,
-                        &raw_cache_key,
-                        parameters.clone(),
-                    )
-                    .await
-                    {
-                        Ok(plan) => plan,
-                        Err(e) => match e {
-                            Error::UnableToExecuteQuery { source } => {
-                                let code = ErrorCode::from(&source);
-                                let snafu_err = Error::UnableToExecuteQuery { source };
-                                if let Some(t) = tracker {
-                                    t.finish_with_error(
-                                        &request_context,
-                                        snafu_err.to_string(),
-                                        code,
-                                    );
+                        parameters,
+                        table_allowlist: Some(allowlist),
+                    } => {
+                        let raw_cache_key = CacheKey::Query(sql, parameters.as_ref())
+                            .as_raw_key(Query::plan_hasher(&ctx.df));
+                        let plan = match Self::get_plan(
+                            &ctx.df,
+                            &session,
+                            sql,
+                            &raw_cache_key,
+                            parameters.clone(),
+                        )
+                        .await
+                        {
+                            Ok(plan) => plan,
+                            Err(e) => match e {
+                                Error::UnableToExecuteQuery { source } => {
+                                    let code = ErrorCode::from(&source);
+                                    let snafu_err = Error::UnableToExecuteQuery { source };
+                                    if let Some(t) = tracker {
+                                        t.finish_with_error(
+                                            &request_context,
+                                            snafu_err.to_string(),
+                                            code,
+                                        );
+                                    }
+                                    return Err(snafu_err);
                                 }
-                                return Err(snafu_err);
-                            }
-                            _ => return Err(e),
-                        },
-                    };
-                    let tables_referenced = plan.as_table_refs();
-                    if let Some(disallowed_table) = tables_referenced
-                        .iter()
-                        .find(|&t| !allowlist.table_is_allowed(t))
-                    {
-                        return Err(Error::TableAccessDisallowed {
-                            table: disallowed_table.to_string(),
-                        });
-                    }
-
-                    (
-                        Box::new(plan),
-                        tracker,
-                        RequestCacheManager::new(CacheStatus::CacheDisabled, raw_cache_key),
-                    )
-                }
-                QueryMethod::Text {
-                    sql,
-                    parameters,
-                    table_allowlist: None,
-                } => {
-                    match Self::get_plan_or_cached(
-                        &ctx.df,
-                        &session,
-                        Arc::clone(&request_context),
-                        sql,
-                        parameters.clone(),
-                        tracker,
-                    )
-                    .await?
-                    {
-                        PlanOrCached::Plan(plan, tracker, cache_manager) => {
-                            (plan, tracker, cache_manager)
+                                _ => return Err(e),
+                            },
+                        };
+                        let tables_referenced = plan.as_table_refs();
+                        if let Some(disallowed_table) = tables_referenced
+                            .iter()
+                            .find(|&t| !allowlist.table_is_allowed(t))
+                        {
+                            return Err(Error::TableAccessDisallowed {
+                                table: disallowed_table.to_string(),
+                            });
                         }
-                        PlanOrCached::Cached(query_result) => return Ok(query_result),
+
+                        (
+                            Box::new(plan),
+                            tracker,
+                            RequestCacheManager::new(CacheStatus::CacheDisabled, raw_cache_key),
+                        )
+                    }
+                    QueryMethod::Text {
+                        sql,
+                        parameters,
+                        table_allowlist: None,
+                    } => {
+                        match Self::get_plan_or_cached(
+                            &ctx.df,
+                            &session,
+                            Arc::clone(&request_context),
+                            sql,
+                            parameters.clone(),
+                            tracker,
+                        )
+                        .await?
+                        {
+                            PlanOrCached::Plan(plan, tracker, cache_manager) => {
+                                (plan, tracker, cache_manager)
+                            }
+                            PlanOrCached::Cached(query_result) => return Ok(query_result),
+                        }
+                    }
+                    QueryMethod::Plan(logical_plan) => {
+                        let cache_manager = RequestCacheManager::new(
+                            CacheStatus::CacheMiss,
+                            CacheKey::LogicalPlan(logical_plan)
+                                .as_raw_key(Query::plan_hasher(&ctx.df)),
+                        );
+                        (logical_plan.clone(), None, cache_manager)
+                    }
+                };
+
+                if let Err(e) = validate_sql_query_operations(&plan, &ctx.df) {
+                    let e = find_datafusion_root(e);
+                    handle_error!(
+                        tracker,
+                        &request_context,
+                        ErrorCode::QueryPlanningError,
+                        e,
+                        UnableToExecuteQuery
+                    )
+                }
+
+                // Proactively invalidate cached query state for tables affected by
+                // DML mutations (INSERT, DELETE, UPDATE).
+                // - results cache must be cleared so repeated SQL does not replay
+                //   pre-mutation answers
+                // - plans cache must be cleared so future queries re-resolve table
+                //   providers with up-to-date in-memory state.
+                if let Some(dml_table) = extract_dml_target_table(&plan)
+                    && let Err(e) = ctx.df.caching().invalidate_for_table(dml_table.clone())
+                {
+                    tracing::warn!(
+                        "Failed to invalidate caches for table {dml_table} before DML: {e}",
+                    );
+                }
+
+                let input_tables = get_logical_plan_input_tables(&plan);
+                if input_tables
+                    .iter()
+                    .any(|tr| matches!(tr.schema(), Some(SPICE_RUNTIME_SCHEMA)))
+                {
+                    inner_span.record("runtime_query", true);
+                }
+
+                // If any of the input tables are accelerated, mark the query as accelerated
+                let mut is_accelerated = false;
+                for tr in &input_tables {
+                    if ctx.df.is_accelerated(tr).await {
+                        is_accelerated = true;
+                        break;
                     }
                 }
-                QueryMethod::Plan(logical_plan) => {
-                    let cache_manager = RequestCacheManager::new(
-                        CacheStatus::CacheMiss,
-                        CacheKey::LogicalPlan(logical_plan).as_raw_key(Query::plan_hasher(&ctx.df)),
-                    );
-                    (logical_plan.clone(), None, cache_manager)
+                if is_accelerated {
+                    tracker = tracker.map(|mut t| {
+                        t.is_accelerated = Some(true);
+                        t
+                    });
                 }
-            };
 
-            if let Err(e) = validate_sql_query_operations(&plan, &ctx.df) {
-                let e = find_datafusion_root(e);
-                handle_error!(
-                    tracker,
-                    &request_context,
-                    ErrorCode::QueryPlanningError,
-                    e,
-                    UnableToExecuteQuery
-                )
-            }
+                let datasets = Arc::new(input_tables);
+                tracker = tracker.map(|t| t.datasets(Arc::clone(&datasets)));
 
-            // Proactively invalidate cached query state for tables affected by
-            // DML mutations (INSERT, DELETE, UPDATE).
-            // - results cache must be cleared so repeated SQL does not replay
-            //   pre-mutation answers
-            // - plans cache must be cleared so future queries re-resolve table
-            //   providers with up-to-date in-memory state.
-            if let LogicalPlan::Dml(dml) = &*plan
-                && let Err(e) = ctx
-                    .df
-                    .caching()
-                    .invalidate_for_table(dml.table_name.clone())
-            {
-                tracing::warn!(
-                    "Failed to invalidate caches for table {} before DML: {e}",
-                    dml.table_name
-                );
-            }
-
-            let input_tables = get_logical_plan_input_tables(&plan);
-            if input_tables
-                .iter()
-                .any(|tr| matches!(tr.schema(), Some(SPICE_RUNTIME_SCHEMA)))
-            {
-                inner_span.record("runtime_query", true);
-            }
-
-            // If any of the input tables are accelerated, mark the query as accelerated
-            let mut is_accelerated = false;
-            for tr in &input_tables {
-                if ctx.df.is_accelerated(tr).await {
-                    is_accelerated = true;
-                    break;
-                }
-            }
-            if is_accelerated {
+                // Start the timer for the query execution
                 tracker = tracker.map(|mut t| {
-                    t.is_accelerated = Some(true);
+                    t.query_execution_duration_timer = Instant::now();
                     t
                 });
-            }
 
-            let datasets = Arc::new(input_tables);
-            tracker = tracker.map(|t| t.datasets(Arc::clone(&datasets)));
-
-            // Start the timer for the query execution
-            tracker = tracker.map(|mut t| {
-                t.query_execution_duration_timer = Instant::now();
-                t
-            });
-
-            // Statement plans (PREPARE, EXECUTE, DEALLOCATE) need special handling
-            // They modify session state rather than producing query results, so must be
-            // executed through SessionContext::execute_logical_plan() instead of create_physical_plan()
-            let (res_stream, physical_plan): (SendableRecordBatchStream, Arc<dyn ExecutionPlan>) =
-                if matches!(&*plan, LogicalPlan::Statement(_)) {
+                // Statement plans (PREPARE, EXECUTE, DEALLOCATE) need special handling
+                // They modify session state rather than producing query results, so must be
+                // executed through SessionContext::execute_logical_plan() instead of create_physical_plan()
+                let (res_stream, physical_plan): (
+                    SendableRecordBatchStream,
+                    Arc<dyn ExecutionPlan>,
+                ) = if matches!(&*plan, LogicalPlan::Statement(_)) {
                     // For Statement plans, use SessionContext::execute_logical_plan()
                     // which handles PREPARE/EXECUTE/DEALLOCATE by modifying session state.
                     // Use the session-specific context if available to ensure prepared statements
@@ -775,80 +776,84 @@ impl Query {
                     (stream, physical_plan)
                 };
 
-            // Skip schema verification for Statement plans (PREPARE/EXECUTE/DEALLOCATE),
-            // DDL plans (CREATE TABLE/DROP TABLE), and DML Delete plans, as their logical
-            // plan schema may differ from the actual execution result (DDL plans may be
-            // rewritten by analyzer rules into extension nodes with different output schemas)
-            let res_stream = if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
-                && !matches!(
-                    &*plan,
-                    LogicalPlan::Dml(dml)
-                        if matches!(
-                            &dml.op,
-                            datafusion::logical_expr::WriteOp::Delete
-                                | datafusion::logical_expr::WriteOp::Update
+                // Skip schema verification for Statement plans (PREPARE/EXECUTE/DEALLOCATE),
+                // DDL plans (CREATE TABLE/DROP TABLE), DML Delete/Update plans, and Spice
+                // DML extension nodes, as their logical plan schema may differ from the
+                // actual execution result (DDL/DML plans may be rewritten by analyzer rules
+                // into extension nodes with different output schemas).
+                let res_stream =
+                    if !matches!(&*plan, LogicalPlan::Statement(_) | LogicalPlan::Ddl(_))
+                        && !matches!(
+                            &*plan,
+                            LogicalPlan::Dml(dml)
+                                if matches!(
+                                    &dml.op,
+                                    datafusion::logical_expr::WriteOp::Delete
+                                        | datafusion::logical_expr::WriteOp::Update
+                                )
                         )
-                ) {
-                let plan_schema = Arc::clone(plan.schema().inner());
-                let res_schema = res_stream.schema();
+                        && !is_dml_extension(&plan)
+                    {
+                        let plan_schema = Arc::clone(plan.schema().inner());
+                        let res_schema = res_stream.schema();
 
-                if let Err(e) = verify_schema(plan_schema.fields(), res_schema.fields()) {
-                    handle_error!(
-                        tracker,
-                        &request_context,
-                        ErrorCode::InternalError,
-                        e,
-                        SchemaMismatch
+                        if let Err(e) = verify_schema(plan_schema.fields(), res_schema.fields()) {
+                            handle_error!(
+                                tracker,
+                                &request_context,
+                                ErrorCode::InternalError,
+                                e,
+                                SchemaMismatch
+                            )
+                        }
+                        // The AggregateStatistics physical optimizer may replace an
+                        // AggregateExec with a ProjectionExec containing a literal
+                        // value, which changes the output nullability (literals report
+                        // nullable = value.is_null()).  Reconcile the execution result
+                        // schema with the logical plan schema so downstream consumers
+                        // (e.g. FlightSQL GetFlightInfo vs DoGet) see consistent
+                        // nullability.
+                        reconcile_stream_nullability(res_stream, &plan_schema)
+                    } else {
+                        res_stream
+                    };
+
+                let final_stream = if cache_manager.should_cache_results() {
+                    Self::wrap_stream_with_cache(
+                        &ctx.df,
+                        res_stream,
+                        cache_manager.raw_cache_key,
+                        datasets,
                     )
-                }
-                // The AggregateStatistics physical optimizer may replace an
-                // AggregateExec with a ProjectionExec containing a literal
-                // value, which changes the output nullability (literals report
-                // nullable = value.is_null()).  Reconcile the execution result
-                // schema with the logical plan schema so downstream consumers
-                // (e.g. FlightSQL GetFlightInfo vs DoGet) see consistent
-                // nullability.
-                reconcile_stream_nullability(res_stream, &plan_schema)
-            } else {
-                res_stream
-            };
+                } else {
+                    res_stream
+                };
 
-            let final_stream = if cache_manager.should_cache_results() {
-                Self::wrap_stream_with_cache(
-                    &ctx.df,
-                    res_stream,
-                    cache_manager.raw_cache_key,
-                    datasets,
-                )
-            } else {
-                res_stream
-            };
-
-            let final_stream = attach_physical_plan_metrics_to_stream(
-                final_stream,
-                physical_plan,
-                Arc::clone(&request_context),
-                inner_span.clone(),
-            );
-
-            let final_stream = attach_query_active_guard_to_stream(
-                final_stream,
-                &request_context,
-                inner_span.clone(),
-            );
-
-            Ok(QueryResult::new(
-                attach_query_tracker_to_stream(
-                    inner_span,
-                    Arc::clone(&request_context),
-                    tracker,
+                let final_stream = attach_physical_plan_metrics_to_stream(
                     final_stream,
-                ),
-                cache_manager.cache_status,
-            ))
-        }
-        .instrument(span.clone())
-        .await;
+                    physical_plan,
+                    Arc::clone(&request_context),
+                    inner_span.clone(),
+                );
+
+                let final_stream = attach_query_active_guard_to_stream(
+                    final_stream,
+                    &request_context,
+                    inner_span.clone(),
+                );
+
+                Ok(QueryResult::new(
+                    attach_query_tracker_to_stream(
+                        inner_span,
+                        Arc::clone(&request_context),
+                        tracker,
+                        final_stream,
+                    ),
+                    cache_manager.cache_status,
+                ))
+            }
+            .instrument(span.clone())
+            .await;
 
         match query_result {
             Ok(result) => Ok(result),
@@ -1337,6 +1342,49 @@ fn reconcile_stream_nullability(
             })
         }),
     ))
+}
+
+/// Extract the target table reference from a DML logical plan.
+///
+/// Handles both standard DataFusion `LogicalPlan::Dml` nodes and
+/// distributed Cayenne DML extension nodes.
+fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
+    match plan {
+        LogicalPlan::Dml(dml) => Some(dml.table_name.clone()),
+        #[cfg(not(windows))]
+        LogicalPlan::Extension(ext) => {
+            use super::cayenne_ddl::logical_nodes::DistributedCayenneDeleteNode;
+            if let Some(n) = ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneDeleteNode>()
+            {
+                return Some(n.table_name.clone());
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Returns `true` if the plan is a distributed DML extension node.
+///
+/// Used to skip schema verification for DML extension nodes, whose output
+/// schema may differ from the logical plan's schema.
+fn is_dml_extension(plan: &LogicalPlan) -> bool {
+    #[cfg(not(windows))]
+    if let LogicalPlan::Extension(ext) = plan {
+        use super::cayenne_ddl::logical_nodes::DistributedCayenneDeleteNode;
+        if ext
+            .node
+            .as_any()
+            .downcast_ref::<DistributedCayenneDeleteNode>()
+            .is_some()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/crates/runtime/tests/acceleration/snapshot_lock_contention.rs
+++ b/crates/runtime/tests/acceleration/snapshot_lock_contention.rs
@@ -384,7 +384,11 @@ async fn run_snapshot_workload(
         let lock_guard = Arc::clone(accelerator_write_mutex).lock_owned().await;
 
         // Create checkpoint
-        if checkpointer.checkpoint(federated_schema, None).await.is_err() {
+        if checkpointer
+            .checkpoint(federated_schema, None)
+            .await
+            .is_err()
+        {
             metrics.record_failure();
             continue;
         }


### PR DESCRIPTION
## Overview

Introduces a **unified SQL statement planner** that intercepts Cayenne DML at the **statement level** — before DataFusion's standard planner — producing `Extension` nodes directly for distributed mode.

This is **Milestone 1** of the [unified planner implementation plan](#10095): establish the planner skeleton and migrate DELETE as the first operation.

## Motivation

The current DML pipeline is fragmented:

```
SQL → session.create_logical_plan(sql)      [DF plans everything]
    → CayenneDdlAnalyzerRule                [rewrites DML→Extension for distributed]
    → run_internal() physical plan dispatch  [re-plans DELETE/UPDATE after DF]
```

Problems:
- DELETE/UPDATE are planned by DataFusion into `LogicalPlan::Dml`, then **re-planned** by Spice into custom physical plans — wasteful double-planning
- The `CayenneDdlAnalyzerRule` adds another layer of DML rewriting for distributed mode
- MERGE cannot enter this pipeline at all because DataFusion rejects `MERGE` statements

The unified planner consolidates this into:

```
SQL → planner::create_logical_plan()         [unified planner]
    → session.sql_to_statement(sql)          [parse once]
    → match statement:
        DELETE  → plan_delete()              [Extension or pass-through]
        _       → session.statement_to_plan() [delegate to DF]
    → session.create_physical_plan()          [standard DF physical planning]
```

## Changes

### New: `datafusion/planner/` module

- **`mod.rs`** — `create_logical_plan()` entry point that parses SQL to a sqlparser `Statement`, matches DELETE for Cayenne catalog tables, and delegates everything else to DataFusion's standard `statement_to_plan()`. Uses `PlannerContext` with `CatalogMode` and `ClusterRole` to determine interception behavior. Fast-path skips statement-level parsing entirely when no Cayenne catalogs are registered.

- **`delete.rs`** — `plan_distributed_delete()` wraps DataFusion's `DmlStatement` into a `DistributedCayenneDeleteNode` for scheduler mode. Local DELETE passes through to DataFusion unchanged — Cayenne's `TableProvider` handles it natively via `DeletionExec`.

- **`logical_nodes.rs`** / **`physical_execs.rs`** — Placeholder modules for future DML operations (UPDATE, MERGE).

### Modified: `datafusion/mod.rs`

- Wired `planner::create_logical_plan()` into `get_or_create_logical_plan()` via new `create_logical_plan()` method.
- Added `has_cayenne_catalog()` helper to determine if any DDL-enabled catalog is Cayenne-backed, used to set `CatalogMode`.

### Modified: `cayenne_ddl/analyzer_rule.rs`

- **Removed** the `Dml(Delete)` arm from `CayenneDdlAnalyzerRule` — DELETE interception for distributed mode is now handled upstream by the statement planner.

### Modified: `datafusion/query.rs`

- **`extract_dml_target_table()`** — Unified cache invalidation that handles both standard `LogicalPlan::Dml` nodes and distributed Cayenne DML extension nodes (replaces the direct `LogicalPlan::Dml` pattern match for cache invalidation).
- **`is_dml_extension()`** — Skip schema verification for DML extension nodes whose output schema may differ from the logical plan's schema.

### Other

- Minor test formatting fixes in `refresh.rs`, `duckdb.rs`, `sqlite.rs`, `snapshot_lock_contention.rs`.

## Next milestones

This PR establishes the planner skeleton. Subsequent PRs will:
- **Milestone 2:** Move `CREATE TABLE` extension extraction into the planner (eliminates `preprocess_create_table_with_options()` string-level hack)
- **Milestone 3:** Migrate UPDATE to the planner
- **Milestone 4:** Migrate INSERT (distributed) to the planner
- **Milestone 5:** Implement MERGE as a natural peer of DELETE/UPDATE/INSERT

Part of #10095