### PR TITLE
Add spiceio setup to sccache-enabled CI workflows

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Set spiceio log path
-        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-features-$$.log" >> "$GITHUB_ENV"
-
       - name: Set up spiceio
         id: setup-spiceio
         uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
@@ -119,5 +116,5 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-features-logs
-          path: ${{ env.SPICEIO_LOG_FILE }}
+          path: ${{ runner.temp }}/spiceio.log
           if-no-files-found: ignore

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -85,9 +85,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Set spiceio log path
-        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-models-build-$$.log" >> "$GITHUB_ENV"
-
       - name: Set up spiceio
         id: setup-spiceio
         uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
@@ -143,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-models-build-logs
-          path: ${{ env.SPICEIO_LOG_FILE }}
+          path: ${{ runner.temp }}/spiceio.log
           if-no-files-found: ignore
 
       - name: Kill spiceio
@@ -409,9 +406,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Set spiceio log path
-        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-models-build-extended-$$.log" >> "$GITHUB_ENV"
-
       - name: Set up spiceio
         id: setup-spiceio
         uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
@@ -465,5 +459,5 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-models-build-extended-logs
-          path: ${{ env.SPICEIO_LOG_FILE }}
+          path: ${{ runner.temp }}/spiceio.log
           if-no-files-found: ignore

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -133,7 +133,18 @@ jobs:
         with:
           name: ai-integration-test-archive
           path: ./integration.tar.zst
-          retention-days: 1
+
+      - name: Kill spiceio
+        if: always() && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: spiceio-models-build-logs
+          path: ${{ env.SPICEIO_LOG_FILE }}
+          if-no-files-found: ignore
 
       - name: Kill spiceio
         if: always() && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -71,3 +71,4 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          title: 'fix: Update Search integration test snapshots'

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Set spiceio log path
-        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-check-$$.log" >> "$GITHUB_ENV"
-
       - name: Set up spiceio
         id: setup-spiceio
         uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
@@ -102,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-check-logs
-          path: ${{ env.SPICEIO_LOG_FILE }}
+          path: ${{ runner.temp }}/spiceio.log
           if-no-files-found: ignore
 
   build-and-test:
@@ -116,9 +113,6 @@ jobs:
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
-
-      - name: Set spiceio log path
-        run: echo "SPICEIO_LOG_FILE=/tmp/spiceio-build-$$.log" >> "$GITHUB_ENV"
 
       - name: Set up spiceio
         id: setup-spiceio
@@ -182,5 +176,5 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: spiceio-build-logs
-          path: ${{ env.SPICEIO_LOG_FILE }}
+          path: ${{ runner.temp }}/spiceio.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Changes

- **Add spiceio setup (v0.4.3)** to CI workflows that use sccache: `pr-develop`, `features`, and `integration_models` (build + build-extended jobs)
- **Add `spiceio_endpoint` input** to `setup-sccache` composite action, replacing the fragile `curl` health check probe with explicit endpoint passthrough from `steps.setup-spiceio.outputs.endpoint`
- **Add kill step and log upload** for spiceio in each sccache-enabled job
- **Log upload path**: Uses `runner.temp/spiceio.log` matching where the setup action writes

## Files Changed

| File | Change |
|------|--------|
| `.github/actions/setup-sccache/action.yml` | Add `spiceio_endpoint` input; use it instead of curl probe |
| `.github/workflows/pr-develop.yml` | Upgrade spiceio v0.4.2 to v0.4.3, add id/kill step, pass endpoint to sccache |
| `.github/workflows/features.yml` | Add spiceio setup, kill step, log upload, pass endpoint to sccache |
| `.github/workflows/integration_models.yml` | Add spiceio to build + build-extended jobs, pass endpoint to sccache |
