### PR TITLE
feat: Implement MERGE INTO for Cayenne catalog tables

### DIFF
--- a/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/analyzer_rule.rs
@@ -35,14 +35,10 @@ use datafusion::prelude::Expr;
 
 use datafusion::sql::TableReference;
 use datafusion::sql::unparser::expr_to_sql;
-use datafusion_expr::{DmlStatement, WriteOp};
 use runtime_table_partition::expression::validate_partition_expression;
 
 use super::is_cayenne_catalog;
-use super::logical_nodes::{
-    CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneInsertNode,
-};
+use super::logical_nodes::{CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode};
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 
@@ -95,6 +91,7 @@ pub struct CayenneDdlAnalyzerRule {
     /// When `true`, DML targeting Cayenne catalogs is rewritten into distributed
     /// extension nodes that forward operations to executors. Only `true` for the
     /// scheduler role.
+    #[expect(dead_code)] // Retained for future use when distributed DML moves fully to planner
     apply_distributed_nodes: bool,
 }
 
@@ -257,34 +254,6 @@ impl AnalyzerRule for CayenneDdlAnalyzerRule {
 
                 Ok(LogicalPlan::Extension(Extension {
                     node: Arc::new(node),
-                }))
-            }
-            LogicalPlan::Dml(DmlStatement {
-                input,
-                table_name,
-                op: WriteOp::Insert(_),
-                output_schema,
-                ..
-            }) => {
-                let catalog_name = table_name
-                    .catalog()
-                    .unwrap_or(SPICE_DEFAULT_CATALOG)
-                    .to_string();
-
-                if !self.is_ddl_enabled(&catalog_name) || !self.is_cayenne_backed(&catalog_name) {
-                    return Ok(plan);
-                }
-
-                if !self.apply_distributed_nodes {
-                    return Ok(plan);
-                }
-
-                Ok(LogicalPlan::Extension(Extension {
-                    node: Arc::new(DistributedCayenneInsertNode::new(
-                        table_name.clone(),
-                        Arc::clone(input),
-                        Arc::clone(output_schema),
-                    )),
                 }))
             }
             LogicalPlan::Ddl(DdlStatement::CreateCatalogSchema(create)) => {

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -167,6 +167,156 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
             ))));
         }
 
+        if let Some(merge) =
+            node.as_any()
+                .downcast_ref::<crate::datafusion::planner::logical_nodes::CayenneMergeNode>()
+        {
+            return plan_merge_extension(merge, session_state).await;
+        }
+
         Ok(None)
     }
+}
+
+/// Build the physical plan for a `CayenneMergeNode`.
+///
+/// Constructs a `DataFusion` INNER JOIN between target and source tables,
+/// projects the SET assignment expressions over the joined schema, and
+/// wraps the result in a [`CayenneMergeExec`] that executes delete + insert.
+async fn plan_merge_extension(
+    merge: &crate::datafusion::planner::logical_nodes::CayenneMergeNode,
+    session_state: &datafusion::execution::SessionState,
+) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+    use std::collections::HashMap;
+
+    use datafusion::datasource::provider_as_source;
+    use datafusion::logical_expr::LogicalPlanBuilder;
+    use datafusion::prelude::{Column, Expr, JoinType, col};
+
+    use crate::datafusion::planner::physical_execs::CayenneMergeExec;
+    use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+
+    // Resolve target and source table providers.
+    async fn resolve_table(
+        session_state: &datafusion::execution::SessionState,
+        table_ref: &datafusion::sql::TableReference,
+    ) -> DFResult<Arc<dyn datafusion::datasource::TableProvider>> {
+        let catalog_name = table_ref.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+        let schema_name = table_ref.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
+        let table_name = table_ref.table();
+
+        let catalog_list = session_state.catalog_list();
+        let catalog = catalog_list.catalog(catalog_name).ok_or_else(|| {
+            datafusion::error::DataFusionError::Plan(format!("Catalog '{catalog_name}' not found"))
+        })?;
+        let schema = catalog.schema(schema_name).ok_or_else(|| {
+            datafusion::error::DataFusionError::Plan(format!("Schema '{schema_name}' not found"))
+        })?;
+        schema
+            .table(table_name)
+            .await
+            .map_err(|e| {
+                datafusion::error::DataFusionError::Plan(format!(
+                    "Failed to resolve table '{table_ref}': {e}"
+                ))
+            })?
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Plan(format!("Table '{table_ref}' not found"))
+            })
+    }
+
+    let target_provider = resolve_table(session_state, &merge.target_table).await?;
+    let source_provider = resolve_table(session_state, &merge.source_table).await?;
+
+    // Use the qualifiers stored on the node — these are the alias (if
+    // provided) or table name. Assignment value SQL references these
+    // qualifiers, so the scan must match.
+    let target_qualifier = merge.target_qualifier.as_str();
+    let source_qualifier = merge.source_qualifier.as_str();
+
+    // Build table scans.
+    let target_scan = LogicalPlanBuilder::scan(
+        target_qualifier,
+        provider_as_source(Arc::clone(&target_provider)),
+        None,
+    )?
+    .build()?;
+    let source_scan = LogicalPlanBuilder::scan(
+        source_qualifier,
+        provider_as_source(Arc::clone(&source_provider)),
+        None,
+    )?
+    .build()?;
+
+    // Build INNER JOIN from pre-normalized key pairs.
+    let (left_keys, right_keys): (Vec<Column>, Vec<Column>) = merge
+        .on_keys
+        .iter()
+        .map(|(t, s)| {
+            (
+                Column::new(Some(target_qualifier.to_string()), t),
+                Column::new(Some(source_qualifier.to_string()), s),
+            )
+        })
+        .unzip();
+
+    let target_key_columns: Vec<String> = merge.on_keys.iter().map(|(t, _)| t.clone()).collect();
+
+    let joined = LogicalPlanBuilder::from(target_scan)
+        .join(source_scan, JoinType::Inner, (left_keys, right_keys), None)?
+        .build()?;
+
+    // Build projection: for each target column, use the assignment expression
+    // or keep the original target column value.
+    let assign_map: HashMap<&str, &str> = merge
+        .assignments
+        .iter()
+        .map(|(c, e)| (c.as_str(), e.as_str()))
+        .collect();
+
+    let target_schema = target_provider.schema();
+    let target_field_names: std::collections::HashSet<&str> = target_schema
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+
+    // Validate all assignment targets exist in the target schema.
+    for (col_name, _) in &merge.assignments {
+        if !target_field_names.contains(col_name.as_str()) {
+            return Err(datafusion::error::DataFusionError::Plan(format!(
+                "MERGE UPDATE SET target column '{col_name}' does not exist in target table"
+            )));
+        }
+    }
+
+    let joined_schema = joined.schema();
+
+    let project_exprs: Vec<Expr> = target_schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let col_name = field.name();
+            let expr = if let Some(value_sql) = assign_map.get(col_name.as_str()) {
+                session_state.create_logical_expr(value_sql, joined_schema)?
+            } else {
+                col(Column::new(Some(target_qualifier.to_string()), col_name))
+            };
+            Ok(expr.alias(col_name))
+        })
+        .collect::<DFResult<Vec<_>>>()?;
+
+    let projected = LogicalPlanBuilder::from(joined)
+        .project(project_exprs)?
+        .build()?;
+
+    // Convert the logical plan to a physical plan.
+    let join_physical = session_state.create_physical_plan(&projected).await?;
+
+    Ok(Some(Arc::new(CayenneMergeExec::new(
+        join_physical,
+        target_provider,
+        session_state.clone(),
+        target_key_columns,
+    ))))
 }

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -95,7 +95,7 @@ pub(super) async fn plan_create_table(
             {
                 tracing::warn!(
                     "Failed to clean up DDL extension store entry for {key} \
-                         after planning failure: {cleanup_err}"
+                     after planning failure: {cleanup_err}"
                 );
             }
             Err(e)

--- a/crates/runtime/src/datafusion/planner/insert.rs
+++ b/crates/runtime/src/datafusion/planner/insert.rs
@@ -20,27 +20,26 @@ limitations under the License.
 //! that forwards the INSERT to executor nodes.
 //!
 //! In local mode, INSERT is handled by Cayenne's `TableProvider` implementation
-//! through DataFusion's standard physical planning — no interception needed.
+//! through `DataFusion`'s standard physical planning — no interception needed.
 
 use std::sync::Arc;
 
-use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::{Extension, LogicalPlan};
 use datafusion_expr::DmlStatement;
 
 use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneInsertNode;
 
-/// Wrap a DataFusion `DmlStatement` (INSERT) into a distributed Cayenne
+/// Wrap a `DataFusion` `DmlStatement` (INSERT) into a distributed Cayenne
 /// extension node for forwarding to executor nodes.
 ///
 /// This is only called in distributed (scheduler) mode. In local mode,
-/// the standard DataFusion plan is returned unchanged by the caller.
-pub(super) fn plan_distributed_insert(dml: &DmlStatement) -> DFResult<LogicalPlan> {
-    Ok(LogicalPlan::Extension(Extension {
+/// the standard `DataFusion` plan is returned unchanged by the caller.
+pub(super) fn plan_distributed_insert(dml: &DmlStatement) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
         node: Arc::new(DistributedCayenneInsertNode::new(
             dml.table_name.clone(),
             Arc::clone(&dml.input),
             Arc::clone(&dml.output_schema),
         )),
-    }))
+    })
 }

