### PR TITLE
feat: Add CREATE TABLE ... (LIKE ...) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19039,7 +19039,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=27754b5810745e3afc7bb703ecc13aa9835732ea#27754b5810745e3afc7bb703ecc13aa9835732ea"
+source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19047,6 +19047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid 1.21.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "27754b5810745e3afc7bb703ecc13aa9835732ea", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6327983bc1a90123e0c754b79781b931c969831e", features = ["server"] }
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -34,6 +34,7 @@ use datafusion_common::utils::get_available_parallelism;
 use datafusion_expr::Expr;
 use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::create_physical_expr;
+use datafusion_physical_expr::expressions as phys_expr;
 use futures::StreamExt;
 use object_store::ObjectStore;
 use roaring::{RoaringBitmap, RoaringTreemap};
@@ -187,6 +188,14 @@ impl CayenneDeletionSink {
             tracing::debug!("No new deletions to persist");
             return Ok(0);
         }
+
+        let total_new_deletions: usize = per_file_row_ids.values().map(std::vec::Vec::len).sum();
+        tracing::debug!(
+            table = %table_name,
+            total_new_deletions,
+            files_with_deletions = per_file_row_ids.len(),
+            "Position-based delete: persisting deletions"
+        );
 
         self.persist_position_based_deletions(per_file_row_ids)
             .await
@@ -471,24 +480,157 @@ fn build_vortex_filter(
         })
         .collect::<datafusion_common::Result<Vec<_>>>()?;
 
-    // Convert to Vortex expressions and combine with AND
+    // Convert to Vortex expressions and combine with AND.
+    // When direct conversion fails (e.g., struct() IN-list from composite-key
+    // deletes), try decomposing the expression into Vortex-compatible form.
     let mut combined: Option<vortex::expr::Expression> = None;
     for phys_filter in &physical_filters {
-        match expr_convertor.convert(phys_filter.as_ref()) {
-            Ok(vortex_expr) => {
-                combined = Some(match combined {
-                    Some(existing) => and(existing, vortex_expr),
-                    None => vortex_expr,
-                });
+        let vortex_expr = match expr_convertor.convert(phys_filter.as_ref()) {
+            Ok(expr) => expr,
+            Err(_) => {
+                match try_decompose_struct_in_list(phys_filter.as_ref(), &expr_convertor, df_schema)
+                {
+                    Some(decomposed) => decomposed,
+                    None => {
+                        return Err(format!(
+                            "Failed to convert filter to Vortex expression. Filter: {phys_filter}"
+                        )
+                        .into());
+                    }
+                }
             }
-            Err(e) => {
-                return Err(format!(
-                    "Failed to convert filter to Vortex expression: {e}. Filter: {phys_filter}"
-                )
-                .into());
-            }
-        }
+        };
+        combined = Some(match combined {
+            Some(existing) => and(existing, vortex_expr),
+            None => vortex_expr,
+        });
     }
 
     Ok(combined)
+}
+
+/// Decompose `struct(col1, col2, ...) IN (struct_lit1, struct_lit2, ...)` into a
+/// balanced OR-tree of AND-equalities that Vortex can evaluate.
+///
+/// `DataFusion` converts `(k1, k2) IN ((v1, w1), (v2, w2))` into
+/// `struct(k1, k2) IN (SET)` which Vortex's expression convertor doesn't support.
+/// This function decomposes it into:
+///   `(k1 = v1 AND k2 = w1) OR (k1 = v2 AND k2 = w2)`
+/// using a balanced binary tree to keep expression depth at O(log N).
+fn try_decompose_struct_in_list(
+    expr: &dyn datafusion_physical_expr::PhysicalExpr,
+    convertor: &DefaultExpressionConvertor,
+    df_schema: &DFSchema,
+) -> Option<vortex::expr::Expression> {
+    use datafusion_common::ScalarValue;
+
+    let in_list = expr.as_any().downcast_ref::<phys_expr::InListExpr>()?;
+
+    // Check that the value expression is struct(col1, col2, ...),
+    // possibly wrapped in a CAST (DataFusion may insert type coercion).
+    let value_expr: &dyn datafusion_physical_expr::PhysicalExpr = in_list.expr().as_ref();
+    let struct_fn = if let Some(sf) = value_expr
+        .as_any()
+        .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>(
+    ) {
+        sf
+    } else if let Some(cast_expr) = value_expr.as_any().downcast_ref::<phys_expr::CastExpr>() {
+        cast_expr
+            .expr()
+            .as_any()
+            .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()?
+    } else {
+        return None;
+    };
+    if struct_fn.name() != "struct" {
+        return None;
+    }
+
+    // Convert each column in struct() args to a Vortex expression.
+    // Also record each column's native data type for literal casting.
+    let mut vortex_columns: Vec<vortex::expr::Expression> =
+        Vec::with_capacity(struct_fn.args().len());
+    let mut col_types: Vec<arrow::datatypes::DataType> = Vec::with_capacity(struct_fn.args().len());
+    let arrow_schema: arrow::datatypes::Schema = df_schema.as_arrow().as_ref().clone();
+    for arg in struct_fn.args() {
+        let vx = convertor.convert(arg.as_ref()).ok()?;
+        let dt = arg.data_type(&arrow_schema).ok()?;
+        vortex_columns.push(vx);
+        col_types.push(dt);
+    }
+
+    if vortex_columns.is_empty() {
+        return None;
+    }
+
+    // Build one AND-conjunction per list element: (col1 = v1 AND col2 = w1)
+    let row_predicates: Vec<vortex::expr::Expression> = in_list
+        .list()
+        .iter()
+        .filter_map(|elem| {
+            let literal = elem.as_any().downcast_ref::<phys_expr::Literal>()?;
+            let ScalarValue::Struct(struct_arr) = literal.value() else {
+                return None;
+            };
+
+            // Build (col1 = v1 AND col2 = w1) for this struct literal.
+            // Cast each field scalar to the column's native type to avoid
+            // Vortex DType mismatches (e.g., i64 literal vs i32 column).
+            let field_eqs: Vec<vortex::expr::Expression> = (0..vortex_columns.len())
+                .map(|i| {
+                    let field_scalar = ScalarValue::try_from_array(struct_arr.column(i), 0).ok()?;
+                    let cast_scalar = field_scalar
+                        .cast_to(&col_types[i])
+                        .ok()
+                        .unwrap_or(field_scalar);
+                    let phys_lit = phys_expr::Literal::new(cast_scalar);
+                    let vortex_lit = convertor.convert(&phys_lit).ok()?;
+                    Some(vortex::expr::eq(vortex_columns[i].clone(), vortex_lit))
+                })
+                .collect::<Option<Vec<_>>>()?;
+
+            let mut conj = field_eqs.into_iter();
+            let first = conj.next()?;
+            Some(conj.fold(first, vortex::expr::and))
+        })
+        .collect();
+
+    if row_predicates.is_empty() {
+        return None;
+    }
+
+    // Build a balanced binary OR-tree to keep depth at O(log N)
+    let result = balanced_or(row_predicates);
+
+    if in_list.negated() {
+        Some(vortex::expr::not(result))
+    } else {
+        Some(result)
+    }
+}
+
+/// Combine expressions with OR using a balanced binary tree.
+/// Depth is O(log N) instead of O(N) from a linear fold, avoiding stack overflow.
+fn balanced_or(mut exprs: Vec<vortex::expr::Expression>) -> vortex::expr::Expression {
+    use vortex::expr::or;
+    debug_assert!(!exprs.is_empty());
+    while exprs.len() > 1 {
+        let mut next = Vec::with_capacity(exprs.len().div_ceil(2));
+        let mut i = 0;
+        while i + 1 < exprs.len() {
+            // Take pairs — using swap_remove-style but preserving order
+            let right = exprs[i + 1].clone();
+            let left = exprs[i].clone();
+            next.push(or(left, right));
+            i += 2;
+        }
+        if i < exprs.len() {
+            next.push(exprs[i].clone());
+        }
+        exprs = next;
+    }
+    match exprs.into_iter().next() {
+        Some(expr) => expr,
+        None => unreachable!("balanced_or called with empty exprs"),
+    }
 }

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -377,6 +377,33 @@ impl PartitionManager {
         }
     }
 
