### PR TITLE
feat: Support struct() IN-list filters in Cayenne position-based delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19039,7 +19039,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=27754b5810745e3afc7bb703ecc13aa9835732ea#27754b5810745e3afc7bb703ecc13aa9835732ea"
+source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19047,6 +19047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid 1.21.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "27754b5810745e3afc7bb703ecc13aa9835732ea", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6327983bc1a90123e0c754b79781b931c969831e", features = ["server"] }
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -34,6 +34,7 @@ use datafusion_common::utils::get_available_parallelism;
 use datafusion_expr::Expr;
 use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::create_physical_expr;
+use datafusion_physical_expr::expressions as phys_expr;
 use futures::StreamExt;
 use object_store::ObjectStore;
 use roaring::{RoaringBitmap, RoaringTreemap};
@@ -187,6 +188,14 @@ impl CayenneDeletionSink {
             tracing::debug!("No new deletions to persist");
             return Ok(0);
         }
+
+        let total_new_deletions: usize = per_file_row_ids.values().map(std::vec::Vec::len).sum();
+        tracing::debug!(
+            table = %table_name,
+            total_new_deletions,
+            files_with_deletions = per_file_row_ids.len(),
+            "Position-based delete: persisting deletions"
+        );
 
         self.persist_position_based_deletions(per_file_row_ids)
             .await
@@ -471,24 +480,157 @@ fn build_vortex_filter(
         })
         .collect::<datafusion_common::Result<Vec<_>>>()?;
 
