### PR TITLE
fix: add CatalogMode::Cayenne guard to INSERT in unified planner

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -328,6 +328,21 @@ impl Caching {
         }
         Ok(())
     }
+
+    /// Drains Moka's deferred predicate-invalidation queue for all sub-caches.
+    /// `invalidate_for_table` uses `invalidate_entries_if` which schedules invalidations lazily;
+    /// calling this method ensures they are applied before the next cache read.
+    pub async fn flush_pending_invalidations(&self) {
+        if let Some(ref results_cache) = self.results {
+            results_cache.checkpoint().await;
+        }
+        if let Some(ref plans_cache) = self.plans {
+            plans_cache.checkpoint().await;
+        }
+        if let Some(ref search_cache) = self.search {
+            search_cache.checkpoint().await;
+        }
+    }
 }
 
 // TODO: sunset ``QueryResultsCacheProvider`` in favor of ``CacheProvider``?
@@ -481,6 +496,13 @@ impl QueryResultsCacheProvider {
     #[must_use]
     pub async fn item_count(&self) -> u64 {
         self.cache.item_count().await
+    }
+
+    /// Drains Moka's deferred predicate-invalidation queue.
+    /// `invalidate_for_table` uses `invalidate_entries_if` which schedules invalidations lazily;
+    /// calling this method ensures they are applied before the next cache read.
+    pub async fn checkpoint(&self) {
+        self.cache.checkpoint().await;
     }
 
     /// Returns the base TTL for cache entries (used for staleness checks).

--- a/crates/cayenne/benches/deletion_strategies.rs
+++ b/crates/cayenne/benches/deletion_strategies.rs
@@ -36,6 +36,7 @@ use cayenne::{
     metadata::CreateTableOptions, CayenneCatalog, CayenneTableProvider, MetadataCatalog,
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -185,8 +186,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) {
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> u64 {
     let ctx = SessionContext::new();
-    let plan = table
-        .delete_from(&ctx.state(), vec![filter])
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
         .await
         .expect("delete");
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx())

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1316,6 +1316,18 @@ impl CayenneTableProvider {
             )
             .await?;
 
+        // Defensively invalidate the list-files cache for the newly created protected snapshot
+        // directory. Although the new UUID-based URL should have no prior cache entry, any
+        // in-flight DataFusion plan that happened to list this directory during the write
+        // (e.g. via insert_into planning) could have cached a stale (empty or partial) listing.
+        // Clearing it here ensures scan_protected_snapshots() always sees the complete file set.
+        let new_snapshot_url = Self::snapshot_dir_url(
+            &self.table_metadata.path,
+            &self.table_metadata.table_id,
+            &new_snapshot_id,
+        );
+        Self::invalidate_list_files_cache(self.context.runtime_env(), &new_snapshot_url);
+
         // Get the maximum delete sequence from current deletions.
         // This snapshot is protected from deletions with seq <= max_delete_seq.
         let max_delete_seq = self.get_max_delete_sequence()?;

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -37,7 +37,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_row::{OwnedRow, RowConverter, SortField};
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use data_components::delete::DeletionExec;
+use data_components::delete::{DeletionExec, DeletionTableProvider};
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
@@ -4093,74 +4093,26 @@ impl TableProvider for CayenneTableProvider {
 
         Ok(Arc::new(DataSinkExec::new(input, sink, None)))
     }
+}
 
+// Implement DeletionTableProvider for Cayenne
+#[async_trait]
+impl DeletionTableProvider for CayenneTableProvider {
     async fn delete_from(
         &self,
         _state: &dyn Session,
-        filters: Vec<Expr>,
+        filters: &[Expr],
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        if self.file_based_deletes_preferred(&filters) {
+        if self.file_based_deletes_preferred(filters) {
             tracing::debug!(
                 "Table '{}': using file-based retention delete path",
                 self.table_metadata.table_name,
             );
-            return self.delete_using_files(&filters);
+            return self.delete_using_files(filters);
         }
 
         // Default path: deletion vectors via CayenneDeletionSink
-        self.delete_using_deletion_vectors(&filters)
-    }
-
-    async fn update(
-        &self,
-        state: &dyn Session,
-        assignments: Vec<(String, Expr)>,
-        filters: Vec<Expr>,
-    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        let schema = self.schema();
-        let table_source = Arc::new(datafusion::datasource::DefaultTableSource::new(Arc::new(
-            self.clone_for_write(),
-        )));
-        let mut plan =
-            datafusion_expr::LogicalPlanBuilder::scan("__update_source", table_source, None)?
-                .build()?;
-
-        if let Some(combined) = filters.clone().into_iter().reduce(Expr::and) {
-            plan = datafusion_expr::LogicalPlanBuilder::from(plan)
-                .filter(combined)?
-                .build()?;
-        }
-
-        let mut proj_exprs = Vec::new();
-        for field in schema.fields() {
-            let col_name = field.name();
-            if let Some((_, expr)) = assignments.iter().find(|(name, _)| name == col_name) {
-                proj_exprs.push(expr.clone().alias(col_name));
-            } else {
-                proj_exprs.push(datafusion_expr::col(col_name));
-            }
-        }
-        plan = datafusion_expr::LogicalPlanBuilder::from(plan)
-            .project(proj_exprs)?
-            .build()?;
-
-        let source_plan = state.create_physical_plan(&plan).await?;
-        let session_state = state
-            .as_any()
-            .downcast_ref::<datafusion::execution::SessionState>()
-            .ok_or_else(|| {
-                datafusion_common::DataFusionError::Internal(
-                    "Session is not a SessionState".to_string(),
-                )
-            })?
-            .clone();
-
-        Ok(Arc::new(data_components::update::UpdateExec::new(
-            source_plan,
-            Arc::new(self.clone_for_write()),
-            session_state,
-            filters,
-        )))
+        self.delete_using_deletion_vectors(filters)
     }
 }
 
@@ -4190,8 +4142,8 @@ impl CayenneTableProvider {
             Some(self.build_protected_snapshot_listing_tables()?)
         };
 
-        Ok(Arc::new(DeletionExec::new(Arc::new(
-            FileBasedDeletionSink::new(
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(FileBasedDeletionSink::new(
                 Arc::clone(&self.listing_table),
                 protected_snapshot_tables,
                 filter.clone(),
@@ -4202,8 +4154,9 @@ impl CayenneTableProvider {
                 self.table_metadata.path.clone(),
                 Arc::clone(self.context.runtime_env()),
                 Arc::clone(&self.write_lock),
-            ),
-        ))))
+            )),
+            &self.table_metadata.schema,
+        )))
     }
 
     /// Main deletion-vector path via [`CayenneDeletionSink`].
@@ -4217,8 +4170,8 @@ impl CayenneTableProvider {
             .map(|(_, table)| table)
             .collect();
 
-        Ok(Arc::new(DeletionExec::new(Arc::new(
-            CayenneDeletionSink::new(
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(CayenneDeletionSink::new(
                 self.table_metadata.clone(),
                 Arc::clone(&self.catalog),
                 Arc::clone(&self.listing_table),
@@ -4230,8 +4183,9 @@ impl CayenneTableProvider {
                 snapshot_tables,
                 Arc::clone(self.context.runtime_env()),
                 Some(Arc::clone(&self.write_lock)),
-            ),
-        ))))
+            )),
+            &self.table_metadata.schema,
+        )))
     }
 
     /// Build listing tables for all protected snapshots.

