### PR TITLE
feat: Add pagination support to HTTP data connector

### DIFF
--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1446,10 +1446,11 @@ impl ExecutionPlan for HttpExec {
                         })?;
 
                         if state.page >= config.max_pages {
-                            return Err(DataFusionError::Execution(format!(
-                                "HTTP pagination query was aborted after reaching the configured safety limit of {} pages. Increase `pagination_max_pages` to fetch additional pages.",
+                            tracing::warn!(
+                                "HTTP pagination reached the configured safety limit of {} pages. Increase `pagination_max_pages` to fetch additional pages.",
                                 config.max_pages
-                            )));
+                            );
+                            return Ok(None);
                         }
 
                         if let Some(limit) = state.limit

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1436,142 +1436,168 @@ impl ExecutionPlan for HttpExec {
                 let provider = Arc::clone(&provider);
 
                 async move {
-                    if state.done {
-                        return Ok::<_, DataFusionError>(None);
-                    }
-
-                    let config = provider.pagination.as_ref().ok_or_else(|| {
-                        DataFusionError::Internal("Pagination config missing".to_string())
-                    })?;
-
-                    if state.page >= config.max_pages {
-                        return Err(DataFusionError::Execution(format!(
-                            "HTTP pagination was cut off after {} pages due to the configured safety limit. Results may be incomplete. Increase `pagination_max_pages` to fetch additional pages.",
-                            config.max_pages
-                        )));
-                    }
-
-                    if let Some(limit) = state.limit
-                        && state.rows_fetched >= limit
-                    {
-                        return Ok(None);
-                    }
-
-                    let page_limit = state.limit.map(|l| l.saturating_sub(state.rows_fetched));
-
-                    // Fetch this page
-                    let fetch_result = if state.page == 0 {
-                        let path_val = state.path.as_deref().unwrap_or("");
-                        let query_val = state.query.as_deref();
-                        let body_val = state.body.as_deref();
-                        state.last_page_path = state.path.clone();
-                        state.last_page_query = state.query.clone();
-                        provider
-                            .get_response(path_val, query_val, body_val)
-                            .await
-                            .map_err(DataFusionError::from)?
-                    } else {
-                        // Subsequent pages bypass the HTTP cache intentionally:
-                        // each page has unique content that shouldn't be cached
-                        // under the same key as the base request.
-                        match &state.next_info {
-                            Some(NextPageInfo::Url(url)) => {
-                                state.last_page_path = Some(url.path().to_string());
-                                state.last_page_query = url.query().map(ToString::to_string);
-                                provider
-                                    .perform_request_with_retry(
-                                        url.clone(),
-                                        state.body.as_deref(),
-                                        &format!("page_{}", state.page),
-                                    )
-                                    .await
-                                    .map_err(DataFusionError::from)?
-                            }
-                            Some(NextPageInfo::Token(token)) => {
-                                let path_val = state.path.as_deref().unwrap_or("");
-                                let token_param = config.token_param.as_deref().unwrap_or("cursor");
-                                // Merge base URL query, partition query, and token param
-                                let base_query = provider.base_url.query();
-                                let merged_query = merge_queries(
-                                    base_query,
-                                    state.query.as_deref(),
-                                    token_param,
-                                    token,
-                                );
-                                state.last_page_path = state.path.clone();
-                                state.last_page_query = Some(merged_query.clone());
-                                let url = provider
-                                    .build_request_url(path_val, Some(&merged_query))
-                                    .map_err(DataFusionError::from)?;
-                                provider
-                                    .perform_request_with_retry(
-                                        url,
-                                        state.body.as_deref(),
-                                        &format!("page_{}", state.page),
-                                    )
-                                    .await
-                                    .map_err(DataFusionError::from)?
-                            }
-                            None => {
-                                return Err(DataFusionError::Internal(
-                                    "page > 0 but no next page info".to_string(),
-                                ));
-                            }
-                        }
-                    };
-
-                    // Extract next page info first (before checking rows)
-                    // so we don't terminate pagination prematurely on empty pages
-                    let next_info = extract_next_page_info(
-                        &fetch_result.content,
-                        &fetch_result.response_headers,
-                        config,
-                        &provider.base_url,
-                    )
-                    .map_err(DataFusionError::from)?;
-
-                    // Extract data rows using data_pointer if configured
-                    let content_rows =
-                        extract_page_data(&fetch_result.content, config, page_limit)?;
-
-                    // Update pagination state before deciding whether to yield a batch
-                    state.page += 1;
-                    state.next_info = next_info;
-                    if state.next_info.is_none() {
-                        state.done = true;
-                    }
-
-                    // Skip empty pages internally instead of yielding empty batches
-                    if content_rows.is_empty() {
+                    loop {
                         if state.done {
+                            return Ok::<_, DataFusionError>(None);
+                        }
+
+                        let config = provider.pagination.as_ref().ok_or_else(|| {
+                            DataFusionError::Internal("Pagination config missing".to_string())
+                        })?;
+
+                        if state.page >= config.max_pages {
+                            return Err(DataFusionError::Execution(format!(
+                                "HTTP pagination query was aborted after reaching the configured safety limit of {} pages. Increase `pagination_max_pages` to fetch additional pages.",
+                                config.max_pages
+                            )));
+                        }
+
+                        if let Some(limit) = state.limit
+                            && state.rows_fetched >= limit
+                        {
                             return Ok(None);
                         }
-                        // Continue to next iteration — try_unfold will call us again
-                        return Ok(Some((
-                            RecordBatch::new_empty(Arc::clone(&exec.projected_schema)),
-                            state,
-                        )));
+
+                        let page_limit = state.limit.map(|l| l.saturating_sub(state.rows_fetched));
+
+                        // Fetch this page
+                        let fetch_result = if state.page == 0 {
+                            let path_val = state.path.as_deref().unwrap_or("");
+                            let query_val = state.query.as_deref();
+                            let body_val = state.body.as_deref();
+                            state.last_page_path = state.path.clone();
+                            state.last_page_query = state.query.clone();
+                            provider
+                                .get_response(path_val, query_val, body_val)
+                                .await
+                                .map_err(DataFusionError::from)?
+                        } else {
+                            // Subsequent pages bypass the HTTP cache intentionally:
+                            // each page has unique content that shouldn't be cached
+                            // under the same key as the base request.
+                            match &state.next_info {
+                                Some(NextPageInfo::Url(url)) => {
+                                    state.last_page_path = Some(url.path().to_string());
+                                    state.last_page_query = url.query().map(ToString::to_string);
+                                    provider
+                                        .perform_request_with_retry(
+                                            url.clone(),
+                                            state.body.as_deref(),
+                                            &format!("page_{}", state.page),
+                                        )
+                                        .await
+                                        .map_err(DataFusionError::from)?
+                                }
+                                Some(NextPageInfo::Token(token)) => {
+                                    let path_val = state.path.as_deref().unwrap_or("");
+                                    let token_param =
+                                        config.token_param.as_deref().unwrap_or("cursor");
+                                    let base_query = provider.base_url.query();
+                                    let merged_query = merge_queries(
+                                        base_query,
+                                        state.query.as_deref(),
+                                        token_param,
+                                        token,
+                                    );
+                                    state.last_page_path = state.path.clone();
+                                    state.last_page_query = Some(merged_query.clone());
+                                    let url = provider
+                                        .build_request_url(path_val, Some(&merged_query))
+                                        .map_err(DataFusionError::from)?;
+                                    provider
+                                        .perform_request_with_retry(
+                                            url,
+                                            state.body.as_deref(),
+                                            &format!("page_{}", state.page),
+                                        )
+                                        .await
+                                        .map_err(DataFusionError::from)?
+                                }
+                                None => {
+                                    return Err(DataFusionError::Internal(
+                                        "page > 0 but no next page info".to_string(),
+                                    ));
+                                }
+                            }
+                        };
+
+                        // Parse response JSON once for both next-page and data extraction
+                        let parsed_json = if config.next_pointer.is_some()
+                            || config.data_pointer.is_some()
+                        {
+                            Some(
+                                    serde_json::from_str::<serde_json::Value>(
+                                        &fetch_result.content,
+                                    )
+                                    .map_err(|source| {
+                                        let pointers: Vec<&str> = [
+                                            config.next_pointer.as_deref(),
+                                            config.data_pointer.as_deref(),
+                                        ]
+                                        .into_iter()
+                                        .flatten()
+                                        .collect();
+                                        DataFusionError::Execution(format!(
+                                            "Failed to parse paginated HTTP response as JSON for pointer(s) {pointers:?}: {source}"
+                                        ))
+                                    })?,
+                                )
+                        } else {
+                            None
+                        };
+
+                        // Extract next page info first (before checking rows)
+                        let next_info = extract_next_page_info(
+                            parsed_json.as_ref(),
+                            &fetch_result.response_headers,
+                            config,
+                            &provider.base_url,
+                        )
+                        .map_err(DataFusionError::from)?;
+
+                        // Extract data rows using data_pointer if configured
+                        let content_rows = extract_page_data(
+                            &fetch_result.content,
+                            parsed_json.as_ref(),
+                            config,
+                            page_limit,
+                        )?;
+
+                        // Update pagination state
+                        state.page += 1;
+                        state.next_info = next_info;
+                        if state.next_info.is_none() {
+                            state.done = true;
+                        }
+
+                        // Skip empty pages internally — loop again instead of yielding
+                        if content_rows.is_empty() {
+                            if state.done {
+                                return Ok(None);
+                            }
+                            continue;
+                        }
+
+                        let num_rows = content_rows.len();
+                        let batch = exec.create_batch_from_rows(
+                            state.last_page_path.as_deref(),
+                            state.last_page_query.as_deref(),
+                            state.body.as_deref(),
+                            &content_rows,
+                            &fetch_result,
+                        )?;
+
+                        state.rows_fetched += num_rows;
+
+                        tracing::debug!(
+                            "Pagination page {}: {} rows fetched, total so far: {}",
+                            state.page - 1,
+                            num_rows,
+                            state.rows_fetched
+                        );
+
+                        return Ok(Some((batch, state)));
                     }
-
-                    let num_rows = content_rows.len();
-                    let batch = exec.create_batch_from_rows(
-                        state.last_page_path.as_deref(),
-                        state.last_page_query.as_deref(),
-                        state.body.as_deref(),
-                        &content_rows,
-                        &fetch_result,
-                    )?;
-
-                    state.rows_fetched += num_rows;
-
-                    tracing::debug!(
-                        "Pagination page {}: {} rows fetched, total so far: {}",
-                        state.page - 1,
-                        num_rows,
-                        state.rows_fetched
-                    );
-
-                    Ok(Some((batch, state)))
                 }
             });
 
