### PR TITLE
fix: Prevent data loss in MERGE when source has duplicate keys

### DIFF
--- a/crates/runtime/src/datafusion/planner/physical_execs.rs
+++ b/crates/runtime/src/datafusion/planner/physical_execs.rs
@@ -202,11 +202,19 @@ async fn execute_merge(
         .collect::<Result<Vec<_>, _>>()
         .map_err(DataFusionError::from)?;
 
-    // Step 2: Build deletion filters from the matched key values.
+    // Step 2: Validate no duplicate target keys in join output.
+    // Per SQL MERGE semantics, each target row must match at most one source row.
+    // If source has duplicate keys, the INNER JOIN produces multiple output rows
+    // per target row. We must detect this *before* any mutations — otherwise the
+    // delete would commit (removing the target row) but the count verification
+    // would fail, leaving permanently missing rows.
+    validate_no_duplicate_target_keys(&normalized_batches, &target_key_columns)?;
+
+    // Step 3: Build deletion filters from the matched key values.
     // Uses tuple-aware OR-of-ANDs to avoid cross-product matches with composite keys.
     let delete_filters = build_delete_filters(&normalized_batches, &target_key_columns)?;
 
-    // Step 3: Delete matched rows from the target.
+    // Step 4: Delete matched rows from the target.
     let delete_plan = target_provider
         .delete_from(&session_state, delete_filters)
         .await?;
@@ -221,7 +229,7 @@ async fn execute_merge(
         )));
     }
 
-    // Step 4: Insert updated rows into the target.
+    // Step 5: Insert updated rows into the target.
     let input_exec = MemorySourceConfig::try_new_exec(&[normalized_batches], target_schema, None)?;
     let insert_plan = target_provider
         .insert_into(&session_state, input_exec, InsertOp::Append)
@@ -237,7 +245,7 @@ async fn execute_merge(
         )));
     }
 
