### PR TITLE
fix(databricks): harden HTTP retries, compression, and token refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,6 +5259,7 @@ dependencies = [
  "bb8",
  "bb8-oracle",
  "bigdecimal",
+ "brotli",
  "bytes",
  "charset",
  "chrono",
@@ -5275,6 +5276,7 @@ dependencies = [
  "document_parse",
  "duckdb",
  "dynamodb-streams",
+ "flate2",
  "flight_client",
  "futures",
  "git2",
@@ -5332,6 +5334,7 @@ dependencies = [
  "util",
  "uuid 1.21.0",
  "zip 7.4.0",
+ "zstd",
 ]
 
 [[package]]
@@ -16010,6 +16013,7 @@ dependencies = [
  "hf-hub",
  "http 1.4.0",
  "http-body-util",
+ "httpdate",
  "humantime",
  "hyper 1.8.1",
  "hyper-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16013,7 +16013,6 @@ dependencies = [
  "hf-hub",
  "http 1.4.0",
  "http-body-util",
- "httpdate",
  "humantime",
  "hyper 1.8.1",
  "hyper-util",

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -43,10 +43,13 @@ use util::fibonacci_backoff::FibonacciBackoffBuilder;
 /// application in the user-agent header of AWS API requests.
 ///
 /// The `AppName::new` call is infallible for this input: the name contains only alphanumeric
-/// characters plus `.` and `-`, all of which are permitted.
+/// characters plus `.` and `-`, all of which are permitted. The name is truncated to 50
+/// characters to stay within the AWS SDK's recommended limit.
 static APN_APP_NAME: LazyLock<AppName> = LazyLock::new(|| {
     let version = env!("CARGO_PKG_VERSION");
-    match AppName::new(format!("Spice-{version}")) {
+    let mut name = format!("Spice-{version}");
+    name.truncate(50);
+    match AppName::new(name) {
         Ok(name) => name,
         Err(_) => unreachable!("Spice version string should always be a valid AppName"),
     }
@@ -961,6 +964,11 @@ mod tests {
         assert!(
             name_str.starts_with("Spice-"),
             "APN app name should start with 'Spice-', got: {name_str}"
+        );
+        assert!(
+            name_str.len() <= 50,
+            "APN app name must be at most 50 characters, got {} ({name_str})",
+            name_str.len()
         );
     }
 

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -170,9 +170,11 @@ test_hadoop_catalog_docker = []
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-array = { workspace = true }
 aws-smithy-types = { workspace = true }
+brotli = "8.0.2"
 chrono = { workspace = true }
 criterion = { version = "0.7", features = ["async_tokio", "html_reports"] }
 ctor = "0.8.0"
+flate2 = "1.1.5"
 iceberg-storage-opendal.workspace = true
 iceberg_test_utils = { workspace = true, features = ["tests"] }
 insta.workspace = true
@@ -180,6 +182,7 @@ object_store = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+zstd = "0.13.3"
 
 [[bench]]
 harness = false

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -1530,9 +1530,11 @@ mod tests {
                         response.status_line,
                         response.body.len()
                     );
-                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
+                        let _ = std::fmt::Write::write_fmt(
+                            &mut http_response,
+                            format_args!("{header_name}: {header_value}\r\n"),
+                        );
                     }
                     http_response.push_str("\r\n");
                     http_response.push_str(&response.body);

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -280,13 +280,19 @@ impl SqlWarehouseApi {
         match self.get_schema_from_information_schema(&token, table).await {
             Ok(schema) => return Ok(schema),
             Err(
-                Error::TableSchemaNotRegistered { .. }
-                | Error::NoColumnsInDataset { .. }
-                | Error::QueryFailure { .. },
+                Error::TableSchemaNotRegistered { .. } | Error::NoColumnsInDataset { .. },
             ) => {
                 tracing::warn!(
                     table = %table,
                     "information_schema.columns has no metadata for this table, falling back to DESCRIBE TABLE. Column nullability will default to nullable."
+                );
+            }
+            Err(Error::QueryFailure { ref message })
+                if message.contains("UNSUPPORTED_DATA_SOURCE") =>
+            {
+                tracing::warn!(
+                    table = %table,
+                    "information_schema query returned UNSUPPORTED_DATA_SOURCE, falling back to DESCRIBE TABLE. Column nullability will default to nullable."
                 );
             }
             Err(e) => return Err(e),
@@ -2319,6 +2325,47 @@ mod tests {
             matches!(&err, Error::QueryFailure { message } if message.contains("UNRESOLVED_COLUMN")),
             "unexpected error: {err}"
         );
+    }
+
+    /// Regression test: tables backed by unsupported data sources (e.g.
+    /// Lakehouse Federation foreign tables) cause `information_schema`
+    /// queries to fail with `UNSUPPORTED_DATA_SOURCE`. The schema fetch
+    /// must fall back to `DESCRIBE TABLE` instead of surfacing the error.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_schema_falls_back_to_describe_on_unsupported_data_source() {
+        let unsupported_response = json!({
+            "status": {
+                "state": "FAILED",
+                "error": {
+                    "message": "[UNSUPPORTED_DATA_SOURCE] The input query contains unsupported data source(s). Only csv, json, avro, delta, kafka, parquet, orc, text, unity_catalog, binaryFile, xml, excel, simplescan, iceberg data sources are supported on Databricks SQL, and only csv, json, avro, delta, kafka, parquet, orc, text, unity_catalog, binaryFile, xml, excel, simplescan, iceberg data sources are allowed to run DML on Databricks SQL. SQLSTATE: 0A000"
+                }
+            },
+            "statement_id": "stmt-1"
+        });
+        // DESCRIBE TABLE succeeds as fallback.
+        let describe_response = json!({
+            "status": { "state": "SUCCEEDED" },
+            "statement_id": "stmt-2",
+            "result": {
+                "data_array": [
+                    ["id", "int", ""],
+                    ["name", "string", ""]
+                ]
+            }
+        });
+
+        let port =
+            start_mock_server(vec![unsupported_response, describe_response], json!({})).await;
+        let api = create_test_api(port);
+        let table = TableReference::full("catalog", "schema", "foreign_table");
+
+        let schema = api
+            .get_schema(&table)
+            .await
+            .expect("should fall back to DESCRIBE TABLE on UNSUPPORTED_DATA_SOURCE");
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "name");
     }
 
     /// Schema parsed from `full_data_type` column values matching a real

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use snafu::{Snafu, prelude::*};
 use std::{
+    error::Error as StdError,
     fmt::{Display, Formatter},
     io::Cursor,
     pin::Pin,
@@ -58,7 +59,7 @@ pub enum Error {
     #[snafu(display("This Databricks SQL Warehouse operation is not implemented"))]
     NotImplemented,
 
-    #[snafu(display("HTTP client build failed: {source}"))]
+    #[snafu(display("HTTP client build failed: {}", format_reqwest_error_chain(source)))]
     ClientBuildFailed { source: reqwest::Error },
 
     #[snafu(display("Databricks datatype {ty} not supported"))]
@@ -96,10 +97,10 @@ pub enum Error {
     #[snafu(display("Long-running operations are not supported (state: 'RUNNING')."))]
     QueryStillRunning,
 
-    #[snafu(display("HTTP request failed: {source}"))]
+    #[snafu(display("HTTP request failed: {}", format_reqwest_error_chain(source)))]
     HttpRequestFailed { source: reqwest::Error },
 
-    #[snafu(display("JSON parsing failed: {source}"))]
+    #[snafu(display("JSON parsing failed: {}", format_reqwest_error_chain(source)))]
     JsonParsingFailed { source: reqwest::Error },
 
     #[snafu(display("Missing JSON field: {field}"))]
@@ -132,6 +133,24 @@ pub enum Error {
         "Failed to execute the query. {message} Verify the query is valid, or report a bug at: https://github.com/spiceai/spiceai/issues"
     ))]
     QueryFailure { message: String },
+}
+
+fn format_reqwest_error_chain(error: &reqwest::Error) -> String {
+    let mut message = error.to_string();
+    let mut current = StdError::source(error);
+
+    while let Some(source) = current {
+        let source_message = source.to_string();
+        if !source_message.is_empty() {
+            let _ = std::fmt::Write::write_fmt(
+                &mut message,
+                format_args!("; caused by: {source_message}"),
+            );
+        }
+        current = StdError::source(source);
+    }
+
+    message
 }
 
 /// Main struct for interacting with Databricks SQL Warehouse
@@ -1847,6 +1866,40 @@ mod tests {
             requests.load(std::sync::atomic::Ordering::SeqCst),
             2,
             "expected the SQL statement request to be retried once"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_http_request_failed_displays_source_chain() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should reserve an unused port");
+        let port = listener
+            .local_addr()
+            .expect("listener should have an address")
+            .port();
+        drop(listener);
+
+        let source = Client::builder()
+            .connect_timeout(std::time::Duration::from_millis(100))
+            .timeout(std::time::Duration::from_millis(100))
+            .build()
+            .expect("should build client")
+            .post(format!("http://127.0.0.1:{port}/api/2.0/sql/statements/"))
+            .send()
+            .await
+            .expect_err("request should fail for a closed local port");
+
+        let err = Error::HttpRequestFailed { source };
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("HTTP request failed: error sending request for url"),
+            "error should include the reqwest request message: {msg}"
+        );
+        assert!(
+            msg.contains("caused by:"),
+            "error should include the underlying source chain: {msg}"
         );
     }
 

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -279,9 +279,7 @@ impl SqlWarehouseApi {
 
         match self.get_schema_from_information_schema(&token, table).await {
             Ok(schema) => return Ok(schema),
-            Err(
-                Error::TableSchemaNotRegistered { .. } | Error::NoColumnsInDataset { .. },
-            ) => {
+            Err(Error::TableSchemaNotRegistered { .. } | Error::NoColumnsInDataset { .. }) => {
                 tracing::warn!(
                     table = %table,
                     "information_schema.columns has no metadata for this table, falling back to DESCRIBE TABLE. Column nullability will default to nullable."

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -279,7 +279,11 @@ impl SqlWarehouseApi {
 
         match self.get_schema_from_information_schema(&token, table).await {
             Ok(schema) => return Ok(schema),
-            Err(Error::TableSchemaNotRegistered { .. } | Error::NoColumnsInDataset { .. }) => {
+            Err(
+                Error::TableSchemaNotRegistered { .. }
+                | Error::NoColumnsInDataset { .. }
+                | Error::QueryFailure { .. },
+            ) => {
                 tracing::warn!(
                     table = %table,
                     "information_schema.columns has no metadata for this table, falling back to DESCRIBE TABLE. Column nullability will default to nullable."

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -498,7 +498,8 @@ impl SqlWarehouseApi {
 
         let stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>> =
             Box::pin(
-                Box::pin(run_once.chain(batch_stream))
+                run_once
+                    .chain(batch_stream)
                     .map_err(|e| DataFusionError::Execution(e.to_string())),
             );
 
@@ -1529,8 +1530,9 @@ mod tests {
                         response.status_line,
                         response.body.len()
                     );
+                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
                     }
                     http_response.push_str("\r\n");
                     http_response.push_str(&response.body);

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -49,6 +49,8 @@ use util::{
     format_datafusion_error,
 };
 
+use crate::resilient_http::{enable_supported_compression, send_request_with_retry};
+
 mod datatypes;
 
 #[derive(Debug, Snafu)]
@@ -232,7 +234,7 @@ impl SqlWarehouseApi {
         sql_warehouse_id: &str,
         token_provider: Arc<dyn TokenProvider>,
     ) -> Result<Self, Error> {
-        let client = ClientBuilder::new()
+        let client = enable_supported_compression(ClientBuilder::new())
             .user_agent(super::user_agent())
             .connect_timeout(std::time::Duration::from_secs(10))
             .timeout(std::time::Duration::from_secs(30))
@@ -362,18 +364,16 @@ impl SqlWarehouseApi {
 
     async fn execute_sql_statement(&self, token: &str, payload: &Value) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/", self.base_url);
-        self.client
-            .post(&url)
-            .bearer_auth(token)
-            .json(payload)
-            .send()
-            .await
-            .context(HttpRequestFailedSnafu)?
-            .error_for_status()
-            .context(HttpRequestFailedSnafu)?
-            .json()
-            .await
-            .context(JsonParsingFailedSnafu)
+        send_request_with_retry("Databricks SQL Warehouse", "execute SQL statement", || {
+            self.client.post(&url).bearer_auth(token).json(payload)
+        })
+        .await
+        .context(HttpRequestFailedSnafu)?
+        .error_for_status()
+        .context(HttpRequestFailedSnafu)?
+        .json()
+        .await
+        .context(JsonParsingFailedSnafu)
     }
 
     async fn get_sql_statement_status(
@@ -382,17 +382,18 @@ impl SqlWarehouseApi {
         statement_id: &str,
     ) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/{statement_id}", self.base_url);
-        self.client
-            .get(&url)
-            .bearer_auth(token)
-            .send()
-            .await
-            .context(HttpRequestFailedSnafu)?
-            .error_for_status()
-            .context(HttpRequestFailedSnafu)?
-            .json()
-            .await
-            .context(JsonParsingFailedSnafu)
+        send_request_with_retry(
+            "Databricks SQL Warehouse",
+            "poll SQL statement status",
+            || self.client.get(&url).bearer_auth(token),
+        )
+        .await
+        .context(HttpRequestFailedSnafu)?
+        .error_for_status()
+        .context(HttpRequestFailedSnafu)?
+        .json()
+        .await
+        .context(JsonParsingFailedSnafu)
     }
 
     // Fetch the arrow data at the external links, repeating for each chunk
@@ -405,10 +406,13 @@ impl SqlWarehouseApi {
 
         // If no external link, return an empty stream
         if initial_external_link.is_none() {
+            let empty_stream: Pin<
+                Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>,
+            > = Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
                 Arc::new(Schema::empty()),
-                Box::pin(stream::empty()),
-            )));
+                empty_stream,
+            )) as SendableRecordBatchStream);
         }
 
         let token = token.clone();
@@ -437,16 +441,15 @@ impl SqlWarehouseApi {
                 let next_link = match link.next_chunk_internal_link {
                     Some(path) => {
                         let url = format!("{}{path}", api.base_url);
-                        match api
-                            .client
-                            .get(&url)
-                            .bearer_auth(&token)
-                            .send()
-                            .await
-                            .context(HttpRequestFailedSnafu)
-                            .and_then(|resp| {
-                                resp.error_for_status().context(HttpRequestFailedSnafu)
-                            }) {
+                        match send_request_with_retry(
+                            "Databricks SQL Warehouse",
+                            "fetch next external chunk link",
+                            || api.client.get(&url).bearer_auth(&token),
+                        )
+                        .await
+                        .context(HttpRequestFailedSnafu)
+                        .and_then(|resp| resp.error_for_status().context(HttpRequestFailedSnafu))
+                        {
                             Ok(response) => match response
                                 .json()
                                 .await
@@ -480,21 +483,26 @@ impl SqlWarehouseApi {
             Some(Ok(batch)) => batch,
             Some(Err(e)) => return Err(e),
             None => {
+                let empty_stream: Pin<
+                    Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>,
+                > = Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
                 return Ok(Box::pin(RecordBatchStreamAdapter::new(
                     Arc::new(Schema::empty()),
-                    Box::pin(stream::empty()),
-                )));
+                    empty_stream,
+                )) as SendableRecordBatchStream);
             }
         };
 
         let schema = first_batch.schema();
         let run_once = stream::once(async move { Ok(first_batch) });
 
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            schema,
-            Box::pin(run_once.chain(batch_stream))
-                .map_err(|e| DataFusionError::Execution(e.to_string())),
-        )))
+        let stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>> =
+            Box::pin(
+                Box::pin(run_once.chain(batch_stream))
+                    .map_err(|e| DataFusionError::Execution(e.to_string())),
+            );
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)) as SendableRecordBatchStream)
     }
 
     /// Deserializes the first [`ExternalLink`] in the `external_links` array, or None if missing or empty
@@ -520,16 +528,18 @@ impl SqlWarehouseApi {
     }
 
     async fn fetch_chunk_data(&self, url: &str) -> Result<bytes::Bytes, Error> {
-        self.client
-            .get(url)
-            .send()
-            .await
-            .context(HttpRequestFailedSnafu)?
-            .error_for_status()
-            .context(HttpRequestFailedSnafu)?
-            .bytes()
-            .await
-            .context(HttpRequestFailedSnafu)
+        send_request_with_retry(
+            "Databricks SQL Warehouse",
+            "fetch statement result chunk",
+            || self.client.get(url),
+        )
+        .await
+        .context(HttpRequestFailedSnafu)?
+        .error_for_status()
+        .context(HttpRequestFailedSnafu)?
+        .bytes()
+        .await
+        .context(HttpRequestFailedSnafu)
     }
 
     fn read_arrow_batches(
@@ -1466,8 +1476,77 @@ mod tests {
         port
     }
 
+    #[derive(Clone)]
+    struct MockHttpResponse {
+        status_line: &'static str,
+        headers: Vec<(String, String)>,
+        body: String,
+    }
+
+    async fn start_mock_http_server(
+        responses: Vec<MockHttpResponse>,
+        default_response: MockHttpResponse,
+    ) -> (u16, Arc<std::sync::atomic::AtomicUsize>) {
+        use std::{
+            collections::VecDeque,
+            sync::atomic::{AtomicUsize, Ordering},
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind to a port");
+        let port = listener
+            .local_addr()
+            .expect("should have an address")
+            .port();
+        let responses = Arc::new(tokio::sync::Mutex::new(VecDeque::from(responses)));
+        let default = Arc::new(default_response);
+        let requests = Arc::new(AtomicUsize::new(0));
+
+        let requests_for_server = Arc::clone(&requests);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let responses = Arc::clone(&responses);
+                let default = Arc::clone(&default);
+                let requests = Arc::clone(&requests_for_server);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buf = vec![0u8; 4096];
+                    let _ = stream.read(&mut buf).await;
+                    requests.fetch_add(1, Ordering::SeqCst);
+
+                    let response = {
+                        let mut q = responses.lock().await;
+                        q.pop_front().unwrap_or_else(|| (*default).clone())
+                    };
+
+                    let mut http_response = format!(
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
+                        response.status_line,
+                        response.body.len()
+                    );
+                    for (header_name, header_value) in response.headers {
+                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                    }
+                    http_response.push_str("\r\n");
+                    http_response.push_str(&response.body);
+
+                    let _ = stream.write_all(http_response.as_bytes()).await;
+                });
+            }
+        });
+
+        (port, requests)
+    }
+
     fn create_test_api(port: u16) -> SqlWarehouseApi {
-        let client = ClientBuilder::new().build().expect("should build client");
+        let client = enable_supported_compression(ClientBuilder::new())
+            .build()
+            .expect("should build client");
         SqlWarehouseApi {
             client,
             base_url: format!("http://127.0.0.1:{port}"),
@@ -1704,7 +1783,6 @@ mod tests {
             !stmt_full.contains(", data_type,"),
             "SQL should not reference plain data_type: {stmt_full}"
         );
-
         let payload_plain = api
             .create_schema_payload(&table, "data_type")
             .expect("should create payload with data_type");
@@ -1718,6 +1796,53 @@ mod tests {
         assert!(
             !stmt_plain.contains("full_data_type"),
             "SQL should not reference full_data_type: {stmt_plain}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_execute_sql_statement_retries_rate_limited_response() {
+        let success_body = json!({
+            "status": { "state": "SUCCEEDED" },
+            "statement_id": "stmt-1",
+            "result": { "data_array": [] }
+        })
+        .to_string();
+
+        let (port, requests) = start_mock_http_server(
+            vec![
+                MockHttpResponse {
+                    status_line: "429 Too Many Requests",
+                    headers: vec![
+                        ("Content-Type".to_string(), "application/json".to_string()),
+                        ("Retry-After".to_string(), "0".to_string()),
+                    ],
+                    body: json!({"error_code": "RATE_LIMITED"}).to_string(),
+                },
+                MockHttpResponse {
+                    status_line: "200 OK",
+                    headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                    body: success_body,
+                },
+            ],
+            MockHttpResponse {
+                status_line: "200 OK",
+                headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                body: json!({"ok": true}).to_string(),
+            },
+        )
+        .await;
+
+        let api = create_test_api(port);
+        let response = api
+            .execute_sql_statement("token", &json!({"statement": "SELECT 1"}))
+            .await
+            .expect("SQL statement should succeed after retrying the rate-limited response");
+
+        assert_eq!(response["status"]["state"], "SUCCEEDED");
+        assert_eq!(
+            requests.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected the SQL statement request to be retried once"
         );
     }
 

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -51,7 +51,9 @@ use util::{
     format_datafusion_error,
 };
 
-use crate::resilient_http::{configure_client_builder, send_request_with_retry};
+use crate::resilient_http::{
+    configure_client_builder, send_request_with_retry_and_concurrency_limit,
+};
 
 mod datatypes;
 
@@ -105,11 +107,6 @@ pub enum Error {
 
     #[snafu(display("JSON parsing failed: {}", format_reqwest_error_chain(source)))]
     JsonParsingFailed { source: reqwest::Error },
-
-    #[snafu(display(
-        "Internal error: failed to acquire a Databricks SQL Warehouse request permit: {source}"
-    ))]
-    RequestPermitFailed { source: tokio::sync::AcquireError },
 
     #[snafu(display("Missing JSON field: {field}"))]
     MissingJsonField { field: String },
@@ -276,13 +273,6 @@ impl SqlWarehouseApi {
         })
     }
 
