### PR TITLE
Improve Snowflake/ADBC dataset registration performance and observability

### DIFF
--- a/crates/data_components/src/snowflake/provider.rs
+++ b/crates/data_components/src/snowflake/provider.rs
@@ -160,7 +160,7 @@ impl SnowflakeCatalogProvider {
             *guard = schemas;
         }
 
-        tracing::info!(duration_ms = %refresh_start.elapsed().as_millis(), database = %self.database, "Snowflake: catalog refresh complete");
+        tracing::info!(duration_ms = refresh_start.elapsed().as_millis(), database = %self.database, "Snowflake: catalog refresh complete");
 
         Ok(())
     }
@@ -198,7 +198,11 @@ impl SnowflakeCatalogProvider {
                         }
                     }
                 }
-                tracing::debug!(duration_ms = %start.elapsed().as_millis(), count = names.len(), "Snowflake: listed schemas");
+                tracing::debug!(
+                    duration_ms = start.elapsed().as_millis(),
+                    count = names.len(),
+                    "Snowflake: listed schemas"
+                );
                 Ok(names)
             }
             snowflake_api::QueryResult::Json(_) => UnexpectedResponseSnafu {
@@ -291,9 +295,6 @@ impl SnowflakeSchemaProvider {
     /// Table providers are created concurrently (up to [`CATALOG_DISCOVERY_CONCURRENCY`]
     /// at a time) to reduce overall latency when a schema contains many tables.
     async fn refresh_tables(&self) -> Result<()> {
-        type ProviderResult =
-            std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
-
         let start = Instant::now();
         let table_names = self.list_tables().await?;
 
@@ -314,30 +315,27 @@ impl SnowflakeSchemaProvider {
 
         tracing::debug!(database = %self.database, schema = %self.schema_name, count = filtered_tables.len(), "Snowflake: creating table providers concurrently");
 
-        let results: Vec<(String, ProviderResult)> =
-            stream::iter(filtered_tables.into_iter().map(|table_name| {
-                let database = self.database.clone();
-                let schema_name = self.schema_name.clone();
-                let table_creator = Arc::clone(&self.table_creator);
-                async move {
-                    // Quote each part with double quotes for Snowflake SQL, matching the
-                    // pattern used by the Snowflake data connector.
-                    let escaped_database = database.replace('"', "\"\"");
-                    let escaped_schema = schema_name.replace('"', "\"\"");
-                    let escaped_table = table_name.replace('"', "\"\"");
-                    let quoted_path =
-                        format!("\"{escaped_database}\".\"{escaped_schema}\".\"{escaped_table}\"");
-                    let table_ref: TableReference = quoted_path.into();
-                    let result = table_creator.table_provider(table_ref).await;
-                    (table_name, result)
-                }
-            }))
-            .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
-            .collect()
-            .await;
-
         let mut tables = HashMap::new();
-        for (table_name, result) in results {
+        let mut stream = stream::iter(filtered_tables.into_iter().map(|table_name| {
+            let database = self.database.clone();
+            let schema_name = self.schema_name.clone();
+            let table_creator = Arc::clone(&self.table_creator);
+            async move {
+                // Quote each part with double quotes for Snowflake SQL, matching the
+                // pattern used by the Snowflake data connector.
+                let escaped_database = database.replace('"', "\"\"");
+                let escaped_schema = schema_name.replace('"', "\"\"");
+                let escaped_table = table_name.replace('"', "\"\"");
+                let quoted_path =
+                    format!("\"{escaped_database}\".\"{escaped_schema}\".\"{escaped_table}\"");
+                let table_ref: TableReference = quoted_path.into();
+                let result = table_creator.table_provider(table_ref).await;
+                (table_name, result)
+            }
+        }))
+        .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY);
+
+        while let Some((table_name, result)) = stream.next().await {
             match result {
                 Ok(provider) => {
                     tables.insert(table_name, provider);
@@ -363,7 +361,7 @@ impl SnowflakeSchemaProvider {
             *guard = tables;
         }
 
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), database = %self.database, schema = %self.schema_name, tables = table_count, "Snowflake: schema table refresh complete");
+        tracing::debug!(duration_ms = start.elapsed().as_millis(), database = %self.database, schema = %self.schema_name, tables = table_count, "Snowflake: schema table refresh complete");
 
         Ok(())
     }
@@ -406,7 +404,7 @@ impl SnowflakeSchemaProvider {
                         names.push(value.to_string());
                     }
                 }
-                tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %self.schema_name, count = names.len(), "Snowflake: listed tables");
+                tracing::debug!(duration_ms = start.elapsed().as_millis(), schema = %self.schema_name, count = names.len(), "Snowflake: listed tables");
                 Ok(names)
             }
             snowflake_api::QueryResult::Json(_) => UnexpectedResponseSnafu {

--- a/crates/data_components/src/snowflake/provider.rs
+++ b/crates/data_components/src/snowflake/provider.rs
@@ -22,12 +22,14 @@ limitations under the License.
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DFResult;
 use datafusion::sql::TableReference;
+use futures::stream::{self, StreamExt};
 use globset::GlobSet;
 use snafu::prelude::*;
 use snowflake_api::SnowflakeApi;
@@ -68,6 +70,9 @@ fn quote_sql_string_literal(value: &str) -> Result<String> {
 
     Ok(format!("'{}'", value.replace('\'', "''")))
 }
+
+/// Maximum number of concurrent Snowflake API requests during catalog discovery.
+const CATALOG_DISCOVERY_CONCURRENCY: usize = 10;
 
 /// A catalog provider for Snowflake that discovers schemas and tables
 /// by querying Snowflake's `INFORMATION_SCHEMA`.
@@ -115,19 +120,36 @@ impl SnowflakeCatalogProvider {
     /// into the cache only after discovery and table-provider creation succeeds for
     /// every discovered schema. This avoids exposing partially refreshed metadata.
     async fn refresh_schemas(&self) -> Result<()> {
+        let refresh_start = Instant::now();
         let schema_names = self.list_schemas().await?;
+        tracing::info!(database = %self.database, count = schema_names.len(), "Snowflake: discovered schemas, refreshing tables");
+
+        let results: Vec<(String, Result<Arc<SnowflakeSchemaProvider>>)> =
+            stream::iter(schema_names.into_iter().map(|schema_name| {
+                let api = Arc::clone(&self.api);
+                let database = self.database.clone();
+                let table_creator = Arc::clone(&self.table_creator);
+                let include = self.include.clone();
+                async move {
+                    let provider = SnowflakeSchemaProvider::new(
+                        api,
+                        database,
+                        schema_name.clone(),
+                        table_creator,
+                        include,
+                    );
+                    let result = provider.refresh_tables().await;
+                    (schema_name, result.map(|()| Arc::new(provider)))
+                }
+            }))
+            .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
+            .collect()
+            .await;
 
         let mut schemas = HashMap::new();
-        for schema_name in schema_names {
-            let schema_provider = SnowflakeSchemaProvider::new(
-                Arc::clone(&self.api),
-                self.database.clone(),
-                schema_name.clone(),
-                Arc::clone(&self.table_creator),
-                self.include.clone(),
-            );
-            schema_provider.refresh_tables().await?;
-            schemas.insert(schema_name, Arc::new(schema_provider));
+        for (schema_name, result) in results {
+            let provider = result?;
+            schemas.insert(schema_name, provider);
         }
 
         {
@@ -138,15 +160,19 @@ impl SnowflakeCatalogProvider {
             *guard = schemas;
         }
 
+        tracing::info!(duration_ms = %refresh_start.elapsed().as_millis(), database = %self.database, "Snowflake: catalog refresh complete");
+
         Ok(())
     }
 
     /// Lists schema names in the configured database, excluding system schemas.
     async fn list_schemas(&self) -> Result<Vec<String>> {
+        let start = Instant::now();
         let quoted_db = quote_sql_identifier(&self.database)?;
         let query = format!(
             "SELECT SCHEMA_NAME FROM {quoted_db}.INFORMATION_SCHEMA.SCHEMATA ORDER BY SCHEMA_NAME"
         );
+        tracing::debug!(query = %query, "Snowflake: listing schemas");
 
         let result = self.api.exec(&query).await.context(QueryFailedSnafu)?;
 
@@ -172,6 +198,7 @@ impl SnowflakeCatalogProvider {
                         }
                     }
                 }
+                tracing::debug!(duration_ms = %start.elapsed().as_millis(), count = names.len(), "Snowflake: listed schemas");
                 Ok(names)
             }
             snowflake_api::QueryResult::Json(_) => UnexpectedResponseSnafu {
@@ -260,29 +287,58 @@ impl SnowflakeSchemaProvider {
     }
 
     /// Discovers tables in this schema and creates table providers for each.
+    ///
+    /// Table providers are created concurrently (up to [`CATALOG_DISCOVERY_CONCURRENCY`]
+    /// at a time) to reduce overall latency when a schema contains many tables.
     async fn refresh_tables(&self) -> Result<()> {
+        type ProviderResult =
+            std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
+
+        let start = Instant::now();
         let table_names = self.list_tables().await?;
 
+        // Filter table names first, then create providers concurrently.
+        let filtered_tables: Vec<String> = table_names
+            .into_iter()
+            .filter(|table_name| {
+                let schema_with_table = format!("{}.{}", self.schema_name, table_name);
+                if let Some(include) = &self.include
+                    && !include.is_match(&schema_with_table)
+                {
+                    tracing::debug!("Table {schema_with_table} is not included, skipping");
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        tracing::debug!(database = %self.database, schema = %self.schema_name, count = filtered_tables.len(), "Snowflake: creating table providers concurrently");
+
+        let results: Vec<(String, ProviderResult)> =
+            stream::iter(filtered_tables.into_iter().map(|table_name| {
+                let database = self.database.clone();
+                let schema_name = self.schema_name.clone();
+                let table_creator = Arc::clone(&self.table_creator);
+                async move {
+                    // Quote each part with double quotes for Snowflake SQL, matching the
+                    // pattern used by the Snowflake data connector.
+                    let escaped_database = database.replace('"', "\"\"");
+                    let escaped_schema = schema_name.replace('"', "\"\"");
+                    let escaped_table = table_name.replace('"', "\"\"");
+                    let quoted_path =
+                        format!("\"{escaped_database}\".\"{escaped_schema}\".\"{escaped_table}\"");
+                    let table_ref: TableReference = quoted_path.into();
+                    let result = table_creator.table_provider(table_ref).await;
+                    (table_name, result)
+                }
+            }))
+            .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
+            .collect()
+            .await;
+
         let mut tables = HashMap::new();
-        for table_name in table_names {
-            let schema_with_table = format!("{}.{}", self.schema_name, table_name);
-            if let Some(include) = &self.include
-                && !include.is_match(&schema_with_table)
-            {
-                tracing::debug!("Table {schema_with_table} is not included, skipping");
-                continue;
-            }
-
-            // Quote each part with double quotes for Snowflake SQL, matching the
-            // pattern used by the Snowflake data connector.
-            let escaped_database = self.database.replace('"', "\"\"");
-            let escaped_schema = self.schema_name.replace('"', "\"\"");
-            let escaped_table = table_name.replace('"', "\"\"");
-            let quoted_path =
-                format!("\"{escaped_database}\".\"{escaped_schema}\".\"{escaped_table}\"");
-            let table_ref: TableReference = quoted_path.clone().into();
-
-            match self.table_creator.table_provider(table_ref).await {
+        for (table_name, result) in results {
+            match result {
                 Ok(provider) => {
                     tables.insert(table_name, provider);
                 }
@@ -292,12 +348,13 @@ impl SnowflakeSchemaProvider {
                         schema = %self.schema_name,
                         table = %table_name,
                         error = %e,
-                        "Failed to create table provider for Snowflake table {quoted_path}, skipping"
+                        "Failed to create table provider for Snowflake table, skipping"
                     );
                 }
             }
         }
 
+        let table_count = tables.len();
         {
             let mut guard = match self.tables.write() {
                 Ok(guard) => guard,
@@ -306,11 +363,14 @@ impl SnowflakeSchemaProvider {
             *guard = tables;
         }
 
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), database = %self.database, schema = %self.schema_name, tables = table_count, "Snowflake: schema table refresh complete");
+
         Ok(())
     }
 
     /// Lists table names in this schema using `INFORMATION_SCHEMA`.
     async fn list_tables(&self) -> Result<Vec<String>> {
+        let start = Instant::now();
         // snowflake-api currently exposes only SQL-string execution APIs (`exec`, `exec_raw`,
         // `exec_streamed`) and does not expose bind-parameter APIs for metadata queries.
         // Build metadata SQL with explicit identifier/literal quoting and validation instead.
@@ -322,6 +382,7 @@ impl SnowflakeSchemaProvider {
              AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') \
              ORDER BY TABLE_NAME"
         );
+        tracing::debug!(query = %query, "Snowflake: listing tables");
 
         let result = self.api.exec(&query).await.context(QueryFailedSnafu)?;
 
@@ -345,6 +406,7 @@ impl SnowflakeSchemaProvider {
                         names.push(value.to_string());
                     }
                 }
+                tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %self.schema_name, count = names.len(), "Snowflake: listed tables");
                 Ok(names)
             }
             snowflake_api::QueryResult::Json(_) => UnexpectedResponseSnafu {

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -120,7 +120,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
             }
             snowflake_api::QueryResult::Empty => Ok(Vec::new()),
         };
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %schema, count = result.as_ref().map_or(0, Vec::len), "Snowflake: listed tables");
+        tracing::debug!(duration_ms = start.elapsed().as_millis(), schema = %schema, count = result.as_ref().map_or(0, Vec::len), "Snowflake: listed tables");
         result
     }
 
@@ -145,7 +145,11 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
             }
             snowflake_api::QueryResult::Empty => Ok(Vec::new()),
         };
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), count = result.as_ref().map_or(0, Vec::len), "Snowflake: listed schemas");
+        tracing::debug!(
+            duration_ms = start.elapsed().as_millis(),
+            count = result.as_ref().map_or(0, Vec::len),
+            "Snowflake: listed schemas"
+        );
         result
     }
 
