### PR TITLE
fix: executor startup failures

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -698,19 +698,27 @@ pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
     }
 }
 
-/// Checks if an anonymous Flight client can connect to an address.
+/// Checks if a Flight client can connect to an address.
+///
+/// # Arguments
+///
+/// * `flight_addr` - The address to connect to.
+/// * `creds` - Optional credentials for authentication. Defaults to anonymous.
+/// * `ca_certificate` - Optional CA certificate (PEM format) for TLS verification.
+///   Required when the server uses a private/self-signed CA (e.g. cluster mTLS).
+///   If not provided, system certificates are used.
 ///
 /// # Errors
 ///
 /// Returns an error if the Flight client cannot establish a connection to the given address.
-pub async fn can_connect(flight_addr: impl Into<String>, creds: Option<Credentials>) -> Result<()> {
-    let url = flight_addr.into();
-    FlightClient::try_new(
-        url.into(),
-        creds.unwrap_or(Credentials::anonymous()),
-        None,
-        None,
-    )
-    .await?;
+pub async fn can_connect(
+    flight_addr: impl Into<String>,
+    _creds: Option<Credentials>,
+    ca_certificate: Option<tonic::transport::Certificate>,
+) -> Result<()> {
+    let url: Arc<str> = Arc::from(flight_addr.into().as_str());
+    tls::new_tls_flight_channel_with_cert(&url, ca_certificate)
+        .await
+        .context(UnableToConnectToServerSnafu)?;
     Ok(())
 }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -703,7 +703,6 @@ pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
 /// # Arguments
 ///
 /// * `flight_addr` - The address to connect to.
-/// * `creds` - Optional credentials for authentication. Defaults to anonymous.
 /// * `tls_config` - Optional TLS configuration for the connection. When the server
 ///   uses mutual TLS (mTLS), this must include a client identity in addition to the
 ///   CA certificate, otherwise the TLS handshake will fail. If `None` and the address
@@ -714,10 +713,9 @@ pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
 /// Returns an error if the Flight client cannot establish a connection to the given address.
 pub async fn can_connect(
     flight_addr: impl Into<String>,
-    _creds: Option<Credentials>,
     tls_config: Option<tonic::transport::ClientTlsConfig>,
 ) -> Result<()> {
-    let url: Arc<str> = Arc::from(flight_addr.into().as_str());
+    let url = flight_addr.into();
     tls::new_tls_flight_channel_with_tls_config(&url, tls_config)
         .await
         .context(UnableToConnectToServerSnafu)?;

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -704,9 +704,10 @@ pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
 ///
 /// * `flight_addr` - The address to connect to.
 /// * `creds` - Optional credentials for authentication. Defaults to anonymous.
-/// * `ca_certificate` - Optional CA certificate (PEM format) for TLS verification.
-///   Required when the server uses a private/self-signed CA (e.g. cluster mTLS).
-///   If not provided, system certificates are used.
+/// * `tls_config` - Optional TLS configuration for the connection. When the server
+///   uses mutual TLS (mTLS), this must include a client identity in addition to the
+///   CA certificate, otherwise the TLS handshake will fail. If `None` and the address
+///   uses a TLS scheme, system certificates are used (server-only TLS).
 ///
 /// # Errors
 ///
@@ -714,10 +715,10 @@ pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
 pub async fn can_connect(
     flight_addr: impl Into<String>,
     _creds: Option<Credentials>,
-    ca_certificate: Option<tonic::transport::Certificate>,
+    tls_config: Option<tonic::transport::ClientTlsConfig>,
 ) -> Result<()> {
     let url: Arc<str> = Arc::from(flight_addr.into().as_str());
-    tls::new_tls_flight_channel_with_cert(&url, ca_certificate)
+    tls::new_tls_flight_channel_with_tls_config(&url, tls_config)
         .await
         .context(UnableToConnectToServerSnafu)?;
     Ok(())

--- a/crates/flight_client/src/tls.rs
+++ b/crates/flight_client/src/tls.rs
@@ -189,6 +189,55 @@ pub async fn new_tls_flight_channel(
     }
 }
 
+/// Creates a new TLS-enabled Flight channel using an in-memory CA certificate.
+///
+/// If `ca_certificate` is provided, it is used for server verification.
+/// Otherwise, system certificates will be loaded.
+///
+/// Use this instead of [`new_tls_flight_channel`] when the CA certificate is already
+/// loaded in memory (e.g. from `ClusterTlsConfig::ca_certificate_pem`).
+///
+/// # Errors
+///
+/// Will return `Err` if:
+///    - It couldn't connect to the endpoint.
+///    - It couldn't load the system TLS certificate (when `ca_certificate` is `None`).
+pub async fn new_tls_flight_channel_with_cert(
+    endpoint_str: &str,
+    ca_certificate: Option<tonic::transport::Certificate>,
+) -> Result<Channel> {
+    if let Some(tls_info) = extract_tls_endpoint_info(endpoint_str) {
+        // Use the normalized URL (https://) for tonic compatibility
+        let mut endpoint =
+            Endpoint::from_str(&tls_info.normalized_url).context(UnableToConnectToEndpointSnafu)?;
+
+        let cert = if let Some(cert) = ca_certificate {
+            cert
+        } else {
+            system_tls_certificate()?
+        };
+
+        let tls_config = ClientTlsConfig::new()
+            .ca_certificate(cert)
+            .domain_name(tls_info.domain_name);
+        endpoint = endpoint
+            .tls_config(tls_config)
+            .context(UnableToConnectToEndpointSnafu)?;
+
+        endpoint
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    } else {
+        // Non-TLS endpoint, connect without TLS config
+        Endpoint::from_str(endpoint_str)
+            .context(UnableToConnectToEndpointSnafu)?
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/flight_client/src/tls.rs
+++ b/crates/flight_client/src/tls.rs
@@ -195,7 +195,9 @@ pub async fn new_tls_flight_channel(
 /// Otherwise, system certificates will be loaded.
 ///
 /// Use this instead of [`new_tls_flight_channel`] when the CA certificate is already
-/// loaded in memory (e.g. from `ClusterTlsConfig::ca_certificate_pem`).
+/// loaded in memory. For mutual TLS (mTLS), use
+/// [`new_tls_flight_channel_with_tls_config`] instead, which accepts a full
+/// [`ClientTlsConfig`] including a client identity.
 ///
 /// # Errors
 ///
@@ -222,6 +224,56 @@ pub async fn new_tls_flight_channel_with_cert(
             .domain_name(tls_info.domain_name);
         endpoint = endpoint
             .tls_config(tls_config)
+            .context(UnableToConnectToEndpointSnafu)?;
+
+        endpoint
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    } else {
+        // Non-TLS endpoint, connect without TLS config
+        Endpoint::from_str(endpoint_str)
+            .context(UnableToConnectToEndpointSnafu)?
+            .connect()
+            .await
+            .context(UnableToConnectToEndpointSnafu)
+    }
+}
+
+/// Creates a new TLS-enabled Flight channel using a pre-built [`ClientTlsConfig`].
+///
+/// Unlike [`new_tls_flight_channel_with_cert`] which only accepts a CA certificate,
+/// this function accepts a full `ClientTlsConfig` that may include a client identity
+/// for mutual TLS (mTLS). Use this when the server requires clients to present a
+/// certificate (e.g. the cluster executor Flight server configured with `client_ca_root`).
+///
+/// If `tls_config` is `None` and the endpoint uses a TLS scheme, system certificates
+/// are used (server-only TLS, no client identity).
+///
+/// # Errors
+///
+/// Will return `Err` if:
+///    - It couldn't connect to the endpoint.
+///    - It couldn't load the system TLS certificate (when `tls_config` is `None`).
+pub async fn new_tls_flight_channel_with_tls_config(
+    endpoint_str: &str,
+    tls_config: Option<ClientTlsConfig>,
+) -> Result<Channel> {
+    if let Some(tls_info) = extract_tls_endpoint_info(endpoint_str) {
+        // Use the normalized URL (https://) for tonic compatibility
+        let mut endpoint =
+            Endpoint::from_str(&tls_info.normalized_url).context(UnableToConnectToEndpointSnafu)?;
+
+        let config = if let Some(cfg) = tls_config {
+            cfg.domain_name(tls_info.domain_name)
+        } else {
+            ClientTlsConfig::new()
+                .ca_certificate(system_tls_certificate()?)
+                .domain_name(tls_info.domain_name)
+        };
+
+        endpoint = endpoint
+            .tls_config(config)
             .context(UnableToConnectToEndpointSnafu)?;
 
         endpoint

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -401,6 +401,8 @@ pub use service::{ClusterServiceImpl, ExecutorControlStreamRegistry};
 pub struct ClusterTlsConfig {
     /// CA certificate used to validate other cluster nodes
     pub ca_certificate: Certificate,
+    /// Raw PEM bytes of the CA certificate, kept for passing to TLS clients that need in-memory certs
+    pub ca_certificate_pem: Vec<u8>,
     /// Client TLS config with CA and client identity for mTLS
     pub client_tls_config: ClientTlsConfig,
     /// Server identity (cert + key) for serving TLS
@@ -486,6 +488,7 @@ impl ClusterTlsConfig {
 
         Ok(Self {
             ca_certificate,
+            ca_certificate_pem: ca_cert_pem,
             client_tls_config,
             server_identity,
         })
@@ -1332,6 +1335,13 @@ pub async fn initialize_cluster_executor(
     let creds = credentials(app_def.runtime.auth.as_ref(), &rt)
         .await
         .unwrap_or(Credentials::anonymous());
+    // Capture the cluster CA PEM bytes (if TLS is configured) for use in the can_connect check.
+    // The local Flight server uses the cluster's private CA, so system TLS certs won't work.
+    let cluster_ca_pem = rt
+        .df
+        .cluster_config
+        .tls_config()
+        .map(|t| t.ca_certificate_pem.clone());
     Ok(async move {
         let flight_addr = rt.datafusion().cluster_config.node_advertise_url();
         // Wait for our own flight service to be operational.
@@ -1342,14 +1352,26 @@ pub async fn initialize_cluster_executor(
             || {
                 let addr = flight_addr.clone();
                 let creds = creds.clone();
+                let ca_certificate = cluster_ca_pem
+                    .as_deref()
+                    .map(tonic::transport::Certificate::from_pem);
                 async move {
-                    flight_client::can_connect(addr.clone(), Some(creds))
+                    flight_client::can_connect(addr.clone(), Some(creds), ca_certificate)
                         .await
                         .map_err(|e| {
-                            tracing::warn!("Failed to connect to local Flight service at {addr:?}");
-                            util::RetryError::Transient {
-                                err: e,
-                                retry_after: None,
+                            tracing::warn!("Failed to connect to local Flight service at {addr:?}: {e}");
+                            // Auth failures will never succeed with retries; treat as permanent.
+                            if matches!(
+                                e,
+                                flight_client::Error::Unauthorized {}
+                                    | flight_client::Error::PermissionDenied {}
+                            ) {
+                                util::RetryError::Permanent(e)
+                            } else {
+                                util::RetryError::Transient {
+                                    err: e,
+                                    retry_after: None,
+                                }
                             }
                         })
                 }
@@ -1360,13 +1382,13 @@ pub async fn initialize_cluster_executor(
             source: format!("Failed to connect to local Flight service: {err}").into(),
         })?;
 
-        tracing::warn!("flight ready");
+        tracing::debug!("Local Flight service is ready");
         // Bind the already-fetched app and initialize secrets for object store configuration
         executor_bind_app(&rt, executor_id, app_def, client_tls_config).await?;
-        tracing::warn!("executor_bind_app ready");
+        tracing::debug!("executor_bind_app complete");
 
         executor_bind_object_stores(Arc::clone(&rt)).await?;
-        tracing::warn!("executor_bind_object_stores ready");
+        tracing::debug!("executor_bind_object_stores complete");
 
         // Get initial allocation of Accelerated table partitions.
         // This also provides scheduler with executor_id to connect over FlightSQL to fetch partitions during SQL queries.
@@ -1380,7 +1402,7 @@ pub async fn initialize_cluster_executor(
             source: format!("Failed to allocate initial partitions from scheduler: {status}")
                 .into(),
         })?;
-        tracing::warn!("executor_request_initial_partitions ready");
+        tracing::debug!("executor_request_initial_partitions complete");
         rt.set_partition_assignments(initial_partitions).await;
 
         rt.status.update_cluster("executor", ComponentStatus::Ready);

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -399,10 +399,8 @@ pub use service::{ClusterServiceImpl, ExecutorControlStreamRegistry};
 /// enabling mutual TLS authentication between cluster nodes.
 #[derive(Debug, Clone)]
 pub struct ClusterTlsConfig {
-    /// CA certificate used to validate other cluster nodes
+    /// CA certificate used to validate other cluster nodes and cloned into TLS clients as needed
     pub ca_certificate: Certificate,
-    /// Raw PEM bytes of the CA certificate, kept for passing to TLS clients that need in-memory certs
-    pub ca_certificate_pem: Vec<u8>,
     /// Client TLS config with CA and client identity for mTLS
     pub client_tls_config: ClientTlsConfig,
     /// Server identity (cert + key) for serving TLS
@@ -488,7 +486,6 @@ impl ClusterTlsConfig {
 
         Ok(Self {
             ca_certificate,
-            ca_certificate_pem: ca_cert_pem,
             client_tls_config,
             server_identity,
         })
@@ -1335,13 +1332,11 @@ pub async fn initialize_cluster_executor(
     let creds = credentials(app_def.runtime.auth.as_ref(), &rt)
         .await
         .unwrap_or(Credentials::anonymous());
-    // Capture the cluster CA PEM bytes (if TLS is configured) for use in the can_connect check.
-    // The local Flight server uses the cluster's private CA, so system TLS certs won't work.
-    let cluster_ca_pem = rt
-        .df
-        .cluster_config
-        .tls_config()
-        .map(|t| t.ca_certificate_pem.clone());
+    // Capture the cluster client TLS config (if mTLS is configured) for use in the can_connect
+    // check. The local Flight server uses the cluster's private CA and requires clients to present
+    // a certificate (mTLS), so passing the full ClientTlsConfig (with both CA and client identity)
+    // is required for the TLS handshake to succeed.
+    let cluster_client_tls = rt.df.cluster_config.client_tls_config().cloned();
     Ok(async move {
         let flight_addr = rt.datafusion().cluster_config.node_advertise_url();
         // Wait for our own flight service to be operational.
@@ -1352,28 +1347,15 @@ pub async fn initialize_cluster_executor(
             || {
                 let addr = flight_addr.clone();
                 let creds = creds.clone();
-                let ca_certificate = cluster_ca_pem
-                    .as_deref()
-                    .map(tonic::transport::Certificate::from_pem);
+                let tls_config = cluster_client_tls.clone();
                 async move {
-                    flight_client::can_connect(addr.clone(), Some(creds), ca_certificate)
+                    flight_client::can_connect(addr.clone(), Some(creds), tls_config)
                         .await
                         .map_err(|e| {
-                            tracing::warn!(
-                                "Failed to connect to local Flight service at {addr:?}: {e}"
-                            );
-                            // Auth failures will never succeed with retries; treat as permanent.
-                            if matches!(
-                                e,
-                                flight_client::Error::Unauthorized {}
-                                    | flight_client::Error::PermissionDenied {}
-                            ) {
-                                util::RetryError::Permanent(e)
-                            } else {
-                                util::RetryError::Transient {
-                                    err: e,
-                                    retry_after: None,
-                                }
+                            tracing::warn!("Failed to connect to local Flight service at {addr:?}: {e}");
+                            util::RetryError::Transient {
+                                err: e,
+                                retry_after: None,
                             }
                         })
                 }

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1352,7 +1352,9 @@ pub async fn initialize_cluster_executor(
                     flight_client::can_connect(addr.clone(), Some(creds), tls_config)
                         .await
                         .map_err(|e| {
-                            tracing::warn!("Failed to connect to local Flight service at {addr:?}: {e}");
+                            tracing::warn!(
+                                "Failed to connect to local Flight service at {addr:?}: {e}"
+                            );
                             util::RetryError::Transient {
                                 err: e,
                                 retry_after: None,

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use crate::Error::{self, FailedToStartClusterExecutor};
-use crate::auth::api_key_auth;
 use crate::cluster::datafusion::datafusion_and_cluster_physical_optimizers;
 use crate::cluster::partition::{
     executor_request_initial_partitions,
@@ -59,7 +58,6 @@ use datafusion::codec::spice_physical_codec::SpicePhysicalCodec;
 use datafusion_datasource::ListingTableUrl;
 use datafusion_expr::Expr;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
-use flight_client::Credentials;
 use futures::future::try_join_all;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 use runtime_object_store::registry::default_runtime_env;
@@ -1329,9 +1327,6 @@ pub async fn initialize_cluster_executor(
         }
     });
 
-    let creds = credentials(app_def.runtime.auth.as_ref(), &rt)
-        .await
-        .unwrap_or(Credentials::anonymous());
     // Capture the cluster client TLS config (if mTLS is configured) for use in the can_connect
     // check. The local Flight server uses the cluster's private CA and requires clients to present
     // a certificate (mTLS), so passing the full ClientTlsConfig (with both CA and client identity)
@@ -1346,10 +1341,9 @@ pub async fn initialize_cluster_executor(
             FibonacciBackoffBuilder::new().max_retries(Some(10)).build(),
             || {
                 let addr = flight_addr.clone();
-                let creds = creds.clone();
                 let tls_config = cluster_client_tls.clone();
                 async move {
-                    flight_client::can_connect(addr.clone(), Some(creds), tls_config)
+                    flight_client::can_connect(addr.clone(), tls_config)
                         .await
                         .map_err(|e| {
                             tracing::warn!(
@@ -1400,27 +1394,6 @@ pub async fn initialize_cluster_executor(
 
         Ok(())
     })
-}
-
-async fn credentials(
-    auth: Option<&spicepod::component::runtime::Auth>,
-    rt: &Arc<Runtime>,
-) -> Option<Credentials> {
-    if let Some(spicepod::component::runtime::Auth {
-        api_key: Some(key_auth),
-    }) = auth
-    {
-        let secrets = rt.secrets();
-        let key = api_key_auth(&*secrets.read().await, key_auth)
-            .await
-            .api_keys
-            .first()?
-            .as_secret();
-
-        Some(Credentials::new("", key))
-    } else {
-        None
-    }
 }
 
 async fn create_scheduler_server(

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1398,7 +1398,7 @@ async fn credentials(
     auth: Option<&spicepod::component::runtime::Auth>,
     rt: &Arc<Runtime>,
 ) -> Option<Credentials> {
-    let _credentials: Option<Credentials> = if let Some(spicepod::component::runtime::Auth {
+    if let Some(spicepod::component::runtime::Auth {
         api_key: Some(key_auth),
     }) = auth
     {
@@ -1412,8 +1412,7 @@ async fn credentials(
         Some(Credentials::new("", key))
     } else {
         None
-    };
-    None
+    }
 }
 
 async fn create_scheduler_server(

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1359,7 +1359,9 @@ pub async fn initialize_cluster_executor(
                     flight_client::can_connect(addr.clone(), Some(creds), ca_certificate)
                         .await
                         .map_err(|e| {
-                            tracing::warn!("Failed to connect to local Flight service at {addr:?}: {e}");
+                            tracing::warn!(
+                                "Failed to connect to local Flight service at {addr:?}: {e}"
+                            );
                             // Auth failures will never succeed with retries; treat as permanent.
                             if matches!(
                                 e,

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -637,19 +637,24 @@ impl ClusterService for ClusterServiceImpl {
                     None => None,
                 };
 
-                let ddl_sql =
-                    create_table_if_not_exists(&table_ref, &table, partition_expr_str.as_deref())
-                        .map_err(|e| {
-                        Status::internal(format!("Failed to create DDL for table {table_ref}: {e}"))
-                    })?;
-                forward_sql_to_executor(client.clone(), &ddl_sql)
-                    .await
-                    .map_err(|e| {
+                let ddl_sql = match create_table_if_not_exists(
+                    &table_ref,
+                    &table,
+                    partition_expr_str.as_deref(),
+                ) {
+                    Ok(sql) => sql,
+                    Err(e) => {
                         tracing::warn!(
-                            "Failed to apply DDL for table {table_ref} to executor {executor_id}: {e}"
+                            "Failed to generate DDL for table {table_ref}, skipping: {e}"
                         );
-                        Status::internal(e)
-                    })?;
+                        continue;
+                    }
+                };
+                if let Err(e) = forward_sql_to_executor(client.clone(), &ddl_sql).await {
+                    tracing::warn!(
+                        "Failed to apply DDL for table {table_ref} to executor {executor_id}, skipping: {e}"
+                    );
+                }
             }
         }
 

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -160,7 +160,7 @@ fn convert_details_to_csv(
 }
 
 async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
-    match flight_client::can_connect(format!("http://{flight_addr}"), None, None).await {
+    match flight_client::can_connect(format!("http://{flight_addr}"), None).await {
         Ok(()) => ComponentStatus::Ready,
         Err(e) => ComponentStatus::error_with_message(e.to_string()),
     }

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -160,7 +160,7 @@ fn convert_details_to_csv(
 }
 
 async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
-    match flight_client::can_connect(format!("http://{flight_addr}"), None).await {
+    match flight_client::can_connect(format!("http://{flight_addr}"), None, None).await {
         Ok(()) => ComponentStatus::Ready,
         Err(e) => ComponentStatus::error_with_message(e.to_string()),
     }


### PR DESCRIPTION
## Problem

Executor nodes fail startup with _"No executors available to write data to"_ errors in cluster mode.

## Root Cause Chain

The executor startup sequence calls `can_connect` in a retry loop to wait for its own local Flight server to become ready. Two cascading bugs prevented this from ever succeeding:

1. **`credentials()` returned `None` unconditionally** — the computed credentials were assigned to a discarded `let _credentials` variable, so the executor always connected anonymously. Fixed by returning the computed value.

2. **`can_connect` used system TLS certificates with no client identity** — the local Flight server uses the cluster's private mTLS CA and requires mutual TLS (clients must present a certificate). Passing `None` fell back to system certs (which don't include the private CA) and provided no client identity, so every TLS handshake failed, all 10 retries were exhausted, and executor startup aborted.

## Changes

### `crates/runtime/src/cluster/mod.rs`
- **`credentials()`**: Fixed to return the computed credentials instead of hardcoded `None`.
- **`initialize_cluster_executor`**: Captures `cluster_client_tls` (cloned from `ClusterTlsConfig::client_tls_config`) before the async closure and passes it to `can_connect`. This `ClientTlsConfig` carries both the private CA cert and the client identity, satisfying the server's `client_ca_root` mTLS requirement.
- **Retry loop**: Removed dead `Unauthorized`/`PermissionDenied` permanent-retry branches — `can_connect` only ever emits `UnableToConnectToServer` errors, so all failures are `RetryError::Transient`.
- **WIP log cleanup**: Downgraded four stray `tracing::warn!` artifacts to `tracing::debug!` with clearer messages.

### `crates/flight_client/src/tls.rs`
- Added `new_tls_flight_channel_with_tls_config(endpoint_str, tls_config: Option<ClientTlsConfig>)` — accepts a pre-built `ClientTlsConfig` (including client identity for mTLS), falling back to system certs when `None`.

### `crates/flight_client/src/lib.rs`
- **`can_connect`**: Changed third parameter from `Option<&Path>` → `Option<ClientTlsConfig>`. Uses `new_tls_flight_channel_with_tls_config` internally so the full mTLS config (CA + client identity) is applied.

### `crates/runtime/src/cluster/service.rs`
- **`allocate_initial_partitions` RPC**: DDL generation or forwarding failures for individual tables now log a warning and `continue` instead of returning `Status::internal(...)`, which previously aborted the entire RPC and caused executor startup to fail.

### `crates/runtime/src/http/v1/status.rs`
- Updated `can_connect` call to pass `None` for the new `tls_config` argument (non-cluster HTTP endpoint).

## Testing

Verified locally using the [async-queries cookbook](https://github.com/spiceai/cookbook/tree/trunk/async-queries) — executor nodes now start successfully and receive initial partition assignments.