+    /// Copy partition-to-executor assignments from one table to another.
+    ///
+    /// Creates (or overwrites) the target table's metadata with the same
+    /// partition expressions, partition values, and executor assignments
+    /// as the source table. This ensures `DoPut` write-through routes data
+    /// to the same executors for both tables.
+    ///
+    /// If the source table has no partition metadata, this is a no-op because
+    /// the source exists but is unpartitioned and there is nothing to copy.
+    pub async fn copy_assignments(
+        &self,
+        source_table: &TableReference,
+        target_table: &TableReference,
+    ) -> Result<()> {
+        let Some(source_metadata) = self.get_table_metadata(source_table).await? else {
+            return Ok(());
+        };
+
+        let now_ms = now_ms()?;
+        let mut target_metadata = source_metadata;
+        target_metadata.table_name = target_table.to_string();
+        target_metadata.updated_at = now_ms;
+
+        let target_key = target_table.to_string();
+        self.write_metadata(&target_key, target_metadata).await
+    }
+
     /// Write metadata using `insert_or_update` with conflict handling.
     pub(crate) async fn write_metadata(
         &self,
@@ -404,4 +431,112 @@ fn now_ms() -> Result<u128> {
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .context(SystemTimeSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    fn test_manager() -> PartitionManager {
+        PartitionManager::new(Arc::new(InMemory::new())).with_prefix("test/")
+    }
+
+    #[tokio::test]
+    async fn copy_assignments_copies_metadata() {
+        let pm = test_manager();
+        let source = TableReference::parse_str("catalog.schema.source");
+        let target = TableReference::parse_str("catalog.schema.target");
+
+        // Initialize source with partition expressions
+        pm.initialize_metadata(&source, vec!["region".to_string()])
+            .await
+            .expect("should initialize");
+
+        // Add a partition and assign it
+        let pv = HashMap::from([("region".to_string(), "us-east-1".to_string())]);
+        pm.set_unassigned_partitions(&source, vec![pv], vec![])
+            .await
+            .expect("should set partitions");
+        let partition_value: PartitionValue =
+            HashMap::from([("region".to_string(), "us-east-1".to_string())]);
+        pm.assign_partition(&source, &partition_value, "executor-1")
+            .await
+            .expect("should assign");
+
+        // Copy assignments
+        pm.copy_assignments(&source, &target)
+            .await
+            .expect("should copy");
+
+        // Verify target has the same metadata
+        let target_meta = pm
+            .get_table_metadata(&target)
+            .await
+            .expect("should get")
+            .expect("should exist");
+
+        assert_eq!(target_meta.table_name, target.to_string());
+        assert_eq!(
+            target_meta.partition_expressions,
+            vec!["region".to_string()]
+        );
+        assert_eq!(target_meta.partitions.len(), 1);
+        assert!(target_meta.partitions[0].is_assigned_to("executor-1"));
+    }
+
+    #[tokio::test]
+    async fn copy_assignments_noop_when_source_missing() {
+        let pm = test_manager();
+        let source = TableReference::parse_str("catalog.schema.missing");
+        let target = TableReference::parse_str("catalog.schema.target");
+
+        // Missing source metadata is a no-op (source exists but is unpartitioned).
+        pm.copy_assignments(&source, &target)
+            .await
+            .expect("should be a no-op for missing source metadata");
+
+        // Target should have no metadata since nothing was copied.
+        let target_meta = pm.get_table_metadata(&target).await.expect("should get");
+        assert!(target_meta.is_none());
+    }
+
+    #[tokio::test]
+    async fn copy_assignments_overwrites_existing_target() {
+        let pm = test_manager();
+        let source = TableReference::parse_str("catalog.schema.source");
+        let target = TableReference::parse_str("catalog.schema.target");
+
+        // Initialize both
+        pm.initialize_metadata(&source, vec!["region".to_string()])
+            .await
+            .expect("should initialize source");
+        pm.initialize_metadata(&target, vec!["old_expr".to_string()])
+            .await
+            .expect("should initialize target");
+
+        // Add partition to source
+        let pv = HashMap::from([("region".to_string(), "eu-west-1".to_string())]);
+        pm.set_unassigned_partitions(&source, vec![pv], vec![])
+            .await
+            .expect("should set partitions");
+
+        // Copy should overwrite target
+        pm.copy_assignments(&source, &target)
+            .await
+            .expect("should copy");
+
+        let target_meta = pm
+            .get_table_metadata(&target)
+            .await
+            .expect("should get")
+            .expect("should exist");
+
+        assert_eq!(target_meta.table_name, target.to_string());
+        assert_eq!(
+            target_meta.partition_expressions,
+            vec!["region".to_string()]
+        );
+        assert_eq!(target_meta.partitions.len(), 1);
+    }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -59,6 +59,9 @@ pub struct CayenneCreateTableNode {
     pub partition_expr_sql: Option<String>,
     /// Primary key column names extracted from SQL constraints.
     pub primary_key: Vec<String>,
+    /// Source table reference for `CREATE TABLE ... (LIKE ...)` syntax.
+    /// When set, partition-to-executor assignments are copied from the source table.
+    pub like_source_table: Option<TableReference>,
     /// Output schema (single "result" column).
     output_schema: DFSchemaRef,
 }
@@ -81,6 +84,7 @@ impl CayenneCreateTableNode {
             partition_expr: None,
             partition_expr_sql: None,
             primary_key: Vec::new(),
+            like_source_table: None,
         }
     }
 }
@@ -95,6 +99,7 @@ pub struct CayenneCreateTableNodeBuilder {
     partition_expr: Option<Expr>,
     partition_expr_sql: Option<String>,
     primary_key: Vec<String>,
+    like_source_table: Option<TableReference>,
 }
 
 impl CayenneCreateTableNodeBuilder {
@@ -129,6 +134,12 @@ impl CayenneCreateTableNodeBuilder {
     }
 
     #[must_use]
+    pub fn like_source_table(mut self, like_source_table: Option<TableReference>) -> Self {
+        self.like_source_table = like_source_table;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> CayenneCreateTableNode {
         CayenneCreateTableNode {
             table_name: self.table_name,
@@ -140,6 +151,7 @@ impl CayenneCreateTableNodeBuilder {
             partition_expr: self.partition_expr,
             partition_expr_sql: self.partition_expr_sql,
             primary_key: self.primary_key,
+            like_source_table: self.like_source_table,
             output_schema: ddl_output_schema(),
         }
     }
@@ -153,6 +165,7 @@ impl Hash for CayenneCreateTableNode {
         self.partition_expr.hash(state);
         self.partition_expr_sql.hash(state);
         self.primary_key.hash(state);
+        self.like_source_table.hash(state);
     }
 }
 
@@ -164,6 +177,7 @@ impl PartialEq for CayenneCreateTableNode {
             && self.partition_expr == other.partition_expr
             && self.partition_expr_sql == other.partition_expr_sql
             && self.primary_key == other.primary_key
+            && self.like_source_table == other.like_source_table
     }
 }
 
@@ -225,6 +239,7 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
             partition_expr,
             partition_expr_sql: self.partition_expr_sql.clone(),
             primary_key: self.primary_key.clone(),
+            like_source_table: self.like_source_table.clone(),
             output_schema: DFSchemaRef::clone(&self.output_schema),
         })
     }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1853,18 +1853,78 @@ async fn validate_partition_compatibility(
         )));
     }
 
