### PR TITLE
fix: remove double trailing slash in Unity Catalog storage locations (fixes #7904)

### DIFF
--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -339,7 +339,12 @@ fn table_reference_creator_spark(uc_table: &UCTable) -> Option<TableReference> {
 
 fn table_reference_creator_delta_lake(uc_table: &UCTable) -> Option<TableReference> {
     let storage_location = uc_table.storage_location.as_deref()?;
-    Some(TableReference::bare(format!("{storage_location}/")))
+    // Don't append a trailing slash here — `DeltaTable::from` calls
+    // `ensure_folder_location` which already adds one when needed.
+    // Unconditionally appending caused double-slash paths (e.g.
+    // "file:///path/to/table//") when the catalog API returned
+    // locations that already ended with '/'.
+    Some(TableReference::bare(storage_location.to_string()))
 }
 
 use token_provider::TokenProvider;
@@ -455,7 +460,7 @@ mod tests {
         );
         match reference {
             TableReference::Bare { table } => {
-                assert_eq!(table.as_ref(), "s3://bucket/path/");
+                assert_eq!(table.as_ref(), "s3://bucket/path");
             }
             _ => unreachable!("already asserted to be Bare table reference"),
         }
@@ -471,7 +476,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_reference_creator_delta_lake_appends_trailing_slash() {
+    fn test_table_reference_creator_delta_lake_preserves_location() {
         let table = make_uc_table(Some("abfss://container@account.dfs.core.windows.net/path"));
         let reference = table_reference_creator_delta_lake(&table).expect("should return Some");
         assert!(
@@ -480,12 +485,32 @@ mod tests {
         );
         match reference {
             TableReference::Bare { table } => {
-                assert!(
-                    table.as_ref().ends_with('/'),
-                    "delta lake reference should end with trailing slash"
+                assert_eq!(
+                    table.as_ref(),
+                    "abfss://container@account.dfs.core.windows.net/path",
+                    "delta lake reference should preserve location without modification"
                 );
             }
             _ => unreachable!("already asserted to be Bare table reference"),
+        }
+    }
+
+    /// Regression test for https://github.com/spiceai/spiceai/issues/7904
+    /// Storage locations ending with '/' must not get a second '/' appended.
+    #[test]
+    fn test_table_reference_creator_delta_lake_no_double_slash() {
+        let table = make_uc_table(Some("s3://bucket/path/"));
+        let reference = table_reference_creator_delta_lake(&table).expect("should return Some");
+        match reference {
+            TableReference::Bare { table } => {
+                assert!(
+                    !table.as_ref().ends_with("//"),
+                    "must not produce double trailing slash, got: {}",
+                    table.as_ref()
+                );
+                assert_eq!(table.as_ref(), "s3://bucket/path/");
+            }
+            _ => panic!("Expected Bare table reference"),
         }
     }
 
@@ -532,7 +557,7 @@ mod tests {
             TableReference::Bare { table } => {
                 assert_eq!(
                     table.as_ref(),
-                    "s3://my-bucket/warehouse/catalog/schema/table/"
+                    "s3://my-bucket/warehouse/catalog/schema/table"
                 );
             }
             _ => unreachable!("already asserted to be Bare table reference"),

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -495,7 +495,7 @@ mod tests {
         }
     }
 
-    /// Regression test for https://github.com/spiceai/spiceai/issues/7904
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/7904>
     /// Storage locations ending with '/' must not get a second '/' appended.
     #[test]
     fn test_table_reference_creator_delta_lake_no_double_slash() {

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -194,7 +194,12 @@ impl CatalogConnector for UnityCatalog {
 
 fn table_reference_creator(uc_table: &UCTable) -> Option<TableReference> {
     let storage_location = uc_table.storage_location.as_deref()?;
-    Some(TableReference::bare(format!("{storage_location}/")))
+    // Don't append a trailing slash here — `DeltaTable::from` calls
+    // `ensure_folder_location` which already adds one when needed.
+    // Unconditionally appending caused double-slash paths (e.g.
+    // "file:///path/to/table//") when the Unity Catalog API returned
+    // locations that already ended with '/'.
+    Some(TableReference::bare(storage_location.to_string()))
 }
 
 #[cfg(test)]
@@ -224,7 +229,7 @@ mod tests {
         );
         match reference {
             TableReference::Bare { table } => {
-                assert_eq!(table.as_ref(), "s3://my-bucket/warehouse/table/");
+                assert_eq!(table.as_ref(), "s3://my-bucket/warehouse/table");
             }
             _ => unreachable!("already asserted to be Bare table reference"),
         }
@@ -240,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_reference_creator_appends_trailing_slash() {
+    fn test_table_reference_creator_preserves_location_as_is() {
         let table = make_uc_table(Some("gs://bucket/path"));
         let reference = table_reference_creator(&table).expect("should return Some");
         assert!(
@@ -249,9 +254,10 @@ mod tests {
         );
         match reference {
             TableReference::Bare { table } => {
-                assert!(
-                    table.as_ref().ends_with('/'),
-                    "reference should end with trailing slash"
+                assert_eq!(
+                    table.as_ref(),
+                    "gs://bucket/path",
+                    "reference should preserve storage location without modification"
                 );
             }
             _ => unreachable!("already asserted to be Bare table reference"),
@@ -272,10 +278,67 @@ mod tests {
             TableReference::Bare { table } => {
                 assert_eq!(
                     table.as_ref(),
-                    "abfss://container@account.dfs.core.windows.net/warehouse/table/"
+                    "abfss://container@account.dfs.core.windows.net/warehouse/table"
                 );
             }
             _ => unreachable!("already asserted to be Bare table reference"),
+        }
+    }
+
+    /// Regression test for https://github.com/spiceai/spiceai/issues/7904
+    /// Unity Catalog API returns storage_location with a trailing slash.
+    /// Previously, `table_reference_creator` unconditionally appended another
+    /// slash, creating a double-slash path like "file:///path/to/table//"
+    /// which caused Delta Lake to fail with "Path does not exist".
+    #[test]
+    fn test_table_reference_creator_no_double_slash_when_location_ends_with_slash() {
+        let table = make_uc_table(Some(
+            "file:///home/unitycatalog/etc/data/managed/unity/default/tables/marksheet/",
+        ));
+        let reference = table_reference_creator(&table).expect("should return Some");
+        match reference {
+            TableReference::Bare { table } => {
+                assert!(
+                    !table.as_ref().ends_with("//"),
+                    "reference must not end with double slash, got: {}",
+                    table.as_ref()
+                );
+                assert_eq!(
+                    table.as_ref(),
+                    "file:///home/unitycatalog/etc/data/managed/unity/default/tables/marksheet/"
+                );
+            }
+            _ => panic!("Expected Bare table reference"),
+        }
+    }
+
+    /// Edge case: storage_location that is just a scheme with no path content.
+    #[test]
+    fn test_table_reference_creator_bare_scheme() {
+        let table = make_uc_table(Some("s3://bucket"));
+        let reference = table_reference_creator(&table).expect("should return Some");
+        match reference {
+            TableReference::Bare { table } => {
+                assert_eq!(table.as_ref(), "s3://bucket");
+            }
+            _ => panic!("Expected Bare table reference"),
+        }
+    }
+
+    /// Edge case: storage_location with file:// scheme for local paths.
+    #[test]
+    fn test_table_reference_creator_file_scheme() {
+        let table = make_uc_table(Some("file:///tmp/marksheet_uniform/"));
+        let reference = table_reference_creator(&table).expect("should return Some");
+        match reference {
+            TableReference::Bare { table } => {
+                assert_eq!(table.as_ref(), "file:///tmp/marksheet_uniform/");
+                assert!(
+                    !table.as_ref().ends_with("//"),
+                    "must not produce double trailing slash"
+                );
+            }
+            _ => panic!("Expected Bare table reference"),
         }
     }
 }

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -312,9 +312,9 @@ mod tests {
         }
     }
 
-    /// Edge case: storage_location that is just a scheme with no path content.
+    /// Edge case: storage_location pointing to a bucket root with no key/path.
     #[test]
-    fn test_table_reference_creator_bare_scheme() {
+    fn test_table_reference_creator_bucket_root() {
         let table = make_uc_table(Some("s3://bucket"));
         let reference = table_reference_creator(&table).expect("should return Some");
         match reference {

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -285,10 +285,10 @@ mod tests {
         }
     }
 
-    /// Regression test for https://github.com/spiceai/spiceai/issues/7904
-    /// Unity Catalog API returns storage_location with a trailing slash.
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/7904>
+    /// Unity Catalog API returns `storage_location` with a trailing slash.
     /// Previously, `table_reference_creator` unconditionally appended another
-    /// slash, creating a double-slash path like "file:///path/to/table//"
+    /// slash, creating a double-slash path like `file:///path/to/table//`
     /// which caused Delta Lake to fail with "Path does not exist".
     #[test]
     fn test_table_reference_creator_no_double_slash_when_location_ends_with_slash() {
@@ -312,7 +312,7 @@ mod tests {
         }
     }
 
-    /// Edge case: storage_location pointing to a bucket root with no key/path.
+    /// Edge case: `storage_location` pointing to a bucket root with no key/path.
     #[test]
     fn test_table_reference_creator_bucket_root() {
         let table = make_uc_table(Some("s3://bucket"));
@@ -325,7 +325,7 @@ mod tests {
         }
     }
 
-    /// Edge case: storage_location with file:// scheme for local paths.
+    /// Edge case: `storage_location` with `file://` scheme for local paths.
     #[test]
     fn test_table_reference_creator_file_scheme() {
         let table = make_uc_table(Some("file:///tmp/marksheet_uniform/"));


### PR DESCRIPTION
## Summary
Fixes #7904

**Root cause**: The `table_reference_creator` functions in both the Unity Catalog and Databricks catalog connectors unconditionally appended a trailing `/` to the `storage_location` from the catalog API. When the Unity Catalog API returned locations that already ended with `/` (e.g. `file:///home/unitycatalog/etc/data/managed/unity/default/tables/marksheet/`), this produced double-slash paths like `file:///path/to/table//`, which caused Delta Lake to fail with "Path does not exist".

The downstream `DeltaTable::from` already calls `ensure_folder_location` which adds a trailing slash only when needed, so the appending in `table_reference_creator` was both redundant and harmful.

## Changes
- Removed the unconditional trailing `/` append from `table_reference_creator` in `unity_catalog.rs`
- Applied the same fix to `table_reference_creator_delta_lake` in `databricks.rs` (same pattern)
- Updated existing tests to reflect the corrected behavior
- Added regression tests for the original bug scenario (file:// URIs with trailing slashes)
- Added edge case tests (bare scheme, file scheme paths)

## Test plan
- [x] Added regression test for the original bug scenario (`test_table_reference_creator_no_double_slash_when_location_ends_with_slash`)
- [x] Added edge case tests for bare scheme and file:// URIs
- [x] Added Databricks regression test (`test_table_reference_creator_delta_lake_no_double_slash`)
- [ ] `make lint` passes
- [ ] `make test` passes

## Checklist
- [x] Root cause identified and fixed
- [x] Regression tests added
- [x] Edge cases covered
- [x] No snapshot deletions
- [ ] Lint clean