@@ -1648,19 +1674,16 @@ fn resolve_and_validate_url(raw: &str, base_url: &Url, context: &str) -> Result<
 /// pagination stops immediately. When the pointer path is missing from the response,
 /// we fall through to check the `Link` header (if configured) before giving up.
 fn extract_next_page_info(
-    content: &str,
+    parsed_json: Option<&serde_json::Value>,
     response_headers: &[(String, String)],
     config: &PaginationConfig,
     base_url: &Url,
 ) -> Result<Option<NextPageInfo>> {
     // Try response body JSON pointer first
     if let Some(ref pointer) = config.next_pointer {
-        let parsed = serde_json::from_str::<serde_json::Value>(content)
-            .map_err(|source| Error::Pagination {
-                message: format!(
-                    "Failed to parse pagination response body as JSON for pointer '{pointer}': {source}"
-                ),
-            })?;
+        let parsed = parsed_json.ok_or_else(|| Error::Pagination {
+            message: format!("JSON not parsed but next_pointer '{pointer}' is configured"),
+        })?;
 
         if let Some(value) = parsed.pointer(pointer) {
             match value {
@@ -1738,13 +1761,14 @@ fn parse_link_header_next(header_value: &str) -> Option<String> {
 /// Extract data rows from a page response, using `data_pointer` if configured.
 fn extract_page_data(
     content: &str,
+    parsed_json: Option<&serde_json::Value>,
     config: &PaginationConfig,
     limit: Option<usize>,
 ) -> DataFusionResult<Vec<String>> {
     if let Some(ref pointer) = config.data_pointer {
-        let json = serde_json::from_str::<serde_json::Value>(content).map_err(|source| {
+        let json = parsed_json.ok_or_else(|| {
             DataFusionError::Execution(format!(
-                "Failed to extract paginated HTTP response data: response is not valid JSON for configured data pointer '{pointer}': {source}"
+                "JSON not parsed but data_pointer '{pointer}' is configured"
             ))
         })?;
 
@@ -2134,6 +2158,41 @@ mod tests {
     /// Build a query string by adding or replacing a token parameter.
     fn build_query_with_token(existing_query: Option<&str>, param: &str, token: &str) -> String {
         merge_queries(None, existing_query, param, token)
+    }
+
+    /// Test helper: parse content and call `extract_next_page_info`
+    fn extract_next_page_info(
+        content: &str,
+        headers: &[(String, String)],
+        config: &PaginationConfig,
+        base_url: &Url,
+    ) -> super::Result<Option<NextPageInfo>> {
+        let parsed = if config.next_pointer.is_some() {
+            Some(
+                serde_json::from_str::<serde_json::Value>(content)
+                    .expect("test content should be valid JSON"),
+            )
+        } else {
+            None
+        };
+        super::extract_next_page_info(parsed.as_ref(), headers, config, base_url)
+    }
+
+    /// Test helper: parse content and call `extract_page_data`
+    fn extract_page_data(
+        content: &str,
+        config: &PaginationConfig,
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Vec<String>> {
+        let parsed = if config.data_pointer.is_some() {
+            Some(
+                serde_json::from_str::<serde_json::Value>(content)
+                    .expect("test content should be valid JSON"),
+            )
+        } else {
+            None
+        };
+        super::extract_page_data(content, parsed.as_ref(), config, limit)
     }
 
     fn base_provider() -> HttpTableProvider {
@@ -4146,13 +4205,13 @@ mod tests {
             next_pointer: Some("/next".to_string()),
             ..Default::default()
         };
-        let content = "this is not json";
+        // When next_pointer is set but parsed_json is None, it should error
         let headers = vec![];
 
-        let result = extract_next_page_info(content, &headers, &config, &base_url);
+        let result = super::extract_next_page_info(None, &headers, &config, &base_url);
         assert!(
             result.is_err(),
-            "invalid JSON should return error when next_pointer is configured"
+            "missing parsed JSON should return error when next_pointer is configured"
         );
     }
 
@@ -4174,16 +4233,16 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_page_data_invalid_json() {
+    fn test_extract_page_data_missing_json() {
         let config = PaginationConfig {
             data_pointer: Some("/results".to_string()),
             ..Default::default()
         };
-        let content = "not valid json";
-        let result = extract_page_data(content, &config, None);
+        // When data_pointer is set but parsed_json is None, it should error
+        let result = super::extract_page_data("", None, &config, None);
         assert!(
             result.is_err(),
-            "invalid JSON should return error when data_pointer is configured"
+            "missing parsed JSON should return error when data_pointer is configured"
         );
     }
 

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1465,23 +1465,10 @@ impl ExecutionPlan for HttpExec {
                         let fetch_result = if state.page == 0 {
                             let path_val = state.path.as_deref().unwrap_or("");
                             let body_val = state.body.as_deref();
-                            // Merge base URL query params with partition query,
-                            // consistent with how subsequent pages handle queries.
-                            let merged_query =
-                                match (provider.base_url.query(), state.query.as_deref()) {
-                                    (Some(base_query), Some(state_query))
-                                        if !base_query.is_empty() && !state_query.is_empty() =>
-                                    {
-                                        Some(format!("{base_query}&{state_query}"))
-                                    }
-                                    (Some(base_query), _) if !base_query.is_empty() => {
-                                        Some(base_query.to_string())
-                                    }
-                                    (_, Some(state_query)) if !state_query.is_empty() => {
-                                        Some(state_query.to_string())
-                                    }
-                                    _ => None,
-                                };
+                            let merged_query = merge_base_and_partition_queries(
+                                provider.base_url.query(),
+                                state.query.as_deref(),
+                            );
                             state.last_page_path = state.path.clone();
                             state.last_page_query = merged_query.clone();
                             provider
@@ -1885,15 +1872,19 @@ fn extract_page_data(
 /// Merge base URL query params, partition query params, and a pagination token
 /// into a single query string. Base URL params come first, then partition params
 /// (overriding any base duplicates), then the token param (overriding any existing).
-fn merge_queries(
+/// Merge base URL query params with partition query params.
+/// Partition params override base params with the same key.
+/// Returns `None` if both inputs are `None`.
+fn merge_base_and_partition_queries(
     base_query: Option<&str>,
     partition_query: Option<&str>,
-    token_param: &str,
-    token: &str,
-) -> String {
+) -> Option<String> {
+    if base_query.is_none() && partition_query.is_none() {
+        return None;
+    }
+
     let mut pairs: Vec<(String, String)> = Vec::new();
 
-    // Start with base URL query params
     if let Some(base) = base_query {
         pairs.extend(
             url::form_urlencoded::parse(base.as_bytes())
@@ -1901,17 +1892,34 @@ fn merge_queries(
         );
     }
 
-    // Override/add partition query params
     if let Some(partition) = partition_query {
         for (key, value) in url::form_urlencoded::parse(partition.as_bytes()) {
-            // Remove any existing base param with the same key
             let key_str: &str = &key;
             pairs.retain(|(k, _)| k != key_str);
             pairs.push((key.into_owned(), value.into_owned()));
         }
     }
 
-    // Remove any existing token param before adding the new one
+    Some(
+        url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(pairs)
+            .finish(),
+    )
+}
+
+fn merge_queries(
+    base_query: Option<&str>,
+    partition_query: Option<&str>,
+    token_param: &str,
+    token: &str,
+) -> String {
+    let merged = merge_base_and_partition_queries(base_query, partition_query).unwrap_or_default();
+
+    // Parse the merged result, add the token param
+    let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(merged.as_bytes())
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
     pairs.retain(|(k, _)| k != token_param);
     pairs.push((token_param.to_string(), token.to_string()));
 
@@ -4591,6 +4599,37 @@ mod tests {
         assert!(
             result.contains("cursor=abc123"),
             "should include token: {result}"
+        );
+    }
+
+    #[test]
+    fn test_merge_base_and_partition_queries() {
+        // Both present — partition overrides base
+        let result =
+            merge_base_and_partition_queries(Some("api_key=secret&page=1"), Some("page=2"));
+        let result = result.expect("should return Some");
+        assert!(result.contains("api_key=secret"), "base param: {result}");
+        assert!(result.contains("page=2"), "partition override: {result}");
+        assert_eq!(
+            result.matches("page=").count(),
+            1,
+            "no duplicates: {result}"
+        );
+
+        // Only base
+        let result = merge_base_and_partition_queries(Some("api_key=secret"), None);
+        let result = result.expect("should return Some");
+        assert!(result.contains("api_key=secret"), "base only: {result}");
+
+        // Only partition
+        let result = merge_base_and_partition_queries(None, Some("filter=active"));
+        let result = result.expect("should return Some");
+        assert!(result.contains("filter=active"), "partition only: {result}");
+
+        // Neither
+        assert!(
+            merge_base_and_partition_queries(None, None).is_none(),
+            "both None should return None"
         );
     }
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -146,7 +146,8 @@ pub struct PaginationConfig {
     /// Example: `/next`, `/pagination/cursor`, `/links/next`
     pub next_pointer: Option<String>,
 
-    /// Use the HTTP `Link` header with `rel="next"` for pagination.
+    /// Use the HTTP `Link` header with `rel="next"` for pagination. Default: `true`.
+    /// Set to `false` to disable Link header auto-detection.
     pub use_link_header: bool,
 
     /// When set, the value from `next_pointer` is treated as a cursor/token
@@ -167,7 +168,7 @@ impl Default for PaginationConfig {
     fn default() -> Self {
         Self {
             next_pointer: None,
-            use_link_header: false,
+            use_link_header: true,
             token_param: None,
             data_pointer: None,
             max_pages: DEFAULT_PAGINATION_MAX_PAGES,
@@ -3955,10 +3956,23 @@ mod tests {
     #[test]
     fn test_pagination_config_validation_requires_next_source() {
         let provider = base_provider();
-        let result = provider.with_pagination(PaginationConfig::default());
+        let result = provider.with_pagination(PaginationConfig {
+            use_link_header: false,
+            ..Default::default()
+        });
         assert!(
             result.is_err(),
             "should require next_pointer or link_header"
+        );
+    }
+
+    #[test]
+    fn test_pagination_default_enables_link_header() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig::default());
+        assert!(
+            result.is_ok(),
+            "default config with link_header=true should be valid"
         );
     }
 

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1235,10 +1235,9 @@ impl HttpExec {
                 "request_body" => {
                     Ok(Arc::new(StringArray::from(vec![body_for_batch; num_rows])) as ArrayRef)
                 }
-                "content" => {
-                    let values: Vec<&str> = content_rows.iter().map(String::as_str).collect();
-                    Ok(Arc::new(StringArray::from(values)) as ArrayRef)
-                }
+                "content" => Ok(Arc::new(StringArray::from_iter_values(
+                    content_rows.iter().map(String::as_str),
+                )) as ArrayRef),
                 "response_status" => Ok(Arc::new(UInt16Array::from(vec![
                     fetch_result
                         .response_status;
@@ -1427,6 +1426,8 @@ impl ExecutionPlan for HttpExec {
                 body,
                 limit,
                 done: false,
+                last_page_path: None,
+                last_page_query: None,
             };
 
             let stream = futures::stream::try_unfold(initial_state, move |mut state| {
@@ -1462,30 +1463,44 @@ impl ExecutionPlan for HttpExec {
                         let path_val = state.path.as_deref().unwrap_or("");
                         let query_val = state.query.as_deref();
                         let body_val = state.body.as_deref();
+                        state.last_page_path = state.path.clone();
+                        state.last_page_query = state.query.clone();
                         provider
                             .get_response(path_val, query_val, body_val)
                             .await
                             .map_err(DataFusionError::from)?
                     } else {
+                        // Subsequent pages bypass the HTTP cache intentionally:
+                        // each page has unique content that shouldn't be cached
+                        // under the same key as the base request.
                         match &state.next_info {
-                            Some(NextPageInfo::Url(url)) => provider
-                                .perform_request_with_retry(
-                                    url.clone(),
-                                    state.body.as_deref(),
-                                    &format!("page_{}", state.page),
-                                )
-                                .await
-                                .map_err(DataFusionError::from)?,
+                            Some(NextPageInfo::Url(url)) => {
+                                state.last_page_path = Some(url.path().to_string());
+                                state.last_page_query = url.query().map(ToString::to_string);
+                                provider
+                                    .perform_request_with_retry(
+                                        url.clone(),
+                                        state.body.as_deref(),
+                                        &format!("page_{}", state.page),
+                                    )
+                                    .await
+                                    .map_err(DataFusionError::from)?
+                            }
                             Some(NextPageInfo::Token(token)) => {
                                 let path_val = state.path.as_deref().unwrap_or("");
                                 let token_param = config.token_param.as_deref().unwrap_or("cursor");
-                                let new_query = build_query_with_token(
+                                // Merge base URL query, partition query, and token param
+                                let base_query = provider.base_url.query();
+                                let merged_query = merge_queries(
+                                    base_query,
                                     state.query.as_deref(),
                                     token_param,
                                     token,
                                 );
+                                state.last_page_path = state.path.clone();
+                                state.last_page_query = Some(merged_query.clone());
                                 let url = provider
-                                    .build_request_url(path_val, Some(&new_query))
+                                    .build_request_url(path_val, Some(&merged_query))
                                     .map_err(DataFusionError::from)?;
                                 provider
                                     .perform_request_with_retry(
@@ -1525,21 +1540,22 @@ impl ExecutionPlan for HttpExec {
                         state.done = true;
                     }
 
+                    // Skip empty pages internally instead of yielding empty batches
                     if content_rows.is_empty() {
-                        // No data rows on this page — if there's a next page, continue;
-                        // otherwise stop.
                         if state.done {
                             return Ok(None);
                         }
-                        // Yield an empty batch to continue the stream
-                        let batch = RecordBatch::new_empty(Arc::clone(&exec.projected_schema));
-                        return Ok(Some((batch, state)));
+                        // Continue to next iteration — try_unfold will call us again
+                        return Ok(Some((
+                            RecordBatch::new_empty(Arc::clone(&exec.projected_schema)),
+                            state,
+                        )));
                     }
 
                     let num_rows = content_rows.len();
                     let batch = exec.create_batch_from_rows(
-                        state.path.as_deref(),
-                        state.query.as_deref(),
+                        state.last_page_path.as_deref(),
+                        state.last_page_query.as_deref(),
                         state.body.as_deref(),
                         &content_rows,
                         &fetch_result,
@@ -1598,6 +1614,10 @@ struct PaginationState {
     body: Option<String>,
     limit: Option<usize>,
     done: bool,
+    /// The actual path/query used for the most recent page fetch.
+    /// Used to populate accurate `request_path`/`request_query` columns.
+    last_page_path: Option<String>,
+    last_page_query: Option<String>,
 }
 
 /// Resolve a next-page URL string (absolute or relative) against the base URL
@@ -1688,6 +1708,9 @@ fn extract_next_page_info(
 }
 
 /// Parse an HTTP `Link` header to find a URI with `rel="next"`.
+/// Handles quoted (`rel="next"`), single-quoted (`rel='next'`), and
+/// unquoted (`rel=next`) forms, as well as multi-value rel lists
+/// (e.g., `rel="next prev"`).
 fn parse_link_header_next(header_value: &str) -> Option<String> {
     for link in header_value.split(',') {
         let link = link.trim();
@@ -1695,7 +1718,14 @@ fn parse_link_header_next(header_value: &str) -> Option<String> {
         let url_part = parts.next()?.trim();
         let is_next = parts.any(|p| {
             let p = p.trim().to_lowercase();
-            p == "rel=\"next\"" || p == "rel='next'"
+            // Strip "rel=" prefix, then strip optional quotes
+            if let Some(val) = p.strip_prefix("rel=") {
+                let val = val.trim_matches('"').trim_matches('\'');
+                // Check if "next" is one of the space-separated rel values
+                val.split_whitespace().any(|v| v == "next")
+            } else {
+                false
+            }
         });
         if is_next && url_part.starts_with('<') && url_part.ends_with('>') {
             return Some(url_part[1..url_part.len() - 1].to_string());
@@ -1738,18 +1768,38 @@ fn extract_page_data(
     Ok(HttpExec::parse_content(content, limit))
 }
 
-/// Build a query string by adding or replacing a token parameter.
-/// Uses `url::form_urlencoded` for proper percent-encoding.
-fn build_query_with_token(existing_query: Option<&str>, param: &str, token: &str) -> String {
-    let mut pairs: Vec<(String, String)> = if let Some(existing) = existing_query {
-        url::form_urlencoded::parse(existing.as_bytes())
-            .filter(|(key, _)| key != param)
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect()
-    } else {
-        Vec::new()
-    };
-    pairs.push((param.to_string(), token.to_string()));
+/// Merge base URL query params, partition query params, and a pagination token
+/// into a single query string. Base URL params come first, then partition params
+/// (overriding any base duplicates), then the token param (overriding any existing).
+fn merge_queries(
+    base_query: Option<&str>,
+    partition_query: Option<&str>,
+    token_param: &str,
+    token: &str,
+) -> String {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+
+    // Start with base URL query params
+    if let Some(base) = base_query {
+        pairs.extend(
+            url::form_urlencoded::parse(base.as_bytes())
+                .map(|(k, v)| (k.into_owned(), v.into_owned())),
+        );
+    }
+
+    // Override/add partition query params
+    if let Some(partition) = partition_query {
+        for (key, value) in url::form_urlencoded::parse(partition.as_bytes()) {
+            // Remove any existing base param with the same key
+            let key_str: &str = &key;
+            pairs.retain(|(k, _)| k != key_str);
+            pairs.push((key.into_owned(), value.into_owned()));
+        }
+    }
+
+    // Remove any existing token param before adding the new one
+    pairs.retain(|(k, _)| k != token_param);
+    pairs.push((token_param.to_string(), token.to_string()));
 
     url::form_urlencoded::Serializer::new(String::new())
         .extend_pairs(pairs)
@@ -2079,6 +2129,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use url::Url;
+
+    /// Build a query string by adding or replacing a token parameter.
+    fn build_query_with_token(existing_query: Option<&str>, param: &str, token: &str) -> String {
+        merge_queries(None, existing_query, param, token)
+    }
 
     fn base_provider() -> HttpTableProvider {
         HttpTableProvider::new(
@@ -4154,6 +4209,91 @@ mod tests {
         assert!(
             result.is_err(),
             "data_pointer without leading '/' should fail"
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_unquoted_rel() {
+        assert_eq!(
+            parse_link_header_next("<https://api.example.com/items?page=2>; rel=next"),
+            Some("https://api.example.com/items?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_multi_rel() {
+        // rel with multiple values: "next prev"
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/items?page=2>; rel="next prev""#),
+            Some("https://api.example.com/items?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_merge_queries_all_sources() {
+        let result = merge_queries(
+            Some("api_key=secret"),
+            Some("filter=active"),
+            "cursor",
+            "abc123",
+        );
+        assert!(
+            result.contains("api_key=secret"),
+            "should include base URL params: {result}"
+        );
+        assert!(
+            result.contains("filter=active"),
+            "should include partition params: {result}"
+        );
+        assert!(
+            result.contains("cursor=abc123"),
+            "should include token: {result}"
+        );
+    }
+
+    #[test]
+    fn test_merge_queries_partition_overrides_base() {
+        let result = merge_queries(
+            Some("page=1&api_key=secret"),
+            Some("page=5"),
+            "cursor",
+            "abc",
+        );
+        // "page" from partition should override base
+        let page_count = result.matches("page=").count();
+        assert_eq!(
+            page_count, 1,
+            "partition should override base param, got: {result}"
+        );
+        assert!(
+            result.contains("page=5"),
+            "partition value should win: {result}"
+        );
+    }
+
+    #[test]
+    fn test_merge_queries_no_base() {
+        let result = merge_queries(None, Some("filter=active"), "cursor", "abc123");
+        assert!(
+            result.contains("filter=active"),
+            "should include partition params: {result}"
+        );
+        assert!(
+            result.contains("cursor=abc123"),
+            "should include token: {result}"
+        );
+    }
+
+    #[test]
+    fn test_merge_queries_no_partition() {
+        let result = merge_queries(Some("api_key=secret"), None, "cursor", "abc123");
+        assert!(
+            result.contains("api_key=secret"),
+            "should include base params: {result}"
+        );
+        assert!(
+            result.contains("cursor=abc123"),
+            "should include token: {result}"
         );
     }
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1219,9 +1219,11 @@ impl HttpExec {
                     let values: Vec<&str> = content_rows.iter().map(String::as_str).collect();
                     Ok(Arc::new(StringArray::from(values)) as ArrayRef)
                 }
-                "response_status" => {
-                    Ok(Arc::new(UInt16Array::from(vec![fetch_result.response_status; num_rows])) as ArrayRef)
-                }
+                "response_status" => Ok(Arc::new(UInt16Array::from(vec![
+                    fetch_result
+                        .response_status;
+                    num_rows
+                ])) as ArrayRef),
                 "response_headers" => {
                     let mut builder = MapBuilder::new(
                         Some(MapFieldNames {
@@ -1421,11 +1423,10 @@ impl ExecutionPlan for HttpExec {
                     })?;
 
                     if state.page >= config.max_pages {
-                        tracing::warn!(
-                            "Reached maximum pagination limit of {} pages",
+                        return Err(DataFusionError::Execution(format!(
+                            "HTTP pagination was cut off after {} pages due to the configured safety limit. Results may be incomplete. Increase `pagination_max_pages` to fetch additional pages.",
                             config.max_pages
-                        );
-                        return Ok(None);
+                        )));
                     }
 
                     if let Some(limit) = state.limit
@@ -1457,8 +1458,7 @@ impl ExecutionPlan for HttpExec {
                                 .map_err(DataFusionError::from)?,
                             Some(NextPageInfo::Token(token)) => {
                                 let path_val = state.path.as_deref().unwrap_or("");
-                                let token_param =
-                                    config.token_param.as_deref().unwrap_or("cursor");
+                                let token_param = config.token_param.as_deref().unwrap_or("cursor");
                                 let new_query = build_query_with_token(
                                     state.query.as_deref(),
                                     token_param,
@@ -1484,11 +1484,8 @@ impl ExecutionPlan for HttpExec {
                         }
                     };
 
-                    // Extract data rows using data_pointer if configured
-                    let content_rows =
-                        extract_page_data(&fetch_result.content, config, page_limit);
-
-                    // Extract next page info
+                    // Extract next page info first (before checking rows)
+                    // so we don't terminate pagination prematurely on empty pages
                     let next_info = extract_next_page_info(
                         &fetch_result.content,
                         &fetch_result.response_headers,
@@ -1497,8 +1494,25 @@ impl ExecutionPlan for HttpExec {
                     )
                     .map_err(DataFusionError::from)?;
 
+                    // Extract data rows using data_pointer if configured
+                    let content_rows = extract_page_data(&fetch_result.content, config, page_limit);
+
+                    // Update pagination state before deciding whether to yield a batch
+                    state.page += 1;
+                    state.next_info = next_info;
+                    if state.next_info.is_none() {
+                        state.done = true;
+                    }
+
                     if content_rows.is_empty() {
-                        return Ok(None);
+                        // No data rows on this page — if there's a next page, continue;
+                        // otherwise stop.
+                        if state.done {
+                            return Ok(None);
+                        }
+                        // Yield an empty batch to continue the stream
+                        let batch = RecordBatch::new_empty(Arc::clone(&exec.projected_schema));
+                        return Ok(Some((batch, state)));
                     }
 
                     let num_rows = content_rows.len();
@@ -1510,19 +1524,14 @@ impl ExecutionPlan for HttpExec {
                         &fetch_result,
                     )?;
 
+                    state.rows_fetched += num_rows;
+
                     tracing::debug!(
                         "Pagination page {}: {} rows fetched, total so far: {}",
-                        state.page,
+                        state.page - 1,
                         num_rows,
-                        state.rows_fetched + num_rows
+                        state.rows_fetched
                     );
-
-                    state.page += 1;
-                    state.rows_fetched += num_rows;
-                    state.next_info = next_info;
-                    if state.next_info.is_none() {
-                        state.done = true;
-                    }
 
                     Ok(Some((batch, state)))
                 }
@@ -1570,7 +1579,32 @@ struct PaginationState {
     done: bool,
 }
 
+/// Resolve a next-page URL string (absolute or relative) against the base URL
+/// and validate same-origin for SSRF protection.
+fn resolve_and_validate_url(raw: &str, base_url: &Url, context: &str) -> Result<Url> {
+    // Try absolute first, fall back to resolving relative against base
+    let resolved = Url::parse(raw)
+        .or_else(|_| base_url.join(raw))
+        .map_err(|e| Error::Pagination {
+            message: format!("Invalid next page URL in {context}: '{raw}': {e}"),
+        })?;
+    if resolved.origin() != base_url.origin() {
+        return Err(Error::Pagination {
+            message: format!(
+                "{context} URL origin '{}' does not match base URL origin '{}'. The next page URL must stay on the same origin.",
+                resolved.origin().ascii_serialization(),
+                base_url.origin().ascii_serialization(),
+            ),
+        });
+    }
+    Ok(resolved)
+}
+
 /// Extract the next page info from an HTTP response body and/or headers.
+///
+/// When `next_pointer` finds an explicit termination signal (null or empty string),
+/// pagination stops immediately. When the pointer path is missing from the response,
+/// we fall through to check the `Link` header (if configured) before giving up.
 fn extract_next_page_info(
     content: &str,
     response_headers: &[(String, String)],
@@ -1578,39 +1612,27 @@ fn extract_next_page_info(
     base_url: &Url,
 ) -> Result<Option<NextPageInfo>> {
     // Try response body JSON pointer first
-    if let Some(ref pointer) = config.next_pointer
-        && let Ok(json) = serde_json::from_str::<serde_json::Value>(content)
-    {
-        if let Some(value) = json.pointer(pointer) {
+    if let Some(ref pointer) = config.next_pointer {
+        let parsed = serde_json::from_str::<serde_json::Value>(content).ok();
+        if let Some(value) = parsed.as_ref().and_then(|json| json.pointer(pointer)) {
             if let Some(next_str) = value.as_str()
                 && !next_str.is_empty()
             {
                 if config.token_param.is_some() {
                     return Ok(Some(NextPageInfo::Token(next_str.to_string())));
                 }
-                let next_url =
-                    Url::parse(next_str).map_err(|e| Error::Pagination {
-                        message: format!(
-                            "Invalid next page URL at '{pointer}': '{next_str}': {e}"
-                        ),
-                    })?;
-                // SSRF protection: the next page URL must have the same origin
-                if next_url.origin() != base_url.origin() {
-                    return Err(Error::Pagination {
-                        message: format!(
-                            "Next page URL origin '{}' does not match base URL origin '{}'. The next page URL must stay on the same origin.",
-                            next_url.origin().ascii_serialization(),
-                            base_url.origin().ascii_serialization(),
-                        ),
-                    });
-                }
+                let next_url = resolve_and_validate_url(
+                    next_str,
+                    base_url,
+                    &format!("JSON pointer '{pointer}'"),
+                )?;
                 return Ok(Some(NextPageInfo::Url(next_url)));
             }
-            // Value is null, empty, or non-string — no more pages
+            // Value is null, empty, or non-string — explicit end of pagination
             return Ok(None);
         }
-        // Pointer path not found — no more pages
-        return Ok(None);
+        // Pointer path not found in response — fall through to Link header
+        // (the API may not include the field on the last page)
     }
 
     // Try HTTP Link header with rel="next"
@@ -1619,21 +1641,7 @@ fn extract_next_page_info(
             if name.eq_ignore_ascii_case("link")
                 && let Some(next_url_str) = parse_link_header_next(value)
             {
-                let next_url =
-                    Url::parse(&next_url_str).map_err(|e| Error::Pagination {
-                        message: format!(
-                            "Invalid URL in Link header: '{next_url_str}': {e}"
-                        ),
-                    })?;
-                if next_url.origin() != base_url.origin() {
-                    return Err(Error::Pagination {
-                        message: format!(
-                            "Link header URL origin '{}' does not match base URL origin '{}'. The next page URL must stay on the same origin.",
-                            next_url.origin().ascii_serialization(),
-                            base_url.origin().ascii_serialization(),
-                        ),
-                    });
-                }
+                let next_url = resolve_and_validate_url(&next_url_str, base_url, "Link header")?;
                 return Ok(Some(NextPageInfo::Url(next_url)));
             }
         }
@@ -1688,26 +1696,21 @@ fn extract_page_data(
 }
 
 /// Build a query string by adding or replacing a token parameter.
+/// Uses `url::form_urlencoded` for proper percent-encoding.
 fn build_query_with_token(existing_query: Option<&str>, param: &str, token: &str) -> String {
-    if let Some(existing) = existing_query {
-        // Remove any existing token param and add the new one
-        let cleaned: String = existing
-            .split('&')
-            .filter(|part| {
-                part.split('=')
-                    .next()
-                    .is_none_or(|key| key != param)
-            })
-            .collect::<Vec<&str>>()
-            .join("&");
-        if cleaned.is_empty() {
-            format!("{param}={token}")
-        } else {
-            format!("{cleaned}&{param}={token}")
-        }
+    let mut pairs: Vec<(String, String)> = if let Some(existing) = existing_query {
+        url::form_urlencoded::parse(existing.as_bytes())
+            .filter(|(key, _)| key != param)
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect()
     } else {
-        format!("{param}={token}")
-    }
+        Vec::new()
+    };
+    pairs.push((param.to_string(), token.to_string()));
+
+    url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(pairs)
+        .finish()
 }
 
 impl HttpTableProvider {
@@ -3758,10 +3761,7 @@ mod tests {
         let headers = vec![];
 
         let result = extract_next_page_info(content, &headers, &config, &base_url);
-        assert!(
-            result.is_err(),
-            "should reject cross-origin next page URLs"
-        );
+        assert!(result.is_err(), "should reject cross-origin next page URLs");
         let err_msg = result.expect_err("expected error").to_string();
         assert!(
             err_msg.contains("does not match"),
@@ -3776,7 +3776,7 @@ mod tests {
             use_link_header: true,
             ..Default::default()
         };
-        let content = r#"[1, 2, 3]"#;
+        let content = r"[1, 2, 3]";
         let headers = vec![(
             "link".to_string(),
             r#"<https://api.example.com/items?page=2>; rel="next""#.to_string(),
@@ -3909,8 +3909,7 @@ mod tests {
             next_pointer: Some("/pagination/next_url".to_string()),
             ..Default::default()
         };
-        let content =
-            r#"{"data": [], "pagination": {"next_url": "https://api.example.com/items?offset=20"}}"#;
+        let content = r#"{"data": [], "pagination": {"next_url": "https://api.example.com/items?offset=20"}}"#;
         let headers = vec![];
 
         let result =
@@ -3938,6 +3937,93 @@ mod tests {
         assert!(
             result.is_none(),
             "empty string next should mean no more pages"
+        );
+    }
+
+    #[test]
+    fn test_extract_next_page_info_relative_url() {
+        let base_url = Url::parse("https://api.example.com/v1").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1], "next": "/v1/items?page=2"}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(url.as_str(), "https://api.example.com/v1/items?page=2");
+            }
+            other => panic!("Expected Url from relative path, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_next_page_info_relative_link_header() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            use_link_header: true,
+            ..Default::default()
+        };
+        let content = r"[1, 2]";
+        let headers = vec![(
+            "link".to_string(),
+            r#"</items?page=3>; rel="next""#.to_string(),
+        )];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(url.as_str(), "https://api.example.com/items?page=3");
+            }
+            other => panic!("Expected Url from relative Link header, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_next_page_info_pointer_missing_falls_through_to_link_header() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/pagination/next_url".to_string()),
+            use_link_header: true,
+            ..Default::default()
+        };
+        // Response has no /pagination/next_url field, but does have a Link header
+        let content = r#"{"data": [1, 2]}"#;
+        let headers = vec![(
+            "link".to_string(),
+            r#"<https://api.example.com/items?page=2>; rel="next""#.to_string(),
+        )];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(
+                    url.as_str(),
+                    "https://api.example.com/items?page=2",
+                    "should fall through to Link header when pointer is missing"
+                );
+            }
+            other => panic!("Expected Url from Link header fallthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_query_with_token_special_chars() {
+        // Tokens with special characters should be properly percent-encoded
+        let result = build_query_with_token(None, "cursor", "abc 123&foo=bar");
+        // url::form_urlencoded encodes spaces as + and & as %26
+        assert!(
+            result.contains("cursor="),
+            "should contain cursor param: {result}"
+        );
+        assert!(
+            !result.contains("&foo="),
+            "special chars in token should be encoded, not treated as params: {result}"
         );
     }
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1464,12 +1464,28 @@ impl ExecutionPlan for HttpExec {
                         // Fetch this page
                         let fetch_result = if state.page == 0 {
                             let path_val = state.path.as_deref().unwrap_or("");
-                            let query_val = state.query.as_deref();
                             let body_val = state.body.as_deref();
+                            // Merge base URL query params with partition query,
+                            // consistent with how subsequent pages handle queries.
+                            let merged_query =
+                                match (provider.base_url.query(), state.query.as_deref()) {
+                                    (Some(base_query), Some(state_query))
+                                        if !base_query.is_empty() && !state_query.is_empty() =>
+                                    {
+                                        Some(format!("{base_query}&{state_query}"))
+                                    }
+                                    (Some(base_query), _) if !base_query.is_empty() => {
+                                        Some(base_query.to_string())
+                                    }
+                                    (_, Some(state_query)) if !state_query.is_empty() => {
+                                        Some(state_query.to_string())
+                                    }
+                                    _ => None,
+                                };
                             state.last_page_path = state.path.clone();
-                            state.last_page_query = state.query.clone();
+                            state.last_page_query = merged_query.clone();
                             provider
-                                .get_response(path_val, query_val, body_val)
+                                .get_response(path_val, merged_query.as_deref(), body_val)
                                 .await
                                 .map_err(DataFusionError::from)?
                         } else {
@@ -1478,6 +1494,23 @@ impl ExecutionPlan for HttpExec {
                             // under the same key as the base request.
                             match &state.next_info {
                                 Some(NextPageInfo::Url(url)) => {
+                                    if let Some((globset, patterns)) = &provider.allowed_paths
+                                        && !globset.is_match(url.path())
+                                    {
+                                        return Err(DataFusionError::External(Box::new(
+                                            Error::Pagination {
+                                                message: format!(
+                                                    "Next page URL path '{}' does not match any allowed path patterns: [{}]. Update 'allowed_request_paths' to include a matching pattern.",
+                                                    url.path(),
+                                                    patterns
+                                                        .iter()
+                                                        .map(|p| format!("'{p}'"))
+                                                        .collect::<Vec<_>>()
+                                                        .join(", ")
+                                                ),
+                                            },
+                                        )));
+                                    }
                                     state.last_page_path = Some(url.path().to_string());
                                     state.last_page_query = url.query().map(ToString::to_string);
                                     provider

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -4409,6 +4409,124 @@ mod tests {
     }
 
     #[test]
+    fn test_split_link_header_top_level_basic() {
+        // Comma outside angle brackets splits normally
+        let result = split_link_header_top_level("<a>; rel=prev, <b>; rel=next", ',');
+        assert_eq!(result, vec!["<a>; rel=prev", "<b>; rel=next"]);
+
+        // Comma inside angle brackets is preserved
+        let result = split_link_header_top_level("<a?x=1,2>; rel=next", ',');
+        assert_eq!(result, vec!["<a?x=1,2>; rel=next"]);
+
+        // Semicolons inside quoted strings are not split
+        let result = split_link_header_top_level(r#"<a>; title="a;b"; rel=next"#, ';');
+        assert_eq!(result, vec!["<a>", r#"title="a;b""#, "rel=next"]);
+    }
+
+    #[test]
+    fn test_split_link_header_top_level_escaped_quotes() {
+        // Escaped quote inside a quoted string should not close the string
+        let result =
+            split_link_header_top_level(r#"<a>; title="has \"escaped\" quotes"; rel=next"#, ';');
+        assert_eq!(
+            result,
+            vec!["<a>", r#"title="has \"escaped\" quotes""#, "rel=next"]
+        );
+    }
+
+    #[test]
+    fn test_split_link_header_top_level_empty_and_single() {
+        assert_eq!(split_link_header_top_level("", ','), vec![""]);
+        assert_eq!(
+            split_link_header_top_level("<a>; rel=next", ','),
+            vec!["<a>; rel=next"]
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_case_insensitive_rel() {
+        // REL and NEXT should be matched case-insensitively
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/page2>; REL="NEXT""#),
+            Some("https://api.example.com/page2".to_string())
+        );
+
+        assert_eq!(
+            parse_link_header_next("<https://api.example.com/page2>; Rel=Next"),
+            Some("https://api.example.com/page2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_extra_params() {
+        // Link with additional params like type and title
+        assert_eq!(
+            parse_link_header_next(
+                r#"<https://api.example.com/page2>; rel="next"; type="application/json"; title="Next Page""#
+            ),
+            Some("https://api.example.com/page2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_whitespace_variations() {
+        // No spaces around semicolons
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/page2>;rel="next""#),
+            Some("https://api.example.com/page2".to_string())
+        );
+
+        // Extra whitespace
+        assert_eq!(
+            parse_link_header_next(r#"  <https://api.example.com/page2> ;  rel="next"  "#),
+            Some("https://api.example.com/page2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_malformed() {
+        // Missing angle brackets
+        assert_eq!(
+            parse_link_header_next(r#"https://api.example.com/page2; rel="next""#),
+            None
+        );
+
+        // No rel param at all
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/page2>; type="text/html""#),
+            None
+        );
+
+        // rel="last" only
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/page2>; rel="last""#),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_next_is_second_link() {
+        // rel="next" is on the second link, not the first
+        assert_eq!(
+            parse_link_header_next(
+                r#"<https://api.example.com/page1>; rel="first", <https://api.example.com/page2>; rel="next", <https://api.example.com/page99>; rel="last""#
+            ),
+            Some("https://api.example.com/page2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_semicolon_in_quoted_title() {
+        // Semicolons inside quoted title param must not break parsing
+        assert_eq!(
+            parse_link_header_next(
+                r#"<https://api.example.com/page2>; title="Page; 2"; rel="next""#
+            ),
+            Some("https://api.example.com/page2".to_string())
+        );
+    }
+
+    #[test]
     fn test_merge_queries_all_sources() {
         let result = merge_queries(
             Some("api_key=secret"),

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1765,28 +1765,83 @@ fn extract_next_page_info(
     Ok(None)
 }
 
+/// Split a Link header value on a delimiter only when it appears at the
+/// top level — outside `<...>` URI references and `"..."` quoted strings.
+fn split_link_header_top_level(value: &str, delimiter: char) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_angle = false;
+    let mut in_quotes = false;
+    let mut escaped = false;
+
+    for (idx, ch) in value.char_indices() {
+        if in_quotes {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_quotes = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_quotes = true,
+            '<' => in_angle = true,
+            '>' => in_angle = false,
+            _ if ch == delimiter && !in_angle => {
+                parts.push(value[start..idx].trim());
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(value[start..].trim());
+    parts
+}
+
 /// Parse an HTTP `Link` header to find a URI with `rel="next"`.
 /// Handles quoted (`rel="next"`), single-quoted (`rel='next'`), and
 /// unquoted (`rel=next`) forms, as well as multi-value rel lists
 /// (e.g., `rel="next prev"`).
+///
+/// Splits on commas and semicolons only at the top level (outside `<...>`
+/// and `"..."`) so that URIs containing commas are handled correctly per
+/// RFC 8288.
 fn parse_link_header_next(header_value: &str) -> Option<String> {
-    for link in header_value.split(',') {
+    for link in split_link_header_top_level(header_value, ',') {
         let link = link.trim();
-        let mut parts = link.split(';');
-        let url_part = parts.next()?.trim();
-        let is_next = parts.any(|p| {
-            let p = p.trim().to_lowercase();
-            // Strip "rel=" prefix, then strip optional quotes
-            if let Some(val) = p.strip_prefix("rel=") {
-                let val = val.trim_matches('"').trim_matches('\'');
-                // Check if "next" is one of the space-separated rel values
-                val.split_whitespace().any(|v| v == "next")
-            } else {
-                false
-            }
-        });
-        if is_next && url_part.starts_with('<') && url_part.ends_with('>') {
-            return Some(url_part[1..url_part.len() - 1].to_string());
+        if !link.starts_with('<') {
+            continue;
+        }
+
+        let end = link.find('>')?;
+        let url_part = &link[1..end];
+        let params = link[end + 1..].trim();
+
+        let is_next = split_link_header_top_level(params, ';')
+            .into_iter()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .any(|param| {
+                let Some((name, value)) = param.split_once('=') else {
+                    return false;
+                };
+                if !name.trim().eq_ignore_ascii_case("rel") {
+                    return false;
+                }
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                value
+                    .split_whitespace()
+                    .any(|relation| relation.eq_ignore_ascii_case("next"))
+            });
+
+        if is_next {
+            return Some(url_part.to_string());
         }
     }
     None
@@ -4333,6 +4388,23 @@ mod tests {
         assert_eq!(
             parse_link_header_next(r#"<https://api.example.com/items?page=2>; rel="next prev""#),
             Some("https://api.example.com/items?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_link_header_uri_with_comma() {
+        // URI containing a comma inside <...> must not be split
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/items?a=1,2&page=2>; rel="next""#),
+            Some("https://api.example.com/items?a=1,2&page=2".to_string())
+        );
+
+        // Multiple links where the first URI contains a comma
+        assert_eq!(
+            parse_link_header_next(
+                r#"<https://api.example.com/items?x=a,b>; rel="prev", <https://api.example.com/items?page=3>; rel="next""#
+            ),
+            Some("https://api.example.com/items?page=3".to_string())
         );
     }
 

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -88,6 +88,9 @@ pub enum Error {
 
     #[snafu(display("HTTP provider configuration error: {message}"))]
     Configuration { message: String },
+
+    #[snafu(display("HTTP pagination error: {message}"))]
+    Pagination { message: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -117,14 +120,60 @@ impl From<Error> for DataFusionError {
             Error::FilterRejected { message } | Error::Configuration { message } => {
                 DataFusionError::Plan(message)
             }
+            Error::Pagination { message } => {
+                DataFusionError::External(Box::new(std::io::Error::other(message)))
+            }
         }
     }
 }
 
 pub const DEFAULT_MAX_QUERY_LENGTH: usize = 1024;
 pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024; // 16 KiB
+pub const DEFAULT_PAGINATION_MAX_PAGES: usize = 100;
 const MAX_REQUEST_PATH_LENGTH: usize = 1024;
 type PartitionSpec = (Option<String>, Option<String>, Option<String>);
+
+/// Configuration for paginated HTTP API requests.
+///
+/// Supports two modes:
+/// - **URL mode**: The response body (via `next_pointer`) or HTTP `Link` header contains
+///   the full URL for the next page.
+/// - **Token mode**: The response contains a cursor/token (via `next_pointer`) that is
+///   passed as a query parameter (specified by `token_param`) in the next request.
+#[derive(Clone, Debug)]
+pub struct PaginationConfig {
+    /// JSON pointer (RFC 6901) to the next page URL or cursor in the response body.
+    /// Example: `/next`, `/pagination/cursor`, `/links/next`
+    pub next_pointer: Option<String>,
+
+    /// Use the HTTP `Link` header with `rel="next"` for pagination.
+    pub use_link_header: bool,
+
+    /// When set, the value from `next_pointer` is treated as a cursor/token
+    /// and passed as this query parameter name in subsequent requests.
+    /// When not set, the value is treated as a full URL.
+    pub token_param: Option<String>,
+
+    /// JSON pointer (RFC 6901) to the data array in each page's response.
+    /// Example: `/data`, `/results`, `/items`
+    /// When set, only the array at this path is returned as data rows.
+    pub data_pointer: Option<String>,
+
+    /// Maximum number of pages to fetch. Default: 100
+    pub max_pages: usize,
+}
+
+impl Default for PaginationConfig {
+    fn default() -> Self {
+        Self {
+            next_pointer: None,
+            use_link_header: false,
+            token_param: None,
+            data_pointer: None,
+            max_pages: DEFAULT_PAGINATION_MAX_PAGES,
+        }
+    }
+}
 
 #[derive(Clone)]
 struct CachedResponse {
@@ -238,6 +287,7 @@ pub struct HttpTableProvider {
     allow_body_filters: bool,
     max_body_bytes: usize,
     health_probe: Option<String>,
+    pagination: Option<PaginationConfig>,
 }
 
 impl std::fmt::Debug for HttpTableProvider {
@@ -246,6 +296,7 @@ impl std::fmt::Debug for HttpTableProvider {
             .field("base_url", &self.base_url)
             .field("file_format", &self.file_format)
             .field("acceleration_enabled", &self.acceleration_enabled)
+            .field("pagination", &self.pagination)
             .finish_non_exhaustive()
     }
 }
@@ -281,6 +332,7 @@ impl HttpTableProvider {
             allow_body_filters: false,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             health_probe: None,
+            pagination: None,
         }
     }
 
@@ -426,6 +478,35 @@ impl HttpTableProvider {
         }
         self.health_probe = health_probe;
         Ok(self)
+    }
+
+    /// Configure pagination for this HTTP table provider.
+    ///
+    /// At least one of `next_pointer` or `use_link_header` must be set in the config.
+    pub fn with_pagination(mut self, config: PaginationConfig) -> Result<Self> {
+        if config.next_pointer.is_none() && !config.use_link_header {
+            return Err(Error::Configuration {
+                message: "Pagination requires either 'pagination_next_pointer' or 'pagination_link_header' to be configured.".to_string(),
+            });
+        }
+        if config.token_param.is_some() && config.next_pointer.is_none() {
+            return Err(Error::Configuration {
+                message: "Pagination 'pagination_token_param' requires 'pagination_next_pointer' to be configured.".to_string(),
+            });
+        }
+        ensure!(
+            config.max_pages > 0,
+            ConfigurationSnafu {
+                message: "pagination_max_pages must be greater than 0".to_string()
+            }
+        );
+        self.pagination = Some(config);
+        Ok(self)
+    }
+
+    #[must_use]
+    pub fn is_paginated(&self) -> bool {
+        self.pagination.is_some()
     }
 
     #[must_use]
@@ -1055,39 +1136,55 @@ impl HttpExec {
             .await
             .map_err(DataFusionError::from)?;
 
-        let HttpFetchResult {
-            content,
-            response_date,
-            response_status,
-            response_headers,
-            ..
-        } = result;
-
-        // Store the actual values from the partition for the primary key
-        let path_for_batch = path.as_deref().unwrap_or("");
-        let query_for_batch = query.as_deref().unwrap_or("");
-        let body_for_batch = body.as_deref().unwrap_or("");
-
-        tracing::debug!(
-            "Creating batch with request_path={:?}, content_len={}",
-            path_for_batch,
-            content.len()
-        );
-
         // Parse content to determine how many rows we'll create
-        let content_rows = Self::parse_content(&content, self.limit);
+        let content_rows = Self::parse_content(&result.content, self.limit);
+
+        self.create_batch_from_rows(
+            path.as_deref(),
+            query.as_deref(),
+            body.as_deref(),
+            &content_rows,
+            &result,
+        )
+    }
+
+    /// Create a `RecordBatch` from pre-parsed content rows and HTTP response metadata.
+    fn create_batch_from_rows(
+        &self,
+        path: Option<&str>,
+        query: Option<&str>,
+        body: Option<&str>,
+        content_rows: &[String],
+        fetch_result: &HttpFetchResult,
+    ) -> DataFusionResult<RecordBatch> {
         let num_rows = content_rows.len();
 
         if num_rows == 0 {
-            tracing::warn!("No rows found in HTTP response for partition {}", partition);
-            return Err(DataFusionError::Execution(
-                "No rows found in HTTP response".to_string(),
-            ));
+            return RecordBatch::try_new(
+                Arc::clone(&self.projected_schema),
+                self.projected_schema
+                    .fields()
+                    .iter()
+                    .map(|f| arrow::array::new_empty_array(f.data_type()))
+                    .collect(),
+            )
+            .map_err(DataFusionError::from);
         }
 
-        // Create columns with the same number of rows
+        // Store the actual values from the partition for the primary key
+        let path_for_batch = path.unwrap_or("");
+        let query_for_batch = query.unwrap_or("");
+        let body_for_batch = body.unwrap_or("");
+
+        tracing::debug!(
+            "Creating batch with request_path={:?}, content_len={}, num_rows={}",
+            path_for_batch,
+            fetch_result.content.len(),
+            num_rows
+        );
+
         // Use response Date header if available, otherwise use current time
-        let timestamp_nanos = if let Some(date) = response_date {
+        let timestamp_nanos = if let Some(date) = fetch_result.response_date {
             i64::try_from(
                 date.duration_since(std::time::UNIX_EPOCH)
                     .map_err(|e| DataFusionError::Execution(format!("Invalid response date: {e}")))?
@@ -1118,9 +1215,12 @@ impl HttpExec {
                 "request_body" => {
                     Ok(Arc::new(StringArray::from(vec![body_for_batch; num_rows])) as ArrayRef)
                 }
-                "content" => Ok(Arc::new(StringArray::from(content_rows.clone())) as ArrayRef),
+                "content" => {
+                    let values: Vec<&str> = content_rows.iter().map(String::as_str).collect();
+                    Ok(Arc::new(StringArray::from(values)) as ArrayRef)
+                }
                 "response_status" => {
-                    Ok(Arc::new(UInt16Array::from(vec![response_status; num_rows])) as ArrayRef)
+                    Ok(Arc::new(UInt16Array::from(vec![fetch_result.response_status; num_rows])) as ArrayRef)
                 }
                 "response_headers" => {
                     let mut builder = MapBuilder::new(
@@ -1133,7 +1233,7 @@ impl HttpExec {
                         StringBuilder::new(),
                     );
                     for _ in 0..num_rows {
-                        for (k, v) in &response_headers {
+                        for (k, v) in &fetch_result.response_headers {
                             builder.keys().append_value(k);
                             builder.values().append_value(v);
                         }
@@ -1292,20 +1392,321 @@ impl ExecutionPlan for HttpExec {
         let provider = Arc::clone(&self.provider);
         let schema = Arc::clone(&self.projected_schema);
 
-        // Use futures::stream::once to create a stream from a single async operation
-        let stream = futures::stream::once(async move {
-            tracing::trace!("Fetching partition {}", partition);
-            let batch = exec.fetch_and_create_batch(&provider, partition).await?;
-            tracing::trace!(
-                "Yielding batch for partition {}: {} rows",
-                partition,
-                batch.num_rows()
-            );
-            Ok(batch)
-        });
+        if provider.is_paginated() {
+            let (path, query, body) = self.partitions[partition].clone();
+            let limit = self.limit;
 
-        let stream_adapter = RecordBatchStreamAdapter::new(schema, stream);
-        Ok(Box::pin(stream_adapter))
+            let initial_state = PaginationState {
+                page: 0,
+                next_info: None,
+                rows_fetched: 0,
+                path,
+                query,
+                body,
+                limit,
+                done: false,
+            };
+
+            let stream = futures::stream::try_unfold(initial_state, move |mut state| {
+                let exec = Arc::clone(&exec);
+                let provider = Arc::clone(&provider);
+
+                async move {
+                    if state.done {
+                        return Ok::<_, DataFusionError>(None);
+                    }
+
+                    let config = provider.pagination.as_ref().ok_or_else(|| {
+                        DataFusionError::Internal("Pagination config missing".to_string())
+                    })?;
+
+                    if state.page >= config.max_pages {
+                        tracing::warn!(
+                            "Reached maximum pagination limit of {} pages",
+                            config.max_pages
+                        );
+                        return Ok(None);
+                    }
+
+                    if let Some(limit) = state.limit
+                        && state.rows_fetched >= limit
+                    {
+                        return Ok(None);
+                    }
+
+                    let page_limit = state.limit.map(|l| l.saturating_sub(state.rows_fetched));
+
+                    // Fetch this page
+                    let fetch_result = if state.page == 0 {
+                        let path_val = state.path.as_deref().unwrap_or("");
+                        let query_val = state.query.as_deref();
+                        let body_val = state.body.as_deref();
+                        provider
+                            .get_response(path_val, query_val, body_val)
+                            .await
+                            .map_err(DataFusionError::from)?
+                    } else {
+                        match &state.next_info {
+                            Some(NextPageInfo::Url(url)) => provider
+                                .perform_request_with_retry(
+                                    url.clone(),
+                                    state.body.as_deref(),
+                                    &format!("page_{}", state.page),
+                                )
+                                .await
+                                .map_err(DataFusionError::from)?,
+                            Some(NextPageInfo::Token(token)) => {
+                                let path_val = state.path.as_deref().unwrap_or("");
+                                let token_param =
+                                    config.token_param.as_deref().unwrap_or("cursor");
+                                let new_query = build_query_with_token(
+                                    state.query.as_deref(),
+                                    token_param,
+                                    token,
+                                );
+                                let url = provider
+                                    .build_request_url(path_val, Some(&new_query))
+                                    .map_err(DataFusionError::from)?;
+                                provider
+                                    .perform_request_with_retry(
+                                        url,
+                                        state.body.as_deref(),
+                                        &format!("page_{}", state.page),
+                                    )
+                                    .await
+                                    .map_err(DataFusionError::from)?
+                            }
+                            None => {
+                                return Err(DataFusionError::Internal(
+                                    "page > 0 but no next page info".to_string(),
+                                ));
+                            }
+                        }
+                    };
+
+                    // Extract data rows using data_pointer if configured
+                    let content_rows =
+                        extract_page_data(&fetch_result.content, config, page_limit);
+
+                    // Extract next page info
+                    let next_info = extract_next_page_info(
+                        &fetch_result.content,
+                        &fetch_result.response_headers,
+                        config,
+                        &provider.base_url,
+                    )
+                    .map_err(DataFusionError::from)?;
+
+                    if content_rows.is_empty() {
+                        return Ok(None);
+                    }
+
+                    let num_rows = content_rows.len();
+                    let batch = exec.create_batch_from_rows(
+                        state.path.as_deref(),
+                        state.query.as_deref(),
+                        state.body.as_deref(),
+                        &content_rows,
+                        &fetch_result,
+                    )?;
+
+                    tracing::debug!(
+                        "Pagination page {}: {} rows fetched, total so far: {}",
+                        state.page,
+                        num_rows,
+                        state.rows_fetched + num_rows
+                    );
+
+                    state.page += 1;
+                    state.rows_fetched += num_rows;
+                    state.next_info = next_info;
+                    if state.next_info.is_none() {
+                        state.done = true;
+                    }
+
+                    Ok(Some((batch, state)))
+                }
+            });
+
+            let stream_adapter = RecordBatchStreamAdapter::new(schema, stream);
+            Ok(Box::pin(stream_adapter))
+        } else {
+            // Non-paginated: single fetch
+            let stream = futures::stream::once(async move {
+                tracing::trace!("Fetching partition {}", partition);
+                let batch = exec.fetch_and_create_batch(&provider, partition).await?;
+                tracing::trace!(
+                    "Yielding batch for partition {}: {} rows",
+                    partition,
+                    batch.num_rows()
+                );
+                Ok(batch)
+            });
+
+            let stream_adapter = RecordBatchStreamAdapter::new(schema, stream);
+            Ok(Box::pin(stream_adapter))
+        }
+    }
+}
+
+// --- Pagination types and helpers ---
+
+#[derive(Clone, Debug)]
+enum NextPageInfo {
+    /// Full URL for the next page.
+    Url(Url),
+    /// Cursor/token to add as a query parameter.
+    Token(String),
+}
+
+struct PaginationState {
+    page: usize,
+    next_info: Option<NextPageInfo>,
+    rows_fetched: usize,
+    path: Option<String>,
+    query: Option<String>,
+    body: Option<String>,
+    limit: Option<usize>,
+    done: bool,
+}
+
+/// Extract the next page info from an HTTP response body and/or headers.
+fn extract_next_page_info(
+    content: &str,
+    response_headers: &[(String, String)],
+    config: &PaginationConfig,
+    base_url: &Url,
+) -> Result<Option<NextPageInfo>> {
+    // Try response body JSON pointer first
+    if let Some(ref pointer) = config.next_pointer
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(content)
+    {
+        if let Some(value) = json.pointer(pointer) {
+            if let Some(next_str) = value.as_str()
+                && !next_str.is_empty()
+            {
+                if config.token_param.is_some() {
+                    return Ok(Some(NextPageInfo::Token(next_str.to_string())));
+                }
+                let next_url =
+                    Url::parse(next_str).map_err(|e| Error::Pagination {
+                        message: format!(
+                            "Invalid next page URL at '{pointer}': '{next_str}': {e}"
+                        ),
+                    })?;
+                // SSRF protection: the next page URL must have the same origin
+                if next_url.origin() != base_url.origin() {
+                    return Err(Error::Pagination {
+                        message: format!(
+                            "Next page URL origin '{}' does not match base URL origin '{}'. The next page URL must stay on the same origin.",
+                            next_url.origin().ascii_serialization(),
+                            base_url.origin().ascii_serialization(),
+                        ),
+                    });
+                }
+                return Ok(Some(NextPageInfo::Url(next_url)));
+            }
+            // Value is null, empty, or non-string — no more pages
+            return Ok(None);
+        }
+        // Pointer path not found — no more pages
+        return Ok(None);
+    }
+
+    // Try HTTP Link header with rel="next"
+    if config.use_link_header {
+        for (name, value) in response_headers {
+            if name.eq_ignore_ascii_case("link")
+                && let Some(next_url_str) = parse_link_header_next(value)
+            {
+                let next_url =
+                    Url::parse(&next_url_str).map_err(|e| Error::Pagination {
+                        message: format!(
+                            "Invalid URL in Link header: '{next_url_str}': {e}"
+                        ),
+                    })?;
+                if next_url.origin() != base_url.origin() {
+                    return Err(Error::Pagination {
+                        message: format!(
+                            "Link header URL origin '{}' does not match base URL origin '{}'. The next page URL must stay on the same origin.",
+                            next_url.origin().ascii_serialization(),
+                            base_url.origin().ascii_serialization(),
+                        ),
+                    });
+                }
+                return Ok(Some(NextPageInfo::Url(next_url)));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Parse an HTTP `Link` header to find a URI with `rel="next"`.
+fn parse_link_header_next(header_value: &str) -> Option<String> {
+    for link in header_value.split(',') {
+        let link = link.trim();
+        let mut parts = link.split(';');
+        let url_part = parts.next()?.trim();
+        let is_next = parts.any(|p| {
+            let p = p.trim().to_lowercase();
+            p == "rel=\"next\"" || p == "rel='next'"
+        });
+        if is_next && url_part.starts_with('<') && url_part.ends_with('>') {
+            return Some(url_part[1..url_part.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+/// Extract data rows from a page response, using `data_pointer` if configured.
+fn extract_page_data(
+    content: &str,
+    config: &PaginationConfig,
+    limit: Option<usize>,
+) -> Vec<String> {
+    if let Some(ref pointer) = config.data_pointer
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(content)
+    {
+        if let Some(data) = json.pointer(pointer) {
+            if let Some(arr) = data.as_array() {
+                return arr
+                    .iter()
+                    .take(limit.unwrap_or(usize::MAX))
+                    .map(std::string::ToString::to_string)
+                    .collect();
+            }
+            // Not an array — return as a single row
+            return vec![data.to_string()];
+        }
+        tracing::warn!("Data pointer '{pointer}' not found in response");
+        return vec![];
+    }
+
+    // No data_pointer — use normal parse_content logic
+    HttpExec::parse_content(content, limit)
+}
+
+/// Build a query string by adding or replacing a token parameter.
+fn build_query_with_token(existing_query: Option<&str>, param: &str, token: &str) -> String {
+    if let Some(existing) = existing_query {
+        // Remove any existing token param and add the new one
+        let cleaned: String = existing
+            .split('&')
+            .filter(|part| {
+                part.split('=')
+                    .next()
+                    .is_none_or(|key| key != param)
+            })
+            .collect::<Vec<&str>>()
+            .join("&");
+        if cleaned.is_empty() {
+            format!("{param}={token}")
+        } else {
+            format!("{cleaned}&{param}={token}")
+        }
+    } else {
+        format!("{param}={token}")
     }
 }
 
@@ -3244,5 +3645,299 @@ mod tests {
 
         let count = count_col.value(0);
         assert_eq!(count, 2, "Should have counted exactly 2 rows for 2 shows");
+    }
+
+    // --- Pagination tests ---
+
+    #[test]
+    fn test_parse_link_header_next() {
+        assert_eq!(
+            parse_link_header_next(
+                r#"<https://api.example.com/items?page=2>; rel="next", <https://api.example.com/items?page=1>; rel="prev""#
+            ),
+            Some("https://api.example.com/items?page=2".to_string())
+        );
+
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/items?page=3>; rel="next""#),
+            Some("https://api.example.com/items?page=3".to_string())
+        );
+
+        // No rel="next"
+        assert_eq!(
+            parse_link_header_next(r#"<https://api.example.com/items?page=1>; rel="prev""#),
+            None
+        );
+
+        // Empty header
+        assert_eq!(parse_link_header_next(""), None);
+    }
+
+    #[test]
+    fn test_extract_next_page_info_json_pointer_url() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1, 2], "next": "https://api.example.com/items?page=2"}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(url.as_str(), "https://api.example.com/items?page=2");
+            }
+            other => panic!("Expected Url, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_next_page_info_json_pointer_token() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/cursor".to_string()),
+            token_param: Some("cursor".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1, 2], "cursor": "abc123"}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Token(token)) => {
+                assert_eq!(token, "abc123");
+            }
+            other => panic!("Expected Token, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_next_page_info_null_means_no_more_pages() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1, 2], "next": null}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        assert!(result.is_none(), "null next should mean no more pages");
+    }
+
+    #[test]
+    fn test_extract_next_page_info_missing_pointer_means_no_more_pages() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next_url".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1, 2]}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        assert!(
+            result.is_none(),
+            "missing pointer should mean no more pages"
+        );
+    }
+
+    #[test]
+    fn test_extract_next_page_info_ssrf_protection() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1], "next": "https://evil.com/steal-data"}"#;
+        let headers = vec![];
+
+        let result = extract_next_page_info(content, &headers, &config, &base_url);
+        assert!(
+            result.is_err(),
+            "should reject cross-origin next page URLs"
+        );
+        let err_msg = result.expect_err("expected error").to_string();
+        assert!(
+            err_msg.contains("does not match"),
+            "error should mention origin mismatch: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_extract_next_page_info_link_header() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            use_link_header: true,
+            ..Default::default()
+        };
+        let content = r#"[1, 2, 3]"#;
+        let headers = vec![(
+            "link".to_string(),
+            r#"<https://api.example.com/items?page=2>; rel="next""#.to_string(),
+        )];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(url.as_str(), "https://api.example.com/items?page=2");
+            }
+            other => panic!("Expected Url from Link header, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_page_data_with_data_pointer() {
+        let config = PaginationConfig {
+            data_pointer: Some("/results".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"results": [{"id": 1}, {"id": 2}], "next": "url"}"#;
+        let rows = extract_page_data(content, &config, None);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], r#"{"id":1}"#);
+        assert_eq!(rows[1], r#"{"id":2}"#);
+    }
+
+    #[test]
+    fn test_extract_page_data_with_limit() {
+        let config = PaginationConfig {
+            data_pointer: Some("/items".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}"#;
+        let rows = extract_page_data(content, &config, Some(2));
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_page_data_without_data_pointer() {
+        let config = PaginationConfig::default();
+        let content = r#"[{"id": 1}, {"id": 2}]"#;
+        let rows = extract_page_data(content, &config, None);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_page_data_missing_pointer() {
+        let config = PaginationConfig {
+            data_pointer: Some("/nonexistent".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"results": [1, 2, 3]}"#;
+        let rows = extract_page_data(content, &config, None);
+        assert!(rows.is_empty(), "missing pointer should return empty");
+    }
+
+    #[test]
+    fn test_build_query_with_token_no_existing() {
+        let result = build_query_with_token(None, "cursor", "abc123");
+        assert_eq!(result, "cursor=abc123");
+    }
+
+    #[test]
+    fn test_build_query_with_token_append() {
+        let result = build_query_with_token(Some("sort=date&limit=10"), "cursor", "abc123");
+        assert_eq!(result, "sort=date&limit=10&cursor=abc123");
+    }
+
+    #[test]
+    fn test_build_query_with_token_replace() {
+        let result =
+            build_query_with_token(Some("sort=date&cursor=old_token"), "cursor", "new_token");
+        assert_eq!(result, "sort=date&cursor=new_token");
+    }
+
+    #[test]
+    fn test_pagination_config_validation_requires_next_source() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig::default());
+        assert!(
+            result.is_err(),
+            "should require next_pointer or link_header"
+        );
+    }
+
+    #[test]
+    fn test_pagination_config_validation_token_needs_pointer() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig {
+            use_link_header: true,
+            token_param: Some("cursor".to_string()),
+            ..Default::default()
+        });
+        assert!(
+            result.is_err(),
+            "token_param without next_pointer should fail"
+        );
+    }
+
+    #[test]
+    fn test_pagination_config_valid_with_next_pointer() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        });
+        assert!(result.is_ok(), "should accept valid pagination config");
+        assert!(
+            result.expect("valid config").is_paginated(),
+            "should report as paginated"
+        );
+    }
+
+    #[test]
+    fn test_pagination_config_valid_with_link_header() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig {
+            use_link_header: true,
+            ..Default::default()
+        });
+        assert!(result.is_ok(), "should accept link_header pagination");
+    }
+
+    #[test]
+    fn test_extract_next_page_info_nested_pointer() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/pagination/next_url".to_string()),
+            ..Default::default()
+        };
+        let content =
+            r#"{"data": [], "pagination": {"next_url": "https://api.example.com/items?offset=20"}}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        match result {
+            Some(NextPageInfo::Url(url)) => {
+                assert_eq!(url.as_str(), "https://api.example.com/items?offset=20");
+            }
+            other => panic!("Expected Url from nested pointer, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_next_page_info_empty_string_means_no_more_pages() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"data": [1], "next": ""}"#;
+        let headers = vec![];
+
+        let result =
+            extract_next_page_info(content, &headers, &config, &base_url).expect("should succeed");
+        assert!(
+            result.is_none(),
+            "empty string next should mean no more pages"
+        );
     }
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -500,6 +500,26 @@ impl HttpTableProvider {
                 message: "pagination_max_pages must be greater than 0".to_string()
             }
         );
+        if let Some(ref pointer) = config.next_pointer {
+            ensure!(
+                pointer.starts_with('/'),
+                ConfigurationSnafu {
+                    message: format!(
+                        "pagination_next_pointer must be a valid JSON Pointer starting with '/': got '{pointer}'"
+                    )
+                }
+            );
+        }
+        if let Some(ref pointer) = config.data_pointer {
+            ensure!(
+                pointer.starts_with('/'),
+                ConfigurationSnafu {
+                    message: format!(
+                        "pagination_data_pointer must be a valid JSON Pointer starting with '/': got '{pointer}'"
+                    )
+                }
+            );
+        }
         self.pagination = Some(config);
         Ok(self)
     }
@@ -1495,7 +1515,8 @@ impl ExecutionPlan for HttpExec {
                     .map_err(DataFusionError::from)?;
 
                     // Extract data rows using data_pointer if configured
-                    let content_rows = extract_page_data(&fetch_result.content, config, page_limit);
+                    let content_rows =
+                        extract_page_data(&fetch_result.content, config, page_limit)?;
 
                     // Update pagination state before deciding whether to yield a batch
                     state.page += 1;
@@ -1613,23 +1634,39 @@ fn extract_next_page_info(
 ) -> Result<Option<NextPageInfo>> {
     // Try response body JSON pointer first
     if let Some(ref pointer) = config.next_pointer {
-        let parsed = serde_json::from_str::<serde_json::Value>(content).ok();
-        if let Some(value) = parsed.as_ref().and_then(|json| json.pointer(pointer)) {
-            if let Some(next_str) = value.as_str()
-                && !next_str.is_empty()
-            {
-                if config.token_param.is_some() {
-                    return Ok(Some(NextPageInfo::Token(next_str.to_string())));
+        let parsed = serde_json::from_str::<serde_json::Value>(content)
+            .map_err(|source| Error::Pagination {
+                message: format!(
+                    "Failed to parse pagination response body as JSON for pointer '{pointer}': {source}"
+                ),
+            })?;
+
+        if let Some(value) = parsed.pointer(pointer) {
+            match value {
+                serde_json::Value::String(next_str) if !next_str.is_empty() => {
+                    if config.token_param.is_some() {
+                        return Ok(Some(NextPageInfo::Token(next_str.clone())));
+                    }
+                    let next_url = resolve_and_validate_url(
+                        next_str,
+                        base_url,
+                        &format!("JSON pointer '{pointer}'"),
+                    )?;
+                    return Ok(Some(NextPageInfo::Url(next_url)));
                 }
-                let next_url = resolve_and_validate_url(
-                    next_str,
-                    base_url,
-                    &format!("JSON pointer '{pointer}'"),
-                )?;
-                return Ok(Some(NextPageInfo::Url(next_url)));
+                serde_json::Value::Null | serde_json::Value::String(_) => {
+                    // Null or empty string is an explicit end of pagination.
+                    return Ok(None);
+                }
+                _ => {
+                    return PaginationSnafu {
+                        message: format!(
+                            "Failed to extract pagination value from JSON pointer '{pointer}': expected a string or null"
+                        ),
+                    }
+                    .fail();
+                }
             }
-            // Value is null, empty, or non-string — explicit end of pagination
-            return Ok(None);
         }
         // Pointer path not found in response — fall through to Link header
         // (the API may not include the field on the last page)
@@ -1672,27 +1709,33 @@ fn extract_page_data(
     content: &str,
     config: &PaginationConfig,
     limit: Option<usize>,
-) -> Vec<String> {
-    if let Some(ref pointer) = config.data_pointer
-        && let Ok(json) = serde_json::from_str::<serde_json::Value>(content)
-    {
-        if let Some(data) = json.pointer(pointer) {
-            if let Some(arr) = data.as_array() {
-                return arr
-                    .iter()
-                    .take(limit.unwrap_or(usize::MAX))
-                    .map(std::string::ToString::to_string)
-                    .collect();
-            }
-            // Not an array — return as a single row
-            return vec![data.to_string()];
+) -> DataFusionResult<Vec<String>> {
+    if let Some(ref pointer) = config.data_pointer {
+        let json = serde_json::from_str::<serde_json::Value>(content).map_err(|source| {
+            DataFusionError::Execution(format!(
+                "Failed to extract paginated HTTP response data: response is not valid JSON for configured data pointer '{pointer}': {source}"
+            ))
+        })?;
+
+        let data = json.pointer(pointer).ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "Failed to extract paginated HTTP response data: configured data pointer '{pointer}' was not found in the response"
+            ))
+        })?;
+
+        if let Some(arr) = data.as_array() {
+            return Ok(arr
+                .iter()
+                .take(limit.unwrap_or(usize::MAX))
+                .map(std::string::ToString::to_string)
+                .collect());
         }
-        tracing::warn!("Data pointer '{pointer}' not found in response");
-        return vec![];
+        // Not an array — return as a single row
+        return Ok(vec![data.to_string()]);
     }
 
     // No data_pointer — use normal parse_content logic
-    HttpExec::parse_content(content, limit)
+    Ok(HttpExec::parse_content(content, limit))
 }
 
 /// Build a query string by adding or replacing a token parameter.
@@ -3799,7 +3842,7 @@ mod tests {
             ..Default::default()
         };
         let content = r#"{"results": [{"id": 1}, {"id": 2}], "next": "url"}"#;
-        let rows = extract_page_data(content, &config, None);
+        let rows = extract_page_data(content, &config, None).expect("should extract page data");
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], r#"{"id":1}"#);
         assert_eq!(rows[1], r#"{"id":2}"#);
@@ -3812,7 +3855,7 @@ mod tests {
             ..Default::default()
         };
         let content = r#"{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}"#;
-        let rows = extract_page_data(content, &config, Some(2));
+        let rows = extract_page_data(content, &config, Some(2)).expect("should extract page data");
         assert_eq!(rows.len(), 2);
     }
 
@@ -3820,7 +3863,7 @@ mod tests {
     fn test_extract_page_data_without_data_pointer() {
         let config = PaginationConfig::default();
         let content = r#"[{"id": 1}, {"id": 2}]"#;
-        let rows = extract_page_data(content, &config, None);
+        let rows = extract_page_data(content, &config, None).expect("should extract page data");
         assert_eq!(rows.len(), 2);
     }
 
@@ -3831,8 +3874,8 @@ mod tests {
             ..Default::default()
         };
         let content = r#"{"results": [1, 2, 3]}"#;
-        let rows = extract_page_data(content, &config, None);
-        assert!(rows.is_empty(), "missing pointer should return empty");
+        let result = extract_page_data(content, &config, None);
+        assert!(result.is_err(), "missing pointer should return error");
     }
 
     #[test]
@@ -4024,6 +4067,93 @@ mod tests {
         assert!(
             !result.contains("&foo="),
             "special chars in token should be encoded, not treated as params: {result}"
+        );
+    }
+
+    #[test]
+    fn test_extract_next_page_info_json_parse_error() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = "this is not json";
+        let headers = vec![];
+
+        let result = extract_next_page_info(content, &headers, &config, &base_url);
+        assert!(
+            result.is_err(),
+            "invalid JSON should return error when next_pointer is configured"
+        );
+    }
+
+    #[test]
+    fn test_extract_next_page_info_non_string_pointer_value_errors() {
+        let base_url = Url::parse("https://api.example.com").expect("valid URL");
+        let config = PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            ..Default::default()
+        };
+        let content = r#"{"next": 42}"#;
+        let headers = vec![];
+
+        let result = extract_next_page_info(content, &headers, &config, &base_url);
+        assert!(
+            result.is_err(),
+            "non-string pointer value should return error"
+        );
+    }
+
+    #[test]
+    fn test_extract_page_data_invalid_json() {
+        let config = PaginationConfig {
+            data_pointer: Some("/results".to_string()),
+            ..Default::default()
+        };
+        let content = "not valid json";
+        let result = extract_page_data(content, &config, None);
+        assert!(
+            result.is_err(),
+            "invalid JSON should return error when data_pointer is configured"
+        );
+    }
+
+    #[test]
+    fn test_with_pagination_invalid_next_pointer() {
+        let provider = HttpTableProvider::new(
+            Url::parse("https://example.com").expect("valid URL"),
+            Client::new(),
+            "json".to_string(),
+            false,
+        );
+        let result = provider.with_pagination(PaginationConfig {
+            next_pointer: Some("next".to_string()),
+            use_link_header: false,
+            ..Default::default()
+        });
+        assert!(
+            result.is_err(),
+            "next_pointer without leading '/' should fail"
+        );
+    }
+
+    #[test]
+    fn test_with_pagination_invalid_data_pointer() {
+        let provider = HttpTableProvider::new(
+            Url::parse("https://example.com").expect("valid URL"),
+            Client::new(),
+            "json".to_string(),
+            false,
+        );
+        let result = provider.with_pagination(PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            data_pointer: Some("results".to_string()),
+            use_link_header: false,
+            ..Default::default()
+        });
+        assert!(
+            result.is_err(),
+            "data_pointer without leading '/' should fail"
         );
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this Https except in compliance with the License.
@@ -141,7 +141,14 @@ impl Https {
             .ok()
             .is_some_and(util::parse_enabled);
 
-        has_allowed_paths || has_query_filters || has_body_filters
+        let has_pagination = self
+            .params
+            .get("pagination")
+            .expose()
+            .ok()
+            .is_some_and(util::parse_enabled);
+
+        has_allowed_paths || has_query_filters || has_body_filters || has_pagination
     }
 }
 
@@ -159,6 +166,7 @@ struct HttpProviderParams {
     allow_body_filters: bool,
     max_body_bytes: usize,
     health_probe: Option<String>,
+    pagination: Option<data_components::http::provider::PaginationConfig>,
 }
 
 impl Https {
@@ -254,6 +262,61 @@ impl Https {
             .ok()
             .map(std::string::ToString::to_string);
 
+        let pagination_enabled = self
+            .params
+            .get("pagination")
+            .expose()
+            .ok()
+            .is_some_and(util::parse_enabled);
+
+        let pagination = if pagination_enabled {
+            let next_pointer = self
+                .params
+                .get("pagination_next_pointer")
+                .expose()
+                .ok()
+                .map(std::string::ToString::to_string);
+
+            let use_link_header = self
+                .params
+                .get("pagination_link_header")
+                .expose()
+                .ok()
+                .is_some_and(util::parse_enabled);
+
+            let token_param = self
+                .params
+                .get("pagination_token_param")
+                .expose()
+                .ok()
+                .map(std::string::ToString::to_string);
+
+            let data_pointer = self
+                .params
+                .get("pagination_data_pointer")
+                .expose()
+                .ok()
+                .map(std::string::ToString::to_string);
+
+            let max_pages = self
+                .params
+                .get("pagination_max_pages")
+                .expose()
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES);
+
+            Some(data_components::http::provider::PaginationConfig {
+                next_pointer,
+                use_link_header,
+                token_param,
+                data_pointer,
+                max_pages,
+            })
+        } else {
+            None
+        };
+
         HttpProviderParams {
             file_format,
             acceleration_enabled: dataset.is_accelerated(),
@@ -268,6 +331,7 @@ impl Https {
             allow_body_filters,
             max_body_bytes,
             health_probe,
+            pagination,
         }
     }
 
@@ -419,6 +483,7 @@ impl Https {
             allow_body_filters,
             max_body_bytes,
             health_probe,
+            pagination,
         } = self.resolve_http_provider_params(dataset);
 
         let mut provider = data_components::http::provider::HttpTableProvider::new(
@@ -460,6 +525,26 @@ impl Https {
         if allow_body_filters {
             tracing::trace!("Enabling body filters with max_bytes={}", max_body_bytes);
             provider = provider.enable_body_filters(max_body_bytes);
+        }
+
+        if let Some(pagination_config) = pagination {
+            tracing::trace!(
+                "Enabling pagination for {}: next_pointer={:?}, link_header={}, token_param={:?}, data_pointer={:?}, max_pages={}",
+                dataset.name,
+                pagination_config.next_pointer,
+                pagination_config.use_link_header,
+                pagination_config.token_param,
+                pagination_config.data_pointer,
+                pagination_config.max_pages,
+            );
+            provider = provider.with_pagination(pagination_config).map_err(|e| {
+                DataConnectorError::InvalidConfiguration {
+                    dataconnector: "https".to_string(),
+                    message: format!("Invalid pagination configuration: {e}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: e.into(),
+                }
+            })?;
         }
 
         let provider = Arc::new(provider);
@@ -575,6 +660,20 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             .description("Maximum size (in bytes) for request_body filter values. Default: 16384 (16KiB)."),
         ParameterSpec::runtime("health_probe")
             .description("Custom health probe path for endpoint validation (e.g., '/health', '/api/status'). The endpoint must return a 2xx status code to pass validation. If not set, a random path is used and any status (including 404) is accepted."),
+        ParameterSpec::runtime("pagination")
+            .description("Set to 'enabled' to enable paginated fetching. Requires at least one of 'pagination_next_pointer' or 'pagination_link_header'.")
+            .one_of(&["enabled", "disabled"]),
+        ParameterSpec::runtime("pagination_next_pointer")
+            .description("JSON pointer (RFC 6901) to the next page URL or cursor in the response body (e.g., '/next', '/pagination/cursor', '/links/next')."),
+        ParameterSpec::runtime("pagination_link_header")
+            .description("Set to 'enabled' to use the HTTP Link header with rel=\"next\" for pagination.")
+            .one_of(&["enabled", "disabled"]),
+        ParameterSpec::runtime("pagination_token_param")
+            .description("When set, the value from 'pagination_next_pointer' is treated as a cursor/token and passed as this query parameter name in subsequent requests. When not set, the value is treated as a full URL."),
+        ParameterSpec::runtime("pagination_data_pointer")
+            .description("JSON pointer (RFC 6901) to the data array in each page's response (e.g., '/data', '/results', '/items'). When set, only the array at this path is returned as data rows."),
+        ParameterSpec::runtime("pagination_max_pages")
+            .description("Maximum number of pages to fetch for pagination. Default: 100."),
     ]);
     all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
     all_parameters

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -293,7 +293,7 @@ impl Https {
                 .map(std::string::ToString::to_string);
 
             let link_header_param = self.params.get("pagination_link_header").expose().ok();
-            let use_link_header = link_header_param.as_deref().is_none_or(util::parse_enabled);
+            let use_link_header = link_header_param.is_none_or(util::parse_enabled);
 
             let token_param = self
                 .params

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -292,12 +292,8 @@ impl Https {
                 .ok()
                 .map(std::string::ToString::to_string);
 
-            let use_link_header = self
-                .params
-                .get("pagination_link_header")
-                .expose()
-                .ok()
-                .is_none_or(util::parse_enabled);
+            let link_header_param = self.params.get("pagination_link_header").expose().ok();
+            let use_link_header = link_header_param.as_deref().is_none_or(util::parse_enabled);
 
             let token_param = self
                 .params
@@ -321,11 +317,13 @@ impl Https {
                 .and_then(|v| v.parse::<usize>().ok())
                 .unwrap_or(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES);
 
-            // In 'auto' mode with no explicit config, use Link header detection only
+            // In 'auto' mode with no explicit pagination sub-params,
+            // use Link header detection only (respecting pagination_link_header if set).
             if pagination_mode == "auto"
                 && next_pointer.is_none()
                 && token_param.is_none()
                 && data_pointer.is_none()
+                && link_header_param.is_none()
             {
                 Some(data_components::http::provider::PaginationConfig {
                     next_pointer: None,

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -146,7 +146,14 @@ impl Https {
             .get("pagination")
             .expose()
             .ok()
-            .map_or(true, |v| v != "disabled");
+            .is_some_and(|v| v == "enabled" || v == "true")
+            || [
+                "pagination_next_pointer",
+                "pagination_token_param",
+                "pagination_data_pointer",
+            ]
+            .iter()
+            .any(|key| self.params.get(key).expose().ok().is_some());
 
         has_allowed_paths || has_query_filters || has_body_filters || has_pagination
     }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -146,11 +146,13 @@ impl Https {
             .get("pagination")
             .expose()
             .ok()
-            .is_some_and(|v| v == "enabled" || v == "true")
+            .is_some_and(|v| v == "enabled" || v == "true" || v == "auto")
             || [
                 "pagination_next_pointer",
                 "pagination_token_param",
                 "pagination_data_pointer",
+                "pagination_link_header",
+                "pagination_max_pages",
             ]
             .iter()
             .any(|key| self.params.get(key).expose().ok().is_some());
@@ -280,7 +282,9 @@ impl Https {
                     _ => "auto",
                 });
 
-        let pagination = if pagination_mode != "disabled" {
+        let pagination = if pagination_mode == "disabled" {
+            None
+        } else {
             let next_pointer = self
                 .params
                 .get("pagination_next_pointer")
@@ -293,7 +297,7 @@ impl Https {
                 .get("pagination_link_header")
                 .expose()
                 .ok()
-                .map_or(true, util::parse_enabled);
+                .is_none_or(util::parse_enabled);
 
             let token_param = self
                 .params
@@ -339,8 +343,6 @@ impl Https {
                     max_pages,
                 })
             }
-        } else {
-            None
         };
 
         HttpProviderParams {
@@ -692,7 +694,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
         ParameterSpec::runtime("pagination_next_pointer")
             .description("JSON pointer (RFC 6901) to the next page URL or cursor in the response body (e.g., '/next', '/pagination/cursor', '/links/next')."),
         ParameterSpec::runtime("pagination_link_header")
-            .description("Set to 'enabled' to use the HTTP Link header with rel=\"next\" for pagination.")
+            .description("Whether to follow HTTP Link headers with rel=\"next\" for pagination. Default: 'enabled' (auto-detected). Set to 'disabled' to ignore Link headers.")
             .one_of(&["enabled", "disabled"]),
         ParameterSpec::runtime("pagination_token_param")
             .description("When set, the value from 'pagination_next_pointer' is treated as a cursor/token and passed as this query parameter name in subsequent requests. When not set, the value is treated as a full URL."),

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -146,7 +146,7 @@ impl Https {
             .get("pagination")
             .expose()
             .ok()
-            .is_some_and(util::parse_enabled);
+            .map_or(true, |v| v != "disabled");
 
         has_allowed_paths || has_query_filters || has_body_filters || has_pagination
     }
@@ -262,14 +262,18 @@ impl Https {
             .ok()
             .map(std::string::ToString::to_string);
 
-        let pagination_enabled = self
-            .params
-            .get("pagination")
-            .expose()
-            .ok()
-            .is_some_and(util::parse_enabled);
+        let pagination_mode =
+            self.params
+                .get("pagination")
+                .expose()
+                .ok()
+                .map_or("auto", |v| match v {
+                    "enabled" | "true" => "enabled",
+                    "disabled" | "false" => "disabled",
+                    _ => "auto",
+                });
 
-        let pagination = if pagination_enabled {
+        let pagination = if pagination_mode != "disabled" {
             let next_pointer = self
                 .params
                 .get("pagination_next_pointer")
@@ -282,7 +286,7 @@ impl Https {
                 .get("pagination_link_header")
                 .expose()
                 .ok()
-                .is_some_and(util::parse_enabled);
+                .map_or(true, util::parse_enabled);
 
             let token_param = self
                 .params
@@ -306,13 +310,28 @@ impl Https {
                 .and_then(|v| v.parse::<usize>().ok())
                 .unwrap_or(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES);
 
-            Some(data_components::http::provider::PaginationConfig {
-                next_pointer,
-                use_link_header,
-                token_param,
-                data_pointer,
-                max_pages,
-            })
+            // In 'auto' mode with no explicit config, use Link header detection only
+            if pagination_mode == "auto"
+                && next_pointer.is_none()
+                && token_param.is_none()
+                && data_pointer.is_none()
+            {
+                Some(data_components::http::provider::PaginationConfig {
+                    next_pointer: None,
+                    use_link_header: true,
+                    token_param: None,
+                    data_pointer: None,
+                    max_pages,
+                })
+            } else {
+                Some(data_components::http::provider::PaginationConfig {
+                    next_pointer,
+                    use_link_header,
+                    token_param,
+                    data_pointer,
+                    max_pages,
+                })
+            }
         } else {
             None
         };
@@ -661,8 +680,8 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
         ParameterSpec::runtime("health_probe")
             .description("Custom health probe path for endpoint validation (e.g., '/health', '/api/status'). The endpoint must return a 2xx status code to pass validation. If not set, a random path is used and any status (including 404) is accepted."),
         ParameterSpec::runtime("pagination")
-            .description("Set to 'enabled' to enable paginated fetching. Requires at least one of 'pagination_next_pointer' or 'pagination_link_header'.")
-            .one_of(&["enabled", "disabled"]),
+            .description("Pagination mode. 'auto' (default): auto-detects Link headers. 'enabled': explicitly enable with config. 'disabled': no pagination.")
+            .one_of(&["auto", "enabled", "disabled"]),
         ParameterSpec::runtime("pagination_next_pointer")
             .description("JSON pointer (RFC 6901) to the next page URL or cursor in the response body (e.g., '/next', '/pagination/cursor', '/links/next')."),
         ParameterSpec::runtime("pagination_link_header")

--- a/crates/runtime/tests/github/snapshots/integration__github__workflows_list_data.snap
+++ b/crates/runtime/tests/github/snapshots/integration__github__workflows_list_data.snap
@@ -2,17 +2,17 @@
 source: crates/runtime/tests/github/mod.rs
 expression: pretty_batches
 ---
-+-------------------------------+-------------------------------------------------+
-| name                          | path                                            |
-+-------------------------------+-------------------------------------------------+
-| spiced_docker                 | .github/workflows/spiced_docker.yml             |
-| Check for forbidden licenses  | .github/workflows/license_check.yml             |
-| CodeQL                        | .github/workflows/codeql-analysis.yml           |
-| build_and_release             | .github/workflows/build_and_release.yml         |
-| pr                            | .github/workflows/pr.yml                        |
-| E2E Test CI                   | .github/workflows/e2e_test_ci.yml               |
-| E2E Test Release Installation | .github/workflows/e2e_test_release_install.yml  |
-| Generate Acknowledgements     | .github/workflows/generate_acknowledgements.yml |
-| check all features            | .github/workflows/features.yml                  |
-| Test types support            | .github/workflows/types_check.yml               |
-+-------------------------------+-------------------------------------------------+
++---------------------------------------+-------------------------------------------------+
+| name                                  | path                                            |
++---------------------------------------+-------------------------------------------------+
+| spiced_docker                         | .github/workflows/spiced_docker.yml             |
+| Check for forbidden licenses          | .github/workflows/license_check.yml             |
+| .github/workflows/codeql-analysis.yml | .github/workflows/codeql-analysis.yml           |
+| build_and_release                     | .github/workflows/build_and_release.yml         |
+| pr                                    | .github/workflows/pr.yml                        |
+| E2E Test CI                           | .github/workflows/e2e_test_ci.yml               |
+| E2E Test Release Installation         | .github/workflows/e2e_test_release_install.yml  |
+| Generate Acknowledgements             | .github/workflows/generate_acknowledgements.yml |
+| check all features                    | .github/workflows/features.yml                  |
+| Test types support                    | .github/workflows/types_check.yml               |
++---------------------------------------+-------------------------------------------------+


### PR DESCRIPTION
## Summary

Add configurable pagination for HTTP API endpoints, enabling the HTTP data connector to automatically fetch and stream multiple pages from paginated REST APIs.

## Changes

### Two pagination modes

- **URL mode**: The next page URL is extracted from the response body (via JSON pointer) or from the HTTP `Link` header with `rel="next"`.
- **Token mode**: A cursor/token is extracted from the response body (via JSON pointer) and passed as a query parameter in subsequent requests.

### Configuration parameters

| Parameter | Description |
|-----------|-------------|
| `pagination` | Set to `enabled` to enable paginated fetching |
| `pagination_next_pointer` | JSON pointer (RFC 6901) to the next URL or cursor in the response body |
| `pagination_link_header` | Set to `enabled` to use the HTTP `Link` header for pagination |
| `pagination_token_param` | Query param name for cursor tokens (switches to token mode) |
| `pagination_data_pointer` | JSON pointer to the data array in each page's response |
| `pagination_max_pages` | Safety limit on pages fetched (default: 100) |

### Example spicepod configuration

```yaml
datasets:
  - from: https://api.example.com/v1/items
    name: items
    params:
      pagination: enabled
      pagination_next_pointer: /links/next
      pagination_data_pointer: /data
      pagination_max_pages: 50
    acceleration:
      enabled: true
      refresh_mode: caching
```

### Design

- **Streaming execution** via `futures::stream::try_unfold` — each page is fetched and yielded as a separate `RecordBatch`, avoiding buffering entire result sets in memory.
- **SSRF protection** — next-page URLs are validated to share the same origin as the base URL.
- **Caching accelerator compatible** — works transparently with caching, append, and full (with `refresh_sql`) acceleration modes since the paginated stream is consumed by the standard `scan()` → `collect()` refresh flow.
- **Refactored** batch creation into `create_batch_from_rows` for reuse between paginated and non-paginated code paths.

### Files changed

- `crates/data_components/src/http/provider.rs` — Core pagination implementation: `PaginationConfig`, streaming execution, next-page extraction, Link header parsing, SSRF validation, data pointer extraction, and 18 unit tests.
- `crates/runtime/src/dataconnector/https.rs` — Parameter parsing for the 6 new pagination params and wiring into the provider.

### Tests

18 new unit tests covering:
- Link header parsing (multiple entries, missing rel="next", empty)
- JSON pointer extraction (URL mode, token mode, nested pointers)
- Termination signals (null, empty string, missing pointer)
- SSRF rejection (cross-origin next page URLs)
- Data pointer extraction with limits
- Token query parameter building/replacement
- Config validation (requires next source, token needs pointer)