### PR TITLE
feat: Add mTLS client auth support to spice sql REPL

### DIFF
--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -53,6 +53,18 @@ pub struct SqlArgs {
     #[arg(long)]
     tls_root_certificate_file: Option<String>,
 
+    /// The path to the client certificate file for mTLS authentication.
+    /// Required when connecting directly to a cluster node that enforces mutual TLS.
+    /// Must be used together with --client-tls-key-file.
+    #[arg(long, requires = "client_tls_key_file")]
+    client_tls_certificate_file: Option<String>,
+
+    /// The path to the client private key file for mTLS authentication.
+    /// Required when connecting directly to a cluster node that enforces mutual TLS.
+    /// Must be used together with --client-tls-certificate-file.
+    #[arg(long, requires = "client_tls_certificate_file")]
+    client_tls_key_file: Option<String>,
+
     /// Custom HTTP headers in format 'Key:Value' (can be specified multiple times)
     #[arg(long = "headers", value_name = "KEY:VALUE")]
     custom_headers: Vec<String>,
@@ -107,6 +119,8 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         repl_flight_endpoint: flight_endpoint,
         http_endpoint,
         tls_root_certificate_file: args.tls_root_certificate_file.clone(),
+        client_tls_certificate_file: args.client_tls_certificate_file.clone(),
+        client_tls_key_file: args.client_tls_key_file.clone(),
         api_key: ctx.api_key().map(String::from),
         user_agent: Some(ctx.user_agent().to_string()),
         cache_control,

--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -94,6 +94,28 @@ pub struct ReplConfig {
     )]
     pub tls_root_certificate_file: Option<String>,
 
+    /// The path to the client certificate file for mTLS authentication.
+    /// Required when connecting to a cluster node that enforces mutual TLS.
+    /// Must be used together with --client-tls-key-file.
+    #[arg(
+        long,
+        requires = "client_tls_key_file",
+        value_name = "CLIENT_TLS_CERTIFICATE_FILE",
+        help_heading = "SQL REPL"
+    )]
+    pub client_tls_certificate_file: Option<String>,
+
+    /// The path to the client private key file for mTLS authentication.
+    /// Required when connecting to a cluster node that enforces mutual TLS.
+    /// Must be used together with --client-tls-certificate-file.
+    #[arg(
+        long,
+        requires = "client_tls_certificate_file",
+        value_name = "CLIENT_TLS_KEY_FILE",
+        help_heading = "SQL REPL"
+    )]
+    pub client_tls_key_file: Option<String>,
+
     /// The API key to use for authentication
     #[arg(long, value_name = "API_KEY", help_heading = "SQL REPL")]
     pub api_key: Option<String>,
@@ -272,6 +294,23 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         new_agent.push_str(&user_agent);
         user_agent = new_agent;
     }
+    // Build mTLS client identity if both cert and key are provided.
+    // Clap `requires` on the CLI flags enforces that both are present or both absent.
+    let client_identity = if let (Some(cert_path), Some(key_path)) = (
+        &repl_config.client_tls_certificate_file,
+        &repl_config.client_tls_key_file,
+    ) {
+        let cert_pem = tokio::fs::read(cert_path).await.map_err(|e| {
+            format!("Failed to read TLS client certificate from '{cert_path}': {e}. Verify the file path and permissions.")
+        })?;
+        let key_pem = tokio::fs::read(key_path).await.map_err(|e| {
+            format!("Failed to read TLS client key from '{key_path}': {e}. Verify the file path and permissions.")
+        })?;
+        Some(tonic::transport::Identity::from_pem(cert_pem, key_pem))
+    } else {
+        None
+    };
+
     let channel = if let Some(tls_root_certificate_file) = repl_config.tls_root_certificate_file {
         let tls_root_certificate = tokio::fs::read(&tls_root_certificate_file)
             .await
@@ -279,18 +318,27 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                 format!("Failed to read TLS root certificate from '{tls_root_certificate_file}': {e}. Verify the file path and permissions.")
             })?;
         let tls_root_certificate = tonic::transport::Certificate::from_pem(tls_root_certificate);
-        let client_tls_config = ClientTlsConfig::new().ca_certificate(tls_root_certificate);
-        if repl_flight_endpoint == "http://localhost:50051" {
-            repl_flight_endpoint = "https://localhost:50051".to_string();
+        let mut client_tls_config = ClientTlsConfig::new().ca_certificate(tls_root_certificate);
+        if let Some(identity) = client_identity {
+            client_tls_config = client_tls_config.identity(identity);
+        }
+        if repl_flight_endpoint.starts_with("http://") {
+            repl_flight_endpoint = repl_flight_endpoint.replacen("http://", "https://", 1);
         }
         Channel::from_shared(repl_flight_endpoint.clone())?
             .user_agent(user_agent.clone())?
             .tls_config(client_tls_config)?
             .connect()
             .await
-    } else if repl_flight_endpoint.starts_with("https://") {
-        // For HTTPS endpoints without a custom certificate, use system certificates
-        let client_tls_config = ClientTlsConfig::new().with_native_roots();
+    } else if client_identity.is_some() || repl_flight_endpoint.starts_with("https://") {
+        // For HTTPS endpoints or mTLS client identity without an explicit CA, use system certificates
+        let mut client_tls_config = ClientTlsConfig::new().with_native_roots();
+        if let Some(identity) = client_identity {
+            client_tls_config = client_tls_config.identity(identity);
+        }
+        if repl_flight_endpoint.starts_with("http://") {
+            repl_flight_endpoint = repl_flight_endpoint.replacen("http://", "https://", 1);
+        }
         Channel::from_shared(repl_flight_endpoint.clone())?
             .user_agent(user_agent.clone())?
             .tls_config(client_tls_config)?


### PR DESCRIPTION
## Changes

Add `--client-tls-certificate-file` and `--client-tls-key-file` flags to `spice sql` to enable mutual TLS authentication when connecting to cluster nodes that enforce client certificate verification.

This allows the REPL to connect directly to executor nodes in distributed cluster mode protected with mTLS, by presenting a client certificate and key signed by the cluster CA.

### What changed

- **`crates/repl/src/lib.rs`**: Add `tls_client_certificate_file` and `tls_client_key_file` fields to `ReplConfig`. Validate both flags are provided together. Construct `ClientTlsConfig` with `Identity::from_pem()` when client identity is provided. Auto-enable TLS with system root CAs when client identity is set without an explicit `--tls-root-certificate-file`.
- **`bin/spice/src/commands/sql.rs`**: Add `--client-tls-certificate-file` and `--client-tls-key-file` CLI args and plumb them through to `ReplConfig`.

### Why

In distributed cluster mode with mTLS, executor Flight servers use `ServerTlsConfig::new().identity(...).client_ca_root(...)` — requiring connecting clients to present a valid certificate signed by the cluster CA. Previously, `spice sql` only supported one-way TLS (verifying the server), so it could not complete the mTLS handshake with executor nodes.

### Usage

```bash
# Generate client cert using existing PKI tooling
spice cluster tls init
spice cluster tls add repl-client --host executor.example.com

# Connect to an executor node with mTLS
spice sql \
  --endpoint grpc+tls://executor.example.com:50052 \
  --tls-root-certificate-file ~/.spice/pki/ca.crt \
  --client-tls-certificate-file ~/.spice/pki/repl-client.crt \
  --client-tls-key-file ~/.spice/pki/repl-client.key
```

### Testing

- `cargo check -p repl -p spice` — compiles cleanly
- `cargo test -p repl` — 45/45 tests pass
- `cargo test -p spice --lib` — 79/79 tests pass