### PR TITLE
Fix failing merge conflicts for benchmarks

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -462,6 +462,8 @@ jobs:
       - name: Upload benchmark snapshots to branch
         if: steps.determine_update_snapshots.outputs.update_snapshots == 'always'
         run: |
+          git fetch --unshallow || true
+
           # if the spiced commit is set, use that as the branch ID
           if [ -n "${{ github.event.inputs.spiced_commit || '' }}" ]; then
             BRANCH_ID=${{ github.event.inputs.spiced_commit }}


### PR DESCRIPTION
## 📝 Summary

We are using `actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8` with no parameters, which results in `fetch-depth: 1`. Which means that when there are conflicts during `pull --rebase` - it can't resolve them.

The fix is to do `git fetch --unshallow`, which will pull history.