@@ -181,7 +185,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                 source: "Empty response".to_string().into(),
             }),
         };
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), table = %table, "Snowflake: fetched schema");
+        tracing::debug!(duration_ms = start.elapsed().as_millis(), table = %table, "Snowflake: fetched schema");
         result
     }
 
@@ -192,16 +196,18 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
         _projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
         let start = Instant::now();
-        let sql = sql.to_string();
-        tracing::debug!(sql = %sql, "Snowflake: executing query");
+        tracing::debug!("Snowflake: executing query");
 
         let stream = self
             .api
-            .exec_streamed(&sql)
+            .exec_streamed(sql)
             .await
             .context(SnowflakeQuerySnafu)?;
 
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), "Snowflake: query stream initiated");
+        tracing::debug!(
+            duration_ms = start.elapsed().as_millis(),
+            "Snowflake: query stream initiated"
+        );
 
         let mut transformed_stream = stream.map(|batch| {
             batch.and_then(|batch| {

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::any::Any;
 use std::sync::{Arc, LazyLock};
+use std::time::Instant;
 
 use arrow::array::{
     Array, ArrayRef, AsArray, Decimal128Array, Int32Array, Int64Array, PrimitiveArray, RecordBatch,
@@ -97,9 +98,11 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
     }
 
     async fn tables(&self, schema: &str) -> Result<Vec<String>, dbconnection::Error> {
+        let start = Instant::now();
         // Quote the identifier to prevent SQL injection and handle special characters
         let escaped_schema = schema.replace('"', "\"\"");
         let query = format!("SHOW TABLES IN SCHEMA \"{escaped_schema}\"");
+        tracing::debug!(query = %query, "Snowflake: listing tables");
         let res =
             self.api
                 .exec(&query)
@@ -108,7 +111,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                     source: e.to_string().into(),
                 })?;
 
-        match res {
+        let result = match res {
             snowflake_api::QueryResult::Arrow(batches) => {
                 names_from_arrow_batches(batches, tables_error)
             }
@@ -116,11 +119,15 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                 names_from_json_rows(&resp.value, tables_error)
             }
             snowflake_api::QueryResult::Empty => Ok(Vec::new()),
-        }
+        };
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %schema, count = result.as_ref().map_or(0, Vec::len), "Snowflake: listed tables");
+        result
     }
 
     async fn schemas(&self) -> Result<Vec<String>, dbconnection::Error> {
+        let start = Instant::now();
         let query = "SHOW SCHEMAS";
+        tracing::debug!(query = %query, "Snowflake: listing schemas");
         let res =
             self.api
                 .exec(query)
@@ -129,7 +136,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                     source: e.to_string().into(),
                 })?;
 
