### PR TITLE
fix: Parse partition expressions to extract column references for MERGE validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19039,7 +19039,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=27754b5810745e3afc7bb703ecc13aa9835732ea#27754b5810745e3afc7bb703ecc13aa9835732ea"
+source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19047,6 +19047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid 1.21.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "27754b5810745e3afc7bb703ecc13aa9835732ea", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6327983bc1a90123e0c754b79781b931c969831e", features = ["server"] }
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -1853,18 +1853,78 @@ async fn validate_partition_compatibility(
         )));
     }
 
-    // Check that the partition column appears in the ON keys (target side).
-    let partition_in_on_keys = on_keys
-        .iter()
-        .any(|(target_col, _)| *target_col == target_part);
-    if !partition_in_on_keys {
+    // Parse the partition expression to extract column references. For transform
+    // partitions like bucket(5, c_nationkey), the referenced column is c_nationkey.
+    // For simple column partitions like n_regionkey, the column is n_regionkey.
+    let partition_cols = extract_partition_column_references(&target_part)?;
+    let all_covered = !partition_cols.is_empty()
+        && partition_cols
+            .iter()
+            .all(|pc| on_keys.iter().any(|(target_col, _)| target_col == pc));
+    if !all_covered {
         return Err(DataFusionError::Plan(format!(
-            "Distributed MERGE requires the partition column '{target_part}' to appear in the \
-             ON clause join keys for correct executor-local execution"
+            "Distributed MERGE requires the partition column(s) referenced by '{target_part}' \
+             to appear in the ON clause join keys for correct executor-local execution"
         )));
     }
 
     Ok(())
+}
+
+/// Extract column name references from a partition expression string by parsing
+/// it as a SQL expression and walking the AST with sqlparser's `Visitor`.
+///
+/// Handles simple column references (`c_nationkey`) and transform expressions
+/// (`bucket(5, c_nationkey)`) — numeric/string literals are naturally excluded
+/// since they parse as `Value` nodes, not `Identifier` nodes.
+fn extract_partition_column_references(partition_expr: &str) -> DFResult<Vec<String>> {
+    use datafusion::sql::sqlparser::ast::{Expr as SqlExpr, Visit, Visitor};
+    use datafusion::sql::sqlparser::dialect::GenericDialect;
+    use datafusion::sql::sqlparser::parser::Parser;
+    use std::ops::ControlFlow;
+
+    struct ColumnCollector {
+        columns: Vec<String>,
+    }
+
+    impl Visitor for ColumnCollector {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &SqlExpr) -> ControlFlow<Self::Break> {
+            match expr {
+                SqlExpr::Identifier(ident) => {
+                    self.columns.push(ident.value.clone());
+                }
+                SqlExpr::CompoundIdentifier(idents) => {
+                    if let Some(last) = idents.last() {
+                        self.columns.push(last.value.clone());
+                    }
+                }
+                _ => {}
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let dialect = GenericDialect {};
+    let mut parser = Parser::new(&dialect)
+        .try_with_sql(partition_expr)
+        .map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to parse partition expression '{partition_expr}': {e}"
+            ))
+        })?;
+    let sql_expr = parser.parse_expr().map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Failed to parse partition expression '{partition_expr}': {e}"
+        ))
+    })?;
+
+    let mut collector = ColumnCollector {
+        columns: Vec::new(),
+    };
+    let _ = sql_expr.visit(&mut collector);
+    Ok(collector.columns)
 }
 
 /// Schema for DML count results — single `count` column with `UInt64` type,
