### PR TITLE
feat: Add ClickHouse Date32 type support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 [[package]]
 name = "clickhouse-rs"
 version = "1.1.0-alpha.1"
-source = "git+https://github.com/spiceai/clickhouse-rs.git?tag=0.2.1#81a652c7c3dc4aff9097c30ece821393f089e3b5"
+source = "git+https://github.com/spiceai/clickhouse-rs.git?tag=0.2.2#7e98394f44cfa33919ebc5a92c06d5bddba708bf"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-rs-cityhash-sys"
 version = "0.1.2"
-source = "git+https://github.com/spiceai/clickhouse-rs.git?tag=0.2.1#81a652c7c3dc4aff9097c30ece821393f089e3b5"
+source = "git+https://github.com/spiceai/clickhouse-rs.git?tag=0.2.2#7e98394f44cfa33919ebc5a92c06d5bddba708bf"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ candle-transformers = { git = "https://github.com/spiceai/candle.git", rev = "af
 charset = "0.1.5"
 chrono = "0.4.44"
 clap = { version = "4.5.60", features = ["derive", "env"] }
-clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0.2.1", features = [
+clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0.2.2", features = [
     "tokio_io",
     "tls",
 ] }

--- a/crates/db_connection_pool/src/dbconnection/clickhouseconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/clickhouseconn.rs
@@ -265,7 +265,7 @@ fn map_clickhouse_type_to_arrow(type_str: &str) -> Result<DataType, clickhouse_r
         "Float32" => Ok(DataType::Float32),
         "Float64" => Ok(DataType::Float64),
         s if s.starts_with("FixedString") => Ok(DataType::Utf8),
-        "Date" => Ok(DataType::Date32),
+        "Date" | "Date32" => Ok(DataType::Date32),
         "DateTime" => Ok(DataType::Timestamp(TimeUnit::Second, None)),
         s if s.starts_with("Decimal") => {
             let parts: Vec<&str> = s
@@ -328,6 +328,8 @@ mod tests {
             ("String", DataType::Utf8),
             ("FixedString(10)", DataType::Utf8),
             ("Date", DataType::Date32),
+            ("Date32", DataType::Date32),
+            ("Nullable(Date32)", DataType::Date32),
             ("DateTime", DataType::Timestamp(TimeUnit::Second, None)),
             ("Decimal(18, 4)", DataType::Decimal128(18, 4)),
             ("Decimal(18)", DataType::Decimal128(18, 0)),


### PR DESCRIPTION
## Problem

The ClickHouse connector fails to load datasets that contain `Date32` columns with:

```
WARN runtime::init::dataset: Failed to load the dataset orders (clickhouse). Unable to construct SQL table: Unable to get schema: Other error: `Unsupported Clickhouse type: Date32`
```

This affects TPC-H benchmark tables (`orders`, `lineitem`) in the `sandbox-clickhouse-benchmark` application where ClickHouse uses `Date32` instead of `Date` for date columns.

## Solution

### clickhouse-rs fork (`spiceai/clickhouse-rs` tag `0.2.2`)
- Added `Value::Date32(i32)` and `ValueRef::Date32(i32)` enum variants for the ClickHouse `Date32` wire type (signed 32-bit days since epoch, range 1900-01-01 to 2299-12-31)
- Implemented `DateConverter for i32` to handle `Date32` column reading via `DateColumnData<i32>`
- Added `"Date32"` to the column factory for wire protocol parsing
- Extended `FromSql for NaiveDate` to handle `ValueRef::Date32`

### spiceai/spiceai (this PR)
- Updated `clickhouse-rs` dependency to tag `0.2.2`
- Added `"Date32"` → `DataType::Date32` mapping in the schema type resolution
- Added test coverage for `Date32` and `Nullable(Date32)` type mapping

## Testing
- All `db_connection_pool` clickhouse unit tests pass
- All `arrow_sql_gen` clickhouse unit tests pass
- `clickhouse-rs` fork unit tests pass