-    // Convert to Vortex expressions and combine with AND
+    // Convert to Vortex expressions and combine with AND.
+    // When direct conversion fails (e.g., struct() IN-list from composite-key
+    // deletes), try decomposing the expression into Vortex-compatible form.
     let mut combined: Option<vortex::expr::Expression> = None;
     for phys_filter in &physical_filters {
-        match expr_convertor.convert(phys_filter.as_ref()) {
-            Ok(vortex_expr) => {
-                combined = Some(match combined {
-                    Some(existing) => and(existing, vortex_expr),
-                    None => vortex_expr,
-                });
+        let vortex_expr = match expr_convertor.convert(phys_filter.as_ref()) {
+            Ok(expr) => expr,
+            Err(_) => {
+                match try_decompose_struct_in_list(phys_filter.as_ref(), &expr_convertor, df_schema)
+                {
+                    Some(decomposed) => decomposed,
+                    None => {
+                        return Err(format!(
+                            "Failed to convert filter to Vortex expression. Filter: {phys_filter}"
+                        )
+                        .into());
+                    }
+                }
             }
-            Err(e) => {
-                return Err(format!(
-                    "Failed to convert filter to Vortex expression: {e}. Filter: {phys_filter}"
-                )
-                .into());
-            }
-        }
+        };
+        combined = Some(match combined {
+            Some(existing) => and(existing, vortex_expr),
+            None => vortex_expr,
+        });
     }
 
     Ok(combined)
+}
+
+/// Decompose `struct(col1, col2, ...) IN (struct_lit1, struct_lit2, ...)` into a
+/// balanced OR-tree of AND-equalities that Vortex can evaluate.
+///
+/// `DataFusion` converts `(k1, k2) IN ((v1, w1), (v2, w2))` into
+/// `struct(k1, k2) IN (SET)` which Vortex's expression convertor doesn't support.
+/// This function decomposes it into:
+///   `(k1 = v1 AND k2 = w1) OR (k1 = v2 AND k2 = w2)`
+/// using a balanced binary tree to keep expression depth at O(log N).
+fn try_decompose_struct_in_list(
+    expr: &dyn datafusion_physical_expr::PhysicalExpr,
+    convertor: &DefaultExpressionConvertor,
+    df_schema: &DFSchema,
+) -> Option<vortex::expr::Expression> {
+    use datafusion_common::ScalarValue;
+
+    let in_list = expr.as_any().downcast_ref::<phys_expr::InListExpr>()?;
+
+    // Check that the value expression is struct(col1, col2, ...),
+    // possibly wrapped in a CAST (DataFusion may insert type coercion).
+    let value_expr: &dyn datafusion_physical_expr::PhysicalExpr = in_list.expr().as_ref();
+    let struct_fn = if let Some(sf) = value_expr
+        .as_any()
+        .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>(
+    ) {
+        sf
+    } else if let Some(cast_expr) = value_expr.as_any().downcast_ref::<phys_expr::CastExpr>() {
+        cast_expr
+            .expr()
+            .as_any()
+            .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()?
+    } else {
+        return None;
+    };
+    if struct_fn.name() != "struct" {
+        return None;
+    }
+
+    // Convert each column in struct() args to a Vortex expression.
+    // Also record each column's native data type for literal casting.
+    let mut vortex_columns: Vec<vortex::expr::Expression> =
+        Vec::with_capacity(struct_fn.args().len());
+    let mut col_types: Vec<arrow::datatypes::DataType> = Vec::with_capacity(struct_fn.args().len());
+    let arrow_schema: arrow::datatypes::Schema = df_schema.as_arrow().as_ref().clone();
+    for arg in struct_fn.args() {
+        let vx = convertor.convert(arg.as_ref()).ok()?;
+        let dt = arg.data_type(&arrow_schema).ok()?;
+        vortex_columns.push(vx);
+        col_types.push(dt);
+    }
+
+    if vortex_columns.is_empty() {
+        return None;
+    }
+
+    // Build one AND-conjunction per list element: (col1 = v1 AND col2 = w1)
+    let row_predicates: Vec<vortex::expr::Expression> = in_list
+        .list()
+        .iter()
+        .filter_map(|elem| {
+            let literal = elem.as_any().downcast_ref::<phys_expr::Literal>()?;
+            let ScalarValue::Struct(struct_arr) = literal.value() else {
+                return None;
+            };
+
+            // Build (col1 = v1 AND col2 = w1) for this struct literal.
+            // Cast each field scalar to the column's native type to avoid
+            // Vortex DType mismatches (e.g., i64 literal vs i32 column).
+            let field_eqs: Vec<vortex::expr::Expression> = (0..vortex_columns.len())
+                .map(|i| {
+                    let field_scalar = ScalarValue::try_from_array(struct_arr.column(i), 0).ok()?;
+                    let cast_scalar = field_scalar
+                        .cast_to(&col_types[i])
+                        .ok()
+                        .unwrap_or(field_scalar);
+                    let phys_lit = phys_expr::Literal::new(cast_scalar);
+                    let vortex_lit = convertor.convert(&phys_lit).ok()?;
+                    Some(vortex::expr::eq(vortex_columns[i].clone(), vortex_lit))
+                })
+                .collect::<Option<Vec<_>>>()?;
+
+            let mut conj = field_eqs.into_iter();
+            let first = conj.next()?;
+            Some(conj.fold(first, vortex::expr::and))
+        })
+        .collect();
+
+    if row_predicates.is_empty() {
+        return None;
+    }
+
+    // Build a balanced binary OR-tree to keep depth at O(log N)
+    let result = balanced_or(row_predicates);
+
+    if in_list.negated() {
+        Some(vortex::expr::not(result))
+    } else {
+        Some(result)
+    }
+}
+
+/// Combine expressions with OR using a balanced binary tree.
+/// Depth is O(log N) instead of O(N) from a linear fold, avoiding stack overflow.
+fn balanced_or(mut exprs: Vec<vortex::expr::Expression>) -> vortex::expr::Expression {
+    use vortex::expr::or;
+    debug_assert!(!exprs.is_empty());
+    while exprs.len() > 1 {
+        let mut next = Vec::with_capacity(exprs.len().div_ceil(2));
+        let mut i = 0;
+        while i + 1 < exprs.len() {
+            // Take pairs — using swap_remove-style but preserving order
+            let right = exprs[i + 1].clone();
+            let left = exprs[i].clone();
+            next.push(or(left, right));
+            i += 2;
+        }
+        if i < exprs.len() {
+            next.push(exprs[i].clone());
+        }
+        exprs = next;
+    }
+    match exprs.into_iter().next() {
+        Some(expr) => expr,
+        None => unreachable!("balanced_or called with empty exprs"),
+    }
 }

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1853,18 +1853,78 @@ async fn validate_partition_compatibility(
         )));
     }
 
