### PR TITLE
feat: Spidapter staging table support and SQL execution extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19039,7 +19039,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=27754b5810745e3afc7bb703ecc13aa9835732ea#27754b5810745e3afc7bb703ecc13aa9835732ea"
+source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -19047,6 +19047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid 1.21.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.37.2"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "27754b5810745e3afc7bb703ecc13aa9835732ea", features = ["server"] } # branch: trunk
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6327983bc1a90123e0c754b79781b931c969831e", features = ["server"] }
 tantivy = "0.25.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -63,6 +63,8 @@ enum RunState {
         flight_url: String,
         /// Normalized API base URL (stored separately from `cloud` to avoid tainted-struct logging).
         api_url: String,
+        /// SQL endpoint URL for DDL execution.
+        sql_url: String,
         /// Cloud client used during provisioning (reused for teardown).
         cloud: CloudClient,
     },
@@ -81,6 +83,20 @@ impl RunState {
         match self {
             Self::Scp { api_key, .. } => api_key.as_str(),
             Self::Local(_) => "",
+        }
+    }
+
+    fn sql_url(&self) -> &str {
+        match self {
+            Self::Scp { sql_url, .. } => sql_url.as_str(),
+            Self::Local(state) => state.sql_url.as_str(),
+        }
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::Scp { api_key, .. } => Some(api_key.as_str()),
+            Self::Local(state) => state.flight_api_key.as_deref(),
         }
     }
 }
@@ -189,6 +205,8 @@ fn sum_opt_f64_as_u64(
 struct SpidapterHandler {
     /// Active runs keyed by run ID.
     runs: HashMap<Uuid, RunState>,
+    /// Datasets from setup, keyed by run ID → dataset name → config.
+    run_datasets: HashMap<Uuid, HashMap<String, DatasetConfig>>,
     /// Full CLI args (includes all flags and env-var-backed configuration).
     args: StdioArgs,
 }
@@ -197,6 +215,7 @@ impl SpidapterHandler {
     fn new(args: &StdioArgs) -> Self {
         Self {
             runs: HashMap::new(),
+            run_datasets: HashMap::new(),
             args: args.clone(),
         }
     }
@@ -271,11 +290,16 @@ impl Handler for SpidapterHandler {
         };
 
         self.runs.insert(run_id, state);
+        self.run_datasets.insert(run_id, datasets);
 
         Ok(response)
     }
 
-    async fn metrics(&mut self, run_id: Uuid) -> std::result::Result<MetricsResponse, String> {
+    async fn metrics(
+        &mut self,
+        run_id: Uuid,
+        _final_scrape: bool,
+    ) -> std::result::Result<MetricsResponse, String> {
         let state = self
             .runs
             .get(&run_id)
@@ -300,6 +324,7 @@ impl Handler for SpidapterHandler {
                         disk_write_bytes: sum_opt_f64_as_u64(&pods, |p| p.disk_write_bytes),
                         disk_read_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_read_operations),
                         disk_write_iops: sum_opt_f64_as_u64(&pods, |p| p.disk_write_operations),
+                        num_compute_nodes: None,
                     }
                 };
 
@@ -331,6 +356,7 @@ impl Handler for SpidapterHandler {
             eprintln!("[stdio] teardown: run_id={run_id} not found (already torn down?)");
             return Ok(TeardownResponse { ok: true });
         };
+        self.run_datasets.remove(&run_id);
 
         match state {
             RunState::Scp {
@@ -353,6 +379,45 @@ impl Handler for SpidapterHandler {
         }
 
         Ok(TeardownResponse { ok: true })
+    }
+
+    async fn create_staging_table(
+        &mut self,
+        run_id: Uuid,
+        source_dataset: &str,
+        staging_table_name: &str,
+    ) -> std::result::Result<system_adapter_protocol::CreateStagingTableResponse, String> {
+        let state = self
+            .runs
+            .get(&run_id)
+            .ok_or_else(|| format!("No active run found for {run_id}"))?;
+        if !self
+            .run_datasets
+            .get(&run_id)
+            .map_or(false, |ds| ds.contains_key(source_dataset))
+        {
+            return Err(format!(
+                "Source dataset '{source_dataset}' not found in run {run_id}"
+            ));
+        }
+
+        // Use CREATE TABLE ... LIKE ... to copy schema, partition expression,
+        // AND partition-to-executor assignments from the source table.
+        let quoted_staging = quote_identifier(staging_table_name);
+        let quoted_source = quote_identifier(source_dataset);
+        let ddl = format!(
+            "CREATE TABLE IF NOT EXISTS spicebench.bench.{quoted_staging} LIKE spicebench.bench.{quoted_source}"
+        );
+
+        eprintln!(
+            "[stdio] create_staging_table: source={source_dataset}, staging={staging_table_name}, sql={ddl}"
+        );
+
+        execute_sql_statement(state.sql_url(), state.api_key(), &ddl)
+            .await
+            .map_err(|e| format!("Failed to execute staging table DDL: {e}"))?;
+
+        Ok(system_adapter_protocol::CreateStagingTableResponse { ok: true })
     }
 }
 
@@ -380,48 +445,9 @@ async fn post_setup_sink_action(
             return Ok(());
         }
 
-        let sql_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(60))
-            .build()?;
-
         for statement in create_table_statements {
             eprintln!("[stdio] Running post-setup SQL: {statement}");
-
-            let mut attempts = 0;
-
-            loop {
-                let mut request = sql_client.post(sql_url).body(statement.clone());
-                // Prefer non-streaming response path for DDL by setting row limit
-                request = request.header("X-Accept-Rows", "999");
-                if let Some(key) = api_key {
-                    request = request.header("X-API-Key", key);
-                }
-                let response = request.send().await?;
-
-                let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-
-                if status.is_success() {
-                    break;
-                }
-
-                attempts += 1;
-
-                if attempts >= POST_SETUP_SQL_MAX_RETRIES {
-                    return Err(anyhow::anyhow!(
-                        "Failed to execute post-setup SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
-                    ));
-                }
-
-                let backoff_seconds = attempts * 2;
-                eprintln!(
-                    "[stdio] Post-setup SQL failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
-                );
-                sleep(Duration::from_secs(backoff_seconds)).await;
-            }
+            execute_sql_statement(sql_url, api_key, &statement).await?;
         }
 
         eprintln!("[stdio] ADBC post-setup table creation complete");
