### PR TITLE
feat: Add distributed MERGE INTO support for Cayenne catalog tables

### DIFF
--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -705,3 +705,128 @@ impl UserDefinedLogicalNodeCore for DistributedCayenneInsertNode {
         })
     }
 }
+
+/// Logical plan node to forward `MERGE` DML operations to Cayenne tables
+/// across relevant executors in distributed mode.
+///
+/// Stores the original MERGE SQL verbatim for forwarding, plus decomposed
+/// fields for partition compatibility validation and `explain` output.
+#[derive(Debug, Clone)]
+pub struct DistributedCayenneMergeNode {
+    /// Fully qualified target table reference.
+    pub target_table: TableReference,
+    /// Fully qualified source table reference.
+    pub source_table: TableReference,
+    /// Scan qualifier for the target side (alias or table name).
+    pub target_qualifier: String,
+    /// Scan qualifier for the source side (alias or table name).
+    pub source_qualifier: String,
+    /// Equi-join key pairs as `(target_col, source_col)` bare column names.
+    pub on_keys: Vec<(String, String)>,
+    /// SET assignments as `(target_col, value_sql)` pairs.
+    pub assignments: Vec<(String, String)>,
+    /// Original MERGE SQL text, forwarded verbatim to executors.
+    pub original_sql: String,
+    /// Output schema: single `count: UInt64` column.
+    pub output_schema: DFSchemaRef,
+}
+
+impl DistributedCayenneMergeNode {
+    /// Create a new `DistributedCayenneMergeNode`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output schema cannot be constructed.
+    pub fn try_new(
+        target_table: TableReference,
+        source_table: TableReference,
+        target_qualifier: String,
+        source_qualifier: String,
+        on_keys: Vec<(String, String)>,
+        assignments: Vec<(String, String)>,
+        original_sql: String,
+    ) -> datafusion::error::Result<Self> {
+        let output_schema = Arc::new(datafusion::common::DFSchema::try_from(Schema::new(vec![
+            Field::new("count", DataType::UInt64, false),
+        ]))?);
+
+        Ok(Self {
+            target_table,
+            source_table,
+            target_qualifier,
+            source_qualifier,
+            on_keys,
+            assignments,
+            original_sql,
+            output_schema,
+        })
+    }
+}
+
+impl Hash for DistributedCayenneMergeNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.target_table.hash(state);
+        self.source_table.hash(state);
+        self.target_qualifier.hash(state);
+        self.source_qualifier.hash(state);
+        self.on_keys.hash(state);
+        self.assignments.hash(state);
+        self.original_sql.hash(state);
+    }
+}
+
+impl PartialEq for DistributedCayenneMergeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_table == other.target_table
+            && self.source_table == other.source_table
+            && self.target_qualifier == other.target_qualifier
+            && self.source_qualifier == other.source_qualifier
+            && self.on_keys == other.on_keys
+            && self.assignments == other.assignments
+            && self.original_sql == other.original_sql
+    }
+}
+
+impl Eq for DistributedCayenneMergeNode {}
+
+impl PartialOrd for DistributedCayenneMergeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.target_table
+            .to_string()
+            .partial_cmp(&other.target_table.to_string())
+    }
+}
+
+impl UserDefinedLogicalNodeCore for DistributedCayenneMergeNode {
+    fn name(&self) -> &'static str {
+        "DistributedCayenneMerge"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedCayenneMerge: target={}, source={}, keys={:?}",
+            self.target_table, self.source_table, self.on_keys
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(self.clone())
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1544,6 +1544,203 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
     }
 }
 