-    // Check that the partition column appears in the ON keys (target side).
-    let partition_in_on_keys = on_keys
-        .iter()
-        .any(|(target_col, _)| *target_col == target_part);
-    if !partition_in_on_keys {
+    // Parse the partition expression to extract column references. For transform
+    // partitions like bucket(5, c_nationkey), the referenced column is c_nationkey.
+    // For simple column partitions like n_regionkey, the column is n_regionkey.
+    let partition_cols = extract_partition_column_references(&target_part)?;
+    let all_covered = !partition_cols.is_empty()
+        && partition_cols
+            .iter()
+            .all(|pc| on_keys.iter().any(|(target_col, _)| target_col == pc));
+    if !all_covered {
         return Err(DataFusionError::Plan(format!(
-            "Distributed MERGE requires the partition column '{target_part}' to appear in the \
-             ON clause join keys for correct executor-local execution"
+            "Distributed MERGE requires the partition column(s) referenced by '{target_part}' \
+             to appear in the ON clause join keys for correct executor-local execution"
         )));
     }
 
     Ok(())
+}
+
+/// Extract column name references from a partition expression string by parsing
+/// it as a SQL expression and walking the AST with sqlparser's `Visitor`.
+///
+/// Handles simple column references (`c_nationkey`) and transform expressions
+/// (`bucket(5, c_nationkey)`) — numeric/string literals are naturally excluded
+/// since they parse as `Value` nodes, not `Identifier` nodes.
+fn extract_partition_column_references(partition_expr: &str) -> DFResult<Vec<String>> {
+    use datafusion::sql::sqlparser::ast::{Expr as SqlExpr, Visit, Visitor};
+    use datafusion::sql::sqlparser::dialect::GenericDialect;
+    use datafusion::sql::sqlparser::parser::Parser;
+    use std::ops::ControlFlow;
+
+    struct ColumnCollector {
+        columns: Vec<String>,
+    }
+
+    impl Visitor for ColumnCollector {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &SqlExpr) -> ControlFlow<Self::Break> {
+            match expr {
+                SqlExpr::Identifier(ident) => {
+                    self.columns.push(ident.value.clone());
+                }
+                SqlExpr::CompoundIdentifier(idents) => {
+                    if let Some(last) = idents.last() {
+                        self.columns.push(last.value.clone());
+                    }
+                }
+                _ => {}
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let dialect = GenericDialect {};
+    let mut parser = Parser::new(&dialect)
+        .try_with_sql(partition_expr)
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to parse partition expression '{partition_expr}': {e}"
+            ))
+        })?;
+    let sql_expr = parser.parse_expr().map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Failed to parse partition expression '{partition_expr}': {e}"
+        ))
+    })?;
+
+    let mut collector = ColumnCollector {
+        columns: Vec::new(),
+    };
+    let _ = sql_expr.visit(&mut collector);
+    Ok(collector.columns)
 }
 
 /// Schema for DML count results — single `count` column with `UInt64` type,
