### PR TITLE
fix: Debezium schema evolution breaks dataset init on reload (fixes #9782)

### DIFF
--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -153,7 +153,7 @@ pub struct Schema {
     pub name: String,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Field {
     #[serde(rename = "type")]
     pub field_type: String,
@@ -164,4 +164,163 @@ pub struct Field {
     pub version: Option<i64>,
     pub parameters: Option<HashMap<String, String>>,
     pub items: Option<Box<Field>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_field(field_type: &str, field_name: &str, optional: bool) -> Field {
+        Field {
+            field_type: field_type.to_string(),
+            fields: None,
+            optional,
+            name: None,
+            field: Some(field_name.to_string()),
+            version: None,
+            parameters: None,
+            items: None,
+        }
+    }
+
+    #[test]
+    fn field_equality_same_fields() {
+        let f1 = make_field("int32", "id", false);
+        let f2 = make_field("int32", "id", false);
+        assert_eq!(f1, f2);
+    }
+
+    #[test]
+    fn field_inequality_different_type() {
+        let f1 = make_field("int32", "id", false);
+        let f2 = make_field("int64", "id", false);
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn field_inequality_different_name() {
+        let f1 = make_field("int32", "id", false);
+        let f2 = make_field("int32", "name", false);
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn field_inequality_different_optionality() {
+        let f1 = make_field("int32", "id", false);
+        let f2 = make_field("int32", "id", true);
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn schema_evolution_column_added() {
+        let old_fields = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+        ];
+        let new_fields = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+            make_field("string", "email", true),
+        ];
+        assert_ne!(old_fields, new_fields);
+    }
+
+    #[test]
+    fn schema_evolution_column_removed() {
+        let old_fields = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+            make_field("string", "obsolete", true),
+        ];
+        let new_fields = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+        ];
+        assert_ne!(old_fields, new_fields);
+    }
+
+    #[test]
+    fn schema_evolution_column_type_changed() {
+        let old_fields = vec![
+            make_field("int32", "id", false),
+            make_field("int32", "count", false),
+        ];
+        let new_fields = vec![
+            make_field("int32", "id", false),
+            make_field("int64", "count", false),
+        ];
+        assert_ne!(old_fields, new_fields);
+    }
+
+    #[test]
+    fn schema_unchanged() {
+        let fields1 = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+        ];
+        let fields2 = vec![
+            make_field("int32", "id", false),
+            make_field("string", "name", true),
+        ];
+        assert_eq!(fields1, fields2);
+    }
+
+    #[test]
+    fn field_with_parameters_equality() {
+        let mut params = HashMap::new();
+        params.insert(
+            "connect.decimal.precision".to_string(),
+            "38".to_string(),
+        );
+        params.insert("scale".to_string(), "9".to_string());
+
+        let f1 = Field {
+            field_type: "bytes".to_string(),
+            fields: None,
+            optional: true,
+            name: Some("org.apache.kafka.connect.data.Decimal".to_string()),
+            field: Some("amount".to_string()),
+            version: Some(1),
+            parameters: Some(params.clone()),
+            items: None,
+        };
+        let f2 = Field {
+            field_type: "bytes".to_string(),
+            fields: None,
+            optional: true,
+            name: Some("org.apache.kafka.connect.data.Decimal".to_string()),
+            field: Some("amount".to_string()),
+            version: Some(1),
+            parameters: Some(params),
+            items: None,
+        };
+        assert_eq!(f1, f2);
+    }
+
+    #[test]
+    fn field_with_different_parameters() {
+        let mut params1 = HashMap::new();
+        params1.insert(
+            "connect.decimal.precision".to_string(),
+            "38".to_string(),
+        );
+        params1.insert("scale".to_string(), "9".to_string());
+
+        let mut params2 = HashMap::new();
+        params2.insert(
+            "connect.decimal.precision".to_string(),
+            "38".to_string(),
+        );
+        params2.insert("scale".to_string(), "18".to_string());
+
+        let f1 = Field {
+            parameters: Some(params1),
+            ..make_field("bytes", "amount", true)
+        };
+        let f2 = Field {
+            parameters: Some(params2),
+            ..make_field("bytes", "amount", true)
+        };
+        assert_ne!(f1, f2);
+    }
 }

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -268,10 +268,7 @@ mod tests {
     #[test]
     fn field_with_parameters_equality() {
         let mut params = HashMap::new();
-        params.insert(
-            "connect.decimal.precision".to_string(),
-            "38".to_string(),
-        );
+        params.insert("connect.decimal.precision".to_string(), "38".to_string());
         params.insert("scale".to_string(), "9".to_string());
 
         let f1 = Field {
@@ -300,17 +297,11 @@ mod tests {
     #[test]
     fn field_with_different_parameters() {
         let mut params1 = HashMap::new();
-        params1.insert(
-            "connect.decimal.precision".to_string(),
-            "38".to_string(),
-        );
+        params1.insert("connect.decimal.precision".to_string(), "38".to_string());
         params1.insert("scale".to_string(), "9".to_string());
 
         let mut params2 = HashMap::new();
-        params2.insert(
-            "connect.decimal.precision".to_string(),
-            "38".to_string(),
-        );
+        params2.insert("connect.decimal.precision".to_string(), "38".to_string());
         params2.insert("scale".to_string(), "18".to_string());
 
         let f1 = Field {

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -317,6 +317,20 @@ impl KafkaConsumer {
             .context(UnableToCommitMessageSnafu)
     }
 
+    /// Seek a specific partition to a given offset.
+    ///
+    /// This is used to rewind after peeking at a message (e.g., for schema
+    /// evolution detection) so the message is re-read by the changes stream.
+    pub fn seek(&self, topic: &str, partition: i32, offset: Offset) -> Result<()> {
+        self.consumer
+            .seek(topic, partition, offset, std::time::Duration::from_secs(5))
+            .context(UnableToRestartTopicSnafu {
+                message: format!(
+                    "Failed to seek partition {partition} to offset {offset:?}"
+                ),
+            })
+    }
+
     pub fn restart_topic(&self, topic: &str) -> Result<()> {
         let mut assignment = self
             .consumer

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -325,9 +325,7 @@ impl KafkaConsumer {
         self.consumer
             .seek(topic, partition, offset, std::time::Duration::from_secs(5))
             .context(UnableToRestartTopicSnafu {
-                message: format!(
-                    "Failed to seek partition {partition} to offset {offset:?}"
-                ),
+                message: format!("Failed to seek partition {partition} to offset {offset:?}"),
             })
     }
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -600,15 +600,21 @@ async fn check_schema_evolution(
     let msg = match peek_result {
         Ok(Ok(Some(msg))) => msg,
         Ok(Ok(None)) => {
-            tracing::debug!("No Kafka message available for schema evolution check on {dataset_name}");
+            tracing::debug!(
+                "No Kafka message available for schema evolution check on {dataset_name}"
+            );
             return;
         }
         Ok(Err(e)) => {
-            tracing::debug!("Could not peek Kafka message for schema evolution check on {dataset_name}: {e}");
+            tracing::debug!(
+                "Could not peek Kafka message for schema evolution check on {dataset_name}: {e}"
+            );
             return;
         }
         Err(_) => {
-            tracing::debug!("Timed out peeking Kafka message for schema evolution check on {dataset_name}");
+            tracing::debug!(
+                "Timed out peeking Kafka message for schema evolution check on {dataset_name}"
+            );
             return;
         }
     };
@@ -631,8 +637,7 @@ async fn check_schema_evolution(
         return;
     };
 
-    let new_fields_owned: Vec<change_event::Field> =
-        new_fields.into_iter().cloned().collect();
+    let new_fields_owned: Vec<change_event::Field> = new_fields.into_iter().cloned().collect();
 
     if new_fields_owned != metadata.schema_fields {
         tracing::info!(
@@ -642,9 +647,7 @@ async fn check_schema_evolution(
 
         if dataset.is_file_accelerated() {
             if let Err(e) = set_metadata_to_accelerator(dataset, metadata).await {
-                tracing::warn!(
-                    "Failed to persist updated schema metadata for {dataset_name}: {e}"
-                );
+                tracing::warn!("Failed to persist updated schema metadata for {dataset_name}: {e}");
             }
         }
     }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -312,7 +312,7 @@ impl DataConnector for Debezium {
 
         let (kafka_consumer, metadata, schema) = match get_metadata_from_accelerator(dataset).await
         {
-            Some(metadata) => {
+            Some(mut metadata) => {
                 if let Some(config_consumer_group_id) = &self.kafka_config.consumer_group_id {
                     ensure!(
                         config_consumer_group_id == &metadata.consumer_group_id,
@@ -349,6 +349,26 @@ impl DataConnector for Debezium {
                     }
                 );
 
+                kafka_consumer.subscribe(topic).boxed().context(
+                    super::UnableToGetReadProviderSnafu {
+                        dataconnector: "debezium",
+                        connector_component: ConnectorComponent::from(dataset),
+                    },
+                )?;
+
+                // Peek at the next available Kafka message to detect schema evolution.
+                // If the source table schema has changed since the metadata was cached,
+                // update the cached schema to avoid stale-schema errors (e.g. refresh SQL
+                // referencing columns that don't exist in the old schema).
+                check_schema_evolution(
+                    &kafka_consumer,
+                    topic,
+                    &dataset_name,
+                    dataset,
+                    &mut metadata,
+                )
+                .await;
+
                 let schema = debezium::arrow::convert_fields_to_arrow_schema(
                     metadata.schema_fields.iter().collect(),
                 )
@@ -357,13 +377,6 @@ impl DataConnector for Debezium {
                     dataconnector: "debezium",
                     connector_component: ConnectorComponent::from(dataset),
                 })?;
-
-                kafka_consumer.subscribe(topic).boxed().context(
-                    super::UnableToGetReadProviderSnafu {
-                        dataconnector: "debezium",
-                        connector_component: ConnectorComponent::from(dataset),
-                    },
-                )?;
 
                 (kafka_consumer, metadata, Arc::new(schema))
             }
@@ -560,4 +573,79 @@ async fn get_metadata_from_kafka(
         })?;
 
     Ok((kafka_consumer, metadata, Arc::new(schema)))
+}
+
+/// Peek at the next Kafka message to detect schema evolution.
+///
+/// When the source table schema has changed (columns added/removed/modified),
+/// Debezium produces messages with the updated schema. This function reads the
+/// next available message, compares its schema fields against the cached metadata,
+/// and updates the cache if the schema has evolved.
+///
+/// After peeking, the consumer is seeked back so the message is re-read by the
+/// changes stream and no CDC events are lost.
+async fn check_schema_evolution(
+    kafka_consumer: &KafkaConsumer,
+    topic: &str,
+    dataset_name: &str,
+    dataset: &Dataset,
+    metadata: &mut DebeziumKafkaMetadata,
+) {
+    let peek_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        kafka_consumer.next_json::<ChangeEventKey, ChangeEvent>(),
+    )
+    .await;
+
+    let msg = match peek_result {
+        Ok(Ok(Some(msg))) => msg,
+        Ok(Ok(None)) => {
+            tracing::debug!("No Kafka message available for schema evolution check on {dataset_name}");
+            return;
+        }
+        Ok(Err(e)) => {
+            tracing::debug!("Could not peek Kafka message for schema evolution check on {dataset_name}: {e}");
+            return;
+        }
+        Err(_) => {
+            tracing::debug!("Timed out peeking Kafka message for schema evolution check on {dataset_name}");
+            return;
+        }
+    };
+
+    // Seek back so the peeked message is re-read by the changes stream.
+    let partition = msg.partition();
+    let offset = msg.offset();
+    if let Err(e) = kafka_consumer.seek(
+        topic,
+        partition,
+        data_components::kafka::rdkafka::Offset::Offset(offset),
+    ) {
+        tracing::warn!(
+            "Failed to seek back after schema evolution check on {dataset_name}: {e}. \
+             A single CDC event may be skipped."
+        );
+    }
+
+    let Some(new_fields) = msg.value().get_schema_fields() else {
+        return;
+    };
+
+    let new_fields_owned: Vec<change_event::Field> =
+        new_fields.into_iter().cloned().collect();
+
+    if new_fields_owned != metadata.schema_fields {
+        tracing::info!(
+            "Detected schema evolution for dataset {dataset_name}. Updating cached schema."
+        );
+        metadata.schema_fields = new_fields_owned;
+
+        if dataset.is_file_accelerated() {
+            if let Err(e) = set_metadata_to_accelerator(dataset, metadata).await {
+                tracing::warn!(
+                    "Failed to persist updated schema metadata for {dataset_name}: {e}"
+                );
+            }
+        }
+    }
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -645,10 +645,10 @@ async fn check_schema_evolution(
         );
         metadata.schema_fields = new_fields_owned;
 
-        if dataset.is_file_accelerated() {
-            if let Err(e) = set_metadata_to_accelerator(dataset, metadata).await {
-                tracing::warn!("Failed to persist updated schema metadata for {dataset_name}: {e}");
-            }
+        if dataset.is_file_accelerated()
+            && let Err(e) = set_metadata_to_accelerator(dataset, metadata).await
+        {
+            tracing::warn!("Failed to persist updated schema metadata for {dataset_name}: {e}");
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes #9782

**Root cause:** The Debezium connector inferred the Arrow schema from the first Kafka message at startup and cached it in the accelerator database. On runtime reload, it used this cached schema without checking whether the source table schema had changed. When columns were added or removed from the source table, refresh SQL validation failed because it validated against the stale schema ("The column 'resources' is not present in the source table").

**Fix:** On reload, the connector now peeks at the next available Kafka message (with a 5-second timeout) and compares its schema fields against the cached metadata. If the schema has evolved, the cache is updated before refresh SQL validation. After peeking, the consumer seeks back to the same offset so the message is re-read by the changes stream and no CDC events are lost.

## Changes
- `change_event.rs`: Added `PartialEq` and `Debug` derives to `Field` struct so cached and fresh schemas can be compared
- `kafka.rs`: Added `KafkaConsumer::seek()` method to rewind a partition after peeking a message
- `debezium.rs`: Added `check_schema_evolution()` function called during the reload path in `read_provider()`. Moved `subscribe()` before schema check so the consumer can read messages.

## Test plan
- [x] Added 10 regression tests for Field equality and schema evolution detection:
  - `field_equality_same_fields` — identical fields compare equal
  - `field_inequality_different_type` — type change detected
  - `field_inequality_different_name` — column rename detected
  - `field_inequality_different_optionality` — nullability change detected
  - `schema_evolution_column_added` — added column detected
  - `schema_evolution_column_removed` — removed column detected
  - `schema_evolution_column_type_changed` — type change in multi-field schema detected
  - `schema_unchanged` — no false positives on identical schemas
  - `field_with_parameters_equality` — decimal fields with same parameters compare equal
  - `field_with_different_parameters` — decimal fields with changed scale detected
- [x] All existing debezium tests pass (22/22)
- [x] `cargo check` passes for both `data_components` and `runtime` crates
- [x] `cargo clippy` passes with no new warnings

## Checklist
- [x] Root cause identified and fixed
- [x] Regression tests added
- [x] Edge cases covered (timeout, no messages, deserialization errors, seek failure)
- [x] No snapshot deletions
- [x] Lint clean