@@ -1881,7 +1941,7 @@ fn dml_count_schema() -> SchemaRef {
 mod tests {
     use datafusion::logical_expr::col;
 
-    use super::partition_label_for_expr;
+    use super::{extract_partition_column_references, partition_label_for_expr};
 
     #[test]
     fn partition_label_for_expr_uses_column_name_when_safe() {
@@ -1899,5 +1959,37 @@ mod tests {
     fn partition_label_for_expr_sanitizes_unsafe_column_names() {
         let expr = col("tenant/../id");
         assert_eq!(partition_label_for_expr(&expr), "tenant____id");
+    }
+
+    #[test]
+    fn extract_partition_cols_simple_column() {
+        let cols = extract_partition_column_references("c_nationkey").expect("simple column");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_bucket_function() {
+        let cols =
+            extract_partition_column_references("bucket(5, c_nationkey)").expect("bucket fn");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_parenthesized() {
+        let cols =
+            extract_partition_column_references("(bucket(5, c_nationkey))").expect("parenthesized");
+        assert_eq!(cols, vec!["c_nationkey"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_quoted_column() {
+        let cols = extract_partition_column_references(r#""order_date""#).expect("quoted column");
+        assert_eq!(cols, vec!["order_date"]);
+    }
+
+    #[test]
+    fn extract_partition_cols_binary_op() {
+        let cols = extract_partition_column_references("a + b").expect("binary op");
+        assert_eq!(cols, vec!["a", "b"]);
     }
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -63,6 +63,8 @@ enum RunState {
         flight_url: String,
         /// Normalized API base URL (stored separately from `cloud` to avoid tainted-struct logging).
         api_url: String,
+        /// SQL endpoint URL for DDL execution.
+        sql_url: String,
         /// Cloud client used during provisioning (reused for teardown).
         cloud: CloudClient,
     },
@@ -81,6 +83,20 @@ impl RunState {
         match self {
             Self::Scp { api_key, .. } => api_key.as_str(),
             Self::Local(_) => "",
+        }
+    }
+
+    fn sql_url(&self) -> &str {
+        match self {
+            Self::Scp { sql_url, .. } => sql_url.as_str(),
+            Self::Local(state) => state.sql_url.as_str(),
+        }
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::Scp { api_key, .. } => Some(api_key.as_str()),
+            Self::Local(state) => state.flight_api_key.as_deref(),
         }
     }
 }
@@ -189,6 +205,8 @@ fn sum_opt_f64_as_u64(
 struct SpidapterHandler {
     /// Active runs keyed by run ID.
     runs: HashMap<Uuid, RunState>,
+    /// Datasets from setup, keyed by run ID → dataset name → config.
+    run_datasets: HashMap<Uuid, HashMap<String, DatasetConfig>>,
     /// Full CLI args (includes all flags and env-var-backed configuration).
     args: StdioArgs,
 }
@@ -197,6 +215,7 @@ impl SpidapterHandler {
     fn new(args: &StdioArgs) -> Self {
         Self {
             runs: HashMap::new(),
+            run_datasets: HashMap::new(),
             args: args.clone(),
         }
     }
@@ -271,11 +290,16 @@ impl Handler for SpidapterHandler {
         };
 
         self.runs.insert(run_id, state);
+        self.run_datasets.insert(run_id, datasets);
 
         Ok(response)
     }
 
-    async fn metrics(&mut self, run_id: Uuid) -> std::result::Result<MetricsResponse, String> {
+    async fn metrics(
+        &mut self,
+        run_id: Uuid,
+        _final_scrape: bool,
+    ) -> std::result::Result<MetricsResponse, String> {
         let state = self
             .runs
             .get(&run_id)
@@ -300,6 +324,7 @@ impl Handler for SpidapterHandler {
                         disk_write_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes),
                         disk_read_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_read_operations),
                         disk_write_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_write_operations),
+                        num_compute_nodes: None,
                     }
                 };
 
@@ -331,6 +356,7 @@ impl Handler for SpidapterHandler {
             eprintln!("[stdio] teardown: run_id={run_id} not found (already torn down?)");
             return Ok(TeardownResponse { ok: true });
         };
+        self.run_datasets.remove(&run_id);
 
         match state {
             RunState::Scp {
@@ -353,6 +379,45 @@ impl Handler for SpidapterHandler {
         }
 
         Ok(TeardownResponse { ok: true })
+    }
+
+    async fn create_staging_table(
+        &mut self,
+        run_id: Uuid,
+        source_dataset: &str,
+        staging_table_name: &str,
+    ) -> std::result::Result<system_adapter_protocol::CreateStagingTableResponse, String> {
+        let state = self
+            .runs
+            .get(&run_id)
+            .ok_or_else(|| format!("No active run found for {run_id}"))?;
+        if !self
+            .run_datasets
+            .get(&run_id)
+            .map_or(false, |ds| ds.contains_key(source_dataset))
+        {
+            return Err(format!(
+                "Source dataset '{source_dataset}' not found in run {run_id}"
+            ));
+        }
+
+        // Use CREATE TABLE ... LIKE ... to copy schema, partition expression,
+        // AND partition-to-executor assignments from the source table.
+        let quoted_staging = quote_identifier(staging_table_name);
+        let quoted_source = quote_identifier(source_dataset);
+        let ddl = format!(
+            "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_staging} LIKE spicebench.bench.{quoted_source}"
+        );
+
+        eprintln!(
+            "[stdio] create_staging_table: source={source_dataset}, staging={staging_table_name}, sql={ddl}"
+        );
+
+        execute_sql_statement(state.sql_url(), state.api_key(), &ddl)
+            .await
+            .map_err(|e| format!("Failed to execute staging table DDL: {e}"))?;
+
+        Ok(system_adapter_protocol::CreateStagingTableResponse { ok: true })
     }
 }
 
@@ -380,48 +445,9 @@ async fn post_setup_sink_action(
             return Ok(());
         }
 
-        let sql_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(60))
-            .build()?;
-
         for statement in create_table_statements {
             eprintln!("[stdio] Running post-setup SQL: {statement}");
-
-            let mut attempts = 0;
-
-            loop {
-                let mut request = sql_client.post(sql_url).body(statement.clone());
-                // Prefer non-streaming response path for DDL by setting row limit
-                request = request.header("X-Accept-Rows", "999");
-                if let Some(key) = api_key {
-                    request = request.header("X-API-Key", key);
-                }
-                let response = request.send().await?;
-
-                let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-
-                if status.is_success() {
-                    break;
-                }
-
-                attempts += 1;
-
-                if attempts >= POST_SETUP_SQL_MAX_RETRIES {
-                    return Err(anyhow::anyhow!(
-                        "Failed to execute post-setup SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
-                    ));
-                }
-
-                let backoff_seconds = attempts * 2;
-                eprintln!(
-                    "[stdio] Post-setup SQL failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
-                );
-                sleep(Duration::from_secs(backoff_seconds)).await;
-            }
+            execute_sql_statement(sql_url, api_key, &statement).await?;
         }
 
         eprintln!("[stdio] ADBC post-setup table creation complete");
@@ -431,6 +457,50 @@ async fn post_setup_sink_action(
         );
     }
     Ok(())
+}
+
+/// Execute a single SQL statement against the system's HTTP SQL endpoint.
+async fn execute_sql_statement(
+    sql_url: &str,
+    api_key: Option<&str>,
+    statement: &str,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let mut attempts = 0;
+    loop {
+        let mut request = client.post(sql_url).body(statement.to_string());
+        request = request.header("X-Accept-Rows", "999");
+        if let Some(key) = api_key {
+            request = request.header("X-API-Key", key);
+        }
+        let response = request.send().await?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        attempts += 1;
+        if attempts >= POST_SETUP_SQL_MAX_RETRIES {
+            return Err(anyhow::anyhow!(
+                "Failed to execute SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
+            ));
+        }
+
+        let backoff_seconds = attempts * 2;
+        eprintln!(
+            "[stdio] SQL execution failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
+        );
+        sleep(Duration::from_secs(backoff_seconds)).await;
+    }
 }
 
 fn generate_adbc_create_table_statements(
@@ -717,6 +787,7 @@ async fn provision_spice_cloud_app(
         api_key,
         flight_url,
         api_url: api_url.to_owned(),
+        sql_url,
         cloud,
     })
 }


### PR DESCRIPTION
Adds `extract_partition_column_references()` using sqlparser's `Visitor` pattern to extract column identifiers from partition expressions like `bucket(5, c_nationkey)`. Used by distributed MERGE to validate that partition columns appear in the ON clause, ensuring correct executor-local execution.

5 unit tests covering simple columns, bucket functions, parenthesized expressions, quoted identifiers, and binary ops.

Part of the MERGE INTO implementation (#10095, #10097).

**Stack:**
1. `phillip/260406-create-table-like` — CREATE TABLE ... LIKE support
2. `phillip/260406-struct-in-list-delete` — struct IN-list filters for position-based delete
3. **→ This PR** — Partition column extraction for MERGE validation
4. `phillip/260406-spidapter-staging` — Spidapter staging table support