@@ -1881,7 +1941,7 @@ fn dml_count_schema() -> SchemaRef {
 mod tests {
     use datafusion::logical_expr::col;
 
-    use super::partition_label_for_expr;
+    use super::{extract_partition_column_references, partition_label_for_expr};
 
     #[test]
     fn partition_label_for_expr_uses_column_name_when_safe() {
@@ -1899,5 +1959,37 @@ mod tests {
     fn partition_label_for_expr_sanitizes_unsafe_column_names() {
         let expr = col("tenant/../id");
         assert_eq!(partition_label_for_expr(&expr), "tenant____id");
+    }
+
+    #[test]
+    fn extract_partition_cols_simple_column() {
+        let cols = extract_partition_column_references("c_nationkey").expect("simple column");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_bucket_function() {
+        let cols =
+            extract_partition_column_references("bucket(5, c_nationkey)").expect("bucket fn");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_parenthesized() {
+        let cols =
+            extract_partition_column_references("(bucket(5, c_nationkey))").expect("parenthesized");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_quoted_column() {
+        let cols = extract_partition_column_references(r#""order_date""#).expect("quoted column");
+        assert_eq!(cols, vec!["order_date"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_binary_op() {
+        let cols = extract_partition_column_references("a + b").expect("binary op");
+        assert_eq!(cols, vec!["a", "b"]);
     }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -286,6 +286,8 @@ pub struct CayenneCreateTableExec {
     executor_registry: Option<Arc<ExecutorRegistry>>,
     partition_expr: Option<Expr>,
     partition_expr_sql: Option<String>,
+    like_source_table: Option<datafusion::sql::TableReference>,
+    ctx: Option<Arc<datafusion::prelude::SessionContext>>,
     properties: PlanProperties,
 }
 
@@ -312,6 +314,8 @@ pub struct CayenneCreateTableExecBuilder {
     executor_registry: Option<Arc<ExecutorRegistry>>,
     partition_expr: Option<Expr>,
     partition_expr_sql: Option<String>,
+    like_source_table: Option<datafusion::sql::TableReference>,
+    ctx: Option<Arc<datafusion::prelude::SessionContext>>,
 }
 
 impl CayenneCreateTableExecBuilder {
@@ -334,6 +338,8 @@ impl CayenneCreateTableExecBuilder {
             executor_registry: None,
             partition_expr: None,
             partition_expr_sql: None,
+            like_source_table: None,
+            ctx: None,
         }
     }
 
@@ -362,6 +368,21 @@ impl CayenneCreateTableExecBuilder {
     }
 
     #[must_use]
+    pub fn like_source_table(
+        mut self,
+        like_source_table: Option<datafusion::sql::TableReference>,
+    ) -> Self {
+        self.like_source_table = like_source_table;
+        self
+    }
+
+    #[must_use]
+    pub fn ctx(mut self, ctx: Option<Arc<datafusion::prelude::SessionContext>>) -> Self {
+        self.ctx = ctx;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> CayenneCreateTableExec {
         let schema = ddl_result_schema();
         let properties = PlanProperties::new(
@@ -381,6 +402,8 @@ impl CayenneCreateTableExecBuilder {
             executor_registry: self.executor_registry,
             partition_expr: self.partition_expr,
             partition_expr_sql: self.partition_expr_sql,
+            like_source_table: self.like_source_table,
+            ctx: self.ctx,
             properties,
         }
     }
@@ -435,7 +458,34 @@ impl ExecutionPlan for CayenneCreateTableExec {
         let executor_registry = self.executor_registry.clone();
         let partition_expr = self.partition_expr.clone();
         let partition_expr_sql = self.partition_expr_sql.clone();
-        let partition_label = partition_expr.as_ref().map(partition_label_for_expr);
+        let like_source_table = self.like_source_table.clone();
+        let ctx = self.ctx.clone();
+        let mut partition_label = partition_expr.as_ref().map(partition_label_for_expr);
+
+        // For LIKE tables where partition_expr is None but partition_expr_sql is
+        // Some, we need to set the partition label early so the Cayenne metadata
+        // is created with the correct partition_column. The full Expr will be
+        // parsed later in the provider creation branch.
+        if partition_label.is_none() && partition_expr_sql.is_some() {
+            partition_label = partition_expr_sql.as_ref().map(|sql| {
+                // Use the SQL expression to derive a safe label
+                // Try to parse it to get a proper label
+                use datafusion::sql::sqlparser::dialect::GenericDialect;
+                use datafusion::sql::sqlparser::parser::Parser;
+                let dialect = GenericDialect {};
+                if let Ok(mut parser) = Parser::new(&dialect).try_with_sql(sql) {
+                    if let Ok(sql_expr) = parser.parse_expr() {
+                        // Check if it's a simple column reference
+                        if let datafusion::sql::sqlparser::ast::Expr::Identifier(ident) = &sql_expr
+                        {
+                            return ident.value.clone();
+                        }
+                    }
+                }
+                // Fall back to auto-generated label
+                format!("expr0")
+            });
+        }
         let result_schema = ddl_result_schema();
         let runtime_env = context.runtime_env();
 
@@ -573,76 +623,148 @@ impl ExecutionPlan for CayenneCreateTableExec {
                 })?;
 
             // Build the table provider: partitioned or non-partitioned
-            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> =
-                if let Some(ref partition_expr) = partition_expr {
-                    let df_schema = vortex_schema.as_ref().clone().to_dfschema()?;
-                    let partition_expr_for_error = partition_expr_sql
-                        .clone()
-                        .unwrap_or_else(|| partition_expr.to_string());
-                    partition_expr.to_field(&df_schema).map_err(|e| {
+            let wrapped_provider: Arc<dyn datafusion::catalog::TableProvider> = if let Some(
+                ref partition_expr,
+            ) =
+                partition_expr
+            {
+                let df_schema = vortex_schema.as_ref().clone().to_dfschema()?;
+                let partition_expr_for_error = partition_expr_sql
+                    .clone()
+                    .unwrap_or_else(|| partition_expr.to_string());
+                tracing::info!(
+                    table = %table_name,
+                    partition_expr = %partition_expr_for_error,
+                    schema_fields = ?df_schema.fields().iter().map(|f| f.name().as_str()).collect::<Vec<_>>(),
+                    "CayenneCreateTableExec: validating partition expression"
+                );
+                partition_expr.to_field(&df_schema).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Invalid PARTITION BY expression '{partition_expr_for_error}': {e}",
+                    ))
+                })?;
+
+                let partition_name = partition_label
+                    .clone()
+                    .unwrap_or_else(|| partition_label_for_expr(partition_expr));
+
+                let partition_by = vec![PartitionedBy {
+                    name: partition_name,
+                    expression: partition_expr.clone(),
+                }];
+
+                let creator = Arc::new(CayennePartitionCreator::new(
+                    metadata_table_name.clone(),
+                    PathBuf::from(&table_data_path),
+                    partition_by.clone(),
+                    Arc::clone(&vortex_schema),
+                    Arc::clone(&metadata_catalog),
+                    table_id,
+                    UnsupportedTypeAction::Error,
+                    Vec::new(), // retention_filters
+                    None,       // time_retention_filter_builder
+                    vortex_config.clone(),
+                    None, // object_store_config (local filesystem)
+                    primary_key.clone(),
+                    on_conflict.clone(),
+                    Arc::clone(&runtime_env),
+                ));
+
+                let partition_provider =
+                    PartitionTableProvider::new(creator, partition_by, Arc::clone(&vortex_schema))
+                        .await
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create partitioned table '{table_name}': {e}"
+                            ))
+                        })?;
+
+                let partition_provider = Arc::new(partition_provider);
+                let deletion_provider: Arc<dyn DeletionTableProvider> = partition_provider;
+                Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                    as Arc<dyn datafusion::catalog::TableProvider>
+            } else if let Some(ref expr_sql) = partition_expr_sql {
+                // LIKE path: partition_expr was not pre-parsed during planning
+                // (the SessionState snapshot may not have all UDFs). Parse it
+                // here using the SessionContext which has the full UDF registry.
+                let ctx_ref = ctx.as_ref().ok_or_else(|| {
                         DataFusionError::Execution(format!(
-                            "Invalid PARTITION BY expression '{partition_expr_for_error}': {e}",
+                            "SessionContext required to parse partition expression '{expr_sql}' for LIKE table '{table_name}'"
                         ))
                     })?;
+                let df_schema = vortex_schema.as_ref().clone().to_dfschema()?;
+                let parsed_expr = ctx_ref.parse_sql_expr(expr_sql, &df_schema).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Invalid PARTITION BY expression '{expr_sql}' for table '{table_name}': {e}"
+                    ))
+                })?;
 
-                    let partition_name = partition_label
-                        .clone()
-                        .unwrap_or_else(|| partition_label_for_expr(partition_expr));
+                parsed_expr.to_field(&df_schema).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Invalid PARTITION BY expression '{expr_sql}': {e}",
+                    ))
+                })?;
 
-                    let partition_by = vec![PartitionedBy {
-                        name: partition_name,
-                        expression: partition_expr.clone(),
-                    }];
+                // Set partition_label so Cayenne metadata gets the correct label.
+                if partition_label.is_none() {
+                    partition_label = Some(partition_label_for_expr(&parsed_expr));
+                }
 
-                    let creator = Arc::new(CayennePartitionCreator::new(
-                        metadata_table_name.clone(),
-                        PathBuf::from(&table_data_path),
-                        partition_by.clone(),
-                        Arc::clone(&vortex_schema),
-                        Arc::clone(&metadata_catalog),
-                        table_id,
-                        UnsupportedTypeAction::Error,
-                        Vec::new(), // retention_filters
-                        None,       // time_retention_filter_builder
-                        vortex_config.clone(),
-                        None, // object_store_config (local filesystem)
-                        primary_key.clone(),
-                        on_conflict.clone(),
-                        Arc::clone(&runtime_env),
-                    ));
+                let partition_name = partition_label
+                    .clone()
+                    .unwrap_or_else(|| partition_label_for_expr(&parsed_expr));
 
-                    let partition_provider = PartitionTableProvider::new(
-                        creator,
-                        partition_by,
-                        Arc::clone(&vortex_schema),
-                    )
-                    .await
-                    .map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to create partitioned table '{table_name}': {e}"
-                        ))
-                    })?;
+                let partition_by = vec![PartitionedBy {
+                    name: partition_name,
+                    expression: parsed_expr,
+                }];
 