-    // Step 5: Return the count of updated rows.
+    // Step 6: Return the count of updated rows.
     Ok(RecordBatch::try_from_iter_with_nullable(vec![(
         "count",
         Arc::new(UInt64Array::from(vec![total_rows as u64])) as ArrayRef,
@@ -260,6 +268,67 @@ fn extract_dml_count(batches: &[RecordBatch]) -> u64 {
                 .flatten()
         })
         .sum()
+}
+
+/// Validate that the join output contains no duplicate target key tuples.
+///
+/// Per SQL MERGE semantics, each target row must match at most one source row.
+/// If the source has duplicate keys, the INNER JOIN produces multiple output
+/// rows per target row. This check runs *before* any mutations to prevent
+/// the scenario where delete commits (removing target rows) but the subsequent
+/// count verification fails, leaving permanently missing rows.
+fn validate_no_duplicate_target_keys(
+    batches: &[RecordBatch],
+    key_columns: &[String],
+) -> Result<(), DataFusionError> {
+    use std::collections::HashSet;
+
+    let mut seen = HashSet::new();
+    for batch in batches {
+        // Resolve column indices for this batch.
+        let col_indices: Vec<usize> = key_columns
+            .iter()
+            .map(|key_col| {
+                batch.schema().index_of(key_col).map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Key column '{key_col}' not found in join output: {e}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for row_idx in 0..batch.num_rows() {
+            // Build a composite key as a Vec<ScalarValue> for hashing.
+            let key: Vec<datafusion::common::ScalarValue> = col_indices
+                .iter()
+                .map(|&idx| {
+                    datafusion::common::ScalarValue::try_from_array(batch.column(idx), row_idx)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            if !seen.insert(key) {
+                let dup_display: Vec<String> = key_columns
+                    .iter()
+                    .zip(&col_indices)
+                    .map(|(name, &idx)| {
+                        let val = datafusion::common::ScalarValue::try_from_array(
+                            batch.column(idx),
+                            row_idx,
+                        )
+                        .map_or_else(|_| "?".to_string(), |v| v.to_string());
+                        format!("{name}={val}")
+                    })
+                    .collect();
+                return Err(DataFusionError::Execution(format!(
+                    "MERGE source has duplicate rows matching target key ({}). \
+                     Per SQL MERGE semantics, each target row must match at most one source row. \
+                     Deduplicate the source table before running MERGE.",
+                    dup_display.join(", ")
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Build deletion filter expressions from matched key column values.

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -1714,3 +1714,117 @@ async fn cayenne_catalog_merge_composite_key_no_cross_product() -> Result<(), St
         })
         .await
 }
+
+// =============================================================================
+// Test: MERGE INTO — duplicate source keys must error without losing target rows
+// =============================================================================
+
+#[tokio::test]
+async fn cayenne_catalog_merge_duplicate_source_keys_rejected() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "cat_dupkey",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_merge_dup_key")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA cat_dupkey.s").await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_dupkey.s.target (
+                    id BIGINT NOT NULL,
+                    val BIGINT NOT NULL
+                ) PARTITION BY id",
+            )
+            .await?;
+
+            exec(
+                &rt,
+                "CREATE TABLE cat_dupkey.s.source (
+                    id BIGINT NOT NULL,
+                    val BIGINT NOT NULL
+                ) PARTITION BY id",
+            )
+            .await?;
+
+            // Insert one row into target.
+            exec(&rt, "INSERT INTO cat_dupkey.s.target VALUES (1, 100)").await?;
+
+            // Insert TWO rows with the same key into source — this is the
+            // duplicate key scenario that must not cause data loss.
+            exec(
+                &rt,
+                "INSERT INTO cat_dupkey.s.source VALUES (1, 200), (1, 300)",
+            )
+            .await?;
+
+            // MERGE should error because source has duplicate keys for the
+            // matched target row.
+            let merge_result = run_query(
+                &rt,
+                "MERGE INTO cat_dupkey.s.target AS t
+                 USING cat_dupkey.s.source AS s
+                 ON t.id = s.id
+                 WHEN MATCHED THEN UPDATE SET val = s.val",
+            )
+            .await;
+            assert!(
+                merge_result.is_err(),
+                "MERGE with duplicate source keys should fail, got: {merge_result:?}"
+            );
+            let err_msg = merge_result.unwrap_err();
+            assert!(
+                err_msg.contains("duplicate"),
+                "Error should mention duplicate keys, got: {err_msg}"
+            );
+
+            // Verify the target table is UNCHANGED — the row must not be lost.
+            let count = query_scalar_i64(&rt, "SELECT COUNT(*) FROM cat_dupkey.s.target").await?;
+            assert_eq!(count, 1, "Target must still have 1 row after failed MERGE");
+
+            let batches = run_query(&rt, "SELECT id, val FROM cat_dupkey.s.target").await?;
+            assert_batches_eq!(
+                [
+                    "+----+-----+",
+                    "| id | val |",
+                    "+----+-----+",
+                    "| 1  | 100 |",
+                    "+----+-----+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
## Summary
- MERGE INTO uses a non-atomic delete+insert pattern. When the source has duplicate keys matching a target row, the delete commits first, then the count check fails — permanently losing the target row.
- Adds `validate_no_duplicate_target_keys()` before any mutations to detect duplicate key tuples in the join output and fail cleanly without side effects.
- Adds regression test `cayenne_catalog_merge_duplicate_source_keys_rejected` that verifies: (a) the MERGE errors with a clear message, and (b) the target table is unchanged after the failed MERGE.

## Test plan
- [x] Added regression test in `crates/runtime/tests/cayenne_catalog_ddl/mod.rs`
- [x] All 5 existing MERGE tests pass (`cargo test -p runtime --test integration cayenne_catalog_merge`)
- [x] `cargo clippy -p runtime --lib` passes (no new warnings)
- [x] `cargo check -p runtime` passes
- Performance impact: negligible — adds a single HashSet scan over join output rows before the existing delete+insert steps