### PR TITLE
fix: collapse nested if to satisfy clippy collapsible_if lint

### DIFF
--- a/crates/dataformat-json/src/file_format.rs
+++ b/crates/dataformat-json/src/file_format.rs
@@ -671,18 +671,17 @@ fn infer_json_schema_for_format(
         // ValueIter cannot parse. serde_json::from_slice rejects input with
         // trailing non-whitespace content, so NDJSON files will fail here and
         // fall through to ValueIter.
-        if matches!(format, Format::Auto | Format::Json) {
-            if let Ok(value) = serde_json::from_slice::<serde_json::Value>(buf) {
-                if value.is_object() {
-                    take_while();
-                    return Ok(infer_json_schema_from_iterator(std::iter::once(Ok::<
-                        _,
-                        ArrowError,
-                    >(
-                        value
-                    )))?);
-                }
-            }
+        if matches!(format, Format::Auto | Format::Json)
+            && let Ok(value) = serde_json::from_slice::<serde_json::Value>(buf)
+            && value.is_object()
+        {
+            take_while();
+            return Ok(infer_json_schema_from_iterator(std::iter::once(Ok::<
+                _,
+                ArrowError,
+            >(
+                value,
+            )))?);
         }
 
         // NDJSON: use line-based ValueIter

--- a/crates/dataformat-json/src/file_format.rs
+++ b/crates/dataformat-json/src/file_format.rs
@@ -680,7 +680,7 @@ fn infer_json_schema_for_format(
                 _,
                 ArrowError,
             >(
-                value,
+                value
             )))?);
         }
 


### PR DESCRIPTION
## Summary

- Collapse three nested `if` conditions in `infer_json_schema_for_format` into a single `if` with `let` chains, fixing `clippy::collapsible_if` warnings from Rust 1.93's stricter linting

## Test plan

- `cargo clippy -p dataformat-json -- -D warnings` passes locally
- CI lint check passes