### PR TITLE
refactor: Migrate UPDATE and INSERT to unified planner

### DIFF
--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -41,7 +41,7 @@ use runtime_table_partition::expression::validate_partition_expression;
 use super::is_cayenne_catalog;
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
+    DistributedCayenneInsertNode,
 };
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
@@ -253,41 +253,6 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
                     drop.if_exists,
                     catalog_name,
                     schema_name,
-                );
-
-                Ok(LogicalPlan::Extension(Extension {
-                    node: Arc::new(node),
-                }))
-            }
-            LogicalPlan::Dml(DmlStatement {
-                input,
-                table_name,
-                op: WriteOp::Update,
-                output_schema,
-                ..
-            }) => {
-                let catalog_name = table_name
-                    .catalog()
-                    .unwrap_or(SPICE_DEFAULT_CATALOG)
-                    .to_string();
-
-                if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
-                    return Ok(plan);
-                }
-
-                if !self.apply_distributed_nodes {
-                    return Ok(plan);
-                }
-
-                let filter_sql = extract_filter_sql(input)?;
-                let assignments_sql = extract_update_assignments(input, table_name)?;
-
-                let node = DistributedCayenneUpdateNode::new(
-                    table_name.clone(),
-                    Arc::clone(input),
-                    Arc::clone(output_schema),
-                    filter_sql,
-                    assignments_sql,
                 );
 
                 Ok(LogicalPlan::Extension(Extension {

--- a/crates/runtime/src/datafusion/planner/insert.rs
+++ b/crates/runtime/src/datafusion/planner/insert.rs
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! INSERT planning for the unified planner.
+//!
+//! In distributed (scheduler) mode, produces a [`DistributedCayenneInsertNode`]
+//! that forwards the INSERT to executor nodes.
+//!
+//! In local mode, INSERT is handled by Cayenne's `TableProvider` implementation
+//! through DataFusion's standard physical planning — no interception needed.
+
+use std::sync::Arc;
+
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion_expr::DmlStatement;
+
+use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneInsertNode;
+
+/// Wrap a DataFusion `DmlStatement` (INSERT) into a distributed Cayenne
+/// extension node for forwarding to executor nodes.
+///
+/// This is only called in distributed (scheduler) mode. In local mode,
+/// the standard DataFusion plan is returned unchanged by the caller.
+pub(super) fn plan_distributed_insert(dml: &DmlStatement) -> DFResult<LogicalPlan> {
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(DistributedCayenneInsertNode::new(
+            dml.table_name.clone(),
+            Arc::clone(&dml.input),
+            Arc::clone(&dml.output_schema),
+        )),
+    }))
+}

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -25,10 +25,10 @@ limitations under the License.
 //!    the AST, stored in the [`DdlExtensionStore`], and stripped before
 //!    delegating to DataFusion.
 //!
-//! 2. **DML interception** — DELETE statements targeting Cayenne catalog
-//!    tables are converted into [`LogicalPlan::Extension`] nodes directly
-//!    for distributed mode. Support for additional DML types (UPDATE,
-//!    INSERT, MERGE) may be added in the future.
+//! 2. **DML interception** — DELETE and UPDATE statements targeting Cayenne
+//!    catalog tables are converted into [`LogicalPlan::Extension`] nodes
+//!    directly for distributed mode. Support for additional DML types
+//!    (INSERT, MERGE) may be added in the future.
 //!
 //! For everything else, the planner delegates to DataFusion's standard
 //! `session.statement_to_plan()` path.
@@ -37,12 +37,15 @@ mod create_table;
 mod delete;
 pub mod logical_nodes;
 pub mod physical_execs;
+mod update;
 
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::sql::TableReference;
 use datafusion::sql::parser::Statement;
 use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
+use datafusion_expr::WriteOp;
 
 use crate::config::ClusterRole;
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
@@ -103,10 +106,15 @@ pub async fn create_logical_plan(
 
             // DML: DELETE on Cayenne tables (only when Cayenne is active)
             SQLStatement::Delete(_) if ctx.catalog_mode == CatalogMode::Cayenne => {
-                return plan_cayenne_delete(statement, session, ctx).await;
+                return plan_cayenne_dml(statement, session, ctx, WriteOp::Delete).await;
             }
 
-            // Future: SQLStatement::Update { .. }, SQLStatement::Merge { .. }
+            // DML: UPDATE on Cayenne tables (only when Cayenne is active)
+            SQLStatement::Update { .. } if ctx.catalog_mode == CatalogMode::Cayenne => {
+                return plan_cayenne_dml(statement, session, ctx, WriteOp::Update).await;
+            }
+
+            // Future: SQLStatement::Merge { .. }
             _ => {}
         }
     }
@@ -115,57 +123,69 @@ pub async fn create_logical_plan(
     session.statement_to_plan(statement).await
 }
 