-    async fn acquire_request_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, Error> {
-        Arc::clone(&self.request_semaphore)
-            .acquire_owned()
-            .await
-            .context(RequestPermitFailedSnafu)
-    }
-
     async fn get_schema(&self, table: &TableReference) -> Result<SchemaRef, Error> {
         let token = self.token_provider.get_token();
         let table_name = table.to_string();
@@ -398,10 +388,12 @@ impl SqlWarehouseApi {
 
     async fn execute_sql_statement(&self, token: &str, payload: &Value) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/", self.base_url);
-        let _permit = self.acquire_request_permit().await?;
-        send_request_with_retry("Databricks SQL Warehouse", "execute SQL statement", || {
-            self.client.post(&url).bearer_auth(token).json(payload)
-        })
+        send_request_with_retry_and_concurrency_limit(
+            "Databricks SQL Warehouse",
+            "execute SQL statement",
+            || self.client.post(&url).bearer_auth(token).json(payload),
+            Some(&self.request_semaphore),
+        )
         .await
         .context(HttpRequestFailedSnafu)?
         .error_for_status()
@@ -417,11 +409,11 @@ impl SqlWarehouseApi {
         statement_id: &str,
     ) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/{statement_id}", self.base_url);
-        let _permit = self.acquire_request_permit().await?;
-        send_request_with_retry(
+        send_request_with_retry_and_concurrency_limit(
             "Databricks SQL Warehouse",
             "poll SQL statement status",
             || self.client.get(&url).bearer_auth(token),
+            Some(&self.request_semaphore),
         )
         .await
         .context(HttpRequestFailedSnafu)?
@@ -477,15 +469,12 @@ impl SqlWarehouseApi {
                 let next_link = match link.next_chunk_internal_link {
                     Some(path) => {
                         let url = format!("{}{path}", api.base_url);
-                        let permit = match api.acquire_request_permit().await {
-                            Ok(permit) => permit,
-                            Err(error) => return Some((Err(error), None)),
-                        };
 
-                        match send_request_with_retry(
+                        match send_request_with_retry_and_concurrency_limit(
                             "Databricks SQL Warehouse",
                             "fetch next external chunk link",
                             || api.client.get(&url).bearer_auth(&token),
+                            Some(&api.request_semaphore),
                         )
                         .await
                         .context(HttpRequestFailedSnafu)
@@ -497,10 +486,7 @@ impl SqlWarehouseApi {
                                 .context(JsonParsingFailedSnafu)
                                 .and_then(Self::extract_external_links)
                             {
-                                Ok(next) => {
-                                    drop(permit);
-                                    next
-                                }
+                                Ok(next) => next,
                                 Err(e) => return Some((Err(e), None)),
                             },
                             Err(e) => return Some((Err(e), None)),
@@ -573,11 +559,11 @@ impl SqlWarehouseApi {
     }
 
     async fn fetch_chunk_data(&self, url: &str) -> Result<bytes::Bytes, Error> {
-        let _permit = self.acquire_request_permit().await?;
-        send_request_with_retry(
+        send_request_with_retry_and_concurrency_limit(
             "Databricks SQL Warehouse",
             "fetch statement result chunk",
             || self.client.get(url),
+            Some(&self.request_semaphore),
         )
         .await
         .context(HttpRequestFailedSnafu)?

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -45,14 +45,17 @@ use std::{
     sync::Arc,
 };
 use token_provider::TokenProvider;
+use tokio::sync::Semaphore;
 use util::{
     fibonacci_backoff::{Backoff, FibonacciBackoffBuilder},
     format_datafusion_error,
 };
 
-use crate::resilient_http::{enable_supported_compression, send_request_with_retry};
+use crate::resilient_http::{configure_client_builder, send_request_with_retry};
 
 mod datatypes;
+
+const SQL_WAREHOUSE_MAX_IN_FLIGHT_REQUESTS: usize = 8;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -102,6 +105,11 @@ pub enum Error {
 
     #[snafu(display("JSON parsing failed: {}", format_reqwest_error_chain(source)))]
     JsonParsingFailed { source: reqwest::Error },
+
+    #[snafu(display(
+        "Internal error: failed to acquire a Databricks SQL Warehouse request permit: {source}"
+    ))]
+    RequestPermitFailed { source: tokio::sync::AcquireError },
 
     #[snafu(display("Missing JSON field: {field}"))]
     MissingJsonField { field: String },
@@ -243,6 +251,7 @@ impl FromStr for ResponseStatus {
 struct SqlWarehouseApi {
     client: Client,
     base_url: String,
+    request_semaphore: Arc<Semaphore>,
     sql_warehouse_id: String,
     token_provider: Arc<dyn TokenProvider>,
 }
@@ -253,19 +262,25 @@ impl SqlWarehouseApi {
         sql_warehouse_id: &str,
         token_provider: Arc<dyn TokenProvider>,
     ) -> Result<Self, Error> {
-        let client = enable_supported_compression(ClientBuilder::new())
+        let client = configure_client_builder(ClientBuilder::new())
             .user_agent(super::user_agent())
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
             .build()
             .context(ClientBuildFailedSnafu)?;
 
         Ok(Self {
             client,
             base_url: format!("https://{host}"),
+            request_semaphore: Arc::new(Semaphore::new(SQL_WAREHOUSE_MAX_IN_FLIGHT_REQUESTS)),
             sql_warehouse_id: sql_warehouse_id.to_string(),
             token_provider,
         })
+    }
+
+    async fn acquire_request_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, Error> {
+        Arc::clone(&self.request_semaphore)
+            .acquire_owned()
+            .await
+            .context(RequestPermitFailedSnafu)
     }
 
     async fn get_schema(&self, table: &TableReference) -> Result<SchemaRef, Error> {
@@ -383,6 +398,7 @@ impl SqlWarehouseApi {
 
     async fn execute_sql_statement(&self, token: &str, payload: &Value) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/", self.base_url);
+        let _permit = self.acquire_request_permit().await?;
         send_request_with_retry("Databricks SQL Warehouse", "execute SQL statement", || {
             self.client.post(&url).bearer_auth(token).json(payload)
         })
@@ -401,6 +417,7 @@ impl SqlWarehouseApi {
         statement_id: &str,
     ) -> Result<Value, Error> {
         let url = format!("{}/api/2.0/sql/statements/{statement_id}", self.base_url);
+        let _permit = self.acquire_request_permit().await?;
         send_request_with_retry(
             "Databricks SQL Warehouse",
             "poll SQL statement status",
@@ -460,6 +477,11 @@ impl SqlWarehouseApi {
                 let next_link = match link.next_chunk_internal_link {
                     Some(path) => {
                         let url = format!("{}{path}", api.base_url);
+                        let permit = match api.acquire_request_permit().await {
+                            Ok(permit) => permit,
+                            Err(error) => return Some((Err(error), None)),
+                        };
+
                         match send_request_with_retry(
                             "Databricks SQL Warehouse",
                             "fetch next external chunk link",
@@ -475,7 +497,10 @@ impl SqlWarehouseApi {
                                 .context(JsonParsingFailedSnafu)
                                 .and_then(Self::extract_external_links)
                             {
-                                Ok(next) => next,
+                                Ok(next) => {
+                                    drop(permit);
+                                    next
+                                }
                                 Err(e) => return Some((Err(e), None)),
                             },
                             Err(e) => return Some((Err(e), None)),
@@ -548,6 +573,7 @@ impl SqlWarehouseApi {
     }
 
     async fn fetch_chunk_data(&self, url: &str) -> Result<bytes::Bytes, Error> {
+        let _permit = self.acquire_request_permit().await?;
         send_request_with_retry(
             "Databricks SQL Warehouse",
             "fetch statement result chunk",
@@ -1567,15 +1593,95 @@ mod tests {
     }
 
     fn create_test_api(port: u16) -> SqlWarehouseApi {
-        let client = enable_supported_compression(ClientBuilder::new())
+        create_test_api_with_request_limit(port, SQL_WAREHOUSE_MAX_IN_FLIGHT_REQUESTS)
+    }
+
+    fn create_test_api_with_request_limit(
+        port: u16,
+        max_in_flight_requests: usize,
+    ) -> SqlWarehouseApi {
+        let client = configure_client_builder(ClientBuilder::new())
             .build()
             .expect("should build client");
         SqlWarehouseApi {
             client,
             base_url: format!("http://127.0.0.1:{port}"),
+            request_semaphore: Arc::new(Semaphore::new(max_in_flight_requests)),
             sql_warehouse_id: "test-warehouse".to_string(),
             token_provider: Arc::new(StaticTokenProvider("test-token".to_string())),
         }
+    }
+
+    async fn start_blocking_mock_http_server(
+        response: MockHttpResponse,
+    ) -> (
+        u16,
+        Arc<std::sync::atomic::AtomicUsize>,
+        tokio::sync::mpsc::UnboundedReceiver<()>,
+        Arc<Semaphore>,
+    ) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind to a port");
+        let port = listener
+            .local_addr()
+            .expect("should have an address")
+            .port();
+        let response = Arc::new(response);
+        let max_active_requests = Arc::new(AtomicUsize::new(0));
+        let active_requests = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let gate = Arc::new(Semaphore::new(0));
+
+        let max_active_requests_for_server = Arc::clone(&max_active_requests);
+        let active_requests_for_server = Arc::clone(&active_requests);
+        let gate_for_server = Arc::clone(&gate);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let response = Arc::clone(&response);
+                let started_tx = started_tx.clone();
+                let max_active_requests = Arc::clone(&max_active_requests_for_server);
+                let active_requests = Arc::clone(&active_requests_for_server);
+                let gate = Arc::clone(&gate_for_server);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buf = vec![0u8; 4096];
+                    let _ = stream.read(&mut buf).await;
+
+                    let active = active_requests.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_active_requests.fetch_max(active, Ordering::SeqCst);
+                    let _ = started_tx.send(());
+
+                    let permit = gate.acquire().await.expect("gate should remain open");
+                    drop(permit);
+
+                    let mut http_response = format!(
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
+                        response.status_line,
+                        response.body.len()
+                    );
+                    for (header_name, header_value) in &response.headers {
+                        let _ = std::fmt::Write::write_fmt(
+                            &mut http_response,
+                            format_args!("{header_name}: {header_value}\r\n"),
+                        );
+                    }
+                    http_response.push_str("\r\n");
+                    http_response.push_str(&response.body);
+
+                    let _ = stream.write_all(http_response.as_bytes()).await;
+                    active_requests.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+        });
+
+        (port, max_active_requests, started_rx, gate)
     }
 
     fn pending_response() -> Value {
@@ -1867,6 +1973,83 @@ mod tests {
             2,
             "expected the SQL statement request to be retried once"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_execute_sql_statement_limits_concurrent_requests() {
+        use std::sync::atomic::Ordering;
+
+        let (port, max_active_requests, mut started_rx, gate) =
+            start_blocking_mock_http_server(MockHttpResponse {
+                status_line: "200 OK",
+                headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                body: json!({
+                    "status": { "state": "SUCCEEDED" },
+                    "statement_id": "stmt-1",
+                    "result": { "data_array": [] }
+                })
+                .to_string(),
+            })
+            .await;
+
+        let api = Arc::new(create_test_api_with_request_limit(port, 1));
+
+        let first_payload = json!({"statement": "SELECT 1"});
+        let first_api = Arc::clone(&api);
+        let first = tokio::spawn(async move {
+            first_api
+                .execute_sql_statement("token", &first_payload)
+                .await
+        });
+
+        started_rx
+            .recv()
+            .await
+            .expect("the first request should reach the server");
+
+        let second_payload = json!({"statement": "SELECT 2"});
+        let second_api = Arc::clone(&api);
+        let second = tokio::spawn(async move {
+            second_api
+                .execute_sql_statement("token", &second_payload)
+                .await
+        });
+
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            max_active_requests.load(Ordering::SeqCst),
+            1,
+            "only one Databricks HTTP request should be in flight at a time"
+        );
+        assert!(
+            started_rx.try_recv().is_err(),
+            "the second request should wait for a permit before reaching the server"
+        );
+
+        gate.add_permits(1);
+
+        started_rx
+            .recv()
+            .await
+            .expect("the second request should start after the first finishes");
+
+        gate.add_permits(1);
+
+        let first_response = first
+            .await
+            .expect("the first task should join")
+            .expect("the first request should succeed");
+        let second_response = second
+            .await
+            .expect("the second task should join")
+            .expect("the second request should succeed");
+
+        assert_eq!(first_response["status"]["state"], "SUCCEEDED");
+        assert_eq!(second_response["status"]["state"], "SUCCEEDED");
+        assert_eq!(max_active_requests.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -56,7 +56,7 @@ pub mod oracle;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 pub mod refresh_skip;
-mod resilient_http;
+pub mod resilient_http;
 pub mod s3_single_file_cached;
 #[cfg(feature = "s3_vectors")]
 pub mod s3_vectors;

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -56,6 +56,7 @@ pub mod oracle;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 pub mod refresh_skip;
+mod resilient_http;
 pub mod s3_single_file_cached;
 #[cfg(feature = "s3_vectors")]
 pub mod s3_vectors;

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -91,6 +91,8 @@ where
                         "Retrying HTTP request after retryable response"
                     );
 
+                    drain_response_body(response, service_name, operation_name, retries, status)
+                        .await;
                     tokio::time::sleep(delay).await;
                     continue;
                 }
@@ -135,6 +137,32 @@ where
 
 pub(crate) fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
     builder.gzip(true).brotli(true).zstd(true).deflate(true)
+}
+
+async fn drain_response_body(
+    mut response: Response,
+    service_name: &str,
+    operation_name: &str,
+    attempt: usize,
+    status: StatusCode,
+) {
+    loop {
+        match response.chunk().await {
+            Ok(Some(_)) => {}
+            Ok(None) => return,
+            Err(error) => {
+                tracing::debug!(
+                    service = service_name,
+                    operation = operation_name,
+                    attempt,
+                    status = %status,
+                    error = %error,
+                    "Failed to drain retry response body before retry"
+                );
+                return;
+            }
+        }
+    }
 }
 
 fn add_supported_accept_encoding_header(request: RequestBuilder) -> RequestBuilder {
@@ -231,7 +259,7 @@ mod tests {
     }
 
     impl MockHttpResponse {
-        fn json(status_line: &'static str, body: serde_json::Value) -> Self {
+        fn json(status_line: &'static str, body: &serde_json::Value) -> Self {
             Self {
                 status_line,
                 headers: vec![("Content-Type".to_string(), "application/json".to_string())],
@@ -271,29 +299,29 @@ mod tests {
                 let queued_responses = Arc::clone(&queued_responses);
                 let captured_requests = Arc::clone(&captured_requests_for_server);
                 tokio::spawn(async move {
-                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    use tokio::io::AsyncWriteExt;
 
-                    let mut buf = vec![0u8; 4096];
-                    let bytes_read = stream.read(&mut buf).await.unwrap_or_default();
+                    let captured_request = read_http_request(&mut stream).await;
                     requests.fetch_add(1, Ordering::SeqCst);
                     captured_requests
                         .lock()
                         .await
-                        .push(String::from_utf8_lossy(&buf[..bytes_read]).into_owned());
+                        .push(String::from_utf8_lossy(&captured_request).into_owned());
 
                     let response = queued_responses
                         .lock()
                         .await
                         .pop_front()
-                        .unwrap_or_else(|| MockHttpResponse::json("200 OK", json!({"ok": true})));
+                        .unwrap_or_else(|| MockHttpResponse::json("200 OK", &json!({"ok": true})));
 
                     let mut http_response = format!(
                         "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
                         response.status_line,
                         response.body.len()
                     );
+                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
                     }
                     http_response.push_str("\r\n");
                     let _ = stream.write_all(http_response.as_bytes()).await;
@@ -303,6 +331,56 @@ mod tests {
         });
 
         (format!("http://{address}"), requests, captured_requests)
+    }
+
+    async fn read_http_request(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+
+        let mut captured_request = Vec::with_capacity(4096);
+        let mut buf = [0u8; 1024];
+        let mut expected_total_len = None;
+
+        loop {
+            let bytes_read = match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(bytes_read) => bytes_read,
+            };
+
+            captured_request.extend_from_slice(&buf[..bytes_read]);
+
+            if expected_total_len.is_none() {
+                expected_total_len = expected_http_request_len(&captured_request);
+            }
+
+            if let Some(expected_total_len) = expected_total_len
+                && captured_request.len() >= expected_total_len
+            {
+                break;
+            }
+        }
+
+        captured_request
+    }
+
+    fn expected_http_request_len(request: &[u8]) -> Option<usize> {
+        let headers_end = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)?;
+
+        let content_length = String::from_utf8_lossy(&request[..headers_end])
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        Some(headers_end.saturating_add(content_length))
     }
 
     fn encode_body(encoding: &str, body: &[u8]) -> Vec<u8> {
@@ -374,7 +452,7 @@ mod tests {
                 body: serde_json::to_vec(&json!({"error_code": "RATE_LIMITED"}))
                     .expect("rate-limit JSON should serialize"),
             },
-            MockHttpResponse::json("200 OK", json!({"ok": true})),
+            MockHttpResponse::json("200 OK", &json!({"ok": true})),
         ])
         .await;
 
@@ -399,8 +477,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_send_request_with_retry_retries_server_error() {
         let (base_url, requests, _) = start_mock_server(vec![
-            MockHttpResponse::json("503 Service Unavailable", json!({"error": "busy"})),
-            MockHttpResponse::json("200 OK", json!({"ok": true})),
+            MockHttpResponse::json("503 Service Unavailable", &json!({"error": "busy"})),
+            MockHttpResponse::json("200 OK", &json!({"ok": true})),
         ])
         .await;
 

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -74,7 +74,7 @@ where
     let mut retries = 0usize;
 
     loop {
-        let _permit =
+        let permit =
             acquire_concurrency_permit(concurrency_limit, service_name, operation_name).await;
         match add_supported_accept_encoding_header(build_request())
             .send()
@@ -114,7 +114,7 @@ where
 
                     drain_response_body(response, service_name, operation_name, retries, status)
                         .await;
-                    drop(_permit);
+                    drop(permit);
                     tokio::time::sleep(delay).await;
                     continue;
                 }
@@ -151,7 +151,7 @@ where
                     "Retrying HTTP request after transient request failure"
                 );
 
-                drop(_permit);
+                drop(permit);
                 tokio::time::sleep(delay).await;
             }
         }
@@ -177,16 +177,15 @@ async fn acquire_concurrency_permit<'a>(
     operation_name: &str,
 ) -> Option<tokio::sync::SemaphorePermit<'a>> {
     let sem = semaphore?;
-    match sem.acquire().await {
-        Ok(permit) => Some(permit),
-        Err(_) => {
-            tracing::warn!(
-                service = service_name,
-                operation = operation_name,
-                "Request concurrency limiter closed; proceeding without limit"
-            );
-            None
-        }
+    if let Ok(permit) = sem.acquire().await {
+        Some(permit)
+    } else {
+        tracing::warn!(
+            service = service_name,
+            operation = operation_name,
+            "Request concurrency limiter closed; proceeding without limit"
+        );
+        None
     }
 }
 

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -25,7 +25,7 @@ const MAX_HTTP_RETRIES: usize = 6;
 const MAX_HTTP_BACKOFF: Duration = Duration::from_secs(300);
 const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
 const X_RETRY_AFTER_MS_HEADER: &str = "x-retry-after-ms";
-pub(crate) const SUPPORTED_ACCEPT_ENCODINGS: &str = "zstd, br, gzip, deflate";
+pub const SUPPORTED_ACCEPT_ENCODINGS: &str = "zstd, br, gzip, deflate";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum RetryReason {
@@ -34,7 +34,7 @@ enum RetryReason {
     Network,
 }
 
-pub(crate) async fn send_request_with_retry<F>(
+pub async fn send_request_with_retry<F>(
     service_name: &str,
     operation_name: &str,
     build_request: F,
@@ -135,7 +135,7 @@ where
     }
 }
 
-pub(crate) fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
+pub fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
     builder.gzip(true).brotli(true).zstd(true).deflate(true)
 }
 

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -1,0 +1,470 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use reqwest::{
+    ClientBuilder, RequestBuilder, Response, StatusCode,
+    header::{ACCEPT_ENCODING, HeaderMap, RETRY_AFTER},
+};
+use std::time::{Duration, SystemTime};
+use util::retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder};
+
+const MAX_HTTP_RETRIES: usize = 6;
+const MAX_HTTP_BACKOFF: Duration = Duration::from_secs(300);
+const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
+const X_RETRY_AFTER_MS_HEADER: &str = "x-retry-after-ms";
+pub(crate) const SUPPORTED_ACCEPT_ENCODINGS: &str = "zstd, br, gzip, deflate";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RetryReason {
+    RateLimit,
+    ServerError,
+    Network,
+}
+
+pub(crate) async fn send_request_with_retry<F>(
+    service_name: &str,
+    operation_name: &str,
+    build_request: F,
+) -> Result<Response, reqwest::Error>
+where
+    F: Fn() -> RequestBuilder,
+{
+    let mut transient_backoff = RetryBackoffBuilder::new()
+        .method(BackoffMethod::Fibonacci)
+        .max_duration(Some(MAX_HTTP_BACKOFF))
+        .build();
+    let mut rate_limit_backoff = RetryBackoffBuilder::new()
+        .method(BackoffMethod::Exponential)
+        .base_interval(Duration::from_secs(1))
+        .max_duration(Some(MAX_HTTP_BACKOFF))
+        .build();
+
+    let mut retries = 0usize;
+
+    loop {
+        match add_supported_accept_encoding_header(build_request())
+            .send()
+            .await
+        {
+            Ok(response) => {
+                let status = response.status();
+                if let Some(reason) = retry_reason_from_status(status) {
+                    if retries >= MAX_HTTP_RETRIES {
+                        tracing::warn!(
+                            service = service_name,
+                            operation = operation_name,
+                            status = %status,
+                            retries,
+                            max_retries = MAX_HTTP_RETRIES,
+                            "HTTP retries exhausted after retryable response"
+                        );
+                        return Ok(response);
+                    }
+
+                    retries += 1;
+                    let retry_after = retry_after_duration(response.headers());
+                    let backoff =
+                        next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
+                    let delay = retry_after.map_or(backoff, |retry_after| retry_after.max(backoff));
+
+                    tracing::warn!(
+                        service = service_name,
+                        operation = operation_name,
+                        attempt = retries,
+                        max_retries = MAX_HTTP_RETRIES,
+                        status = %status,
+                        retry_after = ?retry_after,
+                        delay = ?delay,
+                        "Retrying HTTP request after retryable response"
+                    );
+
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                return Ok(response);
+            }
+            Err(error) => {
+                let Some(reason) = retry_reason_from_error(&error) else {
+                    return Err(error);
+                };
+
+                if retries >= MAX_HTTP_RETRIES {
+                    tracing::warn!(
+                        service = service_name,
+                        operation = operation_name,
+                        retries,
+                        max_retries = MAX_HTTP_RETRIES,
+                        error = %error,
+                        "HTTP retries exhausted after transient request failure"
+                    );
+                    return Err(error);
+                }
+
+                retries += 1;
+                let delay = next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
+
+                tracing::warn!(
+                    service = service_name,
+                    operation = operation_name,
+                    attempt = retries,
+                    max_retries = MAX_HTTP_RETRIES,
+                    delay = ?delay,
+                    error = %error,
+                    "Retrying HTTP request after transient request failure"
+                );
+
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+pub(crate) fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
+    builder.gzip(true).brotli(true).zstd(true).deflate(true)
+}
+
+fn add_supported_accept_encoding_header(request: RequestBuilder) -> RequestBuilder {
+    request.header(ACCEPT_ENCODING, SUPPORTED_ACCEPT_ENCODINGS)
+}
+
+fn next_backoff(
+    reason: RetryReason,
+    transient_backoff: &mut impl Backoff,
+    rate_limit_backoff: &mut impl Backoff,
+) -> Duration {
+    match reason {
+        RetryReason::RateLimit => rate_limit_backoff
+            .next_backoff()
+            .unwrap_or(MAX_HTTP_BACKOFF),
+        RetryReason::ServerError | RetryReason::Network => {
+            transient_backoff.next_backoff().unwrap_or(MAX_HTTP_BACKOFF)
+        }
+    }
+}
+
+fn retry_reason_from_error(error: &reqwest::Error) -> Option<RetryReason> {
+    if error.is_connect() || error.is_timeout() {
+        return Some(RetryReason::Network);
+    }
+
+    error.status().and_then(retry_reason_from_status)
+}
+
+fn retry_reason_from_status(status: StatusCode) -> Option<RetryReason> {
+    match status.as_u16() {
+        408 | 429 => Some(RetryReason::RateLimit),
+        500..=599 => Some(RetryReason::ServerError),
+        _ => None,
+    }
+}
+
+fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
+    retry_after_millis_duration(headers).or_else(|| {
+        headers
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| retry_after_duration_from_value(value, SystemTime::now()))
+    })
+}
+
+fn retry_after_millis_duration(headers: &HeaderMap) -> Option<Duration> {
+    [RETRY_AFTER_MS_HEADER, X_RETRY_AFTER_MS_HEADER]
+        .into_iter()
+        .find_map(|header_name| {
+            headers
+                .get(header_name)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .map(Duration::from_millis)
+        })
+}
+
+fn retry_after_duration_from_value(value: &str, now: SystemTime) -> Option<Duration> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    trimmed
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
+        .or_else(|| {
+            httpdate::parse_http_date(trimmed)
+                .ok()
+                .map(|retry_after| retry_after.duration_since(now).unwrap_or(Duration::ZERO))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use brotli::CompressorReader;
+    use flate2::{
+        Compression,
+        write::{GzEncoder, ZlibEncoder},
+    };
+    use reqwest::Client;
+    use serde_json::json;
+    use std::{collections::VecDeque, io::Read, io::Write, sync::Arc};
+    use tokio::sync::Mutex;
+
+    #[derive(Clone)]
+    struct MockHttpResponse {
+        status_line: &'static str,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    }
+
+    impl MockHttpResponse {
+        fn json(status_line: &'static str, body: serde_json::Value) -> Self {
+            Self {
+                status_line,
+                headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                body: serde_json::to_vec(&body).expect("mock JSON should serialize"),
+            }
+        }
+    }
+
+    async fn start_mock_server(
+        responses: Vec<MockHttpResponse>,
+    ) -> (
+        String,
+        Arc<std::sync::atomic::AtomicUsize>,
+        Arc<Mutex<Vec<String>>>,
+    ) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind to a port");
+        let address = listener
+            .local_addr()
+            .expect("should have a listener address");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let queued_responses = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+
+        let requests_for_server = Arc::clone(&requests);
+        let captured_requests_for_server = Arc::clone(&captured_requests);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+
+                let requests = Arc::clone(&requests_for_server);
+                let queued_responses = Arc::clone(&queued_responses);
+                let captured_requests = Arc::clone(&captured_requests_for_server);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buf = vec![0u8; 4096];
+                    let bytes_read = stream.read(&mut buf).await.unwrap_or_default();
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    captured_requests
+                        .lock()
+                        .await
+                        .push(String::from_utf8_lossy(&buf[..bytes_read]).into_owned());
+
+                    let response = queued_responses
+                        .lock()
+                        .await
+                        .pop_front()
+                        .unwrap_or_else(|| MockHttpResponse::json("200 OK", json!({"ok": true})));
+
+                    let mut http_response = format!(
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
+                        response.status_line,
+                        response.body.len()
+                    );
+                    for (header_name, header_value) in response.headers {
+                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                    }
+                    http_response.push_str("\r\n");
+                    let _ = stream.write_all(http_response.as_bytes()).await;
+                    let _ = stream.write_all(&response.body).await;
+                });
+            }
+        });
+
+        (format!("http://{address}"), requests, captured_requests)
+    }
+
+    fn encode_body(encoding: &str, body: &[u8]) -> Vec<u8> {
+        match encoding {
+            "gzip" => {
+                let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+                encoder
+                    .write_all(body)
+                    .expect("gzip encoder should accept the response body");
+                encoder.finish().expect("gzip encoder should finish")
+            }
+            "deflate" => {
+                let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+                encoder
+                    .write_all(body)
+                    .expect("deflate encoder should accept the response body");
+                encoder.finish().expect("deflate encoder should finish")
+            }
+            "br" => {
+                let mut compressed = Vec::new();
+                let mut reader = CompressorReader::new(body, 4096, 5, 22);
+                reader
+                    .read_to_end(&mut compressed)
+                    .expect("brotli encoder should finish");
+                compressed
+            }
+            "zstd" => zstd::stream::encode_all(body, 0).expect("zstd encoder should finish"),
+            other => panic!("unsupported encoding in test: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_retry_after_duration_from_seconds() {
+        let duration = retry_after_duration_from_value("42", SystemTime::UNIX_EPOCH)
+            .expect("seconds-based Retry-After should parse");
+
+        assert_eq!(duration, Duration::from_secs(42));
+    }
+
+    #[test]
+    fn test_retry_after_duration_from_http_date() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(50);
+        let duration = retry_after_duration_from_value("Thu, 01 Jan 1970 00:01:40 GMT", now)
+            .expect("HTTP-date Retry-After should parse");
+
+        assert_eq!(duration, Duration::from_secs(50));
+    }
+
+    #[test]
+    fn test_retry_after_duration_from_millisecond_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER_MS_HEADER,
+            reqwest::header::HeaderValue::from_static("1250"),
+        );
+
+        assert_eq!(
+            retry_after_duration(&headers),
+            Some(Duration::from_millis(1250))
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_send_request_with_retry_retries_rate_limited_response() {
+        let (base_url, requests, _) = start_mock_server(vec![
+            MockHttpResponse {
+                status_line: "429 Too Many Requests",
+                headers: vec![("Retry-After".to_string(), "0".to_string())],
+                body: serde_json::to_vec(&json!({"error_code": "RATE_LIMITED"}))
+                    .expect("rate-limit JSON should serialize"),
+            },
+            MockHttpResponse::json("200 OK", json!({"ok": true})),
+        ])
+        .await;
+
+        let client = enable_supported_compression(Client::builder())
+            .build()
+            .expect("compression-enabled client should build");
+        let response =
+            send_request_with_retry("Databricks SQL Warehouse", "test rate limit", || {
+                client.get(format!("{base_url}/api/2.0/sql/statements/"))
+            })
+            .await
+            .expect("request should eventually succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            requests.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected a retry after the initial rate-limited response"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_send_request_with_retry_retries_server_error() {
+        let (base_url, requests, _) = start_mock_server(vec![
+            MockHttpResponse::json("503 Service Unavailable", json!({"error": "busy"})),
+            MockHttpResponse::json("200 OK", json!({"ok": true})),
+        ])
+        .await;
+
+        let client = enable_supported_compression(Client::builder())
+            .build()
+            .expect("compression-enabled client should build");
+        let response =
+            send_request_with_retry("Databricks SQL Warehouse", "test server error", || {
+                client.get(format!("{base_url}/api/2.0/sql/statements/"))
+            })
+            .await
+            .expect("request should eventually succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            requests.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected a retry after the initial 503 response"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_send_request_with_retry_requests_supported_encodings_and_decodes_responses() {
+        for encoding in ["zstd", "br", "gzip", "deflate"] {
+            let plain_body = json!({"encoding": encoding}).to_string();
+            let compressed_body = encode_body(encoding, plain_body.as_bytes());
+            let (base_url, requests, captured_requests) =
+                start_mock_server(vec![MockHttpResponse {
+                    status_line: "200 OK",
+                    headers: vec![
+                        ("Content-Type".to_string(), "application/json".to_string()),
+                        ("Content-Encoding".to_string(), encoding.to_string()),
+                    ],
+                    body: compressed_body,
+                }])
+                .await;
+
+            let client = enable_supported_compression(Client::builder())
+                .build()
+                .expect("compression-enabled client should build");
+            let response = send_request_with_retry(
+                "Databricks SQL Warehouse",
+                "decode compressed response",
+                || client.get(format!("{base_url}/api/2.0/sql/statements/")),
+            )
+            .await
+            .expect("request should succeed");
+            let body = response.text().await.expect("response body should decode");
+            let request = captured_requests.lock().await.remove(0);
+
+            assert_eq!(
+                body, plain_body,
+                "{encoding} response should be decompressed"
+            );
+            assert_eq!(
+                requests.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "{encoding} response should not need a retry"
+            );
+            let request_lower = request.to_ascii_lowercase();
+            assert!(
+                request_lower.contains("accept-encoding: zstd, br, gzip, deflate"),
+                "request should advertise all supported encodings: {request}"
+            );
+        }
+    }
+}

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -78,7 +78,7 @@ where
                     let retry_after = retry_after_duration(response.headers());
                     let backoff =
                         next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
-                    let delay = retry_after.map_or(backoff, |retry_after| retry_after.max(backoff));
+                    let delay = bounded_retry_delay(retry_after, backoff, MAX_HTTP_BACKOFF);
 
                     tracing::warn!(
                         service = service_name,
@@ -207,6 +207,16 @@ fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
             .and_then(|value| value.to_str().ok())
             .and_then(|value| retry_after_duration_from_value(value, SystemTime::now()))
     })
+}
+
+fn bounded_retry_delay(
+    retry_after: Option<Duration>,
+    backoff: Duration,
+    max_delay: Duration,
+) -> Duration {
+    retry_after
+        .map_or(backoff, |retry_after| retry_after.max(backoff))
+        .min(max_delay)
 }
 
 fn retry_after_millis_duration(headers: &HeaderMap) -> Option<Duration> {
@@ -443,6 +453,17 @@ mod tests {
             retry_after_duration(&headers),
             Some(Duration::from_millis(1250))
         );
+    }
+
+    #[test]
+    fn test_bounded_retry_delay_clamps_large_retry_after() {
+        let delay = bounded_retry_delay(
+            Some(Duration::from_secs(3600)),
+            Duration::from_secs(5),
+            MAX_HTTP_BACKOFF,
+        );
+
+        assert_eq!(delay, MAX_HTTP_BACKOFF);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -21,6 +21,11 @@ use reqwest::{
 use std::time::{Duration, SystemTime};
 use util::retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder};
 
+const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+const DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST: usize = 16;
 const MAX_HTTP_RETRIES: usize = 6;
 const MAX_HTTP_BACKOFF: Duration = Duration::from_secs(300);
 const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
@@ -137,6 +142,15 @@ where
 
 pub fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
     builder.gzip(true).brotli(true).zstd(true).deflate(true)
+}
+
+pub fn configure_client_builder(builder: ClientBuilder) -> ClientBuilder {
+    enable_supported_compression(builder)
+        .connect_timeout(DEFAULT_HTTP_CONNECT_TIMEOUT)
+        .timeout(DEFAULT_HTTP_REQUEST_TIMEOUT)
+        .pool_idle_timeout(DEFAULT_HTTP_POOL_IDLE_TIMEOUT)
+        .pool_max_idle_per_host(DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST)
+        .tcp_keepalive(DEFAULT_HTTP_TCP_KEEPALIVE)
 }
 
 async fn drain_response_body(

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -74,12 +74,8 @@ where
     let mut retries = 0usize;
 
     loop {
-        let _permit = acquire_concurrency_permit(
-            concurrency_limit,
-            service_name,
-            operation_name,
-        )
-        .await;
+        let _permit =
+            acquire_concurrency_permit(concurrency_limit, service_name, operation_name).await;
         match add_supported_accept_encoding_header(build_request())
             .send()
             .await

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -19,6 +19,7 @@ use reqwest::{
     header::{ACCEPT_ENCODING, HeaderMap, RETRY_AFTER},
 };
 use std::time::{Duration, SystemTime};
+use tokio::sync::Semaphore;
 use util::retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder};
 
 const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -47,6 +48,19 @@ pub async fn send_request_with_retry<F>(
 where
     F: Fn() -> RequestBuilder,
 {
+    send_request_with_retry_and_concurrency_limit(service_name, operation_name, build_request, None)
+        .await
+}
+
+pub async fn send_request_with_retry_and_concurrency_limit<F>(
+    service_name: &str,
+    operation_name: &str,
+    build_request: F,
+    concurrency_limit: Option<&Semaphore>,
+) -> Result<Response, reqwest::Error>
+where
+    F: Fn() -> RequestBuilder,
+{
     let mut transient_backoff = RetryBackoffBuilder::new()
         .method(BackoffMethod::Fibonacci)
         .max_duration(Some(MAX_HTTP_BACKOFF))
@@ -60,6 +74,12 @@ where
     let mut retries = 0usize;
 
     loop {
+        let _permit = acquire_concurrency_permit(
+            concurrency_limit,
+            service_name,
+            operation_name,
+        )
+        .await;
         match add_supported_accept_encoding_header(build_request())
             .send()
             .await
@@ -98,6 +118,7 @@ where
 
                     drain_response_body(response, service_name, operation_name, retries, status)
                         .await;
+                    drop(_permit);
                     tokio::time::sleep(delay).await;
                     continue;
                 }
@@ -134,6 +155,7 @@ where
                     "Retrying HTTP request after transient request failure"
                 );
 
+                drop(_permit);
                 tokio::time::sleep(delay).await;
             }
         }
@@ -151,6 +173,25 @@ pub fn configure_client_builder(builder: ClientBuilder) -> ClientBuilder {
         .pool_idle_timeout(DEFAULT_HTTP_POOL_IDLE_TIMEOUT)
         .pool_max_idle_per_host(DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST)
         .tcp_keepalive(DEFAULT_HTTP_TCP_KEEPALIVE)
+}
+
+async fn acquire_concurrency_permit<'a>(
+    semaphore: Option<&'a Semaphore>,
+    service_name: &str,
+    operation_name: &str,
+) -> Option<tokio::sync::SemaphorePermit<'a>> {
+    let sem = semaphore?;
+    match sem.acquire().await {
+        Ok(permit) => Some(permit),
+        Err(_) => {
+            tracing::warn!(
+                service = service_name,
+                operation = operation_name,
+                "Request concurrency limiter closed; proceeding without limit"
+            );
+            None
+        }
+    }
 }
 
 async fn drain_response_body(

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -319,9 +319,11 @@ mod tests {
                         response.status_line,
                         response.body.len()
                     );
-                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
+                        let _ = std::fmt::Write::write_fmt(
+                            &mut http_response,
+                            format_args!("{header_name}: {header_value}\r\n"),
+                        );
                     }
                     http_response.push_str("\r\n");
                     let _ = stream.write_all(http_response.as_bytes()).await;

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{fmt::Write, sync::Arc, time::Duration};
+use std::{fmt::Write, sync::Arc};
 
 use datafusion::sql::TableReference;
 use serde::Deserialize;

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -23,6 +23,8 @@ use url::Url;
 
 use token_provider::TokenProvider;
 
+use crate::resilient_http::{enable_supported_compression, send_request_with_retry};
+
 pub mod provider;
 
 #[derive(Debug, Snafu)]
@@ -114,7 +116,7 @@ impl UnityCatalog {
             };
         }
 
-        let client = reqwest::Client::builder()
+        let client = enable_supported_compression(reqwest::Client::builder())
             .user_agent(util::spiceai_user_agent())
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(30))
@@ -191,7 +193,7 @@ impl UnityCatalog {
     pub async fn get_table(&self, table_reference: &TableReference) -> Result<Option<UCTable>> {
         let table_name = table_reference.to_string();
         let path = format!("/api/2.1/unity-catalog/tables/{table_name}");
-        let response = self.get_req(&path).send().await.context(ConnectionSnafu)?;
+        let response = self.send_get_with_retry("get table", &path).await?;
 
         if response.status().is_success() {
             let api_response: UCTable = response.json().await.context(ConnectionSnafu)?;
@@ -208,7 +210,7 @@ impl UnityCatalog {
 
     pub async fn get_catalog(&self, catalog_id: &str) -> Result<Option<UCCatalog>> {
         let path = format!("/api/2.1/unity-catalog/catalogs/{catalog_id}");
-        let response = self.get_req(&path).send().await.context(ConnectionSnafu)?;
+        let response = self.send_get_with_retry("get catalog", &path).await?;
 
         tracing::debug!("get_catalog: Response status: {}", response.status());
 
@@ -227,7 +229,7 @@ impl UnityCatalog {
 
     pub async fn list_schemas(&self, catalog_id: &str) -> Result<Option<Vec<UCSchema>>> {
         let path = format!("/api/2.1/unity-catalog/schemas?catalog_name={catalog_id}");
-        let response = self.get_req(&path).send().await.context(ConnectionSnafu)?;
+        let response = self.send_get_with_retry("list schemas", &path).await?;
 
         tracing::debug!("list_schemas: Response status: {}", response.status());
 
@@ -252,7 +254,7 @@ impl UnityCatalog {
         let path = format!(
             "/api/2.1/unity-catalog/tables?catalog_name={catalog_id}&schema_name={schema_name}"
         );
-        let response = self.get_req(&path).send().await.context(ConnectionSnafu)?;
+        let response = self.send_get_with_retry("list tables", &path).await?;
 
         tracing::debug!("list_tables: Response status: {}", response.status());
 
@@ -283,6 +285,12 @@ impl UnityCatalog {
         }
 
         builder
+    }
+
+    async fn send_get_with_retry(&self, operation: &str, path: &str) -> Result<reqwest::Response> {
+        send_request_with_retry("Unity Catalog", operation, || self.get_req(path))
+            .await
+            .context(ConnectionSnafu)
     }
 }
 

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use token_provider::TokenProvider;
 
-use crate::resilient_http::{enable_supported_compression, send_request_with_retry};
+use crate::resilient_http::{configure_client_builder, send_request_with_retry};
 
 pub mod provider;
 
@@ -116,10 +116,8 @@ impl UnityCatalog {
             };
         }
 
-        let client = enable_supported_compression(reqwest::Client::builder())
+        let client = configure_client_builder(reqwest::Client::builder())
             .user_agent(util::spiceai_user_agent())
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
             .build()
             .context(UnableToCreateHttpClientSnafu)?;
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -71,6 +71,7 @@ governor.workspace = true
 graphql-parser.workspace = true
 headers-accept = "0.3.0"
 http.workspace = true
+httpdate.workspace = true
 http-body-util = "0.1.3"
 humantime = { workspace = true, optional = true }
 hyper = "1.7.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -71,7 +71,6 @@ governor.workspace = true
 graphql-parser.workspace = true
 headers-accept = "0.3.0"
 http.workspace = true
-httpdate.workspace = true
 http-body-util = "0.1.3"
 humantime = { workspace = true, optional = true }
 hyper = "1.7.0"

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -326,6 +326,7 @@ where
                         "Retrying Databricks token request after retryable response"
                     );
 
+                    drain_retry_response_body(response, operation_name, retries, status).await;
                     tokio::time::sleep(delay).await;
                     continue;
                 }
@@ -368,6 +369,30 @@ where
 
 fn add_supported_accept_encoding_header(request: RequestBuilder) -> RequestBuilder {
     request.header(ACCEPT_ENCODING, SUPPORTED_ACCEPT_ENCODINGS)
+}
+
+async fn drain_retry_response_body(
+    mut response: Response,
+    operation_name: &str,
+    attempt: usize,
+    status: StatusCode,
+) {
+    loop {
+        match response.chunk().await {
+            Ok(Some(_)) => {}
+            Ok(None) => return,
+            Err(error) => {
+                tracing::debug!(
+                    operation = operation_name,
+                    attempt,
+                    status = %status,
+                    error = %error,
+                    "Failed to drain Databricks token retry response body before retry"
+                );
+                return;
+            }
+        }
+    }
 }
 
 fn next_backoff(
@@ -648,7 +673,7 @@ mod tests {
     }
 
     impl MockHttpResponse {
-        fn json(status_line: &'static str, body: serde_json::Value) -> Self {
+        fn json(status_line: &'static str, body: &serde_json::Value) -> Self {
             Self {
                 status_line,
                 headers: vec![("Content-Type".to_string(), "application/json".to_string())],
@@ -686,19 +711,18 @@ mod tests {
                 let requests = Arc::clone(&requests_for_server);
                 let captured_requests = Arc::clone(&captured_requests_for_server);
                 tokio::spawn(async move {
-                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    use tokio::io::AsyncWriteExt;
 
-                    let mut buf = vec![0u8; 4096];
-                    let bytes_read = stream.read(&mut buf).await.unwrap_or_default();
+                    let captured_request = read_http_request(&mut stream).await;
                     requests.fetch_add(1, Ordering::SeqCst);
                     captured_requests
                         .lock()
                         .await
-                        .push(String::from_utf8_lossy(&buf[..bytes_read]).into_owned());
+                        .push(String::from_utf8_lossy(&captured_request).into_owned());
 
                     let response =
                         responses.lock().await.pop_front().unwrap_or_else(|| {
-                            MockHttpResponse::json("200 OK", json!({"ok": true}))
+                            MockHttpResponse::json("200 OK", &json!({"ok": true}))
                         });
 
                     let mut http_response = format!(
@@ -706,8 +730,9 @@ mod tests {
                         response.status_line,
                         response.body.len()
                     );
+                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
                     }
                     http_response.push_str("\r\n");
                     http_response.push_str(&response.body);
@@ -718,6 +743,56 @@ mod tests {
         });
 
         (format!("http://{addr}"), requests, captured_requests)
+    }
+
+    async fn read_http_request(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+
+        let mut captured_request = Vec::with_capacity(4096);
+        let mut buf = [0u8; 1024];
+        let mut expected_total_len = None;
+
+        loop {
+            let bytes_read = match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(bytes_read) => bytes_read,
+            };
+
+            captured_request.extend_from_slice(&buf[..bytes_read]);
+
+            if expected_total_len.is_none() {
+                expected_total_len = expected_http_request_len(&captured_request);
+            }
+
+            if let Some(expected_total_len) = expected_total_len
+                && captured_request.len() >= expected_total_len
+            {
+                break;
+            }
+        }
+
+        captured_request
+    }
+
+    fn expected_http_request_len(request: &[u8]) -> Option<usize> {
+        let headers_end = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)?;
+
+        let content_length = String::from_utf8_lossy(&request[..headers_end])
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        Some(headers_end.saturating_add(content_length))
     }
 
     fn token_response_body() -> serde_json::Value {
@@ -752,7 +827,7 @@ mod tests {
                 ],
                 body: json!({"error": "rate limited"}).to_string(),
             },
-            MockHttpResponse::json("200 OK", token_response_body()),
+            MockHttpResponse::json("200 OK", &token_response_body()),
         ])
         .await;
 
@@ -771,8 +846,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_get_m2m_access_token_retries_server_error_response() {
         let (endpoint, requests, _) = start_mock_server(vec![
-            MockHttpResponse::json("503 Service Unavailable", json!({"error": "busy"})),
-            MockHttpResponse::json("200 OK", token_response_body()),
+            MockHttpResponse::json("503 Service Unavailable", &json!({"error": "busy"})),
+            MockHttpResponse::json("200 OK", &token_response_body()),
         ])
         .await;
 
@@ -793,7 +868,7 @@ mod tests {
         let (endpoint, requests, captured_requests) =
             start_mock_server(vec![MockHttpResponse::json(
                 "200 OK",
-                token_response_body(),
+                &token_response_body(),
             )])
             .await;
 

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -323,7 +323,8 @@ where
                     let retry_after = retry_after_duration(response.headers());
                     let backoff =
                         next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
-                    let delay = retry_after.map_or(backoff, |retry_after| retry_after.max(backoff));
+                    let delay =
+                        bounded_retry_delay(retry_after, backoff, MAX_TOKEN_REQUEST_BACKOFF);
 
                     tracing::warn!(
                         operation = operation_name,
@@ -442,6 +443,16 @@ fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
             .and_then(|value| value.to_str().ok())
             .and_then(|value| retry_after_duration_from_value(value, SystemTime::now()))
     })
+}
+
+fn bounded_retry_delay(
+    retry_after: Option<Duration>,
+    backoff: Duration,
+    max_delay: Duration,
+) -> Duration {
+    retry_after
+        .map_or(backoff, |retry_after| retry_after.max(backoff))
+        .min(max_delay)
 }
 
 fn retry_after_millis_duration(headers: &HeaderMap) -> Option<Duration> {
@@ -838,6 +849,17 @@ mod tests {
             next_token_refresh_wait(TOKEN_REFRESH_BUFFER_SECS + 15),
             Duration::from_secs(15)
         );
+    }
+
+    #[test]
+    fn test_bounded_retry_delay_clamps_large_retry_after() {
+        let delay = bounded_retry_delay(
+            Some(Duration::from_secs(3600)),
+            Duration::from_secs(5),
+            MAX_TOKEN_REQUEST_BACKOFF,
+        );
+
+        assert_eq!(delay, MAX_TOKEN_REQUEST_BACKOFF);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use std::{fmt, sync::Arc};
 use token_provider::{Result, TokenProvider};
 use tokio::{sync::watch, task::JoinHandle, time::sleep};
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::fibonacci_backoff::{Backoff as _, FibonacciBackoffBuilder};
 
 use crate::request::DatabricksAuthExtension;
 use runtime_request_context::RequestContext;

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -730,9 +730,11 @@ mod tests {
                         response.status_line,
                         response.body.len()
                     );
-                    use std::fmt::Write as _;
                     for (header_name, header_value) in response.headers {
-                        let _ = write!(http_response, "{header_name}: {header_value}\r\n");
+                        let _ = std::fmt::Write::write_fmt(
+                            &mut http_response,
+                            format_args!("{header_name}: {header_value}\r\n"),
+                        );
                     }
                     http_response.push_str("\r\n");
                     http_response.push_str(&response.body);

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -215,15 +215,14 @@ async fn get_m2m_access_token(
         .timeout(Duration::from_secs(30))
         .build()?;
 
-    let response =
-        send_request_with_retry("Databricks", "request M2M access token", || {
-            client
-                .post(&token_endpoint_url)
-                .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
-        })
-        .await?;
+    let response = send_request_with_retry("Databricks", "request M2M access token", || {
+        client
+            .post(&token_endpoint_url)
+            .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
+    })
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -254,16 +254,9 @@ fn databricks_token_endpoint_url(
     let base_url = if endpoint.starts_with("https://") {
         endpoint.to_string()
     } else if endpoint.starts_with("http://") {
-        let host = endpoint
-            .strip_prefix("http://")
-            .unwrap_or(endpoint)
-            .split('/')
-            .next()
-            .unwrap_or("")
-            .split(':')
-            .next()
-            .unwrap_or("");
-        if host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]" {
+        let parsed = url::Url::parse(endpoint)?;
+        let host = parsed.host_str().unwrap_or("");
+        if host == "127.0.0.1" || host == "localhost" || host == "::1" {
             endpoint.to_string()
         } else {
             return Err(format!(
@@ -643,6 +636,11 @@ mod tests {
         assert!(
             databricks_token_endpoint_url("http://dbc.example.databricks.com").is_err(),
             "http:// to non-localhost should be rejected"
+        );
+        assert_eq!(
+            databricks_token_endpoint_url("http://[::1]:1234/")
+                .expect("http://[::1] should be allowed"),
+            "http://[::1]:1234/oidc/v1/token"
         );
     }
 

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -36,6 +36,7 @@ use crate::request::DatabricksAuthExtension;
 use runtime_request_context::RequestContext;
 
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
+const MIN_TOKEN_REFRESH_WAIT_SECS: u64 = 1;
 const MAX_TOKEN_REQUEST_RETRIES: usize = 6;
 const MAX_TOKEN_REQUEST_BACKOFF: Duration = Duration::from_secs(300);
 const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
@@ -115,7 +116,7 @@ impl DatabricksM2MTokenProvider {
 
         let handle = tokio::spawn(async move {
             // Databricks M2M access token lifespan is one hour. Schedule a refresh five minutes before expiration
-            let mut next_wait = Duration::from_secs(expires_in - TOKEN_REFRESH_BUFFER_SECS);
+            let mut next_wait = next_token_refresh_wait(expires_in);
 
             let mut backoff = FibonacciBackoffBuilder::new()
                 .max_duration(Some(Duration::from_secs(300))) // Cap at 5 minutes
@@ -139,7 +140,7 @@ impl DatabricksM2MTokenProvider {
                         backoff.reset();
                         tracing::debug!("M2M token refreshed; expires in {}", expires_in);
                         let _ = cloned_tx.send(access_token.clone());
-                        next_wait = Duration::from_secs(expires_in - TOKEN_REFRESH_BUFFER_SECS);
+                        next_wait = next_token_refresh_wait(expires_in);
                     }
                     Err(e) => {
                         let backoff_duration =
@@ -270,6 +271,14 @@ fn databricks_token_endpoint_url(databricks_endpoint: &str) -> String {
     };
 
     format!("{base_url}/oidc/v1/token")
+}
+
+fn next_token_refresh_wait(expires_in: u64) -> Duration {
+    Duration::from_secs(
+        expires_in
+            .saturating_sub(TOKEN_REFRESH_BUFFER_SECS)
+            .max(MIN_TOKEN_REFRESH_WAIT_SECS),
+    )
 }
 
 async fn send_databricks_token_request_with_retry<F>(
@@ -815,6 +824,19 @@ mod tests {
         assert_eq!(
             databricks_token_endpoint_url("http://127.0.0.1:1234/"),
             "http://127.0.0.1:1234/oidc/v1/token"
+        );
+    }
+
+    #[test]
+    fn test_next_token_refresh_wait_clamps_short_lived_tokens() {
+        assert_eq!(next_token_refresh_wait(0), Duration::from_secs(1));
+        assert_eq!(
+            next_token_refresh_wait(TOKEN_REFRESH_BUFFER_SECS),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            next_token_refresh_wait(TOKEN_REFRESH_BUFFER_SECS + 15),
+            Duration::from_secs(15)
         );
     }
 

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -15,40 +15,22 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
-use reqwest::{
-    RequestBuilder, Response, StatusCode,
-    header::{ACCEPT_ENCODING, HeaderMap, RETRY_AFTER},
-};
+use data_components::resilient_http::{enable_supported_compression, send_request_with_retry};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use snafu::prelude::*;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use std::{fmt, sync::Arc};
 use token_provider::{Result, TokenProvider};
 use tokio::{sync::watch, task::JoinHandle, time::sleep};
-use util::{
-    fibonacci_backoff::FibonacciBackoffBuilder,
-    retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder},
-};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
 
 use crate::request::DatabricksAuthExtension;
 use runtime_request_context::RequestContext;
 
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
 const MIN_TOKEN_REFRESH_WAIT_SECS: u64 = 1;
-const MAX_TOKEN_REQUEST_RETRIES: usize = 6;
-const MAX_TOKEN_REQUEST_BACKOFF: Duration = Duration::from_secs(300);
-const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
-const X_RETRY_AFTER_MS_HEADER: &str = "x-retry-after-ms";
-const SUPPORTED_ACCEPT_ENCODINGS: &str = "zstd, br, gzip, deflate";
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum RetryReason {
-    RateLimit,
-    ServerError,
-    Network,
-}
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -227,24 +209,21 @@ async fn get_m2m_access_token(
 ) -> Result<TokenResponse, Box<dyn std::error::Error + Send + Sync>> {
     let token_endpoint_url = databricks_token_endpoint_url(&databricks_endpoint);
 
-    let client = reqwest::Client::builder()
-        .gzip(true)
-        .brotli(true)
-        .zstd(true)
-        .deflate(true)
+    let client = enable_supported_compression(reqwest::Client::builder())
         .user_agent(util::spiceai_user_agent())
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30))
         .build()?;
 
-    let response = send_databricks_token_request_with_retry("request M2M access token", || {
-        client
-            .post(&token_endpoint_url)
-            .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
-    })
-    .await?;
+    let response =
+        send_request_with_retry("Databricks", "request M2M access token", || {
+            client
+                .post(&token_endpoint_url)
+                .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
+        })
+        .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -279,209 +258,6 @@ fn next_token_refresh_wait(expires_in: u64) -> Duration {
             .saturating_sub(TOKEN_REFRESH_BUFFER_SECS)
             .max(MIN_TOKEN_REFRESH_WAIT_SECS),
     )
-}
-
-async fn send_databricks_token_request_with_retry<F>(
-    operation_name: &str,
-    build_request: F,
-) -> Result<Response, reqwest::Error>
-where
-    F: Fn() -> RequestBuilder,
-{
-    let mut transient_backoff = RetryBackoffBuilder::new()
-        .method(BackoffMethod::Fibonacci)
-        .max_duration(Some(MAX_TOKEN_REQUEST_BACKOFF))
-        .build();
-    let mut rate_limit_backoff = RetryBackoffBuilder::new()
-        .method(BackoffMethod::Exponential)
-        .base_interval(Duration::from_secs(1))
-        .max_duration(Some(MAX_TOKEN_REQUEST_BACKOFF))
-        .build();
-
-    let mut retries = 0usize;
-
-    loop {
-        match add_supported_accept_encoding_header(build_request())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                let status = response.status();
-                if let Some(reason) = retry_reason_from_status(status) {
-                    if retries >= MAX_TOKEN_REQUEST_RETRIES {
-                        tracing::warn!(
-                            operation = operation_name,
-                            status = %status,
-                            retries,
-                            max_retries = MAX_TOKEN_REQUEST_RETRIES,
-                            "Databricks token request retries exhausted after retryable response"
-                        );
-                        return Ok(response);
-                    }
-
-                    retries += 1;
-                    let retry_after = retry_after_duration(response.headers());
-                    let backoff =
-                        next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
-                    let delay =
-                        bounded_retry_delay(retry_after, backoff, MAX_TOKEN_REQUEST_BACKOFF);
-
-                    tracing::warn!(
-                        operation = operation_name,
-                        attempt = retries,
-                        max_retries = MAX_TOKEN_REQUEST_RETRIES,
-                        status = %status,
-                        retry_after = ?retry_after,
-                        delay = ?delay,
-                        "Retrying Databricks token request after retryable response"
-                    );
-
-                    drain_retry_response_body(response, operation_name, retries, status).await;
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
-
-                return Ok(response);
-            }
-            Err(error) => {
-                let Some(reason) = retry_reason_from_error(&error) else {
-                    return Err(error);
-                };
-
-                if retries >= MAX_TOKEN_REQUEST_RETRIES {
-                    tracing::warn!(
-                        operation = operation_name,
-                        retries,
-                        max_retries = MAX_TOKEN_REQUEST_RETRIES,
-                        error = %error,
-                        "Databricks token request retries exhausted after transient failure"
-                    );
-                    return Err(error);
-                }
-
-                retries += 1;
-                let delay = next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
-
-                tracing::warn!(
-                    operation = operation_name,
-                    attempt = retries,
-                    max_retries = MAX_TOKEN_REQUEST_RETRIES,
-                    delay = ?delay,
-                    error = %error,
-                    "Retrying Databricks token request after transient failure"
-                );
-
-                tokio::time::sleep(delay).await;
-            }
-        }
-    }
-}
-
-fn add_supported_accept_encoding_header(request: RequestBuilder) -> RequestBuilder {
-    request.header(ACCEPT_ENCODING, SUPPORTED_ACCEPT_ENCODINGS)
-}
-
-async fn drain_retry_response_body(
-    mut response: Response,
-    operation_name: &str,
-    attempt: usize,
-    status: StatusCode,
-) {
-    loop {
-        match response.chunk().await {
-            Ok(Some(_)) => {}
-            Ok(None) => return,
-            Err(error) => {
-                tracing::debug!(
-                    operation = operation_name,
-                    attempt,
-                    status = %status,
-                    error = %error,
-                    "Failed to drain Databricks token retry response body before retry"
-                );
-                return;
-            }
-        }
-    }
-}
-
-fn next_backoff(
-    reason: RetryReason,
-    transient_backoff: &mut impl Backoff,
-    rate_limit_backoff: &mut impl Backoff,
-) -> Duration {
-    match reason {
-        RetryReason::RateLimit => rate_limit_backoff
-            .next_backoff()
-            .unwrap_or(MAX_TOKEN_REQUEST_BACKOFF),
-        RetryReason::ServerError | RetryReason::Network => transient_backoff
-            .next_backoff()
-            .unwrap_or(MAX_TOKEN_REQUEST_BACKOFF),
-    }
-}
-
-fn retry_reason_from_error(error: &reqwest::Error) -> Option<RetryReason> {
-    if error.is_connect() || error.is_timeout() {
-        return Some(RetryReason::Network);
-    }
-
-    error.status().and_then(retry_reason_from_status)
-}
-
-fn retry_reason_from_status(status: StatusCode) -> Option<RetryReason> {
-    match status.as_u16() {
-        408 | 429 => Some(RetryReason::RateLimit),
-        500..=599 => Some(RetryReason::ServerError),
-        _ => None,
-    }
-}
-
-fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
-    retry_after_millis_duration(headers).or_else(|| {
-        headers
-            .get(RETRY_AFTER)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| retry_after_duration_from_value(value, SystemTime::now()))
-    })
-}
-
-fn bounded_retry_delay(
-    retry_after: Option<Duration>,
-    backoff: Duration,
-    max_delay: Duration,
-) -> Duration {
-    retry_after
-        .map_or(backoff, |retry_after| retry_after.max(backoff))
-        .min(max_delay)
-}
-
-fn retry_after_millis_duration(headers: &HeaderMap) -> Option<Duration> {
-    [RETRY_AFTER_MS_HEADER, X_RETRY_AFTER_MS_HEADER]
-        .into_iter()
-        .find_map(|header_name| {
-            headers
-                .get(header_name)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|value| value.trim().parse::<u64>().ok())
-                .map(Duration::from_millis)
-        })
-}
-
-fn retry_after_duration_from_value(value: &str, now: SystemTime) -> Option<Duration> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    trimmed
-        .parse::<u64>()
-        .ok()
-        .map(Duration::from_secs)
-        .or_else(|| {
-            httpdate::parse_http_date(trimmed)
-                .ok()
-                .map(|retry_after| retry_after.duration_since(now).unwrap_or(Duration::ZERO))
-        })
 }
 
 #[derive(Debug)]

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -15,20 +15,39 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
+use reqwest::{
+    RequestBuilder, Response, StatusCode,
+    header::{ACCEPT_ENCODING, HeaderMap, RETRY_AFTER},
+};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use snafu::prelude::*;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use std::{fmt, sync::Arc};
 use token_provider::{Result, TokenProvider};
 use tokio::{sync::watch, task::JoinHandle, time::sleep};
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::{
+    fibonacci_backoff::FibonacciBackoffBuilder,
+    retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder},
+};
 
 use crate::request::DatabricksAuthExtension;
 use runtime_request_context::RequestContext;
 
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
+const MAX_TOKEN_REQUEST_RETRIES: usize = 6;
+const MAX_TOKEN_REQUEST_BACKOFF: Duration = Duration::from_secs(300);
+const RETRY_AFTER_MS_HEADER: &str = "retry-after-ms";
+const X_RETRY_AFTER_MS_HEADER: &str = "x-retry-after-ms";
+const SUPPORTED_ACCEPT_ENCODINGS: &str = "zstd, br, gzip, deflate";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RetryReason {
+    RateLimit,
+    ServerError,
+    Network,
+}
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -117,6 +136,7 @@ impl DatabricksM2MTokenProvider {
                         expires_in,
                         ..
                     }) => {
+                        backoff.reset();
                         tracing::debug!("M2M token refreshed; expires in {}", expires_in);
                         let _ = cloned_tx.send(access_token.clone());
                         next_wait = Duration::from_secs(expires_in - TOKEN_REFRESH_BUFFER_SECS);
@@ -204,21 +224,26 @@ async fn get_m2m_access_token(
     client_id: String,
     client_secret: SecretString,
 ) -> Result<TokenResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let token_endpoint_url = format!("https://{databricks_endpoint}/oidc/v1/token");
+    let token_endpoint_url = databricks_token_endpoint_url(&databricks_endpoint);
 
     let client = reqwest::Client::builder()
+        .gzip(true)
+        .brotli(true)
+        .zstd(true)
+        .deflate(true)
         .user_agent(util::spiceai_user_agent())
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30))
         .build()?;
 
-    let response = client
-        .post(&token_endpoint_url)
-        .basic_auth(client_id, Some(client_secret.expose_secret()))
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
-        .send()
-        .await?;
+    let response = send_databricks_token_request_with_retry("request M2M access token", || {
+        client
+            .post(&token_endpoint_url)
+            .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
+    })
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -234,6 +259,184 @@ async fn get_m2m_access_token(
     );
 
     Ok(token_response)
+}
+
+fn databricks_token_endpoint_url(databricks_endpoint: &str) -> String {
+    let endpoint = databricks_endpoint.trim_end_matches('/');
+    let base_url = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        format!("https://{endpoint}")
+    };
+
+    format!("{base_url}/oidc/v1/token")
+}
+
+async fn send_databricks_token_request_with_retry<F>(
+    operation_name: &str,
+    build_request: F,
+) -> Result<Response, reqwest::Error>
+where
+    F: Fn() -> RequestBuilder,
+{
+    let mut transient_backoff = RetryBackoffBuilder::new()
+        .method(BackoffMethod::Fibonacci)
+        .max_duration(Some(MAX_TOKEN_REQUEST_BACKOFF))
+        .build();
+    let mut rate_limit_backoff = RetryBackoffBuilder::new()
+        .method(BackoffMethod::Exponential)
+        .base_interval(Duration::from_secs(1))
+        .max_duration(Some(MAX_TOKEN_REQUEST_BACKOFF))
+        .build();
+
+    let mut retries = 0usize;
+
+    loop {
+        match add_supported_accept_encoding_header(build_request())
+            .send()
+            .await
+        {
+            Ok(response) => {
+                let status = response.status();
+                if let Some(reason) = retry_reason_from_status(status) {
+                    if retries >= MAX_TOKEN_REQUEST_RETRIES {
+                        tracing::warn!(
+                            operation = operation_name,
+                            status = %status,
+                            retries,
+                            max_retries = MAX_TOKEN_REQUEST_RETRIES,
+                            "Databricks token request retries exhausted after retryable response"
+                        );
+                        return Ok(response);
+                    }
+
+                    retries += 1;
+                    let retry_after = retry_after_duration(response.headers());
+                    let backoff =
+                        next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
+                    let delay = retry_after.map_or(backoff, |retry_after| retry_after.max(backoff));
+
+                    tracing::warn!(
+                        operation = operation_name,
+                        attempt = retries,
+                        max_retries = MAX_TOKEN_REQUEST_RETRIES,
+                        status = %status,
+                        retry_after = ?retry_after,
+                        delay = ?delay,
+                        "Retrying Databricks token request after retryable response"
+                    );
+
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                return Ok(response);
+            }
+            Err(error) => {
+                let Some(reason) = retry_reason_from_error(&error) else {
+                    return Err(error);
+                };
+
+                if retries >= MAX_TOKEN_REQUEST_RETRIES {
+                    tracing::warn!(
+                        operation = operation_name,
+                        retries,
+                        max_retries = MAX_TOKEN_REQUEST_RETRIES,
+                        error = %error,
+                        "Databricks token request retries exhausted after transient failure"
+                    );
+                    return Err(error);
+                }
+
+                retries += 1;
+                let delay = next_backoff(reason, &mut transient_backoff, &mut rate_limit_backoff);
+
+                tracing::warn!(
+                    operation = operation_name,
+                    attempt = retries,
+                    max_retries = MAX_TOKEN_REQUEST_RETRIES,
+                    delay = ?delay,
+                    error = %error,
+                    "Retrying Databricks token request after transient failure"
+                );
+
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+fn add_supported_accept_encoding_header(request: RequestBuilder) -> RequestBuilder {
+    request.header(ACCEPT_ENCODING, SUPPORTED_ACCEPT_ENCODINGS)
+}
+
+fn next_backoff(
+    reason: RetryReason,
+    transient_backoff: &mut impl Backoff,
+    rate_limit_backoff: &mut impl Backoff,
+) -> Duration {
+    match reason {
+        RetryReason::RateLimit => rate_limit_backoff
+            .next_backoff()
+            .unwrap_or(MAX_TOKEN_REQUEST_BACKOFF),
+        RetryReason::ServerError | RetryReason::Network => transient_backoff
+            .next_backoff()
+            .unwrap_or(MAX_TOKEN_REQUEST_BACKOFF),
+    }
+}
+
+fn retry_reason_from_error(error: &reqwest::Error) -> Option<RetryReason> {
+    if error.is_connect() || error.is_timeout() {
+        return Some(RetryReason::Network);
+    }
+
+    error.status().and_then(retry_reason_from_status)
+}
+
+fn retry_reason_from_status(status: StatusCode) -> Option<RetryReason> {
+    match status.as_u16() {
+        408 | 429 => Some(RetryReason::RateLimit),
+        500..=599 => Some(RetryReason::ServerError),
+        _ => None,
+    }
+}
+
+fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
+    retry_after_millis_duration(headers).or_else(|| {
+        headers
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| retry_after_duration_from_value(value, SystemTime::now()))
+    })
+}
+
+fn retry_after_millis_duration(headers: &HeaderMap) -> Option<Duration> {
+    [RETRY_AFTER_MS_HEADER, X_RETRY_AFTER_MS_HEADER]
+        .into_iter()
+        .find_map(|header_name| {
+            headers
+                .get(header_name)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .map(Duration::from_millis)
+        })
+}
+
+fn retry_after_duration_from_value(value: &str, now: SystemTime) -> Option<Duration> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    trimmed
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
+        .or_else(|| {
+            httpdate::parse_http_date(trimmed)
+                .ok()
+                .map(|retry_after| retry_after.duration_since(now).unwrap_or(Duration::ZERO))
+        })
 }
 
 #[derive(Debug)]
@@ -423,4 +626,196 @@ pub async fn get_u2m_token_provider(
         .map_err(|err| Error::UnableToGetToken {
             source: Box::new(err),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::{
+        collections::VecDeque,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    #[derive(Clone)]
+    struct MockHttpResponse {
+        status_line: &'static str,
+        headers: Vec<(String, String)>,
+        body: String,
+    }
+
+    impl MockHttpResponse {
+        fn json(status_line: &'static str, body: serde_json::Value) -> Self {
+            Self {
+                status_line,
+                headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                body: serde_json::to_string(&body).expect("mock JSON should serialize"),
+            }
+        }
+    }
+
+    async fn start_mock_server(
+        responses: Vec<MockHttpResponse>,
+    ) -> (
+        String,
+        Arc<AtomicUsize>,
+        Arc<tokio::sync::Mutex<Vec<String>>>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind to a port");
+        let addr = listener
+            .local_addr()
+            .expect("should have a listener address");
+        let responses = Arc::new(tokio::sync::Mutex::new(VecDeque::from(responses)));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let captured_requests = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let requests_for_server = Arc::clone(&requests);
+        let captured_requests_for_server = Arc::clone(&captured_requests);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+
+                let responses = Arc::clone(&responses);
+                let requests = Arc::clone(&requests_for_server);
+                let captured_requests = Arc::clone(&captured_requests_for_server);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buf = vec![0u8; 4096];
+                    let bytes_read = stream.read(&mut buf).await.unwrap_or_default();
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    captured_requests
+                        .lock()
+                        .await
+                        .push(String::from_utf8_lossy(&buf[..bytes_read]).into_owned());
+
+                    let response =
+                        responses.lock().await.pop_front().unwrap_or_else(|| {
+                            MockHttpResponse::json("200 OK", json!({"ok": true}))
+                        });
+
+                    let mut http_response = format!(
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
+                        response.status_line,
+                        response.body.len()
+                    );
+                    for (header_name, header_value) in response.headers {
+                        http_response.push_str(&format!("{header_name}: {header_value}\r\n"));
+                    }
+                    http_response.push_str("\r\n");
+                    http_response.push_str(&response.body);
+
+                    let _ = stream.write_all(http_response.as_bytes()).await;
+                });
+            }
+        });
+
+        (format!("http://{addr}"), requests, captured_requests)
+    }
+
+    fn token_response_body() -> serde_json::Value {
+        json!({
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "all-apis"
+        })
+    }
+
+    #[test]
+    fn test_databricks_token_endpoint_url_normalizes_host() {
+        assert_eq!(
+            databricks_token_endpoint_url("dbc.example.databricks.com"),
+            "https://dbc.example.databricks.com/oidc/v1/token"
+        );
+        assert_eq!(
+            databricks_token_endpoint_url("http://127.0.0.1:1234/"),
+            "http://127.0.0.1:1234/oidc/v1/token"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_m2m_access_token_retries_rate_limited_response() {
+        let (endpoint, requests, _) = start_mock_server(vec![
+            MockHttpResponse {
+                status_line: "429 Too Many Requests",
+                headers: vec![
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                    ("Retry-After".to_string(), "0".to_string()),
+                ],
+                body: json!({"error": "rate limited"}).to_string(),
+            },
+            MockHttpResponse::json("200 OK", token_response_body()),
+        ])
+        .await;
+
+        let response = get_m2m_access_token(
+            endpoint,
+            "client-id".to_string(),
+            SecretString::from("client-secret"),
+        )
+        .await
+        .expect("token request should succeed after retrying the rate-limited response");
+
+        assert_eq!(response.expires_in, 3600);
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_get_m2m_access_token_retries_server_error_response() {
+        let (endpoint, requests, _) = start_mock_server(vec![
+            MockHttpResponse::json("503 Service Unavailable", json!({"error": "busy"})),
+            MockHttpResponse::json("200 OK", token_response_body()),
+        ])
+        .await;
+
+        let response = get_m2m_access_token(
+            endpoint,
+            "client-id".to_string(),
+            SecretString::from("client-secret"),
+        )
+        .await
+        .expect("token request should succeed after retrying the transient server error");
+
+        assert_eq!(response.expires_in, 3600);
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_get_m2m_access_token_requests_supported_encodings() {
+        let (endpoint, requests, captured_requests) =
+            start_mock_server(vec![MockHttpResponse::json(
+                "200 OK",
+                token_response_body(),
+            )])
+            .await;
+
+        let response = get_m2m_access_token(
+            endpoint,
+            "client-id".to_string(),
+            SecretString::from("client-secret"),
+        )
+        .await
+        .expect("token request should succeed");
+
+        let request = captured_requests
+            .lock()
+            .await
+            .remove(0)
+            .to_ascii_lowercase();
+
+        assert_eq!(response.expires_in, 3600);
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        assert!(
+            request.contains("accept-encoding: zstd, br, gzip, deflate"),
+            "request should advertise all supported encodings: {request}"
+        );
+    }
 }

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -641,8 +641,7 @@ mod tests {
             "http://127.0.0.1:1234/oidc/v1/token"
         );
         assert!(
-            databricks_token_endpoint_url("http://dbc.example.databricks.com")
-                .is_err(),
+            databricks_token_endpoint_url("http://dbc.example.databricks.com").is_err(),
             "http:// to non-localhost should be rejected"
         );
     }

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -214,7 +214,7 @@ async fn get_m2m_access_token(
     client_id: &str,
     client_secret: &SecretString,
 ) -> Result<TokenResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let token_endpoint_url = databricks_token_endpoint_url(databricks_endpoint);
+    let token_endpoint_url = databricks_token_endpoint_url(databricks_endpoint)?;
 
     let response = send_request_with_retry("Databricks", "request M2M access token", || {
         client
@@ -247,15 +247,35 @@ fn build_m2m_token_client() -> Result<reqwest::Client, reqwest::Error> {
         .build()
 }
 
-fn databricks_token_endpoint_url(databricks_endpoint: &str) -> String {
+fn databricks_token_endpoint_url(
+    databricks_endpoint: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let endpoint = databricks_endpoint.trim_end_matches('/');
-    let base_url = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+    let base_url = if endpoint.starts_with("https://") {
         endpoint.to_string()
+    } else if endpoint.starts_with("http://") {
+        let host = endpoint
+            .strip_prefix("http://")
+            .unwrap_or(endpoint)
+            .split('/')
+            .next()
+            .unwrap_or("")
+            .split(':')
+            .next()
+            .unwrap_or("");
+        if host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]" {
+            endpoint.to_string()
+        } else {
+            return Err(format!(
+                "Databricks token endpoint must use HTTPS for non-localhost hosts, got: {endpoint}"
+            )
+            .into());
+        }
     } else {
         format!("https://{endpoint}")
     };
 
-    format!("{base_url}/oidc/v1/token")
+    Ok(format!("{base_url}/oidc/v1/token"))
 }
 
 fn next_token_refresh_wait(expires_in: u64) -> Duration {
@@ -611,12 +631,19 @@ mod tests {
     #[test]
     fn test_databricks_token_endpoint_url_normalizes_host() {
         assert_eq!(
-            databricks_token_endpoint_url("dbc.example.databricks.com"),
+            databricks_token_endpoint_url("dbc.example.databricks.com")
+                .expect("plain hostname should be accepted"),
             "https://dbc.example.databricks.com/oidc/v1/token"
         );
         assert_eq!(
-            databricks_token_endpoint_url("http://127.0.0.1:1234/"),
+            databricks_token_endpoint_url("http://127.0.0.1:1234/")
+                .expect("http://localhost should be allowed"),
             "http://127.0.0.1:1234/oidc/v1/token"
+        );
+        assert!(
+            databricks_token_endpoint_url("http://dbc.example.databricks.com")
+                .is_err(),
+            "http:// to non-localhost should be rejected"
         );
     }
 

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -255,8 +255,13 @@ fn databricks_token_endpoint_url(
         endpoint.to_string()
     } else if endpoint.starts_with("http://") {
         let parsed = url::Url::parse(endpoint)?;
-        let host = parsed.host_str().unwrap_or("");
-        if host == "127.0.0.1" || host == "localhost" || host == "::1" {
+        let is_localhost = match parsed.host() {
+            Some(url::Host::Domain("localhost")) => true,
+            Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+            Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+            _ => false,
+        };
+        if is_localhost {
             endpoint.to_string()
         } else {
             return Err(format!(
@@ -657,7 +662,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_get_m2m_access_token_retries_rate_limited_response() {
         let (endpoint, requests, _) = start_mock_server(vec![
             MockHttpResponse {
@@ -687,7 +692,7 @@ mod tests {
         assert_eq!(requests.load(Ordering::SeqCst), 2);
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_get_m2m_access_token_retries_server_error_response() {
         let (endpoint, requests, _) = start_mock_server(vec![
             MockHttpResponse::json("503 Service Unavailable", &json!({"error": "busy"})),

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -626,17 +626,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_bounded_retry_delay_clamps_large_retry_after() {
-        let delay = bounded_retry_delay(
-            Some(Duration::from_secs(3600)),
-            Duration::from_secs(5),
-            MAX_TOKEN_REQUEST_BACKOFF,
-        );
-
-        assert_eq!(delay, MAX_TOKEN_REQUEST_BACKOFF);
-    }
-
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_get_m2m_access_token_retries_rate_limited_response() {
         let (endpoint, requests, _) = start_mock_server(vec![

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
-use data_components::resilient_http::{enable_supported_compression, send_request_with_retry};
+use data_components::resilient_http::{configure_client_builder, send_request_with_retry};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use snafu::prelude::*;
@@ -77,12 +77,16 @@ impl DatabricksM2MTokenProvider {
         client_id: String,
         client_secret: SecretString,
     ) -> Result<Self, Error> {
+        let client = build_m2m_token_client().map_err(|e| Error::UnableToGetToken {
+            source: Box::new(e),
+        })?;
+
         // initial fetch
         let TokenResponse {
             access_token,
             expires_in,
             ..
-        } = get_m2m_access_token(endpoint.clone(), client_id.clone(), client_secret.clone())
+        } = get_m2m_access_token(&client, &endpoint, &client_id, &client_secret)
             .await
             .map_err(|e| Error::UnableToGetToken { source: e })?;
 
@@ -93,6 +97,7 @@ impl DatabricksM2MTokenProvider {
         let cloned_client_id = client_id.clone();
         let cloned_endpoint = endpoint.clone();
         let cloned_tx = tx;
+        let refresh_client = client.clone();
 
         let secret = client_secret.clone();
 
@@ -108,9 +113,10 @@ impl DatabricksM2MTokenProvider {
                 sleep(next_wait).await;
 
                 match get_m2m_access_token(
-                    cloned_endpoint.clone(),
-                    cloned_client_id.clone(),
-                    secret.clone(),
+                    &refresh_client,
+                    &cloned_endpoint,
+                    &cloned_client_id,
+                    &secret,
                 )
                 .await
                 {
@@ -203,22 +209,17 @@ impl fmt::Debug for TokenResponse {
 }
 
 async fn get_m2m_access_token(
-    databricks_endpoint: String,
-    client_id: String,
-    client_secret: SecretString,
+    client: &reqwest::Client,
+    databricks_endpoint: &str,
+    client_id: &str,
+    client_secret: &SecretString,
 ) -> Result<TokenResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let token_endpoint_url = databricks_token_endpoint_url(&databricks_endpoint);
-
-    let client = enable_supported_compression(reqwest::Client::builder())
-        .user_agent(util::spiceai_user_agent())
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(30))
-        .build()?;
+    let token_endpoint_url = databricks_token_endpoint_url(databricks_endpoint);
 
     let response = send_request_with_retry("Databricks", "request M2M access token", || {
         client
             .post(&token_endpoint_url)
-            .basic_auth(client_id.as_str(), Some(client_secret.expose_secret()))
+            .basic_auth(client_id, Some(client_secret.expose_secret()))
             .header("Content-Type", "application/x-www-form-urlencoded")
             .form(&[("grant_type", "client_credentials"), ("scope", "all-apis")])
     })
@@ -238,6 +239,12 @@ async fn get_m2m_access_token(
     );
 
     Ok(token_response)
+}
+
+fn build_m2m_token_client() -> Result<reqwest::Client, reqwest::Error> {
+    configure_client_builder(reqwest::Client::builder())
+        .user_agent(util::spiceai_user_agent())
+        .build()
 }
 
 fn databricks_token_endpoint_url(databricks_endpoint: &str) -> String {
@@ -641,10 +648,13 @@ mod tests {
         ])
         .await;
 
+        let client = build_m2m_token_client().expect("should build token client");
+
         let response = get_m2m_access_token(
-            endpoint,
-            "client-id".to_string(),
-            SecretString::from("client-secret"),
+            &client,
+            &endpoint,
+            "client-id",
+            &SecretString::from("client-secret"),
         )
         .await
         .expect("token request should succeed after retrying the rate-limited response");
@@ -661,10 +671,13 @@ mod tests {
         ])
         .await;
 
+        let client = build_m2m_token_client().expect("should build token client");
+
         let response = get_m2m_access_token(
-            endpoint,
-            "client-id".to_string(),
-            SecretString::from("client-secret"),
+            &client,
+            &endpoint,
+            "client-id",
+            &SecretString::from("client-secret"),
         )
         .await
         .expect("token request should succeed after retrying the transient server error");
@@ -682,10 +695,13 @@ mod tests {
             )])
             .await;
 
+        let client = build_m2m_token_client().expect("should build token client");
+
         let response = get_m2m_access_token(
-            endpoint,
-            "client-id".to_string(),
-            SecretString::from("client-secret"),
+            &client,
+            &endpoint,
+            "client-id",
+            &SecretString::from("client-secret"),
         )
         .await
         .expect("token request should succeed");


### PR DESCRIPTION
## Summary

Add resilient HTTP retry infrastructure and harden Databricks API calls:

- **Shared retry helper** (`resilient_http.rs`): new `send_request_with_retry` with bounded retries for 408/429/5xx, transient network errors, `Retry-After` header parsing (seconds, HTTP-date, and `retry-after-ms`/`x-retry-after-ms`), response body draining before retries, and a bounded retry delay cap
- **Databricks SQL Warehouse**: route all API calls through the shared retry helper with compression-enabled clients (zstd, br, gzip, deflate) and add request concurrency control
- **Databricks M2M token provider**: use shared retry helper for token acquisition, add `saturating_sub` for `expires_in` to prevent underflow on short-lived tokens, normalize endpoint URLs, and reset backoff on successful refresh
- **Unity Catalog**: route API calls through the shared retry helper with compression
- **AWS `app_name`**: truncate APN app name to 50 characters to suppress the AWS SDK warning, add length assertion to test

## Testing

```bash
cargo test -p data_components --features databricks resilient_http::tests -- --nocapture
cargo test -p data_components --features databricks test_execute_sql_statement -- --nocapture
cargo test -p runtime token_providers::databricks::tests -- --nocapture
cargo test -p aws-sdk-credential-bridge test_apn_app_name -- --nocapture
```