--- a/crates/cayenne/tests/acid_compliance_test.rs
+++ b/crates/cayenne/tests/acid_compliance_test.rs
@@ -45,6 +45,8 @@ use cayenne::{
 
 use common::TestFixture;
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -173,7 +175,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/deletion_strategy_detection_test.rs
+++ b/crates/cayenne/tests/deletion_strategy_detection_test.rs
@@ -38,6 +38,8 @@ use cayenne::{
 
 use common::TestFixture;
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -97,7 +99,7 @@ async fn test_detects_int64_pk_strategy_impl(fixture: TestFixture) -> TestResult
 
     // Delete and verify it works correctly (Int64Pk strategy)
     let filter = col("id").eq(lit(2i64));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     let deleted = results
         .first()
@@ -175,7 +177,7 @@ async fn test_detects_rowconverter_strategy_for_string_pk_impl(
 
     // Delete and verify
     let filter = col("code").eq(lit("B"));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     let deleted = results
         .first()
@@ -254,7 +256,7 @@ async fn test_detects_rowconverter_strategy_for_composite_pk_impl(
 
     // Delete with composite key
     let filter = col("region").eq(lit("US")).and(col("id").eq(lit(1i64)));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     let deleted = results
         .first()
@@ -329,7 +331,7 @@ async fn test_detects_position_based_strategy_impl(fixture: TestFixture) -> Test
 
     // Delete by value (not PK)
     let filter = col("value").eq(lit(3i64));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     let deleted = results
         .first()
@@ -399,7 +401,7 @@ async fn test_int32_pk_uses_rowconverter_impl(fixture: TestFixture) -> TestResul
 
     // Delete and verify
     let filter = col("id").eq(lit(2i32));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     let deleted = results
         .first()
@@ -477,7 +479,7 @@ async fn test_strategy_persists_on_reopen_int64pk_impl(fixture: TestFixture) -> 
 
     // Delete a row
     let filter = col("id").eq(lit(3i64));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
 
     // Reopen table
@@ -490,7 +492,8 @@ async fn test_strategy_persists_on_reopen_int64pk_impl(fixture: TestFixture) -> 
 
     // Delete another row with reopened table
     let filter2 = col("id").eq(lit(5i64));
-    let plan2 = table2.delete_from(&ctx2.state(), vec![filter2]).await?;
+    let plan2 =
+        DeletionTableProvider::delete_from(table2.as_ref(), &ctx2.state(), &[filter2]).await?;
     datafusion_physical_plan::collect(plan2, ctx2.task_ctx()).await?;
 
     // Verify count
@@ -553,7 +556,7 @@ async fn test_strategy_persists_on_reopen_position_based_impl(
     // Delete
     let ctx = SessionContext::new();
     let filter = col("value").eq(lit(2i64));
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
 
     // Reopen and delete more
@@ -564,7 +567,8 @@ async fn test_strategy_persists_on_reopen_position_based_impl(
             .await?,
     );
     let filter2 = col("value").eq(lit(1i64));
-    let plan2 = table2.delete_from(&ctx2.state(), vec![filter2]).await?;
+    let plan2 =
+        DeletionTableProvider::delete_from(table2.as_ref(), &ctx2.state(), &[filter2]).await?;
     datafusion_physical_plan::collect(plan2, ctx2.task_ctx()).await?;
 
     ctx2.register_table(
@@ -688,19 +692,28 @@ async fn test_multiple_strategies_same_session_impl(fixture: TestFixture) -> Tes
     insert_batch(&table3, batch3).await?;
 
     // Delete from each table
-    let plan1 = table1
-        .delete_from(&ctx.state(), vec![col("id").eq(lit(1i64))])
-        .await?;
+    let plan1 = DeletionTableProvider::delete_from(
+        table1.as_ref(),
+        &ctx.state(),
+        &[col("id").eq(lit(1i64))],
+    )
+    .await?;
     datafusion_physical_plan::collect(plan1, ctx.task_ctx()).await?;
 
-    let plan2 = table2
-        .delete_from(&ctx.state(), vec![col("key").eq(lit("X"))])
-        .await?;
+    let plan2 = DeletionTableProvider::delete_from(
+        table2.as_ref(),
+        &ctx.state(),
+        &[col("key").eq(lit("X"))],
+    )
+    .await?;
     datafusion_physical_plan::collect(plan2, ctx.task_ctx()).await?;
 
-    let plan3 = table3
-        .delete_from(&ctx.state(), vec![col("amount").eq(lit(100i64))])
-        .await?;
+    let plan3 = DeletionTableProvider::delete_from(
+        table3.as_ref(),
+        &ctx.state(),
+        &[col("amount").eq(lit(100i64))],
+    )
+    .await?;
     datafusion_physical_plan::collect(plan3, ctx.task_ctx()).await?;
 
     // Verify each table

--- a/crates/cayenne/tests/deletion_strategy_test.rs
+++ b/crates/cayenne/tests/deletion_strategy_test.rs
@@ -42,6 +42,8 @@ use cayenne::{
     CayenneTableProviderBuilder, MetadataCatalog,
 };
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -66,7 +68,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/deletion_test.rs
+++ b/crates/cayenne/tests/deletion_test.rs
@@ -30,7 +30,8 @@ use cayenne::metadata::CreateTableOptions;
 
 use cayenne::{CayenneTableProvider, MetadataCatalog};
 
-use datafusion::datasource::TableProvider;
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::prelude::*;
 
 use datafusion_physical_plan::collect;
@@ -108,7 +109,8 @@ async fn test_delete_with_primary_key_impl(
     let filter = id_col.eq(lit(3i64));
 
     // Call delete_from directly on the table provider
-    let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
 
     // Execute the deletion plan
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
@@ -147,7 +149,8 @@ async fn test_delete_with_primary_key_impl(
     let id_col = col("id");
     let filter = id_col.clone().eq(lit(1i64)).or(id_col.eq(lit(5i64)));
 
-    let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
     let delete_count = delete_results[0]
         .column(0)
@@ -247,7 +250,8 @@ async fn test_delete_without_primary_key_impl(
     let category_col = col("category");
     let filter = category_col.eq(lit("A"));
 
-    let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
     let delete_count = delete_results[0]
         .column(0)
@@ -329,7 +333,7 @@ async fn test_delete_all_rows_impl(
     println!("✓ Inserted 3 rows");
 
     // 5. Delete all rows (empty filter means delete all)
-    let delete_plan = table.delete_from(&ctx.state(), vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[]).await?;
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
     let delete_count = delete_results[0]
         .column(0)
@@ -410,7 +414,8 @@ async fn test_delete_then_insert_impl(
     let id_col = col("id");
     let filter = id_col.eq(lit(2i64));
 
-    let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
     let delete_count = delete_results[0]
         .column(0)
@@ -531,7 +536,8 @@ async fn test_delete_with_complex_filter_impl(
         .and(value_col.gt(lit(100i64)))
         .and(active_col.eq(lit(false)));
 
-    let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let delete_results = collect(delete_plan, ctx.task_ctx()).await?;
     let delete_count = delete_results[0]
         .column(0)

--- a/crates/cayenne/tests/deletion_vector_bug_test.rs
+++ b/crates/cayenne/tests/deletion_vector_bug_test.rs
@@ -33,6 +33,8 @@ use cayenne::{
     metadata::CreateTableOptions, CayenneCatalog, CayenneTableProvider, MetadataCatalog,
 };
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -116,8 +118,7 @@ async fn delete_records(
     filter: Expr,
 ) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table_provider
-        .delete_from(&ctx.state(), vec![filter])
+    let plan = DeletionTableProvider::delete_from(table_provider.as_ref(), &ctx.state(), &[filter])
         .await?;
 
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;

--- a/crates/cayenne/tests/deletion_vector_integration_test.rs
+++ b/crates/cayenne/tests/deletion_vector_integration_test.rs
@@ -36,6 +36,8 @@ use cayenne::{
     CayenneTableProviderBuilder, MetadataCatalog,
 };
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -64,8 +66,7 @@ async fn delete_records(
     filter: Expr,
 ) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table_provider
-        .delete_from(&ctx.state(), vec![filter])
+    let plan = DeletionTableProvider::delete_from(table_provider.as_ref(), &ctx.state(), &[filter])
         .await?;
 
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Integration tests for file-based retention deletion.
 //!
 //! When a Cayenne table uses **position-based deletion** (no primary key) with
-//! **time-based retention**, the `delete_from` path
+//! **time-based retention**, the [`DeletionTableProvider::delete_from`] path
 //! prefers whole-file deletion over per-row deletion vectors.
 //!
 //! These tests verify that:
@@ -38,6 +38,7 @@ use cayenne::{
     STAGING_DIR_NAME,
 };
 use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
@@ -1105,7 +1106,7 @@ async fn execute_delete(
     filter: Expr,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table, &ctx.state(), &[filter]).await?;
     let results = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/int64_pk_deletion_test.rs
+++ b/crates/cayenne/tests/int64_pk_deletion_test.rs
@@ -45,6 +45,8 @@ use cayenne::{
 
 use common::TestFixture;
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -102,7 +104,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/keybased_deletion_test.rs
+++ b/crates/cayenne/tests/keybased_deletion_test.rs
@@ -49,6 +49,8 @@ use cayenne::{
 
 use common::TestFixture;
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -142,7 +144,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/mutation_model_test.rs
+++ b/crates/cayenne/tests/mutation_model_test.rs
@@ -42,6 +42,7 @@ use cayenne::{
     MetadataCatalog,
 };
 use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::{col, lit, Expr};
@@ -163,7 +164,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/mutation_roundtrip_test.rs
+++ b/crates/cayenne/tests/mutation_roundtrip_test.rs
@@ -42,6 +42,8 @@ use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalo
 
 use common::TestFixture;
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -132,7 +134,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/on_conflict_edge_cases_test.rs
+++ b/crates/cayenne/tests/on_conflict_edge_cases_test.rs
@@ -41,7 +41,8 @@ use cayenne::metadata::CreateTableOptions;
 
 use cayenne::{CayenneTableProvider, MetadataCatalog};
 
-use datafusion::datasource::TableProvider;
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::prelude::{col, lit, Expr, SessionContext};
 
 use datafusion_table_providers::util::{
@@ -58,13 +59,13 @@ async fn insert_batch(
         .map_err(Into::into)
 }
 
-/// Helper to delete records from a table using the `delete_from` API
+/// Helper to delete records from a table using the `DeletionTableProvider` API
 async fn delete_records(
     table: &Arc<CayenneTableProvider>,
     filter: Expr,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/position_based_deletion_test.rs
+++ b/crates/cayenne/tests/position_based_deletion_test.rs
@@ -53,6 +53,8 @@ use cayenne::{
     CayenneTableProviderBuilder, MetadataCatalog,
 };
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -77,7 +79,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/protected_snapshot_projection_test.rs
+++ b/crates/cayenne/tests/protected_snapshot_projection_test.rs
@@ -33,6 +33,7 @@ use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalog};
 use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::*;
@@ -85,7 +86,7 @@ async fn insert_batch(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> 
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/cayenne/tests/read_time_filtering_test.rs
+++ b/crates/cayenne/tests/read_time_filtering_test.rs
@@ -28,6 +28,8 @@ use cayenne::{
     metadata::CreateTableOptions, CayenneCatalog, CayenneTableProvider, MetadataCatalog,
 };
 
+use data_components::delete::DeletionTableProvider;
+
 use datafusion::datasource::TableProvider;
 
 use datafusion::execution::context::SessionContext;
@@ -112,8 +114,7 @@ async fn delete_records(
     filter: Expr,
 ) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table_provider
-        .delete_from(&ctx.state(), vec![filter])
+    let plan = DeletionTableProvider::delete_from(table_provider.as_ref(), &ctx.state(), &[filter])
         .await?;
 
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;

--- a/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/upsert_with_pending_deletions_test.rs
@@ -24,6 +24,7 @@ use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArr
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use cayenne::{metadata::CreateTableOptions, CayenneTableProvider, MetadataCatalog};
 use common::TestFixture;
+use data_components::delete::DeletionTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::{col, lit, Expr};
@@ -113,7 +114,7 @@ async fn get_ids(ctx: &SessionContext, table_name: &str) -> TestResult<Vec<i64>>
 
 async fn delete_records(table: &Arc<CayenneTableProvider>, filter: Expr) -> TestResult<u64> {
     let ctx = SessionContext::new();
-    let plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+    let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
     let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
     Ok(results
         .first()

--- a/crates/data_components/src/arrow.rs
+++ b/crates/data_components/src/arrow.rs
@@ -27,6 +27,8 @@ use datafusion_table_providers::util::on_conflict::OnConflict;
 use hash_index::HashIndexBuilder;
 use std::sync::Arc;
 
+use crate::delete::DeletionTableProviderAdapter;
+
 use self::indexed::SecondaryIndex;
 use self::write::MemTable;
 
@@ -257,7 +259,8 @@ impl TableProviderFactory for ArrowFactory {
                 indexed_table
             };
 
-            return Ok(Arc::new(indexed_table));
+            let delete_adapter = DeletionTableProviderAdapter::new(Arc::new(indexed_table));
+            return Ok(Arc::new(delete_adapter));
         }
 
         // Standard MemTable path (no primary key or hash index disabled)
@@ -288,7 +291,8 @@ impl TableProviderFactory for ArrowFactory {
             }
         }
 
-        Ok(Arc::new(mem_table))
+        let delete_adapter = DeletionTableProviderAdapter::new(Arc::new(mem_table));
+        Ok(Arc::new(delete_adapter))
     }
 }
 
@@ -345,7 +349,7 @@ mod tests {
             .expect("failed to create table");
 
         // The table should be created with an indexed structure
-        assert!(table.as_any().is::<IndexedMemTable>());
+        assert!(table.as_any().is::<DeletionTableProviderAdapter>());
     }
 
     #[tokio::test]
@@ -379,7 +383,7 @@ mod tests {
             .expect("failed to create table");
 
         // Without primary key, should still be a valid table
-        assert!(table.as_any().is::<MemTable>());
+        assert!(table.as_any().is::<DeletionTableProviderAdapter>());
     }
 
     #[tokio::test]
@@ -457,7 +461,7 @@ mod tests {
             .expect("failed to create table");
 
         // With hash_index not specified, should still create successfully (uses non-indexed table)
-        assert!(table.as_any().is::<MemTable>());
+        assert!(table.as_any().is::<DeletionTableProviderAdapter>());
     }
 
     // =============================================================================

--- a/crates/data_components/src/arrow/indexed.rs
+++ b/crates/data_components/src/arrow/indexed.rs
@@ -793,14 +793,6 @@ impl TableProvider for IndexedMemTable {
     fn get_column_default(&self, column: &str) -> Option<&Expr> {
         self.inner.get_column_default(column)
     }
-
-    async fn delete_from(
-        &self,
-        state: &dyn Session,
-        filters: Vec<Expr>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.inner.delete_from(state, filters).await
-    }
 }
 
 #[async_trait]
@@ -965,6 +957,20 @@ impl ExecutionPlan for IndexedLookupExec {
 
     fn metrics(&self) -> Option<datafusion::physical_plan::metrics::MetricsSet> {
         Some(self.metrics.clone_inner())
+    }
+}
+
+// Implement DeletionTableProvider by delegating to inner MemTable
+#[async_trait]
+impl crate::delete::DeletionTableProvider for IndexedMemTable {
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Delegate deletion to inner MemTable
+        // Note: Index should be updated after deletion
+        crate::delete::DeletionTableProvider::delete_from(&self.inner, state, filters).await
     }
 }
 

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -49,7 +49,7 @@ use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use futures::StreamExt;
 use tokio::sync::RwLock;
 
-use crate::delete::{DeletionExec, DeletionSink};
+use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use datafusion_table_providers::util::retriable_error::check_and_mark_retriable_error;
 
 /// A wrapper around `XxHash3_64` that uses a fixed seed (0) for deterministic hashing.
@@ -343,18 +343,6 @@ impl TableProvider for MemTable {
 
     fn get_column_default(&self, column: &str) -> Option<&Expr> {
         self.column_defaults.get(column)
-    }
-
-    async fn delete_from(
-        &self,
-        _state: &dyn Session,
-        filters: Vec<Expr>,
-    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(DeletionExec::new(Arc::new(MemDeletionSink::new(
-            self.batches.clone(),
-            self.schema(),
-            &filters,
-        )))))
     }
 }
 
@@ -1067,6 +1055,24 @@ impl DataSink for MemSink {
     }
 }
 
+#[async_trait]
+impl DeletionTableProvider for MemTable {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(MemDeletionSink::new(
+                self.batches.clone(),
+                self.schema(),
+                filters,
+            )),
+            &self.schema(),
+        )))
+    }
+}
+
 struct MemDeletionSink {
     batches: Vec<PartitionData>,
     schema: SchemaRef,
@@ -1150,7 +1156,7 @@ mod tests {
     };
     use datafusion_table_providers::util::{on_conflict::OnConflict, test::MockExec};
 
-    use crate::arrow::write::MemTable;
+    use crate::{arrow::write::MemTable, delete::DeletionTableProvider};
 
     fn create_batch_with_string_columns(data: &[(&str, Vec<&str>)]) -> (RecordBatch, SchemaRef) {
         let fields: Vec<_> = data
@@ -1696,7 +1702,7 @@ mod tests {
             None,
         )));
 
-        let plan = TableProvider::delete_from(&table, &state, vec![filter])
+        let plan = DeletionTableProvider::delete_from(&table, &state, &[filter])
             .await
             .expect("deletion should be successful");
 
@@ -2138,7 +2144,7 @@ mod tests {
         let filter1 = col("category").eq(lit("A"));
         let filter2 = col("id").eq(lit("4"));
 
-        let plan = TableProvider::delete_from(&table, &state, vec![filter1, filter2])
+        let plan = DeletionTableProvider::delete_from(&table, &state, &[filter1, filter2])
             .await
             .expect("deletion should succeed");
 

--- a/crates/data_components/src/delete.rs
+++ b/crates/data_components/src/delete.rs
@@ -15,16 +15,20 @@ limitations under the License.
 */
 
 #![allow(clippy::missing_errors_doc)]
-use std::{any::Any, error::Error, sync::Arc};
+use std::{any::Any, borrow::Cow, error::Error, sync::Arc};
 
 use ::arrow::{
     array::{ArrayRef, RecordBatch, UInt64Array},
-    datatypes::{DataType, Field, Schema},
+    datatypes::{DataType, Field, Schema, SchemaRef},
 };
 use async_trait::async_trait;
 use datafusion::{
-    error::DataFusionError,
+    catalog::{ScanArgs, ScanResult, Session},
+    common::{Constraints, Statistics},
+    datasource::{TableProvider, TableType},
+    error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
+    logical_expr::{Expr, LogicalPlan, dml::InsertOp},
     physical_expr::EquivalenceProperties,
     physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
@@ -32,6 +36,19 @@ use datafusion::{
         stream::RecordBatchStreamAdapter,
     },
 };
+
+use crate::poly::PolyTableProvider;
+
+#[async_trait]
+pub trait DeletionTableProvider: TableProvider {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        _filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::Plan("Not implemented".to_string()))
+    }
+}
 
 #[async_trait]
 pub trait DeletionSink: Send + Sync {
@@ -44,14 +61,9 @@ pub struct DeletionExec {
 }
 
 impl DeletionExec {
-    pub fn new(deletion_sink: Arc<dyn DeletionSink>) -> Self {
-        let count_schema = Arc::new(Schema::new(vec![Field::new(
-            "count",
-            DataType::UInt64,
-            false,
-        )]));
+    pub fn new(deletion_sink: Arc<dyn DeletionSink>, schema: &SchemaRef) -> Self {
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(count_schema),
+            EquivalenceProperties::new(Arc::clone(schema)),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -135,5 +147,121 @@ impl ExecutionPlan for DeletionExec {
                 }
             })
         })))
+    }
+}
+
+#[derive(Debug)]
+pub struct DeletionTableProviderAdapter {
+    source: Arc<dyn DeletionTableProvider>,
+}
+
+impl DeletionTableProviderAdapter {
+    pub fn new(source: Arc<dyn DeletionTableProvider>) -> Self {
+        Self { source }
+    }
+
+    /// Returns a reference to the inner source table provider.
+    ///
+    /// This is useful for accessing the underlying table provider when the adapter
+    /// is wrapping another provider (e.g., `IndexedMemTable`) that needs direct access
+    /// for operations like index maintenance.
+    #[must_use]
+    pub fn source(&self) -> &Arc<dyn DeletionTableProvider> {
+        &self.source
+    }
+}
+
+#[expect(clippy::needless_pass_by_value)]
+pub fn get_deletion_provider(
+    from: Arc<dyn TableProvider>,
+) -> Option<Arc<dyn DeletionTableProvider>> {
+    if let Some(p) = from.as_any().downcast_ref::<PolyTableProvider>() {
+        return Some(Arc::new(p.clone()));
+    }
+    if let Some(p) = from.as_any().downcast_ref::<DeletionTableProviderAdapter>() {
+        return Some(Arc::clone(&p.source));
+    }
+
+    None
+}
+
+#[async_trait]
+#[deny(clippy::missing_trait_methods)]
+impl TableProvider for DeletionTableProviderAdapter {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        self.source.schema()
+    }
+    fn constraints(&self) -> Option<&Constraints> {
+        self.source.constraints()
+    }
+    fn table_type(&self) -> TableType {
+        self.source.table_type()
+    }
+    fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
+        self.source.get_logical_plan()
+    }
+    fn get_table_definition(&self) -> Option<&str> {
+        self.source.get_table_definition()
+    }
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.source.get_column_default(column)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.source.statistics()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<datafusion::logical_expr::TableProviderFilterPushDown>> {
+        self.source.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.source.scan(state, projection, filters, limit).await
+    }
+
+    async fn scan_with_args<'a>(
+        &self,
+        state: &dyn Session,
+        args: ScanArgs<'a>,
+    ) -> DataFusionResult<ScanResult> {
+        self.source.scan_with_args(state, args).await
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        overwrite: InsertOp,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.source.insert_into(state, input, overwrite).await
+    }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        TableProvider::delete_from(self.source.as_ref(), state, filters).await
+    }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.source.update(state, assignments, filters).await
     }
 }