-                    let partition_provider = Arc::new(partition_provider);
-                    let deletion_provider: Arc<dyn DeletionTableProvider> = partition_provider;
-                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
-                        as Arc<dyn datafusion::catalog::TableProvider>
-                } else {
-                    // Non-partitioned: open the table we just created
-                    let builder = CayenneTableProviderBuilder::new(
-                        Arc::clone(&metadata_catalog),
-                        Arc::clone(&runtime_env),
-                    );
-                    let provider = builder.open(&metadata_table_name).await.map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to open Cayenne table '{table_name}': {e}"
-                        ))
-                    })?;
-                    let provider = Arc::new(provider);
-                    let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
-                    Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
-                        as Arc<dyn datafusion::catalog::TableProvider>
-                };
+                let creator = Arc::new(CayennePartitionCreator::new(
+                    metadata_table_name.clone(),
+                    PathBuf::from(&table_data_path),
+                    partition_by.clone(),
+                    Arc::clone(&vortex_schema),
+                    Arc::clone(&metadata_catalog),
+                    table_id,
+                    UnsupportedTypeAction::Error,
+                    Vec::new(),
+                    None,
+                    vortex_config.clone(),
+                    None,
+                    primary_key.clone(),
+                    on_conflict.clone(),
+                    Arc::clone(&runtime_env),
+                ));
+
+                let partition_provider =
+                    PartitionTableProvider::new(creator, partition_by, Arc::clone(&vortex_schema))
+                        .await
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create partitioned table '{table_name}': {e}"
+                            ))
+                        })?;
+
+                let partition_provider = Arc::new(partition_provider);
+                let deletion_provider: Arc<dyn DeletionTableProvider> = partition_provider;
+                Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                    as Arc<dyn datafusion::catalog::TableProvider>
+            } else {
+                // Non-partitioned: open the table we just created
+                let builder = CayenneTableProviderBuilder::new(
+                    Arc::clone(&metadata_catalog),
+                    Arc::clone(&runtime_env),
+                );
+                let provider = builder.open(&metadata_table_name).await.map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to open Cayenne table '{table_name}': {e}"
+                    ))
+                })?;
+                let provider = Arc::new(provider);
+                let deletion_provider: Arc<dyn DeletionTableProvider> = provider;
+                Arc::new(DeletionTableProviderAdapter::new(deletion_provider))
+                    as Arc<dyn datafusion::catalog::TableProvider>
+            };
 
             // Ensure the schema exists, creating it on demand if needed
             let schema_provider = if let Some(s) = cayenne_provider.schema_provider(&df_schema_name)
