### PR TITLE
fix(databricks): Fix schema introspection and timestamp overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "insta",
  "serde_json",
  "snafu",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/arrow_tools/Cargo.toml
+++ b/crates/arrow_tools/Cargo.toml
@@ -14,6 +14,7 @@ arrow-cast.workspace = true
 arrow-schema.workspace = true
 snafu.workspace = true
 datafusion.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 insta = {workspace = true, features = ["json"]}

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use arrow::{
     array::{Array, ArrayRef, ListArray, RecordBatch, StructArray, new_null_array},
     buffer::{Buffer, OffsetBuffer},
-    datatypes::{DataType, Field, SchemaRef},
+    datatypes::{DataType, Field, SchemaRef, TimeUnit},
     error::ArrowError,
 };
 use arrow_cast::{CastOptions, cast_with_options};
@@ -85,8 +85,7 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
                 if field.contains(existing_field) {
                     Ok(Arc::clone(column))
                 } else {
-                    cast_with_options(column.as_ref(), field.data_type(), &cast_options)
-                        .context(UnableToConvertRecordBatchSnafu)
+                    cast_column(column, existing_field.data_type(), field, &cast_options)
                 }
             } else if field.is_nullable() {
                 Ok(new_null_array(field.data_type(), record_batch.num_rows()))
@@ -111,6 +110,55 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
     }
 
     RecordBatch::try_new(schema, cols).context(UnableToConvertRecordBatchSnafu)
+}
+
+/// Returns `true` when `source` → `target` is a timestamp-to-timestamp cast that
+/// only changes the time unit (and possibly the timezone string), meaning the
+/// underlying physical values need rescaling and may overflow on far-future/past
+/// sentinel dates.
+fn is_timestamp_unit_cast(source: &DataType, target: &DataType) -> bool {
+    matches!(
+        (source, target),
+        (DataType::Timestamp(_, _), DataType::Timestamp(_, _))
+    ) && timestamp_unit(source) != timestamp_unit(target)
+}
+
+fn timestamp_unit(dt: &DataType) -> Option<&TimeUnit> {
+    match dt {
+        DataType::Timestamp(unit, _) => Some(unit),
+        _ => None,
+    }
+}
+
+/// Cast a single column, with special handling for timestamp unit conversions
+/// that may overflow (e.g. far-future sentinel values like year 9999 when
+/// converting from microseconds to nanoseconds).
+fn cast_column(
+    column: &ArrayRef,
+    source_type: &DataType,
+    target_field: &Field,
+    strict_options: &CastOptions,
+) -> Result<ArrayRef> {
+    match cast_with_options(column.as_ref(), target_field.data_type(), strict_options) {
+        Ok(casted) => Ok(casted),
+        Err(ArrowError::CastError(ref msg))
+            if is_timestamp_unit_cast(source_type, target_field.data_type())
+                && msg.contains("Overflow") =>
+        {
+            tracing::warn!(
+                "Timestamp overflow casting column '{}' from {source_type:?} to {:?}. Values outside the representable range will be NULL.",
+                target_field.name(),
+                target_field.data_type(),
+            );
+            let safe_options = CastOptions {
+                safe: true,
+                ..strict_options.clone()
+            };
+            cast_with_options(column.as_ref(), target_field.data_type(), &safe_options)
+                .context(UnableToConvertRecordBatchSnafu)
+        }
+        Err(e) => Err(e).context(UnableToConvertRecordBatchSnafu),
+    }
 }
 
 /// Flattens a list of struct types with a single field into a list of primitive types.
