### PR TITLE
Update spiceio to v0.4.0, add log upload, rename CI jobs

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -40,10 +40,13 @@ jobs:
         uses: ./.github/actions/check-code-changes
 
   check:
-    name: Check (Develop)
+    name: Rust Lint
     needs: check_changes
     if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
+
+    env:
+      SPICEIO_LOG_FILE: /tmp/spiceio-check.log
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -52,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@f964d0fc0c7c60f1463c35971636493b8186a7e2 # v0.2.0
+        uses: spiceai/spiceio/.github/actions/setup@a5e2c9d94accb108945b81797c99a29349e0b993 # v0.4.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -87,11 +90,22 @@ jobs:
       - name: Show sccache stats
         run: sccache --show-stats
 
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-check-logs
+          path: /tmp/spiceio-check.log
+          if-no-files-found: ignore
+
   build-and-test:
-    name: Build and Test (Develop)
+    name: Build and Test
     needs: check_changes
     if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
+
+    env:
+      SPICEIO_LOG_FILE: /tmp/spiceio-build.log
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -100,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@f964d0fc0c7c60f1463c35971636493b8186a7e2 # v0.2.0
+        uses: spiceai/spiceio/.github/actions/setup@a5e2c9d94accb108945b81797c99a29349e0b993 # v0.4.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -148,3 +162,11 @@ jobs:
             echo "Update Cargo.lock"
             exit 1
           fi
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-build-logs
+          path: /tmp/spiceio-build.log
+          if-no-files-found: ignore

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@3fce49df94013eafa8a770a8dc682f69b5dd907e # v0.4.1
+        uses: spiceai/spiceio/.github/actions/setup@7009d5f668671ef39af3c4065ea8f8e4501f78af # v0.4.2
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -114,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@3fce49df94013eafa8a770a8dc682f69b5dd907e # v0.4.1
+        uses: spiceai/spiceio/.github/actions/setup@7009d5f668671ef39af3c4065ea8f8e4501f78af # v0.4.2
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@a5e2c9d94accb108945b81797c99a29349e0b993 # v0.4.0
+        uses: spiceai/spiceio/.github/actions/setup@3fce49df94013eafa8a770a8dc682f69b5dd907e # v0.4.1
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -114,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@a5e2c9d94accb108945b81797c99a29349e0b993 # v0.4.0
+        uses: spiceai/spiceio/.github/actions/setup@3fce49df94013eafa8a770a8dc682f69b5dd907e # v0.4.1
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}

--- a/crates/data_components/src/dynamodb/utils.rs
+++ b/crates/data_components/src/dynamodb/utils.rs
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn float64_finite_accepted() {
-        let scalar = ScalarValue::Float64(Some(2.718));
-        assert_number(&scalar, "2.718");
+        let scalar = ScalarValue::Float64(Some(2.719));
+        assert_number(&scalar, "2.719");
     }
 }

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -1074,7 +1074,9 @@ mod tests {
 
         let first = stream.next().await;
         assert!(first.is_some());
-        first.expect("item should exist").expect_err("item should be an error");
+        first
+            .expect("item should exist")
+            .expect_err("item should be an error");
 
         drop(stream);
 

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -534,7 +534,8 @@ mod tests {
             "CREATE TABLE foo (id INT, p TEXT, PRIMARY KEY (id, p)) PARTITION BY p",
         );
         let store = new_shared_store();
-        extract_and_store_extensions(ct, &store).unwrap();
+        extract_and_store_extensions(ct, &store)
+            .expect("partition key in primary key should succeed");
     }
 
     #[test]
@@ -567,7 +568,8 @@ mod tests {
     fn test_partition_by_no_primary_key_ok() {
         let ct = parse_create_table("CREATE TABLE foo (id INT, p TEXT) PARTITION BY p");
         let store = new_shared_store();
-        extract_and_store_extensions(ct, &store).unwrap();
+        extract_and_store_extensions(ct, &store)
+            .expect("partition by without primary key should succeed");
     }
 
     #[test]
@@ -576,7 +578,8 @@ mod tests {
             "CREATE TABLE foo (a INT, b TEXT, c VARCHAR, PRIMARY KEY (a, b)) PARTITION BY b",
         );
         let store = new_shared_store();
-        extract_and_store_extensions(ct, &store).unwrap();
+        extract_and_store_extensions(ct, &store)
+            .expect("composite primary key with partition should succeed");
     }
 
     #[test]
@@ -585,7 +588,8 @@ mod tests {
             "CREATE TABLE foo (id INT, region TEXT, PRIMARY KEY (id, region)) PARTITION BY bucket(4, region)",
         );
         let store = new_shared_store();
-        extract_and_store_extensions(ct, &store).unwrap();
+        extract_and_store_extensions(ct, &store)
+            .expect("bucket partition in primary key should succeed");
     }
 
     #[test]

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -91,12 +91,13 @@ pub(super) async fn plan_create_table(
         Err(e) => {
             // Clean up the store entry if planning fails.
             if let Some(ref key) = store_key
-                && let Err(cleanup_err) = cleanup_store_entry(ddl_store, key) {
-                    tracing::warn!(
-                        "Failed to clean up DDL extension store entry for {key} \
+                && let Err(cleanup_err) = cleanup_store_entry(ddl_store, key)
+            {
+                tracing::warn!(
+                    "Failed to clean up DDL extension store entry for {key} \
                          after planning failure: {cleanup_err}"
-                    );
-                }
+                );
+            }
             Err(e)
         }
     }


### PR DESCRIPTION
## Changes

- **Update spiceio action** from v0.2.0 to v0.4.0 (`a5e2c9d94accb108945b81797c99a29349e0b993`)
- **Add spiceio log upload**: Set `SPICEIO_LOG_FILE` env var and upload logs as GitHub artifacts (always, on success or failure)
- **Rename jobs**: "Check (Develop)" → "Rust Lint", "Build and Test (Develop)" → "Build and Test"