@@ -664,26 +786,27 @@ impl ExecutionPlan for CayenneCreateTableExec {
             schema_provider.register_table(table_name.clone(), wrapped_provider)?;
 
             // Initialize partition metadata so the scheduler can route queries by partition.
-            if let Some(ref pe) = partition_expr
-                && let Some(ref registry) = executor_registry
-            {
-                let table_ref = datafusion::sql::TableReference::full(
-                    df_catalog_name.clone(),
-                    df_schema_name.clone(),
-                    table_name.clone(),
-                );
-                let expr_sql = partition_expr_sql.clone().unwrap_or_else(|| pe.to_string());
-                let pm = registry.federated_partition_manager();
-                if let Err(e) = pm.initialize_metadata(&table_ref, vec![expr_sql]).await {
-                    tracing::warn!(
-                        table = %table_ref,
-                        error = %e,
-                        "Failed to initialize partition metadata for table"
-                    );
+            let table_ref = datafusion::sql::TableReference::full(
+                df_catalog_name.clone(),
+                df_schema_name.clone(),
+                table_name.clone(),
+            );
+            if let Some(ref registry) = executor_registry {
+                let fallback = partition_expr.as_ref().map(|pe| pe.to_string());
+                let expr_sql = partition_expr_sql.as_ref().or(fallback.as_ref()).cloned();
+                if let Some(expr_sql) = expr_sql {
+                    let pm = registry.federated_partition_manager();
+                    if let Err(e) = pm.initialize_metadata(&table_ref, vec![expr_sql]).await {
+                        tracing::warn!(
+                            table = %table_ref,
+                            error = %e,
+                            "Failed to initialize partition metadata for table"
+                        );
+                    }
                 }
             }
 
-            // Forward the CREATE TABLE DDL to executor nodes
+            // Forward the CREATE TABLE DDL to executor nodes.
             if let Some(ref registry) = executor_registry {
                 let columns_sql: Vec<String> = arrow_schema
                     .fields()
@@ -710,6 +833,26 @@ impl ExecutionPlan for CayenneCreateTableExec {
                     table_elements.join(", ")
                 );
                 forward_ddl_to_executors(registry, &ddl_sql).await?;
+            }
+
+            // If this table was created via LIKE, copy partition-to-executor
+            // assignments from the source table so DoPut routes data to the
+            // same executors.
+            if let Some(ref source) = like_source_table
+                && let Some(ref registry) = executor_registry
+            {
+                let pm = registry.federated_partition_manager();
+                tracing::info!(
+                    source = %source,
+                    target = %table_ref,
+                    "Copying partition assignments from LIKE source table"
+                );
+                if let Err(e) = pm.copy_assignments(source, &table_ref).await {
+                    return Err(DataFusionError::Execution(format!(
+                        "Failed to create table '{table_name}': could not copy partition \
+                         assignments from source table {source}: {e}"
+                    )));
+                }
             }
 
             let batch = RecordBatch::try_new(
@@ -1642,7 +1785,17 @@ impl ExecutionPlan for DistributedCayenneMergeExec {
             .await?;
 
             // Forward the original MERGE SQL to all executors.
+            tracing::info!(
+                target = %target_table,
+                source = %source_table,
+                sql_len = original_sql.len(),
+                "Distributed MERGE: forwarding SQL to executors"
+            );
             forward_dml_to_executors(registry, &original_sql).await?;
+            tracing::info!(
+                target = %target_table,
+                "Distributed MERGE: all executors completed"
+            );
 
             RecordBatch::try_new(result_schema, vec![Arc::new(UInt64Array::from(vec![0u64]))])
                 .map_err(Into::into)

--- a/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/planner.rs
@@ -93,6 +93,10 @@ impl ExtensionPlanner for CayenneDdlExtensionPlanner {
                 .executor_registry(self.executor_registry.clone())
                 .partition_expr(create.partition_expr.clone())
                 .partition_expr_sql(create.partition_expr_sql.clone())
+                .like_source_table(create.like_source_table.clone())
+                .ctx(Some(Arc::new(
+                    datafusion::prelude::SessionContext::new_with_state(session_state.clone()),
+                )))
                 .build(),
             )));
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2720,6 +2720,7 @@ impl DataFusion {
             },
             cluster_role: self.cluster_config.effective_role(),
             ddl_extension_store: Arc::clone(&self.ddl_extension_store),
+            executor_registry: self.executor_registry.clone(),
         };
 
         planner::create_logical_plan(sql, session, &ctx).await

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -32,9 +32,12 @@ use datafusion::sql::sqlparser::ast::{
     TableConstraint,
 };
 
+use crate::datafusion::cayenne_ddl::is_cayenne_catalog;
+use crate::datafusion::cayenne_ddl::logical_nodes::CayenneCreateTableNode;
 use crate::datafusion::ddl::acceleration_options::{
     CreateTableStatementExtension, SharedDdlExtensionStore, parse_ddl_table_options,
 };
+use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 
 /// Returns `true` if the `CREATE TABLE` has extensions we need to intercept:
 /// recognized `WITH (...)` options (`acceleration.*`, `dataset.*`) or a
@@ -185,6 +188,225 @@ fn extract_and_store_extensions(
     }
 
     Ok((create_table, Some(store_key)))
+}
+
+/// Plan a `CREATE TABLE ... (LIKE ...)` statement.
+///
+/// Resolves the source table from the catalog, extracts its schema and
+/// partition expression, and builds a [`CayenneCreateTableNode`] directly
+/// (bypassing `DataFusion`'s standard planner which doesn't support LIKE).
+pub(super) async fn plan_create_table_like(
+    statement: Statement,
+    session: &SessionState,
+    planner_ctx: &super::PlannerContext,
+) -> DFResult<LogicalPlan> {
+    use std::sync::Arc;
+
+    use datafusion::logical_expr::Extension;
+    use datafusion::sql::sqlparser::ast::CreateTableLikeKind;
+
+    // Decompose the Statement to take ownership of the CreateTable AST.
+    let Statement::Statement(sql_stmt) = statement else {
+        return Err(DataFusionError::Internal(
+            "Expected Statement::Statement for CREATE TABLE LIKE".to_string(),
+        ));
+    };
+    let SQLStatement::CreateTable(create_table) = *sql_stmt else {
+        return Err(DataFusionError::Internal(
+            "Expected SQLStatement::CreateTable for LIKE".to_string(),
+        ));
+    };
+
+    // Extract the source table name from the LIKE clause.
+    let like_kind = create_table.like.ok_or_else(|| {
+        DataFusionError::Internal("Expected LIKE clause in CreateTable".to_string())
+    })?;
+
+    // OR REPLACE is not supported with LIKE.
+    if create_table.or_replace {
+        return Err(DataFusionError::Plan(
+            "CREATE OR REPLACE TABLE ... LIKE is not supported. \
+             Use DROP TABLE followed by CREATE TABLE ... LIKE instead."
+                .to_string(),
+        ));
+    }
+
+    let like = match like_kind {
+        CreateTableLikeKind::Parenthesized(like) | CreateTableLikeKind::Plain(like) => like,
+    };
+
+    let source_name = like.name.to_string();
+    let source_table_ref = TableReference::parse_str(&source_name);
+    let source_catalog_name = source_table_ref
+        .catalog()
+        .unwrap_or(SPICE_DEFAULT_CATALOG)
+        .to_string();
+    let source_schema_name = source_table_ref
+        .schema()
+        .unwrap_or(SPICE_DEFAULT_SCHEMA)
+        .to_string();
+    let source_table_name = source_table_ref.table().to_string();
+
+    // Validate the source catalog is Cayenne-backed.
+    let catalog_list = session.catalog_list();
+    let source_catalog = catalog_list.catalog(&source_catalog_name).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Source catalog '{source_catalog_name}' not found for LIKE"
+        ))
+    })?;
+
+    if !is_cayenne_catalog(source_catalog.as_ref()) {
+        return Err(DataFusionError::Plan(format!(
+            "CREATE TABLE ... (LIKE ...) is only supported for Cayenne catalog tables. \
+             Source table '{source_name}' is not in a Cayenne catalog."
+        )));
+    }
+
+    // Resolve the source table provider to get its schema.
+    let source_schema_provider = source_catalog.schema(&source_schema_name).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Schema '{source_schema_name}' not found in catalog '{source_catalog_name}'"
+        ))
+    })?;
+
+    let source_provider = source_schema_provider
+        .table(&source_table_name)
+        .await
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to resolve source table '{source_name}': {e}"
+            ))
+        })?
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!("Source table '{source_name}' not found for LIKE"))
+        })?;
+
+    let arrow_schema = source_provider.schema();
+
+    // Resolve the source table's partition expression from the Cayenne catalog.
+    let partition_aware =
+        crate::datafusion::cayenne_ddl::as_partition_aware(source_catalog.as_ref());
+    let mut partition_expr_sql = if let Some(aware) = partition_aware {
+        aware
+            .table_partition_expr(&source_schema_name, &source_table_name)
+            .await
+            .map_err(|e| {
+                DataFusionError::Plan(format!(
+                    "Failed to get partition expression for source table '{source_name}': {e}"
+                ))
+            })?
+    } else {
+        None
+    };
+
+    // Build a fully-qualified source table reference (needed for partition metadata lookup).
+    let source_full_ref = TableReference::full(
+        source_catalog_name.clone(),
+        source_schema_name.clone(),
+        source_table_name.clone(),
+    );
+
+    // Resolve auto-generated labels (e.g. "expr0") to original SQL expressions
+    // by looking up the partition manager metadata.
+    if let Some(ref expr_str) = partition_expr_sql
+        && let Some(Ok(idx)) = expr_str.strip_prefix("expr").map(str::parse::<usize>)
+        && let Some(ref registry) = planner_ctx.executor_registry
+    {
+        let pm = registry.federated_partition_manager();
+        match pm.get_table_metadata(&source_full_ref).await {
+            Ok(Some(metadata)) => {
+                if let Some(original) = metadata.partition_expressions.get(idx) {
+                    // Strip outer parentheses — the state store stores expressions
+                    // like "(bucket(5, col))" but the SQL parser needs "bucket(5, col)".
+                    let resolved = original.trim();
+                    let resolved = if resolved.starts_with('(') && resolved.ends_with(')') {
+                        &resolved[1..resolved.len() - 1]
+                    } else {
+                        resolved
+                    };
+                    tracing::info!(
+                        source = %source_full_ref,
+                        label = %expr_str,
+                        resolved = %resolved,
+                        "Resolved auto-generated partition label to original SQL expression"
+                    );
+                    partition_expr_sql = Some(resolved.to_string());
+                } else {
+                    tracing::warn!(
+                        source = %source_full_ref,
+                        label = %expr_str,
+                        expressions = ?metadata.partition_expressions,
+                        "Partition expression index {idx} not found in metadata"
+                    );
+                }
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    source = %source_full_ref,
+                    label = %expr_str,
+                    "No partition metadata found for source table"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    source = %source_full_ref,
+                    label = %expr_str,
+                    error = %e,
+                    "Failed to read partition metadata for source table"
+                );
+            }
+        }
+    }
+
+    // Pass the partition expression SQL through to the physical plan.
+    // The CayenneCreateTableExec will parse it against the schema at execution time
+    // using the full SessionContext (with all registered UDFs like bucket()).
+    let partition_expr = None;
+
+    // Resolve the target table reference.
+    let target_name = create_table.name.to_string();
+    let target_table_ref = TableReference::parse_str(&target_name);
+    let target_catalog_name = target_table_ref
+        .catalog()
+        .unwrap_or(SPICE_DEFAULT_CATALOG)
+        .to_string();
+    let target_schema_name = target_table_ref
+        .schema()
+        .unwrap_or(SPICE_DEFAULT_SCHEMA)
+        .to_string();
+    let target_table_name = target_table_ref.table().to_string();
+
+    // Validate the target catalog is also Cayenne-backed.
+    let target_catalog = catalog_list.catalog(&target_catalog_name).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "Target catalog '{target_catalog_name}' not found for LIKE"
+        ))
+    })?;
+
+    if !is_cayenne_catalog(target_catalog.as_ref()) {
+        return Err(DataFusionError::Plan(format!(
+            "CREATE TABLE ... LIKE is only supported for Cayenne catalog tables. \
+             Target catalog '{target_catalog_name}' is not a Cayenne catalog."
+        )));
+    }
+
+    // Build the CayenneCreateTableNode directly.
+    let node = CayenneCreateTableNode::builder(
+        target_table_name,
+        arrow_schema,
+        target_catalog_name,
+        target_schema_name,
+    )
+    .if_not_exists(create_table.if_not_exists)
+    .partition_expr(partition_expr)
+    .partition_expr_sql(partition_expr_sql)
+    .primary_key(vec![]) // LIKE never copies primary keys
+    .like_source_table(Some(source_full_ref))
+    .build();
+
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(node),
+    }))
 }
 
 /// Remove a store entry on error (best-effort).