+/// Physical plan to forward `MERGE` DML operations to Cayenne tables
+/// across relevant executors in distributed mode.
+///
+/// Validates partition compatibility between source and target tables,
+/// then forwards the original MERGE SQL verbatim to all executors.
+pub struct DistributedCayenneMergeExec {
+    target_table: datafusion::sql::TableReference,
+    source_table: datafusion::sql::TableReference,
+    on_keys: Vec<(String, String)>,
+    /// Original MERGE SQL to forward to executors.
+    original_sql: String,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
+    ctx: Arc<datafusion::prelude::SessionContext>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for DistributedCayenneMergeExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DistributedCayenneMergeExec")
+            .field("target_table", &self.target_table.to_string())
+            .field("source_table", &self.source_table.to_string())
+            .field("on_keys", &self.on_keys)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DistributedCayenneMergeExec {
+    #[must_use]
+    pub fn new(
+        target_table: datafusion::sql::TableReference,
+        source_table: datafusion::sql::TableReference,
+        on_keys: Vec<(String, String)>,
+        original_sql: String,
+        executor_registry: Option<Arc<ExecutorRegistry>>,
+        ctx: Arc<datafusion::prelude::SessionContext>,
+    ) -> Self {
+        let schema = dml_count_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            target_table,
+            source_table,
+            on_keys,
+            original_sql,
+            executor_registry,
+            ctx,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for DistributedCayenneMergeExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedCayenneMergeExec: target={}, source={}",
+            self.target_table, self.source_table
+        )
+    }
+}
+
+impl ExecutionPlan for DistributedCayenneMergeExec {
+    fn name(&self) -> &'static str {
+        "DistributedCayenneMergeExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "DistributedCayenneMergeExec has no children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let target_table = self.target_table.clone();
+        let source_table = self.source_table.clone();
+        let on_keys = self.on_keys.clone();
+        let original_sql = self.original_sql.clone();
+        let executor_registry = self.executor_registry.clone();
+        let ctx = Arc::clone(&self.ctx);
+        let result_schema = dml_count_schema();
+
+        let stream = futures::stream::once(async move {
+            let Some(ref registry) = executor_registry else {
+                return Err(DataFusionError::Execution(format!(
+                    "MERGE on '{target_table}' cannot be forwarded: no executor registry available"
+                )));
+            };
+
+            // Validate partition compatibility between source and target.
+            validate_partition_compatibility(
+                registry,
+                &ctx,
+                &target_table,
+                &source_table,
+                &on_keys,
+            )
+            .await?;
+
+            // Forward the original MERGE SQL to all executors.
+            forward_dml_to_executors(registry, &original_sql).await?;
+
+            RecordBatch::try_new(result_schema, vec![Arc::new(UInt64Array::from(vec![0u64]))])
+                .map_err(Into::into)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            dml_count_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Validate that source and target tables have compatible partition layouts
+/// for distributed MERGE execution.
+///
+/// Requirements:
+/// 1. Both tables must have a partition expression
+/// 2. The partition expressions must be identical
+/// 3. The partition column must appear in the ON clause join keys
+async fn validate_partition_compatibility(
+    registry: &ExecutorRegistry,
+    ctx: &datafusion::prelude::SessionContext,
+    target_table: &datafusion::sql::TableReference,
+    source_table: &datafusion::sql::TableReference,
+    on_keys: &[(String, String)],
+) -> DFResult<()> {
+    let target_partition = crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+        ctx,
+        registry,
+        target_table,
+    )
+    .await?;
+    let source_partition = crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+        ctx,
+        registry,
+        source_table,
+    )
+    .await?;
+
+    let Some(target_part) = target_partition else {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires target table '{target_table}' to have PARTITION BY configured"
+        )));
+    };
+    let Some(source_part) = source_partition else {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires source table '{source_table}' to have PARTITION BY configured"
+        )));
+    };
+
+    if target_part != source_part {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires identical partition expressions on source and target. \
+             Target partition: '{target_part}', Source partition: '{source_part}'"
+        )));
+    }
+
+    // Check that the partition column appears in the ON keys (target side).
+    let partition_in_on_keys = on_keys
+        .iter()
+        .any(|(target_col, _)| *target_col == target_part);
+    if !partition_in_on_keys {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires the partition column '{target_part}' to appear in the \
+             ON clause join keys for correct executor-local execution"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Schema for DML count results — single `count` column with `UInt64` type,
 /// matching `DataFusion`'s standard DML output format.
 fn dml_count_schema() -> SchemaRef {

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -28,11 +28,13 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
+    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneMergeNode,
+    DistributedCayenneUpdateNode,
 };
 use super::physical_plans::{
     CayenneCreateSchemaExec, CayenneCreateTableExecBuilder, CayenneDropTableExec,
-    DistributedCayenneDeleteExec, DistributedCayenneInsertExec, DistributedCayenneUpdateExec,
+    DistributedCayenneDeleteExec, DistributedCayenneInsertExec, DistributedCayenneMergeExec,
+    DistributedCayenneUpdateExec,
 };
 use crate::cluster::executor_registry::ExecutorRegistry;
 
@@ -164,6 +166,20 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 ctx,
                 io_runtime,
                 Arc::clone(input),
+            ))));
+        }
+
+        if let Some(merge) = node.as_any().downcast_ref::<DistributedCayenneMergeNode>() {
+            let ctx = Arc::new(datafusion::prelude::SessionContext::new_with_state(
+                session_state.clone(),
+            ));
+            return Ok(Some(Arc::new(DistributedCayenneMergeExec::new(
+                merge.target_table.clone(),
+                merge.source_table.clone(),
+                merge.on_keys.clone(),
+                merge.original_sql.clone(),
+                self.executor_registry.clone(),
+                ctx,
             ))));
         }
 