@@ -799,6 +847,135 @@ mod test {
         assert!(
             result.is_ok(),
             "Decimal cast should succeed when value fits: {result:?}"
+        );
+    }
+
+    /// Casting Timestamp(Microsecond) → Timestamp(Nanosecond) with a far-future
+    /// sentinel value (year 9999) should not panic. Overflowing values become NULL
+    /// via the safe-cast fallback.
+    #[test]
+    fn test_try_cast_to_timestamp_us_to_ns_overflow_produces_null() {
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow::datatypes::TimeUnit;
+
+        // 9999-12-31T23:59:59.999 in microseconds — overflows when multiplied by 1000
+        let sentinel_us: i64 = 253_402_300_799_999_000;
+        let normal_us: i64 = 1_700_000_000_000_000; // ~2023-11-14
+
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            true,
+        )]));
+
+        let source_array = TimestampMicrosecondArray::from(vec![
+            Some(sentinel_us),
+            Some(normal_us),
+            None,
+        ])
+        .with_timezone("UTC");
+
+        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
+            .expect("valid batch");
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            true,
+        )]));
+
+        let result = try_cast_to(batch, target_schema);
+        assert!(
+            result.is_ok(),
+            "timestamp µs→ns cast should not fail on overflow: {:?}",
+            result.err()
+        );
+
+        let casted = result.expect("already checked");
+        let ts_col = casted
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::TimestampNanosecondArray>()
+            .expect("should be TimestampNanosecondArray");
+
+        // Overflowing sentinel becomes NULL
+        assert!(ts_col.is_null(0), "overflowing sentinel should be NULL");
+        // Normal value is correctly scaled (µs * 1000 = ns)
+        assert_eq!(ts_col.value(1), normal_us * 1000);
+        // Original NULL stays NULL
+        assert!(ts_col.is_null(2), "original NULL should stay NULL");
+    }
+
+    /// Casting Timestamp(Microsecond) → Timestamp(Nanosecond) when all values fit
+    /// should succeed with exact values (no fallback needed).
+    #[test]
+    fn test_try_cast_to_timestamp_us_to_ns_no_overflow() {
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow::datatypes::TimeUnit;
+
+        let value_us: i64 = 1_700_000_000_000_000; // ~2023-11-14
+
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            true,
+        )]));
+
+        let source_array =
+            TimestampMicrosecondArray::from(vec![Some(value_us)]).with_timezone("UTC");
+
+        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
+            .expect("valid batch");
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            true,
+        )]));
+
+        let result = try_cast_to(batch, target_schema);
+        assert!(result.is_ok(), "cast should succeed: {:?}", result.err());
+
+        let casted = result.expect("already checked");
+        let ts_col = casted
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::TimestampNanosecondArray>()
+            .expect("should be TimestampNanosecondArray");
+        assert_eq!(ts_col.value(0), value_us * 1000);
+    }
+
+    /// Non-timestamp overflow errors should still propagate (no fallback).
+    #[test]
+    fn test_try_cast_to_non_timestamp_overflow_still_errors() {
+        use arrow::array::Decimal128Array;
+
+        // A value that overflows Decimal128(10, 2)
+        let value: i128 = 99_999_999_999_000_000_000;
+
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "amount",
+            DataType::Decimal128(38, 9),
+            true,
+        )]));
+
+        let source_array = Decimal128Array::from(vec![Some(value)])
+            .with_precision_and_scale(38, 9)
+            .expect("valid");
+
+        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
+            .expect("valid batch");
+
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "amount",
+            DataType::Decimal128(10, 2),
+            true,
+        )]));
+
+        let result = try_cast_to(batch, target_schema);
+        assert!(
+            result.is_err(),
+            "non-timestamp overflow should still return an error"
         );
     }
 }

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -141,9 +141,9 @@ fn cast_column(
 ) -> Result<ArrayRef> {
     match cast_with_options(column.as_ref(), target_field.data_type(), strict_options) {
         Ok(casted) => Ok(casted),
-        Err(ArrowError::CastError(ref msg))
+        Err(ref e)
             if is_timestamp_unit_cast(source_type, target_field.data_type())
-                && msg.contains("Overflow") =>
+                && is_overflow_error(e) =>
         {
             tracing::warn!(
                 "Timestamp overflow casting column '{}' from {source_type:?} to {:?}. Values outside the representable range will be NULL.",
@@ -159,6 +159,14 @@ fn cast_column(
         }
         Err(e) => Err(e).context(UnableToConvertRecordBatchSnafu),
     }
+}
+
+fn is_overflow_error(e: &ArrowError) -> bool {
+    matches!(
+        e,
+        ArrowError::CastError(msg) | ArrowError::ArithmeticOverflow(msg)
+            if msg.contains("Overflow") || msg.contains("overflow")
+    )
 }
 
 /// Flattens a list of struct types with a single field into a list of primitive types.

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -876,15 +876,12 @@ mod test {
             true,
         )]));
 
-        let source_array = TimestampMicrosecondArray::from(vec![
-            Some(sentinel_us),
-            Some(normal_us),
-            None,
-        ])
-        .with_timezone("UTC");
+        let source_array =
+            TimestampMicrosecondArray::from(vec![Some(sentinel_us), Some(normal_us), None])
+                .with_timezone("UTC");
 
