### PR TITLE
feat: Support auto-create table via DoPut CommandStatementIngest

### DIFF
--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -705,3 +705,128 @@ impl UserDefinedLogicalNodeCore for DistributedCayenneInsertNode {
         })
     }
 }
+
+/// Logical plan node to forward `MERGE` DML operations to Cayenne tables
+/// across relevant executors in distributed mode.
+///
+/// Stores the original MERGE SQL verbatim for forwarding, plus decomposed
+/// fields for partition compatibility validation and `explain` output.
+#[derive(Debug, Clone)]
+pub struct DistributedCayenneMergeNode {
+    /// Fully qualified target table reference.
+    pub target_table: TableReference,
+    /// Fully qualified source table reference.
+    pub source_table: TableReference,
+    /// Scan qualifier for the target side (alias or table name).
+    pub target_qualifier: String,
+    /// Scan qualifier for the source side (alias or table name).
+    pub source_qualifier: String,
+    /// Equi-join key pairs as `(target_col, source_col)` bare column names.
+    pub on_keys: Vec<(String, String)>,
+    /// SET assignments as `(target_col, value_sql)` pairs.
+    pub assignments: Vec<(String, String)>,
+    /// Original MERGE SQL text, forwarded verbatim to executors.
+    pub original_sql: String,
+    /// Output schema: single `count: UInt64` column.
+    pub output_schema: DFSchemaRef,
+}
+
+impl DistributedCayenneMergeNode {
+    /// Create a new `DistributedCayenneMergeNode`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output schema cannot be constructed.
+    pub fn try_new(
+        target_table: TableReference,
+        source_table: TableReference,
+        target_qualifier: String,
+        source_qualifier: String,
+        on_keys: Vec<(String, String)>,
+        assignments: Vec<(String, String)>,
+        original_sql: String,
+    ) -> datafusion::error::Result<Self> {
+        let output_schema = Arc::new(datafusion::common::DFSchema::try_from(Schema::new(vec![
+            Field::new("count", DataType::UInt64, false),
+        ]))?);
+
+        Ok(Self {
+            target_table,
+            source_table,
+            target_qualifier,
+            source_qualifier,
+            on_keys,
+            assignments,
+            original_sql,
+            output_schema,
+        })
+    }
+}
+
+impl Hash for DistributedCayenneMergeNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.target_table.hash(state);
+        self.source_table.hash(state);
+        self.target_qualifier.hash(state);
+        self.source_qualifier.hash(state);
+        self.on_keys.hash(state);
+        self.assignments.hash(state);
+        self.original_sql.hash(state);
+    }
+}
+
+impl PartialEq for DistributedCayenneMergeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_table == other.target_table
+            && self.source_table == other.source_table
+            && self.target_qualifier == other.target_qualifier
+            && self.source_qualifier == other.source_qualifier
+            && self.on_keys == other.on_keys
+            && self.assignments == other.assignments
+            && self.original_sql == other.original_sql
+    }
+}
+
+impl Eq for DistributedCayenneMergeNode {}
+
+impl PartialOrd for DistributedCayenneMergeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.target_table
+            .to_string()
+            .partial_cmp(&other.target_table.to_string())
+    }
+}
+
+impl UserDefinedLogicalNodeCore for DistributedCayenneMergeNode {
+    fn name(&self) -> &'static str {
+        "DistributedCayenneMerge"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedCayenneMerge: target={}, source={}, keys={:?}",
+            self.target_table, self.source_table, self.on_keys
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        _inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        Ok(self.clone())
+    }
+}

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1544,6 +1544,203 @@ impl ExecutionPlan for DistributedCayenneInsertExec {
     }
 }
 
