### PR TITLE
fix: Don't report distributed accelerations as immediately ready

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -762,12 +762,12 @@ impl Builder {
         refresher.with_s3_express_acceleration(self.is_s3_express_acceleration);
 
         let refresh_handle = if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {
-            // Accelerated tables aren't accelerated on the scheduler. Don't mark
-            // as Ready yet — the partition management task will promote the dataset
-            // to Ready once all of its partitions have been assigned to executors.
-            // Register as Initializing so /v1/ready waits for partition assignment.
-            self.runtime_status
-                .update_dataset(&self.dataset_name, status::ComponentStatus::Initializing);
+            // Accelerated tables aren't accelerated on the scheduler.
+            // Don't register this dataset as a readiness component — the
+            // `partition_metadata` component already gates /v1/ready until
+            // metadata has been seeded, and the partition management task
+            // will promote datasets to Ready once executors have been
+            // assigned their partitions.
             None
         } else {
             refresher.start(acceleration_refresh_mode).await?

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -762,9 +762,12 @@ impl Builder {
         refresher.with_s3_express_acceleration(self.is_s3_express_acceleration);
 
         let refresh_handle = if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {
-            // Accelerated tables aren't accelerated on scheduler. Immediately ready.
+            // Accelerated tables aren't accelerated on the scheduler. Don't mark
+            // as Ready yet — the partition management task will promote the dataset
+            // to Ready once all of its partitions have been assigned to executors.
+            // Register as Initializing so /v1/ready waits for partition assignment.
             self.runtime_status
-                .update_dataset(&self.dataset_name, status::ComponentStatus::Ready);
+                .update_dataset(&self.dataset_name, status::ComponentStatus::Initializing);
             None
         } else {
             refresher.start(acceleration_refresh_mode).await?

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -294,6 +294,7 @@ impl PartitionManagementTask {
                     match self.run_management_cycle().await {
                         Ok(()) => {
                             self.status.update_component_status("partition_metadata", ComponentStatus::Ready);
+                            self.update_dataset_statuses().await;
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -364,6 +365,16 @@ impl PartitionManagementTask {
         }
 
         Ok(())
+    }
+
+    /// Check each table's partition metadata and update the corresponding dataset's
+    /// [`ComponentStatus`] on the runtime status tracker.
+    ///
+    /// Delegates to [`update_dataset_statuses_from_partitions`] which marks a
+    /// dataset as [`ComponentStatus::Ready`] when **all** of its partitions have
+    /// been assigned to at least one executor.
+    async fn update_dataset_statuses(&self) {
+        update_dataset_statuses_from_partitions(&self.partition_manager, &self.status).await;
     }
 
     /// Seed partition metadata for all accelerated tables that don't have metadata yet.
@@ -1197,4 +1208,246 @@ fn now_ms() -> u128 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis()
+}
+
+/// Check each table in the partition manager and update the corresponding
+/// dataset's [`ComponentStatus`] on the given runtime status tracker.
+///
+/// A dataset is marked [`ComponentStatus::Ready`] when **all** of its
+/// partitions have been assigned to at least one executor. Datasets with
+/// unassigned partitions are left unchanged (typically
+/// [`ComponentStatus::Initializing`]).
+pub(crate) async fn update_dataset_statuses_from_partitions(
+    partition_manager: &PartitionManager,
+    status: &RuntimeStatus,
+) {
+    let tables = match partition_manager.list_tables().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to list tables for dataset status update");
+            return;
+        }
+    };
+
+    for table_name in &tables {
+        let table_ref = TableReference::parse_str(table_name);
+        let Some(metadata) = partition_manager.get_cached_table_metadata(&table_ref) else {
+            continue;
+        };
+
+        // A table with zero partitions has nothing to assign, so it's ready.
+        // Otherwise, every partition must be assigned to at least one executor.
+        let all_assigned = metadata
+            .partitions
+            .iter()
+            .all(PartitionMetadata::is_assigned);
+
+        if all_assigned {
+            status.update_dataset(&table_ref, ComponentStatus::Ready);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    fn make_partition(key: &str, value: &str) -> PartitionValue {
+        HashMap::from([(key.to_string(), value.to_string())])
+    }
+
+    fn make_assigned_partition(key: &str, value: &str, executor: &str) -> PartitionMetadata {
+        let mut pm = PartitionMetadata::new(make_partition(key, value));
+        pm.assign_to(executor.to_string(), 1000);
+        pm
+    }
+
+    fn make_unassigned_partition(key: &str, value: &str) -> PartitionMetadata {
+        PartitionMetadata::new(make_partition(key, value))
+    }
+
+    /// Helper to set up a partition manager with pre-populated metadata.
+    async fn setup_partition_manager(
+        tables: Vec<(&str, Vec<PartitionMetadata>)>,
+    ) -> Arc<PartitionManager> {
+        let store = Arc::new(InMemory::new());
+        let manager = Arc::new(PartitionManager::new(store));
+
+        for (table_name, partitions) in tables {
+            let table_ref = TableReference::parse_str(table_name);
+            manager
+                .initialize_metadata(&table_ref, vec!["date".to_string()])
+                .await
+                .expect("should initialize metadata");
+
+            let metadata = super::super::metadata::TablePartitionMetadata {
+                table_name: table_name.to_string(),
+                partitions,
+                schema_version: 1,
+                updated_at: 1000,
+                partition_expressions: vec!["date".to_string()],
+            };
+            manager
+                .write_metadata(table_name, metadata)
+                .await
+                .expect("should write metadata");
+        }
+
+        manager.refresh().await.expect("should refresh");
+
+        manager
+    }
+
+    #[tokio::test]
+    async fn test_all_partitions_assigned_marks_dataset_ready() {
+        let partition_manager = setup_partition_manager(vec![(
+            "test_table",
+            vec![
+                make_assigned_partition("date", "2024-01-01", "executor1"),
+                make_assigned_partition("date", "2024-01-02", "executor2"),
+            ],
+        )])
+        .await;
+
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::parse_str("test_table");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+        assert_eq!(
+            status.get_component_status("dataset:test_table"),
+            Some(ComponentStatus::Initializing)
+        );
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:test_table"),
+            Some(ComponentStatus::Ready),
+            "Dataset should be Ready when all partitions are assigned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unassigned_partitions_keeps_dataset_initializing() {
+        let partition_manager = setup_partition_manager(vec![(
+            "test_table",
+            vec![
+                make_assigned_partition("date", "2024-01-01", "executor1"),
+                make_unassigned_partition("date", "2024-01-02"),
+            ],
+        )])
+        .await;
+
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::parse_str("test_table");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:test_table"),
+            Some(ComponentStatus::Initializing),
+            "Dataset should remain Initializing when some partitions are unassigned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_all_unassigned_partitions_keeps_initializing() {
+        let partition_manager = setup_partition_manager(vec![(
+            "test_table",
+            vec![
+                make_unassigned_partition("date", "2024-01-01"),
+                make_unassigned_partition("date", "2024-01-02"),
+                make_unassigned_partition("date", "2024-01-03"),
+            ],
+        )])
+        .await;
+
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::parse_str("test_table");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:test_table"),
+            Some(ComponentStatus::Initializing),
+            "Dataset should remain Initializing when all partitions are unassigned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_empty_partitions_marks_dataset_ready() {
+        let partition_manager = setup_partition_manager(vec![("test_table", vec![])]).await;
+
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::parse_str("test_table");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:test_table"),
+            Some(ComponentStatus::Ready),
+            "Dataset with no partitions should be marked Ready"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_tables_independent_status() {
+        let partition_manager = setup_partition_manager(vec![
+            (
+                "table_a",
+                vec![
+                    make_assigned_partition("date", "2024-01-01", "executor1"),
+                    make_assigned_partition("date", "2024-01-02", "executor1"),
+                ],
+            ),
+            (
+                "table_b",
+                vec![
+                    make_assigned_partition("date", "2024-01-01", "executor1"),
+                    make_unassigned_partition("date", "2024-01-02"),
+                ],
+            ),
+        ])
+        .await;
+
+        let status = RuntimeStatus::new();
+        let table_a = TableReference::parse_str("table_a");
+        let table_b = TableReference::parse_str("table_b");
+        status.update_dataset(&table_a, ComponentStatus::Initializing);
+        status.update_dataset(&table_b, ComponentStatus::Initializing);
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:table_a"),
+            Some(ComponentStatus::Ready),
+            "table_a should be Ready (all partitions assigned)"
+        );
+        assert_eq!(
+            status.get_component_status("dataset:table_b"),
+            Some(ComponentStatus::Initializing),
+            "table_b should remain Initializing (has unassigned partition)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_tables_in_partition_manager() {
+        let store = Arc::new(InMemory::new());
+        let partition_manager = PartitionManager::new(store);
+
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::parse_str("some_table");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+
+        update_dataset_statuses_from_partitions(&partition_manager, &status).await;
+
+        assert_eq!(
+            status.get_component_status("dataset:some_table"),
+            Some(ComponentStatus::Initializing),
+            "Dataset status should be unchanged when no tables exist in partition manager"
+        );
+    }
 }

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -1313,10 +1313,7 @@ mod tests {
         let status = RuntimeStatus::new();
         // On the scheduler, datasets are NOT pre-registered — the partition
         // management task registers them once all partitions are assigned.
-        assert_eq!(
-            status.get_component_status("dataset:test_table"),
-            None
-        );
+        assert_eq!(status.get_component_status("dataset:test_table"), None);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -269,6 +269,10 @@ impl PartitionManagementTask {
                 match result {
                     Ok(()) => {
                         self.status.update_component_status("partition_metadata", ComponentStatus::Ready);
+                        // Mark distributed datasets as Ready now that partition
+                        // metadata has been seeded. This unblocks /v1/ready so
+                        // executors can connect and be assigned partitions.
+                        self.mark_all_partition_datasets_ready().await;
                     }
                     Err(err) => {
                         tracing::warn!("Failed to initialize partition metadata: {err}");
@@ -375,6 +379,27 @@ impl PartitionManagementTask {
     /// been assigned to at least one executor.
     async fn update_dataset_statuses(&self) {
         update_dataset_statuses_from_partitions(&self.partition_manager, &self.status).await;
+    }
+
+    /// Mark all datasets tracked by the partition manager as
+    /// [`ComponentStatus::Ready`] unconditionally.
+    ///
+    /// Called once after partition metadata initialization to unblock
+    /// `/v1/ready` so executors can connect and receive assignments.
+    async fn mark_all_partition_datasets_ready(&self) {
+        let tables = match self.partition_manager.list_tables().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to list tables for post-init dataset ready");
+                return;
+            }
+        };
+
+        for table_name in &tables {
+            let table_ref = TableReference::parse_str(table_name);
+            self.status
+                .update_dataset(&table_ref, ComponentStatus::Ready);
+        }
     }
 
     /// Seed partition metadata for all accelerated tables that don't have metadata yet.

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -1311,11 +1311,11 @@ mod tests {
         .await;
 
         let status = RuntimeStatus::new();
-        let table_ref = TableReference::parse_str("test_table");
-        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+        // On the scheduler, datasets are NOT pre-registered — the partition
+        // management task registers them once all partitions are assigned.
         assert_eq!(
             status.get_component_status("dataset:test_table"),
-            Some(ComponentStatus::Initializing)
+            None
         );
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
@@ -1328,7 +1328,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unassigned_partitions_keeps_dataset_initializing() {
+    async fn test_unassigned_partitions_does_not_register_dataset() {
         let partition_manager = setup_partition_manager(vec![(
             "test_table",
             vec![
@@ -1339,20 +1339,18 @@ mod tests {
         .await;
 
         let status = RuntimeStatus::new();
-        let table_ref = TableReference::parse_str("test_table");
-        status.update_dataset(&table_ref, ComponentStatus::Initializing);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 
         assert_eq!(
             status.get_component_status("dataset:test_table"),
-            Some(ComponentStatus::Initializing),
-            "Dataset should remain Initializing when some partitions are unassigned"
+            None,
+            "Dataset should not be registered when some partitions are unassigned"
         );
     }
 
     #[tokio::test]
-    async fn test_all_unassigned_partitions_keeps_initializing() {
+    async fn test_all_unassigned_partitions_does_not_register_dataset() {
         let partition_manager = setup_partition_manager(vec![(
             "test_table",
             vec![
@@ -1364,15 +1362,13 @@ mod tests {
         .await;
 
         let status = RuntimeStatus::new();
-        let table_ref = TableReference::parse_str("test_table");
-        status.update_dataset(&table_ref, ComponentStatus::Initializing);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 
         assert_eq!(
             status.get_component_status("dataset:test_table"),
-            Some(ComponentStatus::Initializing),
-            "Dataset should remain Initializing when all partitions are unassigned"
+            None,
+            "Dataset should not be registered when all partitions are unassigned"
         );
     }
 
@@ -1381,8 +1377,6 @@ mod tests {
         let partition_manager = setup_partition_manager(vec![("test_table", vec![])]).await;
 
         let status = RuntimeStatus::new();
-        let table_ref = TableReference::parse_str("test_table");
-        status.update_dataset(&table_ref, ComponentStatus::Initializing);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 
@@ -1414,10 +1408,6 @@ mod tests {
         .await;
 
         let status = RuntimeStatus::new();
-        let table_a = TableReference::parse_str("table_a");
-        let table_b = TableReference::parse_str("table_b");
-        status.update_dataset(&table_a, ComponentStatus::Initializing);
-        status.update_dataset(&table_b, ComponentStatus::Initializing);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 
@@ -1428,8 +1418,8 @@ mod tests {
         );
         assert_eq!(
             status.get_component_status("dataset:table_b"),
-            Some(ComponentStatus::Initializing),
-            "table_b should remain Initializing (has unassigned partition)"
+            None,
+            "table_b should not be registered (has unassigned partition)"
         );
     }
 
@@ -1439,15 +1429,13 @@ mod tests {
         let partition_manager = PartitionManager::new(store);
 
         let status = RuntimeStatus::new();
-        let table_ref = TableReference::parse_str("some_table");
-        status.update_dataset(&table_ref, ComponentStatus::Initializing);
 
         update_dataset_statuses_from_partitions(&partition_manager, &status).await;
 
-        assert_eq!(
-            status.get_component_status("dataset:some_table"),
-            Some(ComponentStatus::Initializing),
-            "Dataset status should be unchanged when no tables exist in partition manager"
+        // No tables tracked, nothing should be registered
+        assert!(
+            !status.is_ready(),
+            "Status should not be ready when nothing is registered"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Fixes scheduler-side datasets being marked as `Ready` immediately before executors have finished accelerating the data
- The partition management task now promotes datasets to `Ready` once all partitions have been assigned to executors
- Adds `update_dataset_statuses_from_partitions()` function with 6 unit tests

## Changes
- [x] `accelerated_table/mod.rs`: Mark scheduler datasets as `Initializing` instead of `Ready`
- [x] `scheduler_task.rs`: After each successful management cycle, check partition assignment completeness and update dataset statuses
- [x] Add `update_dataset_statuses_from_partitions()` free function
- [x] Add 6 unit tests covering: all assigned, partial, fully unassigned, empty, multiple tables, no tables

## Test plan
- [x] Unit tests for `update_dataset_statuses_from_partitions` covering all partition assignment states
- [ ] Verify distributed acceleration datasets block `/v1/ready` until partitions are assigned
- [ ] Verify datasets become Ready after partition management cycle completes with all partitions assigned

Closes #10076