--- a/crates/data_components/src/delete.rs
+++ b/crates/data_components/src/delete.rs
@@ -61,9 +61,14 @@ pub struct DeletionExec {
 }
 
 impl DeletionExec {
-    pub fn new(deletion_sink: Arc<dyn DeletionSink>, schema: &SchemaRef) -> Self {
+    pub fn new(deletion_sink: Arc<dyn DeletionSink>, _schema: &SchemaRef) -> Self {
+        let count_schema = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]));
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(Arc::clone(schema)),
+            EquivalenceProperties::new(count_schema),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -253,7 +258,7 @@ impl TableProvider for DeletionTableProviderAdapter {
         state: &dyn Session,
         filters: Vec<Expr>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        TableProvider::delete_from(self.source.as_ref(), state, filters).await
+        DeletionTableProvider::delete_from(self.source.as_ref(), state, &filters).await
     }
 
     async fn update(

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -14,11 +14,149 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::{Read, ReadWrite};
+use crate::{
+    Read, ReadWrite,
+    delete::{DeletionExec, DeletionSink, DeletionTableProvider},
+};
 use async_trait::async_trait;
-use datafusion::{datasource::TableProvider, sql::TableReference};
-use datafusion_table_providers::duckdb::DuckDBTableFactory;
+use datafusion::{
+    catalog::Session, datasource::TableProvider, logical_expr::Expr, physical_plan::ExecutionPlan,
+    sql::TableReference,
+};
+use datafusion_table_providers::{
+    duckdb::{DuckDB, DuckDBTableFactory, TableDefinition, write::DuckDBTableWriter},
+    sql::{
+        db_connection_pool::duckdbpool::DuckDbConnectionPool,
+        sql_provider_datafusion::expr::{self, Engine},
+    },
+};
+use duckdb::Transaction;
+use snafu::prelude::*;
 use std::sync::Arc;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to delete data from DuckDB table: {source}"))]
+    UnableToDeleteDuckdbData { source: duckdb::Error },
+
+    #[snafu(display("Failed to query data from DuckDB table: {source}"))]
+    UnableToQueryData { source: duckdb::Error },
+
+    #[snafu(display("Failed to commit DuckDB transaction: {source}"))]
+    UnableToCommitTransaction { source: duckdb::Error },
+
+    #[snafu(display("Failed to begin DuckDB transaction: {source}"))]
+    UnableToBeginTransaction { source: duckdb::Error },
+
+    #[snafu(display(
+        "Unable to delete data from the duckdb table. An internal table and base table exist for the same table. Manually migrate the table by deleting '{internal_table}' or {table_name}', and try again."
+    ))]
+    UnableToDeleteDataInternalTable {
+        internal_table: String,
+        table_name: String,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[async_trait]
+impl DeletionTableProvider for DuckDBTableWriter {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(DuckDBDeletionSink::new(
+                self.pool(),
+                self.table_definition(),
+                filters,
+            )),
+            &self.schema(),
+        )))
+    }
+}
+
+struct DuckDBDeletionSink {
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: Arc<TableDefinition>,
+    filters: Vec<Expr>,
+}
+
+impl DuckDBDeletionSink {
+    fn new(
+        pool: Arc<DuckDbConnectionPool>,
+        table_definition: Arc<TableDefinition>,
+        filters: &[Expr],
+    ) -> Self {
+        Self {
+            pool,
+            table_definition,
+            filters: filters.to_vec(),
+        }
+    }
+}
+
+#[async_trait]
+impl DeletionSink for DuckDBDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let pool = Arc::clone(&self.pool);
+        let table_definition = Arc::clone(&self.table_definition);
+        let filters = self.filters.clone();
+
+        tokio::task::spawn_blocking(
+            move || -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+                let mut db_conn = pool.connect_sync()?;
+                let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let tx = duckdb_conn
+                    .conn
+                    .transaction()
+                    .context(UnableToBeginTransactionSnafu)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let has_table = table_definition
+                    .has_table(&tx)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let mut internal_tables = table_definition
+                    .list_internal_tables(&tx)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let table_name = match (internal_tables.pop(), has_table) {
+                    (Some((table_name, _)), true) => {
+                        return Err(Box::new(Error::UnableToDeleteDataInternalTable {
+                            internal_table: table_name.to_string(),
+                            table_name: table_definition.name().to_string(),
+                        }));
+                    }
+                    (Some((table_name, _)), false) => table_name,
+                    (None, true) => table_definition.name().clone(),
+                    (None, false) => {
+                        return Ok(0);
+                    }
+                };
+
+                // When filters is empty, return 0 to prevent accidental full table deletion.
+                // This is intentional - callers must provide explicit filters for deletion.
+                let count = if filters.is_empty() {
+                    0
+                } else {
+                    let sql_filters: Result<Vec<String>, _> = filters
+                        .iter()
+                        .map(|f| expr::to_sql_with_engine(f, Some(Engine::DuckDB)))
+                        .collect();
+                    let sql = sql_filters
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                        .join(" AND ");
+                    delete_from(&table_name.to_string(), tx, &sql)
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                };
+
+                Ok(count)
+            },
+        )
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+    }
+}
 
 #[async_trait]
 impl Read for DuckDBTableFactory {
@@ -38,4 +176,23 @@ impl ReadWrite for DuckDBTableFactory {
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.read_write_table_provider(table_reference).await
     }
+}
+
+fn delete_from(table_name: &str, tx: Transaction<'_>, where_clause: &str) -> Result<u64> {
+    let count_sql = format!(r#"SELECT COUNT(*) FROM "{table_name}" WHERE {where_clause}"#);
+
+    let mut count: u64 = tx
+        .query_row(&count_sql, [], |row| row.get::<usize, u64>(0))
+        .context(UnableToQueryDataSnafu)?;
+
+    let sql = format!(r#"DELETE FROM "{table_name}" WHERE {where_clause}"#);
+    tx.execute(&sql, [])
+        .context(UnableToDeleteDuckdbDataSnafu)?;
+
+    count -= tx
+        .query_row(&count_sql, [], |row| row.get::<usize, u64>(0))
+        .context(UnableToQueryDataSnafu)?;
+
+    tx.commit().context(UnableToCommitTransactionSnafu)?;
+    Ok(count)
 }

--- a/crates/data_components/src/iceberg/delete.rs
+++ b/crates/data_components/src/iceberg/delete.rs
@@ -344,7 +344,7 @@ impl ExecutionPlan for IcebergDeleteExec {
     }
 }
 
-/// Wrapper that makes an `IcebergTableProvider` support `DELETE FROM`.
+/// Wrapper that makes an `IcebergTableProvider` support `DeletionTableProvider`.
 ///
 /// This is registered as the table provider when the Iceberg data connector
 /// supports writes, enabling `DELETE FROM` SQL statements.
@@ -446,18 +446,11 @@ impl datafusion::datasource::TableProvider for IcebergDeletionProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         self.inner.insert_into(state, input, overwrite).await
     }
-
-    async fn delete_from(
-        &self,
-        state: &dyn Session,
-        filters: Vec<datafusion::logical_expr::Expr>,
-    ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        self.delete_from_impl(state, &filters).await
-    }
 }
 