--- a/crates/runtime/src/datafusion/planner/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/planner/logical_nodes.rs
@@ -14,10 +14,143 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Logical plan nodes for Cayenne DML operations produced by the Spice planner.
-//!
-//! Currently empty — local DELETE is handled by Cayenne's `TableProvider`
-//! implementation through `DataFusion`'s standard physical planning, and
-//! distributed DELETE reuses `DistributedCayenneDeleteNode` from `cayenne_ddl`.
-//!
-//! Future DML operations (UPDATE, MERGE) will add nodes here.
+//! `CayenneMergeNode` — logical plan node for local MERGE execution.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::common::{DFSchema, DFSchemaRef};
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNodeCore};
+use datafusion::sql::TableReference;
+
+/// Logical plan node for a local `MERGE INTO ... USING ... ON ... WHEN MATCHED
+/// THEN UPDATE SET ...` operation on a Cayenne table.
+///
+/// Produced by the statement planner when a MERGE targets a Cayenne table in
+/// local (non-distributed) mode. The extension planner converts this into a
+/// `CayenneMergeExec` that builds a `DataFusion` join plan and executes
+/// delete + insert.
+#[derive(Debug, Clone)]
+pub struct CayenneMergeNode {
+    /// Fully qualified target table reference.
+    pub target_table: TableReference,
+    /// Fully qualified source table reference.
+    pub source_table: TableReference,
+    /// Scan qualifier for the target side — the alias if provided, otherwise
+    /// the table name. Assignment value SQL (e.g. `t.qty + 1`) references
+    /// this qualifier, so the extension planner must use it for schema
+    /// resolution.
+    pub target_qualifier: String,
+    /// Scan qualifier for the source side.
+    pub source_qualifier: String,
+    /// Equi-join key pairs as `(target_col, source_col)` bare column names,
+    /// normalized from the ON clause at plan time.
+    pub on_keys: Vec<(String, String)>,
+    /// SET assignments as `(target_col, value_sql)` pairs.
+    /// The `value_sql` is the raw SQL text of the assignment expression,
+    /// resolved against the joined schema at physical planning time.
+    pub assignments: Vec<(String, String)>,
+    /// Output schema: single `count: UInt64` column.
+    pub output_schema: DFSchemaRef,
+}
+
+impl CayenneMergeNode {
+    /// Create a new `CayenneMergeNode`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output schema cannot be constructed.
+    pub fn try_new(
+        target_table: TableReference,
+        source_table: TableReference,
+        target_qualifier: String,
+        source_qualifier: String,
+        on_keys: Vec<(String, String)>,
+        assignments: Vec<(String, String)>,
+    ) -> datafusion::error::Result<Self> {
+        let output_schema = Arc::new(DFSchema::try_from(Schema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]))?);
+
+        Ok(Self {
+            target_table,
+            source_table,
+            target_qualifier,
+            source_qualifier,
+            on_keys,
+            assignments,
+            output_schema,
+        })
+    }
+}
+
+impl Hash for CayenneMergeNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.target_table.hash(state);
+        self.source_table.hash(state);
+        self.target_qualifier.hash(state);
+        self.source_qualifier.hash(state);
+        self.on_keys.hash(state);
+        self.assignments.hash(state);
+    }
+}
+
+impl PartialEq for CayenneMergeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_table == other.target_table
+            && self.source_table == other.source_table
+            && self.target_qualifier == other.target_qualifier
+            && self.source_qualifier == other.source_qualifier
+            && self.on_keys == other.on_keys
+            && self.assignments == other.assignments
+    }
+}
+
+impl Eq for CayenneMergeNode {}
+
+impl PartialOrd for CayenneMergeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.target_table
+            .to_string()
+            .partial_cmp(&other.target_table.to_string())
+    }
+}
+
+impl UserDefinedLogicalNodeCore for CayenneMergeNode {
+    fn name(&self) -> &'static str {
+        "CayenneMerge"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<datafusion::prelude::Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CayenneMerge: target={}, source={}, keys={:?}, assignments={:?}",
+            self.target_table, self.source_table, self.on_keys, self.assignments
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<datafusion::prelude::Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(self.clone())
+    }
+}

