### PR TITLE
Improve CREATE TABLE LIKE error messages, success output, EXPLAIN, and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-federation",
+ "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-table-providers",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -66,6 +66,7 @@ partition-table-provider = ["dep:runtime-table-partition"]
 [dev-dependencies]
 criterion = { version = "0.7", features = ["html_reports"] }
 datafusion-federation.workspace = true
+datafusion-functions = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 paste.workspace = true
 rstest = "0.26.1"

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -769,7 +769,7 @@ mod tests {
             struct_udf,
             args,
             return_field,
-            Default::default(),
+            Arc::default(),
         ))
     }
 

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -489,6 +489,7 @@ fn build_vortex_filter(
             Ok(expr) => expr,
             Err(_) => {
                 match try_decompose_struct_in_list(phys_filter.as_ref(), &expr_convertor, df_schema)
+                    .or_else(|| try_decompose_struct_eq(phys_filter.as_ref(), &expr_convertor, df_schema))
                 {
                     Some(decomposed) => decomposed,
                     None => {
@@ -609,6 +610,87 @@ fn try_decompose_struct_in_list(
     }
 }
 
+/// Decompose `struct(col1, col2, ...) = struct_literal` into `col1 = v1 AND col2 = v2 AND ...`.
+///
+/// DataFusion optimizes single-element `IN` lists to equality: `(k1, k2) IN ((v1, v2))` becomes
+/// `struct(k1, k2) = {c0:v1, c1:v2}`. Vortex doesn't support struct equality, so we decompose
+/// it the same way `try_decompose_struct_in_list` handles the multi-element case.
+fn try_decompose_struct_eq(
+    expr: &dyn datafusion_physical_expr::PhysicalExpr,
+    convertor: &DefaultExpressionConvertor,
+    df_schema: &DFSchema,
+) -> Option<vortex::expr::Expression> {
+    use datafusion_common::ScalarValue;
+
+    let bin_expr = expr
+        .as_any()
+        .downcast_ref::<datafusion_physical_expr::expressions::BinaryExpr>()?;
+    if *bin_expr.op() != datafusion_expr::Operator::Eq {
+        return None;
+    }
+
+    // LHS must be struct(col1, col2, ...), possibly wrapped in CAST.
+    let lhs: &dyn datafusion_physical_expr::PhysicalExpr = bin_expr.left().as_ref();
+    let struct_fn = if let Some(sf) = lhs
+        .as_any()
+        .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()
+    {
+        sf
+    } else if let Some(cast_expr) = lhs.as_any().downcast_ref::<phys_expr::CastExpr>() {
+        cast_expr
+            .expr()
+            .as_any()
+            .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()?
+    } else {
+        return None;
+    };
+    if struct_fn.name() != "struct" {
+        return None;
+    }
+
+    // RHS must be a struct literal.
+    let rhs_literal = bin_expr
+        .right()
+        .as_any()
+        .downcast_ref::<phys_expr::Literal>()?;
+    let ScalarValue::Struct(struct_arr) = rhs_literal.value() else {
+        return None;
+    };
+
+    // Convert each column arg to a Vortex expression and collect native types.
+    let arrow_schema: arrow::datatypes::Schema = df_schema.as_arrow().as_ref().clone();
+    let mut vortex_columns: Vec<vortex::expr::Expression> =
+        Vec::with_capacity(struct_fn.args().len());
+    let mut col_types: Vec<arrow::datatypes::DataType> =
+        Vec::with_capacity(struct_fn.args().len());
+    for arg in struct_fn.args() {
+        let vx = convertor.convert(arg.as_ref()).ok()?;
+        let dt = arg.data_type(&arrow_schema).ok()?;
+        vortex_columns.push(vx);
+        col_types.push(dt);
+    }
+    if vortex_columns.is_empty() {
+        return None;
+    }
+
+    // Build col1 = v1 AND col2 = v2 AND ...
+    let field_eqs: Vec<vortex::expr::Expression> = (0..vortex_columns.len())
+        .map(|i| {
+            let field_scalar = ScalarValue::try_from_array(struct_arr.column(i), 0).ok()?;
+            let cast_scalar = field_scalar
+                .cast_to(&col_types[i])
+                .ok()
+                .unwrap_or(field_scalar);
+            let phys_lit = phys_expr::Literal::new(cast_scalar);
+            let vortex_lit = convertor.convert(&phys_lit).ok()?;
+            Some(vortex::expr::eq(vortex_columns[i].clone(), vortex_lit))
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let mut conj = field_eqs.into_iter();
+    let first = conj.next()?;
+    Some(conj.fold(first, vortex::expr::and))
+}
 /// Combine expressions with OR using a balanced binary tree.
 /// Depth is O(log N) instead of O(N) from a linear fold, avoiding stack overflow.
 fn balanced_or(mut exprs: Vec<vortex::expr::Expression>) -> vortex::expr::Expression {
@@ -632,5 +714,325 @@ fn balanced_or(mut exprs: Vec<vortex::expr::Expression>) -> vortex::expr::Expres
     match exprs.into_iter().next() {
         Some(expr) => expr,
         None => unreachable!("balanced_or called with empty exprs"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::DFSchema;
+    use datafusion_common::ScalarValue;
+    use datafusion_physical_expr::ScalarFunctionExpr;
+    use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
+    use std::sync::Arc;
+    use vortex_datafusion::DefaultExpressionConvertor;
+
+    /// Build a `struct(col1, col2, ...)` [`ScalarFunctionExpr`] over the given columns.
+    fn make_struct_fn(
+        col_names: &[&str],
+        schema: &Schema,
+    ) -> Arc<dyn datafusion_physical_expr::PhysicalExpr> {
+        let args: Vec<Arc<dyn datafusion_physical_expr::PhysicalExpr>> = col_names
+            .iter()
+            .map(|name| {
+                Arc::new(Column::new_with_schema(name, schema).unwrap())
+                    as Arc<dyn datafusion_physical_expr::PhysicalExpr>
+            })
+            .collect();
+
+        let struct_fields: Vec<Field> = col_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                Field::new(
+                    format!("c{i}"),
+                    schema.field_with_name(name).unwrap().data_type().clone(),
+                    true,
+                )
+            })
+            .collect();
+        let return_field = Arc::new(Field::new(
+            "struct",
+            DataType::Struct(struct_fields.into()),
+            false,
+        ));
+
+        let struct_udf: Arc<datafusion_expr::ScalarUDF> =
+            Arc::new(datafusion_functions::core::r#struct::StructFunc::new().into());
+        Arc::new(ScalarFunctionExpr::new(
+            "struct",
+            struct_udf,
+            args,
+            return_field,
+            Default::default(),
+        ))
+    }
+
+    /// Build a [`ScalarValue::Struct`] literal from a slice of scalar values.
+    fn make_struct_literal(values: &[ScalarValue]) -> ScalarValue {
+        let (fields, arrays): (Vec<_>, Vec<_>) = values
+            .iter()
+            .enumerate()
+            .map(|(i, sv)| {
+                let arr = sv.to_array().unwrap();
+                let field = Arc::new(Field::new(
+                    format!("c{i}"),
+                    arr.data_type().clone(),
+                    true,
+                ));
+                (field, arr)
+            })
+            .unzip();
+
+        let struct_arr =
+            arrow::array::StructArray::new(fields.into(), arrays, None);
+        ScalarValue::Struct(Arc::new(struct_arr))
+    }
+
+    fn two_col_schema() -> (Schema, DFSchema) {
+        let schema = Schema::new(vec![
+            Field::new("k1", DataType::Int32, false),
+            Field::new("k2", DataType::Utf8, false),
+        ]);
+        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        (schema, df_schema)
+    }
+
+    // ── try_decompose_struct_eq ──────────────────────────────────────────
+
+    #[test]
+    fn decompose_struct_eq_two_columns() {
+        let (schema, df_schema) = two_col_schema();
+        let convertor = DefaultExpressionConvertor::default();
+
+        let expr = Arc::new(BinaryExpr::new(
+            make_struct_fn(&["k1", "k2"], &schema),
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(make_struct_literal(&[
+                ScalarValue::Int32(Some(42)),
+                ScalarValue::Utf8(Some("hello".into())),
+            ]))),
+        ));
+
+        let result = try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema);
+        let expected = vortex::expr::and(
+            vortex::expr::eq(
+                vortex::expr::col("k1"),
+                vortex::expr::lit(vortex::scalar::Scalar::from(42_i32)),
+            ),
+            vortex::expr::eq(
+                vortex::expr::col("k2"),
+                vortex::expr::lit(vortex::scalar::Scalar::from("hello")),
+            ),
+        );
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn decompose_struct_eq_single_column() {
+        let schema = Schema::new(vec![Field::new("k1", DataType::Int64, false)]);
+        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        let convertor = DefaultExpressionConvertor::default();
+
+        let expr = Arc::new(BinaryExpr::new(
+            make_struct_fn(&["k1"], &schema),
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(make_struct_literal(&[
+                ScalarValue::Int64(Some(99)),
+            ]))),
+        ));
+
+        let result = try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema);
+        let expected = vortex::expr::eq(
+            vortex::expr::col("k1"),
+            vortex::expr::lit(vortex::scalar::Scalar::from(99_i64)),
+        );
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn decompose_struct_eq_three_columns() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int64, false),
+            Field::new("c", DataType::Utf8, false),
+        ]);
+        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        let convertor = DefaultExpressionConvertor::default();
+
+        let expr = Arc::new(BinaryExpr::new(
+            make_struct_fn(&["a", "b", "c"], &schema),
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(make_struct_literal(&[
+                ScalarValue::Int32(Some(1)),
+                ScalarValue::Int64(Some(2)),
+                ScalarValue::Utf8(Some("three".into())),
+            ]))),
+        ));
+
+        let result = try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema);
+        // fold produces: and(and(a=1, b=2), c='three')
+        let expected = vortex::expr::and(
+            vortex::expr::and(
+                vortex::expr::eq(
+                    vortex::expr::col("a"),
+                    vortex::expr::lit(vortex::scalar::Scalar::from(1_i32)),
+                ),
+                vortex::expr::eq(
+                    vortex::expr::col("b"),
+                    vortex::expr::lit(vortex::scalar::Scalar::from(2_i64)),
+                ),
+            ),
+            vortex::expr::eq(
+                vortex::expr::col("c"),
+                vortex::expr::lit(vortex::scalar::Scalar::from("three")),
+            ),
+        );
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn decompose_struct_eq_with_cast_wrapping() {
+        let (schema, df_schema) = two_col_schema();
+        let convertor = DefaultExpressionConvertor::default();
+
+        // CAST(struct(k1, k2) AS Struct<c0:Int32, c1:Utf8>) = {c0:42, c1:"hello"}
+        let cast_expr = Arc::new(phys_expr::CastExpr::new(
+            make_struct_fn(&["k1", "k2"], &schema),
+            DataType::Struct(
+                vec![
+                    Field::new("c0", DataType::Int32, true),
+                    Field::new("c1", DataType::Utf8, true),
+                ]
+                .into(),
+            ),
+            None,
+        ));
+        let expr = Arc::new(BinaryExpr::new(
+            cast_expr,
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(make_struct_literal(&[
+                ScalarValue::Int32(Some(42)),
+                ScalarValue::Utf8(Some("hello".into())),
+            ]))),
+        ));
+
+        let result = try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema);
+        let expected = vortex::expr::and(
+            vortex::expr::eq(
+                vortex::expr::col("k1"),
+                vortex::expr::lit(vortex::scalar::Scalar::from(42_i32)),
+            ),
+            vortex::expr::eq(
+                vortex::expr::col("k2"),
+                vortex::expr::lit(vortex::scalar::Scalar::from("hello")),
+            ),
+        );
+        assert_eq!(result, Some(expected));
+    }
+
+    // ── Negative / rejection cases ──────────────────────────────────────
+
+    #[test]
+    fn decompose_struct_eq_rejects_not_eq_operator() {
+        let (schema, df_schema) = two_col_schema();
+        let convertor = DefaultExpressionConvertor::default();
+
+        let expr = Arc::new(BinaryExpr::new(
+            make_struct_fn(&["k1", "k2"], &schema),
+            datafusion_expr::Operator::NotEq,
+            Arc::new(Literal::new(make_struct_literal(&[
+                ScalarValue::Int32(Some(1)),
+                ScalarValue::Utf8(Some("x".into())),
+            ]))),
+        ));
+        assert_eq!(
+            try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema),
+            None,
+        );
+    }
+
+    #[test]
+    fn decompose_struct_eq_rejects_non_struct_lhs() {
+        let (_, df_schema) = two_col_schema();
+        let convertor = DefaultExpressionConvertor::default();
+
+        // k1 = 42  (plain column, not struct(...))
+        let expr = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("k1", 0)),
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(42)))),
+        ));
+        assert_eq!(
+            try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema),
+            None,
+        );
+    }
+
+    #[test]
+    fn decompose_struct_eq_rejects_non_struct_rhs() {
+        let (schema, df_schema) = two_col_schema();
+        let convertor = DefaultExpressionConvertor::default();
+
+        // struct(k1, k2) = 42  (RHS is scalar, not struct literal)
+        let expr = Arc::new(BinaryExpr::new(
+            make_struct_fn(&["k1", "k2"], &schema),
+            datafusion_expr::Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(42)))),
+        ));
+        assert_eq!(
+            try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema),
+            None,
+        );
+    }
+
+    // ── build_vortex_filter integration ─────────────────────────────────
+
+    #[test]
+    fn build_filter_empty_returns_none() {
+        let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
+        let df_schema = DFSchema::try_from(schema).unwrap();
+        assert_eq!(build_vortex_filter(&[], &df_schema).unwrap(), None);
+    }
+
+    #[test]
+    fn build_filter_simple_eq() {
+        let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
+        let df_schema = DFSchema::try_from(schema).unwrap();
+
+        let filters = vec![
+            datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(7)))),
+        ];
+        let result = build_vortex_filter(&filters, &df_schema).unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn build_filter_multiple_filters_anded() {
+        let schema = Schema::new(vec![
+            Field::new("k1", DataType::Int32, false),
+            Field::new("k2", DataType::Utf8, false),
+        ]);
+        let df_schema = DFSchema::try_from(schema).unwrap();
+
+        let filters = vec![
+            datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(1)))),
+            datafusion_expr::col("k2").eq(datafusion_expr::lit(ScalarValue::Utf8(Some(
+                "a".into(),
+            )))),
+        ];
+        let result = build_vortex_filter(&filters, &df_schema).unwrap();
+        let expected = vortex::expr::and(
+            vortex::expr::eq(
+                vortex::expr::col("k1"),
+                vortex::expr::lit(vortex::scalar::Scalar::from(1_i32)),
+            ),
+            vortex::expr::eq(
+                vortex::expr::col("k2"),
+                vortex::expr::lit(vortex::scalar::Scalar::from("a")),
+            ),
+        );
+        assert_eq!(result.unwrap(), expected);
     }
 }

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -747,7 +747,11 @@ mod tests {
             .map(|(i, name)| {
                 Field::new(
                     format!("c{i}"),
-                    schema.field_with_name(name).expect("field exists in schema").data_type().clone(),
+                    schema
+                        .field_with_name(name)
+                        .expect("field exists in schema")
+                        .data_type()
+                        .clone(),
                     true,
                 )
             })
@@ -988,7 +992,10 @@ mod tests {
     fn build_filter_empty_returns_none() {
         let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
         let df_schema = DFSchema::try_from(schema).expect("schema conversion");
-        assert_eq!(build_vortex_filter(&[], &df_schema).expect("build filter"), None);
+        assert_eq!(
+            build_vortex_filter(&[], &df_schema).expect("build filter"),
+            None
+        );
     }
 
     #[test]

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -613,7 +613,7 @@ fn try_decompose_struct_in_list(
 
 /// Decompose `struct(col1, col2, ...) = struct_literal` into `col1 = v1 AND col2 = v2 AND ...`.
 ///
-/// DataFusion optimizes single-element `IN` lists to equality: `(k1, k2) IN ((v1, v2))` becomes
+/// `DataFusion` optimizes single-element `IN` lists to equality: `(k1, k2) IN ((v1, v2))` becomes
 /// `struct(k1, k2) = {c0:v1, c1:v2}`. Vortex doesn't support struct equality, so we decompose
 /// it the same way `try_decompose_struct_in_list` handles the multi-element case.
 fn try_decompose_struct_eq(
@@ -736,7 +736,7 @@ mod tests {
         let args: Vec<Arc<dyn datafusion_physical_expr::PhysicalExpr>> = col_names
             .iter()
             .map(|name| {
-                Arc::new(Column::new_with_schema(name, schema).unwrap())
+                Arc::new(Column::new_with_schema(name, schema).expect("column exists in schema"))
                     as Arc<dyn datafusion_physical_expr::PhysicalExpr>
             })
             .collect();
@@ -747,7 +747,7 @@ mod tests {
             .map(|(i, name)| {
                 Field::new(
                     format!("c{i}"),
-                    schema.field_with_name(name).unwrap().data_type().clone(),
+                    schema.field_with_name(name).expect("field exists in schema").data_type().clone(),
                     true,
                 )
             })
@@ -775,7 +775,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, sv)| {
-                let arr = sv.to_array().unwrap();
+                let arr = sv.to_array().expect("scalar to array conversion");
                 let field = Arc::new(Field::new(format!("c{i}"), arr.data_type().clone(), true));
                 (field, arr)
             })
@@ -790,7 +790,7 @@ mod tests {
             Field::new("k1", DataType::Int32, false),
             Field::new("k2", DataType::Utf8, false),
         ]);
-        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        let df_schema = DFSchema::try_from(schema.clone()).expect("schema conversion");
         (schema, df_schema)
     }
 
@@ -827,7 +827,7 @@ mod tests {
     #[test]
     fn decompose_struct_eq_single_column() {
         let schema = Schema::new(vec![Field::new("k1", DataType::Int64, false)]);
-        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        let df_schema = DFSchema::try_from(schema.clone()).expect("schema conversion");
         let convertor = DefaultExpressionConvertor::default();
 
         let expr = Arc::new(BinaryExpr::new(
@@ -853,7 +853,7 @@ mod tests {
             Field::new("b", DataType::Int64, false),
             Field::new("c", DataType::Utf8, false),
         ]);
-        let df_schema = DFSchema::try_from(schema.clone()).unwrap();
+        let df_schema = DFSchema::try_from(schema.clone()).expect("schema conversion");
         let convertor = DefaultExpressionConvertor::default();
 
         let expr = Arc::new(BinaryExpr::new(
@@ -987,18 +987,18 @@ mod tests {
     #[test]
     fn build_filter_empty_returns_none() {
         let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
-        let df_schema = DFSchema::try_from(schema).unwrap();
-        assert_eq!(build_vortex_filter(&[], &df_schema).unwrap(), None);
+        let df_schema = DFSchema::try_from(schema).expect("schema conversion");
+        assert_eq!(build_vortex_filter(&[], &df_schema).expect("build filter"), None);
     }
 
     #[test]
     fn build_filter_simple_eq() {
         let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
-        let df_schema = DFSchema::try_from(schema).unwrap();
+        let df_schema = DFSchema::try_from(schema).expect("schema conversion");
 
         let filters =
             vec![datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(7))))];
-        let result = build_vortex_filter(&filters, &df_schema).unwrap();
+        let result = build_vortex_filter(&filters, &df_schema).expect("build filter");
         assert!(result.is_some());
     }
 
@@ -1008,14 +1008,14 @@ mod tests {
             Field::new("k1", DataType::Int32, false),
             Field::new("k2", DataType::Utf8, false),
         ]);
-        let df_schema = DFSchema::try_from(schema).unwrap();
+        let df_schema = DFSchema::try_from(schema).expect("schema conversion");
 
         let filters = vec![
             datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(1)))),
             datafusion_expr::col("k2")
                 .eq(datafusion_expr::lit(ScalarValue::Utf8(Some("a".into())))),
         ];
-        let result = build_vortex_filter(&filters, &df_schema).unwrap();
+        let result = build_vortex_filter(&filters, &df_schema).expect("build filter");
         let expected = vortex::expr::and(
             vortex::expr::eq(
                 vortex::expr::col("k1"),
@@ -1026,6 +1026,6 @@ mod tests {
                 vortex::expr::lit(vortex::scalar::Scalar::from("a")),
             ),
         );
-        assert_eq!(result.unwrap(), expected);
+        assert_eq!(result.expect("filter should be Some"), expected);
     }
 }

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -489,8 +489,9 @@ fn build_vortex_filter(
             Ok(expr) => expr,
             Err(_) => {
                 match try_decompose_struct_in_list(phys_filter.as_ref(), &expr_convertor, df_schema)
-                    .or_else(|| try_decompose_struct_eq(phys_filter.as_ref(), &expr_convertor, df_schema))
-                {
+                    .or_else(|| {
+                        try_decompose_struct_eq(phys_filter.as_ref(), &expr_convertor, df_schema)
+                    }) {
                     Some(decomposed) => decomposed,
                     None => {
                         return Err(format!(
@@ -661,8 +662,7 @@ fn try_decompose_struct_eq(
     let arrow_schema: arrow::datatypes::Schema = df_schema.as_arrow().as_ref().clone();
     let mut vortex_columns: Vec<vortex::expr::Expression> =
         Vec::with_capacity(struct_fn.args().len());
-    let mut col_types: Vec<arrow::datatypes::DataType> =
-        Vec::with_capacity(struct_fn.args().len());
+    let mut col_types: Vec<arrow::datatypes::DataType> = Vec::with_capacity(struct_fn.args().len());
     for arg in struct_fn.args() {
         let vx = convertor.convert(arg.as_ref()).ok()?;
         let dt = arg.data_type(&arrow_schema).ok()?;
@@ -776,17 +776,12 @@ mod tests {
             .enumerate()
             .map(|(i, sv)| {
                 let arr = sv.to_array().unwrap();
-                let field = Arc::new(Field::new(
-                    format!("c{i}"),
-                    arr.data_type().clone(),
-                    true,
-                ));
+                let field = Arc::new(Field::new(format!("c{i}"), arr.data_type().clone(), true));
                 (field, arr)
             })
             .unzip();
 
-        let struct_arr =
-            arrow::array::StructArray::new(fields.into(), arrays, None);
+        let struct_arr = arrow::array::StructArray::new(fields.into(), arrays, None);
         ScalarValue::Struct(Arc::new(struct_arr))
     }
 
@@ -838,9 +833,9 @@ mod tests {
         let expr = Arc::new(BinaryExpr::new(
             make_struct_fn(&["k1"], &schema),
             datafusion_expr::Operator::Eq,
-            Arc::new(Literal::new(make_struct_literal(&[
-                ScalarValue::Int64(Some(99)),
-            ]))),
+            Arc::new(Literal::new(make_struct_literal(&[ScalarValue::Int64(
+                Some(99),
+            )]))),
         ));
 
         let result = try_decompose_struct_eq(expr.as_ref(), &convertor, &df_schema);
@@ -1001,9 +996,8 @@ mod tests {
         let schema = Schema::new(vec![Field::new("k1", DataType::Int32, false)]);
         let df_schema = DFSchema::try_from(schema).unwrap();
 
-        let filters = vec![
-            datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(7)))),
-        ];
+        let filters =
+            vec![datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(7))))];
         let result = build_vortex_filter(&filters, &df_schema).unwrap();
         assert!(result.is_some());
     }
@@ -1018,9 +1012,8 @@ mod tests {
 
         let filters = vec![
             datafusion_expr::col("k1").eq(datafusion_expr::lit(ScalarValue::Int32(Some(1)))),
-            datafusion_expr::col("k2").eq(datafusion_expr::lit(ScalarValue::Utf8(Some(
-                "a".into(),
-            )))),
+            datafusion_expr::col("k2")
+                .eq(datafusion_expr::lit(ScalarValue::Utf8(Some("a".into())))),
         ];
         let result = build_vortex_filter(&filters, &df_schema).unwrap();
         let expected = vortex::expr::and(

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -60,6 +60,20 @@ pub struct PartitionManager {
     state: ObjectState<TablePartitionMetadata>,
 }
 
+/// Result of copying partition assignments from one table to another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CopyAssignmentsResult {
+    /// Assignments were copied from the source table.
+    Copied {
+        /// Number of partition values with executor assignments that were copied.
+        partition_count: usize,
+    },
+    /// Source table had no partition metadata (unpartitioned or newly created).
+    NoSourceMetadata,
+    /// Source table had partition metadata but no assigned partitions.
+    NoAssignments,
+}
+
 #[derive(Debug, Clone)]
 pub struct AllocationResult {
     pub previously_assigned: Vec<PartitionValue>,
@@ -390,10 +404,16 @@ impl PartitionManager {
         &self,
         source_table: &TableReference,
         target_table: &TableReference,
-    ) -> Result<()> {
+    ) -> Result<CopyAssignmentsResult> {
         let Some(source_metadata) = self.get_table_metadata(source_table).await? else {
-            return Ok(());
+            return Ok(CopyAssignmentsResult::NoSourceMetadata);
         };
+
+        let assigned_count = source_metadata
+            .partitions
+            .iter()
+            .filter(|p| p.is_assigned())
+            .count();
 
         let now_ms = now_ms()?;
         let mut target_metadata = source_metadata;
@@ -401,7 +421,15 @@ impl PartitionManager {
         target_metadata.updated_at = now_ms;
 
         let target_key = target_table.to_string();
-        self.write_metadata(&target_key, target_metadata).await
+        self.write_metadata(&target_key, target_metadata).await?;
+
+        if assigned_count == 0 {
+            Ok(CopyAssignmentsResult::NoAssignments)
+        } else {
+            Ok(CopyAssignmentsResult::Copied {
+                partition_count: assigned_count,
+            })
+        }
     }
 
     /// Write metadata using `insert_or_update` with conflict handling.
@@ -465,9 +493,16 @@ mod tests {
             .expect("should assign");
 
         // Copy assignments
-        pm.copy_assignments(&source, &target)
+        let result = pm
+            .copy_assignments(&source, &target)
             .await
             .expect("should copy");
+        assert_eq!(
+            result,
+            CopyAssignmentsResult::Copied {
+                partition_count: 1
+            }
+        );
 
         // Verify target has the same metadata
         let target_meta = pm
@@ -492,9 +527,11 @@ mod tests {
         let target = TableReference::parse_str("catalog.schema.target");
 
         // Missing source metadata is a no-op (source exists but is unpartitioned).
-        pm.copy_assignments(&source, &target)
+        let result = pm
+            .copy_assignments(&source, &target)
             .await
             .expect("should be a no-op for missing source metadata");
+        assert_eq!(result, CopyAssignmentsResult::NoSourceMetadata);
 
         // Target should have no metadata since nothing was copied.
         let target_meta = pm.get_table_metadata(&target).await.expect("should get");
@@ -522,9 +559,11 @@ mod tests {
             .expect("should set partitions");
 
         // Copy should overwrite target
-        pm.copy_assignments(&source, &target)
+        let result = pm
+            .copy_assignments(&source, &target)
             .await
             .expect("should copy");
+        assert_eq!(result, CopyAssignmentsResult::NoAssignments);
 
         let target_meta = pm
             .get_table_metadata(&target)

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -497,12 +497,7 @@ mod tests {
             .copy_assignments(&source, &target)
             .await
             .expect("should copy");
-        assert_eq!(
-            result,
-            CopyAssignmentsResult::Copied {
-                partition_count: 1
-            }
-        );
+        assert_eq!(result, CopyAssignmentsResult::Copied { partition_count: 1 });
 
         // Verify target has the same metadata
         let target_meta = pm

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -18,6 +18,7 @@ mod discovery;
 pub mod executor_selection;
 mod manager;
 mod metadata;
+pub use manager::CopyAssignmentsResult;
 pub mod scheduler_task;
 mod startup;
 pub(crate) mod write_through;

--- a/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/logical_nodes.rs
@@ -211,7 +211,11 @@ impl UserDefinedLogicalNodeCore for CayenneCreateTableNode {
             f,
             "CayenneCreateTable: {}.{}.{}",
             self.df_catalog_name, self.df_schema_name, self.table_name
-        )
+        )?;
+        if let Some(ref source) = self.like_source_table {
+            write!(f, " (LIKE {source})")?;
+        }
+        Ok(())
     }
 
     fn with_exprs_and_inputs(

--- a/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/physical_plans.rs
@@ -415,7 +415,11 @@ impl DisplayAs for CayenneCreateTableExec {
             f,
             "CayenneCreateTableExec: {}.{}.{}",
             self.df_catalog_name, self.df_schema_name, self.table_name
-        )
+        )?;
+        if let Some(ref source) = self.like_source_table {
+            write!(f, " (LIKE {source})")?;
+        }
+        Ok(())
     }
 }
 
@@ -837,28 +841,77 @@ impl ExecutionPlan for CayenneCreateTableExec {
             // If this table was created via LIKE, copy partition-to-executor
             // assignments from the source table so DoPut routes data to the
             // same executors.
-            if let Some(ref source) = like_source_table
+            let like_detail = if let Some(ref source) = like_source_table
                 && let Some(ref registry) = executor_registry
             {
+                use crate::cluster::partition::CopyAssignmentsResult;
                 let pm = registry.federated_partition_manager();
                 tracing::info!(
                     source = %source,
                     target = %table_ref,
                     "Copying partition assignments from LIKE source table"
                 );
-                if let Err(e) = pm.copy_assignments(source, &table_ref).await {
-                    return Err(DataFusionError::Execution(format!(
-                        "Failed to create table '{table_name}': could not copy partition \
-                         assignments from source table {source}: {e}"
-                    )));
+                match pm.copy_assignments(source, &table_ref).await {
+                    Ok(CopyAssignmentsResult::Copied { partition_count }) => {
+                        tracing::info!(
+                            source = %source,
+                            target = %table_ref,
+                            partition_count,
+                            "Partition assignments copied from LIKE source table"
+                        );
+                        Some(format!(
+                            "LIKE '{source}': schema, partition expression, \
+                             partition assignments copied"
+                        ))
+                    }
+                    Ok(CopyAssignmentsResult::NoAssignments) => {
+                        tracing::info!(
+                            source = %source,
+                            target = %table_ref,
+                            "Source table has no partition assignments to copy"
+                        );
+                        Some(format!(
+                            "LIKE '{source}': schema and partition expression copied; \
+                             no partition assignments to copy"
+                        ))
+                    }
+                    Ok(CopyAssignmentsResult::NoSourceMetadata) => {
+                        tracing::info!(
+                            source = %source,
+                            target = %table_ref,
+                            "Source table has no partition metadata"
+                        );
+                        Some(format!("LIKE '{source}': schema copied"))
+                    }
+                    Err(e) => {
+                        return Err(DataFusionError::Execution(format!(
+                            "Failed to create table '{table_name}': could not copy partition \
+                             assignments from source table {source}: {e}"
+                        )));
+                    }
                 }
-            }
+            } else if let Some(ref source) = like_source_table {
+                // No executor registry (non-distributed mode) — schema was still copied.
+                if partition_expr_sql.is_some() {
+                    Some(format!(
+                        "LIKE '{source}': schema and partition expression copied"
+                    ))
+                } else {
+                    Some(format!("LIKE '{source}': schema copied"))
+                }
+            } else {
+                None
+            };
+
+            let result_msg = if let Some(detail) = like_detail {
+                format!("Table '{table_name}' created ({detail})")
+            } else {
+                format!("Table '{table_name}' created")
+            };
 
             let batch = RecordBatch::try_new(
                 result_schema,
-                vec![Arc::new(StringArray::from(vec![format!(
-                    "Table '{table_name}' created"
-                )]))],
+                vec![Arc::new(StringArray::from(vec![result_msg]))],
             )?;
             Ok(batch)
         });

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -258,7 +258,7 @@ pub(super) async fn plan_create_table_like(
     if !is_cayenne_catalog(source_catalog.as_ref()) {
         return Err(DataFusionError::Plan(format!(
             "CREATE TABLE ... (LIKE ...) is only supported for Cayenne catalog tables. \
-             Source table '{source_name}' is not in a Cayenne catalog."
+             Table '{source_name}' is not in a Cayenne catalog."
         )));
     }
 
@@ -278,7 +278,7 @@ pub(super) async fn plan_create_table_like(
             ))
         })?
         .ok_or_else(|| {
-            DataFusionError::Plan(format!("Source table '{source_name}' not found for LIKE"))
+            DataFusionError::Plan(format!("Table '{source_name}' not found"))
         })?;
 
     let arrow_schema = source_provider.schema();
@@ -385,8 +385,17 @@ pub(super) async fn plan_create_table_like(
 
     if !is_cayenne_catalog(target_catalog.as_ref()) {
         return Err(DataFusionError::Plan(format!(
-            "CREATE TABLE ... LIKE is only supported for Cayenne catalog tables. \
-             Target catalog '{target_catalog_name}' is not a Cayenne catalog."
+            "CREATE TABLE ... (LIKE ...) is only supported for Cayenne catalog tables. \
+             Table '{target_name}' is not in a Cayenne catalog."
+        )));
+    }
+
+    // Validate source and target are in the same catalog.
+    if source_catalog_name != target_catalog_name {
+        return Err(DataFusionError::Plan(format!(
+            "CREATE TABLE ... (LIKE ...) requires the source and target tables to be \
+             in the same catalog. Source '{source_name}' is in catalog \
+             '{source_catalog_name}', but target is in '{target_catalog_name}'."
         )));
     }
 

--- a/crates/runtime/src/datafusion/planner/create_table.rs
+++ b/crates/runtime/src/datafusion/planner/create_table.rs
@@ -277,9 +277,7 @@ pub(super) async fn plan_create_table_like(
                 "Failed to resolve source table '{source_name}': {e}"
             ))
         })?
-        .ok_or_else(|| {
-            DataFusionError::Plan(format!("Table '{source_name}' not found"))
-        })?;
+        .ok_or_else(|| DataFusionError::Plan(format!("Table '{source_name}' not found")))?;
 
     let arrow_schema = source_provider.schema();
 

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -51,6 +51,7 @@ use datafusion::logical_expr::LogicalPlan;
 use datafusion::sql::TableReference;
 use datafusion::sql::parser::Statement;
 use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
+use datafusion::sql::sqlparser::ast::CreateTableOptions;
 use datafusion_expr::WriteOp;
 use datafusion_expr::dml::InsertOp;
 use datafusion_federation::FederatedTableProviderAdaptor;
@@ -108,13 +109,19 @@ pub async fn create_logical_plan(
         match sql_stmt.as_ref() {
             // DDL: CREATE TABLE ... (LIKE ...) — resolve source table and
             // build extension node directly, bypassing DataFusion's planner.
-            // Reject LIKE combined with DDL extensions (PARTITION BY, WITH)
-            // since LIKE inherits everything from the source table.
+            // Reject LIKE combined with any extra clauses (PARTITION BY, WITH,
+            // or additional column definitions) since LIKE inherits everything
+            // from the source table.
             SQLStatement::CreateTable(ct) if ct.like.is_some() => {
-                if create_table::has_ddl_extensions(ct) {
+                let has_columns = !ct.columns.is_empty();
+                let has_partition_by = ct.partition_by.is_some();
+                let has_with = !matches!(ct.table_options, CreateTableOptions::None);
+                if has_columns || has_partition_by || has_with || create_table::has_ddl_extensions(ct) {
                     return Err(DataFusionError::Plan(
-                        "CREATE TABLE ... LIKE cannot be combined with PARTITION BY or WITH options. \
-                         The LIKE clause copies all properties from the source table."
+                        "CREATE TABLE ... (LIKE ...) cannot be combined with PARTITION BY, WITH \
+                         options, or additional column definitions. The new table inherits all \
+                         properties \
+                         from the source table."
                             .to_string(),
                     ));
                 }

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -50,8 +50,8 @@ use datafusion::execution::SessionState;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::sql::TableReference;
 use datafusion::sql::parser::Statement;
-use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
 use datafusion::sql::sqlparser::ast::CreateTableOptions;
+use datafusion::sql::sqlparser::ast::Statement as SQLStatement;
 use datafusion_expr::WriteOp;
 use datafusion_expr::dml::InsertOp;
 use datafusion_federation::FederatedTableProviderAdaptor;
@@ -116,7 +116,11 @@ pub async fn create_logical_plan(
                 let has_columns = !ct.columns.is_empty();
                 let has_partition_by = ct.partition_by.is_some();
                 let has_with = !matches!(ct.table_options, CreateTableOptions::None);
-                if has_columns || has_partition_by || has_with || create_table::has_ddl_extensions(ct) {
+                if has_columns
+                    || has_partition_by
+                    || has_with
+                    || create_table::has_ddl_extensions(ct)
+                {
                     return Err(DataFusionError::Plan(
                         "CREATE TABLE ... (LIKE ...) cannot be combined with PARTITION BY, WITH \
                          options, or additional column definitions. The new table inherits all \


### PR DESCRIPTION
## Changes

Improves the `CREATE TABLE ... (LIKE ...)` implementation with better user-facing feedback, error messages, EXPLAIN output, and validation.

### Error messages
- Consistent use of `CREATE TABLE ... (LIKE ...)` wording across all error messages
- Clearer target-table error: now says `Table '<name>' is not in a Cayenne catalog` instead of referencing the catalog name
- Better rejection message for unsupported clause combinations: explicitly lists `WITH options` and `additional column definitions`

### Validation
- Added cross-catalog validation: source and target must be in the same catalog, with a clear error if they differ
- Added detection of extra clauses (`PARTITION BY`, `WITH`, column definitions) combined with `LIKE`, rejecting them since LIKE inherits everything from the source

### Success output
- Success message now includes details about what was copied from the source table:
  - `LIKE '<source>': schema, partition expression, partition assignments copied`
  - `LIKE '<source>': schema and partition expression copied; no partition assignments to copy`
  - `LIKE '<source>': schema copied`
- Non-distributed mode also reports what was copied

### EXPLAIN output
- `CayenneCreateTable` logical and physical plan nodes now show `(LIKE <source>)` suffix when applicable

### Partition copy result
- `copy_assignments` now returns a typed `CopyAssignmentsResult` enum instead of `()`, distinguishing between:
  - `Copied { partition_count }` — assignments were copied
  - `NoSourceMetadata` — source table is unpartitioned
  - `NoAssignments` — source has partition metadata but no assigned partitions
- Updated tests to assert on the new result type