-impl IcebergDeletionProvider {
-    async fn delete_from_impl(
+#[async_trait]
+impl crate::delete::DeletionTableProvider for IcebergDeletionProvider {
+    async fn delete_from(
         &self,
         state: &dyn Session,
         filters: &[datafusion::logical_expr::Expr],

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -324,7 +324,7 @@ impl IcebergSchemaProvider {
         .await
         {
             Ok(provider) => {
-                // Wrap in IcebergDeletionProvider so that
+                // Wrap in IcebergDeletionProvider + DeletionTableProviderAdapter so that
                 // catalog tables support DELETE FROM via equality delete files.
                 // Access control is handled by the SQL validator, not here.
                 let deletion_provider = crate::iceberg::delete::IcebergDeletionProvider::new(
@@ -333,7 +333,9 @@ impl IcebergSchemaProvider {
                     table_name.name().to_string(),
                     Arc::new(provider),
                 );
-                let adapted: Arc<dyn TableProvider> = Arc::new(deletion_provider);
+                let adapted: Arc<dyn TableProvider> = Arc::new(
+                    crate::delete::DeletionTableProviderAdapter::new(Arc::new(deletion_provider)),
+                );
                 Ok(Some(adapted))
             }
             Err(e) => {

--- a/crates/data_components/src/index_maintenance.rs
+++ b/crates/data_components/src/index_maintenance.rs
@@ -63,6 +63,16 @@ pub async fn perform_index_maintenance(
         return Ok(true);
     }
 
+    // Handle DeletionTableProviderAdapter wrapping an IndexedMemTable
+    if let Some(adapter) = any.downcast_ref::<crate::delete::DeletionTableProviderAdapter>() {
+        // Try to get the inner provider and perform maintenance on it
+        let inner_any = adapter.source().as_any();
+        if let Some(provider) = inner_any.downcast_ref::<crate::arrow::IndexedMemTable>() {
+            provider.perform_maintenance().await?;
+            return Ok(true);
+        }
+    }
+
     // Add additional concrete types here as they implement IndexMaintenanceProvider
     // if let Some(provider) = any.downcast_ref::<SomeOtherType>() {
     //     provider.perform_maintenance().await?;

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -32,17 +32,25 @@ use datafusion_federation::{
 use std::collections::HashMap;
 use std::{any::Any, borrow::Cow, sync::Arc};
 
+use crate::delete::DeletionTableProvider;
+
 #[derive(Debug, Clone)]
 pub struct PolyTableProvider {
     write: Arc<dyn TableProvider>,
+    delete: Arc<dyn DeletionTableProvider>,
     fed: Arc<dyn TableProvider>,
     schema_metadata: HashMap<String, String>,
 }
 
 impl PolyTableProvider {
-    pub fn new(write: Arc<dyn TableProvider>, fed: Arc<dyn TableProvider>) -> Self {
+    pub fn new(
+        write: Arc<dyn TableProvider>,
+        delete: Arc<dyn DeletionTableProvider>,
+        fed: Arc<dyn TableProvider>,
+    ) -> Self {
         PolyTableProvider {
             write,
+            delete,
             fed,
             schema_metadata: HashMap::new(),
         }
@@ -50,11 +58,13 @@ impl PolyTableProvider {
 
     pub fn new_with_schema_metadata(
         write: Arc<dyn TableProvider>,
+        delete: Arc<dyn DeletionTableProvider>,
         fed: Arc<dyn TableProvider>,
         schema_metadata: HashMap<String, String>,
     ) -> Self {
         PolyTableProvider {
             write,
+            delete,
             fed,
             schema_metadata,
         }
@@ -85,6 +95,17 @@ impl PolyTableProvider {
     #[must_use]
     pub fn writer(&self) -> Arc<dyn TableProvider> {
         Arc::clone(&self.write)
+    }
+}
+
+#[async_trait]
+impl DeletionTableProvider for PolyTableProvider {
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        DeletionTableProvider::delete_from(&*self.delete, state, filters).await
     }
 }
 
@@ -150,22 +171,5 @@ impl TableProvider for PolyTableProvider {
         overwrite: InsertOp,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.write.insert_into(state, input, overwrite).await
-    }
-
-    async fn delete_from(
-        &self,
-        state: &dyn Session,
-        filters: Vec<Expr>,
-    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.write.delete_from(state, filters).await
-    }
-
-    async fn update(
-        &self,
-        state: &dyn Session,
-        assignments: Vec<(String, Expr)>,
-        filters: Vec<Expr>,
-    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.write.update(state, assignments, filters).await
     }
 }

--- a/crates/data_components/src/postgres/mod.rs
+++ b/crates/data_components/src/postgres/mod.rs
@@ -17,12 +17,22 @@ limitations under the License.
 pub mod provider;
 
 use async_trait::async_trait;
-use datafusion::{datasource::TableProvider, sql::TableReference};
+use datafusion::{
+    catalog::Session, datasource::TableProvider, logical_expr::Expr, physical_plan::ExecutionPlan,
+    sql::TableReference,
+};
 use std::sync::Arc;
+use tokio_postgres::Transaction;
 
-use crate::{Read, ReadWrite};
+use crate::{
+    Read, ReadWrite,
+    delete::{DeletionExec, DeletionSink, DeletionTableProvider},
+};
 
-use datafusion_table_providers::postgres::PostgresTableFactory;
+use datafusion_table_providers::{
+    postgres::{Postgres, PostgresTableFactory, write::PostgresTableWriter},
+    sql::sql_provider_datafusion::expr,
+};
 
 #[async_trait]
 impl Read for PostgresTableFactory {
@@ -41,5 +51,81 @@ impl ReadWrite for PostgresTableFactory {
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.read_write_table_provider(table_reference).await
+    }
+}
+
+#[async_trait]
+impl DeletionTableProvider for PostgresTableWriter {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(PostgresDeletionSink::new(self.postgres(), filters)),
+            &self.schema(),
+        )))
+    }
+}
+
+struct PostgresDeletionSink {
+    postgres: Arc<Postgres>,
+    filters: Vec<Expr>,
+}
+
+impl PostgresDeletionSink {
+    fn new(postgres: Arc<Postgres>, filters: &[Expr]) -> Self {
+        Self {
+            postgres,
+            filters: filters.to_vec(),
+        }
+    }
+}
+
+#[expect(clippy::cast_sign_loss)]
+async fn delete_from(
+    table_name: &str,
+    transaction: &Transaction<'_>,
+    where_clause: &str,
+) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+    let row = transaction
+        .query_one(
+            format!(
+                r#"WITH deleted AS (DELETE FROM "{table_name}" WHERE {where_clause} RETURNING *) SELECT COUNT(*) FROM deleted"#,
+            )
+            .as_str(),
+            &[],
+        )
+        .await?;
+
+    let deleted: i64 = row.get(0);
+
+    Ok(deleted as u64)
+}
+
+#[async_trait]
+impl DeletionSink for PostgresDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let mut db_conn = self.postgres.connect().await?;
+        let postgres_conn = Postgres::postgres_conn(&mut db_conn)?;
+        let tx = postgres_conn.conn.transaction().await?;
+        // When filters is empty, return 0 to prevent accidental full table deletion.
+        // This is intentional - callers must provide explicit filters for deletion.
+        let count = if self.filters.is_empty() {
+            0
+        } else {
+            let sql_filters: Result<Vec<String>, _> = self
+                .filters
+                .iter()
+                .map(|f| expr::to_sql_with_engine(f, None))
+                .collect();
+            let sql_where = sql_filters
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                .join(" AND ");
+            delete_from(self.postgres.table_name(), &tx, &sql_where).await?
+        };
+        tx.commit().await?;
+
+        Ok(count)
     }
 }

--- a/crates/data_components/src/sqlite.rs
+++ b/crates/data_components/src/sqlite.rs
@@ -13,3 +13,96 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+use async_trait::async_trait;
+use datafusion::{
+    catalog::Session, datasource::TableProvider, logical_expr::Expr, physical_plan::ExecutionPlan,
+};
+use datafusion_table_providers::{
+    sql::sql_provider_datafusion::expr::{self, Engine},
+    sqlite::{Sqlite, write::SqliteTableWriter},
+};
+use rusqlite::Transaction;
+use std::sync::Arc;
+
+use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
+
+#[async_trait]
+impl DeletionTableProvider for SqliteTableWriter {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(SqliteDeletionSink::new(self.sqlite(), filters)),
+            &self.schema(),
+        )))
+    }
+}
+
+struct SqliteDeletionSink {
+    sqlite: Arc<Sqlite>,
+    filters: Vec<Expr>,
+}
+
+impl SqliteDeletionSink {
+    fn new(sqlite: Arc<Sqlite>, filters: &[Expr]) -> Self {
+        Self {
+            sqlite,
+            filters: filters.to_vec(),
+        }
+    }
+}
+
+#[async_trait]
+impl DeletionSink for SqliteDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let mut db_conn = self.sqlite.connect().await?;
+        let sqlite_conn = Sqlite::sqlite_conn(&mut db_conn)?;
+        let sqlite = Arc::clone(&self.sqlite);
+        // When filters is empty, return 0 to prevent accidental full table deletion.
+        // This is intentional - callers must provide explicit filters for deletion.
+        let count: u64 = if self.filters.is_empty() {
+            0
+        } else {
+            let sql_filters: Result<Vec<String>, _> = self
+                .filters
+                .iter()
+                .map(|f| expr::to_sql_with_engine(f, Some(Engine::SQLite)))
+                .collect();
+            let sql = sql_filters
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                .join(" AND ");
+
+            sqlite_conn
+                .conn
+                .call(move |conn| -> rusqlite::Result<u64> {
+                    let tx = conn.transaction()?;
+
+                    let count = delete_from(sqlite.table_name(), &tx, &sql)?;
+
+                    tx.commit()?;
+
+                    Ok(count)
+                })
+                .await?
+        };
+
+        Ok(count)
+    }
+}
+
+fn delete_from(
+    table_name: &str,
+    transaction: &Transaction<'_>,
+    where_clause: &str,
+) -> rusqlite::Result<u64> {
+    transaction.execute(
+        format!(r#"DELETE FROM "{table_name}" WHERE {where_clause}"#).as_str(),
+        [],
+    )?;
+    let count: u64 = transaction.query_row("SELECT changes()", [], |row| row.get(0))?;
+
+    Ok(count)
+}

--- a/crates/data_components/src/turso.rs
+++ b/crates/data_components/src/turso.rs
@@ -123,7 +123,7 @@ use datafusion::{
     scalar::ScalarValue,
     sql::{
         TableReference,
-        sqlparser::ast::{self as sqlast, VisitMut, VisitorMut},
+        sqlparser::ast::{self as sqlast, VisitMut},
         unparser::{
             Unparser,
             dialect::{
@@ -148,7 +148,7 @@ use snafu::prelude::*;
 use turso::{Builder, Connection, Database, Value as TursoValue};
 use turso_shared::{BEGIN_CONCURRENT_SQL, COMMIT_SQL, JOURNAL_MODE_SQL_LITERAL};
 
-use crate::delete::{DeletionExec, DeletionSink};
+use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 
 /// Conversion constants for timestamp storage and conversion.
 ///
@@ -1108,15 +1108,12 @@ impl TursoTableProvider {
     /// Uses the shared `SQLiteIntervalVisitor` to convert INTERVAL literals to
     /// `CAST(date/datetime(col, modifier) AS TEXT)` calls.
     ///
-    /// Also applies `TursoBetweenVisitor` to rewrite numeric `BETWEEN` expressions
-    /// into explicit `CAST(... AS REAL)` comparisons, since Turso does not have the
-    /// `decimal_cmp()` extension available in standard SQLite.
+    /// Note: Unlike the SQLite accelerator, we do NOT run `SQLiteBetweenVisitor`
+    /// here. That visitor rewrites `BETWEEN` into `decimal_cmp()` calls which is not supported by Turso.
     fn turso_ast_analyzer() -> AstAnalyzerRule {
         Box::new(|mut ast| {
             let mut interval_visitor = SQLiteIntervalVisitor::default();
             let _ = ast.visit(&mut interval_visitor);
-            let mut between_visitor = TursoBetweenVisitor;
-            let _ = ast.visit(&mut between_visitor);
             Ok(ast)
         })
     }
@@ -1202,15 +1199,23 @@ impl TableProvider for TursoTableProvider {
         // Wrap in DataSinkExec to execute the insertion
         Ok(Arc::new(DataSinkExec::new(input, sink, None)))
     }
+}
 
+#[async_trait]
+impl DeletionTableProvider for TursoTableProvider {
     async fn delete_from(
         &self,
         _state: &dyn Session,
-        filters: Vec<Expr>,
+        filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(DeletionExec::new(Arc::new(
-            TursoDeletionSink::new(Arc::clone(&self.pool), self.table_name.clone(), &filters),
-        ))))
+        Ok(Arc::new(DeletionExec::new(
+            Arc::new(TursoDeletionSink::new(
+                Arc::clone(&self.pool),
+                self.table_name.clone(),
+                filters,
+            )),
+            &self.schema(),
+        )))
     }
 }
 
@@ -2105,190 +2110,4 @@ fn scalar_value_to_turso(
     };
 
     Ok(turso_value)
-}
-
-/// An AST visitor that rewrites numeric `BETWEEN` expressions into explicit
-/// `CAST(... AS REAL)` comparisons.
-///
-/// Turso (libSQL) inherits SQLite's type affinity rules, which can cause
-/// text-based comparisons on decimal values stored as TEXT.  Standard SQLite
-/// solves this with the `decimal_cmp()` C extension, but Turso does not
-/// support loading C extensions.
-///
-/// This visitor rewrites:
-/// ```sql
-///   expr BETWEEN low AND high
-/// ```
-/// into:
-/// ```sql
-///   CAST(expr AS REAL) >= CAST(low AS REAL)
-///     AND CAST(expr AS REAL) <= CAST(high AS REAL)
-/// ```
-/// (with the obvious inversion for `NOT BETWEEN`).
-///
-/// Only expressions where *both* bounds appear numeric (literal numbers,
-/// unary-minus numbers, or arithmetic on numbers) are rewritten.
-struct TursoBetweenVisitor;
-
-impl TursoBetweenVisitor {
-    /// Wrap `expr` in `CAST(expr AS REAL)`.
-    fn cast_to_real(expr: sqlast::Expr) -> sqlast::Expr {
-        sqlast::Expr::Cast {
-            kind: sqlast::CastKind::Cast,
-            expr: Box::new(expr),
-            data_type: sqlast::DataType::Real,
-            format: None,
-        }
-    }
-
-    /// Returns `true` if the expression looks like a numeric value or
-    /// arithmetic expression that should use numeric comparison.
-    fn is_numeric_expr(expr: &sqlast::Expr) -> bool {
-        match expr {
-            sqlast::Expr::Value(v) => matches!(v.value, sqlast::Value::Number(_, _)),
-            sqlast::Expr::UnaryOp {
-                op: sqlast::UnaryOperator::Minus | sqlast::UnaryOperator::Plus,
-                expr,
-            } => Self::is_numeric_expr(expr),
-            sqlast::Expr::BinaryOp { left, right, .. } => {
-                Self::is_numeric_expr(left) || Self::is_numeric_expr(right)
-            }
-            sqlast::Expr::Nested(inner) => Self::is_numeric_expr(inner),
-            _ => false,
-        }
-    }
-}
-
-impl VisitorMut for TursoBetweenVisitor {
-    type Break = ();
-
-    fn post_visit_expr(&mut self, expr: &mut sqlast::Expr) -> std::ops::ControlFlow<Self::Break> {
-        if let sqlast::Expr::Between {
-            expr: between_expr,
-            negated,
-            low,
-            high,
-        } = expr
-            && Self::is_numeric_expr(low)
-            && Self::is_numeric_expr(high)
-        {
-            let negated = *negated;
-            let cast_expr_low = Self::cast_to_real(*between_expr.clone());
-            let cast_expr_high = Self::cast_to_real(*between_expr.clone());
-            let cast_low = Self::cast_to_real(*low.clone());
-            let cast_high = Self::cast_to_real(*high.clone());
-
-            if negated {
-                // NOT BETWEEN  →  expr < low OR expr > high
-                *expr = sqlast::Expr::BinaryOp {
-                    left: Box::new(sqlast::Expr::BinaryOp {
-                        left: Box::new(cast_expr_low),
-                        op: sqlast::BinaryOperator::Lt,
-                        right: Box::new(cast_low),
-                    }),
-                    op: sqlast::BinaryOperator::Or,
-                    right: Box::new(sqlast::Expr::BinaryOp {
-                        left: Box::new(cast_expr_high),
-                        op: sqlast::BinaryOperator::Gt,
-                        right: Box::new(cast_high),
-                    }),
-                };
-            } else {
-                // BETWEEN  →  expr >= low AND expr <= high
-                *expr = sqlast::Expr::BinaryOp {
-                    left: Box::new(sqlast::Expr::BinaryOp {
-                        left: Box::new(cast_expr_low),
-                        op: sqlast::BinaryOperator::GtEq,
-                        right: Box::new(cast_low),
-                    }),
-                    op: sqlast::BinaryOperator::And,
-                    right: Box::new(sqlast::Expr::BinaryOp {
-                        left: Box::new(cast_expr_high),
-                        op: sqlast::BinaryOperator::LtEq,
-                        right: Box::new(cast_high),
-                    }),
-                };
-            }
-        }
-        std::ops::ControlFlow::Continue(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use datafusion::sql::sqlparser::parser::Parser;
-
-    fn rewrite_between(sql: &str) -> String {
-        let dialect = datafusion::sql::sqlparser::dialect::GenericDialect {};
-        let mut stmts = Parser::parse_sql(&dialect, sql).expect("valid SQL");
-        let mut visitor = TursoBetweenVisitor;
-        for stmt in &mut stmts {
-            let _ = stmt.visit(&mut visitor);
-        }
-        stmts[0].to_string()
-    }
-
-    #[test]
-    fn test_turso_between_numeric_rewrite() {
-        let input = "SELECT * FROM t WHERE x BETWEEN 0.05 AND 0.07";
-        let result = rewrite_between(input);
-        assert!(
-            !result.contains("BETWEEN"),
-            "BETWEEN should be rewritten, got: {result}"
-        );
-        assert!(
-            result.contains("CAST(x AS REAL) >= CAST(0.05 AS REAL)"),
-            "should cast to REAL: {result}"
-        );
-        assert!(
-            result.contains("CAST(x AS REAL) <= CAST(0.07 AS REAL)"),
-            "should cast to REAL: {result}"
-        );
-    }
-
-    #[test]
-    fn test_turso_between_arithmetic_bounds() {
-        let input = "SELECT * FROM t WHERE x BETWEEN 0.06 - 0.01 AND 0.06 + 0.01";
-        let result = rewrite_between(input);
-        assert!(
-            !result.contains("BETWEEN"),
-            "BETWEEN with arithmetic bounds should be rewritten, got: {result}"
-        );
-        assert!(result.contains("CAST"), "should contain CAST: {result}");
-    }
-
-    #[test]
-    fn test_turso_not_between_numeric_rewrite() {
-        let input = "SELECT * FROM t WHERE x NOT BETWEEN 1 AND 10";
-        let result = rewrite_between(input);
-        assert!(
-            !result.contains("BETWEEN"),
-            "NOT BETWEEN should be rewritten, got: {result}"
-        );
-        assert!(
-            result.contains(" OR "),
-            "NOT BETWEEN should use OR: {result}"
-        );
-    }
-
-    #[test]
-    fn test_turso_between_non_numeric_unchanged() {
-        let input = "SELECT * FROM t WHERE name BETWEEN 'a' AND 'z'";
-        let result = rewrite_between(input);
-        assert!(
-            result.contains("BETWEEN"),
-            "Non-numeric BETWEEN should be unchanged, got: {result}"
-        );
-    }
-
-    #[test]
-    fn test_turso_between_negative_bounds() {
-        let input = "SELECT * FROM t WHERE x BETWEEN -1.5 AND 1.5";
-        let result = rewrite_between(input);
-        assert!(
-            !result.contains("BETWEEN"),
-            "BETWEEN with negative bounds should be rewritten, got: {result}"
-        );
-    }
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -19,7 +19,7 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 use arrow::array::{Array, UInt64Array};
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use data_components::delete::{DeletionExec, DeletionSink};
+use data_components::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use datafusion::{
     catalog::{Session, TableProvider},
     common::{Constraints, DFSchema, Statistics, project_schema},
@@ -391,11 +391,16 @@ impl TableProvider for PartitionTableProvider {
             .execute_insert(input, insert_op, &ctx)
             .await
     }
+}
 
+/// Implement `DeletionTableProvider` to support retention checks and delete operations
+/// on partitioned tables. Deletion is applied to all partitions.
+#[async_trait]
+impl DeletionTableProvider for PartitionTableProvider {
     async fn delete_from(
         &self,
         state: &dyn Session,
-        filters: Vec<Expr>,
+        filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         // Collect all partitions that need deletion
         let partitions = self.partitions.read().await;
@@ -405,11 +410,11 @@ impl TableProvider for PartitionTableProvider {
         // Create a deletion sink that will iterate over all partitions
         let deletion_sink = Arc::new(PartitionedDeletionSink::new(
             partition_list,
-            filters,
+            filters.to_vec(),
             state.task_ctx(),
         ));
 
-        Ok(Arc::new(DeletionExec::new(deletion_sink)))
+        Ok(Arc::new(DeletionExec::new(deletion_sink, &self.schema)))
     }
 }
 
@@ -436,30 +441,46 @@ impl DeletionSink for PartitionedDeletionSink {
         let mut total_deleted = 0u64;
 
         for partition in &self.partitions {
-            // Create a simple session state for executing the deletion
-            let session_ctx = datafusion::execution::context::SessionContext::new();
-            let state = session_ctx.state();
+            // Try to downcast the partition's table provider to DeletionTableProvider
+            // The partition's table provider might be a CayenneTableProvider or similar
+            // that implements DeletionTableProvider
+            let deletion_provider = data_components::delete::get_deletion_provider(Arc::clone(
+                &partition.table_provider,
+            ));
 
-            // Execute deletion on this partition using native TableProvider::delete_from
-            let plan = partition
-                .table_provider
-                .delete_from(&state, self.filters.clone())
+            if let Some(deletion_provider) = deletion_provider {
+                // Create a simple session state for executing the deletion
+                let session_ctx = datafusion::execution::context::SessionContext::new();
+                let state = session_ctx.state();
+
+                // Execute deletion on this partition
+                let plan = DeletionTableProvider::delete_from(
+                    deletion_provider.as_ref(),
+                    &state,
+                    &self.filters,
+                )
                 .await?;
 
-            // Execute the deletion plan
-            let results = collect(plan, Arc::clone(&self.task_ctx)).await?;
+                // Execute the deletion plan
+                let results = collect(plan, Arc::clone(&self.task_ctx)).await?;
 
-            // Extract the count from results
-            for batch in results {
-                if let Some(count_col) = batch.column_by_name("count")
-                    && let Some(uint_array) = count_col.as_any().downcast_ref::<UInt64Array>()
-                {
-                    for i in 0..uint_array.len() {
-                        if !uint_array.is_null(i) {
-                            total_deleted += uint_array.value(i);
+                // Extract the count from results
+                for batch in results {
+                    if let Some(count_col) = batch.column_by_name("count")
+                        && let Some(uint_array) = count_col.as_any().downcast_ref::<UInt64Array>()
+                    {
+                        for i in 0..uint_array.len() {
+                            if !uint_array.is_null(i) {
+                                total_deleted += uint_array.value(i);
+                            }
                         }
                     }
                 }
+            } else {
+                tracing::warn!(
+                    partition_values = ?partition.partition_values,
+                    "Partition table provider does not support deletion. Skipping."
+                );
             }
         }
 

--- a/crates/runtime-table-partition/tests/partition_table_provider.rs
+++ b/crates/runtime-table-partition/tests/partition_table_provider.rs
@@ -17,7 +17,9 @@ limitations under the License.
 use arrow_schema::TimeUnit;
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone as _, Utc};
-use data_components::delete::{DeletionExec, DeletionSink};
+use data_components::delete::{
+    DeletionExec, DeletionSink, DeletionTableProvider, DeletionTableProviderAdapter,
+};
 use datafusion::arrow::array::{
     Array, ArrayRef, Int32Array, Int64Array, StringArray, TimestampNanosecondArray, UInt64Array,
 };
@@ -1462,10 +1464,10 @@ async fn test_bucket_partition_inequality_snapshot() -> Result<(), Box<dyn std::
 }
 
 // ============================================================================
-// Deletion Tests for PartitionTableProvider
+// Deletion Tests for PartitionTableProvider implementing DeletionTableProvider
 // ============================================================================
 
-/// A `MemTable` wrapper that implements `TableProvider::delete_from` for testing purposes
+/// A `MemTable` wrapper that implements `DeletionTableProvider` for testing purposes
 #[derive(Debug)]
 struct DeletablePartitionMemTable {
     mem_table: Arc<MemTable>,
@@ -1523,20 +1525,6 @@ impl TableProvider for DeletablePartitionMemTable {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         self.mem_table.insert_into(state, input, insert_op).await
     }
-
-    async fn delete_from(
-        &self,
-        _state: &dyn Session,
-        _filters: Vec<Expr>,
-    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        // Simulate deleting 10 rows per partition
-        let deletion_sink = Arc::new(MockDeletionSink {
-            deleted_count: Arc::clone(&self.deleted_count),
-            count_to_delete: 10,
-        });
-
-        Ok(Arc::new(DeletionExec::new(deletion_sink)))
-    }
 }
 
 /// Mock deletion sink that simulates deletion and tracks deleted count
@@ -1551,6 +1539,26 @@ impl DeletionSink for MockDeletionSink {
         let mut guard = self.deleted_count.write().await;
         *guard += self.count_to_delete;
         Ok(self.count_to_delete)
+    }
+}
+
+#[async_trait]
+impl DeletionTableProvider for DeletablePartitionMemTable {
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        _filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // Simulate deleting 10 rows per partition
+        let deletion_sink = Arc::new(MockDeletionSink {
+            deleted_count: Arc::clone(&self.deleted_count),
+            count_to_delete: 10,
+        });
+
+        Ok(Arc::new(DeletionExec::new(
+            deletion_sink,
+            &self.mem_table.schema(),
+        )))
     }
 }
 
@@ -1609,9 +1617,12 @@ impl PartitionCreator for DeletableTestPartitionCreator {
             partition_value.to_string(),
             Arc::clone(&deletable_mem_table),
         );
+        // Wrap in DeletionTableProviderAdapter so get_deletion_provider can find it
+        let adapted_table: Arc<dyn TableProvider> =
+            Arc::new(DeletionTableProviderAdapter::new(deletable_mem_table));
         Ok(Partition {
             partition_values: vec![partition_value],
-            table_provider: deletable_mem_table,
+            table_provider: adapted_table,
         })
     }
 
@@ -1676,7 +1687,7 @@ async fn test_deletion_table_provider_single_partition() -> Result<(), Box<dyn s
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -1750,7 +1761,7 @@ async fn test_deletion_table_provider_multiple_partitions() -> Result<(), Box<dy
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -1818,7 +1829,8 @@ async fn test_deletion_table_provider_with_filters() -> Result<(), Box<dyn std::
     let state = ctx.state();
     // Filter: value > 100 (this filter is passed to delete_from but currently mock doesn't use it)
     let filters = vec![col("value").gt(lit(100i64))];
-    let delete_plan = partition_provider.delete_from(&state, filters).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(partition_provider, &state, &filters).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -1873,7 +1885,7 @@ async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn s
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -1901,7 +1913,7 @@ async fn test_deletion_table_provider_empty_partitions() -> Result<(), Box<dyn s
 // ============================================================================
 
 /// Test that a partition provider without deletion support logs a warning and continues
-/// (non-deletable partition creator that returns regular `MemTable` without `delete_from`)
+/// (non-deletable partition creator that returns regular `MemTable` without `DeletionTableProviderAdapter`)
 #[derive(Debug)]
 struct NonDeletablePartitionCreator {
     schema: SchemaRef,
@@ -1959,10 +1971,9 @@ impl PartitionCreator for NonDeletablePartitionCreator {
     }
 }
 
-/// Test deletion with empty filters deletes all rows (`DataFusion`'s `MemTable` treats
-/// empty filters as "match all").
+/// Test deletion with partitions that don't support deletion (should return 0 and log warning)
 #[tokio::test]
-async fn test_deletion_with_empty_filters_deletes_all() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_deletion_with_non_deletable_partitions() -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
         Field::new("region", DataType::Utf8, false),
@@ -1994,7 +2005,7 @@ async fn test_deletion_with_empty_filters_deletes_all() -> Result<(), Box<dyn st
     df.write_table("test_table", DataFrameWriteOptions::new())
         .await?;
 
-    // Get the table provider and call delete_from with empty filters
+    // Get the table provider and call delete_from
     let table = ctx.table_provider("test_table").await?;
     let partition_provider = table
         .as_any()
@@ -2002,12 +2013,12 @@ async fn test_deletion_with_empty_filters_deletes_all() -> Result<(), Box<dyn st
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
 
-    // Empty filters = delete all rows
+    // Should return 0 since the partition doesn't support deletion
     assert_eq!(result.len(), 1, "Expected 1 result batch");
     let count_col = result[0]
         .column_by_name("count")
@@ -2018,8 +2029,8 @@ async fn test_deletion_with_empty_filters_deletes_all() -> Result<(), Box<dyn st
         .expect("Expected UInt64Array");
     assert_eq!(
         count_array.value(0),
-        3,
-        "Expected all 3 rows deleted with empty filters"
+        0,
+        "Expected 0 deleted rows from non-deletable partition"
     );
 
     Ok(())
@@ -2081,7 +2092,7 @@ async fn test_deletion_many_partitions() -> Result<(), Box<dyn std::error::Error
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -2157,7 +2168,8 @@ async fn test_deletion_complex_filters() -> Result<(), Box<dyn std::error::Error
             .and(col("status").eq(lit("active")))
             .or(col("id").eq(lit(1i64))),
     ];
-    let delete_plan = partition_provider.delete_from(&state, filters).await?;
+    let delete_plan =
+        DeletionTableProvider::delete_from(partition_provider, &state, &filters).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -2226,7 +2238,7 @@ async fn test_deletion_with_null_partition_value() -> Result<(), Box<dyn std::er
         .expect("Expected PartitionTableProvider");
 
     let state = ctx.state();
-    let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+    let delete_plan = DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
 
     // Execute the deletion plan
     let result = collect(delete_plan, ctx.task_ctx()).await?;
@@ -2292,7 +2304,8 @@ async fn test_deletion_repeated_calls() -> Result<(), Box<dyn std::error::Error>
 
     // Call delete_from multiple times
     for i in 0..3 {
-        let delete_plan = partition_provider.delete_from(&state, vec![]).await?;
+        let delete_plan =
+            DeletionTableProvider::delete_from(partition_provider, &state, &[]).await?;
         let result = collect(delete_plan, ctx.task_ctx()).await?;
 
         assert_eq!(result.len(), 1, "Iteration {i}: Expected 1 result batch");

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -22,6 +22,7 @@ use arrow::array::{ArrayRef, Int32Array, Int64Array, RecordBatch, StringArray, U
 use arrow::datatypes::DataType;
 use cache::Caching;
 use data_components::cdc::{self, ChangeBatch, ChangeOperation, ChangesStream};
+use data_components::delete::{DeletionTableProvider, get_deletion_provider};
 #[cfg(feature = "dynamodb")]
 use data_components::dynamodb::stream::StreamError as DynamoDBStreamError;
 #[cfg(any(feature = "debezium", feature = "kafka"))]
@@ -179,7 +180,11 @@ impl RefreshTask {
         for (op_type, row_indices) in sub_batches {
             match op_type {
                 ChangeOperationType::Delete => {
-                    self.process_delete_batch(&change_batch, &row_indices)
+                    let deletion_provider = get_deletion_provider(Arc::clone(&self.accelerator))
+                        .context(
+                            crate::accelerated_table::AcceleratedTableDoesntSupportDeleteSnafu,
+                        )?;
+                    self.process_delete_batch(&change_batch, &row_indices, &deletion_provider)
                         .await?;
                     had_change = true;
                 }
@@ -281,6 +286,7 @@ impl RefreshTask {
         &self,
         change_batch: &ChangeBatch,
         row_indices: &[usize],
+        deletion_provider: &Arc<dyn DeletionTableProvider>,
     ) -> crate::accelerated_table::Result<()> {
         let dataset_name = &self.dataset_name;
 
@@ -300,12 +306,14 @@ impl RefreshTask {
             let session_state = ctx.state();
 
             let _lock_guard = self.accelerator_write_mutex.lock().await;
-            let delete_plan = self
-                .accelerator
-                .delete_from(&session_state, vec![combined])
-                .await
-                .map_err(find_datafusion_root)
-                .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+            let delete_plan = DeletionTableProvider::delete_from(
+                deletion_provider.as_ref(),
+                &session_state,
+                &[combined],
+            )
+            .await
+            .map_err(find_datafusion_root)
+            .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
             collect(delete_plan, ctx.task_ctx())
                 .await
                 .map_err(find_datafusion_root)
@@ -531,6 +539,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use data_components::arrow::write::MemTable;
     use data_components::cdc::changes_schema;
+    use data_components::delete::DeletionTableProviderAdapter;
     use datafusion::datasource::TableProvider;
 
     use std::sync::Arc;
@@ -870,7 +879,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_change_delete_returns_data_written() {
-        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let adapter = Arc::new(DeletionTableProviderAdapter::new(make_mem_table()));
+        let task = make_refresh_task(adapter as Arc<dyn TableProvider>);
         let change_batch =
             create_test_change_batch(vec!["d"], &[vec!["id"]], vec![1], vec![Some("Alice")]);
         assert_eq!(

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 use arrow::array::UInt64Array;
 use cache::Caching;
+use data_components::delete::{DeletionTableProvider, get_deletion_provider};
 use datafusion::{
     catalog::TableProvider,
     logical_expr::Operator,
@@ -56,7 +57,7 @@ impl super::AcceleratedTable {
             // Lock the accelerator to protect concurrent access to the accelerator during cache/snapshot operations
             let _lock_guard = accelerator_write_mutex.lock().await;
 
-            {
+            if let Some(deleted_table_provider) = get_deletion_provider(Arc::clone(&accelerator)) {
                 let mut exprs = Vec::new();
 
                 // convert retention filters into data eviction expressions
@@ -136,7 +137,12 @@ impl super::AcceleratedTable {
                     default_runtime_env(io_runtime.clone()),
                 );
 
-                let plan = accelerator.delete_from(&ctx.state(), vec![expr]).await;
+                let plan = DeletionTableProvider::delete_from(
+                    deleted_table_provider.as_ref(),
+                    &ctx.state(),
+                    &[expr],
+                )
+                .await;
                 match plan {
                     Ok(plan) => match collect(plan, ctx.task_ctx()).await {
                         Err(e) => {
@@ -168,6 +174,8 @@ impl super::AcceleratedTable {
                         tracing::error!("[retention] Error running retention check: {e}");
                     }
                 }
+            } else {
+                tracing::error!("[retention] Accelerated table does not support delete");
             }
         }
     }
@@ -228,8 +236,8 @@ mod tests {
         array::{BooleanArray, Int64Array, RecordBatch, StringArray},
         datatypes::{DataType, Field, Schema},
     };
-    use data_components::arrow::write::MemTable;
-    use datafusion::{catalog::TableProvider, physical_plan::collect, prelude::SessionContext};
+    use data_components::{arrow::write::MemTable, delete::DeletionTableProviderAdapter};
+    use datafusion::{physical_plan::collect, prelude::SessionContext};
     use tokio::time::{Duration, sleep};
 
     fn create_test_schema() -> Arc<Schema> {
@@ -303,7 +311,8 @@ mod tests {
         let mem_table =
             MemTable::try_new(schema, vec![vec![batch]]).expect("mem table should be created");
 
-        let accelerator = Arc::new(mem_table) as Arc<dyn TableProvider>;
+        let accelerator = Arc::new(DeletionTableProviderAdapter::new(Arc::new(mem_table)))
+            as Arc<dyn TableProvider>;
 
         // Create retention configuration
         let retention_delete_expr = retention_sql.map(|sql| {

--- a/crates/runtime/src/catalogconnector/cayenne/provider.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/provider.rs
@@ -39,8 +39,7 @@ use crate::component::catalog::Catalog;
 use crate::parameters::Parameters;
 use crate::spice_data_base_path;
 use data_components::RefreshableCatalogProvider;
-use data_components::poly::PolyTableProvider;
-use runtime_table_partition::provider::PartitionTableProvider;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 
 use crate::catalogconnector::PartitionAwareCatalog;
 
@@ -503,92 +502,31 @@ impl CayenneSchemaProvider {
         existing_provider: &Arc<dyn TableProvider>,
         refreshed_provider: &Arc<dyn TableProvider>,
     ) -> bool {
-        // Case 1: Non-partitioned CayenneTableProvider — refresh in place from the
-        // freshly-loaded provider.
-        if let Some(existing_cayenne) = Self::cayenne_table_from_provider(existing_provider) {
-            let Some(refreshed_cayenne) = Self::cayenne_table_from_provider(refreshed_provider)
-            else {
-                return false;
-            };
-
-            if let Err(err) = existing_cayenne.refresh(refreshed_cayenne).await {
-                tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
-                return false;
-            }
-
-            return true;
-        }
-
-        // Case 2: PolyTableProvider — extract the writer and check its inner type.
-        let Some(poly) = existing_provider
-            .as_any()
-            .downcast_ref::<PolyTableProvider>()
-        else {
+        let Some(existing_cayenne) = Self::cayenne_table_from_provider(existing_provider) else {
+            return false;
+        };
+        let Some(refreshed_cayenne) = Self::cayenne_table_from_provider(refreshed_provider) else {
             return false;
         };
 
-        let existing_writer = poly.writer();
-
-        // Case 2a: Non-partitioned CayenneTableProvider inside PolyTableProvider.
-        if let Some(existing_cayenne) = existing_writer
-            .as_any()
-            .downcast_ref::<CayenneTableProvider>()
-        {
-            let refreshed_writer = refreshed_provider
-                .as_any()
-                .downcast_ref::<PolyTableProvider>()
-                .map(PolyTableProvider::writer);
-
-            let refreshed_cayenne = refreshed_writer
-                .as_ref()
-                .and_then(|w| w.as_any().downcast_ref::<CayenneTableProvider>());
-
-            if let Some(refreshed) = refreshed_cayenne {
-                if let Err(err) = existing_cayenne.refresh(refreshed).await {
-                    tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
-                    return false;
-                }
-                return true;
-            }
-
+        if let Err(err) = existing_cayenne.refresh(refreshed_cayenne).await {
+            tracing::warn!("Failed to refresh Cayenne table provider in place: {err}");
             return false;
         }
 
-        // Case 2b: PartitionTableProvider inside PolyTableProvider — refresh each
-        // partition's inner CayenneTableProvider from itself (reloads deletion
-        // vectors, protected snapshots, snapshot ID, and listing table from the
-        // catalog).
-        if let Some(partition_provider) = existing_writer
-            .as_any()
-            .downcast_ref::<PartitionTableProvider>()
-        {
-            let providers = partition_provider.partition_table_providers().await;
-            for provider in &providers {
-                // Each partition's inner provider is a CayenneTableProvider.
-                let Some(cayenne) = provider.as_any().downcast_ref::<CayenneTableProvider>() else {
-                    tracing::warn!(
-                        "Partition sub-provider is not a CayenneTableProvider, skipping refresh"
-                    );
-                    continue;
-                };
-                if let Err(err) = cayenne.refresh(cayenne).await {
-                    tracing::warn!("Failed to refresh partitioned Cayenne table in place: {err}");
-                    // Fail safely: keep the existing partitioned provider rather than
-                    // signaling failure that would cause it to be replaced by a
-                    // non-partitioned provider.
-                    return true;
-                }
-            }
-            return true;
-        }
-
-        false
+        true
     }
 
     fn cayenne_table_from_provider(
         provider: &Arc<dyn TableProvider>,
     ) -> Option<&CayenneTableProvider> {
-        provider.as_any().downcast_ref::<CayenneTableProvider>()
+        let adapter = provider
+            .as_any()
+            .downcast_ref::<DeletionTableProviderAdapter>()?;
+        adapter
+            .source()
+            .as_any()
+            .downcast_ref::<CayenneTableProvider>()
     }
 
     fn clear_tables(&self) {
@@ -625,7 +563,13 @@ impl CayenneSchemaProvider {
                     CayenneTableProviderBuilder::new(Arc::clone(catalog), Arc::clone(runtime_env));
 
                 match builder.open(table_name).await {
-                    Ok(provider) => Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>)),
+                    Ok(provider) => {
+                        let provider = Arc::new(provider);
+                        let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                        Ok(Some(Arc::new(DeletionTableProviderAdapter::new(
+                            deletion_provider,
+                        ))))
+                    }
                     Err(e) => {
                         tracing::warn!("Failed to open Cayenne table '{table_name}': {e}");
                         Ok(None)

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -26,6 +26,7 @@ use regex::Regex;
 use arrow::datatypes::DataType;
 use arrow_schema::Schema;
 use async_trait::async_trait;
+use data_components::delete::DeletionTableProviderAdapter;
 use data_components::poly::PolyTableProvider;
 use datafusion::common::DFSchema;
 use datafusion::common::arrow::datatypes::SchemaRef;
@@ -1167,7 +1168,7 @@ impl DataAccelerator for CayenneAccelerator {
         if partition_by.is_empty() {
             // Non-partitioned table - wrap in PolyTableProvider for proper deletion/retention support
             // Wrap with upsert deduplication if needed based on on_conflict settings
-            let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+            let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
                 cayenne_table,
                 &cmd.options,
                 cmd.constraints.clone(),
@@ -1181,6 +1182,7 @@ impl DataAccelerator for CayenneAccelerator {
 
             let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
                 Arc::clone(&write_provider),
+                delete_provider,
                 write_provider,
                 schema_metadata,
             ));
@@ -1263,7 +1265,7 @@ impl DataAccelerator for CayenneAccelerator {
             );
 
             // Wrap with upsert deduplication if needed based on on_conflict settings
-            let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+            let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
                 partition_provider,
                 &cmd.options,
                 cmd.constraints.clone(),
@@ -1277,6 +1279,7 @@ impl DataAccelerator for CayenneAccelerator {
 
             let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
                 Arc::clone(&write_provider),
+                delete_provider,
                 write_provider,
                 schema_metadata,
             ));
@@ -1548,9 +1551,13 @@ impl PartitionCreator for CayennePartitionCreator {
             .boxed()
             .context(creator::CreatePartitionSnafu)?;
 
+        // Wrap in DeletionTableProviderAdapter so get_deletion_provider can find it
+        let adapted_table: Arc<dyn TableProvider> =
+            Arc::new(DeletionTableProviderAdapter::new(Arc::new(cayenne_table)));
+
         Ok(Partition {
             partition_values,
-            table_provider: Arc::new(cayenne_table),
+            table_provider: adapted_table,
         })
     }
 
@@ -1617,9 +1624,13 @@ impl PartitionCreator for CayennePartitionCreator {
                 .boxed()
                 .context(creator::InferringPartitionsSnafu)?;
 
+            // Wrap in DeletionTableProviderAdapter so get_deletion_provider can find it
+            let adapted_table: Arc<dyn TableProvider> =
+                Arc::new(DeletionTableProviderAdapter::new(Arc::new(cayenne_table)));
+
             result.push(Partition {
                 partition_values,
-                table_provider: Arc::new(cayenne_table),
+                table_provider: adapted_table,
             });
         }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -590,7 +590,7 @@ pub(crate) async fn create_table_provider(
     };
 
     // Wrap with upsert deduplication if needed
-    let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+    let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
         duckdb_writer,
         &cmd.options,
         cmd.constraints.clone(),
@@ -615,6 +615,7 @@ pub(crate) async fn create_table_provider(
 
     let table_provider = Arc::new(PolyTableProvider::new_with_schema_metadata(
         write_provider,
+        delete_provider,
         read_provider,
         schema_metadata,
     ));
@@ -800,6 +801,7 @@ mod tests {
         array::{Int64Array, RecordBatch, StringArray, TimestampSecondArray, UInt64Array},
         datatypes::{DataType, Field, Schema},
     };
+    use data_components::delete::{DeletionTableProvider, get_deletion_provider};
     use datafusion::{
         common::{Constraints, TableReference, ToDFSchema},
         execution::context::SessionContext,
@@ -1162,6 +1164,9 @@ mod tests {
             .await
             .expect("insert successful");
 
+        let delete_table = get_deletion_provider(Arc::clone(&table))
+            .expect("table should be returned as deletion provider");
+
         let filter = cast(
             col("time_in_string"),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
@@ -1170,10 +1175,10 @@ mod tests {
             Some(1354360272000),
             None,
         )));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
-            .await
-            .expect("deletion should be successful");
+        let plan =
+            DeletionTableProvider::delete_from(delete_table.as_ref(), &ctx.state(), &[filter])
+                .await
+                .expect("deletion should be successful");
 
         let result = collect(plan, ctx.task_ctx())
             .await
@@ -1189,10 +1194,10 @@ mod tests {
         assert_eq!(actual, &expected);
 
         let filter = col("time_int").lt(lit(1354360273));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
-            .await
-            .expect("deletion should be successful");
+        let plan =
+            DeletionTableProvider::delete_from(delete_table.as_ref(), &ctx.state(), &[filter])
+                .await
+                .expect("deletion should be successful");
 
         let result = collect(plan, ctx.task_ctx())
             .await
@@ -1220,14 +1225,17 @@ mod tests {
             .await
             .expect("insert successful");
 
+        let delete_table = get_deletion_provider(Arc::clone(&table))
+            .expect("table should be returned as deletion provider");
+
         let filter = col("time").lt(lit(ScalarValue::TimestampMillisecond(
             Some(1354360272000),
             None,
         )));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
-            .await
-            .expect("deletion should be successful");
+        let plan =
+            DeletionTableProvider::delete_from(delete_table.as_ref(), &ctx.state(), &[filter])
+                .await
+                .expect("deletion should be successful");
 
         let result = collect(plan, ctx.task_ctx())
             .await
@@ -1251,14 +1259,17 @@ mod tests {
             .await
             .expect("insert successful");
 
+        let delete_table = get_deletion_provider(Arc::clone(&table))
+            .expect("table should be returned as deletion provider");
+
         let filter = col("time_with_zone").lt(lit(ScalarValue::TimestampMillisecond(
             Some(1354360272000),
             None,
         )));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
-            .await
-            .expect("deletion should be successful");
+        let plan =
+            DeletionTableProvider::delete_from(delete_table.as_ref(), &ctx.state(), &[filter])
+                .await
+                .expect("deletion should be successful");
 
         let result = collect(plan, ctx.task_ctx())
             .await

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -921,6 +921,7 @@ mod accelerator_compat_tests {
         },
         datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
     };
+    use data_components::delete::{DeletionTableProvider, get_deletion_provider};
     use datafusion::{
         common::{Constraints, TableReference, ToDFSchema},
         datasource::TableProvider,
@@ -2161,10 +2162,12 @@ mod accelerator_compat_tests {
             let data = generate_test_data(Arc::clone(&schema), 50, 0);
             insert_test_data(&table, &ctx, data).await;
 
+            // Get deletion provider
+            let table = get_deletion_provider(table).expect("should support deletion");
+
             // Delete rows where id > 3 (should delete ids 4-49, which is 46 rows)
             let filter = col("id").gt(lit(3_i64));
-            let plan = table
-                .delete_from(&ctx.state(), vec![filter])
+            let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
                 .await
                 .expect("deletion should be successful");
 

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -175,13 +175,17 @@ impl DataAccelerator for PostgresAccelerator {
         let postgres_writer = Arc::new(postgres_writer.clone());
 
         // Wrap with upsert deduplication if needed
-        let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+        let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
             postgres_writer,
             &cmd.options,
             cmd.constraints.clone(),
         );
 
-        let table_provider = Arc::new(PolyTableProvider::new(write_provider, read_provider));
+        let table_provider = Arc::new(PolyTableProvider::new(
+            write_provider,
+            delete_provider,
+            read_provider,
+        ));
 
         Ok(table_provider)
     }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -359,13 +359,17 @@ impl DataAccelerator for SqliteAccelerator {
         let sqlite_writer = Arc::new(sqlite_writer.clone());
 
         // Wrap with upsert deduplication if needed
-        let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+        let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
             sqlite_writer,
             &cmd.options,
             cmd.constraints.clone(),
         );
 
-        let table_provider = Arc::new(PolyTableProvider::new(write_provider, read_provider));
+        let table_provider = Arc::new(PolyTableProvider::new(
+            write_provider,
+            delete_provider,
+            read_provider,
+        ));
 
         Ok(table_provider)
     }
@@ -390,6 +394,7 @@ mod tests {
         array::{Int64Array, RecordBatch, StringArray, UInt64Array},
         datatypes::{DataType, Schema},
     };
+    use data_components::delete::{DeletionTableProvider, get_deletion_provider};
     use datafusion::{
         common::{Constraints, TableReference, ToDFSchema},
         execution::context::SessionContext,
@@ -454,6 +459,9 @@ mod tests {
             .await
             .expect("insert successful");
 
+        let table =
+            get_deletion_provider(table).expect("table should be returned as deletion provider");
+
         let filter = cast(
             col("time_in_string"),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
@@ -462,8 +470,7 @@ mod tests {
             Some(1354360272000),
             None,
         )));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
+        let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
             .await
             .expect("deletion should be successful");
 
@@ -483,8 +490,7 @@ mod tests {
         assert_eq!(actual, &expected);
 
         let filter = col("time_int").lt(lit(1354360273));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
+        let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
             .await
             .expect("deletion should be successful");
 

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -659,13 +659,17 @@ impl DataAccelerator for TursoAccelerator {
         ) as Arc<dyn TableProvider>;
 
         // Wrap with upsert deduplication if needed
-        let write_provider = upsert_dedup::wrap_with_upsert_dedup_if_needed(
+        let (write_provider, delete_provider) = upsert_dedup::wrap_with_upsert_dedup_if_needed(
             turso_provider,
             &cmd.options,
             cmd.constraints.clone(),
         );
 
-        let table_provider = Arc::new(PolyTableProvider::new(write_provider, fed_provider));
+        let table_provider = Arc::new(PolyTableProvider::new(
+            write_provider,
+            delete_provider,
+            fed_provider,
+        ));
 
         Ok(table_provider)
     }
@@ -691,6 +695,7 @@ mod tests {
         array::{Int64Array, RecordBatch, StringArray, UInt64Array},
         datatypes::{DataType, Schema},
     };
+    use data_components::delete::{DeletionTableProvider, get_deletion_provider};
     use datafusion::{
         common::{Constraints, TableReference, ToDFSchema},
         execution::context::SessionContext,
@@ -878,6 +883,9 @@ mod tests {
             .await
             .expect("insert successful");
 
+        let table =
+            get_deletion_provider(table).expect("table should be returned as deletion provider");
+
         let filter = cast(
             col("time_in_string"),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
@@ -886,8 +894,7 @@ mod tests {
             Some(1354360272000),
             None,
         )));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
+        let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
             .await
             .expect("deletion should be successful");
 
@@ -905,8 +912,7 @@ mod tests {
         assert_eq!(actual, &expected);
 
         let filter = col("time_int").lt(lit(1354360273));
-        let plan = table
-            .delete_from(&ctx.state(), vec![filter])
+        let plan = DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter])
             .await
             .expect("deletion should be successful");
 

--- a/crates/runtime/src/dataaccelerator/upsert_dedup.rs
+++ b/crates/runtime/src/dataaccelerator/upsert_dedup.rs
@@ -24,6 +24,7 @@ use std::{any::Any, sync::Arc};
 
 use arrow::{compute::concat_batches, datatypes::SchemaRef};
 use async_trait::async_trait;
+use data_components::delete::DeletionTableProvider;
 use datafusion::{
     catalog::Session,
     common::Constraints,
@@ -45,8 +46,10 @@ use futures::StreamExt;
 /// This is used to handle the `UpsertDedup` `on_conflict` behavior, which removes
 /// duplicate rows (based on primary key) from incoming batches before insertion.
 pub struct UpsertDedupTableProvider {
-    /// The underlying table provider for write and delete operations
+    /// The underlying table provider for write operations
     inner: Arc<dyn TableProvider>,
+    /// The underlying deletion provider for delete operations
+    deletion_provider: Arc<dyn DeletionTableProvider>,
     /// Options controlling deduplication behavior
     upsert_options: UpsertOptions,
     /// Constraints for deduplication (e.g., primary key)
@@ -58,17 +61,20 @@ impl UpsertDedupTableProvider {
     /// Creates a new `UpsertDedupTableProvider` wrapping the given provider.
     ///
     /// # Arguments
-    /// * `inner` - The underlying table provider to wrap
+    /// * `inner` - The underlying table provider to wrap (must implement `DeletionTableProvider`)
     /// * `upsert_options` - Options controlling deduplication behavior
     /// * `constraints` - Constraints for deduplication (e.g., primary key)
     #[must_use]
     pub fn new(
-        inner: Arc<dyn TableProvider>,
+        inner: Arc<dyn DeletionTableProvider>,
         upsert_options: UpsertOptions,
         constraints: Constraints,
     ) -> Self {
+        // Clone the Arc as TableProvider for regular operations
+        let inner_tp: Arc<dyn TableProvider> = Arc::<dyn DeletionTableProvider>::clone(&inner);
         Self {
-            inner,
+            inner: inner_tp,
+            deletion_provider: inner,
             upsert_options,
             constraints,
         }
@@ -161,13 +167,16 @@ impl TableProvider for UpsertDedupTableProvider {
 
         self.inner.insert_into(state, dedup_exec, op).await
     }
+}
 
+#[async_trait]
+impl DeletionTableProvider for UpsertDedupTableProvider {
     async fn delete_from(
         &self,
         state: &dyn Session,
-        filters: Vec<Expr>,
+        filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        self.inner.delete_from(state, filters).await
+        DeletionTableProvider::delete_from(self.deletion_provider.as_ref(), state, filters).await
     }
 }
 
@@ -326,20 +335,24 @@ pub fn extract_upsert_options<S: std::hash::BuildHasher>(
 ///
 /// Returns the original provider if deduplication is not needed.
 #[must_use]
-pub fn wrap_with_upsert_dedup_if_needed<T: TableProvider + 'static, S: std::hash::BuildHasher>(
+pub fn wrap_with_upsert_dedup_if_needed<
+    T: DeletionTableProvider + 'static,
+    S: std::hash::BuildHasher,
+>(
     provider: Arc<T>,
     options: &std::collections::HashMap<String, String, S>,
     constraints: Constraints,
-) -> Arc<dyn TableProvider> {
+) -> (Arc<dyn TableProvider>, Arc<dyn DeletionTableProvider>) {
     let upsert_options = extract_upsert_options(options);
 
     if upsert_options.remove_duplicates || upsert_options.last_write_wins {
-        Arc::new(UpsertDedupTableProvider::new(
+        let wrapper = Arc::new(UpsertDedupTableProvider::new(
             provider,
             upsert_options,
             constraints,
-        ))
+        ));
+        (Arc::<UpsertDedupTableProvider>::clone(&wrapper), wrapper)
     } else {
-        provider
+        (Arc::<T>::clone(&provider), provider)
     }
 }

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -380,14 +380,18 @@ impl DataConnector for IcebergDataConnector {
             Err(e) => return Some(Err(e)),
         };
 
-        // Wrap in IcebergDeletionProvider for DELETE FROM support.
+        // Wrap in IcebergDeletionProvider for DELETE FROM support, then in
+        // DeletionTableProviderAdapter so get_deletion_provider can find it.
         let deletion_provider = data_components::iceberg::delete::IcebergDeletionProvider::new(
             parts.catalog,
             parts.namespace,
             parts.table_name,
             parts.provider,
         );
-        Some(Ok(Arc::new(deletion_provider)))
+        let adapted: Arc<dyn TableProvider> = Arc::new(
+            data_components::delete::DeletionTableProviderAdapter::new(Arc::new(deletion_provider)),
+        );
+        Some(Ok(adapted))
     }
 }
 

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -20,7 +20,8 @@ limitations under the License.
 //! metadata catalog via `metadata_catalog.create_table(...)`, then opens and
 //! registers the corresponding `TableProvider` in the `DataFusion` catalog.
 //! Depending on the presence of a `PARTITION BY` expression, it constructs
-//! either a partitioned `PartitionTableProvider` or a non-partitioned provider, with data
+//! either a partitioned `PartitionTableProvider` wrapped in
+//! `DeletionTableProviderAdapter` or a non-partitioned provider, with data
 //! stored in Vortex columnar format on local filesystem paths managed by the
 //! Cayenne catalog provider. S3 Express One Zone applies to the Cayenne
 //! accelerator path, not Cayenne DDL catalog storage.
@@ -41,6 +42,7 @@ use arrow::array::{RecordBatch, StringArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use cayenne::CayenneTableProviderBuilder;
 use cayenne::metadata::CreateTableOptions;
+use data_components::delete::{DeletionTableProvider, DeletionTableProviderAdapter};
 use datafusion::catalog::{CatalogProviderList, SchemaProvider};
 use datafusion::common::ToDFSchema;
 use datafusion::error::{DataFusionError, Result as DFResult};
@@ -533,8 +535,10 @@ impl ExecutionPlan for CayenneCreateTableExec {
                             Arc::clone(&runtime_env),
                         );
                         if let Ok(provider) = builder.open(&metadata_table_name).await {
+                            let provider = Arc::new(provider);
+                            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
                             let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
-                                Arc::new(provider);
+                                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
                             if let Err(e) =
                                 schema_provider.register_table(table_name.clone(), wrapped_provider)
                             {
@@ -651,7 +655,10 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         ))
                     })?;
 
-                    Arc::new(partition_provider) as Arc<dyn datafusion::catalog::TableProvider>
+                    let partition_provider = Arc::new(partition_provider);
+                    let deletion_provider: Arc<dyn DeletionTableProvider> = partition_provider;
+                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                        as Arc<dyn datafusion::catalog::TableProvider>
                 } else {
                     // Non-partitioned: open the table we just created
                     let builder = CayenneTableProviderBuilder::new(
@@ -663,7 +670,10 @@ impl ExecutionPlan for CayenneCreateTableExec {
                             "Failed to open Cayenne table '{table_name}': {e}"
                         ))
                     })?;
-                    Arc::new(provider) as Arc<dyn datafusion::catalog::TableProvider>
+                    let provider = Arc::new(provider);
+                    let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                        as Arc<dyn datafusion::catalog::TableProvider>
                 };
 
             // Ensure the schema exists, creating it on demand if needed

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -294,7 +294,9 @@ impl ExecutionPlan for IcebergCreateTableExec {
                             raw_provider,
                         );
                     let adapted: Arc<dyn datafusion::datasource::TableProvider> =
-                        Arc::new(deletion_provider);
+                        Arc::new(data_components::delete::DeletionTableProviderAdapter::new(
+                            Arc::new(deletion_provider),
+                        ));
                     schema_provider.register_table(table_name.clone(), adapted)?;
                     Ok(())
                 };

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1263,6 +1263,7 @@ impl DataFusion {
                 "Failed to invalidate caches for table {table_reference} after write: {e}"
             );
         }
+        self.caching().flush_pending_invalidations().await;
 
         self.runtime_status
             .update_dataset(table_reference, status::ComponentStatus::Ready);
@@ -1328,6 +1329,7 @@ impl DataFusion {
                 "Failed to invalidate caches for table {table_reference} after streaming write: {e}"
             );
         }
+        self.caching().flush_pending_invalidations().await;
 
         Ok(())
     }

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -25,10 +25,9 @@ limitations under the License.
 //!    the AST, stored in the [`DdlExtensionStore`], and stripped before
 //!    delegating to `DataFusion`.
 //!
-//! 2. **DML interception** — DELETE and UPDATE statements targeting Cayenne
-//!    catalog tables are converted into [`LogicalPlan::Extension`] nodes
-//!    directly for distributed mode. Support for additional DML types
-//!    (INSERT, MERGE) may be added in the future.
+//! 2. **DML interception** — DELETE, UPDATE, INSERT, and MERGE statements
+//!    targeting Cayenne catalog tables are converted into
+//!    [`LogicalPlan::Extension`] nodes directly for distributed mode.
 //!
 //! For everything else, the planner delegates to `DataFusion`'s standard
 //! `session.statement_to_plan()` path.
@@ -117,8 +116,8 @@ pub async fn create_logical_plan(
                 return plan_cayenne_dml(statement, session, ctx, WriteOp::Update).await;
             }
 
-            // DML: INSERT on Cayenne tables
-            SQLStatement::Insert(_) => {
+            // DML: INSERT on Cayenne tables (only when Cayenne is active)
+            SQLStatement::Insert(_) if ctx.catalog_mode == CatalogMode::Cayenne => {
                 return plan_cayenne_dml(
                     statement,
                     session,

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -24,10 +24,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use app::AppBuilder;
 use arrow::array::RecordBatch;
-use datafusion::{
-    assert_batches_eq, datasource::TableProvider, physical_plan::collect, prelude::*,
-    sql::TableReference,
-};
+use data_components::delete::{DeletionTableProvider, get_deletion_provider};
+use datafusion::{assert_batches_eq, physical_plan::collect, prelude::*, sql::TableReference};
 use futures::TryStreamExt;
 use runtime::{Runtime, accelerated_table::AcceleratedTable};
 use runtime_request_context::{CacheControl, Protocol, RequestContext, UserAgent};
@@ -497,7 +495,7 @@ async fn test_cayenne_primary_key_delete() -> Result<(), anyhow::Error> {
             let expected = ["+-----+", "| cnt |", "+-----+", "| 5   |", "+-----+"];
             assert_batches_eq!(expected, &result);
 
-            // Delete by primary key using TableProvider::delete_from
+            // Delete by primary key using DeletionTableProvider::delete_from
             // (SQL DELETE is not supported through the runtime's SQL interface)
             let table_ref = TableReference::bare("pk_test");
             let table = rt
@@ -513,10 +511,14 @@ async fn test_cayenne_primary_key_delete() -> Result<(), anyhow::Error> {
                 .ok_or_else(|| anyhow::anyhow!("Table is not an AcceleratedTable"))?;
 
             let accelerator = accelerated_table.get_accelerator();
+            let deletion_provider = get_deletion_provider(Arc::clone(&accelerator))
+                .ok_or_else(|| anyhow::anyhow!("Accelerator does not support deletion"))?;
 
             let ctx = rt.datafusion().ctx.state();
             let filter = col("id").eq(lit(3i64));
-            let delete_plan = accelerator.delete_from(&ctx, vec![filter]).await?;
+            let delete_plan =
+                DeletionTableProvider::delete_from(deletion_provider.as_ref(), &ctx, &[filter])
+                    .await?;
             collect(delete_plan, rt.datafusion().ctx.task_ctx()).await?;
 
             // Verify deletion
@@ -1674,9 +1676,10 @@ async fn test_cayenne_delete_then_insert_new() -> Result<(), anyhow::Error> {
             let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
             assert_batches_eq!(expected, &result);
 
-            // Delete row with id=2
+            // Delete row with id=2 using DeletionTableProvider
             let filter = col("id").eq(lit(2i64));
-            let delete_plan = table.delete_from(&ctx.state(), vec![filter]).await?;
+            let delete_plan =
+                DeletionTableProvider::delete_from(table.as_ref(), &ctx.state(), &[filter]).await?;
             collect(delete_plan, ctx.task_ctx()).await?;
 
             // Verify deletion


### PR DESCRIPTION
## 📝 Summary

Fixes a data integrity regression introduced in #10101 (commit `e68ca0d`) and #10105 (commit `f155675`).

The `SQLStatement::Insert` arm in the unified statement planner (`crates/runtime/src/datafusion/planner/mod.rs`) was missing the `CatalogMode::Cayenne` guard that `DELETE`, `UPDATE`, and `MERGE` all have. This caused every `INSERT` statement — regardless of target table type — to be intercepted by `plan_cayenne_dml`.

In Scheduler (distributed) mode, this meant `INSERT` into a partitioned Cayenne table was routed through `DistributedCayenneInsertExec` correctly, but `INSERT` into non-Cayenne tables also hit this path unnecessarily. More critically, the regression window between `e68ca0d` (which removed the `INSERT` handler from `CayenneDdlAnalyzerRule`) and `f155675` (which wired `INSERT` into the planner without the guard) left distributed `INSERT` on Cayenne tables either unhandled or incorrectly routed, causing permanent data loss.

This was caught by the spicebench run ([#103](https://github.com/spiceai/spicebench/actions/runs/23939436268/job/69822334461)), where the `customer` table (TPC-H SF=1, 150,000 rows, `PARTITION BY bucket(5, c_nationkey)`) permanently landed at **130,112 rows** after ETL — 19,888 rows silently lost on executor nodes that never received their INSERT batches.

### Change

```diff
- SQLStatement::Insert(_) => {
+ SQLStatement::Insert(_) if ctx.catalog_mode == CatalogMode::Cayenne => {
```

All four DML arms are now symmetric:

```rust
SQLStatement::Delete(_)     if ctx.catalog_mode == CatalogMode::Cayenne => { ... }
SQLStatement::Update { .. } if ctx.catalog_mode == CatalogMode::Cayenne => { ... }
SQLStatement::Insert(_)     if ctx.catalog_mode == CatalogMode::Cayenne => { ... } // fixed
SQLStatement::Merge { .. }  if ctx.catalog_mode == CatalogMode::Cayenne => { ... }
```

INSERT into non-Cayenne tables (DuckDB, Postgres, Arrow accelerated tables, etc.) now falls through to `session.statement_to_plan()` unchanged, as it did before the unified planner was introduced.

Also updates the module doc comment to reflect that INSERT and MERGE are now implemented (not future work).

## 🔗 Related

Regression introduced by: #10101, #10105
Caught by: https://github.com/spiceai/spicebench/actions/runs/23939436268/job/69822334461