### PR TITLE
Upgrade DataFusion to v52.5.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=869b1a0245244accfcc725de82e95ec7e604349a#869b1a0245244accfcc725de82e95ec7e604349a"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=869b1a0245244accfcc725de82e95ec7e604349a#869b1a0245244accfcc725de82e95ec7e604349a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ad88031f002aec4ec63dc1fabd81dfd3cf69fb22#ad88031f002aec4ec63dc1fabd81dfd3cf69fb22"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=869b1a0245244accfcc725de82e95ec7e604349a#869b1a0245244accfcc725de82e95ec7e604349a"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5356,8 +5356,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5410,8 +5410,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5434,8 +5434,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5458,8 +5458,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5481,8 +5481,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "futures",
  "log",
@@ -5491,8 +5491,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5527,8 +5527,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5550,8 +5550,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5572,8 +5572,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5593,8 +5593,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,13 +5622,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 
 [[package]]
 name = "datafusion-execution"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5647,8 +5647,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5669,8 +5669,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.4.2"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=9b7e0f48c00deefe1276a46890562523b4b97c41#9b7e0f48c00deefe1276a46890562523b4b97c41"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=e1318d3f7530234356caa87ba59e4bbc05dbe72a#e1318d3f7530234356caa87ba59e4bbc05dbe72a"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -5694,8 +5694,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5724,8 +5724,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5744,8 +5744,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5768,8 +5768,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -5790,8 +5790,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5805,8 +5805,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5822,8 +5822,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -5831,8 +5831,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -5841,8 +5841,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "chrono",
@@ -5890,8 +5890,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5913,8 +5913,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5927,8 +5927,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5943,8 +5943,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5961,8 +5961,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5991,8 +5991,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "chrono",
@@ -6020,8 +6020,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6032,8 +6032,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6048,8 +6048,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6061,8 +6061,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spark"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6083,8 +6083,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6100,8 +6100,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
+version = "52.5.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c434c7b5a4e1ddb3137f1cea8da1006c514ae889#c434c7b5a4e1ddb3137f1cea8da1006c514ae889"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=408e2c554db2433670ea2ffb43a4289fefe739ad#408e2c554db2433670ea2ffb43a4289fefe739ad"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=57fd1335870409a63555036e86a78627b9a29382#57fd1335870409a63555036e86a78627b9a29382"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -23631,13 +23631,3 @@ checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
 dependencies = [
  "zune-core 0.5.1",
 ]
-
-[[patch.unused]]
-name = "datafusion-datasource-avro"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"
-
-[[patch.unused]]
-name = "datafusion-ffi"
-version = "52.4.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15#f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=57fd1335870409a63555036e86a78627b9a29382#57fd1335870409a63555036e86a78627b9a29382"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139#64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,12 +325,12 @@ util = { path = "crates/util", default-features = false }
 uuid = "1"
 
 # We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-datafusion = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-datafusion = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "4c63970cf1d78c71eb69e2f4346d5d4795631b47" } # branch: trunk
@@ -355,49 +355,47 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                       # spiceai-52
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }               # spiceai-52
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }       # spiceai-52
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                # spiceai-52
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }        # spiceai-52
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }            # spiceai-52
-datafusion-datasource-avro = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }       # spiceai-52
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }        # spiceai-52
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }       # spiceai-52
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }    # spiceai-52
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                   # spiceai-52
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }             # spiceai-52
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                  # spiceai-52
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }           # spiceai-52
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }             # spiceai-52
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }         # spiceai-52
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" } # spiceai-52
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }  # spiceai-52
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }         # spiceai-52
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                 # spiceai-52
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }          # spiceai-52
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }               # spiceai-52
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }               # spiceai-52
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                   # spiceai-52
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }     # spiceai-52
-datafusion-ffi = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                  # spiceai-52
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }  # spiceai-52
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }  # spiceai-52
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }     # spiceai-52
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }          # spiceai-52
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }         # spiceai-52
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }  # spiceai-52
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                   # spiceai-52
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                # spiceai-52
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }       # spiceai-52
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                    # spiceai-52
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "f9e35b561eaeabc6dc6268ebbfd03ebe46e31e15" }                # spiceai-52
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                       # spiceai-52.5
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }               # spiceai-52.5
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }       # spiceai-52.5
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }        # spiceai-52.5
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }            # spiceai-52.5
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }        # spiceai-52.5
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }       # spiceai-52.5
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }    # spiceai-52.5
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                   # spiceai-52.5
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }             # spiceai-52.5
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                  # spiceai-52.5
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }           # spiceai-52.5
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }             # spiceai-52.5
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }         # spiceai-52.5
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" } # spiceai-52.5
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }  # spiceai-52.5
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }         # spiceai-52.5
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                 # spiceai-52.5
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }          # spiceai-52.5
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }               # spiceai-52.5
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }               # spiceai-52.5
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                   # spiceai-52.5
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }     # spiceai-52.5
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }  # spiceai-52.5
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }  # spiceai-52.5
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }     # spiceai-52.5
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }          # spiceai-52.5
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }         # spiceai-52.5
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }  # spiceai-52.5
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                   # spiceai-52.5
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }       # spiceai-52.5
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                    # spiceai-52.5
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "408e2c554db2433670ea2ffb43a4289fefe739ad" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "408e2c554db2433670ea2ffb43a4289fefe739ad" } # spiceai-52.5
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52.5
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52.5
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52.5
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 
@@ -408,12 +406,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }              # spiceai-52
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }              # spiceai-52.5
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52.5
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52.5
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52.5
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" } # spiceai-52.5
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "6c9b9709c572fe40484ec00aa969d1f62f2b0fe7" }   # spiceai-52.5
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }
 
