### PR TITLE
fix: propagate JoinError from partition insert tasks

### DIFF
--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -272,14 +272,15 @@ impl ExecutionPlan for PartitionerExec {
 
                 for handle in handles {
                     match handle.await {
-                        Ok(result) => result.map_err(|e| DataFusionError::Execution(
-                            format!("Failed to insert into partition: {e}")
-                        ))?,
+                        Ok(result) => result.map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to insert into partition: {e}"
+                            ))
+                        })?,
                         Err(e) => {
-                            tracing::error!("Partition insert task failed unexpectedly: {e}");
-                            return Err(DataFusionError::Execution(
-                                "Failed to insert into partition".to_string()
-                            ));
+                            return Err(DataFusionError::Execution(format!(
+                                "Failed to complete partition task: {e}"
+                            )));
                         }
                     }
                 }

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -271,10 +271,16 @@ impl ExecutionPlan for PartitionerExec {
                 drop(partition_senders);
 
                 for handle in handles {
-                    if let Ok(output) = handle.await {
-                        output.map_err(|e| DataFusionError::Execution(
-                            format!("An error occurred while writing to one or more partition files. Some partitions may contain outdated or corrupted data. It is recommended to delete and recreate the accelerated files: {e}")
-                        ))?;
+                    match handle.await {
+                        Ok(result) => result.map_err(|e| DataFusionError::Execution(
+                            format!("Failed to insert into partition: {e}")
+                        ))?,
+                        Err(e) => {
+                            tracing::error!("Partition insert task failed unexpectedly: {e}");
+                            return Err(DataFusionError::Execution(
+                                "Failed to insert into partition".to_string()
+                            ));
+                        }
                     }
                 }
 


### PR DESCRIPTION
This pull request improves error handling and logging in the `PartitionerExec` implementation for partition insert operations. The main change is to better distinguish between errors that occur during the execution of partition insert tasks and errors returned by the tasks themselves, providing clearer error messages and logging unexpected task failures.

**Error handling and logging improvements:**

* Improved error handling in the `PartitionerExec` implementation by distinguishing between errors returned by partition insert tasks and unexpected task failures, adding a specific log message for unexpected failures and making error messages more concise and actionable. (`crates/runtime-table-partition/src/insert.rs`)