### PR TITLE
fix: prevent silent batch loss in Flight write-through forwarding to executors

### DIFF
--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -177,6 +177,11 @@ impl CayenneDataSink {
     ///
     /// Returns an error if the data cannot be inserted.
     async fn write_all_append(&self, data: SendableRecordBatchStream) -> super::Result<u64> {
+        tracing::info!(
+            "write_all_append: starting for table '{}'",
+            self.table.table_name(),
+        );
+
         // Ensure no incomplete write from a previous crash before proceeding.
         // A leftover staging WAL indicates an interrupted file-move operation,
         // meaning the table may contain partial data. Block all writes until resolved.
@@ -324,6 +329,12 @@ impl CayenneDataSink {
         self.table.refresh_listing_table()?;
 
         // Write lock is released when `_write_guard` drops (in write_all).
+
+        tracing::info!(
+            "write_all_append: completed for table '{}', returning {} rows",
+            self.table.table_name(),
+            total_rows,
+        );
 
         Ok(total_rows)
     }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1498,6 +1498,14 @@ impl CayenneTableProvider {
         let total_rows = total_rows_written.load(Ordering::Relaxed);
         let writer_ops = usize::from(total_rows > 0); // 1 writer op if we wrote any rows, otherwise 0
 
+        tracing::info!(
+            "write_to_snapshot completed for table '{}' snapshot '{}': {} rows in {} writer op(s)",
+            self.table_metadata.table_name,
+            snapshot_id,
+            total_rows,
+            writer_ops,
+        );
+
         // Log final summary for S3 Express uploads
         if is_s3_storage {
             let elapsed = start_time.elapsed();

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -278,8 +278,8 @@ impl ExecutionPlan for PartitionerExec {
                             ))?;
                         }
                         Err(join_err) => {
-                            tracing::info!(
-                                "Partition write task failed (task panicked or was cancelled): {join_err}; rows_received_so_far={row_count}"
+                            tracing::error!(
+                                "Partition write task failed (task panicked or was cancelled): {join_err}"
                             );
                             return Err(DataFusionError::Execution(format!(
                                 "Partition write task failed (task panicked or was cancelled): {join_err}"

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -271,10 +271,20 @@ impl ExecutionPlan for PartitionerExec {
                 drop(partition_senders);
 
                 for handle in handles {
-                    if let Ok(output) = handle.await {
-                        output.map_err(|e| DataFusionError::Execution(
-                            format!("An error occurred while writing to one or more partition files. Some partitions may contain outdated or corrupted data. It is recommended to delete and recreate the accelerated files: {e}")
-                        ))?;
+                    match handle.await {
+                        Ok(output) => {
+                            output.map_err(|e| DataFusionError::Execution(
+                                format!("An error occurred while writing to one or more partition files. Some partitions may contain outdated or corrupted data. It is recommended to delete and recreate the accelerated files: {e}")
+                            ))?;
+                        }
+                        Err(join_err) => {
+                            tracing::info!(
+                                "Partition write task failed (task panicked or was cancelled): {join_err}; rows_received_so_far={row_count}"
+                            );
+                            return Err(DataFusionError::Execution(format!(
+                                "Partition write task failed (task panicked or was cancelled): {join_err}"
+                            )));
+                        }
                     }
                 }
 

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -338,14 +338,25 @@ pub(crate) async fn forward_partitioned_batches(
 
     // Route each batch through partition filters to the appropriate executor.
     let mut routing_error: Option<Error> = None;
+    let mut routed_batches: u64 = 0;
+    let mut routed_rows: u64 = 0;
     while let Some(batch_result) = StreamExt::next(&mut batches).await {
         let batch = match batch_result {
             Ok(b) => b,
             Err(e) => {
+                tracing::error!(
+                    table = %path,
+                    routed_batches,
+                    routed_rows,
+                    error = %e,
+                    "Routing loop: error reading batch from input stream; stopping routing"
+                );
                 routing_error = Some(e);
                 break;
             }
         };
+        routed_batches += 1;
+        routed_rows += batch.num_rows() as u64;
         if let Err(e) = route_batch_and_assign_unseen(
             &batch,
             &mut executor_filters,
@@ -358,10 +369,25 @@ pub(crate) async fn forward_partitioned_batches(
         )
         .await
         {
+            tracing::error!(
+                table = %path,
+                routed_batches,
+                routed_rows,
+                error = %e,
+                "Routing loop: error routing batch to executor; stopping routing"
+            );
             routing_error = Some(e);
             break;
         }
     }
+
+    tracing::info!(
+        table = %path,
+        executors = all_executor_ids.len(),
+        routed_batches,
+        routed_rows,
+        "Scheduler routing loop complete"
+    );
 
     // Signal completion by dropping senders, then await all forwarding tasks.
     // Collect executor-side errors even when routing failed — the forwarding

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -976,32 +976,84 @@ async fn forward_batches_to_executor(
         }
     };
 
-    if let Err(e) = response.into_inner().try_collect::<Vec<_>>().await {
-        encoder_handle.abort();
-        tracing::error!(
-            executor = %executor_id,
-            table = %table_label,
-            elapsed_ms = elapsed_ms(),
-            batches = batches_forwarded.load(Ordering::Relaxed),
-            keepalives = keepalives_sent.load(Ordering::Relaxed),
-            error = %e,
-            "Executor `DoPut` acknowledgement failed",
-        );
-        return Err(Error::DoPutAck { source: e });
-    }
-
-    tracing::info!(
-        executor = %executor_id,
-        table = %table_label,
-        elapsed_ms = elapsed_ms(),
-        batches = batches_forwarded.load(Ordering::Relaxed),
-        keepalives = keepalives_sent.load(Ordering::Relaxed),
-        "Executor forwarding task completed successfully",
+    // Drive the encoder task and the DoPut response stream concurrently.
+    //
+    // The executor sends PutResult acks as it receives and commits each batch,
+    // and closes the response stream only after it has processed everything.
+    // The encoder task encodes RecordBatches from `rx` into FlightData and sends
+    // them into `flight_rx`; it signals completion (or an error) via
+    // `encode_result_tx` once `rx` is fully drained.
+    //
+    // We must wait for BOTH to finish before declaring success:
+    //  - The encoder must fully drain `rx` and close `flight_rx` so the executor
+    //    receives every batch — if we dropped `flight_rx` early, the encoder's
+    //    remaining sends would fail and those batches would be silently lost.
+    //  - The response stream must be fully consumed so we know the executor has
+    //    committed every batch it received.
+    //
+    // `join!` runs both futures concurrently on the same task. Dropping either
+    // future here would abort the other, so we let join! drive them to completion.
+    let (encode_result, ack_result) = tokio::join!(
+        async {
+            match encode_result_rx.await {
+                Ok(result) => result.map_err(|message| Error::Encode { message }),
+                Err(_) => {
+                    // The sender was dropped without sending a result, which
+                    // means the encoder task was aborted or panicked.
+                    Err(Error::Encode {
+                        message: "encoder task ended unexpectedly without sending a result"
+                            .to_string(),
+                    })
+                }
+            }
+        },
+        async {
+            response
+                .into_inner()
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| Error::DoPutAck { source: e })
+        },
     );
 
-    match encode_result_rx.await {
-        Ok(Ok(())) | Err(_) => Ok(()),
-        Ok(Err(message)) => Err(Error::Encode { message }),
+    match (encode_result, ack_result) {
+        (Ok(()), Ok(_)) => {
+            tracing::info!(
+                executor = %executor_id,
+                table = %table_label,
+                elapsed_ms = elapsed_ms(),
+                batches = batches_forwarded.load(Ordering::Relaxed),
+                keepalives = keepalives_sent.load(Ordering::Relaxed),
+                "Executor forwarding task completed successfully",
+            );
+            Ok(())
+        }
+        (Err(e), _) => {
+            encoder_handle.abort();
+            tracing::error!(
+                executor = %executor_id,
+                table = %table_label,
+                elapsed_ms = elapsed_ms(),
+                batches = batches_forwarded.load(Ordering::Relaxed),
+                keepalives = keepalives_sent.load(Ordering::Relaxed),
+                error = %e,
+                "Executor forwarding encoder failed",
+            );
+            Err(e)
+        }
+        (_, Err(e)) => {
+            encoder_handle.abort();
+            tracing::error!(
+                executor = %executor_id,
+                table = %table_label,
+                elapsed_ms = elapsed_ms(),
+                batches = batches_forwarded.load(Ordering::Relaxed),
+                keepalives = keepalives_sent.load(Ordering::Relaxed),
+                error = %e,
+                "Executor `DoPut` acknowledgement failed",
+            );
+            Err(e)
+        }
     }
 }
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -598,14 +598,19 @@ impl ClusterService for ClusterServiceImpl {
                 );
             })
             .map_err(|e| Status::internal(format!("Failed to create Flight SQL client: {e}")))?;
-        {
-            let mut flight_client_registry =
-                self.executor_registry.flight_sql_clients.write().await;
-            flight_client_registry.insert(executor_id.to_string(), client.clone());
-        }
 
         // Forward `CREATE TABLE IF NOT EXISTS` DDL to executor, including PARTITION BY
         // when the table has a partition expression in the Cayenne metadata catalog.
+        //
+        // IMPORTANT: The executor client is intentionally NOT yet registered in
+        // `flight_sql_clients` at this point. Registering it before the DDL is applied
+        // would open a race: a concurrent write-through could see the executor in the
+        // registry, open a DoPut channel to it, and fail immediately because the target
+        // table does not yet exist on the executor. That DoPut failure would close the
+        // sender channel, causing the routing loop to break out early and silently drop
+        // all remaining batches in the stream. By deferring registration until after DDL
+        // and partition allocation are complete the executor is only visible to writers
+        // once it is fully ready to receive data.
         #[cfg(not(windows))]
         for table_ref in discover_cayenne_tables(&self.datafusion).await {
             if let Some(table) = self.datafusion.get_table(&table_ref).await {
@@ -674,6 +679,15 @@ impl ClusterService for ClusterServiceImpl {
                     tracing::warn!("Failed to allocate partitions to executor {executor_id}: {e}");
                 }
             }
+        }
+
+        // Register the executor client only after DDL has been applied and partitions
+        // have been allocated. This ensures the executor is fully ready to receive
+        // write-through traffic before it becomes visible to the routing loop.
+        {
+            let mut flight_client_registry =
+                self.executor_registry.flight_sql_clients.write().await;
+            flight_client_registry.insert(executor_id.to_string(), client);
         }
 
         Ok(Response::new(AllocateInitialPartitionsResponse {

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -493,10 +493,11 @@ impl ExecutionPlan for CayenneCreateTableExec {
             let metadata_table_name = format!("{df_schema_name}/{table_name}");
 
             // Check if table already exists via the metadata catalog
-            let exists = metadata_catalog
+            let existing_table_metadata = metadata_catalog
                 .get_table(&metadata_table_name)
                 .await
-                .is_ok();
+                .ok();
+            let exists = existing_table_metadata.is_some();
 
             if exists {
                 if if_not_exists {
@@ -520,21 +521,146 @@ impl ExecutionPlan for CayenneCreateTableExec {
                         };
 
                     // Open and register the existing table provider if not already present.
+                    // IMPORTANT: for partitioned tables, we must register a PartitionTableProvider
+                    // (not a plain CayenneTableProvider) so that DoPut writes are routed correctly
+                    // through PartitionerExec. Registering a plain provider would cause all writes
+                    // to bypass partition routing and write to a single non-partitioned sub-table.
                     if !schema_provider.table_exist(&table_name) {
-                        let builder = CayenneTableProviderBuilder::new(
-                            Arc::clone(&metadata_catalog),
-                            Arc::clone(&runtime_env),
-                        );
-                        if let Ok(provider) = builder.open(&metadata_table_name).await {
-                            let provider = Arc::new(provider);
-                            let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
-                            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
-                                Arc::new(DeletionTableProviderAdapter::new(deletion_provider));
-                            if let Err(e) =
-                                schema_provider.register_table(table_name.clone(), wrapped_provider)
-                            {
-                                tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
-                            }
+                        let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
+                            if let Some(ref partition_expr) = partition_expr {
+                                // Partitioned table: reconstruct PartitionTableProvider so writes
+                                // are routed through PartitionerExec.
+                                let table_id = existing_table_metadata
+                                    .as_ref()
+                                    .map(|m| m.table_id.clone())
+                                    .unwrap_or_default();
+
+                                let table_data_path = format!(
+                                    "{}{metadata_table_name}/",
+                                    data_base_path.trim_end_matches('/').to_string() + "/"
+                                );
+
+                                let vortex_schema =
+                                    match transform_schema_for_vortex(
+                                        &arrow_schema,
+                                        UnsupportedTypeAction::Error,
+                                    ) {
+                                        Ok(s) => Arc::new(s),
+                                        Err(e) => {
+                                            tracing::error!(
+                                                table_name,
+                                                error = %e,
+                                                "Failed to transform schema for Vortex while registering existing partitioned table"
+                                            );
+                                            return Ok(RecordBatch::try_new(
+                                                result_schema,
+                                                vec![Arc::new(StringArray::from(vec![format!(
+                                                    "Table '{table_name}' already exists"
+                                                )]))],
+                                            )?);
+                                        }
+                                    };
+
+                                let partition_name = partition_label
+                                    .clone()
+                                    .unwrap_or_else(|| partition_label_for_expr(partition_expr));
+
+                                let on_conflict = if primary_key.is_empty() {
+                                    None
+                                } else {
+                                    Some(OnConflict::Upsert(ColumnReference::new(
+                                        primary_key.clone(),
+                                    )))
+                                };
+
+                                let partition_by = vec![PartitionedBy {
+                                    name: partition_name,
+                                    expression: partition_expr.clone(),
+                                }];
+
+                                let creator = Arc::new(CayennePartitionCreator::new(
+                                    metadata_table_name.clone(),
+                                    PathBuf::from(&table_data_path),
+                                    partition_by.clone(),
+                                    Arc::clone(&vortex_schema),
+                                    Arc::clone(&metadata_catalog),
+                                    table_id,
+                                    UnsupportedTypeAction::Error,
+                                    Vec::new(), // retention_filters
+                                    None,       // time_retention_filter_builder
+                                    vortex_config.clone(),
+                                    None, // object_store_config (local filesystem)
+                                    primary_key.clone(),
+                                    on_conflict,
+                                    Arc::clone(&runtime_env),
+                                ));
+
+                                match PartitionTableProvider::new(
+                                    creator,
+                                    partition_by,
+                                    Arc::clone(&vortex_schema),
+                                )
+                                .await
+                                {
+                                    Ok(partition_provider) => {
+                                        let partition_provider = Arc::new(partition_provider);
+                                        let deletion_provider: Arc<dyn DeletionTableProvider> =
+                                            partition_provider;
+                                        Arc::new(DeletionTableProviderAdapter::new(
+                                            deletion_provider,
+                                        ))
+                                            as Arc<dyn datafusion::catalog::TableProvider>
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            table_name,
+                                            error = %e,
+                                            "Failed to reconstruct PartitionTableProvider for existing partitioned table on restart"
+                                        );
+                                        return Ok(RecordBatch::try_new(
+                                            result_schema,
+                                            vec![Arc::new(StringArray::from(vec![format!(
+                                                "Table '{table_name}' already exists"
+                                            )]))],
+                                        )?);
+                                    }
+                                }
+                            } else {
+                                // Non-partitioned table: open the plain CayenneTableProvider.
+                                let builder = CayenneTableProviderBuilder::new(
+                                    Arc::clone(&metadata_catalog),
+                                    Arc::clone(&runtime_env),
+                                );
+                                match builder.open(&metadata_table_name).await {
+                                    Ok(provider) => {
+                                        let provider = Arc::new(provider);
+                                        let deletion_provider: Arc<dyn DeletionTableProvider> =
+                                            provider;
+                                        Arc::new(DeletionTableProviderAdapter::new(
+                                            deletion_provider,
+                                        ))
+                                            as Arc<dyn datafusion::catalog::TableProvider>
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            table_name,
+                                            error = %e,
+                                            "Failed to open existing Cayenne table on restart"
+                                        );
+                                        return Ok(RecordBatch::try_new(
+                                            result_schema,
+                                            vec![Arc::new(StringArray::from(vec![format!(
+                                                "Table '{table_name}' already exists"
+                                            )]))],
+                                        )?);
+                                    }
+                                }
+                            };
+
+                        if let Err(e) =
+                            schema_provider.register_table(table_name.clone(), wrapped_provider)
+                        {
+                            tracing::error!(table_name, error = %e, "Failed to register existing Cayenne table in schema provider");
                         }
                     }
 

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -386,7 +386,12 @@ fn create_response_stream(
         let path = path.clone();
         let mut write_future = Box::pin(df.write_streaming_data(&path, streaming_update));
 
+        let mut batches_received: u64 = 0;
+        let mut rows_received: u64 = 0;
+
         if let Some(first_batch) = first_batch {
+            batches_received += 1;
+            rows_received += first_batch.num_rows() as u64;
             yield handle_record_batch(first_batch, &batch_tx, &path.to_string()).await;
         }
 
@@ -418,12 +423,44 @@ fn create_response_stream(
                             // ended. This can happen when the data sink does not
                             // consume the input stream or finishes early. Drain
                             // remaining messages and report success.
-                            tracing::warn!("Write operation completed before stream ended for dataset: {path}");
+                            tracing::warn!(
+                                dataset = %path,
+                                batches_received,
+                                rows_received,
+                                "Write operation completed before Flight stream ended; draining remaining messages without writing"
+                            );
+                            let mut drained_batches: u64 = 0;
+                            let mut drained_rows: u64 = 0;
                             while let Some(msg) = streaming_flight.next().await {
-                                if let Err(e) = msg {
-                                    tracing::error!("Error reading remaining message after early write completion: {e}");
+                                match msg {
+                                    Ok(data) => {
+                                        // Attempt to decode to get the row count for logging
+                                        if let Ok(batch) = arrow_flight::utils::flight_data_to_arrow_batch(
+                                            &data,
+                                            Arc::clone(&schema),
+                                            &std::collections::HashMap::new(),
+                                        ) {
+                                            drained_batches += 1;
+                                            drained_rows += batch.num_rows() as u64;
+                                        } else {
+                                            drained_batches += 1;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(dataset = %path, "Error reading remaining message after early write completion: {e}");
+                                    }
                                 }
                             }
+                            tracing::info!(
+                                dataset = %path,
+                                batches_received,
+                                rows_received,
+                                drained_batches,
+                                drained_rows,
+                                "Early write completion drain finished; {} rows in {} batches were NOT written",
+                                drained_rows,
+                                drained_batches,
+                            );
                             yield Ok(PutResult::default());
                             break;
                         }
@@ -459,6 +496,9 @@ fn create_response_stream(
                                 }
                             };
 
+                            batches_received += 1;
+                            rows_received += new_batch.num_rows() as u64;
+
                             // Only report errors; a success message is sent as the final step upon successful write completion
                             if let Err(err) = handle_record_batch(new_batch, &batch_tx, &path.to_string()).await {
                                 yield Err(err);
@@ -472,10 +512,21 @@ fn create_response_stream(
 
                             // Wait for the write operation to complete
                             if let Err(e) = write_future.await {
-                                tracing::error!("Write operation failed. Details included in the response.");
+                                tracing::error!(
+                                    dataset = %path,
+                                    batches_received,
+                                    rows_received,
+                                    "Write operation failed after receiving all batches. Details included in the response."
+                                );
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
+                            } else {
+                                tracing::info!(
+                                    dataset = %path,
+                                    batches_received,
+                                    rows_received,
+                                    "Write operation completed successfully"
+                                );
                             }
-                            tracing::debug!("Write operation completed successfully for dataset: {path}");
                             yield Ok(PutResult::default())
                             break;
                         }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -386,7 +386,12 @@ fn create_response_stream(
         let path = path.clone();
         let mut write_future = Box::pin(df.write_streaming_data(&path, streaming_update));
 
+        let mut received_batches: u64 = 0;
+        let mut received_rows: u64 = 0;
+
         if let Some(first_batch) = first_batch {
+            received_batches += 1;
+            received_rows += first_batch.num_rows() as u64;
             yield handle_record_batch(first_batch, &batch_tx, &path.to_string()).await;
         }
 
@@ -401,6 +406,8 @@ fn create_response_stream(
                 () = &mut deadline => {
                     tracing::error!(
                         dataset = %path,
+                        received_batches,
+                        received_rows,
                         "Timeout: no record batch received within {} seconds",
                         idle_timeout.as_secs()
                     );
@@ -420,6 +427,8 @@ fn create_response_stream(
                             // remaining messages and report success.
                             tracing::warn!(
                                 dataset = %path,
+                                received_batches,
+                                received_rows,
                                 "Write operation completed before Flight stream ended; draining remaining messages without writing"
                             );
                             while let Some(msg) = streaming_flight.next().await {
@@ -431,7 +440,12 @@ fn create_response_stream(
                             break;
                         }
                         Err(e) => {
-                            tracing::error!("Write operation failed. Details included in the response.");
+                            tracing::error!(
+                                dataset = %path,
+                                received_batches,
+                                received_rows,
+                                "Write operation failed. Details included in the response."
+                            );
                             yield Err(Status::internal(format!("Write operation failed: {e}")));
                             break;
                         }
@@ -456,14 +470,28 @@ fn create_response_stream(
                             ) {
                                 Ok(batches) => batches,
                                 Err(e) => {
-                                    tracing::error!("Failed to convert flight data to batches: {e}");
+                                    tracing::error!(
+                                        dataset = %path,
+                                        received_batches,
+                                        received_rows,
+                                        "Failed to convert flight data to batches: {e}"
+                                    );
                                     yield Err(Status::internal(format!("Failed to convert flight data to batches: {e}")));
                                     break;
                                 }
                             };
 
+                            received_batches += 1;
+                            received_rows += new_batch.num_rows() as u64;
+
                             // Only report errors; a success message is sent as the final step upon successful write completion
                             if let Err(err) = handle_record_batch(new_batch, &batch_tx, &path.to_string()).await {
+                                tracing::error!(
+                                    dataset = %path,
+                                    received_batches,
+                                    received_rows,
+                                    "Failed to forward batch to write channel"
+                                );
                                 yield Err(err);
                                 break;
                             }
@@ -471,12 +499,19 @@ fn create_response_stream(
                         None => {
                             // End of the stream; signal that stream is completed and data write should be finalized
                             drop(batch_tx);
-                            tracing::trace!("No more messages in the stream, finalizing write operation for path: {path}");
+                            tracing::info!(
+                                dataset = %path,
+                                received_batches,
+                                received_rows,
+                                "DoPut stream ended; finalizing write"
+                            );
 
                             // Wait for the write operation to complete
                             if let Err(e) = write_future.await {
                                 tracing::error!(
                                     dataset = %path,
+                                    received_batches,
+                                    received_rows,
                                     "Write operation failed after receiving all batches. Details included in the response."
                                 );
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
@@ -485,7 +520,12 @@ fn create_response_stream(
                             break;
                         }
                         Some(Err(e)) => {
-                            tracing::error!("Error reading message: {e}");
+                            tracing::error!(
+                                dataset = %path,
+                                received_batches,
+                                received_rows,
+                                "Error reading message from Flight stream: {e}"
+                            );
                             yield Err(Status::internal(format!("Error reading message: {e}")));
                             break;
                         }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -386,12 +386,7 @@ fn create_response_stream(
         let path = path.clone();
         let mut write_future = Box::pin(df.write_streaming_data(&path, streaming_update));
 
-        let mut batches_received: u64 = 0;
-        let mut rows_received: u64 = 0;
-
         if let Some(first_batch) = first_batch {
-            batches_received += 1;
-            rows_received += first_batch.num_rows() as u64;
             yield handle_record_batch(first_batch, &batch_tx, &path.to_string()).await;
         }
 
@@ -425,42 +420,13 @@ fn create_response_stream(
                             // remaining messages and report success.
                             tracing::warn!(
                                 dataset = %path,
-                                batches_received,
-                                rows_received,
                                 "Write operation completed before Flight stream ended; draining remaining messages without writing"
                             );
-                            let mut drained_batches: u64 = 0;
-                            let mut drained_rows: u64 = 0;
                             while let Some(msg) = streaming_flight.next().await {
-                                match msg {
-                                    Ok(data) => {
-                                        // Attempt to decode to get the row count for logging
-                                        if let Ok(batch) = arrow_flight::utils::flight_data_to_arrow_batch(
-                                            &data,
-                                            Arc::clone(&schema),
-                                            &std::collections::HashMap::new(),
-                                        ) {
-                                            drained_batches += 1;
-                                            drained_rows += batch.num_rows() as u64;
-                                        } else {
-                                            drained_batches += 1;
-                                        }
-                                    }
-                                    Err(e) => {
-                                        tracing::error!(dataset = %path, "Error reading remaining message after early write completion: {e}");
-                                    }
+                                if let Err(e) = msg {
+                                    tracing::error!(dataset = %path, "Error reading remaining message after early write completion: {e}");
                                 }
                             }
-                            tracing::info!(
-                                dataset = %path,
-                                batches_received,
-                                rows_received,
-                                drained_batches,
-                                drained_rows,
-                                "Early write completion drain finished; {} rows in {} batches were NOT written",
-                                drained_rows,
-                                drained_batches,
-                            );
                             yield Ok(PutResult::default());
                             break;
                         }
@@ -496,9 +462,6 @@ fn create_response_stream(
                                 }
                             };
 
-                            batches_received += 1;
-                            rows_received += new_batch.num_rows() as u64;
-
                             // Only report errors; a success message is sent as the final step upon successful write completion
                             if let Err(err) = handle_record_batch(new_batch, &batch_tx, &path.to_string()).await {
                                 yield Err(err);
@@ -514,18 +477,9 @@ fn create_response_stream(
                             if let Err(e) = write_future.await {
                                 tracing::error!(
                                     dataset = %path,
-                                    batches_received,
-                                    rows_received,
                                     "Write operation failed after receiving all batches. Details included in the response."
                                 );
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
-                            } else {
-                                tracing::info!(
-                                    dataset = %path,
-                                    batches_received,
-                                    rows_received,
-                                    "Write operation completed successfully"
-                                );
                             }
                             yield Ok(PutResult::default())
                             break;


### PR DESCRIPTION
## Summary

Fixes a data integrity bug where batches could be silently dropped during distributed Flight `DoPut` write-through from the scheduler to executors.

### Root cause

In `forward_batches_to_executor` (`write_through.rs`), the DoPut response stream (`try_collect`) was awaited independently — and could complete (executor closed the ack stream) before the encoder task had finished draining all batches from its 64-slot `mpsc` channel. When the response future returned, `flight_rx` was dropped, causing the encoder's remaining `tx.send()` calls to fail. The encoder then sent `Ok(())` on its result channel and exited, silently discarding the queued batches. Compounding this, `Err(_)` on `encode_result_rx.await` (encoder task dropped without sending) was also treated as `Ok(())`.

The result: ~7,500 rows (~1 full batch) dropped per run, non-deterministically.

### Fix

Drive the encoder task and the DoPut response stream **concurrently** with `tokio::join!`, so neither is dropped until both have completed:

- The encoder fully drains `rx`, encodes all batches, and signals completion via `encode_result_tx`
- The executor receives and commits every batch, then closes the ack stream
- Only after both succeed is the forwarding task considered successful

`Err(_)` on `encode_result_rx` (encoder aborted/panicked without sending a result) is now treated as an error rather than silently swallowed.

### Additional fixes

- `insert.rs`: `JoinError` on a partition write task was previously silently ignored (`if let Ok`). Now matched explicitly and returned as an error, with `tracing::error!` instead of `tracing::info!`.
- `do_put.rs`: Removed debug-only `batches_received`/`rows_received` counters added during investigation. Kept functional improvements: centralized `do_put_idle_timeout()`, keepalive message skip, and structured error logging.

## Related

Closes the data integrity issue observed during spicebench runs (expected 82,500 customer rows, actual ~75,000–75,885 — ~7,500 rows missing per run).