@@ -444,9 +442,9 @@ parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "96190c47f7a1
 
 object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "f0a772cd49d2ebb1f19f487ccd93d705f48dc891" }
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-datafusion = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-datafusion = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,7 +393,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "57fd1335870409a63555036e86a78627b9a29382" } # spiceai-52.5
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" } # spiceai-52.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,9 @@ url = { version = "2.5", features = ["serde"] }
 util = { path = "crates/util", default-features = false }
 uuid = "1"
 
-# We can't use patches for vortex, because their tagged release version .tomls have a version of 0.1.0 not the actual release version
+# Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
+# so we specify git deps here directly. The [patch.crates-io] entries below exist to override
+# transitive vortex dependencies pulled in by other patched crates.
 vortex = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
 vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5
 vortex-datafusion = { git = "https://github.com/spiceai/vortex.git", rev = "d694abda6cf4081a7a6e93b08da1bba28204f41e" } # spiceai-52.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ datafusion-common-runtime = "52.0.0"
 datafusion-datasource = "52.0.0"
 datafusion-execution = "52.0.0"
 datafusion-expr = "52.0.0"
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9b7e0f48c00deefe1276a46890562523b4b97c41", features = ["sql"] } # SHA format (short vs full) must match to what datafusion-table-providers use for datafusion-federation
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e1318d3f7530234356caa87ba59e4bbc05dbe72a", features = ["sql"] } # SHA format (short vs full) must match to what datafusion-table-providers use for datafusion-federation
 datafusion-functions = "52.0.0"
 datafusion-functions-json = "0.52"
 datafusion-physical-expr = "52.0.0"
@@ -391,11 +391,11 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "408e2c554db2433670ea2ffb43a4289fefe739ad" } # spiceai-52.5
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "57fd1335870409a63555036e86a78627b9a29382" } # spiceai-52.5
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" }      # spiceai-52.5
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52.5
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ad88031f002aec4ec63dc1fabd81dfd3cf69fb22" } # spiceai-52.5
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" }      # spiceai-52.5
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" } # spiceai-52.5
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" } # spiceai-52.5
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 


### PR DESCRIPTION
Upgrades DataFusion from v52.0.0 to v52.5.0-rc1.

## Changes
- Updated all 35 datafusion-* `[patch.crates-io]` entries to new fork commit `c434c7b5` (branch `spiceai-52.5`)
- Removed 2 unused patch entries (`datafusion-datasource-avro`, `datafusion-ffi`)
- Updated `datafusion-federation` to `e1318d3f` (spiceai-52.5)
- Updated `datafusion-ballista` to `869b1a02` (spiceai-52.5)
- Updated `datafusion-table-providers` to `57fd1335` (spiceai-52.5)
- Vortex and Iceberg: no code changes needed (version reqs already compatible)

## Fork PRs
- spiceai/datafusion: https://github.com/spiceai/datafusion/pull/152
- spiceai/datafusion-federation: https://github.com/spiceai/datafusion-federation/pull/69
- spiceai/datafusion-ballista: https://github.com/spiceai/datafusion-ballista/pull/25
- datafusion-contrib/datafusion-table-providers: https://github.com/datafusion-contrib/datafusion-table-providers/pull/599
- spiceai/vortex: No changes needed (`datafusion = "52"` already compatible)
- spiceai/iceberg-rust: No changes needed (`datafusion = "52.2"` already compatible)

## Verification
- `cargo check` passes with no patch warnings
- 1,159 library unit tests pass (3 pre-existing turso failures unrelated to this change)

Closes #10234