### PR TITLE
Use balanced expression tree for partition filter combination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16243,6 +16243,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "util",
 ]
 
 [[package]]

--- a/crates/runtime-datafusion/Cargo.toml
+++ b/crates/runtime-datafusion/Cargo.toml
@@ -29,6 +29,7 @@ search = { path = "../search", default-features = false }
 snafu.workspace = true
 tracing.workspace = true
 url.workspace = true
+util = { path = "../util", features = ["datafusion"] }
 
 [dev-dependencies]
 chrono.workspace = true

--- a/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
+++ b/crates/runtime-datafusion/src/analyzer_rule/partitioned_table_scan_rewrite.rs
@@ -156,7 +156,9 @@ impl AnalyzerRule for PartitionedTableScanRewrite {
                     })
                     .collect::<Result<Vec<_>, _>>()?;
 
-                if let Some(partition_filter) = partition_exprs.into_iter().reduce(Expr::or) {
+                if let Some(partition_filter) =
+                    util::expr::combine_exprs_balanced(partition_exprs, Expr::or)
+                {
                     filters.push(partition_filter);
                 }
                 let plan = LogicalPlanBuilder::scan_with_filters(

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -127,11 +127,11 @@ pub fn get_partition_filter_exprs(
     if partitions.is_empty() {
         return vec![];
     }
-    // Combine multiple partition expressions with OR (union of partitions),
-    // then wrap in a single-element Vec so `.filter()` applies it as one predicate.
-    let combined = partitions
-        .into_iter()
-        .reduce(Expr::or)
+    // Combine multiple partition expressions with OR (union of partitions) using a
+    // balanced tree to avoid O(n)-depth nesting that can exceed recursion limits
+    // during expression traversal/serialization. Wrap in a single-element Vec so
+    // `.filter()` applies it as one predicate.
+    let combined = util::expr::combine_exprs_balanced(partitions, Expr::or)
         .unwrap_or_else(|| unreachable!("partitions is not empty"));
     vec![combined]
 }

--- a/crates/runtime/src/cluster/partition/write_through.rs
+++ b/crates/runtime/src/cluster/partition/write_through.rs
@@ -516,13 +516,13 @@ async fn route_batch_and_assign_unseen(
                 // Rebuild physical filter for this executor from its full predicate list.
                 let df_schema = DFSchema::try_from(batch.schema().as_ref().clone())
                     .context(CreateDFSchemaSnafu)?;
-                let combined = partitions_by_executor[&executor_id]
-                    .iter()
-                    .cloned()
-                    .reduce(Expr::or)
-                    .ok_or(Error::EmptyPartitionExprs {
-                        executor_id: executor_id.clone(),
-                    })?;
+                let combined = util::expr::combine_exprs_balanced(
+                    partitions_by_executor[&executor_id].clone(),
+                    Expr::or,
+                )
+                .ok_or(Error::EmptyPartitionExprs {
+                    executor_id: executor_id.clone(),
+                })?;
                 let physical = datafusion::physical_expr::create_physical_expr(
                     &combined,
                     &df_schema,
@@ -760,13 +760,11 @@ fn build_executor_filters(
     let mut filters = Vec::with_capacity(partitions_by_executor.len());
     for (executor_id, exprs) in partitions_by_executor {
         let combined =
-            exprs
-                .iter()
-                .cloned()
-                .reduce(Expr::or)
-                .ok_or_else(|| Error::EmptyPartitionExprs {
+            util::expr::combine_exprs_balanced(exprs.clone(), Expr::or).ok_or_else(|| {
+                Error::EmptyPartitionExprs {
                     executor_id: executor_id.clone(),
-                })?;
+                }
+            })?;
         let physical = datafusion::physical_expr::create_physical_expr(
             &combined,
             &df_schema,


### PR DESCRIPTION
## 📝 Summary

Fixes #10183

Partition filter expressions were combined using `.reduce(Expr::or)`, creating a left-skewed chain with O(n) depth. With many partitions (e.g., 50 buckets), this produces deeply nested expressions resulting in `Recursion limit exceeded` error.

Affected code paths:
- `get_partition_filter_exprs` — partition filters for data refresh
- `PartitionedTableScanRewrite` — partition filters injected at query time
- `write_through.rs` — executor partition filter construction for write routing

## Fix

Replaced `.reduce(Expr::or)` with `combine_exprs_balanced` (from `util::expr`) which builds a balanced binary tree with O(log n) depth.

## 🔗 Related

Fixes #10183

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
