### PR TITLE
Serialize/ship RequestContext for distributed queries

### DIFF
--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -433,6 +433,8 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use std::sync::{Arc, Mutex};
 
+    use runtime_request_context::{Protocol, RequestContextBuilder};
+
     use crate::extension::bytes_processed::{BytesEmittedCallback, BytesProcessedExec};
 
     fn make_test_table() -> Result<Arc<dyn TableProvider>> {
@@ -622,6 +624,105 @@ mod tests {
             "Expected non-zero bytes tracked after repartitioning"
         );
 
+        Ok(())
+    }
+
+    /// Verify that a stored `RequestContext` (via `with_request_context`) takes precedence
+    /// over a context supplied through the `TaskContext` session config extension.
+    #[tokio::test]
+    async fn test_stored_request_context_takes_precedence() -> Result<()> {
+        let ctx = make_test_context();
+        let test_table = make_test_table()?;
+        let data_source_exec = test_table.scan(&ctx.state(), None, &[], None).await?;
+
+        let stored_ctx = Arc::new(
+            RequestContextBuilder::new(Protocol::Flight)
+                .with_authorization_header(Some("Bearer stored-token".to_string()))
+                .build(),
+        );
+
+        let captured_protocol = Arc::new(Mutex::new(Vec::new()));
+        let captured_ref = Arc::clone(&captured_protocol);
+        let callback: Arc<BytesEmittedCallback> = Arc::new(Box::new(move |_bytes, dims| {
+            // The protocol dimension tells us which RequestContext was used.
+            for kv in dims {
+                if kv.key.as_str() == "protocol" {
+                    captured_ref
+                        .lock()
+                        .expect("mutex should not be poisoned")
+                        .push(kv.value.to_string());
+                }
+            }
+        }));
+
+        let exec = BytesProcessedExec::new(data_source_exec, callback)
+            .with_request_context(stored_ctx)
+            .fallback_to_new_context();
+
+        // Put a different protocol context on the session config so we can detect which one wins.
+        let session_req_ctx = RequestContextBuilder::new(Protocol::Http).build();
+        let session_with_ext = SessionContext::new_with_config(
+            SessionConfig::new()
+                .with_target_partitions(2)
+                .with_extension(Arc::new(session_req_ctx)),
+        );
+        let task_ctx = session_with_ext.task_ctx();
+        let _batches = collect(Arc::new(exec), task_ctx).await?;
+
+        let protocols = captured_protocol
+            .lock()
+            .expect("mutex should not be poisoned");
+        assert!(
+            !protocols.is_empty(),
+            "Expected at least one bytes-processed callback"
+        );
+        for p in protocols.iter() {
+            assert_eq!(
+                p, "flight",
+                "Expected stored context (Flight) to win over session context (Http)"
+            );
+        }
+        Ok(())
+    }
+
+    /// Verify that `fallback_to_new_context()` creates an Internal protocol context
+    /// when no stored context or session extension is available.
+    #[tokio::test]
+    async fn test_fallback_to_new_context() -> Result<()> {
+        let ctx = make_test_context();
+        let test_table = make_test_table()?;
+        let data_source_exec = test_table.scan(&ctx.state(), None, &[], None).await?;
+
+        let captured_protocol = Arc::new(Mutex::new(Vec::new()));
+        let captured_ref = Arc::clone(&captured_protocol);
+        let callback: Arc<BytesEmittedCallback> = Arc::new(Box::new(move |_bytes, dims| {
+            for kv in dims {
+                if kv.key.as_str() == "protocol" {
+                    captured_ref
+                        .lock()
+                        .expect("mutex should not be poisoned")
+                        .push(kv.value.to_string());
+                }
+            }
+        }));
+
+        // No stored context, no session extension — fallback should produce Internal.
+        let exec = BytesProcessedExec::new(data_source_exec, callback).fallback_to_new_context();
+        let _batches = collect(Arc::new(exec), ctx.task_ctx()).await?;
+
+        let protocols = captured_protocol
+            .lock()
+            .expect("mutex should not be poisoned");
+        assert!(
+            !protocols.is_empty(),
+            "Expected at least one bytes-processed callback"
+        );
+        for p in protocols.iter() {
+            assert_eq!(
+                p, "internal",
+                "Expected fallback to produce Internal protocol"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -103,10 +103,9 @@ impl PhysicalOptimizerRule for BytesProcessedPhysicalOptimizer {
                 return Ok(Transformed::new(plan, false, TreeNodeRecursion::Continue));
             }
 
-            let exec_plan =
-                BytesProcessedExec::new(plan, Arc::clone(&self.emit_bytes_callback))
-                    .with_request_context(Arc::clone(&request_context))
-                    .fallback_to_new_context();
+            let exec_plan = BytesProcessedExec::new(plan, Arc::clone(&self.emit_bytes_callback))
+                .with_request_context(Arc::clone(&request_context))
+                .fallback_to_new_context();
 
             Ok(Transformed::new(
                 Arc::new(exec_plan),

--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -88,6 +88,12 @@ impl PhysicalOptimizerRule for BytesProcessedPhysicalOptimizer {
         plan: std::sync::Arc<dyn ExecutionPlan>,
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        // Capture the current request context so it survives distribution to remote executors.
+        // SAFETY: The optimizer runs synchronously within the async task scope of the originating
+        // request, so the tokio task-local `REQUEST_CONTEXT` is set. Outside a request scope
+        // (e.g. refresh tasks) this returns the INTERNAL context, which is the correct fallback.
+        let request_context = unsafe { RequestContext::current_sync() };
+
         plan.transform_down(|plan| {
             if plan.as_any().downcast_ref::<BytesProcessedExec>().is_some() {
                 return Ok(Transformed::new(plan, false, TreeNodeRecursion::Jump));
@@ -97,10 +103,10 @@ impl PhysicalOptimizerRule for BytesProcessedPhysicalOptimizer {
                 return Ok(Transformed::new(plan, false, TreeNodeRecursion::Continue));
             }
 
-            let mut exec_plan =
-                BytesProcessedExec::new(plan, Arc::clone(&self.emit_bytes_callback));
-
-            exec_plan = exec_plan.fallback_to_new_context();
+            let exec_plan =
+                BytesProcessedExec::new(plan, Arc::clone(&self.emit_bytes_callback))
+                    .with_request_context(Arc::clone(&request_context))
+                    .fallback_to_new_context();
 
             Ok(Transformed::new(
                 Arc::new(exec_plan),
@@ -161,6 +167,10 @@ pub struct BytesProcessedExec {
     input_exec: Arc<dyn ExecutionPlan>,
     emit_bytes_callback: Arc<BytesEmittedCallback>,
     fallback_to_new_context: bool,
+    /// Pre-captured request context for distributed execution.
+    /// When present, this context is used instead of reading from the `TaskContext` session config.
+    /// This allows trace IDs and protocol information to survive scheduler-to-executor distribution.
+    request_context: Option<Arc<RequestContext>>,
 }
 
 impl BytesProcessedExec {
@@ -172,6 +182,7 @@ impl BytesProcessedExec {
             input_exec,
             emit_bytes_callback,
             fallback_to_new_context: false,
+            request_context: None,
         }
     }
 
@@ -179,6 +190,19 @@ impl BytesProcessedExec {
     pub fn fallback_to_new_context(mut self) -> Self {
         self.fallback_to_new_context = true;
         self
+    }
+
+    /// Attach a pre-captured `RequestContext` so it is preserved across distributed execution.
+    #[must_use]
+    pub fn with_request_context(mut self, request_context: Arc<RequestContext>) -> Self {
+        self.request_context = Some(request_context);
+        self
+    }
+
+    /// Returns the stored request context, if any.
+    #[must_use]
+    pub fn request_context(&self) -> Option<&Arc<RequestContext>> {
+        self.request_context.as_ref()
     }
 }
 
@@ -275,6 +299,7 @@ impl ExecutionPlan for BytesProcessedExec {
             input_exec: input,
             emit_bytes_callback: Arc::clone(&self.emit_bytes_callback),
             fallback_to_new_context: self.fallback_to_new_context,
+            request_context: self.request_context.clone(),
         }))
     }
 
@@ -299,7 +324,9 @@ impl ExecutionPlan for BytesProcessedExec {
         let stream = self.input_exec.execute(partition, Arc::clone(&context))?;
         let schema = stream.schema();
 
-        let request_context = if let Some(request_context) =
+        let request_context = if let Some(request_context) = &self.request_context {
+            Arc::clone(request_context)
+        } else if let Some(request_context) =
             context.session_config().get_extension::<RequestContext>()
         {
             request_context

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -198,12 +198,30 @@ message MetricsResponse {
     bytes otlp_metrics = 2;
 }
 
+// Serialized RequestContext for distributed query execution.
+// Carries the essential request metadata so that trace IDs and protocol
+// information survive scheduler-to-executor distribution.
+message RequestContextProto {
+    // Protocol enum value (see runtime_request_context::Protocol).
+    uint32 protocol = 1;
+    // W3C traceparent trace-id as a 32-char lowercase hex string.
+    optional string trace_id = 2;
+    // W3C traceparent span-id as a 16-char lowercase hex string.
+    optional string span_id = 3;
+    // Raw Authorization header value from the original request.
+    optional string authorization_header = 4;
+}
+
 // Physical plan
 message SchemaCastScanExecNode {
     bytes schema = 1;
 }
 
-message BytesProcessedExecNode {}
+message BytesProcessedExecNode {
+    // The request context captured at plan optimization time on the scheduler.
+    // Allows executors to reconstruct the RequestContext (trace IDs, protocol, etc.).
+    optional RequestContextProto request_context = 1;
+}
 
 message CayenneAccelerationExecNode {}
 

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -27,12 +27,15 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::ScalarUDF;
 use datafusion_proto::generated::datafusion_common;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use opentelemetry::trace::{SpanId, TraceId};
 use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
 use runtime_proto::{
-    BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode, UdtfExecNode,
+    BytesProcessedExecNode, CayenneAccelerationExecNode, RequestContextProto,
+    SchemaCastScanExecNode, UdtfExecNode,
 };
+use runtime_request_context::{Protocol, RequestContext, RequestContextBuilder, TraceParent};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -87,14 +90,17 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             ));
 
             Ok(exec)
-        } else if BytesProcessedExecNode::decode(buf).is_ok() {
-            Ok(Arc::new(
-                BytesProcessedExec::new(
-                    Arc::clone(&inputs[0]),
-                    Arc::new(Box::new(track_bytes_processed)),
-                )
-                .fallback_to_new_context(),
-            ))
+        } else if let Ok(node) = BytesProcessedExecNode::decode(buf) {
+            let request_context = request_context_from_proto(node.request_context);
+            let mut exec = BytesProcessedExec::new(
+                Arc::clone(&inputs[0]),
+                Arc::new(Box::new(track_bytes_processed)),
+            )
+            .fallback_to_new_context();
+            if let Some(ctx) = request_context {
+                exec = exec.with_request_context(Arc::new(ctx));
+            }
+            Ok(Arc::new(exec))
         } else if CayenneAccelerationExecNode::decode(buf).is_ok() {
             #[cfg(not(windows))]
             {
@@ -144,8 +150,11 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             let node = SchemaCastScanExecNode { schema: schema_buf };
             node.encode(buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        } else if node.as_any().downcast_ref::<BytesProcessedExec>().is_some() {
-            let node = BytesProcessedExecNode {};
+        } else if let Some(bytes_exec) = node.as_any().downcast_ref::<BytesProcessedExec>() {
+            let request_context = bytes_exec
+                .request_context()
+                .map(|ctx| request_context_to_proto(ctx));
+            let node = BytesProcessedExecNode { request_context };
             node.encode(buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         } else if let Some(udtf_exec) = node.as_any().downcast_ref::<UdtfExec>() {
@@ -187,4 +196,47 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
     fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
         self.runtime()?.df.ctx.udf(name)
     }
+}
+
+/// Serialize the essential fields of a [`RequestContext`] into a proto message.
+fn request_context_to_proto(ctx: &RequestContext) -> RequestContextProto {
+    let (trace_id, span_id) = ctx
+        .trace_parent()
+        .as_ref()
+        .map_or((None, None), |tp| {
+            (
+                Some(tp.trace_id.to_string()),
+                Some(tp.span_id.to_string()),
+            )
+        });
+
+    RequestContextProto {
+        protocol: ctx.protocol() as u32,
+        trace_id,
+        span_id,
+        authorization_header: ctx.authorization_header().map(str::to_string),
+    }
+}
+
+/// Reconstruct a [`RequestContext`] from its proto representation, if present.
+fn request_context_from_proto(proto: Option<RequestContextProto>) -> Option<RequestContext> {
+    let proto = proto?;
+
+    let protocol = Protocol::from(proto.protocol as u8);
+
+    let trace_parent = match (proto.trace_id, proto.span_id) {
+        (Some(tid), Some(sid)) => {
+            let trace_id = TraceId::from_hex(&tid).ok()?;
+            let span_id = SpanId::from_hex(&sid).ok()?;
+            Some(TraceParent { trace_id, span_id })
+        }
+        _ => None,
+    };
+
+    let ctx = RequestContextBuilder::new(protocol)
+        .with_trace_parent(trace_parent)
+        .with_authorization_header(proto.authorization_header)
+        .build();
+
+    Some(ctx)
 }

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -80,17 +80,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             return Ok(plan);
         }
 
-        if let Ok(node) = SchemaCastScanExecNode::decode(buf) {
-            let schema = datafusion_common::Schema::decode(&*node.schema)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-            let exec = Arc::new(SchemaCastScanExec::new(
-                Arc::clone(&inputs[0]),
-                Arc::new(Schema::try_from(&schema)?),
-            ));
-
-            Ok(exec)
-        } else if let Ok(node) = BytesProcessedExecNode::decode(buf) {
+        if let Ok(node) = BytesProcessedExecNode::decode(buf) {
             let request_context = request_context_from_proto(node.request_context);
             let mut exec = BytesProcessedExec::new(
                 Arc::clone(&inputs[0]),
@@ -101,6 +91,16 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 exec = exec.with_request_context(Arc::new(ctx));
             }
             Ok(Arc::new(exec))
+        } else if let Ok(node) = SchemaCastScanExecNode::decode(buf) {
+            let schema = datafusion_common::Schema::decode(&*node.schema)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            let exec = Arc::new(SchemaCastScanExec::new(
+                Arc::clone(&inputs[0]),
+                Arc::new(Schema::try_from(&schema)?),
+            ));
+
+            Ok(exec)
         } else if CayenneAccelerationExecNode::decode(buf).is_ok() {
             #[cfg(not(windows))]
             {
@@ -216,14 +216,16 @@ fn request_context_to_proto(ctx: &RequestContext) -> RequestContextProto {
 fn request_context_from_proto(proto: Option<RequestContextProto>) -> Option<RequestContext> {
     let proto = proto?;
 
-    let protocol = Protocol::from(proto.protocol as u8);
+    let protocol = match u8::try_from(proto.protocol).ok().map(Protocol::from) {
+        Some(Protocol::Invalid) | None => return None,
+        Some(protocol) => protocol,
+    };
 
     let trace_parent = match (proto.trace_id, proto.span_id) {
-        (Some(tid), Some(sid)) => {
-            let trace_id = TraceId::from_hex(&tid).ok()?;
-            let span_id = SpanId::from_hex(&sid).ok()?;
-            Some(TraceParent { trace_id, span_id })
-        }
+        (Some(tid), Some(sid)) => match (TraceId::from_hex(&tid), SpanId::from_hex(&sid)) {
+            (Ok(trace_id), Ok(span_id)) => Some(TraceParent { trace_id, span_id }),
+            _ => None,
+        },
         _ => None,
     };
 

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -200,15 +200,9 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 
 /// Serialize the essential fields of a [`RequestContext`] into a proto message.
 fn request_context_to_proto(ctx: &RequestContext) -> RequestContextProto {
-    let (trace_id, span_id) = ctx
-        .trace_parent()
-        .as_ref()
-        .map_or((None, None), |tp| {
-            (
-                Some(tp.trace_id.to_string()),
-                Some(tp.span_id.to_string()),
-            )
-        });
+    let (trace_id, span_id) = ctx.trace_parent().as_ref().map_or((None, None), |tp| {
+        (Some(tp.trace_id.to_string()), Some(tp.span_id.to_string()))
+    });
 
     RequestContextProto {
         protocol: ctx.protocol() as u32,


### PR DESCRIPTION
## Description

Fixes https://github.com/spiceai/spiceai/issues/7610

Serializes and ships the `RequestContext` (trace IDs, protocol, authorization header) across scheduler→executor boundaries in distributed queries, so that observability trace correlation is preserved.

### Changes

**Proto** (`spice.proto`)
- Added `RequestContextProto` message with `protocol`, `trace_id`, `span_id`, and `authorization_header` fields.
- Updated `BytesProcessedExecNode` to carry an optional `RequestContextProto`.

**BytesProcessedExec** (`bytes_processed.rs`)
- Added `request_context: Option<Arc<RequestContext>>` field with `with_request_context()` builder method and `request_context()` accessor.
- The `BytesProcessedPhysicalOptimizer` now captures the current `RequestContext` at plan optimization time and stores it on each `BytesProcessedExec` node.
- `execute()` prefers the stored context over the `TaskContext` session config extension, then falls back to a new internal context.

**SpicePhysicalCodec** (`spice_physical_codec.rs`)
- `try_encode` serializes the stored `RequestContext` from `BytesProcessedExec` into the proto.
- `try_decode` reconstructs the `RequestContext` from proto and attaches it via `with_request_context()`.
- Added `request_context_to_proto()` and `request_context_from_proto()` conversion helpers.

### Testing
- All existing `BytesProcessedExec` unit tests pass (3 tests).
- All codec unit tests pass (4 tests).
- Clippy clean.