-    // Check that the partition column appears in the ON keys (target side).
-    let partition_in_on_keys = on_keys
-        .iter()
-        .any(|(target_col, _)| *target_col == target_part);
-    if !partition_in_on_keys {
+    // Parse the partition expression to extract column references. For transform
+    // partitions like bucket(5, c_nationkey), the referenced column is c_nationkey.
+    // For simple column partitions like n_regionkey, the column is n_regionkey.
+    let partition_cols = extract_partition_column_references(&target_part)?;
+    let all_covered = !partition_cols.is_empty()
+        && partition_cols
+            .iter()
+            .all(|pc| on_keys.iter().any(|(target_col, _)| target_col == pc));
+    if !all_covered {
         return Err(DataFusionError::Plan(format!(
-            "Distributed MERGE requires the partition column '{target_part}' to appear in the \
-             ON clause join keys for correct executor-local execution"
+            "Distributed MERGE requires the partition column(s) referenced by '{target_part}' \
+             to appear in the ON clause join keys for correct executor-local execution"
         )));
     }
 
     Ok(())
+}
+
+/// Extract column name references from a partition expression string by parsing
+/// it as a SQL expression and walking the AST with sqlparser's `Visitor`.
+///
+/// Handles simple column references (`c_nationkey`) and transform expressions
+/// (`bucket(5, c_nationkey)`) — numeric/string literals are naturally excluded
+/// since they parse as `Value` nodes, not `Identifier` nodes.
+fn extract_partition_column_references(partition_expr: &str) -> DFResult<Vec<String>> {
+    use datafusion::sql::sqlparser::ast::{Expr as SqlExpr, Visit, Visitor};
+    use datafusion::sql::sqlparser::dialect::GenericDialect;
+    use datafusion::sql::sqlparser::parser::Parser;
+    use std::ops::ControlFlow;
+
+    struct ColumnCollector {
+        columns: Vec<String>,
+    }
+
+    impl Visitor for ColumnCollector {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &SqlExpr) -> ControlFlow<Self::Break> {
+            match expr {
+                SqlExpr::Identifier(ident) => {
+                    self.columns.push(ident.value.clone());
+                }
+                SqlExpr::CompoundIdentifier(idents) => {
+                    if let Some(last) = idents.last() {
+                        self.columns.push(last.value.clone());
+                    }
+                }
+                _ => {}
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let dialect = GenericDialect {};
+    let mut parser = Parser::new(&dialect)
+        .try_with_sql(partition_expr)
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to parse partition expression '{partition_expr}': {e}"
+            ))
+        })?;
+    let sql_expr = parser.parse_expr().map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Failed to parse partition expression '{partition_expr}': {e}"
+        ))
+    })?;
+
+    let mut collector = ColumnCollector {
+        columns: Vec::new(),
+    };
+    let _ = sql_expr.visit(&mut collector);
+    Ok(collector.columns)
 }
 
 /// Schema for DML count results — single `count` column with `UInt64` type,
