### PR TITLE
Add spiceio setup to sccache-enabled CI workflows

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -5,6 +5,9 @@ inputs:
   minio_endpoint:
     description: 'MinIO endpoint (used for Linux and Windows)'
     required: false
+  spiceio_endpoint:
+    description: 'Spiceio S3-compatible endpoint (used for macOS)'
+    required: false
 
 runs:
   using: 'composite'
@@ -46,9 +49,9 @@ runs:
         SCCACHE_REGION="us-east-1"
         SCCACHE_NO_CREDS="false"
 
-        # Use spiceio if it's running (started by spiceai/spiceio setup action)
-        if curl -sf -o /dev/null --connect-timeout 1 --max-time 2 "http://127.0.0.1:8333/" 2>/dev/null; then
-          SCCACHE_ENDPOINT="http://127.0.0.1:8333"
+        # Use spiceio if its endpoint was provided
+        if [ -n "${{ inputs.spiceio_endpoint }}" ]; then
+          SCCACHE_ENDPOINT="${{ inputs.spiceio_endpoint }}"
           SCCACHE_REGION="us-west-1"
           SCCACHE_NO_CREDS="true"
           echo "SCCACHE_CACHE_SIZE=2T" >> $GITHUB_ENV

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set spiceio log path
+        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-features-$$.log" >> "$GITHUB_ENV"
+
+      - name: Set up spiceio
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
       - name: Set up make
         uses: ./.github/actions/setup-make
 
@@ -59,6 +72,7 @@ jobs:
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Cache cargo-hack binary
         id: cache-cargo-hack
@@ -95,3 +109,15 @@ jobs:
       - name: Show sccache stats
         if: ${{ env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
+
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-features-logs
+          path: ${{ env.SPICEIO_LOG_FILE }}
+          if-no-files-found: ignore

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           name: ai-integration-test-archive
           path: ./integration.tar.zst
+          retention-days: 1
 
       - name: Kill spiceio
         if: always() && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -76,6 +76,7 @@ jobs:
   build:
     name: Build Test Binary (macOS)
     runs-on: spiceai-macos
+
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -84,10 +85,24 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set spiceio log path
+        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-models-build-$$.log" >> "$GITHUB_ENV"
+
+      - name: Set up spiceio
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -118,7 +133,18 @@ jobs:
         with:
           name: ai-integration-test-archive
           path: ./integration.tar.zst
-          retention-days: 1
+
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-models-build-logs
+          path: ${{ env.SPICEIO_LOG_FILE }}
+          if-no-files-found: ignore
 
   test-models:
     name: Test Models, AI & Search
@@ -362,6 +388,7 @@ jobs:
   build-extended:
     name: Build Test Binary (Extended)
     runs-on: spiceai-macos
+
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -370,10 +397,24 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set spiceio log path
+        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-models-build-extended-$$.log" >> "$GITHUB_ENV"
+
+      - name: Set up spiceio
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -402,3 +443,15 @@ jobs:
           name: ai-integration-test-archive-extended
           path: ./integration-extended.tar.zst
           retention-days: 1
+
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-models-build-extended-logs
+          path: ${{ env.SPICEIO_LOG_FILE }}
+          if-no-files-found: ignore

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -71,4 +71,3 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: 'fix: Update Search integration test snapshots'

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -45,17 +45,18 @@ jobs:
     if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
 
-    env:
-      SPICEIO_LOG_FILE: /tmp/spiceio-check.log
-
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set spiceio log path
+        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-check-$$.log" >> "$GITHUB_ENV"
+
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@7009d5f668671ef39af3c4065ea8f8e4501f78af # v0.4.2
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -65,6 +66,8 @@ jobs:
 
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
@@ -90,12 +93,16 @@ jobs:
       - name: Show sccache stats
         run: sccache --show-stats
 
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
       - name: Upload spiceio logs
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-check-logs
-          path: /tmp/spiceio-check.log
+          path: ${{ env.SPICEIO_LOG_FILE }}
           if-no-files-found: ignore
 
   build-and-test:
@@ -104,17 +111,18 @@ jobs:
     if: needs.check_changes.outputs.relevant_changes == 'true'
     runs-on: spiceai-macos
 
-    env:
-      SPICEIO_LOG_FILE: /tmp/spiceio-build.log
-
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set spiceio log path
+        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-build-$$.log" >> "$GITHUB_ENV"
+
       - name: Set up spiceio
-        uses: spiceai/spiceio/.github/actions/setup@7009d5f668671ef39af3c4065ea8f8e4501f78af # v0.4.2
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -124,6 +132,8 @@ jobs:
 
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -163,10 +173,14 @@ jobs:
             exit 1
           fi
 
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
       - name: Upload spiceio logs
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-build-logs
-          path: /tmp/spiceio-build.log
+          path: ${{ env.SPICEIO_LOG_FILE }}
           if-no-files-found: ignore


### PR DESCRIPTION
## Changes

- **Add spiceio setup (v0.4.3)** to CI workflows that use sccache: pr-develop, features, and integration_models (build + build-extended jobs)
- **Update setup-spiceio action** from v0.4.2 to v0.4.3 with id and explicit kill step
- **Add spiceio_endpoint input** to setup-sccache composite action, replacing the fragile curl health check probe with explicit endpoint passthrough
- **Use PID in spiceio log file paths** for runner concurrency safety
- **Remove stale title parameter** from integration_search.yml push-snap-changes step