@@ -431,6 +457,50 @@ async fn post_setup_sink_action(
         );
     }
     Ok(())
+}
+
+/// Execute a single SQL statement against the system's HTTP SQL endpoint.
+async fn execute_sql_statement(
+    sql_url: &str,
+    api_key: Option<&str>,
+    statement: &str,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let mut attempts = 0;
+    loop {
+        let mut request = client.post(sql_url).body(statement.to_string());
+        request = request.header("X-Accept-Rows", "999");
+        if let Some(key) = api_key {
+            request = request.header("X-API-Key", key);
+        }
+        let response = request.send().await?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        attempts += 1;
+        if attempts >= POST_SETUP_SQL_MAX_RETRIES {
+            return Err(anyhow::anyhow!(
+                "Failed to execute SQL against {sql_url} after {POST_SETUP_SQL_MAX_RETRIES} attempts: status={status}, sql={statement}, body={body}"
+            ));
+        }
+
+        let backoff_seconds = attempts * 2;
+        eprintln!(
+            "[stdio] SQL execution failed (status={status}, body={body}), retrying in {backoff_seconds}s (attempt {attempts}/{POST_SETUP_SQL_MAX_RETRIES})"
+        );
+        sleep(Duration::from_secs(backoff_seconds)).await;
+    }
 }
 
 fn generate_adbc_create_table_statements(
@@ -717,6 +787,7 @@ async fn provision_spice_cloud_app(
         api_key,
         flight_url,
         api_url: api_url.to_owned(),
+        sql_url,
         cloud,
     })
 }


### PR DESCRIPTION
Adds staging table lifecycle support to the spidapter system adapter and spicebench ETL pipeline:

- **JSON-RPC `create_staging_table` method**: New protocol extension in `system-adapter-protocol` with request/response types, client method, and server dispatch.
- **`StagingTableHook` trait**: Decouples staging table creation/cleanup from `AdbcSink`. `SystemAdapterStagingHook` delegates to the system adapter via JSON-RPC; `NoOpStagingTableHook` for non-distributed use.
- **Spidapter handler**: Generates `CREATE TABLE ... LIKE` DDL to copy schema, partition expression, and partition-to-executor assignments from source to staging table.
- **`execute_sql_statement()` helper**: Extracted from `post_setup_sink_action` to eliminate duplicate HTTP retry loops.
- **`sql_url` on SCP `RunState`**: Exposes the runtime's SQL endpoint for staging DDL execution.

Part of the MERGE INTO implementation (#10095, #10097).

**Stack:**
1. `phillip/260406-create-table-like` — CREATE TABLE ... LIKE support
2. `phillip/260406-struct-in-list-delete` — struct IN-list filters for position-based delete
3. `phillip/260406-partition-col-refs` — Partition column extraction for MERGE validation
4. **→ This PR** — Spidapter staging table support