@@ -602,5 +824,43 @@ mod tests {
             .expect_err("should error")
             .to_string();
         assert!(err.contains("region"));
+    }
+
+    // -----------------------------------------------------------------------
+    // LIKE detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_like_plain_detected() {
+        let ct = parse_create_table("CREATE TABLE staging LIKE source_table");
+        assert!(
+            ct.like.is_some(),
+            "LIKE should be detected in CreateTable AST"
+        );
+    }
+
+    #[test]
+    fn test_like_if_not_exists_detected() {
+        let ct = parse_create_table("CREATE TABLE IF NOT EXISTS staging LIKE source_table");
+        assert!(ct.like.is_some());
+        assert!(ct.if_not_exists);
+    }
+
+    #[test]
+    fn test_like_qualified_source_detected() {
+        let ct = parse_create_table(
+            r#"CREATE TABLE IF NOT EXISTS "catalog"."schema"."staging" LIKE "catalog"."schema"."source""#,
+        );
+        assert!(ct.like.is_some());
+        assert!(ct.if_not_exists);
+    }
+
+    #[test]
+    fn test_like_not_treated_as_ddl_extension() {
+        let ct = parse_create_table("CREATE TABLE staging LIKE source_table");
+        assert!(
+            !has_ddl_extensions(&ct),
+            "LIKE should not be treated as a DDL extension"
+        );
     }
 }

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -85,6 +85,11 @@ pub struct PlannerContext {
     /// Shared store for DDL extensions extracted from `CREATE TABLE` statements.
     /// Populated by the planner, consumed by the analyzer rules.
     pub ddl_extension_store: SharedDdlExtensionStore,
+
+    /// Executor registry, if running in a distributed cluster.
+    /// Used by `CREATE TABLE ... LIKE` to resolve auto-generated partition
+    /// labels (e.g. `expr0`) back to the original SQL expression.
+    pub executor_registry: Option<Arc<crate::cluster::executor_registry::ExecutorRegistry>>,
 }
 
 /// Create a [`LogicalPlan`] from SQL, intercepting DDL extensions and
@@ -101,6 +106,21 @@ pub async fn create_logical_plan(
     // Step 2: Dispatch based on statement type
     if let Statement::Statement(ref sql_stmt) = statement {
         match sql_stmt.as_ref() {
+            // DDL: CREATE TABLE ... (LIKE ...) — resolve source table and
+            // build extension node directly, bypassing DataFusion's planner.
+            // Reject LIKE combined with DDL extensions (PARTITION BY, WITH)
+            // since LIKE inherits everything from the source table.
+            SQLStatement::CreateTable(ct) if ct.like.is_some() => {
+                if create_table::has_ddl_extensions(ct) {
+                    return Err(DataFusionError::Plan(
+                        "CREATE TABLE ... LIKE cannot be combined with PARTITION BY or WITH options. \
+                         The LIKE clause copies all properties from the source table."
+                            .to_string(),
+                    ));
+                }
+                return create_table::plan_create_table_like(statement, session, ctx).await;
+            }
+
             // DDL: CREATE TABLE with extensions (WITH options, PARTITION BY).
             // Intercepted regardless of catalog mode — extensions apply to
             // all catalog types (Cayenne, Iceberg, etc.).

--- a/crates/runtime/src/datafusion/planner/physical_execs.rs
+++ b/crates/runtime/src/datafusion/planner/physical_execs.rs
@@ -196,6 +196,7 @@ async fn execute_merge(
 
     // Normalize output to match the target table schema (including nullability).
     let target_schema = target_provider.schema();
+
     let normalized_batches = updated_batches
         .into_iter()
         .map(|batch| arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema)))
@@ -413,11 +414,13 @@ fn build_delete_filters(
         ));
     }
 
-    // Combine all row predicates with OR.
-    match row_predicates.into_iter().reduce(datafusion_expr::Expr::or) {
+    // Combine all row predicates with OR using a balanced binary tree.
+    // A linear fold creates O(N) depth causing stack overflow for large N.
+    // A balanced tree keeps depth at O(log N).
+    match util::expr::combine_exprs_balanced(row_predicates, datafusion::prelude::Expr::or) {
         Some(combined) => Ok(vec![combined]),
         None => Err(DataFusionError::Internal(
-            "Failed to build delete filters: reduce produced no result".to_string(),
+            "Failed to build delete filters: no row predicates generated".to_string(),
         )),
     }
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -63,6 +63,8 @@ enum RunState {
         flight_url: String,
         /// Normalized API base URL (stored separately from `cloud` to avoid tainted-struct logging).
         api_url: String,
+        /// SQL endpoint URL for DDL execution.
+        sql_url: String,
         /// Cloud client used during provisioning (reused for teardown).
         cloud: CloudClient,
     },
@@ -81,6 +83,20 @@ impl RunState {
         match self {
             Self::Scp { api_key, .. } => api_key.as_str(),
             Self::Local(_) => "",
+        }
+    }
+
+    fn sql_url(&self) -> &str {
+        match self {
+            Self::Scp { sql_url, .. } => sql_url.as_str(),
+            Self::Local(state) => state.sql_url.as_str(),
+        }
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::Scp { api_key, .. } => Some(api_key.as_str()),
+            Self::Local(state) => state.flight_api_key.as_deref(),
         }
     }
 }