--- a/crates/runtime/src/datafusion/planner/merge.rs
+++ b/crates/runtime/src/datafusion/planner/merge.rs
@@ -1,0 +1,762 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! MERGE INTO planning for the unified planner.
+//!
+//! Phase 1 supports only:
+//! ```sql
+//! MERGE INTO target [AS t]
+//! USING source [AS s]
+//! ON <equality_conjunction>
+//! WHEN MATCHED THEN UPDATE SET col1 = expr1, ...
+//! ```
+//!
+//! Both source and target must be Cayenne catalog tables. Single-node
+//! execution only (distributed mode returns an error). Target must not
+//! have `primary_key` or `on_conflict` configured.
+
+use std::sync::Arc;
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::SessionState;
+use datafusion::logical_expr::{Extension, LogicalPlan};
+use datafusion::sql::TableReference;
+use datafusion::sql::parser::Statement;
+use datafusion::sql::sqlparser::ast::{
+    AssignmentTarget, BinaryOperator, Expr as SQLExpr, MergeAction, MergeClause, MergeClauseKind,
+    Statement as SQLStatement, TableFactor,
+};
+
+use super::logical_nodes::CayenneMergeNode;
+use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
+
+/// Plan a `MERGE INTO` statement for local Cayenne execution.
+///
+/// Parses the AST, validates phase 1 constraints, normalizes the ON clause
+/// into bare `(target_col, source_col)` key pairs, and produces a
+/// `CayenneMergeNode` extension node.
+pub(super) async fn plan_merge(
+    statement: Statement,
+    session: &SessionState,
+) -> DFResult<LogicalPlan> {
+    let Statement::Statement(sql_stmt) = statement else {
+        return Err(DataFusionError::Internal(
+            "Expected Statement::Statement for MERGE".to_string(),
+        ));
+    };
+    let SQLStatement::Merge {
+        table,
+        source,
+        on,
+        clauses,
+        output,
+        ..
+    } = *sql_stmt
+    else {
+        return Err(DataFusionError::Internal(
+            "Expected SQLStatement::Merge".to_string(),
+        ));
+    };
+
+    if output.is_some() {
+        return Err(DataFusionError::Plan(
+            "MERGE with OUTPUT clause is not supported".to_string(),
+        ));
+    }
+
+    // --- Extract target and source tables ---
+    let (target_name, target_alias) = extract_table_ref(&table, "target")?;
+    let target_ref = TableReference::parse_str(&target_name);
+    let target_qualifier = target_alias
+        .clone()
+        .unwrap_or_else(|| target_ref.table().to_string());
+
+    let (source_name, source_alias) = extract_table_ref(&source, "source")?;
+    let source_ref = TableReference::parse_str(&source_name);
+    let source_qualifier = source_alias
+        .clone()
+        .unwrap_or_else(|| source_ref.table().to_string());
+
+    // --- Validate both are Cayenne tables ---
+    if !is_cayenne_table(session, &target_ref) {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE target '{target_name}' is not a Cayenne catalog table"
+        )));
+    }
+    if !is_cayenne_table(session, &source_ref) {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE source '{source_name}' is not a Cayenne catalog table"
+        )));
+    }
+
+    // --- Validate target has no primary_key / on_conflict ---
+    validate_target_metadata(session, &target_ref, &target_name).await?;
+
+    // --- Parse ON clause into normalized (target_col, source_col) pairs ---
+    // Aliases are used here for disambiguation then discarded.
+    let target_qualifiers: Vec<&str> = std::iter::once(target_ref.table())
+        .chain(target_alias.as_deref())
+        .collect();
+    let source_qualifiers: Vec<&str> = std::iter::once(source_ref.table())
+        .chain(source_alias.as_deref())
+        .collect();
+    let on_keys = parse_on_keys(&on, &target_qualifiers, &source_qualifiers)?;
+
+    if on_keys.is_empty() {
+        return Err(DataFusionError::Plan(
+            "MERGE ON clause must contain at least one equality predicate".to_string(),
+        ));
+    }
+
+    // --- Validate exactly one WHEN MATCHED THEN UPDATE SET clause ---
+    if clauses.len() != 1 {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE currently supports exactly one WHEN clause, got {}",
+            clauses.len()
+        )));
+    }
+    let assignments =
+        validate_and_extract_assignments(&clauses[0], target_ref.table(), target_alias.as_deref())?;
+
+    let node = CayenneMergeNode::try_new(
+        target_ref,
+        source_ref,
+        target_qualifier,
+        source_qualifier,
+        on_keys,
+        assignments,
+    )?;
+
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(node),
+    }))
+}
+
+/// Extract a table name and optional alias from a `TableFactor`.
+///
+/// Only `TableFactor::Table` (plain table reference) is supported in phase 1.
+fn extract_table_ref(factor: &TableFactor, role: &str) -> DFResult<(String, Option<String>)> {
+    let TableFactor::Table { name, alias, .. } = factor else {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE {role} must be a table reference (subqueries are not supported)"
+        )));
+    };
+    let table_name = name.to_string();
+    let alias_name = alias.as_ref().map(|a| a.name.value.clone());
+    Ok((table_name, alias_name))
+}
+
+/// Validate that the target table does not have `primary_key` or `on_conflict`
+/// configured, which would conflict with MERGE's delete+insert execution.
+///
+/// Uses the Cayenne metadata catalog directly (via `CayenneSchemaProvider`)
+/// rather than downcasting the `TableProvider`, because partitioned tables
+/// are wrapped in `PartitionTableProvider` which doesn't expose the inner
+/// `CayenneTableProvider`.
+async fn validate_target_metadata(
+    session: &SessionState,
+    target_ref: &TableReference,
+    target_name: &str,
+) -> DFResult<()> {
+    use crate::catalogconnector::cayenne::provider::CayenneSchemaProvider;
+
+    let catalog_name = target_ref.catalog().unwrap_or(SPICE_DEFAULT_CATALOG);
+    let schema_name = target_ref.schema().unwrap_or(SPICE_DEFAULT_SCHEMA);
+    let table_name = target_ref.table();
+
+    let catalog_list = session.catalog_list();
+    let catalog = catalog_list
+        .catalog(catalog_name)
+        .ok_or_else(|| DataFusionError::Plan(format!("Catalog '{catalog_name}' not found")))?;
+    let schema = catalog
+        .schema(schema_name)
+        .ok_or_else(|| DataFusionError::Plan(format!("Schema '{schema_name}' not found")))?;
+
+    // Downcast to CayenneSchemaProvider to access the metadata catalog.
+    // This works for all Cayenne table shapes (plain and partitioned).
+    let Some(cayenne_schema) = schema.as_any().downcast_ref::<CayenneSchemaProvider>() else {
+        // Not a Cayenne schema — skip validation (caller already verified
+        // this is a Cayenne catalog table via `is_cayenne_table`).
+        return Ok(());
+    };
+
+    let full_name = format!("{schema_name}/{table_name}");
+    let metadata = cayenne_schema
+        .metadata_catalog()
+        .get_table(&full_name)
+        .await
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to read metadata for table '{target_name}': {e}"
+            ))
+        })?;
+
+    if !metadata.primary_key.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE is not supported on table '{target_name}' because it has a primary key configured. \
+             MERGE uses delete+insert execution which conflicts with primary key on-conflict behavior."
+        )));
+    }
+    if metadata.on_conflict.is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "MERGE is not supported on table '{target_name}' because it has on_conflict configured."
+        )));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// ON clause parsing
+// ---------------------------------------------------------------------------
+
+/// Parse the ON clause into normalized `(target_col, source_col)` pairs.
+///
+/// Iteratively flattens AND conjunctions, validates each conjunct is an
+/// equality between qualified column references, and uses the provided
+/// qualifier lists (table name + optional alias) to attribute each side
+/// to target or source. Returns bare column names.
+fn parse_on_keys(
+    on_expr: &SQLExpr,
+    target_qualifiers: &[&str],
+    source_qualifiers: &[&str],
+) -> DFResult<Vec<(String, String)>> {
+    let conjuncts = flatten_and_conjuncts(on_expr);
+    let mut keys = Vec::with_capacity(conjuncts.len());
+
+    for conjunct in conjuncts {
+        let SQLExpr::BinaryOp { left, op, right } = conjunct else {
+            return Err(DataFusionError::Plan(format!(
+                "MERGE ON clause must contain only equality predicates, found: {conjunct}"
+            )));
+        };
+        if *op != BinaryOperator::Eq {
+            return Err(DataFusionError::Plan(format!(
+                "MERGE ON clause must contain only equality predicates (AND-connected), \
+                 found operator: {op}"
+            )));
+        }
+
+        let (lhs_qualifier, lhs_col) = extract_column_ref(left)?;
+        let (rhs_qualifier, rhs_col) = extract_column_ref(right)?;
+
+        let lhs_is_target = matches_qualifier(lhs_qualifier.as_ref(), target_qualifiers);
+        let rhs_is_target = matches_qualifier(rhs_qualifier.as_ref(), target_qualifiers);
+        let lhs_is_source = matches_qualifier(lhs_qualifier.as_ref(), source_qualifiers);
+        let rhs_is_source = matches_qualifier(rhs_qualifier.as_ref(), source_qualifiers);
+
+        if lhs_is_target && rhs_is_source {
+            keys.push((lhs_col, rhs_col));
+        } else if lhs_is_source && rhs_is_target {
+            keys.push((rhs_col, lhs_col));
+        } else {
+            return Err(DataFusionError::Plan(format!(
+                "Cannot determine target/source for MERGE ON predicate: {conjunct}. \
+                 Use table aliases to disambiguate (e.g., t.id = s.id)."
+            )));
+        }
+    }
+
+    Ok(keys)
+}
+
+/// Iteratively flatten an AND-connected expression tree into leaf conjuncts.
+fn flatten_and_conjuncts(expr: &SQLExpr) -> Vec<&SQLExpr> {
+    let mut result = Vec::new();
+    let mut stack = vec![expr];
+
+    while let Some(e) = stack.pop() {
+        match e {
+            SQLExpr::BinaryOp {
+                left,
+                op: BinaryOperator::And,
+                right,
+            } => {
+                // Push right first so left is processed first (preserves order).
+                stack.push(right);
+                stack.push(left);
+            }
+            SQLExpr::Nested(inner) => {
+                stack.push(inner);
+            }
+            other => result.push(other),
+        }
+    }
+
+    result
+}
+
+/// Extract `(optional_qualifier, column_name)` from a column reference.
+fn extract_column_ref(expr: &SQLExpr) -> DFResult<(Option<String>, String)> {
+    match expr {
+        SQLExpr::Identifier(ident) => Ok((None, ident.value.clone())),
+        SQLExpr::CompoundIdentifier(parts) if parts.len() == 2 => {
+            Ok((Some(parts[0].value.clone()), parts[1].value.clone()))
+        }
+        _ => Err(DataFusionError::Plan(format!(
+            "MERGE ON clause columns must be simple column references, found: {expr}"
+        ))),
+    }
+}
+
+/// Check if a column qualifier matches any of the accepted qualifiers
+/// (table name or alias) for a given side.
+fn matches_qualifier(qualifier: Option<&String>, accepted: &[&str]) -> bool {
+    match qualifier {
+        Some(q) => accepted.iter().any(|a| q.eq_ignore_ascii_case(a)),
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHEN clause validation
+// ---------------------------------------------------------------------------
+
+/// Validate the WHEN clause is `WHEN MATCHED THEN UPDATE SET ...` and extract
+/// the assignment pairs as `(column_name, value_sql)`.
+///
+/// `target_table_name` and `target_alias` are used to validate that qualified
+/// assignment targets (e.g., `t.qty`) reference the target, not the source.
+fn validate_and_extract_assignments(
+    clause: &MergeClause,
+    target_table_name: &str,
+    target_alias: Option<&str>,
+) -> DFResult<Vec<(String, String)>> {
+    if clause.clause_kind != MergeClauseKind::Matched {
+        return Err(DataFusionError::Plan(format!(
+            "Only WHEN MATCHED is supported in MERGE, found: WHEN {}",
+            clause.clause_kind
+        )));
+    }
+    if clause.predicate.is_some() {
+        return Err(DataFusionError::Plan(
+            "WHEN MATCHED with additional predicates (AND ...) is not supported".to_string(),
+        ));
+    }
+
+    let MergeAction::Update { assignments } = &clause.action else {
+        return Err(DataFusionError::Plan(format!(
+            "Only UPDATE SET is supported in WHEN MATCHED, found: {}",
+            clause.action
+        )));
+    };
+
+    if assignments.is_empty() {
+        return Err(DataFusionError::Plan(
+            "MERGE UPDATE SET must have at least one assignment".to_string(),
+        ));
+    }
+
+    let mut result = Vec::with_capacity(assignments.len());
+    let mut seen_columns = std::collections::HashSet::new();
+    for assignment in assignments {
+        let col_name = match &assignment.target {
+            AssignmentTarget::ColumnName(name) => {
+                // Extract bare column name from potentially qualified name.
+                // e.g., `t.qty` -> `qty`, `qty` -> `qty`
+                let parts: Vec<String> = name
+                    .0
+                    .iter()
+                    .map(|p| match p.as_ident() {
+                        Some(ident) => Ok(ident.value.clone()),
+                        None => Err(DataFusionError::Plan(format!(
+                            "Invalid assignment target '{name}': function-based identifiers are not supported"
+                        ))),
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                match parts.as_slice() {
+                    [column] => column.clone(),
+                    [qualifier, column] => {
+                        // Qualified targets must reference the MERGE target
+                        // relation. Reject source-qualified targets like `s.qty`.
+                        let qualifier_matches_target = qualifier
+                            .eq_ignore_ascii_case(target_table_name)
+                            || target_alias.is_some_and(|a| qualifier.eq_ignore_ascii_case(a));
+                        if !qualifier_matches_target {
+                            return Err(DataFusionError::Plan(format!(
+                                "Invalid assignment target '{name}': qualifier '{qualifier}' does not \
+                                 match MERGE target '{target_table_name}'{}",
+                                target_alias.map_or_else(String::new, |alias| format!(
+                                    " or alias '{alias}'"
+                                ))
+                            )));
+                        }
+                        column.clone()
+                    }
+                    _ => {
+                        return Err(DataFusionError::Plan(format!(
+                            "Invalid assignment target '{name}': expected [qualifier.]column"
+                        )));
+                    }
+                }
+            }
+            AssignmentTarget::Tuple(_) => {
+                return Err(DataFusionError::Plan(
+                    "Tuple assignments are not supported in MERGE UPDATE SET".to_string(),
+                ));
+            }
+        };
+        if !seen_columns.insert(col_name.clone()) {
+            return Err(DataFusionError::Plan(format!(
+                "Duplicate assignment target column '{col_name}' in MERGE UPDATE SET"
+            )));
+        }
+        let value_sql = assignment.value.to_string();
+        result.push((col_name, value_sql));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::sql::sqlparser::ast::{MergeClause, Statement as SQLStatement};
+    use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+    use datafusion::sql::sqlparser::parser::Parser;
+
+    fn parse_merge(sql: &str) -> SQLStatement {
+        let stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql).expect("should parse");
+        stmts.into_iter().next().expect("should have a statement")
+    }
+
+    fn extract_on_and_clauses(stmt: SQLStatement) -> (Box<SQLExpr>, Vec<MergeClause>) {
+        let SQLStatement::Merge { on, clauses, .. } = stmt else {
+            panic!("Expected Merge statement");
+        };
+        (on, clauses)
+    }
+
+    // --- ON clause tests ---
+
+    #[test]
+    fn test_parse_on_keys_single() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(keys, vec![("id".to_string(), "id".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_on_keys_composite() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.a = s.a AND t.b = s.b \
+             WHEN MATCHED THEN UPDATE SET val = s.val",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(
+            keys,
+            vec![
+                ("a".to_string(), "a".to_string()),
+                ("b".to_string(), "b".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_on_keys_reversed_order() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON s.id = t.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(keys, vec![("id".to_string(), "id".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_on_keys_no_alias_uses_table_name() {
+        let stmt = parse_merge(
+            "MERGE INTO target USING source ON target.id = source.id \
+             WHEN MATCHED THEN UPDATE SET name = source.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        // No aliases — only table names as qualifiers.
+        let keys = parse_on_keys(&on, &["target"], &["source"]).expect("should parse");
+        assert_eq!(keys, vec![("id".to_string(), "id".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_on_keys_rejects_non_equality() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id > s.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let err = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect_err("should fail");
+        assert!(err.to_string().contains("equality"));
+    }
+
+    #[test]
+    fn test_parse_on_keys_rejects_unqualified() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON id = id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let err = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect_err("should fail");
+        assert!(err.to_string().contains("disambiguate"));
+    }
+
+    #[test]
+    fn test_parse_on_keys_parenthesized() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s \
+             ON (t.a = s.a) AND (t.b = s.b) \
+             WHEN MATCHED THEN UPDATE SET val = s.val",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(
+            keys,
+            vec![
+                ("a".to_string(), "a".to_string()),
+                ("b".to_string(), "b".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_on_keys_different_column_names() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.src_id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(keys, vec![("id".to_string(), "src_id".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_on_keys_rejects_literal() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = 42 \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let err = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect_err("should fail");
+        assert!(err.to_string().contains("column references"));
+    }
+
+    #[test]
+    fn test_parse_on_keys_rejects_or() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.a = s.a OR t.b = s.b \
+             WHEN MATCHED THEN UPDATE SET val = s.val",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let err = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect_err("should fail");
+        assert!(err.to_string().contains("equality"));
+    }
+
+    #[test]
+    fn test_parse_on_keys_rejects_both_sides_same_table() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.a = t.b \
+             WHEN MATCHED THEN UPDATE SET val = s.val",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let err = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect_err("should fail");
+        assert!(err.to_string().contains("disambiguate"));
+    }
+
+    #[test]
+    fn test_parse_on_keys_case_insensitive_qualifier() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON T.id = S.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let keys = parse_on_keys(&on, &["target", "t"], &["source", "s"]).expect("should parse");
+        assert_eq!(keys, vec![("id".to_string(), "id".to_string())]);
+    }
+
+    #[test]
+    fn test_flatten_and_conjuncts_deeply_nested() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s \
+             ON t.a = s.a AND t.b = s.b AND t.c = s.c \
+             WHEN MATCHED THEN UPDATE SET val = s.val",
+        );
+        let (on, _) = extract_on_and_clauses(stmt);
+        let conjuncts = flatten_and_conjuncts(&on);
+        assert_eq!(conjuncts.len(), 3);
+    }
+
+    // --- WHEN clause tests ---
+
+    #[test]
+    fn test_validate_matched_update_set() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name, value = s.value + 1",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let assignments = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect("should succeed");
+        assert_eq!(assignments[1].0, "value");
+        assert_eq!(assignments[1].1, "s.value + 1");
+    }
+
+    #[test]
+    fn test_reject_not_matched() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let err = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect_err("should fail");
+        assert!(err.to_string().contains("WHEN MATCHED"));
+    }
+
+    #[test]
+    fn test_reject_matched_delete() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN DELETE",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let err = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect_err("should fail");
+        assert!(err.to_string().contains("UPDATE SET"));
+    }
+
+    // --- Table ref extraction tests ---
+
+    #[test]
+    fn test_extract_table_ref_plain() {
+        let stmt = parse_merge(
+            "MERGE INTO my_table USING source ON 1=1 WHEN MATCHED THEN UPDATE SET a = 1",
+        );
+        let SQLStatement::Merge { table, .. } = stmt else {
+            panic!();
+        };
+        let (name, alias) = extract_table_ref(&table, "target").expect("should succeed");
+        assert_eq!(name, "my_table");
+        assert_eq!(alias, None);
+    }
+
+    #[test]
+    fn test_extract_table_ref_with_alias() {
+        let stmt = parse_merge(
+            "MERGE INTO my_table AS t USING other AS s ON 1=1 \
+             WHEN MATCHED THEN UPDATE SET a = 1",
+        );
+        let SQLStatement::Merge { table, source, .. } = stmt else {
+            panic!();
+        };
+        let (name, alias) = extract_table_ref(&table, "target").expect("should succeed");
+        assert_eq!(name, "my_table");
+        assert_eq!(alias, Some("t".to_string()));
+
+        let (name, alias) = extract_table_ref(&source, "source").expect("should succeed");
+        assert_eq!(name, "other");
+        assert_eq!(alias, Some("s".to_string()));
+    }
+
+    // --- Assignment validation tests ---
+
+    #[test]
+    fn test_assignment_strips_qualifier() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET t.name = s.name, t.value = s.value",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let assignments = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect("should succeed");
+        assert_eq!(assignments.len(), 2);
+        // Qualified `t.name` should be stripped to bare `name`
+        assert_eq!(assignments[0].0, "name");
+        assert_eq!(assignments[1].0, "value");
+    }
+
+    #[test]
+    fn test_assignment_bare_column() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let assignments = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect("should succeed");
+        assert_eq!(assignments[0].0, "name");
+    }
+
+    #[test]
+    fn test_assignment_rejects_duplicate_target() {
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET name = s.name, name = s.other",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let err = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect_err("should fail");
+        assert!(
+            err.to_string().contains("Duplicate assignment target"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_assignment_rejects_triple_qualified() {
+        let stmt = parse_merge(
+            "MERGE INTO cat.schema.target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET cat.schema.target.name = s.name",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let err = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect_err("should fail");
+        assert!(
+            err.to_string().contains("expected [qualifier.]column"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_assignment_rejects_source_qualified_target() {
+        // `s.qty` as an assignment target should be rejected since `s` is the source alias
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET s.qty = s.qty",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let err = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect_err("should fail");
+        assert!(
+            err.to_string().contains("does not match MERGE target"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_assignment_accepts_table_name_qualifier() {
+        // Using the table name (not alias) as qualifier should work
+        let stmt = parse_merge(
+            "MERGE INTO target AS t USING source AS s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET target.qty = s.qty",
+        );
+        let (_, clauses) = extract_on_and_clauses(stmt);
+        let assignments = validate_and_extract_assignments(&clauses[0], "target", Some("t"))
+            .expect("should succeed");
+        assert_eq!(assignments[0].0, "qty");
+    }
+}

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -35,7 +35,9 @@ limitations under the License.
 
 mod create_table;
 mod delete;
+mod insert;
 pub mod logical_nodes;
+mod merge;
 pub mod physical_execs;
 mod update;
 
@@ -46,11 +48,12 @@ use datafusion::sql::TableReference;
 use datafusion::sql::parser::Statement;
 use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
 use datafusion_expr::WriteOp;
+use datafusion_expr::dml::InsertOp;
 
 use crate::config::ClusterRole;
 use crate::datafusion::ddl::acceleration_options::SharedDdlExtensionStore;
 
-use super::SPICE_DEFAULT_CATALOG;
+use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 
 /// The type of catalog backing the planner's DML interception.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,7 +117,27 @@ pub async fn create_logical_plan(
                 return plan_cayenne_dml(statement, session, ctx, WriteOp::Update).await;
             }
 
-            // Future: SQLStatement::Merge { .. }
+            // DML: INSERT on Cayenne tables
+            SQLStatement::Insert(_) => {
+                return plan_cayenne_dml(
+                    statement,
+                    session,
+                    ctx,
+                    WriteOp::Insert(InsertOp::Append),
+                )
+                .await;
+            }
+
+            // DML: MERGE on Cayenne tables (local single-node only)
+            SQLStatement::Merge { .. } if ctx.catalog_mode == CatalogMode::Cayenne => {
+                if matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
+                    return Err(DataFusionError::Plan(
+                        "MERGE INTO is not supported in distributed mode".to_string(),
+                    ));
+                }
+                return merge::plan_merge(statement, session).await;
+            }
+
             _ => {}
         }
     }
@@ -167,9 +190,10 @@ async fn plan_cayenne_dml(
     match expected_op {
         WriteOp::Delete => delete::plan_distributed_delete(dml),
         WriteOp::Update => update::plan_distributed_update(dml),
-        _ => Err(DataFusionError::Internal(format!(
-            "Unsupported DML operation: {expected_op:?}"
-        ))),
+        WriteOp::Insert(_) => Ok(insert::plan_distributed_insert(dml)),
+        WriteOp::Ctas => Err(DataFusionError::Internal(
+            "CTAS should not reach DML planner".to_string(),
+        )),
     }
 }
 

--- a/crates/runtime/src/datafusion/planner/physical_execs.rs
+++ b/crates/runtime/src/datafusion/planner/physical_execs.rs
@@ -14,10 +14,341 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Physical execution plans for Cayenne DML operations.
-//!
-//! Currently empty — local DELETE is handled by Cayenne's `TableProvider`
-//! implementation through `DataFusion`'s standard physical planning, and
-//! distributed DELETE reuses `DistributedCayenneDeleteExec` from `cayenne_ddl`.
-//!
-//! Future DML operations (UPDATE, MERGE) will add execution plans here.
+//! Physical execution plans for planner-produced logical nodes.
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
+use datafusion::execution::{SendableRecordBatchStream, SessionState, TaskContext};
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, execute_stream,
+};
+use datafusion_datasource::memory::MemorySourceConfig;
+
+/// Physical execution plan for MERGE INTO on a Cayenne table.
+///
+/// Executes a streaming join between target and source (provided as
+/// `join_plan`), then deletes matched target rows and inserts the
+/// updated rows.
+///
+/// Memory usage is `O(|source| + |matched|)` — the target table is
+/// never fully materialized.
+pub struct CayenneMergeExec {
+    /// Physical plan that produces the joined + projected rows
+    /// (matched rows with updated column values).
+    join_plan: Arc<dyn ExecutionPlan>,
+    /// Target table provider for `insert_into`.
+    target_provider: Arc<dyn TableProvider>,
+    /// Session state for creating delete/insert plans.
+    session_state: SessionState,
+    /// Target-side ON key column names, used to build deletion filters.
+    target_key_columns: Vec<String>,
+    /// Output properties.
+    properties: PlanProperties,
+}
+
+impl CayenneMergeExec {
+    #[must_use]
+    pub fn new(
+        join_plan: Arc<dyn ExecutionPlan>,
+        target_provider: Arc<dyn TableProvider>,
+        session_state: SessionState,
+        target_key_columns: Vec<String>,
+    ) -> Self {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]));
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(schema),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            join_plan,
+            target_provider,
+            session_state,
+            target_key_columns,
+            properties,
+        }
+    }
+}
+
+impl std::fmt::Debug for CayenneMergeExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneMergeExec")
+            .field("target_key_columns", &self.target_key_columns)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for CayenneMergeExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CayenneMergeExec: keys={:?}", self.target_key_columns)
+    }
+}
+
+impl ExecutionPlan for CayenneMergeExec {
+    fn name(&self) -> &'static str {
+        "CayenneMergeExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.join_plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "CayenneMergeExec requires exactly one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(Self::new(
+            Arc::clone(&children[0]),
+            Arc::clone(&self.target_provider),
+            self.session_state.clone(),
+            self.target_key_columns.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(format!(
+                "CayenneMergeExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let join_plan = Arc::clone(&self.join_plan);
+        let target_provider = Arc::clone(&self.target_provider);
+        let session_state = self.session_state.clone();
+        let target_key_columns = self.target_key_columns.clone();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]));
+
+        let stream = futures::stream::once(async move {
+            execute_merge(
+                join_plan,
+                target_provider,
+                session_state,
+                target_key_columns,
+                context,
+            )
+            .await
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+/// Core merge execution: run the join plan, delete matched rows, insert updated rows.
+async fn execute_merge(
+    join_plan: Arc<dyn ExecutionPlan>,
+    target_provider: Arc<dyn TableProvider>,
+    session_state: SessionState,
+    target_key_columns: Vec<String>,
+    context: Arc<TaskContext>,
+) -> Result<RecordBatch, DataFusionError> {
+    use futures::TryStreamExt;
+
+    // Step 1: Execute the join plan to get matched rows with updated values.
+    let join_stream = execute_stream(Arc::clone(&join_plan), Arc::clone(&context))?;
+    let updated_batches: Vec<RecordBatch> = join_stream.try_collect().await?;
+
+    let total_rows: usize = updated_batches.iter().map(RecordBatch::num_rows).sum();
+
+    if total_rows == 0 {
+        // No matches — nothing to do.
+        return Ok(RecordBatch::try_from_iter_with_nullable(vec![(
+            "count",
+            Arc::new(UInt64Array::from(vec![0u64])) as ArrayRef,
+            false,
+        )])?);
+    }
+
+    // Normalize output to match the target table schema (including nullability).
+    let target_schema = target_provider.schema();
+    let normalized_batches = updated_batches
+        .into_iter()
+        .map(|batch| arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema)))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(DataFusionError::from)?;
+
+    // Step 2: Build deletion filters from the matched key values.
+    // Uses tuple-aware OR-of-ANDs to avoid cross-product matches with composite keys.
+    let delete_filters = build_delete_filters(&normalized_batches, &target_key_columns)?;
+
+    // Step 3: Delete matched rows from the target.
+    let delete_plan = target_provider
+        .delete_from(&session_state, delete_filters)
+        .await?;
+    let delete_stream = execute_stream(delete_plan, Arc::clone(&context))?;
+    let delete_batches: Vec<RecordBatch> = delete_stream.try_collect().await?;
+
+    // Verify the delete count matches the expected number of rows.
+    let delete_count = extract_dml_count(&delete_batches);
+    if delete_count != total_rows as u64 {
+        return Err(DataFusionError::Execution(format!(
+            "MERGE delete count mismatch: expected {total_rows} rows deleted, got {delete_count}"
+        )));
+    }
+
+    // Step 4: Insert updated rows into the target.
+    let input_exec = MemorySourceConfig::try_new_exec(&[normalized_batches], target_schema, None)?;
+    let insert_plan = target_provider
+        .insert_into(&session_state, input_exec, InsertOp::Append)
+        .await?;
+    let insert_stream = execute_stream(insert_plan, Arc::clone(&context))?;
+    let insert_batches: Vec<RecordBatch> = insert_stream.try_collect().await?;
+
+    // Verify the insert count matches.
+    let insert_count = extract_dml_count(&insert_batches);
+    if insert_count != total_rows as u64 {
+        return Err(DataFusionError::Execution(format!(
+            "MERGE insert count mismatch: expected {total_rows} rows inserted, got {insert_count}"
+        )));
+    }
+
+    // Step 5: Return the count of updated rows.
+    Ok(RecordBatch::try_from_iter_with_nullable(vec![(
+        "count",
+        Arc::new(UInt64Array::from(vec![total_rows as u64])) as ArrayRef,
+        false,
+    )])?)
+}
+
+/// Extract the row count from DML output batches (e.g., from `delete_from` or `insert_into`).
+///
+/// DML operations return a single batch with a `count` column. This sums all count values.
+fn extract_dml_count(batches: &[RecordBatch]) -> u64 {
+    batches
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column_by_name("count")
+                .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
+                .into_iter()
+                .flat_map(|arr| arr.iter())
+                .flatten()
+        })
+        .sum()
+}
+
+/// Build deletion filter expressions from matched key column values.
+///
+/// For single-column keys, builds `key_col IN (val1, val2, ...)`.
+/// For composite keys, builds tuple-aware OR-of-ANDs to avoid cross-product matches:
+///   `(k1 = a1 AND k2 = b1) OR (k1 = a2 AND k2 = b2)`
+fn build_delete_filters(
+    batches: &[RecordBatch],
+    key_columns: &[String],
+) -> Result<Vec<datafusion::prelude::Expr>, DataFusionError> {
+    use datafusion::prelude::*;
+
+    // Fast path: single key column uses simple IN-list.
+    if key_columns.len() == 1 {
+        let key_col = &key_columns[0];
+        let mut values: Vec<datafusion::prelude::Expr> = Vec::new();
+        for batch in batches {
+            let col_idx = batch.schema().index_of(key_col).map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "Key column '{key_col}' not found in join output: {e}"
+                ))
+            })?;
+            let array = batch.column(col_idx);
+            for row_idx in 0..array.len() {
+                let scalar = datafusion::common::ScalarValue::try_from_array(array, row_idx)?;
+                values.push(lit(scalar));
+            }
+        }
+        if values.is_empty() {
+            return Err(DataFusionError::Internal(
+                "Failed to build delete filters: no key values extracted from matched rows"
+                    .to_string(),
+            ));
+        }
+        return Ok(vec![col(key_col).in_list(values, false)]);
+    }
+
+    // Composite keys: build OR-of-ANDs for exact tuple matching.
+    // Each matched row produces (k1 = v1 AND k2 = v2 AND ...) and rows are OR'd together.
+    let col_indices: Vec<(&String, Vec<usize>)> = key_columns
+        .iter()
+        .map(|key_col| {
+            let indices: Vec<usize> = batches
+                .iter()
+                .map(|batch| {
+                    batch.schema().index_of(key_col).map_err(|e| {
+                        DataFusionError::Internal(format!(
+                            "Key column '{key_col}' not found in join output: {e}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok((key_col, indices))
+        })
+        .collect::<Result<Vec<_>, DataFusionError>>()?;
+
+    let mut row_predicates: Vec<datafusion::prelude::Expr> = Vec::new();
+    for (batch_idx, batch) in batches.iter().enumerate() {
+        for row_idx in 0..batch.num_rows() {
+            // Build AND of all key column equalities for this row.
+            let mut row_and: Option<datafusion::prelude::Expr> = None;
+            for (key_col, indices) in &col_indices {
+                let array = batch.column(indices[batch_idx]);
+                let scalar = datafusion::common::ScalarValue::try_from_array(array, row_idx)?;
+                let eq_expr = col(key_col.as_str()).eq(lit(scalar));
+                row_and = Some(match row_and {
+                    Some(existing) => existing.and(eq_expr),
+                    None => eq_expr,
+                });
+            }
+            if let Some(predicate) = row_and {
+                row_predicates.push(predicate);
+            }
+        }
+    }
+
+    if row_predicates.is_empty() {
+        return Err(DataFusionError::Internal(
+            "Failed to build delete filters: no row predicates generated from matched rows"
+                .to_string(),
+        ));
+    }
+
+    // Combine all row predicates with OR.
+    match row_predicates.into_iter().reduce(|acc, pred| acc.or(pred)) {
+        Some(combined) => Ok(vec![combined]),
+        None => Err(DataFusionError::Internal(
+            "Failed to build delete filters: reduce produced no result".to_string(),
+        )),
+    }
+}

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1321,8 +1321,10 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
         #[cfg(not(windows))]
         LogicalPlan::Extension(ext) => {
             use super::cayenne_ddl::logical_nodes::{
-                DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+                DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
+                DistributedCayenneUpdateNode,
             };
+            use super::planner::logical_nodes::CayenneMergeNode;
             if let Some(n) = ext
                 .node
                 .as_any()
@@ -1337,13 +1339,23 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
             {
                 return Some(n.table_name.clone());
             }
+            if let Some(n) = ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneInsertNode>()
+            {
+                return Some(n.table_name.clone());
+            }
+            if let Some(n) = ext.node.as_any().downcast_ref::<CayenneMergeNode>() {
+                return Some(n.target_table.clone());
+            }
             None
         }
         _ => None,
     }
 }
 
-/// Returns `true` if the plan is a distributed DML extension node.
+/// Returns `true` if the plan is a DML extension node.
 ///
 /// Used to skip schema verification for DML extension nodes, whose output
 /// schema may differ from the logical plan's schema.
@@ -1351,21 +1363,30 @@ fn is_dml_extension(plan: &LogicalPlan) -> bool {
     #[cfg(not(windows))]
     if let LogicalPlan::Extension(ext) = plan {
         use super::cayenne_ddl::logical_nodes::{
-            DistributedCayenneDeleteNode, DistributedCayenneUpdateNode,
+            DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
+            DistributedCayenneUpdateNode,
         };
+        use super::planner::logical_nodes::CayenneMergeNode;
         if ext
             .node
             .as_any()
             .downcast_ref::<DistributedCayenneDeleteNode>()
             .is_some()
-        {
-            return true;
-        }
-        if ext
-            .node
-            .as_any()
-            .downcast_ref::<DistributedCayenneUpdateNode>()
-            .is_some()
+            || ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneUpdateNode>()
+                .is_some()
+            || ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneInsertNode>()
+                .is_some()
+            || ext
+                .node
+                .as_any()
+                .downcast_ref::<CayenneMergeNode>()
+                .is_some()
         {
             return true;
         }

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -1066,3 +1066,651 @@ async fn cayenne_catalog_ddl_multiple_schemas() -> Result<(), String> {
         })
         .await
 }
+
+// =============================================================================
+// Test: MERGE INTO — matched update with aliases, expressions, no-match rows
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_merge_into() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_merge",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_merge_into")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_merge.s").await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_merge.s.inventory (
+                    id BIGINT NOT NULL,
+                    name VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY id",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_merge.s.updates (
+                    id BIGINT NOT NULL,
+                    name VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY id",
+            )
+            .await?;
+
+            // -----------------------------------------------------------------
+            // Seed data
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "INSERT INTO cat_merge.s.inventory VALUES
+                    (1, 'apple',  10),
+                    (2, 'banana', 20),
+                    (3, 'cherry', 30)",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "INSERT INTO cat_merge.s.updates VALUES
+                    (1, 'apple',  50),
+                    (3, 'cherry', 100)",
+            )
+            .await?;
+
+            // -----------------------------------------------------------------
+            // Step 1: Basic MERGE — update qty from source
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "MERGE INTO cat_merge.s.inventory AS t
+                 USING cat_merge.s.updates AS s
+                 ON t.id = s.id
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, qty FROM cat_merge.s.inventory ORDER BY id",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-----+",
+                    "| id | name   | qty |",
+                    "+----+--------+-----+",
+                    "| 1  | apple  | 50  |",
+                    "| 2  | banana | 20  |",
+                    "| 3  | cherry | 100 |",
+                    "+----+--------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 2: MERGE with expression — qty = s.qty + t.qty
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "MERGE INTO cat_merge.s.inventory AS t
+                 USING cat_merge.s.updates AS s
+                 ON t.id = s.id
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty + t.qty",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, qty FROM cat_merge.s.inventory ORDER BY id",
+            )
+            .await?;
+
+            // apple: 50 + 50 = 100, cherry: 100 + 100 = 200, banana unchanged
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-----+",
+                    "| id | name   | qty |",
+                    "+----+--------+-----+",
+                    "| 1  | apple  | 100 |",
+                    "| 2  | banana | 20  |",
+                    "| 3  | cherry | 200 |",
+                    "+----+--------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 3: MERGE updating multiple columns
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "MERGE INTO cat_merge.s.inventory AS t
+                 USING cat_merge.s.updates AS s
+                 ON t.id = s.id
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty, name = s.name",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, qty FROM cat_merge.s.inventory ORDER BY id",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-----+",
+                    "| id | name   | qty |",
+                    "+----+--------+-----+",
+                    "| 1  | apple  | 50  |",
+                    "| 2  | banana | 20  |",
+                    "| 3  | cherry | 100 |",
+                    "+----+--------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 4: MERGE without aliases (table-name qualifiers)
+            // -----------------------------------------------------------------
+            exec(
+                &rt,
+                "MERGE INTO cat_merge.s.inventory
+                 USING cat_merge.s.updates
+                 ON inventory.id = updates.id
+                 WHEN MATCHED THEN UPDATE SET qty = updates.qty + 1",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, qty FROM cat_merge.s.inventory ORDER BY id",
+            )
+            .await?;
+
+            // apple: 50 + 1 = 51, cherry: 100 + 1 = 101
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-----+",
+                    "| id | name   | qty |",
+                    "+----+--------+-----+",
+                    "| 1  | apple  | 51  |",
+                    "| 2  | banana | 20  |",
+                    "| 3  | cherry | 101 |",
+                    "+----+--------+-----+",
+                ],
+                &batches
+            );
+
+            // -----------------------------------------------------------------
+            // Step 5: MERGE with zero matches — no rows should change
+            // -----------------------------------------------------------------
+            // Replace source data with a non-matching ID.
+            exec(&rt, "DELETE FROM cat_merge.s.updates WHERE id IN (1, 3)").await?;
+            exec(
+                &rt,
+                "INSERT INTO cat_merge.s.updates VALUES (99, 'ghost', 999)",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "MERGE INTO cat_merge.s.inventory AS t
+                 USING cat_merge.s.updates AS s
+                 ON t.id = s.id
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT id, name, qty FROM cat_merge.s.inventory ORDER BY id",
+            )
+            .await?;
+
+            // Unchanged from step 4.
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-----+",
+                    "| id | name   | qty |",
+                    "+----+--------+-----+",
+                    "| 1  | apple  | 51  |",
+                    "| 2  | banana | 20  |",
+                    "| 3  | cherry | 101 |",
+                    "+----+--------+-----+",
+                ],
+                &batches
+            );
+
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_merge.s.inventory").await?;
+            assert_eq!(count, 3, "Row count should remain 3 after zero-match MERGE");
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: MERGE INTO with partition key different from join key
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_merge_partition_key_differs_from_join_key() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_mp",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_merge_partition")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_mp.s").await?;
+
+            // Partitioned by `region` but MERGE joins on `sku`.
+            exec(
+                &rt,
+                "CREATE TABLE cat_mp.s.stock (
+                    sku VARCHAR NOT NULL,
+                    region VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY region",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_mp.s.inbound (
+                    sku VARCHAR NOT NULL,
+                    region VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY region",
+            )
+            .await?;
+
+            // Stock spans two partitions (US and EU).
+            exec(
+                &rt,
+                "INSERT INTO cat_mp.s.stock VALUES
+                    ('A', 'US', 10),
+                    ('B', 'US', 20),
+                    ('A', 'EU', 30),
+                    ('C', 'EU', 40)",
+            )
+            .await?;
+
+            // Inbound shipments only for SKU A across both regions.
+            exec(
+                &rt,
+                "INSERT INTO cat_mp.s.inbound VALUES
+                    ('A', 'US', 100),
+                    ('A', 'EU', 200)",
+            )
+            .await?;
+
+            // MERGE on sku + region (composite ON) — updates rows in both partitions.
+            exec(
+                &rt,
+                "MERGE INTO cat_mp.s.stock AS t
+                 USING cat_mp.s.inbound AS s
+                 ON t.sku = s.sku AND t.region = s.region
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT sku, region, qty FROM cat_mp.s.stock ORDER BY region, sku",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+-----+--------+-----+",
+                    "| sku | region | qty |",
+                    "+-----+--------+-----+",
+                    "| A   | EU     | 200 |",
+                    "| C   | EU     | 40  |",
+                    "| A   | US     | 100 |",
+                    "| B   | US     | 20  |",
+                    "+-----+--------+-----+",
+                ],
+                &batches
+            );
+
+            // Verify row count unchanged.
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_mp.s.stock").await?;
+            assert_eq!(count, 4);
+
+            Ok(())
+        })
+        .await
+}
+
+// =============================================================================
+// Test: MERGE INTO across multiple partitions with 3-way composite ON key
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_merge_composite_on_key() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_mcp",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_merge_composite")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_mcp.s").await?;
+
+            // Partitioned by month, MERGE joins on sensor_id + year + month.
+            exec(
+                &rt,
+                "CREATE TABLE cat_mcp.s.metrics (
+                    sensor_id BIGINT NOT NULL,
+                    year BIGINT NOT NULL,
+                    month BIGINT NOT NULL,
+                    reading DOUBLE NOT NULL
+                ) PARTITION BY month",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_mcp.s.corrections (
+                    sensor_id BIGINT NOT NULL,
+                    year BIGINT NOT NULL,
+                    month BIGINT NOT NULL,
+                    reading DOUBLE NOT NULL
+                ) PARTITION BY month",
+            )
+            .await?;
+
+            // Data spanning two partitions (month=1 and month=2).
+            exec(
+                &rt,
+                "INSERT INTO cat_mcp.s.metrics VALUES
+                    (1, 2025, 1, 10.0),
+                    (2, 2025, 1, 20.0),
+                    (1, 2025, 2, 30.0),
+                    (3, 2025, 2, 40.0)",
+            )
+            .await?;
+
+            // Corrections for sensor 1 in both months, sensor 2 in Jan only.
+            exec(
+                &rt,
+                "INSERT INTO cat_mcp.s.corrections VALUES
+                    (1, 2025, 1, 11.5),
+                    (2, 2025, 1, 22.5),
+                    (1, 2025, 2, 33.5)",
+            )
+            .await?;
+
+            // MERGE joining on sensor_id + year + month (3-way composite ON key).
+            exec(
+                &rt,
+                "MERGE INTO cat_mcp.s.metrics AS t
+                 USING cat_mcp.s.corrections AS s
+                 ON t.sensor_id = s.sensor_id
+                    AND t.year = s.year
+                    AND t.month = s.month
+                 WHEN MATCHED THEN UPDATE SET reading = s.reading",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT sensor_id, year, month, reading
+                 FROM cat_mcp.s.metrics
+                 ORDER BY year, month, sensor_id",
+            )
+            .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+-----------+------+-------+---------+",
+                    "| sensor_id | year | month | reading |",
+                    "+-----------+------+-------+---------+",
+                    "| 1         | 2025 | 1     | 11.5    |",
+                    "| 2         | 2025 | 1     | 22.5    |",
+                    "| 1         | 2025 | 2     | 33.5    |",
+                    "| 3         | 2025 | 2     | 40.0    |",
+                    "+-----------+------+-------+---------+",
+                ],
+                &batches
+            );
+
+            // sensor 3 in Feb should remain untouched (no matching correction).
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_mcp.s.metrics").await?;
+            assert_eq!(count, 4);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Regression test: composite ON keys must use tuple-aware deletion predicates.
+///
+/// With two composite key columns (region, sku), if the matched rows are
+/// (US, A) and (EU, B), the old independent IN-list approach would build:
+///   `region IN ('US','EU') AND sku IN ('A','B')`
+/// which also matches (US, B) and (EU, A) — corrupting unmatched rows.
+///
+/// This test has exactly that pattern: target has (US,A), (US,B), (EU,A), (EU,B)
+/// but source only matches (US,A) and (EU,B). The unmatched rows (US,B) and (EU,A)
+/// must be preserved unchanged.
+#[tokio::test]
+async fn cayenne_catalog_merge_composite_key_no_cross_product() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_xprod",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_merge_cross_product")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_xprod.s").await?;
+
+            // Target table with composite key (region, sku). Partitioned by region.
+            exec(
+                &rt,
+                "CREATE TABLE cat_xprod.s.inventory (
+                    region VARCHAR NOT NULL,
+                    sku VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY region",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_xprod.s.updates (
+                    region VARCHAR NOT NULL,
+                    sku VARCHAR NOT NULL,
+                    qty BIGINT NOT NULL
+                ) PARTITION BY region",
+            )
+            .await?;
+
+            // All 4 combinations of region x sku exist in target.
+            exec(
+                &rt,
+                "INSERT INTO cat_xprod.s.inventory VALUES
+                    ('US', 'A', 10),
+                    ('US', 'B', 20),
+                    ('EU', 'A', 30),
+                    ('EU', 'B', 40)",
+            )
+            .await?;
+
+            // Source only updates the diagonal: (US, A) and (EU, B).
+            // A cross-product bug would also delete/corrupt (US, B) and (EU, A).
+            exec(
+                &rt,
+                "INSERT INTO cat_xprod.s.updates VALUES
+                    ('US', 'A', 99),
+                    ('EU', 'B', 88)",
+            )
+            .await?;
+
+            // MERGE with composite ON key.
+            exec(
+                &rt,
+                "MERGE INTO cat_xprod.s.inventory AS t
+                 USING cat_xprod.s.updates AS s
+                 ON t.region = s.region AND t.sku = s.sku
+                 WHEN MATCHED THEN UPDATE SET qty = s.qty",
+            )
+            .await?;
+
+            let batches = run_query(
+                &rt,
+                "SELECT region, sku, qty
+                 FROM cat_xprod.s.inventory
+                 ORDER BY region, sku",
+            )
+            .await?;
+
+            // Only (US,A) and (EU,B) should be updated.
+            // (US,B) and (EU,A) must be UNCHANGED — not deleted, not modified.
+            assert_batches_eq!(
+                &[
+                    "+--------+-----+-----+",
+                    "| region | sku | qty |",
+                    "+--------+-----+-----+",
+                    "| EU     | A   | 30  |",
+                    "| EU     | B   | 88  |",
+                    "| US     | A   | 99  |",
+                    "| US     | B   | 20  |",
+                    "+--------+-----+-----+",
+                ],
+                &batches
+            );
+
+            // Row count must still be 4 — no rows lost.
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_xprod.s.inventory").await?;
+            assert_eq!(count, 4);
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
> **Stacked on** #10101 ← #10100 ← #10099

