### PR TITLE
fix: resolve clippy lint errors in cayenne, write_through, iceberg_ddl, and planner

### DIFF
--- a/crates/cayenne/tests/common/mod.rs
+++ b/crates/cayenne/tests/common/mod.rs
@@ -16,6 +16,11 @@ limitations under the License.
 
 //! Common test utilities for Cayenne with multiple metastore backends
 
+#![expect(
+    dead_code,
+    reason = "Shared test helper module compiled into multiple test crates; not every item is used by every crate"
+)]
+
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
@@ -29,7 +34,6 @@ use tempfile::TempDir;
 
 /// Backend type for parameterized tests
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum BackendType {
     Sqlite,
     #[cfg(feature = "turso")]
@@ -37,7 +41,6 @@ pub enum BackendType {
 }
 
 impl BackendType {
-    #[allow(dead_code)]
     pub fn name(self) -> &'static str {
         match self {
             BackendType::Sqlite => "SQLite",
@@ -48,19 +51,15 @@ impl BackendType {
 }
 
 /// Test fixture that sets up a temporary directory and catalog
-#[allow(dead_code)]
 pub struct TestFixture {
-    #[allow(dead_code)]
     pub temp_dir: TempDir,
     pub catalog: Arc<CayenneCatalog>,
     pub data_path: std::path::PathBuf,
-    #[allow(dead_code)]
     pub backend_type: BackendType,
 }
 
 impl TestFixture {
     /// Create a new test fixture with the specified backend
-    #[allow(dead_code)]
     pub async fn new(backend: BackendType) -> Result<Self, Box<dyn std::error::Error>> {
         let temp_dir = TempDir::new()?;
         let data_path = temp_dir.path().join("data");
@@ -90,7 +89,6 @@ impl TestFixture {
     }
 
     /// Get the database path for SQLite-specific verification
-    #[allow(dead_code)]
     pub fn db_path(&self) -> std::path::PathBuf {
         self.temp_dir.path().join("test.db")
     }
@@ -118,7 +116,6 @@ macro_rules! test_with_backends {
 }
 
 /// Helper to run a test function with a specific backend
-#[allow(dead_code)]
 pub async fn run_with_backend<F, Fut>(
     backend: BackendType,
     test_fn: F,
@@ -141,7 +138,6 @@ where
 /// Insert a single batch using `insert_into()` (append mode).
 ///
 /// Creates a temporary `SessionContext` internally.
-#[allow(dead_code)]
 pub async fn insert_batch(provider: &CayenneTableProvider, batch: RecordBatch) -> DFResult<u64> {
     insert_batches(provider, vec![batch]).await
 }
@@ -149,7 +145,6 @@ pub async fn insert_batch(provider: &CayenneTableProvider, batch: RecordBatch) -
 /// Insert record batches using `insert_into()` API (append mode).
 ///
 /// Creates a temporary `SessionContext` internally.
-#[allow(dead_code)]
 pub async fn insert_batches(
     provider: &CayenneTableProvider,
     batches: Vec<RecordBatch>,
@@ -174,7 +169,6 @@ pub async fn insert_batches(
 }
 
 /// Extract the row count from insert result batches.
-#[allow(dead_code)]
 fn extract_row_count(results: &[RecordBatch]) -> u64 {
     use arrow::datatypes::DataType;
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1327,7 +1327,7 @@ impl TableProvider for AcceleratedTable {
             } => write_through::insert_write_through(
                 input,
                 overwrite,
-                cayenne_target,
+                cayenne_target.as_ref(),
                 Arc::clone(federated_provider),
                 &self.refresher,
                 self.schema(),

--- a/crates/runtime/src/accelerated_table/write_through.rs
+++ b/crates/runtime/src/accelerated_table/write_through.rs
@@ -52,14 +52,14 @@ use runtime_table_partition::provider::PartitionTableProvider;
 /// Target for Cayenne-based write-through operations.
 #[derive(Debug)]
 pub(crate) enum CayenneWriteTarget {
-    Staged(CayenneTableProvider),
+    Staged(Box<CayenneTableProvider>),
     Partitioned(Arc<dyn TableProvider>),
 }
 
 impl Clone for CayenneWriteTarget {
     fn clone(&self) -> Self {
         match self {
-            Self::Staged(provider) => Self::Staged(provider.clone_for_write_operations()),
+            Self::Staged(provider) => Self::Staged(Box::new(provider.clone_for_write_operations())),
             Self::Partitioned(provider) => Self::Partitioned(Arc::clone(provider)),
         }
     }
@@ -77,7 +77,7 @@ pub(crate) enum WriteMode {
     /// Writes go simultaneously to both the federated source and the local Cayenne
     /// accelerator using staged append/commit/rollback semantics.
     WriteThrough {
-        cayenne_target: CayenneWriteTarget,
+        cayenne_target: Box<CayenneWriteTarget>,
         federated_provider: Arc<dyn TableProvider>,
     },
 }
@@ -117,7 +117,7 @@ impl WriteMode {
         })?;
 
         Ok(Self::WriteThrough {
-            cayenne_target,
+            cayenne_target: Box::new(cayenne_target),
             federated_provider,
         })
     }
@@ -557,9 +557,9 @@ fn extract_cayenne_write_target(
         .as_any()
         .downcast_ref::<CayenneTableProvider>()
     {
-        return Some(CayenneWriteTarget::Staged(
+        return Some(CayenneWriteTarget::Staged(Box::new(
             cayenne.clone_for_write_operations(),
-        ));
+        )));
     }
 
     if let Some(partitioned) = table_provider

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -19,6 +19,7 @@ limitations under the License.
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::Write as _;
 use std::sync::{Arc, Weak};
 
 use app::App;
@@ -71,8 +72,10 @@ impl IcebergDdlAccelerationSource {
         acceleration: RuntimeAcceleration,
         time_column: Option<String>,
     ) -> Self {
-        let mut app = App::default();
-        app.name = app_name;
+        let app = App {
+            name: app_name,
+            ..App::default()
+        };
 
         Self {
             app: Arc::new(app),
@@ -757,9 +760,7 @@ async fn create_accelerated_iceberg_table(
     source_provider: Arc<dyn datafusion::datasource::TableProvider>,
     acceleration: &Acceleration,
     dataset_options: &DatasetOptions,
-    catalog_name: &str,
-    schema_name: &str,
-    table_name: &str,
+    dataset_name: TableReference,
     partition_expr_sql: Option<&str>,
 ) -> Result<AcceleratedTable, DataFusionError> {
     use crate::accelerated_table::refresh::Refresh;
@@ -772,6 +773,10 @@ async fn create_accelerated_iceberg_table(
             "DataFusion runtime is no longer available for accelerated table creation".to_string(),
         )
     })?;
+
+    let table_name = dataset_name.table();
+    let catalog_name = dataset_name.catalog().unwrap_or_default();
+    let schema_name = dataset_name.schema().unwrap_or_default();
 
     // Convert spicepod Acceleration → runtime Acceleration (parses durations, engine, etc.)
     let mut runtime_accel = RuntimeAcceleration::try_from(acceleration.clone()).map_err(|e| {
@@ -794,11 +799,6 @@ async fn create_accelerated_iceberg_table(
     validate_write_through_acceleration(acceleration)?;
     validate_ddl_acceleration_runtime_requirements(acceleration)?;
 
-    let dataset_name = TableReference::full(
-        catalog_name.to_string(),
-        schema_name.to_string(),
-        table_name.to_string(),
-    );
     let source_string = format!("{catalog_name}.{schema_name}.{table_name}");
 
     let source_schema = source_provider.schema();
@@ -911,9 +911,11 @@ async fn build_registered_provider(
         raw_provider,
         acceleration,
         dataset_options,
-        df_catalog_name,
-        df_schema_name,
-        &table_name,
+        TableReference::full(
+            df_catalog_name.to_string(),
+            df_schema_name.to_string(),
+            table_name,
+        ),
         partition_expr_sql.map(String::as_str),
     )
     .await?;
@@ -1086,15 +1088,15 @@ fn build_forwarded_create_sql(
         options.push(format!("\"dataset.time_column\" = '{time_column}'"));
     }
     if let Some(time_format) = &dataset_options.time_format {
-        options.push(format!("\"dataset.time_format\" = '{}'", time_format));
+        options.push(format!("\"dataset.time_format\" = '{time_format}'"));
     }
 
     if !options.is_empty() {
-        sql.push_str(&format!(" WITH ({})", options.join(", ")));
+        let _ = write!(sql, " WITH ({})", options.join(", "));
     }
 
     if let Some(partition_expr_sql) = partition_expr_sql {
-        sql.push_str(&format!(" PARTITION BY {partition_expr_sql}"));
+        let _ = write!(sql, " PARTITION BY {partition_expr_sql}");
     }
 
     Ok(sql)

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -244,10 +244,9 @@ fn is_write_through_table_provider(table_provider: &Arc<dyn TableProvider>) -> b
         .as_any()
         .downcast_ref::<FederatedTableProviderAdaptor>()
         && let Some(inner_provider) = adaptor.table_provider.as_ref()
+        && let Some(accelerated) = inner_provider.as_any().downcast_ref::<AcceleratedTable>()
     {
-        if let Some(accelerated) = inner_provider.as_any().downcast_ref::<AcceleratedTable>() {
-            return accelerated.is_write_through();
-        }
+        return accelerated.is_write_through();
     }
 
     false


### PR DESCRIPTION
## 📝 Summary

Fixes multiple clippy lint errors blocking CI:

- **`cayenne/tests/common/mod.rs`**: Replace per-item `#[allow(dead_code)]` / `#[expect(dead_code)]` annotations (which were either forbidden by `clippy::allow_attributes` or unfulfilled when compiled into test crates that use all items) with a single module-level `#![expect(dead_code)]` inner attribute.
- **`accelerated_table/write_through.rs`**: Box `CayenneWriteTarget::Staged` and `WriteMode::WriteThrough.cayenne_target` to fix `clippy::large_enum_variant`.
- **`datafusion/iceberg_ddl/physical_plans.rs`**:
  - Fix `clippy::field_reassign_with_default` by using struct update syntax for `App` initialization.
  - Reduce `create_accelerated_iceberg_table` from 8 to 6 arguments (accept `TableReference` instead of separate `catalog_name`/`schema_name`/`table_name`) to fix `clippy::too_many_arguments`.
  - Fix `clippy::uninlined_format_args` and `clippy::format_push_string` by inlining format args and using `write!` instead of `push_str(&format!(...))`.
- **`datafusion/planner/mod.rs`**: Collapse nested `if let` into a single chained `if let` to fix `clippy::collapsible_if`.
- **`runtime-table-partition/src/provider.rs`**: Add missing `# Errors` doc section on `get_or_create_partition_provider`.
- **`cayenne/src/provider/staging_wal.rs`**: Add missing `# Errors` doc sections on all public `Result`-returning functions.