-        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
-            .expect("valid batch");
+        let batch =
+            RecordBatch::try_new(source_schema, vec![Arc::new(source_array)]).expect("valid batch");
 
         let target_schema = Arc::new(Schema::new(vec![Field::new(
             "ts",
@@ -932,8 +929,8 @@ mod test {
         let source_array =
             TimestampMicrosecondArray::from(vec![Some(value_us)]).with_timezone("UTC");
 
-        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
-            .expect("valid batch");
+        let batch =
+            RecordBatch::try_new(source_schema, vec![Arc::new(source_array)]).expect("valid batch");
 
         let target_schema = Arc::new(Schema::new(vec![Field::new(
             "ts",
@@ -971,8 +968,8 @@ mod test {
             .with_precision_and_scale(38, 9)
             .expect("valid");
 
-        let batch = RecordBatch::try_new(source_schema, vec![Arc::new(source_array)])
-            .expect("valid batch");
+        let batch =
+            RecordBatch::try_new(source_schema, vec![Arc::new(source_array)]).expect("valid batch");
 
         let target_schema = Arc::new(Schema::new(vec![Field::new(
             "amount",

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -253,10 +253,10 @@ impl SqlWarehouseApi {
 
         match schema_from_json(&response, &table.to_string()) {
             Ok(schema) => Ok(schema),
-            Err(Error::QueryFailure { ref message })
-                if message.contains("UNRESOLVED_COLUMN") =>
-            {
-                tracing::warn!("Databricks information_schema does not have 'full_data_type' column, falling back to 'data_type'. Complex types (ARRAY, MAP, STRUCT) may lose inner type details.");
+            Err(Error::QueryFailure { ref message }) if message.contains("UNRESOLVED_COLUMN") => {
+                tracing::warn!(
+                    "Databricks information_schema does not have 'full_data_type' column, falling back to 'data_type'. Complex types (ARRAY, MAP, STRUCT) may lose inner type details."
+                );
                 let payload = self.create_schema_payload(table, "data_type")?;
                 let response = self.execute_sql_statement(&token, &payload).await?;
                 let response = self.wait_for_statement_completion(&token, response).await?;
@@ -1641,8 +1641,11 @@ mod tests {
             }
         });
 
-        let port =
-            start_mock_server(vec![unresolved_column_response, success_response], json!({})).await;
+        let port = start_mock_server(
+            vec![unresolved_column_response, success_response],
+            json!({}),
+        )
+        .await;
         let api = create_test_api(port);
         let table = TableReference::full("my_catalog", "my_schema", "my_table");
 
@@ -1735,7 +1738,9 @@ mod tests {
             Arc::clone(&ipc_schema),
             vec![
                 Arc::new(arrow::array::Int32Array::from(vec![1])),
-                Arc::new(TimestampMicrosecondArray::from(vec![sentinel_us]).with_timezone("Etc/UTC")),
+                Arc::new(
+                    TimestampMicrosecondArray::from(vec![sentinel_us]).with_timezone("Etc/UTC"),
+                ),
                 Arc::new(TimestampMicrosecondArray::from(vec![sentinel_us])),
             ],
         )
@@ -1755,7 +1760,11 @@ mod tests {
             .as_any()
             .downcast_ref::<TimestampMicrosecondArray>()
             .expect("should be TimestampMicrosecondArray");
-        assert_eq!(ts_col.value(0), sentinel_us, "sentinel value must be preserved");
+        assert_eq!(
+            ts_col.value(0),
+            sentinel_us,
+            "sentinel value must be preserved"
+        );
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -253,9 +253,11 @@ impl SqlWarehouseApi {
 
         match schema_from_json(&response, &table.to_string()) {
             Ok(schema) => Ok(schema),
-            Err(Error::QueryFailure { ref message }) if message.contains("UNRESOLVED_COLUMN") => {
+            Err(Error::QueryFailure { ref message })
+                if message.contains("UNRESOLVED_COLUMN") && message.contains("full_data_type") =>
+            {
                 tracing::warn!(
-                    "Databricks information_schema does not have 'full_data_type' column, falling back to 'data_type'. Complex types (ARRAY, MAP, STRUCT) may lose inner type details."
+                    "Databricks information_schema for '{table}' does not have 'full_data_type' column, falling back to 'data_type'. Complex types (ARRAY, MAP, STRUCT) may lose inner type details."
                 );
                 let payload = self.create_schema_payload(table, "data_type")?;
                 let response = self.execute_sql_statement(&token, &payload).await?;
@@ -1788,6 +1790,33 @@ mod tests {
             .expect_err("should propagate non-UNRESOLVED_COLUMN error");
         assert!(
             matches!(&err, Error::QueryFailure { message } if message.contains("Table or view not found")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_schema_no_fallback_for_unresolved_column_other_than_full_data_type() {
+        // UNRESOLVED_COLUMN for a column other than full_data_type should NOT trigger fallback.
+        let unresolved_other = json!({
+            "status": {
+                "state": "FAILED",
+                "error": {
+                    "message": "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `some_other_col` cannot be resolved."
+                }
+            },
+            "statement_id": "stmt-1"
+        });
+
+        let port = start_mock_server(vec![unresolved_other], json!({})).await;
+        let api = create_test_api(port);
+        let table = TableReference::full("catalog", "schema", "my_table");
+
+        let err = api
+            .get_schema(&table)
+            .await
+            .expect_err("should not fall back for unrelated UNRESOLVED_COLUMN");
+        assert!(
+            matches!(&err, Error::QueryFailure { message } if message.contains("UNRESOLVED_COLUMN")),
             "unexpected error: {err}"
         );
     }

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -247,13 +247,30 @@ impl SqlWarehouseApi {
 
     async fn get_schema(&self, table: &TableReference) -> Result<SchemaRef, Error> {
         let token = self.token_provider.get_token();
-        let payload = self.create_schema_payload(table)?;
+        let payload = self.create_schema_payload(table, "full_data_type")?;
         let response = self.execute_sql_statement(&token, &payload).await?;
         let response = self.wait_for_statement_completion(&token, response).await?;
-        schema_from_json(&response, &table.to_string())
+
+        match schema_from_json(&response, &table.to_string()) {
+            Ok(schema) => Ok(schema),
+            Err(Error::QueryFailure { ref message })
+                if message.contains("UNRESOLVED_COLUMN") =>
+            {
+                tracing::warn!("Databricks information_schema does not have 'full_data_type' column, falling back to 'data_type'. Complex types (ARRAY, MAP, STRUCT) may lose inner type details.");
+                let payload = self.create_schema_payload(table, "data_type")?;
+                let response = self.execute_sql_statement(&token, &payload).await?;
+                let response = self.wait_for_statement_completion(&token, response).await?;
+                schema_from_json(&response, &table.to_string())
+            }
+            Err(e) => Err(e),
+        }
     }
 
-    fn create_schema_payload(&self, table: &TableReference) -> Result<Value, Error> {
+    fn create_schema_payload(
+        &self,
+        table: &TableReference,
+        data_type_column: &str,
+    ) -> Result<Value, Error> {
         let table_schema = table.schema().ok_or_else(|| Error::FullyQualifiedPath {
             reason: "missing schema".into(),
         })?;
@@ -265,7 +282,7 @@ impl SqlWarehouseApi {
         let escaped_schema = table_schema.replace('\'', "''");
         let escaped_catalog = table_catalog.replace('\'', "''");
         let sql = format!(
-            "SELECT column_name, full_data_type, is_nullable FROM information_schema.columns WHERE table_name = '{escaped_table}' AND table_schema = '{escaped_schema}' AND table_catalog = '{escaped_catalog}'"
+            "SELECT column_name, {data_type_column}, is_nullable FROM information_schema.columns WHERE table_name = '{escaped_table}' AND table_schema = '{escaped_schema}' AND table_catalog = '{escaped_catalog}'"
         );
         // Databricks SQL Statements API max wait_timeout is 50s.
         // https://docs.databricks.com/api/workspace/statementexecution/executestatement
@@ -891,7 +908,7 @@ mod tests {
         assert_eq!(schema.field(4).data_type(), &DataType::Date32);
         assert_eq!(
             schema.field(5).data_type(),
-            &DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, Some("UTC".into()))
+            &DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into()))
         );
         assert_eq!(schema.field(6).data_type(), &DataType::Binary);
         assert_eq!(schema.field(7).data_type(), &DataType::Decimal128(10, 2));
@@ -1158,7 +1175,7 @@ mod tests {
         let table = TableReference::full("my_catalog", "my_schema", "my_table");
 
         let payload = api
-            .create_schema_payload(&table)
+            .create_schema_payload(&table, "full_data_type")
             .expect("should create payload");
 
         assert_eq!(payload["format"], "JSON_ARRAY");
@@ -1186,7 +1203,7 @@ mod tests {
         let table = TableReference::bare("just_table");
 
         let err = api
-            .create_schema_payload(&table)
+            .create_schema_payload(&table, "full_data_type")
             .expect_err("should fail without schema");
         assert!(
             matches!(&err, Error::FullyQualifiedPath { reason } if reason.contains("missing schema")),
@@ -1205,7 +1222,7 @@ mod tests {
         let table = TableReference::partial("my_schema", "my_table");
 
         let err = api
-            .create_schema_payload(&table)
+            .create_schema_payload(&table, "full_data_type")
             .expect_err("should fail without catalog");
         assert!(
             matches!(&err, Error::FullyQualifiedPath { reason } if reason.contains("missing catalog")),
@@ -1224,7 +1241,7 @@ mod tests {
         let table = TableReference::full("cat'alog", "sch'ema", "tab'le");
 
         let payload = api
-            .create_schema_payload(&table)
+            .create_schema_payload(&table, "full_data_type")
             .expect("should create payload");
         let stmt = payload["statement"]
             .as_str()
@@ -1514,5 +1531,255 @@ mod tests {
         assert_eq!(schema.fields().len(), 2);
         assert_eq!(schema.field(0).name(), "id");
         assert_eq!(schema.field(1).name(), "name");
+    }
+
+    #[test]
+    fn test_create_schema_payload_uses_data_type_column() {
+        let api = SqlWarehouseApi::new(
+            "host.example.com",
+            "wh-1",
+            Arc::new(StaticTokenProvider("t".to_string())),
+        )
+        .expect("should create api");
+        let table = TableReference::full("my_catalog", "my_schema", "my_table");
+
+        let payload_full = api
+            .create_schema_payload(&table, "full_data_type")
+            .expect("should create payload with full_data_type");
+        let stmt_full = payload_full["statement"]
+            .as_str()
+            .expect("statement should be string");
+        assert!(
+            stmt_full.contains("full_data_type"),
+            "SQL should reference full_data_type: {stmt_full}"
+        );
+        assert!(
+            !stmt_full.contains(", data_type,"),
+            "SQL should not reference plain data_type: {stmt_full}"
+        );
+
+        let payload_plain = api
+            .create_schema_payload(&table, "data_type")
+            .expect("should create payload with data_type");
+        let stmt_plain = payload_plain["statement"]
+            .as_str()
+            .expect("statement should be string");
+        assert!(
+            stmt_plain.contains(", data_type,"),
+            "SQL should reference data_type: {stmt_plain}"
+        );
+        assert!(
+            !stmt_plain.contains("full_data_type"),
+            "SQL should not reference full_data_type: {stmt_plain}"
+        );
+    }
+
+    #[test]
+    fn test_schema_from_json_parameterless_complex_types() {
+        // When using `data_type` column, complex types lack inner type info.
+        let response = make_schema_response(&json!([
+            ["id", "int", "NO"],
+            ["tags", "ARRAY", "YES"],
+            ["metadata", "MAP", "YES"],
+            ["details", "STRUCT", "YES"],
+            ["price", "DECIMAL", "YES"]
+        ]));
+
+        let schema = schema_from_json(&response, "test_table")
+            .expect("should parse parameterless complex types");
+        assert_eq!(schema.fields().len(), 5);
+
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(0).data_type(), &DataType::Int32);
+
+        // ARRAY without type params falls back to List(Utf8)
+        assert_eq!(schema.field(1).name(), "tags");
+        assert!(
+            matches!(schema.field(1).data_type(), DataType::List(_)),
+            "ARRAY should become List, got {:?}",
+            schema.field(1).data_type()
+        );
+
+        // MAP without type params falls back to Map(Utf8, Utf8)
+        assert_eq!(schema.field(2).name(), "metadata");
+        assert!(
+            matches!(schema.field(2).data_type(), DataType::Map(_, _)),
+            "MAP should become Map, got {:?}",
+            schema.field(2).data_type()
+        );
+
+        // STRUCT without type params falls back to Utf8
+        assert_eq!(schema.field(3).name(), "details");
+        assert_eq!(schema.field(3).data_type(), &DataType::Utf8);
+
+        // DECIMAL without precision/scale falls back to Decimal128(38,10)
+        assert_eq!(schema.field(4).name(), "price");
+        assert_eq!(schema.field(4).data_type(), &DataType::Decimal128(38, 10));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_schema_falls_back_to_data_type_on_unresolved_column() {
+        // First call returns UNRESOLVED_COLUMN error (full_data_type doesn't exist).
+        // Second call returns a successful schema response using data_type column.
+        let unresolved_column_response = json!({
+            "status": {
+                "state": "FAILED",
+                "error": {
+                    "message": "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `full_data_type` cannot be resolved."
+                }
+            },
+            "statement_id": "stmt-1"
+        });
+        let success_response = json!({
+            "status": { "state": "SUCCEEDED" },
+            "statement_id": "stmt-2",
+            "result": {
+                "data_array": [
+                    ["id", "int", "NO"],
+                    ["name", "string", "YES"]
+                ]
+            }
+        });
+
+        let port =
+            start_mock_server(vec![unresolved_column_response, success_response], json!({})).await;
+        let api = create_test_api(port);
+        let table = TableReference::full("my_catalog", "my_schema", "my_table");
+
+        let schema = api
+            .get_schema(&table)
+            .await
+            .expect("should succeed via data_type fallback");
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "name");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_schema_succeeds_with_full_data_type() {
+        let success_response = json!({
+            "status": { "state": "SUCCEEDED" },
+            "statement_id": "stmt-1",
+            "result": {
+                "data_array": [
+                    ["id", "bigint", "NO"],
+                    ["amount", "decimal(10,2)", "YES"]
+                ]
+            }
+        });
+
+        let port = start_mock_server(vec![success_response], json!({})).await;
+        let api = create_test_api(port);
+        let table = TableReference::full("catalog", "schema", "orders");
+
+        let schema = api
+            .get_schema(&table)
+            .await
+            .expect("should succeed on first try with full_data_type");
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).data_type(), &DataType::Decimal128(10, 2));
+    }
+
+    /// Regression test: Databricks sends timestamps as `Timestamp(Microsecond, "Etc/UTC")`
+    /// in Arrow IPC. The declared schema must also use Microsecond so that `try_cast_to`
+    /// doesn't attempt a µs→ns multiplication that overflows for far-future sentinel
+    /// values like year 9999 (253402300799999000 µs × 1000 > i64::MAX).
+    #[test]
+    fn test_schema_from_json_timestamp_microsecond_avoids_overflow() {
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow_tools::record_batch::try_cast_to;
+
+        // Parse schema from a Databricks JSON response with timestamp columns
+        let response = make_schema_response(&json!([
+            ["id", "int", "NO"],
+            ["edw_end_datetime", "timestamp", "YES"],
+            ["created_ntz", "timestamp_ntz", "YES"]
+        ]));
+        let declared_schema =
+            schema_from_json(&response, "test_table").expect("should parse schema");
+
+        // Verify both timestamp fields use Microsecond
+        assert_eq!(
+            declared_schema.field(1).data_type(),
+            &DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into())),
+            "TIMESTAMP must be Microsecond"
+        );
+        assert_eq!(
+            declared_schema.field(2).data_type(),
+            &DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None),
+            "TIMESTAMP_NTZ must be Microsecond"
+        );
+
+        // Simulate Databricks Arrow IPC: data arrives as Timestamp(Microsecond, "Etc/UTC")
+        // with a far-future sentinel value (year 9999).
+        let sentinel_us: i64 = 253_402_300_799_999_000; // 9999-12-31T23:59:59.999 in µs
+        let ipc_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "edw_end_datetime",
+                DataType::Timestamp(
+                    arrow::datatypes::TimeUnit::Microsecond,
+                    Some("Etc/UTC".into()),
+                ),
+                true,
+            ),
+            Field::new(
+                "created_ntz",
+                DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&ipc_schema),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1])),
+                Arc::new(TimestampMicrosecondArray::from(vec![sentinel_us]).with_timezone("Etc/UTC")),
+                Arc::new(TimestampMicrosecondArray::from(vec![sentinel_us])),
+            ],
+        )
+        .expect("should create batch");
+
+        // Cast from IPC schema to declared schema — must NOT overflow
+        let result = try_cast_to(batch, declared_schema);
+        assert!(
+            result.is_ok(),
+            "try_cast_to should not overflow for year-9999 sentinel: {:?}",
+            result.err()
+        );
+
+        let casted = result.expect("already checked");
+        let ts_col = casted
+            .column(1)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .expect("should be TimestampMicrosecondArray");
+        assert_eq!(ts_col.value(0), sentinel_us, "sentinel value must be preserved");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_schema_propagates_non_unresolved_column_errors() {
+        // A FAILED response that is NOT about UNRESOLVED_COLUMN should not trigger fallback.
+        let other_failure = json!({
+            "status": {
+                "state": "FAILED",
+                "error": { "message": "Table or view not found: my_table" }
+            },
+            "statement_id": "stmt-1"
+        });
+
+        let port = start_mock_server(vec![other_failure], json!({})).await;
+        let api = create_test_api(port);
+        let table = TableReference::full("catalog", "schema", "my_table");
+
+        let err = api
+            .get_schema(&table)
+            .await
+            .expect_err("should propagate non-UNRESOLVED_COLUMN error");
+        assert!(
+            matches!(&err, Error::QueryFailure { message } if message.contains("Table or view not found")),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
+++ b/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
@@ -527,19 +527,15 @@ mod tests {
         // come without type parameters (e.g. just "ARRAY" instead of "ARRAY<STRING>").
         let mut parser = Parser::new("ARRAY");
         let result = parser.parse().expect("parse ARRAY without params");
-        let expected_array = ArrowDataType::List(Arc::new(ArrowField::new(
-            "item",
-            ArrowDataType::Utf8,
-            true,
-        )));
+        let expected_array =
+            ArrowDataType::List(Arc::new(ArrowField::new("item", ArrowDataType::Utf8, true)));
         assert_eq!(result, expected_array);
 
         let mut parser = Parser::new("MAP");
         let result = parser.parse().expect("parse MAP without params");
         let key = Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
         let val = Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true));
-        let entries =
-            Arc::new(ArrowField::new_struct("entries", vec![key, val], true));
+        let entries = Arc::new(ArrowField::new_struct("entries", vec![key, val], true));
         let expected_map = ArrowDataType::Map(entries, false);
         assert_eq!(result, expected_map);
 

--- a/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
+++ b/crates/data_components/src/databricks/sql_warehouse/datatypes.rs
@@ -199,13 +199,13 @@ impl<'input> Parser<'input> {
             Some(Ok(Token::Timestamp)) => {
                 self.advance();
                 Ok(ArrowDataType::Timestamp(
-                    TimeUnit::Nanosecond,
+                    TimeUnit::Microsecond,
                     Some("UTC".into()),
                 ))
             }
             Some(Ok(Token::TimestampNtz)) => {
                 self.advance();
-                Ok(ArrowDataType::Timestamp(TimeUnit::Nanosecond, None))
+                Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
             }
             Some(Ok(Token::TinyInt)) => {
                 self.advance();
@@ -213,11 +213,17 @@ impl<'input> Parser<'input> {
             }
             Some(Ok(Token::Array)) => {
                 self.advance();
-                self.expect(&Token::LAngle)?;
-                let inner_type = self.parse_data_type_with_depth(depth + 1)?;
-                self.expect(&Token::RAngle)?;
-                let field = ArrowField::new("item", inner_type, true);
-                Ok(ArrowDataType::List(Arc::new(field)))
+                if self.current == Some(Ok(Token::LAngle)) {
+                    self.advance();
+                    let inner_type = self.parse_data_type_with_depth(depth + 1)?;
+                    self.expect(&Token::RAngle)?;
+                    let field = ArrowField::new("item", inner_type, true);
+                    Ok(ArrowDataType::List(Arc::new(field)))
+                } else {
+                    // Fallback: no element type specified (e.g. from data_type column)
+                    let field = ArrowField::new("item", ArrowDataType::Utf8, true);
+                    Ok(ArrowDataType::List(Arc::new(field)))
+                }
             }
             Some(Ok(Token::Map)) => self.parse_map_with_depth(depth),
             Some(Ok(Token::Struct)) => self.parse_struct_with_depth(depth),
@@ -227,7 +233,18 @@ impl<'input> Parser<'input> {
 
     fn parse_map_with_depth(&mut self, depth: usize) -> Result<ArrowDataType, String> {
         self.advance();
-        self.expect(&Token::LAngle)?;
+        if self.current != Some(Ok(Token::LAngle)) {
+            // Fallback: no type parameters (e.g. from data_type column)
+            let key_field = Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
+            let value_field = Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true));
+            let entry_struct = Arc::new(ArrowField::new_struct(
+                "entries",
+                vec![key_field, value_field],
+                true,
+            ));
+            return Ok(ArrowDataType::Map(entry_struct, false));
+        }
+        self.advance();
         let key_type = self.parse_data_type_with_depth(depth + 1)?;
         self.expect(&Token::Comma)?;
         let value_type = self.parse_data_type_with_depth(depth + 1)?;
@@ -244,6 +261,10 @@ impl<'input> Parser<'input> {
 
     fn parse_struct_with_depth(&mut self, depth: usize) -> Result<ArrowDataType, String> {
         self.advance();
+        if self.current != Some(Ok(Token::LAngle)) {
+            // Fallback: no field definitions (e.g. from data_type column)
+            return Ok(ArrowDataType::Utf8);
+        }
         self.expect(&Token::LAngle)?;
         let mut fields = Vec::new();
         if self.current != Some(Ok(Token::RAngle)) {
@@ -388,10 +409,10 @@ mod tests {
             ArrowDataType::Int16,
             ArrowDataType::Utf8,
             ArrowDataType::Utf8,
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
             ArrowDataType::Int8,
             ArrowDataType::Int8,
             ArrowDataType::Null,
@@ -498,5 +519,69 @@ mod tests {
         let mut parser = Parser::new(input);
         let result = parser.parse().expect("parse success");
         assert_eq!(result, expected, "Failed for input: {input}");
+    }
+
+    #[test]
+    fn test_parameterless_complex_types() {
+        // When using `data_type` column instead of `full_data_type`, complex types
+        // come without type parameters (e.g. just "ARRAY" instead of "ARRAY<STRING>").
+        let mut parser = Parser::new("ARRAY");
+        let result = parser.parse().expect("parse ARRAY without params");
+        let expected_array = ArrowDataType::List(Arc::new(ArrowField::new(
+            "item",
+            ArrowDataType::Utf8,
+            true,
+        )));
+        assert_eq!(result, expected_array);
+
+        let mut parser = Parser::new("MAP");
+        let result = parser.parse().expect("parse MAP without params");
+        let key = Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
+        let val = Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true));
+        let entries =
+            Arc::new(ArrowField::new_struct("entries", vec![key, val], true));
+        let expected_map = ArrowDataType::Map(entries, false);
+        assert_eq!(result, expected_map);
+
+        let mut parser = Parser::new("STRUCT");
+        let result = parser.parse().expect("parse STRUCT without params");
+        assert_eq!(result, ArrowDataType::Utf8);
+
+        let mut parser = Parser::new("DECIMAL");
+        let result = parser.parse().expect("parse DECIMAL without params");
+        assert_eq!(result, ArrowDataType::Decimal128(38, 10));
+    }
+
+    /// Databricks sends Arrow IPC data with `Timestamp(Microsecond, ...)` but
+    /// the schema parser previously declared `Timestamp(Nanosecond, ...)`,
+    /// causing arithmetic overflow when casting far-future sentinel values
+    /// (e.g. year 9999: 253402300799999000 µs × 1000 > i64::MAX).
+    ///
+    /// This test ensures the parser declares Microsecond to match the wire format.
+    #[test]
+    fn test_timestamp_uses_microsecond_to_prevent_overflow() {
+        let mut parser = Parser::new("TIMESTAMP");
+        let result = parser.parse().expect("parse TIMESTAMP");
+        assert_eq!(
+            result,
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            "TIMESTAMP must use Microsecond to match Databricks Arrow IPC format"
+        );
+
+        let mut parser = Parser::new("TIMESTAMP_NTZ");
+        let result = parser.parse().expect("parse TIMESTAMP_NTZ");
+        assert_eq!(
+            result,
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            "TIMESTAMP_NTZ must use Microsecond to match Databricks Arrow IPC format"
+        );
+
+        // Verify the sentinel value 9999-12-31T23:59:59.999 fits in i64 microseconds
+        // but would overflow in nanoseconds (253402300799999000 * 1000 > i64::MAX).
+        let sentinel_us: i64 = 253_402_300_799_999_000;
+        assert!(
+            sentinel_us.checked_mul(1000).is_none(),
+            "year-9999 sentinel must overflow when converting µs→ns"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Two issues affecting Databricks connector initialization:

1. **`UNRESOLVED_COLUMN` error on schema introspection** — The schema query references `full_data_type` from `information_schema.columns`, which only exists in Databricks environments with Unity Catalog on recent runtimes. Older or non-UC environments return `UNRESOLVED_COLUMN.WITH_SUGGESTION / SQLSTATE 42703`.

2. **Timestamp overflow** — `Unable to cast column 'edw_end_datetime' from Timestamp(µs, "Etc/UTC") to Timestamp(ns, "UTC"): Arithmetic overflow: Overflow happened on: 253402300799999000 * 1000`. The schema parser declared timestamps as `Timestamp(Nanosecond)` but Databricks sends `Timestamp(Microsecond)` in Arrow IPC. The µs→ns cast overflows for far-future sentinel values like year 9999.

## Changes

### Databricks connector (`data_components`)
- **Schema introspection fallback**: `get_schema()` now tries `full_data_type` first; if the query fails with `UNRESOLVED_COLUMN`, retries with `data_type` and logs a warning.
- **Parameterless complex type parsing**: The type parser handles `ARRAY`, `MAP`, `STRUCT`, `DECIMAL` without type parameters (as returned by `data_type` column), defaulting to reasonable fallback types.
- **Timestamp unit fix**: Changed declared timestamp types from `Nanosecond` to `Microsecond` to match what Databricks actually sends in Arrow IPC streams.

### Arrow tools (`arrow_tools`)
- **Safe-cast fallback for timestamp overflow**: `try_cast_to()` now catches arithmetic overflow errors specifically for timestamp unit conversions and falls back to a safe cast (overflowing values become NULL). Non-timestamp overflows still error as before.

## Tests
- Schema payload column selection (`full_data_type` vs `data_type`)
- Parameterless complex type parsing
- End-to-end `get_schema` fallback via mock server
- Non-UNRESOLVED_COLUMN error propagation (no false fallback)
- Timestamp µs→ns overflow produces NULL (not crash)
- Timestamp µs→ns with normal values succeeds exactly
- Non-timestamp overflows still error