### PR TITLE
Update setup-spiceio action to v0.5.0

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up spiceio
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set up spiceio
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -408,7 +408,7 @@ jobs:
 
       - name: Set up spiceio
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up spiceio
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set up spiceio
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@8c7781c6707cd60f1a18acb197168bebc9338532 # v0.4.3
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}


### PR DESCRIPTION
Update the `setup-spiceio` GitHub Action from [v0.4.3](https://github.com/spiceai/spiceio/commit/8c7781c6707cd60f1a18acb197168bebc9338532) to [v0.5.0](https://github.com/spiceai/spiceio/commit/07f50ad2b40d272a857ca2483712d8b0ade6480b).

Changes in spiceio v0.5.0:
- Buffered write-ahead-log (WAL) for streaming PutObject
- SET_INFO command with FileRenameInformation for atomic rename
- Pipelined write support
- Fix pipelined read ordering bug (out-of-order SMB2 responses)
- Pipeline depth increased from 8 to 64
- TCP socket buffers increased from 1 MB to 4 MB