### PR TITLE
docs: Update v2.0.0-rc.2 release notes with latest changes

### DIFF
--- a/docs/release_notes/v2.0.0-rc.2.md
+++ b/docs/release_notes/v2.0.0-rc.2.md
@@ -221,7 +221,7 @@ To upgrade to v2.0.0-rc.2, use one of the following methods:
 **CLI**:
 
 ```console
-spice upgrade
+spice upgrade v2.0.0-rc.2
 ```
 
 **Homebrew**:

--- a/docs/release_notes/v2.0.0-rc.2.md
+++ b/docs/release_notes/v2.0.0-rc.2.md
@@ -206,7 +206,6 @@ datasets:
 - [@penberg](https://github.com/penberg)
 - [@phillipleblanc](https://github.com/phillipleblanc)
 - [@sgrebnov](https://github.com/sgrebnov)
-- [@vyershov](https://github.com/vyershov)
 
 ## Breaking Changes
 

--- a/docs/release_notes/v2.0.0-rc.2.md
+++ b/docs/release_notes/v2.0.0-rc.2.md
@@ -5,7 +5,7 @@ v2.0.0-rc.2 is the second release candidate for advanced testing of v2.0, buildi
 Highlights in this release candidate include:
 
 - **Distributed Spice Cayenne Query and Write Improvements** with data-local query routing and partition-aware write-through
-- **DataFusion v52.3.0 Upgrade** with aligned `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`
+- **DataFusion v52.4.0 Upgrade** with aligned `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`
 - **MERGE INTO for Spice Cayenne** catalog tables with distributed support across executors
 - **`PARTITION BY` Support for Cayenne** enabling SQL-defined partitioning in `CREATE TABLE` statements
 - **ADBC Data Connector & Catalog** with full query federation, BigQuery support, and schema/table discovery
@@ -113,13 +113,13 @@ datasets:
       json_pointer: /data/users
 ```
 
-### DataFusion v52.3.0 Upgrade
+### DataFusion v52.4.0 Upgrade
 
-[Apache DataFusion](https://datafusion.apache.org/) has been upgraded from v52.2.0 to v52.3.0, with aligned updates across `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`.
+[Apache DataFusion](https://datafusion.apache.org/) has been upgraded from v52.2.0 to v52.4.0, with aligned updates across `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`.
 
 **Key improvements**:
 
-- **DataFusion v52.3.0**: Brings the latest fixes and compatibility improvements across query planning and execution.
+- **DataFusion v52.4.0**: Brings the latest fixes and compatibility improvements across query planning and execution.
 - **Strict Overflow Handling**: `try_cast_to` now uses strict cast to return errors on overflow instead of silently producing NULL values.
 - **Federation Fix**: Fixed SQL unparsing for Inexact filter pushdown with aliases.
 - **Partial Aggregation Optimization**: Improved partial aggregation performance for `FlightSQLExec`.
@@ -132,8 +132,8 @@ datasets:
 | **iceberg-rust**               | v0.9                                               |
 | **Vortex**                     | Map type support, stack-safe IN-lists              |
 | **arrow-rs**                   | Arrow v57.2.0                                      |
-| **datafusion-federation**      | Updated for DataFusion v52.3.0 alignment           |
-| **datafusion-table-providers** | Updated for DataFusion v52.3.0 alignment           |
+| **datafusion-federation**      | Updated for DataFusion v52.4.0 alignment           |
+| **datafusion-table-providers** | Updated for DataFusion v52.4.0 alignment           |
 | **datafusion-ballista**        | Bumped to fix BatchCoalescer schema mismatch panic |
 
 ### Other Improvements

--- a/docs/release_notes/v2.0.0-rc.2.md
+++ b/docs/release_notes/v2.0.0-rc.2.md
@@ -1,15 +1,21 @@
-# Spice v2.0.0-rc.2 (Mar 16, 2026)
+# Spice v2.0.0-rc.2 (Apr 9, 2026)
 
 v2.0.0-rc.2 is the second release candidate for advanced testing of v2.0, building on [v2.0.0-rc.1](https://github.com/spiceai/spiceai/releases/tag/v2.0.0-rc.1).
 
 Highlights in this release candidate include:
 
 - **Distributed Spice Cayenne Query and Write Improvements** with data-local query routing and partition-aware write-through
+- **DataFusion v52.3.0 Upgrade** with aligned `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`
+- **MERGE INTO for Spice Cayenne** catalog tables with distributed support across executors
 - **`PARTITION BY` Support for Cayenne** enabling SQL-defined partitioning in `CREATE TABLE` statements
+- **ADBC Data Connector & Catalog** with full query federation, BigQuery support, and schema/table discovery
+- **Databricks Lakehouse Federation Improvements** with improved reliability, resilience, DESCRIBE TABLE fallback, and source-native type parsing
+- **Delta Lake Column Mapping** supporting Name and Id mapping modes
+- **HTTP Pagination** support for paginated API endpoints in the HTTP data connector
 - **New Catalog Connectors** for PostgreSQL, MySQL, MSSQL, and Snowflake
 - **JSON Ingestion Improvements** with single-object support, `soda` (Socrata Open Data) format support, `json_pointer` extraction, and auto-detection
-- **DataFusion v52.3.0 Upgrade** with aligned `arrow-rs`, `datafusion-federation`, and `datafusion-table-providers`
-- Dependency upgrades including **Turso v0.5** and **Vortex** Map type support
+- **Per-Model Rate-Limited AI UDF Execution** for controlling concurrent AI function invocations
+- Dependency upgrades including **Turso v0.5.3**, **iceberg-rust v0.9**, and **Vortex** improvements
 
 ## What's New in v2.0.0-rc.2
 
@@ -23,6 +29,21 @@ Highlights in this release candidate include:
 - **Partition-Aware Write Through**: Scheduler-side Flight `DoPut` ingestion now splits partitioned Cayenne writes and forwards them to the responsible executors instead of routing through a single raw-forward path.
 - **Dynamic Partition Assignment**: Newly observed partitions can be added and assigned atomically as data arrives, with persisted partition metadata for future routing.
 - **Better Cluster Coordination**: Partition management is now separated for accelerated and federated tables, improving routing behavior for distributed Cayenne catalog workloads.
+- **Distributed UPDATE/DELETE DML**: UPDATE and DELETE statements for Cayenne catalog tables are now forwarded to all executors in distributed mode, with all executors required to succeed.
+- **Distributed `runtime.task_history`**: Task history is now replicated across the distributed cluster for observability.
+- **RefreshDataset Control Stream**: Dataset refresh operations are now distributed via the control stream to executors.
+- **Executor DDL Sync**: When an executor connects, it receives DDL for all existing tables, ensuring late-joining executors have full table state.
+
+### MERGE INTO for Spice Cayenne
+
+Spice now supports `MERGE INTO` statements for [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) catalog tables, enabling upsert-style data operations with full distributed support.
+
+**Key improvements**:
+
+- **MERGE INTO Support**: Execute `MERGE INTO` statements against Cayenne catalog tables for combined insert/update/delete operations.
+- **Distributed MERGE**: MERGE operations are automatically distributed across executors in cluster mode.
+- **Data Safety**: Duplicate source keys are detected and prevented to avoid data loss during MERGE operations.
+- **Chunked Delete Filters**: Large MERGE delete filter lists are chunked to prevent stack overflow with Vortex IN-list expressions.
 
 ### `PARTITION BY` Support for Cayenne
 
@@ -51,6 +72,7 @@ Spice now includes additional catalog connectors for major database systems, imp
 - **New Catalog Connectors**: Added catalog connectors for [PostgreSQL](https://spiceai.org/docs/components/catalogs/postgres), [MySQL](https://spiceai.org/docs/components/catalogs/mysql), [MSSQL](https://spiceai.org/docs/components/catalogs/mssql), and [Snowflake](https://spiceai.org/docs/components/catalogs/snowflake).
 - **Schema and Table Discovery**: Connectors use native metadata catalogs such as `information_schema` / `INFORMATION_SCHEMA` to discover schemas and tables.
 - **Improved Federation Workflows**: These connectors make it easier to expose external database metadata through Spice for cross-system [federation](https://spiceai.org/docs/features/query-federation) scenarios.
+- **PostgreSQL Partitioned Tables**: Fixed schema discovery for PostgreSQL partitioned tables.
 
 Example PostgreSQL catalog configuration:
 
@@ -77,7 +99,7 @@ JSON ingestion is now more flexible and robust.
 
 - **More JSON Formats**: Added support for single-object JSON documents, auto-detected JSON formats, and Socrata SODA responses.
 - **`json_pointer` Extraction**: Extract nested payloads before schema inference and reading using RFC 6901 JSON Pointer syntax.
-- **Better Auto-Detection**: JSON format detection now handles arrays, objects, JSONL, and BOM-prefixed input more reliably.
+- **Better Auto-Detection**: JSON format detection now handles arrays, objects, JSONL, and BOM-prefixed input more reliably, including single multi-line objects.
 - **SODA Support**: Added schema extraction and data conversion for Socrata Open Data API responses.
 - **Broader Compatibility**: Improved handling for BOM-prefixed files, CRLF-delimited JSONL, nested payloads, mixed structures, and wrapped documents.
 
@@ -98,13 +120,17 @@ datasets:
 **Key improvements**:
 
 - **DataFusion v52.3.0**: Brings the latest fixes and compatibility improvements across query planning and execution.
+- **Strict Overflow Handling**: `try_cast_to` now uses strict cast to return errors on overflow instead of silently producing NULL values.
+- **Federation Fix**: Fixed SQL unparsing for Inexact filter pushdown with aliases.
+- **Partial Aggregation Optimization**: Improved partial aggregation performance for `FlightSQLExec`.
 
 ### Dependency Upgrades
 
 | Dependency                     | Version / Update                                   |
 | ------------------------------ | -------------------------------------------------- |
-| **Turso (libsql)**             | v0.5 (from v0.4.4)                                 |
-| **Vortex**                     | Map type support improvements                      |
+| **Turso (libsql)**             | v0.5.3 (from v0.4.4)                               |
+| **iceberg-rust**               | v0.9                                               |
+| **Vortex**                     | Map type support, stack-safe IN-lists              |
 | **arrow-rs**                   | Arrow v57.2.0                                      |
 | **datafusion-federation**      | Updated for DataFusion v52.3.0 alignment           |
 | **datafusion-table-providers** | Updated for DataFusion v52.3.0 alignment           |
@@ -113,6 +139,15 @@ datasets:
 ### Other Improvements
 
 - **Cayenne released as RC**: [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) data accelerator is now promoted to release candidate status.
+- **File Update Acceleration Mode**: Added `mode: file_update` acceleration mode for file-based data refresh.
+- **`spice completions` Command**: New CLI command for generating shell completion scripts, with auto-detection of shell directory.
+- **`--endpoint` Flag**: Added `--endpoint` flag to `spice run` with scheme-based routing for custom endpoints.
+- **mTLS Client Auth**: Added mTLS client authentication support to the `spice sql` REPL.
+- **DynamoDB DML**: Implemented DML (INSERT, UPDATE, DELETE) support for the [DynamoDB](https://spiceai.org/docs/components/data-connectors/dynamodb) table provider.
+- **Caching Retention**: Added retention policies for cached query results.
+- **GraphQL Custom Auth Headers**: Added custom authorization header support for the [GraphQL](https://spiceai.org/docs/components/data-connectors/graphql) connector.
+- **ClickHouse Date32 Support**: Added `Date32` type support for the [ClickHouse](https://spiceai.org/docs/components/data-connectors/clickhouse) connector.
+- **AWS IAM Role Source**: Added `iam_role_source` parameter for fine-grained AWS credential configuration.
 - **S3 Metadata Columns**: Metadata columns renamed to `_location`, `_last_modified`, `_size` for consistency, with more robust handling in projected queries.
 - **S3 URL Style**: Added `s3_url_style` parameter for [S3 connector](https://spiceai.org/docs/components/data-connectors/s3) URL addressing (path-style vs virtual-hosted). Useful for S3-compatible stores like MinIO:
 
@@ -121,6 +156,7 @@ datasets:
     s3_endpoint: https://minio.local:9000
     s3_url_style: path
   ```
+- **S3 Parquet Performance**: Improved S3 parquet read performance.
 - **HTTP Caching**: Transient [HTTP](https://spiceai.org/docs/components/data-connectors/http) error responses such as `429` and `5xx` are no longer cached, preventing stale error payloads from being served from cache.
 - **HTTP Connector Metadata**: Added `response_headers` as structured map data for [HTTP](https://spiceai.org/docs/components/data-connectors/http) datasets.
 - **Views `on_zero_results`**: Accelerated views now support `on_zero_results: use_source` to fall back to the source when no results are found:
@@ -137,20 +173,32 @@ datasets:
         on_zero_results: use_source
   ```
 - **Flight `DoPut` Ingestion Metrics**: Added `rows_written` and `bytes_written` metrics for [Flight `DoPut`](https://spiceai.org/docs/features/flight-sql) / ADBC ETL ingestion.
-- **Acceleration Metrics**: Added `dataset_acceleration_size_bytes` metric for acceleration refresh ingestion.
+- **EXPLAIN ANALYZE Metrics**: Added metrics for EXPLAIN ANALYZE in FlightSQLExec.
+- **Scheduler Executor Metrics**: Added `scheduler_active_executors_count` metric for monitoring active executors.
+- **Query Memory Limit**: Updated default query memory limit from 70% to 90%, with `GreedyMemoryPool` for improved memory management.
+- **MetastoreTransaction Support**: Added transaction support to prevent concurrent metastore transaction conflicts.
+- **Iceberg REST Catalog**: Coerce unsupported Arrow types to Iceberg v2 equivalents in the REST catalog API.
 - **CDC Cache Invalidation**: Improved cache invalidation for CDC-backed datasets.
 - **Spice.ai Connector Alignment**: Parameter names aligned across catalog and data connectors for Spice.ai Cloud.
 - **Cayenne File Size**: Cayenne now correctly respects the configured target file size (defaults to 128MB).
 - **Cayenne Primary Keys**: Properly set `primary_keys`/`on_conflict` for Cayenne tables.
 - **Turso Metastore Performance**: Cached metastore connections and prepared statements for improved [Turso](https://spiceai.org/docs/components/data-connectors/turso) and [SQLite](https://spiceai.org/docs/components/data-accelerators/sqlite) metastore performance.
+- **Turso SQL Robustness**: More robust SQL unparsing and date comparison handling for Turso.
+- **Dictionary Type Normalization**: Normalize Arrow Dictionary types for DuckDB and SQLite acceleration.
+- **GitHub Connector Resilience**: Improved GraphQL client resilience, performance, and ref filter handling.
+- **ODBC Fix**: Fixed ODBC queries silently returning 0 rows on query failure.
 - **Anthropic Fixes**: Fixed compatibility issues with Anthropic model provider.
+- **v1/responses API Fix**: The `/v1/responses` API now correctly preserves client instructions when `system_prompt` is set.
 - **Shared Acceleration Snapshots**: Show an error when snapshots are enabled on a shared acceleration file.
 - **Distributed Mode Error Handling**: Improved error handling for distributed mode and `state_location` configuration.
+- **Helm Chart**: Added support for ServiceAccount annotations and AWS IRSA example.
+- **Perplexity Removed**: Removed Perplexity model provider support.
 - **Rust v1.93.1**: Upgraded Rust toolchain to v1.93.1.
 
 ## Contributors
 
 - [@cluster2600](https://github.com/cluster2600)
+- [@ewgenius](https://github.com/ewgenius)
 - [@Jeadie](https://github.com/Jeadie)
 - [@krinart](https://github.com/krinart)
 - [@lukekim](https://github.com/lukekim)
@@ -158,11 +206,14 @@ datasets:
 - [@penberg](https://github.com/penberg)
 - [@phillipleblanc](https://github.com/phillipleblanc)
 - [@sgrebnov](https://github.com/sgrebnov)
+- [@vyershov](https://github.com/vyershov)
 
 ## Breaking Changes
 
 - **S3 metadata columns renamed**: S3 metadata columns renamed from `location`, `last_modified`, `size` to `_location`, `_last_modified`, `_size`.
 - **`v1/evals` API removed**: The `/v1/evals` endpoint has been removed.
+- **Perplexity removed**: Perplexity model provider support has been removed.
+- **Default query memory limit changed**: Default query memory limit increased from 70% to 90%.
 
 ## Upgrading
 
@@ -215,7 +266,7 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 - Update spicepod.schema.json by [@app/github-actions](https://github.com/app/github-actions) in [#9640](https://github.com/spiceai/spiceai/pull/9640)
 - Update testoperator dispatch to use release/2.0 branch by [@phillipleblanc](https://github.com/phillipleblanc) in [#9641](https://github.com/spiceai/spiceai/pull/9641)
 - fix: Align CUDA asset names in Dockerfile and install tests with build output by [@phillipleblanc](https://github.com/phillipleblanc) in [#9639](https://github.com/spiceai/spiceai/pull/9639)
-- Fix expect test scripts in  E2E Installation AI test by [@sgrebnov](https://github.com/sgrebnov) in [#9643](https://github.com/spiceai/spiceai/pull/9643)
+- Fix expect test scripts in E2E Installation AI test by [@sgrebnov](https://github.com/sgrebnov) in [#9643](https://github.com/spiceai/spiceai/pull/9643)
 - testoperator for partitioned arrow accelerator by [@Jeadie](https://github.com/Jeadie) in [#9635](https://github.com/spiceai/spiceai/pull/9635)
 - Remove default 1s refresh_check_interval from spidapter for hive datasets by [@phillipleblanc](https://github.com/phillipleblanc) in [#9645](https://github.com/spiceai/spiceai/pull/9645)
 - Fix scheduler panic and cancel race condition by [@phillipleblanc](https://github.com/phillipleblanc) in [#9644](https://github.com/spiceai/spiceai/pull/9644)
@@ -223,99 +274,155 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 - docs: update distribution details and add NAS support in release notes by [@lukekim](https://github.com/lukekim) in [#9650](https://github.com/spiceai/spiceai/pull/9650)
 - Enable `postgres-accel` in CI builds for benchmarks by [@sgrebnov](https://github.com/sgrebnov) in [#9649](https://github.com/spiceai/spiceai/pull/9649)
 - perf: Cache Turso metastore connection across operations by [@penberg](https://github.com/penberg) in [#9646](https://github.com/spiceai/spiceai/pull/9646)
-- Add 'scheduler_state_location' to spidapter. by [@Jeadie](https://github.com/Jeadie) in [#9655](https://github.com/spiceai/spiceai/pull/9655)
+- Add 'scheduler_state_location' to spidapter by [@Jeadie](https://github.com/Jeadie) in [#9655](https://github.com/spiceai/spiceai/pull/9655)
 - Implement Cayenne S3 Express multi-zone live test with data validation by [@lukekim](https://github.com/lukekim) in [#9631](https://github.com/spiceai/spiceai/pull/9631)
 - chore(spidapter): bump default memory limit from 8Gi to 32Gi by [@phillipleblanc](https://github.com/phillipleblanc) in [#9661](https://github.com/spiceai/spiceai/pull/9661)
 - perf: Use prepare_cached() in Turso and SQLite metastore backends by [@penberg](https://github.com/penberg) in [#9662](https://github.com/spiceai/spiceai/pull/9662)
-- Fix lint for Turso change by [@lukekim](https://github.com/lukekim) in [#9665](https://github.com/spiceai/spiceai/pull/9665)
 - Improve CDC cache invalidation by [@krinart](https://github.com/krinart) in [#9651](https://github.com/spiceai/spiceai/pull/9651)
-- Re-enable Turso TPCH SF1 bench dispatch by [@lukekim](https://github.com/lukekim) in [#9668](https://github.com/spiceai/spiceai/pull/9668)
 - Refactor Cayenne IDs to use UUIDv7 strings by [@lukekim](https://github.com/lukekim) in [#9667](https://github.com/spiceai/spiceai/pull/9667)
 - fix: add liveness check for dead executors in partition routing by [@Jeadie](https://github.com/Jeadie) in [#9657](https://github.com/spiceai/spiceai/pull/9657)
 - fix(s3): Fix metadata column schema mismatches in projected queries by [@sgrebnov](https://github.com/sgrebnov) in [#9664](https://github.com/spiceai/spiceai/pull/9664)
-- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9674](https://github.com/spiceai/spiceai/pull/9674)
 - s3_metadata_columns tests: include test for location outside table prefix by [@sgrebnov](https://github.com/sgrebnov) in [#9676](https://github.com/spiceai/spiceai/pull/9676)
-- docs: Update DuckDB, GCS, Git connector and Cayenne documentation for clarity and detail by [@lukekim](https://github.com/lukekim) in [#9671](https://github.com/spiceai/spiceai/pull/9671)
+- docs: Update DuckDB, GCS, Git connector and Cayenne documentation by [@lukekim](https://github.com/lukekim) in [#9671](https://github.com/spiceai/spiceai/pull/9671)
 - Add s3_url_style support for S3 connector URL addressing by [@phillipleblanc](https://github.com/phillipleblanc) in [#9642](https://github.com/spiceai/spiceai/pull/9642)
 - Consolidate E2E workflows and require WSL for Windows runtime by [@lukekim](https://github.com/lukekim) in [#9660](https://github.com/spiceai/spiceai/pull/9660)
 - Upgrade to Rust v1.93.1 by [@lukekim](https://github.com/lukekim) in [#9669](https://github.com/spiceai/spiceai/pull/9669)
 - Security fixes and improvements by [@lukekim](https://github.com/lukekim) in [#9666](https://github.com/spiceai/spiceai/pull/9666)
 - feat(flight): add DoPut rows/bytes written metrics for DoPut ETL ingestion tracking by [@phillipleblanc](https://github.com/phillipleblanc) in [#9663](https://github.com/spiceai/spiceai/pull/9663)
-- Skip caching http error response + add `reponse_headers` by [@krinart](https://github.com/krinart) in [#9670](https://github.com/spiceai/spiceai/pull/9670)
+- Skip caching http error response + add `response_headers` by [@krinart](https://github.com/krinart) in [#9670](https://github.com/spiceai/spiceai/pull/9670)
 - refactor: Remove `v1/evals` functionality by [@Jeadie](https://github.com/Jeadie) in [#9420](https://github.com/spiceai/spiceai/pull/9420)
-- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9684](https://github.com/spiceai/spiceai/pull/9684)
-- Make a test harness for Distributed Spice integration tests. by [@Jeadie](https://github.com/Jeadie) in [#9615](https://github.com/spiceai/spiceai/pull/9615)
-- v1.11.3 release notes by [@phillipleblanc](https://github.com/phillipleblanc) in [#9686](https://github.com/spiceai/spiceai/pull/9686)
-- Enable 'data_components test_primary_key_value_matches_batch' test by [@Jeadie](https://github.com/Jeadie) in [#9687](https://github.com/spiceai/spiceai/pull/9687)
+- Make a test harness for Distributed Spice integration tests by [@Jeadie](https://github.com/Jeadie) in [#9615](https://github.com/spiceai/spiceai/pull/9615)
 - Enable `on_zero_results: use_source` for views by [@krinart](https://github.com/krinart) in [#9699](https://github.com/spiceai/spiceai/pull/9699)
-- build(deps): batch merge dependabot updates by [@phillipleblanc](https://github.com/phillipleblanc) in [#9703](https://github.com/spiceai/spiceai/pull/9703)
 - fix(spidapter): Lower memory limit, passthrough AWS secrets, override flight URL by [@peasee](https://github.com/peasee) in [#9704](https://github.com/spiceai/spiceai/pull/9704)
-- fix(ci): resolve setup-rust toolchain in isolated cargo home by [@lukekim](https://github.com/lukekim) in [#9700](https://github.com/spiceai/spiceai/pull/9700)
 - Show an error on a shared acceleration file with snapshots enabled by [@krinart](https://github.com/krinart) in [#9698](https://github.com/spiceai/spiceai/pull/9698)
 - Fixes for anthropic by [@Jeadie](https://github.com/Jeadie) in [#9707](https://github.com/spiceai/spiceai/pull/9707)
-- Use `max_partitions_per_executor ` in `allocate_initial_partitions`.  by [@Jeadie](https://github.com/Jeadie) in [#9659](https://github.com/spiceai/spiceai/pull/9659)
+- Use `max_partitions_per_executor` in `allocate_initial_partitions` by [@Jeadie](https://github.com/Jeadie) in [#9659](https://github.com/spiceai/spiceai/pull/9659)
 - [SpiceDQ] Accelerations must have partition key by [@Jeadie](https://github.com/Jeadie) in [#9711](https://github.com/spiceai/spiceai/pull/9711)
 - Upgrade to Turso v0.5 by [@lukekim](https://github.com/lukekim) in [#9628](https://github.com/spiceai/spiceai/pull/9628)
 - feat: Rename metadata columns to _location, _last_modified, _size by [@phillipleblanc](https://github.com/phillipleblanc) in [#9712](https://github.com/spiceai/spiceai/pull/9712)
-- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9675](https://github.com/spiceai/spiceai/pull/9675)
-- refactor: Simplify Rust toolchain installation by [@lukekim](https://github.com/lukekim) in [#9720](https://github.com/spiceai/spiceai/pull/9720)
-- fix: bump datafusion-ballista to fix BatchCoalescer schema mismatch panic in distributed queries by [@phillipleblanc](https://github.com/phillipleblanc) in [#9716](https://github.com/spiceai/spiceai/pull/9716)
-- fix: Reduce s3_url_style auto-detection log verbosity by [@phillipleblanc](https://github.com/phillipleblanc) in [#9722](https://github.com/spiceai/spiceai/pull/9722)
-- Improve test_accelerated_view_on_zero_results_use_source test by [@sgrebnov](https://github.com/sgrebnov) in [#9719](https://github.com/spiceai/spiceai/pull/9719)
-- fix(spidapter): Add IF NOT EXISTS to setup table creation and fix test YAML kind casing by [@phillipleblanc](https://github.com/phillipleblanc) in [#9726](https://github.com/spiceai/spiceai/pull/9726)
-- Add v1.11.4 release notes by [@sgrebnov](https://github.com/sgrebnov) in [#9717](https://github.com/spiceai/spiceai/pull/9717)
+- fix: bump datafusion-ballista to fix BatchCoalescer schema mismatch panic by [@phillipleblanc](https://github.com/phillipleblanc) in [#9716](https://github.com/spiceai/spiceai/pull/9716)
 - fix: Ensure Cayenne respects target file size by [@peasee](https://github.com/peasee) in [#9730](https://github.com/spiceai/spiceai/pull/9730)
-- Add v1.11.2..4 as supported versions in SECURITY.md by [@sgrebnov](https://github.com/sgrebnov) in [#9735](https://github.com/spiceai/spiceai/pull/9735)
 - refactor: Make DDL preprocessing generic from Iceberg DDL processing by [@peasee](https://github.com/peasee) in [#9731](https://github.com/spiceai/spiceai/pull/9731)
-- [SpiceDQ] Distribute query of Cayenne Catalog to executors with data.  by [@Jeadie](https://github.com/Jeadie) in [#9727](https://github.com/spiceai/spiceai/pull/9727)
+- [SpiceDQ] Distribute query of Cayenne Catalog to executors with data by [@Jeadie](https://github.com/Jeadie) in [#9727](https://github.com/spiceai/spiceai/pull/9727)
 - Properly set `primary_keys`/`on_conflict` for Cayenne tables by [@krinart](https://github.com/krinart) in [#9739](https://github.com/spiceai/spiceai/pull/9739)
 - Add executor resource and replica support to cloud app config by [@ewgenius](https://github.com/ewgenius) in [#9734](https://github.com/spiceai/spiceai/pull/9734)
 - feat: Support PARTITION BY in Cayenne Catalog table creation by [@peasee](https://github.com/peasee) in [#9741](https://github.com/spiceai/spiceai/pull/9741)
 - Update datafusion and related packages to version 52.3.0 by [@lukekim](https://github.com/lukekim) in [#9708](https://github.com/spiceai/spiceai/pull/9708)
 - Route FlightSQL statement updates through QueryBuilder by [@phillipleblanc](https://github.com/phillipleblanc) in [#9754](https://github.com/spiceai/spiceai/pull/9754)
 - JSON file format improvements by [@lukekim](https://github.com/lukekim) in [#9743](https://github.com/spiceai/spiceai/pull/9743)
-- Potential fix for 1 code quality finding by [@lukekim](https://github.com/lukekim) in [#9753](https://github.com/spiceai/spiceai/pull/9753)
-- [SpiceDQ] Partition Cayenne catalogs writes through to executors, dynamically updating partition assignments.  by [@Jeadie](https://github.com/Jeadie) in [#9737](https://github.com/spiceai/spiceai/pull/9737)
-- build(deps): bump quinn-proto from 0.11.13 to 0.11.14 in the cargo group across 1 directory by [@app/dependabot](https://github.com/app/dependabot) in [#9709](https://github.com/spiceai/spiceai/pull/9709)
+- [SpiceDQ] Partition Cayenne catalogs writes through to executors by [@Jeadie](https://github.com/Jeadie) in [#9737](https://github.com/spiceai/spiceai/pull/9737)
 - Update to DF v52.3.0 versions of datafusion & datafusion-tableproviders by [@lukekim](https://github.com/lukekim) in [#9756](https://github.com/spiceai/spiceai/pull/9756)
 - Make S3 metadata column handling more robust by [@sgrebnov](https://github.com/sgrebnov) in [#9762](https://github.com/spiceai/spiceai/pull/9762)
 - Fetch API keys from dedicated endpoint instead of apps response by [@phillipleblanc](https://github.com/phillipleblanc) in [#9767](https://github.com/spiceai/spiceai/pull/9767)
-- ci: switch integration_models from pull_request_target to pull_request by [@phillipleblanc](https://github.com/phillipleblanc) in [#9768](https://github.com/spiceai/spiceai/pull/9768)
 - Update arrow-rs, datafusion-federation, and datafusion-table-providers dependencies by [@phillipleblanc](https://github.com/phillipleblanc) in [#9769](https://github.com/spiceai/spiceai/pull/9769)
-- Minor fixes for streaming benchmarks by [@krinart](https://github.com/krinart) in [#9537](https://github.com/spiceai/spiceai/pull/9537)
-- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9785](https://github.com/spiceai/spiceai/pull/9785)
-- Add `arrow` query override to skip TPC-DS q72 by [@sgrebnov](https://github.com/sgrebnov) in [#9786](https://github.com/spiceai/spiceai/pull/9786)
-- Skip ClickBench zero-row queries in row count validation (partial data is used) by [@sgrebnov](https://github.com/sgrebnov) in [#9790](https://github.com/spiceai/spiceai/pull/9790)
-- Databricks benchmark: increase ready timeout to allow warehouse to unpause by [@sgrebnov](https://github.com/sgrebnov) in [#9789](https://github.com/spiceai/spiceai/pull/9789)
-- Skip TPC-DS zero-row queries for SQLite row count validation (SF 0.01) by [@sgrebnov](https://github.com/sgrebnov) in [#9791](https://github.com/spiceai/spiceai/pull/9791)
-- docs: Release Cayenne as RC by [@peasee](https://github.com/peasee) in [#9766](https://github.com/spiceai/spiceai/pull/9766)
-- build(deps): bump Swatinem/rust-cache from 2.8.2 to 2.9.1 by [@app/dependabot](https://github.com/app/dependabot) in [#9774](https://github.com/spiceai/spiceai/pull/9774)
-- build(deps): bump actions/download-artifact from 8.0.0 to 8.0.1 by [@app/dependabot](https://github.com/app/dependabot) in [#9776](https://github.com/spiceai/spiceai/pull/9776)
-- build(deps): bump aws-smithy-runtime-api from 1.11.5 to 1.11.6 by [@app/dependabot](https://github.com/app/dependabot) in [#9780](https://github.com/spiceai/spiceai/pull/9780)
-- build(deps): bump aws-smithy-async from 1.2.13 to 1.2.14 by [@app/dependabot](https://github.com/app/dependabot) in [#9778](https://github.com/spiceai/spiceai/pull/9778)
+- Chunk metastore batch inserts to respect SQLite parameter limits by [@phillipleblanc](https://github.com/phillipleblanc) in [#9770](https://github.com/spiceai/spiceai/pull/9770)
 - Improve JSON SODA support by [@lukekim](https://github.com/lukekim) in [#9795](https://github.com/spiceai/spiceai/pull/9795)
 - Add ADBC Data Connector by [@lukekim](https://github.com/lukekim) in [#9723](https://github.com/spiceai/spiceai/pull/9723)
-- Increase `ready_wait` for turso benchmarks by [@krinart](https://github.com/krinart) in [#9798](https://github.com/spiceai/spiceai/pull/9798)
-- build(deps): bump github/codeql-action from 4.32.6 to 4.33.0 by [@app/dependabot](https://github.com/app/dependabot) in [#9775](https://github.com/spiceai/spiceai/pull/9775)
-- Chunk metastore batch inserts to respect SQLite parameter limits by [@phillipleblanc](https://github.com/phillipleblanc) in [#9770](https://github.com/spiceai/spiceai/pull/9770)
-- build(deps): bump actions/create-github-app-token from 2.2.1 to 3.0.0 by [@app/dependabot](https://github.com/app/dependabot) in [#9773](https://github.com/spiceai/spiceai/pull/9773)
+- docs: Release Cayenne as RC by [@peasee](https://github.com/peasee) in [#9766](https://github.com/spiceai/spiceai/pull/9766)
 - cli[feat]: cloud mode to use region-specific endpoints by [@lukekim](https://github.com/lukekim) in [#9803](https://github.com/spiceai/spiceai/pull/9803)
-- Revert change in TPCH q18.sql by [@sgrebnov](https://github.com/sgrebnov) in [#9788](https://github.com/spiceai/spiceai/pull/9788)
-- Add overrides for catalog benchmarks by [@krinart](https://github.com/krinart) in [#9797](https://github.com/spiceai/spiceai/pull/9797)
 - Include updated JSON formats in HTTPS connector by [@lukekim](https://github.com/lukekim) in [#9800](https://github.com/spiceai/spiceai/pull/9800)
 - Flight DoPut: Partition-aware write-through forwarding by [@Jeadie](https://github.com/Jeadie) in [#9759](https://github.com/spiceai/spiceai/pull/9759)
-- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9807](https://github.com/spiceai/spiceai/pull/9807)
 - Pass through authentication to ADBC connector by [@lukekim](https://github.com/lukekim) in [#9801](https://github.com/spiceai/spiceai/pull/9801)
 - Move scheduler_state_location from adapter metadata to env var by [@phillipleblanc](https://github.com/phillipleblanc) in [#9802](https://github.com/spiceai/spiceai/pull/9802)
 - Fix Cayenne DoPut upsert returning stale data after 3+ writes by [@phillipleblanc](https://github.com/phillipleblanc) in [#9806](https://github.com/spiceai/spiceai/pull/9806)
 - Fix JSON column projection producing schema mismatch by [@sgrebnov](https://github.com/sgrebnov) in [#9811](https://github.com/spiceai/spiceai/pull/9811)
-- Fix runtime-table-partition bucket pruning tests after Bucket::return_type change by [@sgrebnov](https://github.com/sgrebnov) in [#9812](https://github.com/spiceai/spiceai/pull/9812)
-- Fix Dockerfile: add `libclang-dev` by [@krinart](https://github.com/krinart) in [#9815](https://github.com/spiceai/spiceai/pull/9815)
-- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9809](https://github.com/spiceai/spiceai/pull/9809)
-- Update openapi.json by [@app/github-actions](https://github.com/app/github-actions) in [#9738](https://github.com/spiceai/spiceai/pull/9738)
-- Add install-build target and script for CI build artifact installation by [@lukekim](https://github.com/lukekim) in [#9816](https://github.com/spiceai/spiceai/pull/9816)
-- Remove Go and unused target_arch_go variables from workflow files by [@lukekim](https://github.com/lukekim) in [#9817](https://github.com/spiceai/spiceai/pull/9817)
 - Fix http connector by [@krinart](https://github.com/krinart) in [#9818](https://github.com/spiceai/spiceai/pull/9818)
 - Fix ADBC Connector build and test by [@lukekim](https://github.com/lukekim) in [#9813](https://github.com/spiceai/spiceai/pull/9813)
+- Support update & delete DML for distributed cayenne catalog by [@Jeadie](https://github.com/Jeadie) in [#9805](https://github.com/spiceai/spiceai/pull/9805)
+- Set allow_http param when S3 endpoint uses http scheme by [@phillipleblanc](https://github.com/phillipleblanc) in [#9834](https://github.com/spiceai/spiceai/pull/9834)
+- fix: Cayenne Catalog DDL requires a connected executor in distributed mode by [@Jeadie](https://github.com/Jeadie) in [#9838](https://github.com/spiceai/spiceai/pull/9838)
+- fix: Add conditional put support for file:// scheduler state location by [@Jeadie](https://github.com/Jeadie) in [#9842](https://github.com/spiceai/spiceai/pull/9842)
+- fix: Require the DDL primary key contain the partition key by [@Jeadie](https://github.com/Jeadie) in [#9844](https://github.com/spiceai/spiceai/pull/9844)
+- fix: Databricks SQL Warehouse schema retrieval with INLINE disposition and async retry by [@lukekim](https://github.com/lukekim) in [#9846](https://github.com/spiceai/spiceai/pull/9846)
+- Filter pushdown improvements for SqlTable by [@lukekim](https://github.com/lukekim) in [#9852](https://github.com/spiceai/spiceai/pull/9852)
+- feat: add iam_role_source parameter for AWS credential configuration by [@lukekim](https://github.com/lukekim) in [#9854](https://github.com/spiceai/spiceai/pull/9854)
+- Fix ODBC queries silently returning 0 rows on query failure by [@lukekim](https://github.com/lukekim) in [#9864](https://github.com/spiceai/spiceai/pull/9864)
+- feat(adbc): Add ADBC catalog connector with schema/table discovery by [@lukekim](https://github.com/lukekim) in [#9865](https://github.com/spiceai/spiceai/pull/9865)
+- Make Turso SQL unparsing more robust and fix date comparisons by [@lukekim](https://github.com/lukekim) in [#9871](https://github.com/spiceai/spiceai/pull/9871)
+- Fix Flight/FlightSQL filter precedence and mutable query consistency by [@lukekim](https://github.com/lukekim) in [#9876](https://github.com/spiceai/spiceai/pull/9876)
+- Partial Aggregation optimisation for `FlightSQLExec` by [@lukekim](https://github.com/lukekim) in [#9882](https://github.com/spiceai/spiceai/pull/9882)
+- fix: v1/responses API preserves client instructions when system_prompt is set by [@Jeadie](https://github.com/Jeadie) in [#9884](https://github.com/spiceai/spiceai/pull/9884)
+- feat: emit `scheduler_active_executors_count` and use it in spidapter by [@Jeadie](https://github.com/Jeadie) in [#9885](https://github.com/spiceai/spiceai/pull/9885)
+- feat: Add custom auth header support for GraphQL connector by [@krinart](https://github.com/krinart) in [#9899](https://github.com/spiceai/spiceai/pull/9899)
+- Add --endpoint flag to spice run with scheme-based routing by [@lukekim](https://github.com/lukekim) in [#9903](https://github.com/spiceai/spiceai/pull/9903)
+- When executor connects, send DDL for existing tables by [@Jeadie](https://github.com/Jeadie) in [#9904](https://github.com/spiceai/spiceai/pull/9904)
+- fix: Improve ADBC driver shutdown handling and error classification by [@lukekim](https://github.com/lukekim) in [#9905](https://github.com/spiceai/spiceai/pull/9905)
+- fix: require all executors to succeed for distributed DML (DELETE/UPDATE) forwarding by [@Jeadie](https://github.com/Jeadie) in [#9908](https://github.com/spiceai/spiceai/pull/9908)
+- fix(cayenne catalog): fix catalog refresh race condition causing duplicate primary keys by [@Jeadie](https://github.com/Jeadie) in [#9909](https://github.com/spiceai/spiceai/pull/9909)
+- Remove Perplexity support by [@Jeadie](https://github.com/Jeadie) in [#9910](https://github.com/spiceai/spiceai/pull/9910)
+- Fix refresh_sql support for debezium constraints by [@krinart](https://github.com/krinart) in [#9912](https://github.com/spiceai/spiceai/pull/9912)
+- Implement DML for DynamoDBTableProvider by [@lukekim](https://github.com/lukekim) in [#9915](https://github.com/spiceai/spiceai/pull/9915)
+- chore: Update iceberg-rust fork to v0.9 by [@lukekim](https://github.com/lukekim) in [#9917](https://github.com/spiceai/spiceai/pull/9917)
+- Run physical optimizer on `FallbackOnZeroResultsScanExec` fallback plan by [@sgrebnov](https://github.com/sgrebnov) in [#9927](https://github.com/spiceai/spiceai/pull/9927)
+- Improve Databricks error message when dataset has no columns by [@sgrebnov](https://github.com/sgrebnov) in [#9928](https://github.com/spiceai/spiceai/pull/9928)
+- Delta Lake: fix data skipping for >= timestamp predicates by [@sgrebnov](https://github.com/sgrebnov) in [#9932](https://github.com/spiceai/spiceai/pull/9932)
+- fix: Ensure distributed Cayenne DML inserts are forwarded to executors by [@Jeadie](https://github.com/Jeadie) in [#9948](https://github.com/spiceai/spiceai/pull/9948)
+- Add full query federation support for ADBC data connector by [@lukekim](https://github.com/lukekim) in [#9953](https://github.com/spiceai/spiceai/pull/9953)
+- Make time_format deserialization case-insensitive by [@vyershov](https://github.com/vyershov) in [#9955](https://github.com/spiceai/spiceai/pull/9955)
+- Hash ADBC join-pushdown context to prevent credential leaks in EXPLAIN plans by [@lukekim](https://github.com/lukekim) in [#9956](https://github.com/spiceai/spiceai/pull/9956)
+- fix: Normalize Arrow Dictionary types for DuckDB and SQLite acceleration by [@sgrebnov](https://github.com/sgrebnov) in [#9959](https://github.com/spiceai/spiceai/pull/9959)
+- ADBC BigQuery: Improve BigQuery dialect date/time and interval SQL generation by [@lukekim](https://github.com/lukekim) in [#9967](https://github.com/spiceai/spiceai/pull/9967)
+- Make `BigQueryDialect` more robust and add BigQuery TPC-H benchmark support by [@lukekim](https://github.com/lukekim) in [#9969](https://github.com/spiceai/spiceai/pull/9969)
+- fix: Show proper unauthorized error instead of misleading runtime unavailable by [@lukekim](https://github.com/lukekim) in [#9972](https://github.com/spiceai/spiceai/pull/9972)
+- fix: Enforce target_chunk_size as hard maximum in chunking by [@lukekim](https://github.com/lukekim) in [#9973](https://github.com/spiceai/spiceai/pull/9973)
+- Add caching retention by [@krinart](https://github.com/krinart) in [#9984](https://github.com/spiceai/spiceai/pull/9984)
+- fix: improve Databricks schema error detection and messages by [@lukekim](https://github.com/lukekim) in [#9987](https://github.com/spiceai/spiceai/pull/9987)
+- fix: Set default S3 region for opendal operator and fix cayenne nextest by [@phillipleblanc](https://github.com/phillipleblanc) in [#9995](https://github.com/spiceai/spiceai/pull/9995)
+- fix(PostgreSQL): fix schema discovery for PostgreSQL partitioned tables by [@sgrebnov](https://github.com/sgrebnov) in [#9997](https://github.com/spiceai/spiceai/pull/9997)
+- fix: Defer cache size check until after encoding for compressed results by [@krinart](https://github.com/krinart) in [#10001](https://github.com/spiceai/spiceai/pull/10001)
+- fix: Rewrite numeric BETWEEN to CAST(AS REAL) for Turso by [@lukekim](https://github.com/lukekim) in [#10003](https://github.com/spiceai/spiceai/pull/10003)
+- fix: Handle integer time columns in append refresh for all accelerators by [@sgrebnov](https://github.com/sgrebnov) in [#10004](https://github.com/spiceai/spiceai/pull/10004)
+- fix: preserve s3a:// scheme when building OpenDalStorageFactory with custom endpoint by [@phillipleblanc](https://github.com/phillipleblanc) in [#10006](https://github.com/spiceai/spiceai/pull/10006)
+- Fix ISO8601 time_format with Vortex/Cayenne append refresh by [@sgrebnov](https://github.com/sgrebnov) in [#10009](https://github.com/spiceai/spiceai/pull/10009)
+- fix: Address data correctness bugs found in audit by [@sgrebnov](https://github.com/sgrebnov) in [#10015](https://github.com/spiceai/spiceai/pull/10015)
+- fix(federation): fix SQL unparsing for Inexact filter pushdown with alias by [@lukekim](https://github.com/lukekim) in [#10017](https://github.com/spiceai/spiceai/pull/10017)
+- Improve GitHub connector ref handling and resilience by [@lukekim](https://github.com/lukekim) in [#10023](https://github.com/spiceai/spiceai/pull/10023)
+- feat: Add spice completions command for shell completion generation by [@lukekim](https://github.com/lukekim) in [#10024](https://github.com/spiceai/spiceai/pull/10024)
+- fix: Fix data correctness bugs in DynamoDB decimal conversion and GraphQL pagination by [@sgrebnov](https://github.com/sgrebnov) in [#10054](https://github.com/spiceai/spiceai/pull/10054)
+- Implement RefreshDataset for distributed control stream by [@Jeadie](https://github.com/Jeadie) in [#10055](https://github.com/spiceai/spiceai/pull/10055)
+- perf: Improve S3 parquet read performance by [@sgrebnov](https://github.com/sgrebnov) in [#10064](https://github.com/spiceai/spiceai/pull/10064)
+- fix: Prevent write-through stalls and preserve PartitionTableProvider during catalog refresh by [@Jeadie](https://github.com/Jeadie) in [#10066](https://github.com/spiceai/spiceai/pull/10066)
+- feat: `spice completions` auto-detects shell directory and writes file by [@lukekim](https://github.com/lukekim) in [#10068](https://github.com/spiceai/spiceai/pull/10068)
+- fix: Bug in DynamoDB, GraphQL, and ISO8601 refresh data handling by [@sgrebnov](https://github.com/sgrebnov) in [#10063](https://github.com/spiceai/spiceai/pull/10063)
+- fix partial aggregation deduplication on string checking by [@lukekim](https://github.com/lukekim) in [#10078](https://github.com/spiceai/spiceai/pull/10078)
+- fix: add MetastoreTransaction support to prevent concurrent transaction conflicts by [@phillipleblanc](https://github.com/phillipleblanc) in [#10080](https://github.com/spiceai/spiceai/pull/10080)
+- fix: Use GreedyMemoryPool, add spidapter query memory limit arg by [@phillipleblanc](https://github.com/phillipleblanc) in [#10082](https://github.com/spiceai/spiceai/pull/10082)
+- feat: Add metrics for EXPLAIN ANALYZE in FlightSQLExec by [@lukekim](https://github.com/lukekim) in [#10084](https://github.com/spiceai/spiceai/pull/10084)
+- Use strict cast in `try_cast_to` to error on overflow instead of silent NULL by [@sgrebnov](https://github.com/sgrebnov) in [#10104](https://github.com/spiceai/spiceai/pull/10104)
+- feat: Implement MERGE INTO for Cayenne catalog tables by [@peasee](https://github.com/peasee) in [#10105](https://github.com/spiceai/spiceai/pull/10105)
+- feat: Add distributed MERGE INTO support for Cayenne catalog tables by [@peasee](https://github.com/peasee) in [#10106](https://github.com/spiceai/spiceai/pull/10106)
+- Improve JSON format auto-detection for single multi-line objects by [@lukekim](https://github.com/lukekim) in [#10107](https://github.com/spiceai/spiceai/pull/10107)
+- Add mode: file_update acceleration mode by [@krinart](https://github.com/krinart) in [#10108](https://github.com/spiceai/spiceai/pull/10108)
+- Coerce unsupported Arrow types to Iceberg v2 equivalents in REST catalog API by [@peasee](https://github.com/peasee) in [#10109](https://github.com/spiceai/spiceai/pull/10109)
+- fix: Update default query memory limit to 90% from 70% by [@phillipleblanc](https://github.com/phillipleblanc) in [#10112](https://github.com/spiceai/spiceai/pull/10112)
+- feat: Add mTLS client auth support to spice sql REPL by [@lukekim](https://github.com/lukekim) in [#10113](https://github.com/spiceai/spiceai/pull/10113)
+- fix(datafusion-federation): report error on overflow instead of silent NULL by [@sgrebnov](https://github.com/sgrebnov) in [#10124](https://github.com/spiceai/spiceai/pull/10124)
+- fix: Prevent data loss in MERGE when source has duplicate keys by [@peasee](https://github.com/peasee) in [#10126](https://github.com/spiceai/spiceai/pull/10126)
+- feat: Add ClickHouse Date32 type support by [@sgrebnov](https://github.com/sgrebnov) in [#10132](https://github.com/spiceai/spiceai/pull/10132)
+- Add Delta Lake column mapping support (Name/Id modes) by [@sgrebnov](https://github.com/sgrebnov) in [#10134](https://github.com/spiceai/spiceai/pull/10134)
+- fix: Restore Turso numeric BETWEEN rewrite lost in DML revert by [@lukekim](https://github.com/lukekim) in [#10139](https://github.com/spiceai/spiceai/pull/10139)
+- fix: Enable arm64 Linux builds with fp16 and lld workarounds by [@lukekim](https://github.com/lukekim) in [#10142](https://github.com/spiceai/spiceai/pull/10142)
+- fix: remove double trailing slash in Unity Catalog storage locations by [@sgrebnov](https://github.com/sgrebnov) in [#10147](https://github.com/spiceai/spiceai/pull/10147)
+- fix: Improve GitHub GraphQL client resilience and performance by [@lukekim](https://github.com/lukekim) in [#10151](https://github.com/spiceai/spiceai/pull/10151)
+- Enable reqwest compression and optimize HTTP client settings by [@lukekim](https://github.com/lukekim) in [#10154](https://github.com/spiceai/spiceai/pull/10154)
+- fix: executor startup failures by [@Jeadie](https://github.com/Jeadie) in [#10155](https://github.com/spiceai/spiceai/pull/10155)
+- feat: Distributed runtime.task_history support by [@Jeadie](https://github.com/Jeadie) in [#10156](https://github.com/spiceai/spiceai/pull/10156)
+- fix: Preserve timestamp timezone in DDL forwarding to executors by [@peasee](https://github.com/peasee) in [#10159](https://github.com/spiceai/spiceai/pull/10159)
+- feat: Per-model rate-limited concurrent AI UDF execution by [@Jeadie](https://github.com/Jeadie) in [#10160](https://github.com/spiceai/spiceai/pull/10160)
+- fix(Turso): Reject subquery/outer-ref filter pushdown in Turso provider by [@lukekim](https://github.com/lukekim) in [#10174](https://github.com/spiceai/spiceai/pull/10174)
+- Fix linux/macos `spice upgrade` by [@phillipleblanc](https://github.com/phillipleblanc) in [#10194](https://github.com/spiceai/spiceai/pull/10194)
+- Improve CREATE TABLE LIKE error messages, success output, EXPLAIN, and validation by [@peasee](https://github.com/peasee) in [#10203](https://github.com/spiceai/spiceai/pull/10203)
+- fix: chunk MERGE delete filters and update Vortex for stack-safe IN-lists by [@peasee](https://github.com/peasee) in [#10207](https://github.com/spiceai/spiceai/pull/10207)
+- Propagate `runtime.params.parquet_page_index` to Delta Lake connector by [@sgrebnov](https://github.com/sgrebnov) in [#10209](https://github.com/spiceai/spiceai/pull/10209)
+- Properly mark dataset as Ready on Scheduler by [@Jeadie](https://github.com/Jeadie) in [#10215](https://github.com/spiceai/spiceai/pull/10215)
+- fix: handle Utf8View/LargeUtf8 in GitHub connector ref filters by [@lukekim](https://github.com/lukekim) in [#10217](https://github.com/spiceai/spiceai/pull/10217)
+- fix(databricks): Fix schema introspection and timestamp overflow by [@lukekim](https://github.com/lukekim) in [#10226](https://github.com/spiceai/spiceai/pull/10226)
+- fix(databricks): Fix schema introspection failures for non-Unity-Catalog environments by [@lukekim](https://github.com/lukekim) in [#10227](https://github.com/spiceai/spiceai/pull/10227)
+- feat: Add pagination support to HTTP data connector by [@lukekim](https://github.com/lukekim) in [#10228](https://github.com/spiceai/spiceai/pull/10228)
+- feat(databricks): DESCRIBE TABLE fallback and source-native type parsing for Lakehouse Federation by [@lukekim](https://github.com/lukekim) in [#10229](https://github.com/spiceai/spiceai/pull/10229)
+- fix(databricks): harden HTTP retries, compression, and token refresh by [@lukekim](https://github.com/lukekim) in [#10232](https://github.com/spiceai/spiceai/pull/10232)
+- feat[helm chart]: Add support for ServiceAccount annotations and AWS IRSA example by [@peasee](https://github.com/peasee) in [#9833](https://github.com/spiceai/spiceai/pull/9833)
+- fix: Log warning and fall back gracefully on Cayenne config change by [@krinart](https://github.com/krinart) in [#9092](https://github.com/spiceai/spiceai/pull/9092)
+- fix: Handle engine mismatch gracefully in snapshot fallback loop by [@krinart](https://github.com/krinart) in [#9187](https://github.com/spiceai/spiceai/pull/9187)
 
 **Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.0.0-rc.1...v2.0.0-rc.2>


### PR DESCRIPTION
Update the v2.0.0-rc.2 release notes to include all changes since the initial draft.

### Key additions:
- **Distributed Cayenne Query and Write Improvements** moved to top feature
- **DataFusion v52.3.0 Upgrade** highlighted as second feature
- **ADBC Data Connector & Catalog** — full federation, BigQuery support, catalog discovery
- **MERGE INTO for Cayenne** — with distributed support and data safety
- **Databricks Lakehouse Federation Improvements** — reliability, resilience, DESCRIBE TABLE fallback
- **Delta Lake Column Mapping** — Name/Id modes
- **HTTP Pagination** — paginated API support
- **Per-Model Rate-Limited AI UDF Execution**
- New features: file_update mode, spice completions, --endpoint flag, mTLS, DynamoDB DML, caching retention, GraphQL custom auth, ClickHouse Date32, AWS iam_role_source
- Updated contributors, breaking changes, dependency table, and changelog
- Date updated to Apr 9, 2026