## Overview

Implements `MERGE INTO ... USING ... ON ... WHEN MATCHED THEN UPDATE SET ...` for single-node Cayenne catalog tables.

This is **Milestone 5** of the [unified planner implementation plan](#10095) — the primary deliverable of the issue.

## Supported syntax

```sql
MERGE INTO target [AS t]
USING source [AS s]
ON <equality_conjunction>
WHEN MATCHED THEN UPDATE SET col1 = expr1, col2 = expr2, ...
```

### Phase 1 constraints

- Only `WHEN MATCHED THEN UPDATE SET` (no INSERT, DELETE, NOT MATCHED clauses)
- Source and target must both be Cayenne catalog tables
- ON clause must be a conjunction of equality predicates only (`t.id = s.id AND t.region = s.region`)
- No clause-level predicates (`WHEN MATCHED AND x > 0`)
- Target must not have `primary_key` or `on_conflict` configured (conflicts with delete+insert execution)
- Single-node only (distributed mode returns an error)

## Execution strategy

The execution is streaming and memory-safe:

1. **Build a DataFusion INNER JOIN** between target and source, with SET assignment expressions projected over the joined schema
2. **DataFusion's `HashJoinExec`** uses source as the build side (in memory) and streams through target as the probe side
3. **Collect matched rows** with updated column values — bounded by `min(|source|, |target|)`, practically by `|source|`
4. **Delete matched target rows** using IN-list filters on the join key columns
5. **Insert updated rows** via `TableProvider::insert_into`

Memory usage: **O(|source| + |matched|)** — the target table is never fully materialized.

## Changes

### New: `planner/merge.rs` (476 lines)

Statement-level parsing and validation of MERGE AST:
- `plan_merge()` — entry point: decomposes the `SQLStatement::Merge`, validates phase 1 constraints, produces `CayenneMergeNode`
- `extract_table_ref()` — extracts table name + alias from `TableFactor` (rejects subqueries)
- `validate_target_metadata()` — checks target has no `primary_key`/`on_conflict` via `CayenneTableProvider` metadata
- `parse_on_keys()` / `collect_equality_predicates()` — recursively decomposes AND-connected equality predicates into `(target_col, source_col)` pairs
- `resolve_equality_columns()` — attributes each side of `col = col` to target or source using aliases
- `validate_and_extract_assignments()` — validates exactly one `WHEN MATCHED THEN UPDATE SET` clause, extracts `(column, value_sql)` pairs
- **7 unit tests** covering single/composite/reversed ON keys, non-equality rejection, assignment extraction, NOT MATCHED rejection, and MATCHED DELETE rejection

### New: `planner/logical_nodes.rs` — `CayenneMergeNode`

Implements `UserDefinedLogicalNodeCore`:
- Carries `target_table`, `source_table`, aliases, `on_keys`, `assignments`, output schema (`count: UInt64`)
- No logical plan inputs — the join plan is built at physical planning time by the extension planner
- Implements `Hash`, `PartialEq`, `Eq`, `PartialOrd` for plan comparison

### New: `planner/physical_execs.rs` — `CayenneMergeExec`

Implements `ExecutionPlan`:
- Holds the `join_plan` (physical), `target_provider`, `session_state`, `target_key_columns`
- `execute()` spawns an async stream that runs `execute_merge()`:
  1. Execute join plan → collect matched batches
  2. Normalize batches to target schema (nullability reconciliation)
  3. `build_delete_filters()` — extract key column values into IN-list filters
  4. `target_provider.delete_from()` with filters
  5. `target_provider.insert_into()` with `InsertOp::Append`
  6. Return count

### Modified: `cayenne_ddl/planner.rs` — `plan_merge_extension()` (135 lines)

The extension planner converts `CayenneMergeNode` → `CayenneMergeExec`:
1. Resolves target and source table providers from the catalog
2. Builds `LogicalPlanBuilder` scans with proper qualifiers (alias or table name)
3. Constructs INNER JOIN on ON key columns
4. Projects SET assignments — resolved via `session_state.create_logical_expr()` against the joined schema (handles `s.value + 1` style expressions)
5. Converts to physical plan via `session_state.create_physical_plan()` — DataFusion chooses `HashJoinExec`
6. Wraps in `CayenneMergeExec`

### Modified: `planner/mod.rs`

- Added `SQLStatement::Insert` and `SQLStatement::Merge` dispatch
- INSERT routes through `plan_cayenne_dml()` for distributed mode, MERGE routes to `merge::plan_merge()` directly (local only)

### Modified: `cayenne_ddl/analyzer_rule.rs`

Removed the last DML arm (`Dml(Insert)`), completing the DML migration. The analyzer rule now **only handles DDL**: `CreateMemoryTable`, `DropTable`, `CreateCatalogSchema`.

### Modified: `query.rs`

Extended `extract_dml_target_table()` and `is_dml_extension()` to handle:
- `CayenneMergeNode` (cache invalidation for target table)
- `DistributedCayenneInsertNode` (was missing from previous PR)

## Design notes

### Why delete+insert instead of in-place update?

Cayenne's storage layer exposes `DeletionTableProvider::delete_from()` and `TableProvider::insert_into()` but not a native "update in place" API. The existing `UpdateExec` already uses this pattern. MERGE follows the same approach.

### Why the primary_key/on_conflict restriction?

Tables with `primary_key` + `on_conflict` have automatic upsert behavior on INSERT. The delete+insert execution would trigger this on-conflict handling during the insert step, potentially producing incorrect results. Phase 2 can lift this restriction by using the primary key for more efficient targeted updates.

### Expression resolution

SET assignment expressions (e.g., `SET value = s.value + 1`) are resolved at physical planning time via `session_state.create_logical_expr(value_sql, joined_schema)`. This leverages DataFusion's full expression resolution including type coercion, column resolution against the joined schema, and function evaluation.

Resolves #10095