@@ -1881,7 +1941,7 @@ fn dml_count_schema() -> SchemaRef {
 mod tests {
     use datafusion::logical_expr::col;
 
-    use super::partition_label_for_expr;
+    use super::{extract_partition_column_references, partition_label_for_expr};
 
     #[test]
     fn partition_label_for_expr_uses_column_name_when_safe() {
@@ -1899,5 +1959,37 @@ mod tests {
     fn partition_label_for_expr_sanitizes_unsafe_column_names() {
         let expr = col("tenant/../id");
         assert_eq!(partition_label_for_expr(&expr), "tenant____id");
+    }
+
+    #[test]
+    fn extract_partition_cols_simple_column() {
+        let cols = extract_partition_column_references("c_nationkey").expect("simple column");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_bucket_function() {
+        let cols =
+            extract_partition_column_references("bucket(5, c_nationkey)").expect("bucket fn");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_parenthesized() {
+        let cols =
+            extract_partition_column_references("(bucket(5, c_nationkey))").expect("parenthesized");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_quoted_column() {
+        let cols = extract_partition_column_references(r#""order_date""#).expect("quoted column");
+        assert_eq!(cols, vec!["order_date"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_binary_op() {
+        let cols = extract_partition_column_references("a + b").expect("binary op");
+        assert_eq!(cols, vec!["a", "b"]);
     }
 }

--- a/crates/runtime/src/datafusion/planner/physical_execs.rs
+++ b/crates/runtime/src/datafusion/planner/physical_execs.rs
@@ -196,6 +196,7 @@ async fn execute_merge(
 
     // Normalize output to match the target table schema (including nullability).
     let target_schema = target_provider.schema();
+
     let normalized_batches = updated_batches
         .into_iter()
         .map(|batch| arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema)))
@@ -413,11 +414,13 @@ fn build_delete_filters(
         ));
     }
 
-    // Combine all row predicates with OR.
-    match row_predicates.into_iter().reduce(datafusion_expr::Expr::or) {
+    // Combine all row predicates with OR using a balanced binary tree.
+    // A linear fold creates O(N) depth causing stack overflow for large N.
+    // A balanced tree keeps depth at O(log N).
+    match util::expr::combine_exprs_balanced(row_predicates, datafusion::prelude::Expr::or) {
         Some(combined) => Ok(vec![combined]),
         None => Err(DataFusionError::Internal(
-            "Failed to build delete filters: reduce produced no result".to_string(),
+            "Failed to build delete filters: no row predicates generated".to_string(),
         )),
     }
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -63,6 +63,8 @@ enum RunState {
         flight_url: String,
         /// Normalized API base URL (stored separately from `cloud` to avoid tainted-struct logging).
         api_url: String,
+        /// SQL endpoint URL for DDL execution.
+        sql_url: String,
         /// Cloud client used during provisioning (reused for teardown).
         cloud: CloudClient,
     },
@@ -81,6 +83,20 @@ impl RunState {
         match self {
             Self::Scp { api_key, .. } => api_key.as_str(),
             Self::Local(_) => "",
+        }
+    }
+
+    fn sql_url(&self) -> &str {
+        match self {
+            Self::Scp { sql_url, .. } => sql_url.as_str(),
+            Self::Local(state) => state.sql_url.as_str(),
+        }
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::Scp { api_key, .. } => Some(api_key.as_str()),
+            Self::Local(state) => state.flight_api_key.as_deref(),
         }
     }
 }
@@ -189,6 +205,8 @@ fn sum_opt_f64_as_u64(
 struct SpidapterHandler {
     /// Active runs keyed by run ID.
     runs: HashMap<Uuid, RunState>,
+    /// Datasets from setup, keyed by run ID → dataset name → config.
+    run_datasets: HashMap<Uuid, HashMap<String, DatasetConfig>>,
     /// Full CLI args (includes all flags and env-var-backed configuration).
     args: StdioArgs,
 }
@@ -197,6 +215,7 @@ impl SpidapterHandler {
     fn new(args: &StdioArgs) -> Self {
         Self {
             runs: HashMap::new(),
+            run_datasets: HashMap::new(),
             args: args.clone(),
         }
     }
@@ -271,11 +290,16 @@ impl Handler for SpidapterHandler {
         };
 
         self.runs.insert(run_id, state);
+        self.run_datasets.insert(run_id, datasets);
 
         Ok(response)
     }
 
-    async fn metrics(&mut self, run_id: Uuid) -> std::result::Result<MetricsResponse, String> {
+    async fn metrics(
+        &mut self,
+        run_id: Uuid,
+        _final_scrape: bool,
+    ) -> std::result::Result<MetricsResponse, String> {
         let state = self
             .runs
             .get(&run_id)
@@ -300,6 +324,7 @@ impl Handler for SpidapterHandler {
                         disk_write_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes),
                         disk_read_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_read_operations),
                         disk_write_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_write_operations),
+                        num_compute_nodes: None,
                     }
                 };
 
@@ -331,6 +356,7 @@ impl Handler for SpidapterHandler {
             eprintln!("[stdio] teardown: run_id={run_id} not found (already torn down?)");
             return Ok(TeardownResponse { ok: true });
         };
+        self.run_datasets.remove(&run_id);
 
         match state {
             RunState::Scp {
@@ -353,6 +379,45 @@ impl Handler for SpidapterHandler {
         }
 
         Ok(TeardownResponse { ok: true })
+    }
+
+    async fn create_staging_table(
+        &mut self,
+        run_id: Uuid,
+        source_dataset: &str,
+        staging_table_name: &str,
+    ) -> std::result::Result<system_adapter_protocol::CreateStagingTableResponse, String> {
+        let state = self
+            .runs
+            .get(&run_id)
+            .ok_or_else(|| format!("No active run found for {run_id}"))?;
+        if !self
+            .run_datasets
+            .get(&run_id)
+            .map_or(false, |ds| ds.contains_key(source_dataset))
+        {
+            return Err(format!(
+                "Source dataset '{source_dataset}' not found in run {run_id}"
+            ));
+        }
+
+        // Use CREATE TABLE ... LIKE ... to copy schema, partition expression,
+        // AND partition-to-executor assignments from the source table.
+        let quoted_staging = quote_identifier(staging_table_name);
+        let quoted_source = quote_identifier(source_dataset);
+        let ddl = format!(
+            "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_staging} LIKE spicebench.bench.{quoted_source}"
+        );
+
+        eprintln!(
+            "[stdio] create_staging_table: source={source_dataset}, staging={staging_table_name}, sql={ddl}"
+        );
+
+        execute_sql_statement(state.sql_url(), state.api_key(), &ddl)
+            .await
+            .map_err(|e| format!("Failed to execute staging table DDL: {e}"))?;
+
+        Ok(system_adapter_protocol::CreateStagingTableResponse { ok: true })
     }
 }
 
@@ -380,48 +445,9 @@ async fn post_setup_sink_action(
             return Ok(());
         }
 
-        let sql_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(60))
-            .build()?;
-
         for statement in create_table_statements {
             eprintln!("[stdio] Running post-setup SQL: {statement}");
-
-            let mut attempts = 0;
-
-            loop {
-                let mut request = sql_client.post(sql_url).body(statement.clone());
-                // Prefer non-streaming response path for DDL by setting row limit
-                request = request.header("X-Accept-Rows", "999");
-                if let Some(key) = api_key {
-                    request = request.header("X-API-Key", key);
-                }
-                let response = request.send().await?;
-
-                let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-
-                if status.is_success() {
-                    break;
-                }
-
-                attempts += 1;
-
-                if attempts >= POST_SETUP_SQL_MAX_RETRIES {
-                    return Err(anyhow::anyhow!(
-                        "Failed to execute post-setup SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
-                    ));
-                }
-
-                let backoff_seconds = attempts * 2;
-                eprintln!(
-                    "[stdio] Post-setup SQL failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
-                );
-                sleep(Duration::from_secs(backoff_seconds)).await;
-            }
+            execute_sql_statement(sql_url, api_key, &statement).await?;
         }
 
         eprintln!("[stdio] ADBC post-setup table creation complete");
@@ -431,6 +457,50 @@ async fn post_setup_sink_action(
         );
     }
     Ok(())
+}
+
+/// Execute a single SQL statement against the system's HTTP SQL endpoint.
+async fn execute_sql_statement(
+    sql_url: &str,
+    api_key: Option<&str>,
+    statement: &str,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let mut attempts = 0;
+    loop {
+        let mut request = client.post(sql_url).body(statement.to_string());
+        request = request.header("X-Accept-Rows", "999");
+        if let Some(key) = api_key {
+            request = request.header("X-API-Key", key);
+        }
+        let response = request.send().await?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        attempts += 1;
+        if attempts >= POST_SETUP_SQL_MAX_RETRIES {
+            return Err(anyhow::anyhow!(
+                "Failed to execute SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
+            ));
+        }
+
+        let backoff_seconds = attempts * 2;
+        eprintln!(
+            "[stdio] SQL execution failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
+        );
+        sleep(Duration::from_secs(backoff_seconds)).await;
+    }
 }
 
 fn generate_adbc_create_table_statements(
@@ -717,6 +787,7 @@ async fn provision_spice_cloud_app(
         api_key,
         flight_url,
         api_url: api_url.to_owned(),
+        sql_url,
         cloud,
     })
 }


### PR DESCRIPTION
Adds `try_decompose_struct_in_list()` to handle composite-key `DELETE FROM ... WHERE (k1, k2) IN ((v1,v2), ...)` filters in Cayenne's position-based deletion path. Uses a balanced OR-tree (`balanced_or_exprs()`) to avoid stack overflow with large IN-lists.

Part of the MERGE INTO implementation (#10095, #10097).

**Stack:**
1. `phillip/260406-create-table-like` — CREATE TABLE ... LIKE support
2. **→ This PR** — struct IN-list filters for position-based delete
3. `phillip/260406-partition-col-refs` — Partition column extraction for MERGE validation
4. `phillip/260406-spidapter-staging` — Spidapter staging table support