+/// Physical plan to forward `MERGE` DML operations to Cayenne tables
+/// across relevant executors in distributed mode.
+///
+/// Validates partition compatibility between source and target tables,
+/// then forwards the original MERGE SQL verbatim to all executors.
+pub struct DistributedCayenneMergeExec {
+    target_table: datafusion::sql::TableReference,
+    source_table: datafusion::sql::TableReference,
+    on_keys: Vec<(String, String)>,
+    /// Original MERGE SQL to forward to executors.
+    original_sql: String,
+    executor_registry: Option<Arc<ExecutorRegistry>>,
+    ctx: Arc<datafusion::prelude::SessionContext>,
+    properties: PlanProperties,
+}
+
+impl fmt::Debug for DistributedCayenneMergeExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DistributedCayenneMergeExec")
+            .field("target_table", &self.target_table.to_string())
+            .field("source_table", &self.source_table.to_string())
+            .field("on_keys", &self.on_keys)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DistributedCayenneMergeExec {
+    #[must_use]
+    pub fn new(
+        target_table: datafusion::sql::TableReference,
+        source_table: datafusion::sql::TableReference,
+        on_keys: Vec<(String, String)>,
+        original_sql: String,
+        executor_registry: Option<Arc<ExecutorRegistry>>,
+        ctx: Arc<datafusion::prelude::SessionContext>,
+    ) -> Self {
+        let schema = dml_count_schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+        Self {
+            target_table,
+            source_table,
+            on_keys,
+            original_sql,
+            executor_registry,
+            ctx,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for DistributedCayenneMergeExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedCayenneMergeExec: target={}, source={}",
+            self.target_table, self.source_table
+        )
+    }
+}
+
+impl ExecutionPlan for DistributedCayenneMergeExec {
+    fn name(&self) -> &'static str {
+        "DistributedCayenneMergeExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "DistributedCayenneMergeExec has no children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<datafusion::execution::SendableRecordBatchStream> {
+        let target_table = self.target_table.clone();
+        let source_table = self.source_table.clone();
+        let on_keys = self.on_keys.clone();
+        let original_sql = self.original_sql.clone();
+        let executor_registry = self.executor_registry.clone();
+        let ctx = Arc::clone(&self.ctx);
+        let result_schema = dml_count_schema();
+
+        let stream = futures::stream::once(async move {
+            let Some(ref registry) = executor_registry else {
+                return Err(DataFusionError::Execution(format!(
+                    "MERGE on '{target_table}' cannot be forwarded: no executor registry available"
+                )));
+            };
+
+            // Validate partition compatibility between source and target.
+            validate_partition_compatibility(
+                registry,
+                &ctx,
+                &target_table,
+                &source_table,
+                &on_keys,
+            )
+            .await?;
+
+            // Forward the original MERGE SQL to all executors.
+            forward_dml_to_executors(registry, &original_sql).await?;
+
+            RecordBatch::try_new(result_schema, vec![Arc::new(UInt64Array::from(vec![0u64]))])
+                .map_err(Into::into)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            dml_count_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Validate that source and target tables have compatible partition layouts
+/// for distributed MERGE execution.
+///
+/// Requirements:
+/// 1. Both tables must have a partition expression
+/// 2. The partition expressions must be identical
+/// 3. The partition column must appear in the ON clause join keys
+async fn validate_partition_compatibility(
+    registry: &ExecutorRegistry,
+    ctx: &datafusion::prelude::SessionContext,
+    target_table: &datafusion::sql::TableReference,
+    source_table: &datafusion::sql::TableReference,
+    on_keys: &[(String, String)],
+) -> DFResult<()> {
+    let target_partition = crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+        ctx,
+        registry,
+        target_table,
+    )
+    .await?;
+    let source_partition = crate::datafusion::DataFusion::get_table_partition_expr_from_ctx(
+        ctx,
+        registry,
+        source_table,
+    )
+    .await?;
+
+    let Some(target_part) = target_partition else {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires target table '{target_table}' to have PARTITION BY configured"
+        )));
+    };
+    let Some(source_part) = source_partition else {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires source table '{source_table}' to have PARTITION BY configured"
+        )));
+    };
+
+    if target_part != source_part {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires identical partition expressions on source and target. \
+             Target partition: '{target_part}', Source partition: '{source_part}'"
+        )));
+    }
+
+    // Check that the partition column appears in the ON keys (target side).
+    let partition_in_on_keys = on_keys
+        .iter()
+        .any(|(target_col, _)| *target_col == target_part);
+    if !partition_in_on_keys {
+        return Err(DataFusionError::Plan(format!(
+            "Distributed MERGE requires the partition column '{target_part}' to appear in the \
+             ON clause join keys for correct executor-local execution"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Schema for DML count results — single `count` column with `UInt64` type,
 /// matching `DataFusion`'s standard DML output format.
 fn dml_count_schema() -> SchemaRef {

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -28,11 +28,13 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use super::logical_nodes::{
     CayenneCreateSchemaNode, CayenneCreateTableNode, CayenneDropTableNode,
-    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneUpdateNode,
+    DistributedCayenneDeleteNode, DistributedCayenneInsertNode, DistributedCayenneMergeNode,
+    DistributedCayenneUpdateNode,
 };
 use super::physical_plans::{
     CayenneCreateSchemaExec, CayenneCreateTableExecBuilder, CayenneDropTableExec,
-    DistributedCayenneDeleteExec, DistributedCayenneInsertExec, DistributedCayenneUpdateExec,
+    DistributedCayenneDeleteExec, DistributedCayenneInsertExec, DistributedCayenneMergeExec,
+    DistributedCayenneUpdateExec,
 };
 use crate::cluster::executor_registry::ExecutorRegistry;
 
@@ -164,6 +166,20 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 ctx,
                 io_runtime,
                 Arc::clone(input),
+            ))));
+        }
+
+        if let Some(merge) = node.as_any().downcast_ref::<DistributedCayenneMergeNode>() {
+            let ctx = Arc::new(datafusion::prelude::SessionContext::new_with_state(
+                session_state.clone(),
+            ));
+            return Ok(Some(Arc::new(DistributedCayenneMergeExec::new(
+                merge.target_table.clone(),
+                merge.source_table.clone(),
+                merge.on_keys.clone(),
+                merge.original_sql.clone(),
+                self.executor_registry.clone(),
+                ctx,
             ))));
         }
 

--- a/crates/runtime/src/datafusion/planner/merge.rs
+++ b/crates/runtime/src/datafusion/planner/merge.rs
@@ -24,9 +24,12 @@ limitations under the License.
 //! WHEN MATCHED THEN UPDATE SET col1 = expr1, ...
 //! ```
 //!
-//! Both source and target must be Cayenne catalog tables. Single-node
-//! execution only (distributed mode returns an error). Target must not
+//! Both source and target must be Cayenne catalog tables. Target must not
 //! have `primary_key` or `on_conflict` configured.
+//!
+//! In single-node mode, a local `CayenneMergeNode` is produced.
+//! In distributed (scheduler) mode, a `DistributedCayenneMergeNode` is
+//! produced which forwards the original SQL to connected executors.
 
 use std::sync::Arc;
 