-/// Plan a DELETE statement, producing either a local or distributed Cayenne
-/// extension node.
+/// Plan a DML statement (DELETE or UPDATE), producing either a local or
+/// distributed Cayenne extension node.
 ///
 /// For local mode, returns the standard DataFusion plan unchanged — Cayenne's
-/// `TableProvider` implementation handles DELETE natively via `DeletionExec`.
+/// `TableProvider` implementation handles DML natively.
 ///
-/// For distributed (scheduler) mode, wraps the plan into a
-/// `DistributedCayenneDeleteNode` that forwards the operation to executors.
-async fn plan_cayenne_delete(
+/// For distributed (scheduler) mode, wraps the plan into a distributed
+/// extension node that forwards the operation to executors.
+async fn plan_cayenne_dml(
     statement: Statement,
     session: &SessionState,
     ctx: &PlannerContext,
+    expected_op: WriteOp,
 ) -> DFResult<LogicalPlan> {
-    // Let DataFusion plan the DELETE to get the validated DmlStatement
+    // Let DataFusion plan the DML to get the validated DmlStatement
     let df_plan = session.statement_to_plan(statement).await?;
 
-    // If not in distributed mode, Cayenne's TableProvider handles DELETE
+    // If not in distributed mode, Cayenne's TableProvider handles DML
     // natively through DataFusion's standard physical planning. Return as-is.
     if !matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
         return Ok(df_plan);
     }
 
     let LogicalPlan::Dml(dml) = &df_plan else {
-        return Err(DataFusionError::Internal(
-            "Expected LogicalPlan::Dml for DELETE statement".to_string(),
-        ));
+        return Err(DataFusionError::Internal(format!(
+            "Expected LogicalPlan::Dml for {expected_op:?} statement"
+        )));
     };
 
-    if !matches!(&dml.op, datafusion::logical_expr::WriteOp::Delete) {
+    if !matches_write_op(&dml.op, &expected_op) {
         return Err(DataFusionError::Internal(format!(
-            "Expected WriteOp::Delete, got {:?}",
+            "Expected WriteOp::{expected_op:?}, got {:?}",
             dml.op
         )));
     }
 
     // Check if the target table is in a Cayenne catalog
-    let catalog_name = dml.table_name.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
-
-    let is_cayenne = {
-        let catalog_list = session.catalog_list();
-        if let Some(catalog) = catalog_list.catalog(catalog_name) {
-            super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref())
-        } else {
-            false
-        }
-    };
-
-    // If not a Cayenne table, return the standard DF plan unchanged
-    if !is_cayenne {
+    if !is_cayenne_table(session, &dml.table_name) {
         return Ok(df_plan);
     }
 
-    delete::plan_distributed_delete(dml)
+    match expected_op {
+        WriteOp::Delete => delete::plan_distributed_delete(dml),
+        WriteOp::Update => update::plan_distributed_update(dml),
+        _ => Err(DataFusionError::Internal(format!(
+            "Unsupported DML operation: {expected_op:?}"
+        ))),
+    }
+}
+
+/// Check if a table is in a Cayenne-backed catalog.
+fn is_cayenne_table(session: &SessionState, table_name: &TableReference) -> bool {
+    let catalog_name = table_name.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+    let catalog_list = session.catalog_list();
+    if let Some(catalog) = catalog_list.catalog(catalog_name) {
+        super::cayenne_ddl::is_cayenne_catalog(catalog.as_ref())
+    } else {
+        false
+    }
+}
+
+/// Check if `WriteOp` matches the expected operation.
+/// `Insert` variants carry data, so use discriminant-level matching.
+fn matches_write_op(actual: &WriteOp, expected: &WriteOp) -> bool {
+    std::mem::discriminant(actual) == std::mem::discriminant(expected)
 }

--- a/crates/runtime/src/datafusion/planner/update.rs
+++ b/crates/runtime/src/datafusion/planner/update.rs
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! UPDATE planning for the unified planner.
+//!
+//! In distributed (scheduler) mode, produces a [`DistributedCayenneUpdateNode`]
+//! that forwards the UPDATE to executor nodes.
+//!
+//! In local mode, UPDATE is handled by Cayenne's `TableProvider` implementation
+//! through DataFusion's standard physical planning — no interception needed.
+
+use std::sync::Arc;
+
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion_expr::DmlStatement;
+
+use crate::datafusion::cayenne_ddl::analyzer_rule::{
+    extract_filter_sql, extract_update_assignments,
+};
+use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneUpdateNode;
+
+/// Wrap a DataFusion `DmlStatement` (UPDATE) into a distributed Cayenne
+/// extension node for forwarding to executor nodes.
+///
+/// This is only called in distributed (scheduler) mode. In local mode,
+/// the standard DataFusion plan is returned unchanged by the caller.
+pub(super) fn plan_distributed_update(dml: &DmlStatement) -> DFResult<LogicalPlan> {
+    let filter_sql = extract_filter_sql(&dml.input)?;
+    let assignments_sql = extract_update_assignments(&dml.input, &dml.table_name)?;
+
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(DistributedCayenneUpdateNode::new(
+            dml.table_name.clone(),
+            Arc::clone(&dml.input),
+            Arc::clone(&dml.output_schema),
+            filter_sql,
+            assignments_sql,
+        )),
+    }))
+}

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1320,11 +1320,20 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
         LogicalPlan::Dml(dml) => Some(dml.table_name.clone()),
         #[cfg(not(windows))]
         LogicalPlan::Extension(ext) => {
-            use super::cayenne_ddl::logical_nodes::DistributedCayenneDeleteNode;
+            use super::cayenne_ddl::logical_nodes::{
+                DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+            };
             if let Some(n) = ext
                 .node
                 .as_any()
                 .downcast_ref::<DistributedCayenneDeleteNode>()
+            {
+                return Some(n.table_name.clone());
+            }
+            if let Some(n) = ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneUpdateNode>()
             {
                 return Some(n.table_name.clone());
             }
@@ -1341,11 +1350,21 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
 fn is_dml_extension(plan: &LogicalPlan) -> bool {
     #[cfg(not(windows))]
     if let LogicalPlan::Extension(ext) = plan {
-        use super::cayenne_ddl::logical_nodes::DistributedCayenneDeleteNode;
+        use super::cayenne_ddl::logical_nodes::{
+            DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+        };
         if ext
             .node
             .as_any()
             .downcast_ref::<DistributedCayenneDeleteNode>()
+            .is_some()
+        {
+            return true;
+        }
+        if ext
+            .node
+            .as_any()
+            .downcast_ref::<DistributedCayenneUpdateNode>()
             .is_some()
         {
             return true;


### PR DESCRIPTION
> **Stacked on** #10100 ← #10099

## Overview

Completes the DML migration by moving distributed UPDATE and INSERT interception from `CayenneDdlAnalyzerRule` into the unified statement planner. After this change, the analyzer rule **only handles DDL** (`CreateMemoryTable`, `DropTable`, `CreateCatalogSchema`).

## Changes

### New: `planner/update.rs`

`plan_distributed_update()` wraps DataFusion's `DmlStatement` into a `DistributedCayenneUpdateNode` for scheduler mode, extracting filter SQL and assignment expressions. Local UPDATE passes through to DataFusion unchanged.

### New: `planner/insert.rs`

`plan_distributed_insert()` wraps DataFusion's `DmlStatement` into a `DistributedCayenneInsertNode` for scheduler mode. Local INSERT passes through to DataFusion unchanged (Cayenne's `TableProvider::insert_into()` handles it natively).

### Refactored: `planner/mod.rs`

- **Generalized** `plan_cayenne_delete()` → `plan_cayenne_dml()` — a single function handles DELETE, UPDATE, and INSERT via `WriteOp` dispatch, eliminating code duplication
- **Extracted** `is_cayenne_table()` helper — shared table-to-catalog resolution logic
- **Extracted** `matches_write_op()` helper — discriminant-level `WriteOp` matching (INSERT variants carry data, so direct pattern matching doesn't work)
- Added `SQLStatement::Update` dispatch in statement matching

### Modified: `cayenne_ddl/analyzer_rule.rs`

Removed all remaining DML arms:
- `Dml(Update)` arm (was rewriting into `DistributedCayenneUpdateNode`)
- `Dml(Insert)` arm (was rewriting into `DistributedCayenneInsertNode`)
- Removed unused imports (`DmlStatement`, `WriteOp`, `DistributedCayenneInsertNode`, `DistributedCayenneUpdateNode`)

The analyzer rule now **only** handles DDL: `CreateMemoryTable`, `DropTable`, `CreateCatalogSchema`.

### Modified: `query.rs`

Extended cache invalidation and schema verification skip to cover the new distributed extension nodes:
- `extract_dml_target_table()` — added `DistributedCayenneUpdateNode` downcast
- `is_dml_extension()` — added `DistributedCayenneUpdateNode` downcast

(INSERT doesn't need cache invalidation since it creates new rows, not modifying existing cached results.)

## Design notes

The `plan_cayenne_dml()` function follows a consistent pattern for all three operations:
1. Let DataFusion plan the statement → get validated `DmlStatement`
2. If not in scheduler mode → return DataFusion's plan unchanged (local mode)
3. If target is not a Cayenne table → return unchanged (non-Cayenne DML)
4. Dispatch to operation-specific distributed node constructor

This eliminates the analyzer-rule approach where DML was first fully planned by DataFusion, then post-hoc rewritten during analysis — the planner now intercepts at the right level.

Part of #10095