--- a/crates/runtime/src/datafusion/planner/merge.rs
+++ b/crates/runtime/src/datafusion/planner/merge.rs
@@ -41,7 +41,9 @@ use datafusion::sql::sqlparser::ast::{
 };
 
 use super::logical_nodes::CayenneMergeNode;
-use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
+use super::{PlannerContext, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
+use crate::config::ClusterRole;
+use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneMergeNode;
 
 /// Plan a `MERGE INTO` statement for local Cayenne execution.
 ///
@@ -51,6 +53,8 @@ use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
 pub(super) async fn plan_merge(
     statement: Statement,
     session: &SessionState,
+    ctx: &PlannerContext,
+    original_sql: &str,
 ) -> DFResult<LogicalPlan> {
     let Statement::Statement(sql_stmt) = statement else {
         return Err(DataFusionError::Internal(
@@ -131,6 +135,23 @@ pub(super) async fn plan_merge(
     let assignments =
         validate_and_extract_assignments(&clauses[0], target_ref.table(), target_alias.as_deref())?;
 
+    // Distributed (scheduler) mode: produce forwarding node with original SQL.
+    if matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
+        let node = DistributedCayenneMergeNode::try_new(
+            target_ref,
+            source_ref,
+            target_qualifier,
+            source_qualifier,
+            on_keys,
+            assignments,
+            original_sql.to_string(),
+        )?;
+        return Ok(LogicalPlan::Extension(Extension {
+            node: Arc::new(node),
+        }));
+    }
+
+    // Local mode: produce local execution node.
     let node = CayenneMergeNode::try_new(
         target_ref,
         source_ref,

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -128,14 +128,9 @@ pub async fn create_logical_plan(
                 .await;
             }
 
-            // DML: MERGE on Cayenne tables (local single-node only)
+            // DML: MERGE on Cayenne tables
             SQLStatement::Merge { .. } if ctx.catalog_mode == CatalogMode::Cayenne => {
-                if matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
-                    return Err(DataFusionError::Plan(
-                        "MERGE INTO is not supported in distributed mode".to_string(),
-                    ));
-                }
-                return merge::plan_merge(statement, session).await;
+                return merge::plan_merge(statement, session, ctx, sql).await;
             }
 
             _ => {}

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1322,7 +1322,7 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
         LogicalPlan::Extension(ext) => {
             use super::cayenne_ddl::logical_nodes::{
                 DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
-                DistributedCayenneUpdateNode,
+                DistributedCayenneMergeNode, DistributedCayenneUpdateNode,
             };
             use super::planner::logical_nodes::CayenneMergeNode;
             if let Some(n) = ext
@@ -1349,6 +1349,13 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
             if let Some(n) = ext.node.as_any().downcast_ref::<CayenneMergeNode>() {
                 return Some(n.target_table.clone());
             }
+            if let Some(n) = ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneMergeNode>()
+            {
+                return Some(n.target_table.clone());
+            }
             None
         }
         _ => None,
@@ -1364,7 +1371,7 @@ fn is_dml_extension(plan: &LogicalPlan) -> bool {
     if let LogicalPlan::Extension(ext) = plan {
         use super::cayenne_ddl::logical_nodes::{
             DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
-            DistributedCayenneUpdateNode,
+            DistributedCayenneMergeNode, DistributedCayenneUpdateNode,
         };
         use super::planner::logical_nodes::CayenneMergeNode;
         if ext
@@ -1386,6 +1393,11 @@ fn is_dml_extension(plan: &LogicalPlan) -> bool {
                 .node
                 .as_any()
                 .downcast_ref::<CayenneMergeNode>()
+                .is_some()
+            || ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneMergeNode>()
                 .is_some()
         {
             return true;


### PR DESCRIPTION
> **Stacked on** #10105 ← #10101 ← #10100 ← #10099

## Overview

Extends the local MERGE INTO engine to the distributed scheduler/executor architecture. The scheduler validates partition compatibility between source and target tables, then forwards the original MERGE SQL verbatim to all executors via FlightSQL. Each executor runs the local MERGE engine independently against its local Cayenne partitions.

Issue: #10097
Depends-on: #10095

## How it works

```
Scheduler receives MERGE SQL
  → planner/merge.rs validates AST (same as local)
  → detects ClusterRole::Scheduler
  → produces DistributedCayenneMergeNode (stores original SQL)
  → extension planner → DistributedCayenneMergeExec
  → at execution time:
      1. validate_partition_compatibility()
      2. forward_dml_to_executors(original_sql)
  → each executor runs local MERGE engine against its partitions
```

### Partition compatibility requirements

For distributed MERGE to produce correct results, the data must be co-partitioned so each executor can run the MERGE independently:

1. **Both source and target must have `PARTITION BY` configured**
2. **Partition expressions must be identical** (same column, same transform)
3. **The partition column must appear in the ON clause join keys** — ensures matched rows are always co-located on the same executor

Incompatible layouts are rejected with actionable error messages.

## Changes

### New: `DistributedCayenneMergeNode` (`cayenne_ddl/logical_nodes.rs`, 125 lines)

Logical node for distributed MERGE forwarding:
- Carries `target_table`, `source_table`, qualifiers, `on_keys`, `assignments`, and `original_sql`
- Implements `UserDefinedLogicalNodeCore` with `Hash`, `PartialEq`, `Eq`, `PartialOrd`
- No logical plan inputs — the SQL is forwarded verbatim

### New: `DistributedCayenneMergeExec` (`cayenne_ddl/physical_plans.rs`, 197 lines)

Physical execution plan:
- At `execute()` time:
  1. Calls `validate_partition_compatibility()` to verify both tables have matching partition expressions and the partition column is in the ON keys
  2. Calls `forward_dml_to_executors()` (reuses existing infrastructure from distributed DELETE/UPDATE/INSERT) to send the original SQL to all executors
  3. Returns a count result batch

### New: `validate_partition_compatibility()` (`cayenne_ddl/physical_plans.rs`)

Uses `DataFusion::get_table_partition_expr_from_ctx()` to look up partition expressions for both tables, then verifies:
- Both have partitions (`Some`)
- Expressions are identical (string equality)
- Partition column name appears in `on_keys` target side

### Modified: `planner/merge.rs`

- `plan_merge()` now accepts `PlannerContext` and `original_sql`
- When `ClusterRole::Scheduler`, produces `DistributedCayenneMergeNode` instead of `CayenneMergeNode`
- Shared validation (AST parsing, table checks, ON keys, assignments) runs for both modes
- Extracted `target_qualifier`/`source_qualifier` computation (alias or table name) to pass into the distributed node

### Modified: `planner/mod.rs`

- Passes `ctx` and `sql` to `merge::plan_merge()` for distributed mode support

### Modified: `cayenne_ddl/planner.rs`

- Added `DistributedCayenneMergeNode` → `DistributedCayenneMergeExec` physical planning branch
- Constructs a `SessionContext` for partition expression lookups

### Modified: `query.rs`

- Added `DistributedCayenneMergeNode` to `extract_dml_target_table()` for cache invalidation
- Added `DistributedCayenneMergeNode` to `is_dml_extension()` for schema verification skip

## Design notes

### Why forward SQL verbatim?

The distributed DELETE/UPDATE/INSERT nodes all use SQL forwarding via `forward_dml_to_executors()`. MERGE follows the same pattern — the original SQL is sent to each executor, which parses and plans it locally using the local MERGE engine from #10105. This avoids serializing complex logical/physical plans across the network.

### Why validate partitions at execution time?

Partition metadata is resolved from the executor registry, which is only fully populated at execution time. The validation runs before any mutation, so incompatible partitions are caught before any data is changed.