@@ -45,11 +48,13 @@ use super::{PlannerContext, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_caye
 use crate::config::ClusterRole;
 use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneMergeNode;
 
-/// Plan a `MERGE INTO` statement for local Cayenne execution.
+/// Plan a `MERGE INTO` statement for Cayenne execution.
 ///
 /// Parses the AST, validates phase 1 constraints, normalizes the ON clause
-/// into bare `(target_col, source_col)` key pairs, and produces a
-/// `CayenneMergeNode` extension node.
+/// into bare `(target_col, source_col)` key pairs, and produces either a
+/// local `CayenneMergeNode` or (when running on the scheduler in distributed
+/// mode) a `DistributedCayenneMergeNode` that forwards the original SQL to
+/// connected executors.
 pub(super) async fn plan_merge(
     statement: Statement,
     session: &SessionState,

--- a/crates/runtime/src/datafusion/planner/merge.rs
+++ b/crates/runtime/src/datafusion/planner/merge.rs
@@ -41,7 +41,9 @@ use datafusion::sql::sqlparser::ast::{
 };
 
 use super::logical_nodes::CayenneMergeNode;
-use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
+use super::{PlannerContext, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
+use crate::config::ClusterRole;
+use crate::datafusion::cayenne_ddl::logical_nodes::DistributedCayenneMergeNode;
 
 /// Plan a `MERGE INTO` statement for local Cayenne execution.
 ///
@@ -51,6 +53,8 @@ use super::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, is_cayenne_table};
 pub(super) async fn plan_merge(
     statement: Statement,
     session: &SessionState,
+    ctx: &PlannerContext,
+    original_sql: &str,
 ) -> DFResult<LogicalPlan> {
     let Statement::Statement(sql_stmt) = statement else {
         return Err(DataFusionError::Internal(
@@ -131,6 +135,23 @@ pub(super) async fn plan_merge(
     let assignments =
         validate_and_extract_assignments(&clauses[0], target_ref.table(), target_alias.as_deref())?;
 
+    // Distributed (scheduler) mode: produce forwarding node with original SQL.
+    if matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
+        let node = DistributedCayenneMergeNode::try_new(
+            target_ref,
+            source_ref,
+            target_qualifier,
+            source_qualifier,
+            on_keys,
+            assignments,
+            original_sql.to_string(),
+        )?;
+        return Ok(LogicalPlan::Extension(Extension {
+            node: Arc::new(node),
+        }));
+    }
+
+    // Local mode: produce local execution node.
     let node = CayenneMergeNode::try_new(
         target_ref,
         source_ref,

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -128,14 +128,9 @@ pub async fn create_logical_plan(
                 .await;
             }
 
-            // DML: MERGE on Cayenne tables (local single-node only)
+            // DML: MERGE on Cayenne tables
             SQLStatement::Merge { .. } if ctx.catalog_mode == CatalogMode::Cayenne => {
-                if matches!(ctx.cluster_role, Some(ClusterRole::Scheduler)) {
-                    return Err(DataFusionError::Plan(
-                        "MERGE INTO is not supported in distributed mode".to_string(),
-                    ));
-                }
-                return merge::plan_merge(statement, session).await;
+                return merge::plan_merge(statement, session, ctx, sql).await;
             }
 
             _ => {}

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1322,7 +1322,7 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
         LogicalPlan::Extension(ext) => {
             use super::cayenne_ddl::logical_nodes::{
                 DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
-                DistributedCayenneUpdateNode,
+                DistributedCayenneMergeNode, DistributedCayenneUpdateNode,
             };
             use super::planner::logical_nodes::CayenneMergeNode;
             if let Some(n) = ext
@@ -1349,6 +1349,13 @@ fn extract_dml_target_table(plan: &LogicalPlan) -> Option<TableReference> {
             if let Some(n) = ext.node.as_any().downcast_ref::<CayenneMergeNode>() {
                 return Some(n.target_table.clone());
             }
+            if let Some(n) = ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneMergeNode>()
+            {
+                return Some(n.target_table.clone());
+            }
             None
         }
         _ => None,
@@ -1364,7 +1371,7 @@ fn is_dml_extension(plan: &LogicalPlan) -> bool {
     if let LogicalPlan::Extension(ext) = plan {
         use super::cayenne_ddl::logical_nodes::{
             DistributedCayenneDeleteNode, DistributedCayenneInsertNode,
-            DistributedCayenneUpdateNode,
+            DistributedCayenneMergeNode, DistributedCayenneUpdateNode,
         };
         use super::planner::logical_nodes::CayenneMergeNode;
         if ext
@@ -1386,6 +1393,11 @@ fn is_dml_extension(plan: &LogicalPlan) -> bool {
                 .node
                 .as_any()
                 .downcast_ref::<CayenneMergeNode>()
+                .is_some()
+            || ext
+                .node
+                .as_any()
+                .downcast_ref::<DistributedCayenneMergeNode>()
                 .is_some()
         {
             return true;

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -583,7 +583,7 @@ async fn handle_table_definition_options(
                          Set `access: read_write_create` on the catalog to enable DDL.",
                     )));
                 }
-                let drop_sql = format!("DROP TABLE {path}");
+                let drop_sql = format!("DROP TABLE {}", path.to_quoted_string());
                 tracing::info!("DoPut: dropping existing table `{path}` for if_exists=Replace");
                 datafusion
                     .ctx
@@ -650,7 +650,7 @@ async fn auto_create_table(
     let create_sql = if let Some(like_table) = opts.ingest_options.get("create_like_table") {
         build_create_like_table_sql(datafusion, path, like_table).await?
     } else {
-        arrow_schema_to_create_table_sql(path, incoming_schema)
+        arrow_schema_to_create_table_sql(path, incoming_schema)?
     };
 
     tracing::info!("DoPut: auto-creating table `{path}` via DDL: {create_sql}");
@@ -686,7 +686,7 @@ async fn build_create_like_table_sql(
             ))
         })?;
 
-    let mut sql = arrow_schema_to_create_table_sql(target_path, &source_schema);
+    let mut sql = arrow_schema_to_create_table_sql(target_path, &source_schema)?;
 
     // Copy partition expression from source table if it has one.
     // Propagate errors — silently omitting a partition expression would cause
@@ -708,53 +708,63 @@ async fn build_create_like_table_sql(
 }
 
 /// Convert an Arrow schema to a `CREATE TABLE IF NOT EXISTS` SQL statement.
-fn arrow_schema_to_create_table_sql(path: &TableReference, schema: &Schema) -> String {
-    let columns: Vec<String> = schema
+fn arrow_schema_to_create_table_sql(
+    path: &TableReference,
+    schema: &Schema,
+) -> Result<String, Status> {
+    let columns: Result<Vec<String>, Status> = schema
         .fields()
         .iter()
         .map(|field| {
             let col_name = quote_identifier(field.name());
-            let col_type = arrow_type_to_sql(field.data_type());
+            let col_type = arrow_type_to_sql(field.data_type())?;
             let nullable = if field.is_nullable() { "" } else { " NOT NULL" };
-            format!("{col_name} {col_type}{nullable}")
+            Ok(format!("{col_name} {col_type}{nullable}"))
         })
         .collect();
     let quoted_path = path.to_quoted_string();
-    format!(
+    Ok(format!(
         "CREATE TABLE IF NOT EXISTS {quoted_path} ({})",
-        columns.join(", ")
-    )
+        columns?.join(", ")
+    ))
 }
 
 /// Map Arrow data types to SQL type names for CREATE TABLE DDL.
-fn arrow_type_to_sql(data_type: &DataType) -> String {
+///
+/// Unsigned integer types are mapped to the next-larger signed SQL type to
+/// preserve the full value range (e.g. `UInt32` -> `BIGINT`). Unsupported
+/// Arrow types return an error rather than silently falling back to `TEXT`.
+fn arrow_type_to_sql(data_type: &DataType) -> Result<String, Status> {
     match data_type {
-        DataType::Boolean => "BOOLEAN".to_string(),
-        DataType::Int8 | DataType::UInt8 => "TINYINT".to_string(),
-        DataType::Int16 | DataType::UInt16 => "SMALLINT".to_string(),
-        DataType::Int32 | DataType::UInt32 => "INTEGER".to_string(),
-        DataType::Int64 | DataType::UInt64 => "BIGINT".to_string(),
-        DataType::Float16 => "REAL".to_string(),
-        DataType::Float32 => "REAL".to_string(),
-        DataType::Float64 => "DOUBLE".to_string(),
-        DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => {
-            format!("DECIMAL({p},{s})")
-        }
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => "TEXT".to_string(),
-        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => "BYTEA".to_string(),
-        DataType::Date32 | DataType::Date64 => "DATE".to_string(),
-        DataType::Timestamp(_, Some(_)) => "TIMESTAMPTZ".to_string(),
-        DataType::Timestamp(_, None) => "TIMESTAMP".to_string(),
-        DataType::Time32(_) | DataType::Time64(_) => "TIME".to_string(),
-        DataType::Duration(_) => "BIGINT".to_string(),
-        DataType::Interval(_) => "INTERVAL".to_string(),
-        DataType::FixedSizeBinary(_) => "BYTEA".to_string(), // no fixed-size binary in SQL; use BYTEA
+        DataType::Boolean => Ok("BOOLEAN".to_string()),
+        DataType::Int8 => Ok("TINYINT".to_string()),
+        DataType::UInt8 => Ok("SMALLINT".to_string()),
+        DataType::Int16 => Ok("SMALLINT".to_string()),
+        DataType::UInt16 => Ok("INTEGER".to_string()),
+        DataType::Int32 => Ok("INTEGER".to_string()),
+        DataType::UInt32 => Ok("BIGINT".to_string()),
+        DataType::Int64 => Ok("BIGINT".to_string()),
+        DataType::UInt64 => Ok("DECIMAL(20,0)".to_string()),
+        DataType::Float16 => Ok("REAL".to_string()),
+        DataType::Float32 => Ok("REAL".to_string()),
+        DataType::Float64 => Ok("DOUBLE".to_string()),
+        DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => Ok(format!("DECIMAL({p},{s})")),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok("TEXT".to_string()),
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => Ok("BYTEA".to_string()),
+        DataType::Date32 | DataType::Date64 => Ok("DATE".to_string()),
+        DataType::Timestamp(_, Some(_)) => Ok("TIMESTAMPTZ".to_string()),
+        DataType::Timestamp(_, None) => Ok("TIMESTAMP".to_string()),
+        DataType::Time32(_) | DataType::Time64(_) => Ok("TIME".to_string()),
+        DataType::Duration(_) => Ok("BIGINT".to_string()),
+        DataType::Interval(_) => Ok("INTERVAL".to_string()),
+        DataType::FixedSizeBinary(_) => Ok("BYTEA".to_string()),
         DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
-            let inner = arrow_type_to_sql(field.data_type());
-            format!("{inner}[]")
+            let inner = arrow_type_to_sql(field.data_type())?;
+            Ok(format!("{inner}[]"))
         }
-        // Fallback: use TEXT for unsupported types
-        _ => "TEXT".to_string(),
+        _ => Err(Status::invalid_argument(format!(
+            "Unsupported Arrow data type for auto-created table: {data_type}"
+        ))),
     }
 }
 
@@ -890,7 +900,7 @@ mod tests {
             Field::new("score", DataType::Float64, true),
         ]);
         let path = TableReference::full("catalog", "schema", "my_table");
-        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        let sql = arrow_schema_to_create_table_sql(&path, &schema).expect("should succeed");
         assert_eq!(
             sql,
             r#"CREATE TABLE IF NOT EXISTS catalog.schema.my_table ("id" BIGINT NOT NULL, "name" TEXT, "score" DOUBLE)"#
@@ -923,7 +933,7 @@ mod tests {
             ),
         ]);
         let path = TableReference::bare("test");
-        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        let sql = arrow_schema_to_create_table_sql(&path, &schema).expect("should succeed");
         assert!(sql.contains("\"col_bool\" BOOLEAN"));
         assert!(sql.contains("\"col_i8\" TINYINT"));
         assert!(sql.contains("\"col_i16\" SMALLINT"));
@@ -946,7 +956,7 @@ mod tests {
             Field::new("optional", DataType::Int32, true),
         ]);
         let path = TableReference::bare("t");
-        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        let sql = arrow_schema_to_create_table_sql(&path, &schema).expect("should succeed");
         assert!(sql.contains("\"required\" INTEGER NOT NULL"));
         assert!(sql.contains("\"optional\" INTEGER"));
         // "optional" should NOT contain "NOT NULL"
@@ -961,7 +971,7 @@ mod tests {
             true,
         )]);
         let path = TableReference::bare("t");
-        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        let sql = arrow_schema_to_create_table_sql(&path, &schema).expect("should succeed");
         assert!(sql.contains("\"tags\" TEXT[]"));
     }
 
@@ -969,19 +979,43 @@ mod tests {
 
     #[test]
     fn test_arrow_type_to_sql_utf8_variants() {
-        assert_eq!(arrow_type_to_sql(&DataType::Utf8), "TEXT");
-        assert_eq!(arrow_type_to_sql(&DataType::LargeUtf8), "TEXT");
-        assert_eq!(arrow_type_to_sql(&DataType::Utf8View), "TEXT");
+        assert_eq!(arrow_type_to_sql(&DataType::Utf8).unwrap(), "TEXT");
+        assert_eq!(arrow_type_to_sql(&DataType::LargeUtf8).unwrap(), "TEXT");
+        assert_eq!(arrow_type_to_sql(&DataType::Utf8View).unwrap(), "TEXT");
+    }
+
+    #[test]
+    fn test_arrow_type_to_sql_unsigned_integers() {
+        // UInt types should map to the next-larger signed type to preserve full value range
+        assert_eq!(arrow_type_to_sql(&DataType::UInt8).unwrap(), "SMALLINT");
+        assert_eq!(arrow_type_to_sql(&DataType::UInt16).unwrap(), "INTEGER");
+        assert_eq!(arrow_type_to_sql(&DataType::UInt32).unwrap(), "BIGINT");
+        assert_eq!(
+            arrow_type_to_sql(&DataType::UInt64).unwrap(),
+            "DECIMAL(20,0)"
+        );
+    }
+
+    #[test]
+    fn test_arrow_type_to_sql_unsupported_returns_error() {
+        // Unsupported types should return an error, not silently fall back to TEXT
+        let result = arrow_type_to_sql(&DataType::Null);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().message().to_string();
+        assert!(
+            err_msg.contains("Unsupported Arrow data type"),
+            "got: {err_msg}"
+        );
     }
 
     #[test]
     fn test_arrow_type_to_sql_decimal() {
         assert_eq!(
-            arrow_type_to_sql(&DataType::Decimal128(10, 2)),
+            arrow_type_to_sql(&DataType::Decimal128(10, 2)).unwrap(),
             "DECIMAL(10,2)"
         );
         assert_eq!(
-            arrow_type_to_sql(&DataType::Decimal256(38, 0)),
+            arrow_type_to_sql(&DataType::Decimal256(38, 0)).unwrap(),
             "DECIMAL(38,0)"
         );
     }
@@ -989,14 +1023,15 @@ mod tests {
     #[test]
     fn test_arrow_type_to_sql_timestamp_tz() {
         assert_eq!(
-            arrow_type_to_sql(&DataType::Timestamp(TimeUnit::Microsecond, None)),
+            arrow_type_to_sql(&DataType::Timestamp(TimeUnit::Microsecond, None)).unwrap(),
             "TIMESTAMP"
         );
         assert_eq!(
             arrow_type_to_sql(&DataType::Timestamp(
                 TimeUnit::Microsecond,
                 Some("UTC".into())
-            )),
+            ))
+            .unwrap(),
             "TIMESTAMPTZ"
         );
     }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -17,14 +17,15 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use arrow::array::RecordBatch;
+use arrow::datatypes::DataType;
 use arrow_flight::{
     FlightData, PutResult,
     flight_service_server::FlightService,
-    sql::{Any, Command},
+    sql::{Any, Command, CommandStatementIngest, TableExistsOption, TableNotExistOption},
     utils::flight_data_to_arrow_batch,
 };
 use arrow_ipc::convert::try_schema_from_flatbuffer_bytes;
-use arrow_schema::SchemaRef;
+use arrow_schema::{Schema, SchemaRef};
 use arrow_tools::schema::verify_schema;
 use datafusion::{
     error::DataFusionError, execution::SendableRecordBatchStream,
@@ -53,6 +54,54 @@ use super::{
     middleware::rate_limit::RateLimiterExtension,
 };
 
+/// Options extracted from `CommandStatementIngest.table_definition_options`.
+///
+/// Controls auto-creation and existence-check behavior for DoPut ingestion.
+struct DoPutTableOptions {
+    if_not_exist: TableNotExistOption,
+    if_exists: TableExistsOption,
+    /// Backend-specific options from `CommandStatementIngest.options`.
+    /// Used to carry `create_like_table` for staging table creation.
+    ingest_options: HashMap<String, String>,
+}
+
+impl DoPutTableOptions {
+    /// Extract table definition options from a `CommandStatementIngest`.
+    fn from_ingest_cmd(cmd: &CommandStatementIngest) -> Self {
+        let (if_not_exist, if_exists) = cmd
+            .table_definition_options
+            .as_ref()
+            .map(|opts| {
+                (
+                    TableNotExistOption::try_from(opts.if_not_exist)
+                        .unwrap_or(TableNotExistOption::Fail),
+                    TableExistsOption::try_from(opts.if_exists)
+                        .unwrap_or(TableExistsOption::Append),
+                )
+            })
+            .unwrap_or((TableNotExistOption::Fail, TableExistsOption::Append));
+
+        // When `create_like_table` is present, imply Create + Append
+        let has_create_like = cmd.options.contains_key("create_like_table");
+        let if_not_exist = if has_create_like {
+            TableNotExistOption::Create
+        } else {
+            if_not_exist
+        };
+        let if_exists = if has_create_like && if_exists == TableExistsOption::Unspecified {
+            TableExistsOption::Append
+        } else {
+            if_exists
+        };
+
+        Self {
+            if_not_exist,
+            if_exists,
+            ingest_options: cmd.options.clone(),
+        }
+    }
+}
+
 pub(crate) async fn handle(
     request: Request<Streaming<FlightData>>,
 ) -> Result<Response<<Service as FlightService>::DoPutStream>, Status> {
@@ -73,8 +122,8 @@ pub(crate) async fn handle(
         return Err(Status::invalid_argument("No flight descriptor provided"));
     };
 
-    // Extract table path from FlightSQL commands if present
-    let table_path_override = if let Ok(message) = Any::decode(&*fd.cmd) {
+    // Extract table path and table options from FlightSQL commands if present
+    let (table_path_override, table_options) = if let Ok(message) = Any::decode(&*fd.cmd) {
         match Command::try_from(message).map_err(|e| Status::internal(format!("{e:?}")))? {
             Command::CommandPreparedStatementQuery(query) => {
                 return prepared_statement_query::do_put_query(query, streaming_flight).await;
@@ -93,7 +142,7 @@ pub(crate) async fn handle(
                 // Handle FlightSQL bulk ingestion command
                 // Prefer descriptor path when command is under-qualified (table only).
                 // This preserves fully-qualified paths forwarded by the scheduler.
-                match (ingest_cmd.catalog.as_ref(), ingest_cmd.schema.as_ref()) {
+                let path = match (ingest_cmd.catalog.as_ref(), ingest_cmd.schema.as_ref()) {
                     (Some(catalog), Some(schema)) => Some(vec![
                         catalog.clone(),
                         schema.clone(),
@@ -122,12 +171,14 @@ pub(crate) async fn handle(
                             None
                         }
                     }
-                }
+                };
+                let opts = Some(DoPutTableOptions::from_ingest_cmd(&ingest_cmd));
+                (path, opts)
             }
-            _ => None,
+            _ => (None, None),
         }
     } else {
-        None
+        (None, None)
     };
 
     // Check if the request should be rate limited.
@@ -254,6 +305,11 @@ pub(crate) async fn handle(
     let schema = try_schema_from_flatbuffer_bytes(&first_message.data_header)
         .map_err(|e| Status::internal(format!("Failed to get schema from data header: {e}")))?;
     let schema = Arc::new(schema);
+
+    // Auto-create / existence-check based on table_definition_options
+    if let Some(ref opts) = table_options {
+        handle_table_definition_options(&datafusion, &path, &schema, opts).await?;
+    }
 
     let target_schema = datafusion
         .get_arrow_schema(path.clone())
@@ -493,6 +549,221 @@ fn create_response_stream(
     }
 }
 
+/// Handle `table_definition_options` semantics from `CommandStatementIngest`.
+///
+/// - `if_not_exist == Create`: auto-create the table from the incoming schema
+///   (or from `create_like_table` if specified) when it doesn't exist and the
+///   catalog allows DDL.
+/// - `if_exists == Fail`: error if the table already exists.
+/// - `if_exists == Replace`: drop and recreate the table.
+/// - `if_exists == Append` (default): no action, fall through to normal write.
+async fn handle_table_definition_options(
+    datafusion: &DataFusion,
+    path: &TableReference,
+    incoming_schema: &Schema,
+    opts: &DoPutTableOptions,
+) -> Result<(), Status> {
+    let table_exists = datafusion.table_exists(path.clone());
+
+    if table_exists {
+        match opts.if_exists {
+            TableExistsOption::Fail => {
+                return Err(Status::already_exists(format!(
+                    "Table `{path}` already exists and if_exists=Fail was specified",
+                )));
+            }
+            TableExistsOption::Replace => {
+                // Verify catalog allows DDL before dropping
+                let catalog_name = path
+                    .catalog()
+                    .unwrap_or(crate::datafusion::SPICE_DEFAULT_CATALOG);
+                if !datafusion.is_catalog_ddl_enabled(catalog_name) {
+                    return Err(Status::permission_denied(format!(
+                        "Cannot replace table `{path}`: catalog `{catalog_name}` does not allow DDL operations. \
+                         Set `access: read_write_create` on the catalog to enable DDL.",
+                    )));
+                }
+                let drop_sql = format!("DROP TABLE {path}");
+                tracing::info!("DoPut: dropping existing table `{path}` for if_exists=Replace");
+                datafusion
+                    .ctx
+                    .sql(&drop_sql)
+                    .await
+                    .map_err(|e| Status::internal(format!("Failed to drop table `{path}`: {e}")))?
+                    .collect()
+                    .await
+                    .map_err(|e| Status::internal(format!("Failed to drop table `{path}`: {e}")))?;
+
+                // Fall through to auto-create below
+                auto_create_table(datafusion, path, incoming_schema, opts).await?;
+            }
+            // Append or Unspecified: no action, table exists, proceed to normal write
+            _ => {}
+        }
+    } else {
+        // Table doesn't exist
+        match opts.if_not_exist {
+            TableNotExistOption::Create => {
+                auto_create_table(datafusion, path, incoming_schema, opts).await?;
+            }
+            TableNotExistOption::Fail | TableNotExistOption::Unspecified => {
+                return Err(Status::not_found(format!(
+                    "Table `{path}` does not exist and if_not_exist=Create was not specified",
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Auto-create a table via DDL.
+///
+/// If `create_like_table` is present in `opts.ingest_options`, copies the referenced
+/// table's schema and, when available, its partition expression.
+/// Otherwise, creates from the incoming data schema.
+async fn auto_create_table(
+    datafusion: &DataFusion,
+    path: &TableReference,
+    incoming_schema: &Schema,
+    opts: &DoPutTableOptions,
+) -> Result<(), Status> {
+    let catalog_name = path
+        .catalog()
+        .unwrap_or(crate::datafusion::SPICE_DEFAULT_CATALOG);
+
+    // Gate: catalog must allow DDL (read_write_create)
+    if !datafusion.is_catalog_ddl_enabled(catalog_name) {
+        return Err(Status::permission_denied(format!(
+            "Cannot auto-create table `{path}`: catalog `{catalog_name}` does not allow DDL operations. \
+             Set `access: read_write_create` on the catalog to enable DDL.",
+        )));
+    }
+
+    // Gate: catalog must be Cayenne-backed
+    if !datafusion.is_cayenne_catalog(path) {
+        return Err(Status::unimplemented(format!(
+            "Cannot auto-create table `{path}`: auto-creation is only supported for Cayenne-backed catalogs",
+        )));
+    }
+
+    let create_sql = if let Some(like_table) = opts.ingest_options.get("create_like_table") {
+        build_create_like_table_sql(datafusion, path, like_table).await?
+    } else {
+        arrow_schema_to_create_table_sql(path, incoming_schema)
+    };
+
+    tracing::info!("DoPut: auto-creating table `{path}` via DDL: {create_sql}");
+    datafusion
+        .ctx
+        .sql(&create_sql)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to auto-create table `{path}`: {e}")))?
+        .collect()
+        .await
+        .map_err(|e| Status::internal(format!("Failed to auto-create table `{path}`: {e}")))?;
+
+    Ok(())
+}
+
+/// Build a `CREATE TABLE` SQL statement by copying the definition of an existing table.
+///
+/// Copies schema and partition expression (when available) from the referenced source table.
+async fn build_create_like_table_sql(
+    datafusion: &DataFusion,
+    target_path: &TableReference,
+    source_table_name: &str,
+) -> Result<String, Status> {
+    let source_ref = TableReference::parse_str(source_table_name);
+
+    // Get the source table's schema
+    let source_schema = datafusion
+        .get_arrow_schema(source_ref.clone())
+        .await
+        .map_err(|e| {
+            Status::not_found(format!(
+                "Cannot create table like `{source_table_name}`: failed to get source table schema: {e}"
+            ))
+        })?;
+
+    let mut sql = arrow_schema_to_create_table_sql(target_path, &source_schema);
+
+    // Copy partition expression from source table if it has one.
+    // Propagate errors — silently omitting a partition expression would cause
+    // hard-to-diagnose failures in distributed MERGE routing.
+    match datafusion.get_table_partition_expr(&source_ref).await {
+        Ok(Some(partition_sql)) => {
+            sql = format!("{sql} PARTITION BY {partition_sql}");
+        }
+        Ok(None) => { /* source table has no partition expression — OK */ }
+        Err(e) => {
+            return Err(Status::internal(format!(
+                "Cannot create table like `{source_table_name}`: \
+                 failed to resolve partition expression: {e}"
+            )));
+        }
+    }
+
+    Ok(sql)
+}
+
+/// Convert an Arrow schema to a `CREATE TABLE IF NOT EXISTS` SQL statement.
+fn arrow_schema_to_create_table_sql(path: &TableReference, schema: &Schema) -> String {
+    let columns: Vec<String> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let col_name = quote_identifier(field.name());
+            let col_type = arrow_type_to_sql(field.data_type());
+            let nullable = if field.is_nullable() { "" } else { " NOT NULL" };
+            format!("{col_name} {col_type}{nullable}")
+        })
+        .collect();
+    let quoted_path = path.to_quoted_string();
+    format!(
+        "CREATE TABLE IF NOT EXISTS {quoted_path} ({})",
+        columns.join(", ")
+    )
+}
+
+/// Map Arrow data types to SQL type names for CREATE TABLE DDL.
+fn arrow_type_to_sql(data_type: &DataType) -> String {
+    match data_type {
+        DataType::Boolean => "BOOLEAN".to_string(),
+        DataType::Int8 | DataType::UInt8 => "TINYINT".to_string(),
+        DataType::Int16 | DataType::UInt16 => "SMALLINT".to_string(),
+        DataType::Int32 | DataType::UInt32 => "INTEGER".to_string(),
+        DataType::Int64 | DataType::UInt64 => "BIGINT".to_string(),
+        DataType::Float16 => "REAL".to_string(),
+        DataType::Float32 => "REAL".to_string(),
+        DataType::Float64 => "DOUBLE".to_string(),
+        DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => {
+            format!("DECIMAL({p},{s})")
+        }
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => "TEXT".to_string(),
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => "BYTEA".to_string(),
+        DataType::Date32 | DataType::Date64 => "DATE".to_string(),
+        DataType::Timestamp(_, Some(_)) => "TIMESTAMPTZ".to_string(),
+        DataType::Timestamp(_, None) => "TIMESTAMP".to_string(),
+        DataType::Time32(_) | DataType::Time64(_) => "TIME".to_string(),
+        DataType::Duration(_) => "BIGINT".to_string(),
+        DataType::Interval(_) => "INTERVAL".to_string(),
+        DataType::FixedSizeBinary(_) => "BYTEA".to_string(), // no fixed-size binary in SQL; use BYTEA
+        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
+            let inner = arrow_type_to_sql(field.data_type());
+            format!("{inner}[]")
+        }
+        // Fallback: use TEXT for unsupported types
+        _ => "TEXT".to_string(),
+    }
+}
+
+/// Quote a SQL identifier if it contains special characters or is a reserved word.
+fn quote_identifier(name: &str) -> String {
+    // Always quote to be safe — avoids issues with reserved words and special chars
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
 async fn handle_record_batch(
     batch: RecordBatch,
     batch_tx: &Sender<Result<RecordBatch, DataFusionError>>,
@@ -511,4 +782,239 @@ async fn handle_record_batch(
         )));
     }
     Ok(PutResult::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow_flight::sql::{
+        CommandStatementIngest, TableDefinitionOptions, TableExistsOption, TableNotExistOption,
+    };
+    use datafusion::sql::TableReference;
+    use std::collections::HashMap;
+
+    use super::*;
+
+    // ── DoPutTableOptions extraction tests ──
+
+    #[test]
+    fn test_from_ingest_cmd_with_explicit_options() {
+        let cmd = CommandStatementIngest {
+            table_definition_options: Some(TableDefinitionOptions {
+                if_not_exist: TableNotExistOption::Create as i32,
+                if_exists: TableExistsOption::Append as i32,
+            }),
+            table: "test_table".to_string(),
+            schema: None,
+            catalog: None,
+            temporary: false,
+            transaction_id: None,
+            options: HashMap::new(),
+        };
+        let opts = DoPutTableOptions::from_ingest_cmd(&cmd);
+        assert_eq!(opts.if_not_exist, TableNotExistOption::Create);
+        assert_eq!(opts.if_exists, TableExistsOption::Append);
+        assert!(opts.ingest_options.is_empty());
+    }
+
+    #[test]
+    fn test_from_ingest_cmd_defaults_when_no_options() {
+        let cmd = CommandStatementIngest {
+            table_definition_options: None,
+            table: "test_table".to_string(),
+            schema: None,
+            catalog: None,
+            temporary: false,
+            transaction_id: None,
+            options: HashMap::new(),
+        };
+        let opts = DoPutTableOptions::from_ingest_cmd(&cmd);
+        assert_eq!(opts.if_not_exist, TableNotExistOption::Fail);
+        assert_eq!(opts.if_exists, TableExistsOption::Append);
+    }
+
+    #[test]
+    fn test_from_ingest_cmd_create_like_implies_create_append() {
+        let mut options = HashMap::new();
+        options.insert(
+            "create_like_table".to_string(),
+            "my_catalog.my_schema.source_table".to_string(),
+        );
+        let cmd = CommandStatementIngest {
+            table_definition_options: None, // No explicit options
+            table: "staging_table".to_string(),
+            schema: None,
+            catalog: None,
+            temporary: false,
+            transaction_id: None,
+            options,
+        };
+        let opts = DoPutTableOptions::from_ingest_cmd(&cmd);
+        // create_like_table implies Create + Append
+        assert_eq!(opts.if_not_exist, TableNotExistOption::Create);
+        assert_eq!(opts.if_exists, TableExistsOption::Append);
+        assert_eq!(
+            opts.ingest_options.get("create_like_table"),
+            Some(&"my_catalog.my_schema.source_table".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_ingest_cmd_create_like_preserves_explicit_if_exists() {
+        let mut options = HashMap::new();
+        options.insert("create_like_table".to_string(), "source".to_string());
+        let cmd = CommandStatementIngest {
+            table_definition_options: Some(TableDefinitionOptions {
+                if_not_exist: TableNotExistOption::Fail as i32, // will be overridden
+                if_exists: TableExistsOption::Fail as i32,      // explicit, should be preserved
+            }),
+            table: "staging".to_string(),
+            schema: None,
+            catalog: None,
+            temporary: false,
+            transaction_id: None,
+            options,
+        };
+        let opts = DoPutTableOptions::from_ingest_cmd(&cmd);
+        assert_eq!(opts.if_not_exist, TableNotExistOption::Create); // overridden by create_like
+        assert_eq!(opts.if_exists, TableExistsOption::Fail); // preserved
+    }
+
+    // ── Arrow schema to SQL conversion tests ──
+
+    #[test]
+    fn test_arrow_schema_to_create_table_basic() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("score", DataType::Float64, true),
+        ]);
+        let path = TableReference::full("catalog", "schema", "my_table");
+        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        assert_eq!(
+            sql,
+            r#"CREATE TABLE IF NOT EXISTS catalog.schema.my_table ("id" BIGINT NOT NULL, "name" TEXT, "score" DOUBLE)"#
+        );
+    }
+
+    #[test]
+    fn test_arrow_schema_to_create_table_all_types() {
+        let schema = Schema::new(vec![
+            Field::new("col_bool", DataType::Boolean, true),
+            Field::new("col_i8", DataType::Int8, true),
+            Field::new("col_i16", DataType::Int16, true),
+            Field::new("col_i32", DataType::Int32, true),
+            Field::new("col_i64", DataType::Int64, true),
+            Field::new("col_f32", DataType::Float32, true),
+            Field::new("col_f64", DataType::Float64, true),
+            Field::new("col_decimal", DataType::Decimal128(18, 4), true),
+            Field::new("col_text", DataType::Utf8, true),
+            Field::new("col_binary", DataType::Binary, true),
+            Field::new("col_date", DataType::Date32, true),
+            Field::new(
+                "col_ts",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+            Field::new(
+                "col_tstz",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+        ]);
+        let path = TableReference::bare("test");
+        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        assert!(sql.contains("\"col_bool\" BOOLEAN"));
+        assert!(sql.contains("\"col_i8\" TINYINT"));
+        assert!(sql.contains("\"col_i16\" SMALLINT"));
+        assert!(sql.contains("\"col_i32\" INTEGER"));
+        assert!(sql.contains("\"col_i64\" BIGINT"));
+        assert!(sql.contains("\"col_f32\" REAL"));
+        assert!(sql.contains("\"col_f64\" DOUBLE"));
+        assert!(sql.contains("\"col_decimal\" DECIMAL(18,4)"));
+        assert!(sql.contains("\"col_text\" TEXT"));
+        assert!(sql.contains("\"col_binary\" BYTEA"));
+        assert!(sql.contains("\"col_date\" DATE"));
+        assert!(sql.contains("\"col_ts\" TIMESTAMP"));
+        assert!(sql.contains("\"col_tstz\" TIMESTAMPTZ"));
+    }
+
+    #[test]
+    fn test_arrow_schema_to_create_table_not_null() {
+        let schema = Schema::new(vec![
+            Field::new("required", DataType::Int32, false),
+            Field::new("optional", DataType::Int32, true),
+        ]);
+        let path = TableReference::bare("t");
+        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        assert!(sql.contains("\"required\" INTEGER NOT NULL"));
+        assert!(sql.contains("\"optional\" INTEGER"));
+        // "optional" should NOT contain "NOT NULL"
+        assert!(!sql.contains("\"optional\" INTEGER NOT NULL"));
+    }
+
+    #[test]
+    fn test_arrow_schema_to_create_table_list_types() {
+        let schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            true,
+        )]);
+        let path = TableReference::bare("t");
+        let sql = arrow_schema_to_create_table_sql(&path, &schema);
+        assert!(sql.contains("\"tags\" TEXT[]"));
+    }
+
+    // ── arrow_type_to_sql tests ──
+
+    #[test]
+    fn test_arrow_type_to_sql_utf8_variants() {
+        assert_eq!(arrow_type_to_sql(&DataType::Utf8), "TEXT");
+        assert_eq!(arrow_type_to_sql(&DataType::LargeUtf8), "TEXT");
+        assert_eq!(arrow_type_to_sql(&DataType::Utf8View), "TEXT");
+    }
+
+    #[test]
+    fn test_arrow_type_to_sql_decimal() {
+        assert_eq!(
+            arrow_type_to_sql(&DataType::Decimal128(10, 2)),
+            "DECIMAL(10,2)"
+        );
+        assert_eq!(
+            arrow_type_to_sql(&DataType::Decimal256(38, 0)),
+            "DECIMAL(38,0)"
+        );
+    }
+
+    #[test]
+    fn test_arrow_type_to_sql_timestamp_tz() {
+        assert_eq!(
+            arrow_type_to_sql(&DataType::Timestamp(TimeUnit::Microsecond, None)),
+            "TIMESTAMP"
+        );
+        assert_eq!(
+            arrow_type_to_sql(&DataType::Timestamp(
+                TimeUnit::Microsecond,
+                Some("UTC".into())
+            )),
+            "TIMESTAMPTZ"
+        );
+    }
+
+    // ── quote_identifier tests ──
+
+    #[test]
+    fn test_quote_identifier_simple() {
+        assert_eq!(quote_identifier("name"), r#""name""#);
+    }
+
+    #[test]
+    fn test_quote_identifier_with_quotes() {
+        assert_eq!(quote_identifier(r#"has"quote"#), r#""has""quote""#);
+    }
+
+    #[test]
+    fn test_quote_identifier_reserved_word() {
+        assert_eq!(quote_identifier("select"), r#""select""#);
+    }
 }


### PR DESCRIPTION
## Summary

Handle `table_definition_options` from FlightSQL `CommandStatementIngest` to auto-create tables in Cayenne catalogs during DoPut ingestion.

This enables the spicebench `staging_table` update strategy, which bulk-ingests update batches into a temporary staging table via ADBC `IngestMode::CreateAppend`, then executes `MERGE INTO target USING staging ...`. Previously, Spice's DoPut handler ignored the `table_definition_options` field and failed when the table didn't exist.

## Changes

### Milestone 1: Parse & propagate `table_definition_options`
- `DoPutTableOptions` struct extracts `if_not_exist`, `if_exists`, and `ingest_options` from `CommandStatementIngest`
- `create_like_table` option in `ingest_options` implies `Create + Append` semantics automatically
- Options propagated as `Option<DoPutTableOptions>` through the DoPut handler; `None` for non-ingest commands (behavior unchanged)

### Milestone 2: Auto-create in Cayenne catalogs
- `handle_table_definition_options()` — dispatches based on table existence:
  - Table doesn't exist + `if_not_exist=Create` → auto-create via DDL
  - Table doesn't exist + `if_not_exist=Fail` → error
  - Table exists + `if_exists=Fail` → error
  - Table exists + `if_exists=Replace` → DROP + CREATE
  - Table exists + `if_exists=Append` → no-op (normal write path)
- `auto_create_table()` — gates on `is_catalog_ddl_enabled` + `is_cayenne_catalog`, then executes DDL via `ctx.sql()` (reuses existing DDL pipeline including distributed forwarding to executors)
- `build_create_like_table_sql()` — for `create_like_table` option: copies schema + partition expression from the named source table

### Milestone 3: Arrow schema → SQL conversion
- `arrow_schema_to_create_table_sql()` — generates `CREATE TABLE IF NOT EXISTS` DDL from Arrow schema
- `arrow_type_to_sql()` — maps all common Arrow `DataType` variants to SQL types
- `quote_identifier()` — always-quote strategy for safe identifier handling

## Access control

Auto-create enforces the same gates as the existing Cayenne DDL path:
- `access: read_write` catalogs → DoPut appends work, but auto-create is rejected (DDL not allowed)
- `access: read_write_create` catalogs → DoPut auto-create works
- Non-Cayenne catalogs → auto-create rejected (unsupported)

## `create_like_table` option (distributed mode)

In distributed mode, staging tables need the same partition expression as the target table for DoPut routing and `MERGE INTO` partition compatibility. The `CommandStatementIngest.options` map carries a `create_like_table` key naming the target table. When present, the auto-created table copies the full definition (schema, partition expression) from the referenced table instead of using the incoming data schema.

## Tests

14 unit tests covering:
- `DoPutTableOptions` extraction (explicit options, defaults, `create_like` implication, `if_exists` preservation)
- Schema-to-SQL conversion (basic, all types, NOT NULL, list types)
- Type mapping (utf8 variants, decimal, timestamp/tz)
- Identifier quoting

## Related

Implements the DoPut auto-create portion of the staging table strategy for spicebench.