### PR TITLE
ci: Add setup-spiceio and sccache to CodeQL workflow on macOS runners

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
+      - name: Set up spiceio
+        if: runner.os == 'macOS'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@07f50ad2b40d272a857ca2483712d8b0ade6480b # v0.5.0
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
+      - name: Set up sccache
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/setup-sccache
+        with:
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
@@ -70,5 +87,13 @@ jobs:
       #   make bootstrap
       #   make release
 
+      - name: Show sccache stats
+        if: runner.os == 'macOS'
+        run: sccache --show-stats
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true


### PR DESCRIPTION
When CodeQL runs on `spiceai-macos` (macOS) self-hosted runners, set up spiceio and sccache to accelerate builds — matching the pattern used in `pr-develop.yml`.

**Changes:**
- Add `setup-spiceio` step (conditioned on `runner.os == 'macOS'`)
- Add `setup-sccache` step (conditioned on `runner.os == 'macOS'`)
- Add `sccache --show-stats` step after build
- Add cleanup step to kill spiceio process