@@ -189,6 +205,8 @@ fn sum_opt_f64_as_u64(
 struct SpidapterHandler {
     /// Active runs keyed by run ID.
     runs: HashMap<Uuid, RunState>,
+    /// Datasets from setup, keyed by run ID → dataset name → config.
+    run_datasets: HashMap<Uuid, HashMap<String, DatasetConfig>>,
     /// Full CLI args (includes all flags and env-var-backed configuration).
     args: StdioArgs,
 }
@@ -197,6 +215,7 @@ impl SpidapterHandler {
     fn new(args: &StdioArgs) -> Self {
         Self {
             runs: HashMap::new(),
+            run_datasets: HashMap::new(),
             args: args.clone(),
         }
     }
@@ -271,11 +290,16 @@ impl Handler for SpidapterHandler {
         };
 
         self.runs.insert(run_id, state);
+        self.run_datasets.insert(run_id, datasets);
 
         Ok(response)
     }
 
-    async fn metrics(&mut self, run_id: Uuid) -> std::result::Result<MetricsResponse, String> {
+    async fn metrics(
+        &mut self,
+        run_id: Uuid,
+        _final_scrape: bool,
+    ) -> std::result::Result<MetricsResponse, String> {
         let state = self
             .runs
             .get(&run_id)
@@ -300,6 +324,7 @@ impl Handler for SpidapterHandler {
                         disk_write_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes),
                         disk_read_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_read_operations),
                         disk_write_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_write_operations),
+                        num_compute_nodes: None,
                     }
                 };
 
@@ -331,6 +356,7 @@ impl Handler for SpidapterHandler {
             eprintln!("[stdio] teardown: run_id={run_id} not found (already torn down?)");
             return Ok(TeardownResponse { ok: true });
         };
+        self.run_datasets.remove(&run_id);
 
         match state {
             RunState::Scp {
@@ -353,6 +379,45 @@ impl Handler for SpidapterHandler {
         }
 
         Ok(TeardownResponse { ok: true })
+    }
+
+    async fn create_staging_table(
+        &mut self,
+        run_id: Uuid,
+        source_dataset: &str,
+        staging_table_name: &str,
+    ) -> std::result::Result<system_adapter_protocol::CreateStagingTableResponse, String> {
+        let state = self
+            .runs
+            .get(&run_id)
+            .ok_or_else(|| format!("No active run found for {run_id}"))?;
+        if !self
+            .run_datasets
+            .get(&run_id)
+            .map_or(false, |ds| ds.contains_key(source_dataset))
+        {
+            return Err(format!(
+                "Source dataset '{source_dataset}' not found in run {run_id}"
+            ));
+        }
+
+        // Use CREATE TABLE ... LIKE ... to copy schema, partition expression,
+        // AND partition-to-executor assignments from the source table.
+        let quoted_staging = quote_identifier(staging_table_name);
+        let quoted_source = quote_identifier(source_dataset);
+        let ddl = format!(
+            "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_staging} LIKE spicebench.bench.{quoted_source}"
+        );
+
+        eprintln!(
+            "[stdio] create_staging_table: source={source_dataset}, staging={staging_table_name}, sql={ddl}"
+        );
+
+        execute_sql_statement(state.sql_url(), state.api_key(), &ddl)
+            .await
+            .map_err(|e| format!("Failed to execute staging table DDL: {e}"))?;
+
+        Ok(system_adapter_protocol::CreateStagingTableResponse { ok: true })
     }
 }
 
@@ -380,48 +445,9 @@ async fn post_setup_sink_action(
             return Ok(());
         }
 
-        let sql_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(60))
-            .build()?;
-
         for statement in create_table_statements {
             eprintln!("[stdio] Running post-setup SQL: {statement}");
-
-            let mut attempts = 0;
-
-            loop {
-                let mut request = sql_client.post(sql_url).body(statement.clone());
-                // Prefer non-streaming response path for DDL by setting row limit
-                request = request.header("X-Accept-Rows", "999");
-                if let Some(key) = api_key {
-                    request = request.header("X-API-Key", key);
-                }
-                let response = request.send().await?;
-
-                let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-
-                if status.is_success() {
-                    break;
-                }
-
-                attempts += 1;
-
-                if attempts >= POST_SETUP_SQL_MAX_RETRIES {
-                    return Err(anyhow::anyhow!(
-                        "Failed to execute post-setup SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
-                    ));
-                }
-
-                let backoff_seconds = attempts * 2;
-                eprintln!(
-                    "[stdio] Post-setup SQL failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
-                );
-                sleep(Duration::from_secs(backoff_seconds)).await;
-            }
+            execute_sql_statement(sql_url, api_key, &statement).await?;
         }
 
         eprintln!("[stdio] ADBC post-setup table creation complete");
@@ -431,6 +457,50 @@ async fn post_setup_sink_action(
         );
     }
     Ok(())
+}
+
+/// Execute a single SQL statement against the system's HTTP SQL endpoint.
+async fn execute_sql_statement(
+    sql_url: &str,
+    api_key: Option<&str>,
+    statement: &str,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let mut attempts = 0;
+    loop {
+        let mut request = client.post(sql_url).body(statement.to_string());
+        request = request.header("X-Accept-Rows", "999");
+        if let Some(key) = api_key {
+            request = request.header("X-API-Key", key);
+        }
+        let response = request.send().await?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        attempts += 1;
+        if attempts >= POST_SETUP_SQL_MAX_RETRIES {
+            return Err(anyhow::anyhow!(
+                "Failed to execute SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
+            ));
+        }
+
+        let backoff_seconds = attempts * 2;
+        eprintln!(
+            "[stdio] SQL execution failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
+        );
+        sleep(Duration::from_secs(backoff_seconds)).await;
+    }
 }
 
 fn generate_adbc_create_table_statements(
@@ -717,6 +787,7 @@ async fn provision_spice_cloud_app(
         api_key,
         flight_url,
         api_url: api_url.to_owned(),
+        sql_url,
         cloud,
     })
 }


### PR DESCRIPTION
## Problem

Staging tables used for MERGE-based updates in distributed mode get independent partition-to-executor assignments from the target table. When the scheduler's `forward_federated_partitioned_write()` processes a DoPut to a staging table, the staging table's partition value X may land on a different executor than the target table's partition value X. The MERGE SQL is forwarded to all executors, but each executor joins only its local staging data with its local target data — partial matches, data corruption.

Closes #10177

## Solution

Add `CREATE TABLE new_table LIKE source_table` support to Cayenne DDL. This standard SQL syntax tells the runtime that the new table is derived from the source. The DDL handler:

1. Copies the source table's schema (no regeneration needed)
2. Copies the source table's partition expression
3. **Copies the source table's partition-to-executor assignments** at DDL time, before any DoPut arrives

Because the assignments are pre-seeded, subsequent DoPuts to the staging table route data to the same executors as the target table.

## Scope

- `CREATE TABLE t LIKE s` — copies schema, partition expression, partition assignments
- `IF NOT EXISTS` is supported
- LIKE only supported for Cayenne catalog tables
- Primary keys are never copied (staging tables don't need them)

## Testing

- 7 new unit tests (3 for `copy_assignments`, 4 for LIKE detection/parsing)
- Manual distributed mode test (scheduler + executor with mTLS) verified:
  - Staging table created with same schema and partition expression
  - Data routed to same executor for both source and staging tables
  - `IF NOT EXISTS` works correctly
  - Proper error messages for non-existent/non-Cayenne source tables