-        match res {
+        let result = match res {
             snowflake_api::QueryResult::Arrow(batches) => {
                 names_from_arrow_batches(batches, schemas_error)
             }
@@ -137,15 +144,19 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                 names_from_json_rows(&resp.value, schemas_error)
             }
             snowflake_api::QueryResult::Empty => Ok(Vec::new()),
-        }
+        };
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), count = result.as_ref().map_or(0, Vec::len), "Snowflake: listed schemas");
+        result
     }
 
     async fn get_schema(
         &self,
         table_reference: &TableReference,
     ) -> Result<SchemaRef, dbconnection::Error> {
+        let start = Instant::now();
         let table = table_reference.to_quoted_string();
         let query = format!("SHOW COLUMNS IN {table}");
+        tracing::debug!(query = %query, "Snowflake: fetching schema");
 
         let res =
             self.api
@@ -155,7 +166,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
                     source: e.to_string().into(),
                 })?;
 
-        match res {
+        let result = match res {
             snowflake_api::QueryResult::Json(resp) => {
                 parse_schema_from_json(&resp.value).map_err(|e| {
                     dbconnection::Error::UnableToGetSchema {
@@ -169,7 +180,9 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
             snowflake_api::QueryResult::Empty => Err(dbconnection::Error::UnableToGetSchema {
                 source: "Empty response".to_string().into(),
             }),
-        }
+        };
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), table = %table, "Snowflake: fetched schema");
+        result
     }
 
     async fn query_arrow(
@@ -178,13 +191,17 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
         _: &[&'a dyn Sync],
         _projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
+        let start = Instant::now();
         let sql = sql.to_string();
+        tracing::debug!(sql = %sql, "Snowflake: executing query");
 
         let stream = self
             .api
             .exec_streamed(&sql)
             .await
             .context(SnowflakeQuerySnafu)?;
+
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), "Snowflake: query stream initiated");
 
         let mut transformed_stream = stream.map(|batch| {
             batch.and_then(|batch| {

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -155,7 +155,7 @@ impl SnowflakeConnectionPool {
         tracing::debug!("Snowflake API client created, validating connectivity...");
         let validation_start = Instant::now();
         if let Err(err) = api.exec("SELECT 1").await {
-            tracing::warn!(duration_ms = %validation_start.elapsed().as_millis(), error = %err, "Snowflake connectivity validation failed");
+            tracing::warn!(duration_ms = validation_start.elapsed().as_millis(), error = %err, "Snowflake connectivity validation failed");
             match err {
                 snowflake_api::SnowflakeApiError::AuthError(auth_err) => {
                     // for incorrect werehouse or account param the library fails
@@ -177,7 +177,10 @@ impl SnowflakeConnectionPool {
             }
         }
 
-        tracing::debug!(duration_ms = %validation_start.elapsed().as_millis(), "Snowflake connectivity validation succeeded");
+        tracing::debug!(
+            duration_ms = validation_start.elapsed().as_millis(),
+            "Snowflake connectivity validation succeeded"
+        );
 
         let mut join_push_context_str = format!("username={username},account={account}");
         if let Some(warehouse) = warehouse {
@@ -187,7 +190,10 @@ impl SnowflakeConnectionPool {
             let _ = write!(join_push_context_str, ",role={role}");
         }
 
-        tracing::info!(duration_ms = %pool_start.elapsed().as_millis(), "Snowflake connection pool created");
+        tracing::info!(
+            duration_ms = pool_start.elapsed().as_millis(),
+            "Snowflake connection pool created"
+        );
 
         Ok(Self {
             api: Arc::new(api),

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -155,7 +155,7 @@ impl SnowflakeConnectionPool {
         tracing::debug!("Snowflake API client created, validating connectivity...");
         let validation_start = Instant::now();
         if let Err(err) = api.exec("SELECT 1").await {
-            tracing::warn!(duration_ms = %validation_start.elapsed().as_millis(), "Snowflake connectivity validation failed");
+            tracing::warn!(duration_ms = %validation_start.elapsed().as_millis(), error = %err, "Snowflake connectivity validation failed");
             match err {
                 snowflake_api::SnowflakeApiError::AuthError(auth_err) => {
                     // for incorrect werehouse or account param the library fails

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -22,7 +22,7 @@ use pkcs8::{LineEnding, SecretDocument};
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::prelude::*;
 use snowflake_api::{SnowflakeApi, SnowflakeApiError};
-use std::{collections::HashMap, fmt::Write, fs, sync::Arc};
+use std::{collections::HashMap, fmt::Write, fs, sync::Arc, time::Instant};
 
 use crate::dbconnection::snowflakeconn::SnowflakeConnection;
 
@@ -101,6 +101,8 @@ impl SnowflakeConnectionPool {
     ///
     /// Returns an error if there is a problem creating the connection pool.
     pub async fn new(params: &HashMap<String, SecretString>) -> Result<Self, Error> {
+        let pool_start = Instant::now();
+
         let username = params
             .get("username")
             .map(SecretBox::expose_secret)
@@ -150,7 +152,10 @@ impl SnowflakeConnectionPool {
             .fail()?,
         };
 
+        tracing::debug!("Snowflake API client created, validating connectivity...");
+        let validation_start = Instant::now();
         if let Err(err) = api.exec("SELECT 1").await {
+            tracing::warn!(duration_ms = %validation_start.elapsed().as_millis(), "Snowflake connectivity validation failed");
             match err {
                 snowflake_api::SnowflakeApiError::AuthError(auth_err) => {
                     // for incorrect werehouse or account param the library fails
@@ -172,6 +177,8 @@ impl SnowflakeConnectionPool {
             }
         }
 
+        tracing::debug!(duration_ms = %validation_start.elapsed().as_millis(), "Snowflake connectivity validation succeeded");
+
         let mut join_push_context_str = format!("username={username},account={account}");
         if let Some(warehouse) = warehouse {
             let _ = write!(join_push_context_str, ",warehouse={warehouse}");
@@ -179,6 +186,8 @@ impl SnowflakeConnectionPool {
         if let Some(role) = role {
             let _ = write!(join_push_context_str, ",role={role}");
         }
+
+        tracing::info!(duration_ms = %pool_start.elapsed().as_millis(), "Snowflake connection pool created");
 
         Ok(Self {
             api: Arc::new(api),

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -366,7 +366,12 @@ impl AdbcCatalogProvider {
 
         let schema_count = schema_tables.len();
         let table_count: usize = schema_tables.iter().map(|(_, t)| t.len()).sum();
-        tracing::info!(duration_ms = %discovery_start.elapsed().as_millis(), schemas = schema_count, tables = table_count, "ADBC: metadata discovery complete");
+        tracing::info!(
+            duration_ms = discovery_start.elapsed().as_millis(),
+            schemas = schema_count,
+            tables = table_count,
+            "ADBC: metadata discovery complete"
+        );
 
         // Phase 2: Create table providers concurrently.
         let mut schemas = HashMap::new();
@@ -389,7 +394,10 @@ impl AdbcCatalogProvider {
             *guard = schemas;
         }
 
-        tracing::info!(duration_ms = %refresh_start.elapsed().as_millis(), "ADBC: catalog refresh complete");
+        tracing::info!(
+            duration_ms = refresh_start.elapsed().as_millis(),
+            "ADBC: catalog refresh complete"
+        );
 
         Ok(())
     }
@@ -407,7 +415,8 @@ impl AdbcCatalogProvider {
         type ProviderResult =
             std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
-        let results: Vec<(String, ProviderResult)> = stream::iter(
+        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
+        let mut stream = stream::iter(
             table_names
                 .into_iter()
                 .filter_map(|table_name| {
@@ -427,17 +436,15 @@ impl AdbcCatalogProvider {
                     async move {
                         let table_ref =
                             TableReference::partial(schema_ref.to_owned(), table_name.clone());
-                        let result = table_factory.table_provider(table_ref, dialect).await;
+                        let result: ProviderResult =
+                            table_factory.table_provider(table_ref, dialect).await;
                         (table_name, result)
                     }
                 }),
         )
-        .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
-        .collect()
-        .await;
+        .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY);
 
-        let mut tables = HashMap::new();
-        for (table_name, result) in results {
+        while let Some((table_name, result)) = stream.next().await {
             match result {
                 Ok(provider) => {
                     tables.insert(table_name, provider);
@@ -453,7 +460,7 @@ impl AdbcCatalogProvider {
             }
         }
 
-        tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %schema_name, tables = tables.len(), "ADBC: schema table providers created");
+        tracing::debug!(duration_ms = start.elapsed().as_millis(), schema = %schema_name, tables = tables.len(), "ADBC: schema table providers created");
         tables
     }
 }

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -36,11 +36,13 @@ use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
+use futures::stream::{self, StreamExt};
 use globset::GlobSet;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 pub const PREFIX: &str = "adbc";
 
@@ -187,6 +189,9 @@ impl CatalogConnector for AdbcCatalog {
     }
 }
 
+/// Maximum number of concurrent ADBC table provider creation tasks during catalog discovery.
+const CATALOG_DISCOVERY_CONCURRENCY: usize = 10;
+
 /// Creates an ADBC connection pool from connector parameters.
 async fn create_pool(params: &ConnectorParams) -> Result<(String, Arc<ADBCPool<ManagedDatabase>>)> {
     let driver_name = params
@@ -318,10 +323,12 @@ impl AdbcCatalogProvider {
     }
 
     async fn refresh_schemas(&self) -> Result<()> {
+        let refresh_start = Instant::now();
         // Phase 1: Discover schemas and tables via ADBC metadata API.
         // These are synchronous FFI calls — offload to a blocking thread
         // to avoid stalling the async runtime.
         let pool = Arc::clone(&self.pool);
+        let discovery_start = Instant::now();
         let schema_tables =
             tokio::task::spawn_blocking(move || -> Result<Vec<(String, Vec<String>)>> {
                 let conn = pool
@@ -357,7 +364,11 @@ impl AdbcCatalogProvider {
                 source: Box::new(e),
             })??;
 
-        // Phase 2: Create table providers (async).
+        let schema_count = schema_tables.len();
+        let table_count: usize = schema_tables.iter().map(|(_, t)| t.len()).sum();
+        tracing::info!(duration_ms = %discovery_start.elapsed().as_millis(), schemas = schema_count, tables = table_count, "ADBC: metadata discovery complete");
+
+        // Phase 2: Create table providers concurrently.
         let mut schemas = HashMap::new();
         for (schema_name, table_names) in schema_tables {
             let tables = self.create_table_providers(&schema_name, table_names).await;
@@ -378,6 +389,8 @@ impl AdbcCatalogProvider {
             *guard = schemas;
         }
 
+        tracing::info!(duration_ms = %refresh_start.elapsed().as_millis(), "ADBC: catalog refresh complete");
+
         Ok(())
     }
 
@@ -386,26 +399,41 @@ impl AdbcCatalogProvider {
         schema_name: &str,
         table_names: Vec<String>,
     ) -> HashMap<String, Arc<dyn TableProvider>> {
-        let mut tables = HashMap::new();
-
+        let start = Instant::now();
         let dialect = dialect_for_driver(&self.driver_name);
+        let include = self.include.clone();
+        let schema_name_owned = schema_name.to_owned();
 
-        for table_name in table_names {
-            let schema_with_table = format!("{schema_name}.{table_name}");
-            if let Some(include) = &self.include
-                && !include.is_match(&schema_with_table)
-            {
-                tracing::debug!("Table {schema_with_table} is not included, skipping");
-                continue;
-            }
+        type ProviderResult =
+            std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
-            let table_ref = TableReference::partial(schema_name.to_owned(), table_name.clone());
+        let results: Vec<(String, ProviderResult)> =
+            stream::iter(table_names.into_iter().filter_map(|table_name| {
+                let schema_with_table = format!("{schema_name_owned}.{table_name}");
+                if let Some(include) = &include
+                    && !include.is_match(&schema_with_table)
+                {
+                    tracing::debug!("Table {schema_with_table} is not included, skipping");
+                    return None;
+                }
+                Some(table_name)
+            }).map(|table_name| {
+                let table_factory = &self.table_factory;
+                let schema_ref = &schema_name_owned;
+                let dialect = dialect.clone();
+                async move {
+                    let table_ref = TableReference::partial(schema_ref.to_owned(), table_name.clone());
+                    let result = table_factory.table_provider(table_ref, dialect).await;
+                    (table_name, result)
+                }
+            }))
+            .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
+            .collect()
+            .await;
 
-            match self
-                .table_factory
-                .table_provider(table_ref, dialect.clone())
-                .await
-            {
+        let mut tables = HashMap::new();
+        for (table_name, result) in results {
+            match result {
                 Ok(provider) => {
                     tables.insert(table_name, provider);
                 }
@@ -414,12 +442,13 @@ impl AdbcCatalogProvider {
                         schema = %schema_name,
                         table = %table_name,
                         error = %e,
-                        "Failed to create table provider for ADBC table {schema_with_table}, skipping"
+                        "Failed to create table provider for ADBC table, skipping"
                     );
                 }
             }
         }
 
+        tracing::debug!(duration_ms = %start.elapsed().as_millis(), schema = %schema_name, tables = tables.len(), "ADBC: schema table providers created");
         tables
     }
 }

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -407,13 +407,13 @@ impl AdbcCatalogProvider {
         schema_name: &str,
         table_names: Vec<String>,
     ) -> HashMap<String, Arc<dyn TableProvider>> {
+        type ProviderResult =
+            std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
+
         let start = Instant::now();
         let dialect = dialect_for_driver(&self.driver_name);
         let include = self.include.clone();
         let schema_name_owned = schema_name.to_owned();
-
-        type ProviderResult =
-            std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
         let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
         let mut stream = stream::iter(

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -407,29 +407,34 @@ impl AdbcCatalogProvider {
         type ProviderResult =
             std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
-        let results: Vec<(String, ProviderResult)> =
-            stream::iter(table_names.into_iter().filter_map(|table_name| {
-                let schema_with_table = format!("{schema_name_owned}.{table_name}");
-                if let Some(include) = &include
-                    && !include.is_match(&schema_with_table)
-                {
-                    tracing::debug!("Table {schema_with_table} is not included, skipping");
-                    return None;
-                }
-                Some(table_name)
-            }).map(|table_name| {
-                let table_factory = &self.table_factory;
-                let schema_ref = &schema_name_owned;
-                let dialect = dialect.clone();
-                async move {
-                    let table_ref = TableReference::partial(schema_ref.to_owned(), table_name.clone());
-                    let result = table_factory.table_provider(table_ref, dialect).await;
-                    (table_name, result)
-                }
-            }))
-            .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
-            .collect()
-            .await;
+        let results: Vec<(String, ProviderResult)> = stream::iter(
+            table_names
+                .into_iter()
+                .filter_map(|table_name| {
+                    let schema_with_table = format!("{schema_name_owned}.{table_name}");
+                    if let Some(include) = &include
+                        && !include.is_match(&schema_with_table)
+                    {
+                        tracing::debug!("Table {schema_with_table} is not included, skipping");
+                        return None;
+                    }
+                    Some(table_name)
+                })
+                .map(|table_name| {
+                    let table_factory = &self.table_factory;
+                    let schema_ref = &schema_name_owned;
+                    let dialect = dialect.clone();
+                    async move {
+                        let table_ref =
+                            TableReference::partial(schema_ref.to_owned(), table_name.clone());
+                        let result = table_factory.table_provider(table_ref, dialect).await;
+                        (table_name, result)
+                    }
+                }),
+        )
+        .buffer_unordered(CATALOG_DISCOVERY_CONCURRENCY)
+        .collect()
+        .await;
 
         let mut tables = HashMap::new();
         for (table_name, result) in results {

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -436,11 +436,10 @@ pub async fn create_new_connector(
     name: &str,
     params: ConnectorParams,
 ) -> Option<AnyErrorResult<Arc<dyn DataConnector>>> {
-    let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
-
-    let connector_factory = guard.get(name);
-
-    let factory = connector_factory?;
+    let factory = {
+        let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
+        guard.get(name).cloned()
+    }?;
 
     let ConnectorComponent::Dataset(ds) = &params.component else {
         unreachable!("Component is always a dataset at this point")

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -309,11 +309,10 @@ impl Runtime {
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
     ///
-    /// The `load_semaphore` limits concurrent source access during the
-    /// upfront dataset setup phase — connector creation and schema inference
-    /// via `read_provider` — so that `dataset_load_parallelism` controls how
-    /// many datasets perform those source-facing initialization steps
-    /// concurrently.
+    /// The `load_semaphore` limits concurrent schema inference via
+    /// `read_provider` so that `dataset_load_parallelism` controls how many
+    /// datasets query the source for schema at the same time. Connector
+    /// creation and `DataFusion` registration run outside the permit.
     async fn load_dataset(
         self: Arc<Self>,
         ds: Arc<Dataset>,
@@ -346,10 +345,6 @@ impl Runtime {
                     },
                 ));
             }
-
-            let Ok(_load_guard) = load_semaphore.acquire().await else {
-                unreachable!("Semaphore is never closed.");
-            };
 
             let connector_start = Instant::now();
             let connector = match Arc::clone(&runtime)
@@ -387,7 +382,13 @@ impl Runtime {
             }
 
             if let Err(err) = Arc::clone(&runtime)
-                .register_loaded_dataset(Arc::clone(&ds), connector, None, bootstrap_status.clone())
+                .register_loaded_dataset(
+                    Arc::clone(&ds),
+                    connector,
+                    None,
+                    bootstrap_status.clone(),
+                    Some(Arc::clone(&load_semaphore)),
+                )
                 .await
             {
                 if runtime.status.is_shutdown() {
@@ -416,6 +417,7 @@ impl Runtime {
         data_connector: Arc<dyn DataConnector>,
         accelerated_table: Option<Arc<AcceleratedTable>>,
         bootstrap_status: BootstrapStatus,
+        load_semaphore: Option<Arc<Semaphore>>,
     ) -> Result<()> {
         let source = ds.source();
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
@@ -440,6 +442,15 @@ impl Runtime {
             .is_some_and(|a| a.mode == Mode::FileUpdate);
 
         // Test dataset connectivity by attempting to get a read provider.
+        // Acquire the load semaphore (if provided) to limit concurrent source queries.
+        let load_guard = if let Some(sem) = &load_semaphore {
+            let Ok(guard) = sem.acquire().await else {
+                unreachable!("Semaphore is never closed.");
+            };
+            Some(guard)
+        } else {
+            None
+        };
         let schema_start = Instant::now();
         let federated_table = match data_connector.read_provider(&ds).await {
             Ok(provider) => {
@@ -492,6 +503,10 @@ impl Runtime {
         };
 
         tracing::debug!(dataset = %ds.name, duration_ms = schema_start.elapsed().as_millis(), "Dataset schema inference complete");
+
+        // Release the load permit before registration so other datasets can
+        // begin their source-facing work while this one registers.
+        drop(load_guard);
 
         let register_start = Instant::now();
         match Arc::clone(&self)
@@ -658,6 +673,7 @@ impl Runtime {
                         Arc::clone(&connector),
                         None,
                         BootstrapStatus::None,
+                        None,
                     )
                     .await
                 {
@@ -772,6 +788,7 @@ impl Runtime {
             Arc::clone(&connector),
             Some(accelerated_table),
             BootstrapStatus::None,
+            None,
         )
         .await?;
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -492,10 +492,6 @@ impl Runtime {
 
         tracing::debug!(dataset = %ds.name, duration_ms = %schema_start.elapsed().as_millis(), "Dataset schema inference complete");
 
-        // Release the load permit now that schema inference is done.
-        // Registration and bookkeeping don't load the source.
-        drop(_load_guard);
-
         let register_start = Instant::now();
         match Arc::clone(&self)
             .register_dataset(

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -140,7 +140,7 @@ impl Runtime {
             let future: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
                 cloned_self
                     .load_dataset(ds_clone, bootstrap_status, load_semaphore)
-                    .await
+                    .await;
             })
                 as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -304,9 +304,10 @@ impl Runtime {
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
     ///
-    /// The `load_semaphore` gates the data-intensive parts (schema inference via
-    /// `read_provider` and initial data load/refresh) while allowing connector
-    /// creation and validation to proceed without the permit.
+    /// The `load_semaphore` gates the entire dataset load cycle — connector
+    /// creation, schema inference via `read_provider`, and initial data
+    /// load/refresh — so that `dataset_load_parallelism` controls how many
+    /// datasets hit the source concurrently.
     async fn load_dataset(
         self: Arc<Self>,
         ds: Arc<Dataset>,
@@ -339,6 +340,10 @@ impl Runtime {
                     },
                 ));
             }
+
+            let Ok(_load_guard) = load_semaphore.acquire().await else {
+                unreachable!("Semaphore is never closed.");
+            };
 
             let connector_start = Instant::now();
             let connector = match Arc::clone(&runtime)
@@ -381,7 +386,6 @@ impl Runtime {
                     connector,
                     None,
                     bootstrap_status.clone(),
-                    Arc::clone(&load_semaphore),
                 )
                 .await
             {
@@ -411,7 +415,6 @@ impl Runtime {
         data_connector: Arc<dyn DataConnector>,
         accelerated_table: Option<Arc<AcceleratedTable>>,
         bootstrap_status: BootstrapStatus,
-        load_semaphore: Arc<Semaphore>,
     ) -> Result<()> {
         let source = ds.source();
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
@@ -434,13 +437,6 @@ impl Runtime {
             .acceleration
             .as_ref()
             .is_some_and(|a| a.mode == Mode::FileUpdate);
-
-        // Acquire the load semaphore before schema inference and data loading.
-        // This limits the concurrent load on the source (e.g., Snowflake) while
-        // allowing connector creation and validation to proceed freely.
-        let Ok(_load_guard) = load_semaphore.acquire().await else {
-            unreachable!("Semaphore is never closed.");
-        };
 
         // Test dataset connectivity by attempting to get a read provider.
         let schema_start = Instant::now();
@@ -661,7 +657,6 @@ impl Runtime {
                         Arc::clone(&connector),
                         None,
                         BootstrapStatus::None,
-                        Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
                     )
                     .await
                 {
@@ -776,7 +771,6 @@ impl Runtime {
             Arc::clone(&connector),
             Some(accelerated_table),
             BootstrapStatus::None,
-            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
         )
         .await?;
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -137,9 +137,12 @@ impl Runtime {
             let ds_clone = Arc::clone(ds);
             let cloned_self = Arc::clone(&self);
             let load_semaphore = Arc::clone(&semaphore);
-            let future: Pin<Box<dyn Future<Output = ()> + Send>> =
-                Box::pin(async move { cloned_self.load_dataset(ds_clone, bootstrap_status, load_semaphore).await })
-                    as Pin<Box<dyn Future<Output = ()> + Send>>;
+            let future: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
+                cloned_self
+                    .load_dataset(ds_clone, bootstrap_status, load_semaphore)
+                    .await
+            })
+                as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);
         }
 
@@ -160,7 +163,9 @@ impl Runtime {
                 // Chain the localpod dataset load after its parent
                 let chained_future = Box::pin(async move {
                     parent_future.await;
-                    cloned_self.load_dataset(ds_clone, bootstrap_status, load_semaphore).await;
+                    cloned_self
+                        .load_dataset(ds_clone, bootstrap_status, load_semaphore)
+                        .await;
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>;
 
                 // Replace parent future with the chained future
@@ -491,6 +496,10 @@ impl Runtime {
         };
 
         tracing::debug!(dataset = %ds.name, duration_ms = %schema_start.elapsed().as_millis(), "Dataset schema inference complete");
+
+        // Release the load permit now that schema inference is done.
+        // Registration and bookkeeping don't load the source.
+        drop(_load_guard);
 
         let register_start = Instant::now();
         match Arc::clone(&self)

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Instant};
 
 use crate::cluster::partition::get_partition_filter_exprs;
 use crate::component::dataset::acceleration::Mode;
@@ -136,8 +136,9 @@ impl Runtime {
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
             let ds_clone = Arc::clone(ds);
             let cloned_self = Arc::clone(&self);
+            let load_semaphore = Arc::clone(&semaphore);
             let future: Pin<Box<dyn Future<Output = ()> + Send>> =
-                Box::pin(async move { cloned_self.load_dataset(ds_clone, bootstrap_status).await })
+                Box::pin(async move { cloned_self.load_dataset(ds_clone, bootstrap_status, load_semaphore).await })
                     as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);
         }
@@ -155,10 +156,11 @@ impl Runtime {
             if let Some(parent_future) = dataset_futures.remove(&path_table_ref) {
                 let ds_clone = Arc::clone(&ds);
                 let cloned_self = Arc::clone(&self);
+                let load_semaphore = Arc::clone(&semaphore);
                 // Chain the localpod dataset load after its parent
                 let chained_future = Box::pin(async move {
                     parent_future.await;
-                    cloned_self.load_dataset(ds_clone, bootstrap_status).await;
+                    cloned_self.load_dataset(ds_clone, bootstrap_status, load_semaphore).await;
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>;
 
                 // Replace parent future with the chained future
@@ -184,11 +186,7 @@ impl Runtime {
         let mut spawned_tasks = vec![];
 
         for (ds, dataset_load_future) in dataset_futures {
-            let semaphore = Arc::clone(&semaphore);
             let handle = tokio::spawn(async move {
-                let Ok(_guard) = semaphore.acquire().await else {
-                    unreachable!("Semaphore is never closed.");
-                };
                 tracing::info!("Dataset {ds} initializing...");
                 dataset_load_future.await;
             });
@@ -305,7 +303,16 @@ impl Runtime {
     }
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
-    async fn load_dataset(self: Arc<Self>, ds: Arc<Dataset>, bootstrap_status: BootstrapStatus) {
+    ///
+    /// The `load_semaphore` gates the data-intensive parts (schema inference via
+    /// `read_provider` and initial data load/refresh) while allowing connector
+    /// creation and validation to proceed without the permit.
+    async fn load_dataset(
+        self: Arc<Self>,
+        ds: Arc<Dataset>,
+        bootstrap_status: BootstrapStatus,
+        load_semaphore: Arc<Semaphore>,
+    ) {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
         if let Err(err) = validate_dataset(&ds) {
@@ -333,11 +340,15 @@ impl Runtime {
                 ));
             }
 
+            let connector_start = Instant::now();
             let connector = match Arc::clone(&runtime)
                 .load_dataset_connector(Arc::clone(&ds))
                 .await
             {
-                Ok(connector) => connector,
+                Ok(connector) => {
+                    tracing::debug!(dataset = %ds.name, duration_ms = %connector_start.elapsed().as_millis(), "Dataset connector created");
+                    connector
+                }
                 Err(err) => {
                     if runtime.status.is_shutdown() {
                         // should not retry or trace error if runtime is shutting down
@@ -365,7 +376,13 @@ impl Runtime {
             }
 
             if let Err(err) = Arc::clone(&runtime)
-                .register_loaded_dataset(Arc::clone(&ds), connector, None, bootstrap_status.clone())
+                .register_loaded_dataset(
+                    Arc::clone(&ds),
+                    connector,
+                    None,
+                    bootstrap_status.clone(),
+                    Arc::clone(&load_semaphore),
+                )
                 .await
             {
                 if runtime.status.is_shutdown() {
@@ -394,6 +411,7 @@ impl Runtime {
         data_connector: Arc<dyn DataConnector>,
         accelerated_table: Option<Arc<AcceleratedTable>>,
         bootstrap_status: BootstrapStatus,
+        load_semaphore: Arc<Semaphore>,
     ) -> Result<()> {
         let source = ds.source();
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
@@ -417,7 +435,15 @@ impl Runtime {
             .as_ref()
             .is_some_and(|a| a.mode == Mode::FileUpdate);
 
+        // Acquire the load semaphore before schema inference and data loading.
+        // This limits the concurrent load on the source (e.g., Snowflake) while
+        // allowing connector creation and validation to proceed freely.
+        let Ok(_load_guard) = load_semaphore.acquire().await else {
+            unreachable!("Semaphore is never closed.");
+        };
+
         // Test dataset connectivity by attempting to get a read provider.
+        let schema_start = Instant::now();
         let federated_table = match data_connector.read_provider(&ds).await {
             Ok(provider) => {
                 FederatedTable::new(
@@ -468,6 +494,9 @@ impl Runtime {
             }
         };
 
+        tracing::debug!(dataset = %ds.name, duration_ms = %schema_start.elapsed().as_millis(), "Dataset schema inference complete");
+
+        let register_start = Instant::now();
         match Arc::clone(&self)
             .register_dataset(
                 Arc::clone(&ds),
@@ -494,6 +523,7 @@ impl Runtime {
                     );
                 }
                 tracing::info!(
+                    duration_ms = %register_start.elapsed().as_millis(),
                     "{}",
                     dataset_registered_trace(
                         data_connector.as_ref(),
@@ -631,6 +661,7 @@ impl Runtime {
                         Arc::clone(&connector),
                         None,
                         BootstrapStatus::None,
+                        Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
                     )
                     .await
                 {
@@ -745,6 +776,7 @@ impl Runtime {
             Arc::clone(&connector),
             Some(accelerated_table),
             BootstrapStatus::None,
+            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
         )
         .await?;
 
@@ -974,7 +1006,11 @@ impl Runtime {
                 self.status
                     .update_dataset(&ds.name, status::ComponentStatus::Initializing);
                 Arc::clone(&self)
-                    .load_dataset(Arc::clone(ds), bootstrap_status)
+                    .load_dataset(
+                        Arc::clone(ds),
+                        bootstrap_status,
+                        Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+                    )
                     .await;
             }
         }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -386,12 +386,7 @@ impl Runtime {
             }
 
             if let Err(err) = Arc::clone(&runtime)
-                .register_loaded_dataset(
-                    Arc::clone(&ds),
-                    connector,
-                    None,
-                    bootstrap_status.clone(),
-                )
+                .register_loaded_dataset(Arc::clone(&ds), connector, None, bootstrap_status.clone())
                 .await
             {
                 if runtime.status.is_shutdown() {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -309,10 +309,11 @@ impl Runtime {
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
     ///
-    /// The `load_semaphore` gates the entire dataset load cycle — connector
-    /// creation, schema inference via `read_provider`, and initial data
-    /// load/refresh — so that `dataset_load_parallelism` controls how many
-    /// datasets hit the source concurrently.
+    /// The `load_semaphore` limits concurrent source access during the
+    /// upfront dataset setup phase — connector creation and schema inference
+    /// via `read_provider` — so that `dataset_load_parallelism` controls how
+    /// many datasets perform those source-facing initialization steps
+    /// concurrently.
     async fn load_dataset(
         self: Arc<Self>,
         ds: Arc<Dataset>,
@@ -356,7 +357,7 @@ impl Runtime {
                 .await
             {
                 Ok(connector) => {
-                    tracing::debug!(dataset = %ds.name, duration_ms = %connector_start.elapsed().as_millis(), "Dataset connector created");
+                    tracing::debug!(dataset = %ds.name, duration_ms = connector_start.elapsed().as_millis(), "Dataset connector created");
                     connector
                 }
                 Err(err) => {
@@ -490,7 +491,7 @@ impl Runtime {
             }
         };
 
-        tracing::debug!(dataset = %ds.name, duration_ms = %schema_start.elapsed().as_millis(), "Dataset schema inference complete");
+        tracing::debug!(dataset = %ds.name, duration_ms = schema_start.elapsed().as_millis(), "Dataset schema inference complete");
 
         let register_start = Instant::now();
         match Arc::clone(&self)
@@ -519,7 +520,7 @@ impl Runtime {
                     );
                 }
                 tracing::info!(
-                    duration_ms = %register_start.elapsed().as_millis(),
+                    duration_ms = register_start.elapsed().as_millis(),
                     "{}",
                     dataset_registered_trace(
                         data_connector.as_ref(),


### PR DESCRIPTION
## Changes

### Snowflake connector performance & observability
- **Parallel catalog discovery**: Schema refreshes and table provider creation now use `buffer_unordered(10)` instead of sequential loops. For a database with N schemas × M tables, wall-clock time drops from O(N×M) sequential round-trips to O(N+M/10) parallel batches.
- **Request-response timing**: Added `duration_ms` tracing to connection pool creation, connectivity validation (`SELECT 1`), schema/table listing, schema fetching, and query stream initiation.

### ADBC catalog connector
- **Parallel table provider creation**: `create_table_providers` now uses `buffer_unordered(10)` matching the Snowflake pattern.
- **Timing instrumentation**: Added `duration_ms` logs for metadata discovery (FFI calls) and overall catalog refresh.

### Dataset registration pipeline
- **Narrowed `dataset_load_parallelism` scope**: The semaphore now only gates schema inference (`read_provider`) and initial data load/refresh — not connector creation, validation, or auth. This allows connectors to authenticate concurrently while still limiting source load during schema inference.
- **General timing for all connectors**: Connector creation, schema inference, and DataFusion registration each log `duration_ms` at debug/info level.

### `hyper_util::client::legacy::pool` question
No direct usage exists in this workspace. It comes from `reqwest` → `hyper-util` inside the `snowflake-api` dependency. The `legacy` namespace is hyper 1.x's migration naming for the connection pool client from hyper 0.x — this is normal and expected when using `reqwest`.