### PR TITLE
Databricks UC permission prechecks: explicit denial as permanent error, ambiguous cases advisory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ venv
 /result
 
 .env
+.make-lint.log
 .spice
 .data/
 data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,18 +4366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13041,7 +13029,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
- "tracing",
 ]
 
 [[package]]
@@ -13050,13 +13037,9 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "base64 0.22.1",
- "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
@@ -14450,21 +14433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
-dependencies = [
- "bitflags 2.10.0",
- "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15082,15 +15050,6 @@ name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -21026,12 +20985,6 @@ dependencies = [
  "thiserror 1.0.69",
  "ug 0.5.0",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,6 +4017,7 @@ dependencies = [
 name = "connector-databricks"
 version = "2.0.0-unstable"
 dependencies = [
+ "app",
  "async-trait",
  "aws-sdk-credential-bridge",
  "data_components",
@@ -4029,6 +4030,7 @@ dependencies = [
  "runtime-secrets",
  "secrecy",
  "snafu",
+ "spicepod",
  "token_provider",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,14 +223,14 @@ opentelemetry = { version = "0.31", default-features = false, features = [
     "metrics",
     "trace",
 ] }
-opentelemetry-http = { version = "0.31", features = ["reqwest-rustls"] }
+opentelemetry-http = { version = "0.31", default-features = false, features = ["reqwest-rustls"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
     "metrics",
     "grpc-tonic",
     "http-proto",
     "reqwest-rustls",
 ] }
-opentelemetry-prometheus = "0.31"
+opentelemetry-prometheus = { version = "0.31", default-features = false }
 opentelemetry-zipkin = { version = "0.31", default-features = false, features = [
     "reqwest",
     "reqwest-rustls",

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -90,37 +90,40 @@ const INTERNAL_COMPONENTS: &[&str] = &[
 ];
 
 const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,delta_kernel::listed_log_files=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
-const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off";
+const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off,opentelemetry=warn";
 
 fn specific_env_filter(filter: &str) -> String {
     format!("{OFF_FILTERS},{filter}")
 }
 
+fn env_filter_string(v: &LogVerbosity) -> String {
+    fn internal_components(level: &str) -> String {
+        INTERNAL_COMPONENTS
+            .iter()
+            .map(|component| format!("{component}={level}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    match v {
+        LogVerbosity::Default => format!(
+            "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},WARN",
+            internal_components("INFO")
+        ),
+        LogVerbosity::Verbose => format!(
+            "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},INFO",
+            internal_components("DEBUG")
+        ),
+        LogVerbosity::VeryVerbose => {
+            format!("{},{OFF_FILTERS},DEBUG", internal_components("TRACE"))
+        }
+        LogVerbosity::Specific(filter) => specific_env_filter(filter),
+    }
+}
+
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {
-        fn internal_components(level: &str) -> String {
-            INTERNAL_COMPONENTS
-                .iter()
-                .map(|component| format!("{component}={level}"))
-                .collect::<Vec<_>>()
-                .join(",")
-        }
-
-        match v {
-            LogVerbosity::Default => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},WARN",
-                internal_components("INFO")
-            )),
-            LogVerbosity::Verbose => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},INFO",
-                internal_components("DEBUG")
-            )),
-            LogVerbosity::VeryVerbose => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},DEBUG",
-                internal_components("TRACE")
-            )),
-            LogVerbosity::Specific(filter) => EnvFilter::new(specific_env_filter(&filter)),
-        }
+        EnvFilter::new(env_filter_string(&v))
     }
 }
 
@@ -489,5 +492,12 @@ mod tests {
     #[test]
     fn specific_filter_keeps_off_filters() {
         assert_eq!(specific_env_filter("trace"), format!("{OFF_FILTERS},trace"));
+    }
+
+    #[test]
+    fn verbose_filter_suppresses_opentelemetry_info() {
+        assert!(env_filter_string(&LogVerbosity::Default).contains("opentelemetry=warn"));
+        assert!(env_filter_string(&LogVerbosity::Verbose).contains("opentelemetry=warn"));
+        assert!(!env_filter_string(&LogVerbosity::VeryVerbose).contains("opentelemetry=warn"));
     }
 }

--- a/crates/data-connectors/connector-databricks/Cargo.toml
+++ b/crates/data-connectors/connector-databricks/Cargo.toml
@@ -42,3 +42,8 @@ tracing.workspace = true
 [features]
 default = []
 spark = []
+
+[dev-dependencies]
+app = { path = "../../app" }
+spicepod = { path = "../../spicepod" }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -594,9 +594,10 @@ impl Databricks {
     /// Returns `Ok(())` if validation passes or if it cannot be performed
     /// (e.g., table not found in UC — the table may not be a UC table at all).
     ///
-    /// Returns an error only when the UC API definitively reports an unsupported
-    /// table type. Permission prechecks are advisory because Databricks query-time
-    /// validation is the authoritative source of truth for table access.
+    /// Returns an error when the UC API definitively reports an unsupported
+    /// table type or when effective-permissions explicitly denies read access.
+    /// Ambiguous permission results (missing or unreachable) are advisory —
+    /// Databricks query-time validation is the authoritative access check.
     async fn validate_uc_table(
         &self,
         uc_client: &UnityCatalogClient,

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -654,18 +654,18 @@ impl Databricks {
         if should_validate_permissions {
             match uc_client.get_effective_permissions(&full_name).await {
                 Ok(Some(perms)) => {
-                    if !perms.has_read_permission() {
+                    if perms.has_read_permission() {
+                        tracing::debug!(
+                            table = %full_name,
+                            principals = ?perms.principals(),
+                            "Unity Catalog permission check passed"
+                        );
+                    } else {
                         tracing::warn!(
                             table = %full_name,
                             principals = ?perms.principals(),
                             privileges = ?perms.all_privileges(),
                             "Unity Catalog effective-permissions did not report a read-compatible privilege; proceeding and deferring to Databricks query-time validation"
-                        );
-                    } else {
-                        tracing::debug!(
-                            table = %full_name,
-                            principals = ?perms.principals(),
-                            "Unity Catalog permission check passed"
                         );
                     }
                 }
@@ -1736,8 +1736,14 @@ mod tests {
             result.is_ok(),
             "positive UC permission prechecks should still allow initialization"
         );
-        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
-        assert_eq!(request_count, 2, "expected table metadata and permission requests");
+        assert_eq!(
+            read_call_count, 1,
+            "expected the Databricks read to be attempted"
+        );
+        assert_eq!(
+            request_count, 2,
+            "expected table metadata and permission requests"
+        );
         assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
         assert_request_seen(
             &captured_requests,
@@ -1801,8 +1807,14 @@ mod tests {
             result.is_ok(),
             "missing effective-permissions responses should not block Databricks dataset initialization"
         );
-        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
-        assert_eq!(request_count, 2, "expected table metadata and permission requests");
+        assert_eq!(
+            read_call_count, 1,
+            "expected the Databricks read to be attempted"
+        );
+        assert_eq!(
+            request_count, 2,
+            "expected table metadata and permission requests"
+        );
         assert_request_seen(
             &captured_requests,
             "/api/2.1/unity-catalog/effective-permissions/table/",
@@ -1828,7 +1840,10 @@ mod tests {
             result.is_ok(),
             "effective-permissions lookup errors should not block Databricks dataset initialization"
         );
-        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
+        assert_eq!(
+            read_call_count, 1,
+            "expected the Databricks read to be attempted"
+        );
         assert!(
             request_count >= 2,
             "expected at least the table metadata request and one permission attempt"
@@ -1855,8 +1870,14 @@ mod tests {
             result.is_ok(),
             "foreign tables should skip strict permission prechecks and proceed"
         );
-        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
-        assert_eq!(request_count, 1, "foreign tables should skip the permission request");
+        assert_eq!(
+            read_call_count, 1,
+            "expected the Databricks read to be attempted"
+        );
+        assert_eq!(
+            request_count, 1,
+            "foreign tables should skip the permission request"
+        );
         assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
         assert_request_not_seen(
             &captured_requests,
@@ -1879,11 +1900,18 @@ mod tests {
         let err = result.expect_err("unsupported UC table types should still fail");
 
         assert!(
-            err.to_string().contains("Unsupported Unity Catalog table type 'VIEW'"),
+            err.to_string()
+                .contains("Unsupported Unity Catalog table type 'VIEW'"),
             "unexpected error: {err}"
         );
-        assert_eq!(read_call_count, 0, "unsupported types should fail before reading");
-        assert_eq!(request_count, 1, "unsupported types should stop after table metadata");
+        assert_eq!(
+            read_call_count, 0,
+            "unsupported types should fail before reading"
+        );
+        assert_eq!(
+            request_count, 1,
+            "unsupported types should stop after table metadata"
+        );
         assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
         assert_request_not_seen(
             &captured_requests,

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -1347,12 +1347,8 @@ mod tests {
         arrow::datatypes::{DataType, Field, Schema},
         datasource::MemTable,
     };
-    use runtime::component::{
-        access::AccessMode,
-        dataset::{CheckAvailability, ReadyState},
-    };
+    use runtime::component::dataset::builder::DatasetBuilder;
     use secrecy::ExposeSecret;
-    use spicepod::metric::Metrics;
     use std::{
         collections::{HashMap, VecDeque},
         sync::{
@@ -1520,29 +1516,13 @@ mod tests {
     }
 
     async fn make_dataset(from: &str, name: &str) -> Dataset {
-        Dataset {
-            from: from.to_string(),
-            name: TableReference::bare(name),
-            access: AccessMode::Read,
-            params: HashMap::new(),
-            metadata: HashMap::new(),
-            columns: Vec::new(),
-            has_metadata_table: false,
-            replication: None,
-            time_column: None,
-            time_format: None,
-            time_partition_column: None,
-            time_partition_format: None,
-            acceleration: None,
-            embeddings: Vec::new(),
-            app: Arc::new(App::default()),
-            unsupported_type_action: None,
-            ready_state: ReadyState::default(),
-            metrics: Metrics::default(),
-            runtime: Arc::new(Runtime::builder().build().await),
-            vectors: None,
-            check_availability: CheckAvailability::default(),
-        }
+        let runtime = Arc::new(Runtime::builder().build().await);
+        DatasetBuilder::try_new(from.to_string(), name)
+            .expect("valid test dataset name")
+            .with_app(Arc::new(App::default()))
+            .with_runtime(runtime)
+            .build()
+            .expect("test dataset should build")
     }
 
     async fn run_read_provider_with_uc_responses(

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -661,21 +661,29 @@ impl Databricks {
                             "Unity Catalog permission check passed"
                         );
                     } else {
-                        tracing::warn!(
-                            table = %full_name,
-                            principals = ?perms.principals(),
-                            privileges = ?perms.all_privileges(),
-                            "Unity Catalog effective-permissions did not report a read-compatible privilege; proceeding and deferring to Databricks query-time validation"
-                        );
+                        // Explicit denial: the API returned privileges but none
+                        // grant read access. This is a permanent error — the
+                        // user must fix permissions and restart the runtime.
+                        return Err(DataConnectorError::InsufficientPermissions {
+                            dataconnector: "databricks".to_string(),
+                            connector_component: ConnectorComponent::from(dataset),
+                            source: Box::new(Error::InsufficientPermissions {
+                                table_name: full_name,
+                            }),
+                        });
                     }
                 }
                 Ok(None) => {
-                    tracing::debug!(
+                    // Ambiguous: table not found in permissions endpoint.
+                    // Warn and let Databricks query-time validation decide.
+                    tracing::warn!(
                         table = %full_name,
-                        "Table not found when checking permissions; proceeding"
+                        "Table not found when checking permissions; proceeding and deferring to Databricks query-time validation"
                     );
                 }
                 Err(e) => {
+                    // Ambiguous: could not reach the permissions API.
+                    // Warn and let Databricks query-time validation decide.
                     tracing::warn!(
                         table = %full_name,
                         error = %e,
@@ -1752,7 +1760,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_provider_proceeds_when_uc_permission_precheck_lacks_read_privilege() {
+    async fn test_read_provider_fails_with_permanent_error_when_uc_permission_explicitly_denied() {
         let (result, read_call_count, request_count, captured_requests) =
             run_read_provider_with_uc_responses(
                 "databricks:workspace.tpch_sf400.part",
@@ -1769,13 +1777,21 @@ mod tests {
             )
             .await;
 
+        let err = result.expect_err(
+            "explicit UC permission denial should produce an InsufficientPermissions error",
+        );
         assert!(
-            result.is_ok(),
-            "negative UC permission prechecks should not block Databricks dataset initialization"
+            !err.is_retriable(),
+            "permission denial should be a permanent error requiring a runtime restart"
+        );
+        assert!(
+            err.to_string()
+                .contains("Insufficient permissions to access"),
+            "unexpected error: {err}"
         );
         assert_eq!(
-            read_call_count, 1,
-            "the authoritative Databricks read should still be attempted"
+            read_call_count, 0,
+            "should not attempt Databricks read after explicit permission denial"
         );
         assert_eq!(
             request_count, 2,
@@ -1823,6 +1839,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_provider_proceeds_when_effective_permissions_check_errors() {
+        // Queue enough 500 responses to exhaust the UC client's internal
+        // retries (3 retries + 1 initial attempt = 4 requests total).
         let (result, read_call_count, request_count, captured_requests) =
             run_read_provider_with_uc_responses(
                 "databricks:workspace.tpch_sf400.part",
@@ -1831,6 +1849,9 @@ mod tests {
                         "200 OK",
                         r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"MANAGED","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
                     ),
+                    MockHttpResponse::empty("500 Internal Server Error"),
+                    MockHttpResponse::empty("500 Internal Server Error"),
+                    MockHttpResponse::empty("500 Internal Server Error"),
                     MockHttpResponse::empty("500 Internal Server Error"),
                 ],
             )

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -1350,7 +1350,7 @@ mod tests {
     use runtime::component::dataset::builder::DatasetBuilder;
     use secrecy::ExposeSecret;
     use std::{
-        collections::{HashMap, VecDeque},
+        collections::VecDeque,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -589,13 +589,14 @@ impl Databricks {
     }
 
     /// Validates that a Unity Catalog table is of a supported type and that the
-    /// current principal has read permissions on it.
+    /// dataset metadata is compatible with Databricks query-time access checks.
     ///
     /// Returns `Ok(())` if validation passes or if it cannot be performed
     /// (e.g., table not found in UC — the table may not be a UC table at all).
     ///
     /// Returns an error only when the UC API definitively reports an unsupported
-    /// table type or missing permissions.
+    /// table type. Permission prechecks are advisory because Databricks query-time
+    /// validation is the authoritative source of truth for table access.
     async fn validate_uc_table(
         &self,
         uc_client: &UnityCatalogClient,
@@ -654,19 +655,19 @@ impl Databricks {
             match uc_client.get_effective_permissions(&full_name).await {
                 Ok(Some(perms)) => {
                     if !perms.has_read_permission() {
-                        return Err(DataConnectorError::InsufficientPermissions {
-                            dataconnector: "databricks".to_string(),
-                            connector_component: ConnectorComponent::from(dataset),
-                            source: Box::new(Error::InsufficientPermissions {
-                                table_name: full_name,
-                            }),
-                        });
+                        tracing::warn!(
+                            table = %full_name,
+                            principals = ?perms.principals(),
+                            privileges = ?perms.all_privileges(),
+                            "Unity Catalog effective-permissions did not report a read-compatible privilege; proceeding and deferring to Databricks query-time validation"
+                        );
+                    } else {
+                        tracing::debug!(
+                            table = %full_name,
+                            principals = ?perms.principals(),
+                            "Unity Catalog permission check passed"
+                        );
                     }
-                    tracing::debug!(
-                        table = %full_name,
-                        principals = ?perms.principals(),
-                        "Unity Catalog permission check passed"
-                    );
                 }
                 Ok(None) => {
                     tracing::debug!(
@@ -1332,7 +1333,259 @@ fn table_reference_creator_delta_lake(uc_table: &UCTable) -> Option<TableReferen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use app::App;
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema},
+        datasource::MemTable,
+    };
+    use runtime::component::{
+        access::AccessMode,
+        dataset::{CheckAvailability, ReadyState},
+    };
     use secrecy::ExposeSecret;
+    use spicepod::metric::Metrics;
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        sync::Mutex,
+    };
+
+    #[derive(Clone)]
+    struct MockRead {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Read for MockRead {
+        async fn table_provider(
+            &self,
+            _table_reference: TableReference,
+        ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+            let table = MemTable::try_new(Arc::clone(&schema), vec![Vec::new()])?;
+
+            Ok(Arc::new(table))
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockHttpResponse {
+        status_line: &'static str,
+        headers: Vec<(String, String)>,
+        body: String,
+    }
+
+    impl MockHttpResponse {
+        fn json(status_line: &'static str, body: impl Into<String>) -> Self {
+            Self {
+                status_line,
+                headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+                body: body.into(),
+            }
+        }
+
+        fn empty(status_line: &'static str) -> Self {
+            Self {
+                status_line,
+                headers: Vec::new(),
+                body: String::new(),
+            }
+        }
+    }
+
+    async fn start_mock_server(
+        responses: Vec<MockHttpResponse>,
+    ) -> (String, Arc<AtomicUsize>, Arc<Mutex<Vec<String>>>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind to a port");
+        let addr = listener
+            .local_addr()
+            .expect("should have a listener address");
+        let queued_responses = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+
+        let requests_for_server = Arc::clone(&requests);
+        let captured_requests_for_server = Arc::clone(&captured_requests);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+
+                let queued_responses = Arc::clone(&queued_responses);
+                let requests = Arc::clone(&requests_for_server);
+                let captured_requests = Arc::clone(&captured_requests_for_server);
+                tokio::spawn(async move {
+                    let captured_request = read_http_request(&mut stream).await;
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    captured_requests
+                        .lock()
+                        .await
+                        .push(String::from_utf8_lossy(&captured_request).into_owned());
+
+                    let response = queued_responses
+                        .lock()
+                        .await
+                        .pop_front()
+                        .unwrap_or_else(|| MockHttpResponse::json("200 OK", r#"{"ok":true}"#));
+
+                    let mut http_response = format!(
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\n",
+                        response.status_line,
+                        response.body.len()
+                    );
+                    for (header_name, header_value) in response.headers {
+                        let _ = std::fmt::Write::write_fmt(
+                            &mut http_response,
+                            format_args!("{header_name}: {header_value}\r\n"),
+                        );
+                    }
+                    http_response.push_str("\r\n");
+                    http_response.push_str(&response.body);
+
+                    let _ = stream.write_all(http_response.as_bytes()).await;
+                });
+            }
+        });
+
+        (format!("http://{addr}"), requests, captured_requests)
+    }
+
+    async fn read_http_request(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut captured_request = Vec::with_capacity(4096);
+        let mut buf = [0u8; 1024];
+        let mut expected_total_len = None;
+
+        loop {
+            let bytes_read = match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(bytes_read) => bytes_read,
+            };
+
+            captured_request.extend_from_slice(&buf[..bytes_read]);
+
+            if expected_total_len.is_none() {
+                expected_total_len = expected_http_request_len(&captured_request);
+            }
+
+            if let Some(expected_total_len) = expected_total_len
+                && captured_request.len() >= expected_total_len
+            {
+                break;
+            }
+        }
+
+        captured_request
+    }
+
+    fn expected_http_request_len(request: &[u8]) -> Option<usize> {
+        let headers_end = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)?;
+
+        let content_length = String::from_utf8_lossy(&request[..headers_end])
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        Some(headers_end.saturating_add(content_length))
+    }
+
+    async fn make_dataset(from: &str, name: &str) -> Dataset {
+        Dataset {
+            from: from.to_string(),
+            name: TableReference::bare(name),
+            access: AccessMode::Read,
+            params: HashMap::new(),
+            metadata: HashMap::new(),
+            columns: Vec::new(),
+            has_metadata_table: false,
+            replication: None,
+            time_column: None,
+            time_format: None,
+            time_partition_column: None,
+            time_partition_format: None,
+            acceleration: None,
+            embeddings: Vec::new(),
+            app: Arc::new(App::default()),
+            unsupported_type_action: None,
+            ready_state: ReadyState::default(),
+            metrics: Metrics::default(),
+            runtime: Arc::new(Runtime::builder().build().await),
+            vectors: None,
+            check_availability: CheckAvailability::default(),
+        }
+    }
+
+    async fn run_read_provider_with_uc_responses(
+        dataset_from: &str,
+        responses: Vec<MockHttpResponse>,
+    ) -> (DataConnectorResult<()>, usize, usize, Vec<String>) {
+        let (endpoint, requests, captured_requests) = start_mock_server(responses).await;
+
+        let read_call_count = Arc::new(AtomicUsize::new(0));
+        let connector = Databricks {
+            read_provider: Arc::new(MockRead {
+                call_count: Arc::clone(&read_call_count),
+            }),
+            initialization: ComponentInitialization::default(),
+            metrics: None,
+            uc_client: Some(Arc::new(
+                UnityCatalogClient::new(Endpoint(endpoint), None, None)
+                    .expect("mock Unity Catalog client should be created"),
+            )),
+        };
+        let dataset = make_dataset(dataset_from, "tpch_sf400_part").await;
+
+        let result = DataConnector::read_provider(&connector, &dataset)
+            .await
+            .map(|_| ());
+        let captured_requests = captured_requests.lock().await.clone();
+
+        (
+            result,
+            read_call_count.load(Ordering::SeqCst),
+            requests.load(Ordering::SeqCst),
+            captured_requests,
+        )
+    }
+
+    fn assert_request_seen(captured_requests: &[String], path_fragment: &str) {
+        assert!(
+            captured_requests
+                .iter()
+                .any(|request| request.contains(path_fragment)),
+            "expected request containing '{path_fragment}', got: {captured_requests:?}"
+        );
+    }
+
+    fn assert_request_not_seen(captured_requests: &[String], path_fragment: &str) {
+        assert!(
+            captured_requests
+                .iter()
+                .all(|request| !request.contains(path_fragment)),
+            "did not expect request containing '{path_fragment}', got: {captured_requests:?}"
+        );
+    }
 
     #[test]
     fn test_build_auth_credentials_token_only() {
@@ -1459,5 +1712,182 @@ mod tests {
         if let Err(error) = result {
             assert!(error.to_string().contains("Choose either `databricks_token` or `databricks_client_id` and `databricks_client_secret`"));
         }
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_proceeds_when_uc_permission_precheck_has_read_privilege() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"MANAGED","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
+                    ),
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"privilege_assignments":[{"principal":"analytics-team","privileges":[{"privilege":"SELECT"}]}]}"#,
+                    ),
+                ],
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "positive UC permission prechecks should still allow initialization"
+        );
+        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
+        assert_eq!(request_count, 2, "expected table metadata and permission requests");
+        assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
+        assert_request_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_proceeds_when_uc_permission_precheck_lacks_read_privilege() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"MANAGED","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
+                    ),
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"privilege_assignments":[{"principal":"analytics-team","privileges":[{"privilege":"MODIFY"}]}]}"#,
+                    ),
+                ],
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "negative UC permission prechecks should not block Databricks dataset initialization"
+        );
+        assert_eq!(
+            read_call_count, 1,
+            "the authoritative Databricks read should still be attempted"
+        );
+        assert_eq!(
+            request_count, 2,
+            "expected table metadata and effective-permissions requests"
+        );
+        assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
+        assert_request_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_proceeds_when_effective_permissions_are_missing() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"MANAGED","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
+                    ),
+                    MockHttpResponse::empty("404 Not Found"),
+                ],
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "missing effective-permissions responses should not block Databricks dataset initialization"
+        );
+        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
+        assert_eq!(request_count, 2, "expected table metadata and permission requests");
+        assert_request_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_proceeds_when_effective_permissions_check_errors() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![
+                    MockHttpResponse::json(
+                        "200 OK",
+                        r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"MANAGED","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
+                    ),
+                    MockHttpResponse::empty("500 Internal Server Error"),
+                ],
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "effective-permissions lookup errors should not block Databricks dataset initialization"
+        );
+        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
+        assert!(
+            request_count >= 2,
+            "expected at least the table metadata request and one permission attempt"
+        );
+        assert_request_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_skips_effective_permissions_for_foreign_tables() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![MockHttpResponse::json(
+                    "200 OK",
+                    r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"FOREIGN","data_source_format":"DELTA","columns":[],"storage_location":null}"#,
+                )],
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "foreign tables should skip strict permission prechecks and proceed"
+        );
+        assert_eq!(read_call_count, 1, "expected the Databricks read to be attempted");
+        assert_eq!(request_count, 1, "foreign tables should skip the permission request");
+        assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
+        assert_request_not_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_provider_fails_for_unsupported_uc_table_types() {
+        let (result, read_call_count, request_count, captured_requests) =
+            run_read_provider_with_uc_responses(
+                "databricks:workspace.tpch_sf400.part",
+                vec![MockHttpResponse::json(
+                    "200 OK",
+                    r#"{"name":"part","catalog_name":"workspace","schema_name":"tpch_sf400","table_type":"VIEW","data_source_format":"VIEW","columns":[],"storage_location":null}"#,
+                )],
+            )
+            .await;
+
+        let err = result.expect_err("unsupported UC table types should still fail");
+
+        assert!(
+            err.to_string().contains("Unsupported Unity Catalog table type 'VIEW'"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(read_call_count, 0, "unsupported types should fail before reading");
+        assert_eq!(request_count, 1, "unsupported types should stop after table metadata");
+        assert_request_seen(&captured_requests, "/api/2.1/unity-catalog/tables/");
+        assert_request_not_seen(
+            &captured_requests,
+            "/api/2.1/unity-catalog/effective-permissions/table/",
+        );
     }
 }

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -185,9 +185,10 @@ impl UnityCatalogSchemaProvider {
             candidates.push((table, table_reference));
         }
 
-        // Second pass: run advisory permission checks concurrently (bounded).
+        // Second pass: check permissions concurrently (bounded). Explicitly
+        // denied tables are excluded; ambiguous/unreachable cases are kept.
         let max_concurrent_permission_checks = 5;
-        let permission_results: Vec<(UCTable, TableReference)> =
+        let permission_results: Vec<Option<(UCTable, TableReference)>> =
             futures::stream::iter(candidates.into_iter().map(|(table, table_ref)| {
                 let client = Arc::clone(&client);
                 async move {
@@ -197,17 +198,20 @@ impl UnityCatalogSchemaProvider {
                             table_type = %table.table_type,
                             "Skipping strict Unity Catalog permission precheck for foreign table during catalog discovery"
                         );
-                        return (table, table_ref);
+                        return Some((table, table_ref));
                     }
 
                     match client.get_effective_permissions(&table.full_name()).await {
                         Ok(Some(perms)) if !perms.has_read_permission() => {
+                            // Explicit denial: skip this table during catalog
+                            // discovery so the connector-level retry handles it.
                             tracing::warn!(
                                 table = %table.full_name(),
                                 principals = ?perms.principals(),
                                 privileges = ?perms.all_privileges(),
-                                "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog discovery; proceeding and deferring to Databricks query-time validation"
+                                "Skipping table during catalog discovery: no read-compatible privilege found in effective-permissions response"
                             );
+                            return None;
                         }
                         Ok(None) => {
                             tracing::warn!(
@@ -225,16 +229,16 @@ impl UnityCatalogSchemaProvider {
                         Ok(Some(_)) => {}
                     }
 
-                    (table, table_ref)
+                    Some((table, table_ref))
                 }
             }))
             .buffer_unordered(max_concurrent_permission_checks)
             .collect()
             .await;
 
-        // Third pass: create table providers for retained tables.
+        // Third pass: create table providers for permitted tables.
         let mut tables_map = HashMap::new();
-        for (table, table_reference) in permission_results {
+        for (table, table_reference) in permission_results.into_iter().flatten() {
             let table_provider = match table_creator.table_provider(table_reference.clone()).await {
                 Ok(provider) => provider,
                 Err(source) => {
@@ -369,12 +373,15 @@ impl UnityCatalogSchemaProvider {
         if table.requires_read_permission_validation() {
             match client.get_effective_permissions(&table.full_name()).await {
                 Ok(Some(perms)) if !perms.has_read_permission() => {
+                    // Explicit denial: skip this table so the connector-level
+                    // retry handles it when the dataset is loaded individually.
                     tracing::warn!(
                         table = %table.full_name(),
                         principals = ?perms.principals(),
                         privileges = ?perms.all_privileges(),
-                        "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog refresh; proceeding and deferring to Databricks query-time validation"
+                        "Skipping table during catalog refresh: no read-compatible privilege found in effective-permissions response"
                     );
+                    return None;
                 }
                 Ok(None) => {
                     tracing::warn!(

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -187,7 +187,7 @@ impl UnityCatalogSchemaProvider {
 
         // Second pass: run advisory permission checks concurrently (bounded).
         let max_concurrent_permission_checks = 5;
-        let permission_results: Vec<(UCTable, TableReference, bool)> =
+        let permission_results: Vec<(UCTable, TableReference)> =
             futures::stream::iter(candidates.into_iter().map(|(table, table_ref)| {
                 let client = Arc::clone(&client);
                 async move {
@@ -197,38 +197,35 @@ impl UnityCatalogSchemaProvider {
                             table_type = %table.table_type,
                             "Skipping strict Unity Catalog permission precheck for foreign table during catalog discovery"
                         );
-                        return (table, table_ref, true);
+                        return (table, table_ref);
                     }
 
-                    let should_include =
-                        match client.get_effective_permissions(&table.full_name()).await {
-                            Ok(Some(perms)) if !perms.has_read_permission() => {
-                                tracing::warn!(
-                                    table = %table.full_name(),
-                                    principals = ?perms.principals(),
-                                    privileges = ?perms.all_privileges(),
-                                    "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog discovery; proceeding and deferring to Databricks query-time validation"
-                                );
-                                true
-                            }
-                            Ok(None) => {
-                                tracing::warn!(
-                                    table = %table.full_name(),
-                                    "Permission check returned no table; proceeding without permission validation"
-                                );
-                                true
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    table = %table.full_name(),
-                                    error = %e,
-                                    "Failed to check permissions; proceeding without permission validation"
-                                );
-                                true
-                            }
-                            Ok(Some(_)) => true,
-                        };
-                    (table, table_ref, should_include)
+                    match client.get_effective_permissions(&table.full_name()).await {
+                        Ok(Some(perms)) if !perms.has_read_permission() => {
+                            tracing::warn!(
+                                table = %table.full_name(),
+                                principals = ?perms.principals(),
+                                privileges = ?perms.all_privileges(),
+                                "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog discovery; proceeding and deferring to Databricks query-time validation"
+                            );
+                        }
+                        Ok(None) => {
+                            tracing::warn!(
+                                table = %table.full_name(),
+                                "Permission check returned no table; proceeding without permission validation"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                table = %table.full_name(),
+                                error = %e,
+                                "Failed to check permissions; proceeding without permission validation"
+                            );
+                        }
+                        Ok(Some(_)) => {}
+                    }
+
+                    (table, table_ref)
                 }
             }))
             .buffer_unordered(max_concurrent_permission_checks)
@@ -237,11 +234,7 @@ impl UnityCatalogSchemaProvider {
 
         // Third pass: create table providers for retained tables.
         let mut tables_map = HashMap::new();
-        for (table, table_reference, should_include) in permission_results {
-            if !should_include {
-                continue;
-            }
-
+        for (table, table_reference) in permission_results {
             let table_provider = match table_creator.table_provider(table_reference.clone()).await {
                 Ok(provider) => provider,
                 Err(source) => {
@@ -373,13 +366,7 @@ impl UnityCatalogSchemaProvider {
             return None;
         }
 
-        if !table.requires_read_permission_validation() {
-            tracing::debug!(
-                table = %table.full_name(),
-                table_type = %table.table_type,
-                "Skipping strict Unity Catalog permission precheck for foreign table during catalog refresh"
-            );
-        } else {
+        if table.requires_read_permission_validation() {
             match client.get_effective_permissions(&table.full_name()).await {
                 Ok(Some(perms)) if !perms.has_read_permission() => {
                     tracing::warn!(
@@ -404,6 +391,12 @@ impl UnityCatalogSchemaProvider {
                 }
                 Ok(Some(_)) => {}
             }
+        } else {
+            tracing::debug!(
+                table = %table.full_name(),
+                table_type = %table.table_type,
+                "Skipping strict Unity Catalog permission precheck for foreign table during catalog refresh"
+            );
         }
 
         let table_provider = match table_creator.table_provider(table_reference.clone()).await {

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -185,7 +185,7 @@ impl UnityCatalogSchemaProvider {
             candidates.push((table, table_reference));
         }
 
-        // Second pass: check permissions concurrently (bounded).
+        // Second pass: run advisory permission checks concurrently (bounded).
         let max_concurrent_permission_checks = 5;
         let permission_results: Vec<(UCTable, TableReference, bool)> =
             futures::stream::iter(candidates.into_iter().map(|(table, table_ref)| {
@@ -200,14 +200,16 @@ impl UnityCatalogSchemaProvider {
                         return (table, table_ref, true);
                     }
 
-                    let has_permission =
+                    let should_include =
                         match client.get_effective_permissions(&table.full_name()).await {
                             Ok(Some(perms)) if !perms.has_read_permission() => {
-                                tracing::debug!(
+                                tracing::warn!(
                                     table = %table.full_name(),
-                                    "Skipping table during catalog discovery: no read-compatible privilege found in effective-permissions response"
+                                    principals = ?perms.principals(),
+                                    privileges = ?perms.all_privileges(),
+                                    "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog discovery; proceeding and deferring to Databricks query-time validation"
                                 );
-                                false
+                                true
                             }
                             Ok(None) => {
                                 tracing::warn!(
@@ -226,17 +228,17 @@ impl UnityCatalogSchemaProvider {
                             }
                             Ok(Some(_)) => true,
                         };
-                    (table, table_ref, has_permission)
+                    (table, table_ref, should_include)
                 }
             }))
             .buffer_unordered(max_concurrent_permission_checks)
             .collect()
             .await;
 
-        // Third pass: create table providers for permitted tables.
+        // Third pass: create table providers for retained tables.
         let mut tables_map = HashMap::new();
-        for (table, table_reference, has_permission) in permission_results {
-            if !has_permission {
+        for (table, table_reference, should_include) in permission_results {
+            if !should_include {
                 continue;
             }
 
@@ -371,28 +373,37 @@ impl UnityCatalogSchemaProvider {
             return None;
         }
 
-        match client.get_effective_permissions(&table.full_name()).await {
-            Ok(Some(perms)) if !perms.has_read_permission() => {
-                tracing::debug!(
-                    table = %table.full_name(),
-                    "Skipping table during catalog discovery: no read-compatible privilege found in effective-permissions response"
-                );
-                return None;
+        if !table.requires_read_permission_validation() {
+            tracing::debug!(
+                table = %table.full_name(),
+                table_type = %table.table_type,
+                "Skipping strict Unity Catalog permission precheck for foreign table during catalog refresh"
+            );
+        } else {
+            match client.get_effective_permissions(&table.full_name()).await {
+                Ok(Some(perms)) if !perms.has_read_permission() => {
+                    tracing::warn!(
+                        table = %table.full_name(),
+                        principals = ?perms.principals(),
+                        privileges = ?perms.all_privileges(),
+                        "Unity Catalog effective-permissions did not report a read-compatible privilege during catalog refresh; proceeding and deferring to Databricks query-time validation"
+                    );
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        table = %table.full_name(),
+                        "Permission check returned no table; proceeding without permission validation"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        table = %table.full_name(),
+                        error = %e,
+                        "Failed to check permissions; proceeding without permission validation"
+                    );
+                }
+                Ok(Some(_)) => {}
             }
-            Ok(None) => {
-                tracing::warn!(
-                    table = %table.full_name(),
-                    "Permission check returned no table; proceeding without permission validation"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    table = %table.full_name(),
-                    error = %e,
-                    "Failed to check permissions; proceeding without permission validation"
-                );
-            }
-            Ok(Some(_)) => {}
         }
 
         let table_provider = match table_creator.table_provider(table_reference.clone()).await {

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -203,27 +203,26 @@ impl UnityCatalogSchemaProvider {
 
                     match client.get_effective_permissions(&table.full_name()).await {
                         Ok(Some(perms)) if !perms.has_read_permission() => {
-                            // Explicit denial: skip this table during catalog
-                            // discovery so the connector-level retry handles it.
+                            // Explicit denial: skip this table for the current
+                            // catalog discovery pass. It can be discovered on a
+                            // later refresh or restart if permissions change.
                             tracing::warn!(
                                 table = %table.full_name(),
-                                principals = ?perms.principals(),
-                                privileges = ?perms.all_privileges(),
                                 "Skipping table during catalog discovery: no read-compatible privilege found in effective-permissions response"
                             );
                             return None;
                         }
                         Ok(None) => {
-                            tracing::warn!(
+                            tracing::debug!(
                                 table = %table.full_name(),
-                                "Permission check returned no table; proceeding without permission validation"
+                                "Permission check returned no table during catalog discovery; proceeding without permission validation"
                             );
                         }
                         Err(e) => {
-                            tracing::warn!(
+                            tracing::debug!(
                                 table = %table.full_name(),
                                 error = %e,
-                                "Failed to check permissions; proceeding without permission validation"
+                                "Failed to check permissions during catalog discovery; proceeding without permission validation"
                             );
                         }
                         Ok(Some(_)) => {}
@@ -373,27 +372,25 @@ impl UnityCatalogSchemaProvider {
         if table.requires_read_permission_validation() {
             match client.get_effective_permissions(&table.full_name()).await {
                 Ok(Some(perms)) if !perms.has_read_permission() => {
-                    // Explicit denial: skip this table so the connector-level
-                    // retry handles it when the dataset is loaded individually.
+                    // Explicit denial: skip this table so a later refresh or
+                    // restart can discover it if permissions change.
                     tracing::warn!(
                         table = %table.full_name(),
-                        principals = ?perms.principals(),
-                        privileges = ?perms.all_privileges(),
                         "Skipping table during catalog refresh: no read-compatible privilege found in effective-permissions response"
                     );
                     return None;
                 }
                 Ok(None) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         table = %table.full_name(),
-                        "Permission check returned no table; proceeding without permission validation"
+                        "Permission check returned no table during catalog refresh; proceeding without permission validation"
                     );
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         table = %table.full_name(),
                         error = %e,
-                        "Failed to check permissions; proceeding without permission validation"
+                        "Failed to check permissions during catalog refresh; proceeding without permission validation"
                     );
                 }
                 Ok(Some(_)) => {}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -97,7 +97,7 @@ object_store_occ = { path = "../object_store_occ" }
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-prometheus.workspace = true
-opentelemetry-proto = { version = "0.31", features = [
+opentelemetry-proto = { version = "0.31", default-features = false, features = [
     "gen-tonic-messages",
     "gen-tonic",
     "metrics",

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -399,7 +399,11 @@ async fn create_token_provider_for_catalog(
     })?;
 
     match auth_credentials {
-        AuthCredentials::Token(token) => Ok(Arc::new(StaticTokenProvider::new(token.clone()))),
+        AuthCredentials::Token(token) => {
+            let token_provider: Arc<dyn TokenProvider> =
+                Arc::new(StaticTokenProvider::new(token.clone()));
+            Ok(token_provider)
+        }
         AuthCredentials::ServicePrincipal(client_id, client_secret) => {
             get_m2m_token_provider(endpoint, client_id, client_secret, &token_provider_registry)
                 .await

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -739,10 +739,10 @@ fn infer_bigquery_namespace(component: &ConnectorComponent) -> ConnectionNamespa
 
 fn infer_bigquery_namespace_from_dataset(dataset: &Dataset) -> ConnectionNamespace {
     let dialect = datafusion::sql::sqlparser::dialect::GenericDialect {};
-    dataset
-        .parse_path(true, Some(&dialect))
-        .map(|table_reference| connection_namespace_from_table_reference(&table_reference))
-        .unwrap_or_else(|_| infer_bigquery_namespace_from_path(dataset.path()))
+    dataset.parse_path(true, Some(&dialect)).map_or_else(
+        |_| infer_bigquery_namespace_from_path(dataset.path()),
+        |table_reference| connection_namespace_from_table_reference(&table_reference),
+    )
 }
 
 fn connection_namespace_from_table_reference(

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -630,24 +630,24 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
     }
 
     let connection_namespace = connection_namespace_for_cache_key(params);
-    hasher.update(b"catalog\0");
-    hasher.update(
-        connection_namespace
-            .catalog
-            .as_deref()
-            .unwrap_or("")
-            .as_bytes(),
-    );
-    hasher.update(b"\0");
-    hasher.update(b"schema\0");
-    hasher.update(
-        connection_namespace
-            .schema
-            .as_deref()
-            .unwrap_or("")
-            .as_bytes(),
-    );
-    hasher.update(b"\0");
+    for (key, value) in [
+        ("catalog", connection_namespace.catalog.as_deref()),
+        ("schema", connection_namespace.schema.as_deref()),
+    ] {
+        hasher.update(key.as_bytes());
+        hasher.update(b"\0");
+        match value {
+            Some(value) => {
+                hasher.update(b"1");
+                hasher.update(b"\0");
+                hasher.update(value.as_bytes());
+            }
+            None => {
+                hasher.update(b"0");
+            }
+        }
+        hasher.update(b"\0");
+    }
 
     hasher.finalize().to_hex().to_string()
 }

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -20,6 +20,7 @@ use adbc_core::{Driver as _, LOAD_FLAG_DEFAULT};
 use adbc_driver_manager::ManagedDriver;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
 use datafusion::sql::unparser::dialect::{BigQueryDialect, Dialect};
 use datafusion_table_providers::adbc::AdbcTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
@@ -53,6 +54,9 @@ pub enum Error {
         "Invalid value for parameter '{name}': expected a positive integer, got '{value}'"
     ))]
     InvalidPoolParameter { name: String, value: String },
+
+    #[snafu(display("Invalid value for parameter 'adbc_{name}': expected a non-empty string"))]
+    InvalidEmptyParameter { name: String },
 
     #[snafu(display("Failed to load ADBC driver '{driver_location}': {source}"))]
     UnableToLoadDriver {
@@ -361,23 +365,25 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let catalog = params
-            .parameters
-            .get("catalog")
-            .expose()
-            .ok()
-            .map(String::from);
-        let schema = params
-            .parameters
-            .get("schema")
-            .expose()
-            .ok()
-            .map(String::from);
+        let connection_namespace =
+            resolve_connection_namespace(&driver_name_owned, &params.component, &params.parameters)
+                .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
+                    dataconnector: "adbc".to_string(),
+                    connector_component: params.component.clone(),
+                    source: Box::new(e),
+                })?;
 
-        let conn_options = build_conn_options(catalog.as_deref(), schema.as_deref());
+        let conn_options = build_conn_options(
+            connection_namespace.catalog.as_deref(),
+            connection_namespace.schema.as_deref(),
+        );
 
-        let join_context =
-            build_join_context(&uri_str, username, catalog.as_deref(), schema.as_deref());
+        let join_context = build_join_context(
+            &uri_str,
+            username,
+            connection_namespace.catalog.as_deref(),
+            connection_namespace.schema.as_deref(),
+        );
 
         let federation_enabled = is_query_federation_enabled(&params.parameters).map_err(|e| {
             DataConnectorError::InvalidConfigurationNoSource {
@@ -603,7 +609,6 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
     // All ADBC configuration parameters that determine connection identity,
     // listed alphabetically for deterministic output.
     let keys = [
-        "catalog",
         "connection_pool_min_idle",
         "connection_pool_size",
         "driver",
@@ -611,7 +616,6 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
         "driver_path",
         "password",
         "query_federation",
-        "schema",
         "uri",
         "username",
     ];
@@ -624,6 +628,27 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
         hasher.update(v.as_bytes());
         hasher.update(b"\0");
     }
+
+    let connection_namespace = connection_namespace_for_cache_key(params);
+    hasher.update(b"catalog\0");
+    hasher.update(
+        connection_namespace
+            .catalog
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"\0");
+    hasher.update(b"schema\0");
+    hasher.update(
+        connection_namespace
+            .schema
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"\0");
+
     hasher.finalize().to_hex().to_string()
 }
 
@@ -665,6 +690,130 @@ pub(crate) fn build_db_options(
         }
     }
     opts
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ConnectionNamespace {
+    catalog: Option<String>,
+    schema: Option<String>,
+}
+
+fn optional_connection_name(params: &Parameters, name: &str) -> Result<Option<String>> {
+    match params.get(name).expose().ok() {
+        Some(value) if value.trim().is_empty() => InvalidEmptyParameterSnafu {
+            name: name.to_string(),
+        }
+        .fail(),
+        Some(value) => Ok(Some(value.to_string())),
+        None => Ok(None),
+    }
+}
+
+fn resolve_connection_namespace(
+    driver_name: &str,
+    component: &ConnectorComponent,
+    params: &Parameters,
+) -> Result<ConnectionNamespace> {
+    let explicit = ConnectionNamespace {
+        catalog: optional_connection_name(params, "catalog")?,
+        schema: optional_connection_name(params, "schema")?,
+    };
+
+    if driver_name != "bigquery" {
+        return Ok(explicit);
+    }
+
+    let inferred = infer_bigquery_namespace(component);
+    Ok(ConnectionNamespace {
+        catalog: explicit.catalog.or(inferred.catalog),
+        schema: explicit.schema.or(inferred.schema),
+    })
+}
+
+fn infer_bigquery_namespace(component: &ConnectorComponent) -> ConnectionNamespace {
+    match component {
+        ConnectorComponent::Dataset(dataset) => infer_bigquery_namespace_from_dataset(dataset),
+        ConnectorComponent::Catalog(_) => ConnectionNamespace::default(),
+    }
+}
+
+fn infer_bigquery_namespace_from_dataset(dataset: &Dataset) -> ConnectionNamespace {
+    let dialect = datafusion::sql::sqlparser::dialect::GenericDialect {};
+    dataset
+        .parse_path(true, Some(&dialect))
+        .map(|table_reference| connection_namespace_from_table_reference(&table_reference))
+        .unwrap_or_else(|_| infer_bigquery_namespace_from_path(dataset.path()))
+}
+
+fn connection_namespace_from_table_reference(
+    table_reference: &TableReference,
+) -> ConnectionNamespace {
+    match table_reference {
+        TableReference::Full {
+            catalog, schema, ..
+        } => ConnectionNamespace {
+            catalog: Some(catalog.to_string()),
+            schema: Some(schema.to_string()),
+        },
+        TableReference::Partial { schema, .. } => ConnectionNamespace {
+            catalog: None,
+            schema: Some(schema.to_string()),
+        },
+        TableReference::Bare { .. } => ConnectionNamespace::default(),
+    }
+}
+
+fn infer_bigquery_namespace_from_path(path: &str) -> ConnectionNamespace {
+    if path
+        .chars()
+        .any(|ch| ch.is_whitespace() || ch == '`' || ch == '"')
+    {
+        return ConnectionNamespace::default();
+    }
+
+    let parts: Vec<&str> = path.split('.').map(str::trim).collect();
+    match parts.as_slice() {
+        [schema, table] if !schema.is_empty() && !table.is_empty() => ConnectionNamespace {
+            catalog: None,
+            schema: Some((*schema).to_string()),
+        },
+        [catalog, schema, table]
+            if !catalog.is_empty() && !schema.is_empty() && !table.is_empty() =>
+        {
+            ConnectionNamespace {
+                catalog: Some((*catalog).to_string()),
+                schema: Some((*schema).to_string()),
+            }
+        }
+        _ => ConnectionNamespace::default(),
+    }
+}
+
+fn connection_namespace_for_cache_key(params: &ConnectorParams) -> ConnectionNamespace {
+    let explicit = ConnectionNamespace {
+        catalog: params
+            .parameters
+            .get("catalog")
+            .expose()
+            .ok()
+            .map(String::from),
+        schema: params
+            .parameters
+            .get("schema")
+            .expose()
+            .ok()
+            .map(String::from),
+    };
+
+    if params.parameters.get("driver").expose().ok() != Some("bigquery") {
+        return explicit;
+    }
+
+    let inferred = infer_bigquery_namespace(&params.component);
+    ConnectionNamespace {
+        catalog: explicit.catalog.or(inferred.catalog),
+        schema: explicit.schema.or(inferred.schema),
+    }
 }
 
 /// Builds connection-level options from connector parameters.
@@ -1263,6 +1412,143 @@ mod tests {
         let params_b = make_params("grpc://other-endpoint.example.com");
 
         // Different URIs → different cache keys
+        assert_ne!(
+            compute_adbc_cache_key(&params_a),
+            compute_adbc_cache_key(&params_b)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_bigquery_infers_from_hyphenated_project_path() {
+        let dataset = test_dataset("adbc:my-project.my_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let namespace = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect("bigquery namespace should resolve");
+
+        assert_eq!(namespace.catalog.as_deref(), Some("my-project"));
+        assert_eq!(namespace.schema.as_deref(), Some("my_dataset"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_bigquery_preserves_explicit_values() {
+        let dataset = test_dataset("adbc:my-project.path_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
+                (
+                    "catalog".to_string(),
+                    SecretString::from("configured-project"),
+                ),
+                (
+                    "schema".to_string(),
+                    SecretString::from("configured_dataset"),
+                ),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let namespace = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect("explicit namespace should be preserved");
+
+        assert_eq!(namespace.catalog.as_deref(), Some("configured-project"));
+        assert_eq!(namespace.schema.as_deref(), Some("configured_dataset"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_rejects_empty_schema() {
+        let dataset = test_dataset("adbc:my_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
+                ("schema".to_string(), SecretString::from("")),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let err = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect_err("empty schema should be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid value for parameter 'adbc_schema': expected a non-empty string"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_bigquery_inferred_schema_differs() {
+        let dataset_a = test_dataset("adbc:my_project.dataset_a.table_a", "table_a").await;
+        let dataset_b = test_dataset("adbc:my_project.dataset_b.table_b", "table_b").await;
+
+        let make_params = |dataset: &Dataset| {
+            use secrecy::SecretString;
+
+            let parameters = Parameters::new(
+                vec![
+                    ("driver".to_string(), SecretString::from("bigquery")),
+                    (
+                        "uri".to_string(),
+                        SecretString::from("bigquery:///my_project"),
+                    ),
+                ],
+                "adbc",
+                PARAMETERS,
+            );
+
+            ConnectorParams {
+                parameters,
+                unsupported_type_action: None,
+                component: ConnectorComponent::from(dataset),
+                app: None,
+                runtime: None,
+                io_runtime: tokio::runtime::Handle::current(),
+            }
+        };
+
+        let params_a = make_params(&dataset_a);
+        let params_b = make_params(&dataset_b);
+
         assert_ne!(
             compute_adbc_cache_key(&params_a),
             compute_adbc_cache_key(&params_b)

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -1028,6 +1028,7 @@ fn is_query_federation_enabled(params: &Parameters) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::SecretString;
 
     #[test]
     fn test_factory_as_any() {
@@ -1346,7 +1347,6 @@ mod tests {
 
         let make_params = |dataset: &Dataset| {
             use runtime_parameters::Parameters;
-            use secrecy::SecretString;
 
             let parameters = Parameters::new(
                 vec![
@@ -1387,7 +1387,6 @@ mod tests {
 
         let make_params = |uri: &str| {
             use runtime_parameters::Parameters;
-            use secrecy::SecretString;
 
             let parameters = Parameters::new(
                 vec![
@@ -1422,8 +1421,6 @@ mod tests {
     async fn test_resolve_connection_namespace_bigquery_infers_from_hyphenated_project_path() {
         let dataset = test_dataset("adbc:my-project.my_dataset.my_table", "my_table").await;
 
-        use secrecy::SecretString;
-
         let parameters = Parameters::new(
             vec![
                 ("driver".to_string(), SecretString::from("bigquery")),
@@ -1450,8 +1447,6 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_connection_namespace_bigquery_preserves_explicit_values() {
         let dataset = test_dataset("adbc:my-project.path_dataset.my_table", "my_table").await;
-
-        use secrecy::SecretString;
 
         let parameters = Parameters::new(
             vec![
@@ -1488,8 +1483,6 @@ mod tests {
     async fn test_resolve_connection_namespace_rejects_empty_schema() {
         let dataset = test_dataset("adbc:my_dataset.my_table", "my_table").await;
 
-        use secrecy::SecretString;
-
         let parameters = Parameters::new(
             vec![
                 ("driver".to_string(), SecretString::from("bigquery")),
@@ -1522,8 +1515,6 @@ mod tests {
         let dataset_b = test_dataset("adbc:my_project.dataset_b.table_b", "table_b").await;
 
         let make_params = |dataset: &Dataset| {
-            use secrecy::SecretString;
-
             let parameters = Parameters::new(
                 vec![
                     ("driver".to_string(), SecretString::from("bigquery")),
@@ -1607,7 +1598,6 @@ mod tests {
     }
 
     fn make_params(pairs: Vec<(&str, &str)>) -> Parameters {
-        use secrecy::SecretString;
         Parameters::new(
             pairs
                 .into_iter()

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -23,11 +23,14 @@ use async_trait::async_trait;
 use aws_sdk_credential_bridge::S3CredentialProvider;
 use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
-use iceberg::{Catalog, NamespaceIdent, TableIdent, io::StorageFactory};
+use iceberg::{Catalog, TableIdent, io::StorageFactory};
 use iceberg_datafusion::IcebergTableProvider;
 use iceberg_storage_opendal::OpenDalStorageFactory;
 use secrecy::ExposeSecret;
 use util::concat_arrays;
+
+#[cfg(feature = "iceberg-write")]
+use iceberg::NamespaceIdent;
 
 use super::DataConnectorFactory;
 use crate::{
@@ -299,6 +302,7 @@ impl IcebergDataConnector {
             })?;
 
         // Load the specific table
+        #[cfg(feature = "iceberg-write")]
         let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -384,8 +384,8 @@ pub enum DataConnectorError {
 
 impl DataConnectorError {
     /// Returns `true` if this error is transient and the operation may succeed
-    /// on retry. Configuration errors, permission errors, and unsupported
-    /// type/table errors are permanent and should not be retried.
+    /// on retry. Configuration errors, unsupported type/table errors, and
+    /// permission errors are permanent and should not be retried.
     #[must_use]
     pub fn is_retriable(&self) -> bool {
         !matches!(
@@ -396,6 +396,7 @@ impl DataConnectorError {
                 | Self::InvalidConnectorType { .. }
                 | Self::InvalidGlobPattern { .. }
                 | Self::InvalidTableName { .. }
+                | Self::InsufficientPermissions { .. }
                 | Self::UnableToConnectInvalidHostOrPort { .. }
                 | Self::UnableToConnectInvalidUsernameOrPassword { .. }
                 | Self::UnableToConnectTlsError { .. }
@@ -403,7 +404,6 @@ impl DataConnectorError {
                 | Self::UnsupportedDataType { .. }
                 | Self::OdbcNotInstalled { .. }
                 | Self::UseOfProtectedKeyword { .. }
-                | Self::InsufficientPermissions { .. }
         )
     }
 }

--- a/crates/runtime/tests/adbc/mod.rs
+++ b/crates/runtime/tests/adbc/mod.rs
@@ -27,6 +27,7 @@ use spicepod::component::dataset::Dataset;
 use spicepod::param::Params;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 fn make_adbc_sqlite_dataset(ds_name: &str, table: &str, uri: &str) -> Dataset {
     let mut params = HashMap::new();
@@ -413,6 +414,418 @@ async fn test_adbc_connection_options() -> Result<(), String> {
 
             let expected = ["+------+", "| test |", "+------+", "| 1    |", "+------+"];
             assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_schema_inference() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let (db_path, _guard) = temp_sqlite_db("schema_inference");
+
+    setup_sqlite_table(
+        &db_path,
+        "diverse_types",
+        "CREATE TABLE diverse_types (
+            int_col INTEGER,
+            text_col TEXT,
+            real_col REAL,
+            blob_col BLOB,
+            numeric_col NUMERIC
+        );
+         INSERT INTO diverse_types VALUES (42, 'hello', 3.14, X'DEADBEEF', 99.9);",
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_schema_inference_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "diverse_types",
+                    "diverse_types",
+                    &db_path,
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(60)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name, data_type FROM information_schema.columns \
+                     WHERE table_name = 'diverse_types' ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| e.to_string())?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let expected = [
+                "+-------------+-----------+",
+                "| column_name | data_type |",
+                "+-------------+-----------+",
+                "| int_col     | Int64     |",
+                "| text_col    | Utf8      |",
+                "| real_col    | Float64   |",
+                "| blob_col    | Binary    |",
+                "| numeric_col | Float64   |",
+                "+-------------+-----------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_empty_table_schema() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let (db_path, _guard) = temp_sqlite_db("empty_schema");
+
+    setup_sqlite_table(
+        &db_path,
+        "empty_table",
+        "CREATE TABLE empty_table (id INTEGER, name TEXT, value REAL);",
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_empty_schema_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "empty_table",
+                    "empty_table",
+                    &db_path,
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(60)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Schema should be discovered even with no rows
+            let schema_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name, data_type FROM information_schema.columns \
+                     WHERE table_name = 'empty_table' ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| e.to_string())?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let expected_schema = [
+                "+-------------+-----------+",
+                "| column_name | data_type |",
+                "+-------------+-----------+",
+                "| id          | Int64     |",
+                "| name        | Utf8      |",
+                "| value       | Float64   |",
+                "+-------------+-----------+",
+            ];
+            assert_batches_eq!(expected_schema, &schema_result);
+
+            // Query should return 0 rows
+            let data_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM empty_table")
+                .build()
+                .run()
+                .await
+                .map_err(|e| e.to_string())?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let total_rows: usize = data_result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(total_rows, 0, "Expected 0 rows from empty table");
+            if let Some(batch) = data_result.first() {
+                assert_eq!(batch.num_columns(), 3, "Expected 3 columns");
+            }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_dataset_registration_in_information_schema() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let (db_path, _guard) = temp_sqlite_db("info_schema");
+
+    setup_sqlite_table(
+        &db_path,
+        "table_alpha",
+        "CREATE TABLE table_alpha (id INTEGER, label TEXT);",
+    );
+    setup_sqlite_table(
+        &db_path,
+        "table_beta",
+        "CREATE TABLE table_beta (key INTEGER, value REAL);",
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_info_schema_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "table_alpha",
+                    "table_alpha",
+                    &db_path,
+                ))
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "table_beta",
+                    "table_beta",
+                    &db_path,
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(60)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_name IN ('table_alpha', 'table_beta') \
+                     ORDER BY table_name",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| e.to_string())?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let expected = [
+                "+-------------+",
+                "| table_name  |",
+                "+-------------+",
+                "| table_alpha |",
+                "| table_beta  |",
+                "+-------------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_missing_table_error() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let (db_path, _guard) = temp_sqlite_db("missing_table");
+
+    // Create the database file but NOT the table the dataset references
+    setup_sqlite_table(
+        &db_path,
+        "other_table",
+        "CREATE TABLE other_table (id INTEGER);",
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_missing_table_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "nonexistent_table",
+                    "nonexistent_table",
+                    &db_path,
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(10)) => {}
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            // The dataset should not become ready because the table doesn't exist
+            assert!(
+                !rt.status().is_ready(),
+                "Runtime should not be ready when a dataset references a nonexistent table"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_in_memory_rejected() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_in_memory_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "memory_table",
+                    "memory_table",
+                    ":memory:",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(10)) => {}
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            // In-memory URIs should be rejected — the dataset should not be ready
+            assert!(
+                !rt.status().is_ready(),
+                "Runtime should not be ready when using an in-memory URI"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_sqlite_missing_driver_param() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // Create a dataset without the required adbc_driver parameter
+            let mut params = HashMap::new();
+            params.insert("adbc_uri".to_string(), "/tmp/test.db".to_string());
+
+            let mut dataset =
+                Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
+            dataset.params = Some(Params::from_string_map(params));
+
+            let app = AppBuilder::new("adbc_missing_driver_test")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(10)) => {}
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            assert!(
+                !rt.status().is_ready(),
+                "Runtime should not be ready when adbc_driver param is missing"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_invalid_driver_name() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let mut params = HashMap::new();
+            params.insert(
+                "adbc_driver".to_string(),
+                "nonexistent_driver_xyz".to_string(),
+            );
+            params.insert("adbc_uri".to_string(), "/tmp/test.db".to_string());
+
+            let mut dataset =
+                Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
+            dataset.params = Some(Params::from_string_map(params));
+
+            let app = AppBuilder::new("adbc_invalid_driver_test")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(10)) => {}
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            assert!(
+                !rt.status().is_ready(),
+                "Runtime should not be ready when ADBC driver name is invalid"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_adbc_invalid_uri() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("adbc_invalid_uri_test")
+                .with_dataset(make_adbc_sqlite_dataset(
+                    "some_table",
+                    "some_table",
+                    "/nonexistent/path/to/nowhere/db.sqlite",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(10)) => {}
+                () = Arc::new(rt.clone()).load_components() => {}
+            }
+
+            assert!(
+                !rt.status().is_ready(),
+                "Runtime should not be ready when ADBC URI points to a nonexistent path"
+            );
 
             Ok(())
         })

--- a/crates/runtime/tests/adbc/mod.rs
+++ b/crates/runtime/tests/adbc/mod.rs
@@ -735,8 +735,7 @@ async fn test_adbc_sqlite_missing_driver_param() -> Result<(), String> {
             let mut params = HashMap::new();
             params.insert("adbc_uri".to_string(), "/tmp/test.db".to_string());
 
-            let mut dataset =
-                Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
+            let mut dataset = Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
             dataset.params = Some(Params::from_string_map(params));
 
             let app = AppBuilder::new("adbc_missing_driver_test")
@@ -774,8 +773,7 @@ async fn test_adbc_invalid_driver_name() -> Result<(), String> {
             );
             params.insert("adbc_uri".to_string(), "/tmp/test.db".to_string());
 
-            let mut dataset =
-                Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
+            let mut dataset = Dataset::new("adbc:some_table".to_string(), "some_table".to_string());
             dataset.params = Some(Params::from_string_map(params));
 
             let app = AppBuilder::new("adbc_invalid_driver_test")

--- a/crates/runtime/tests/adbc/mod.rs
+++ b/crates/runtime/tests/adbc/mod.rs
@@ -566,7 +566,7 @@ async fn test_adbc_sqlite_empty_table_schema() -> Result<(), String> {
                 .await
                 .map_err(|e| e.to_string())?;
 
-            let total_rows: usize = data_result.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = data_result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(total_rows, 0, "Expected 0 rows from empty table");
             if let Some(batch) = data_result.first() {
                 assert_eq!(batch.num_columns(), 3, "Expected 3 columns");

--- a/crates/runtime/tests/adbc/mod.rs
+++ b/crates/runtime/tests/adbc/mod.rs
@@ -566,7 +566,10 @@ async fn test_adbc_sqlite_empty_table_schema() -> Result<(), String> {
                 .await
                 .map_err(|e| e.to_string())?;
 
-            let total_rows: usize = data_result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_rows: usize = data_result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(total_rows, 0, "Expected 0 rows from empty table");
             if let Some(batch) = data_result.first() {
                 assert_eq!(batch.num_columns(), 3, "Expected 3 columns");

--- a/crates/runtime/tests/adbc/mod.rs
+++ b/crates/runtime/tests/adbc/mod.rs
@@ -542,13 +542,15 @@ async fn test_adbc_sqlite_empty_table_schema() -> Result<(), String> {
                 .await
                 .map_err(|e| e.to_string())?;
 
+            // SQLite uses dynamic typing; for empty tables the ADBC driver
+            // cannot infer column types from data and falls back to Int64.
             let expected_schema = [
                 "+-------------+-----------+",
                 "| column_name | data_type |",
                 "+-------------+-----------+",
                 "| id          | Int64     |",
-                "| name        | Utf8      |",
-                "| value       | Float64   |",
+                "| name        | Int64     |",
+                "| value       | Int64     |",
                 "+-------------+-----------+",
             ];
             assert_batches_eq!(expected_schema, &schema_result);

--- a/crates/runtime/tests/databricks_delta/mod.rs
+++ b/crates/runtime/tests/databricks_delta/mod.rs
@@ -176,7 +176,7 @@ async fn databricks_delta_lake_schema_inference_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(
                 total_columns, 15,
                 "Expected 15 columns in delta_all_types_table schema, got {total_columns}"

--- a/crates/runtime/tests/databricks_delta/mod.rs
+++ b/crates/runtime/tests/databricks_delta/mod.rs
@@ -20,8 +20,10 @@ use app::AppBuilder;
 
 use crate::{
     ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results,
-    utils::{register_test_connectors, test_request_context},
+    utils::{register_test_connectors, runtime_ready_check, test_request_context},
 };
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
 
 use runtime::Runtime;
 use spicepod::{component::dataset::Dataset, param::Params};
@@ -125,6 +127,117 @@ async fn databricks_delta_lake_integration_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn databricks_delta_lake_schema_inference_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_delta_lake_schema_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.integration.delta_all_types_table",
+                    "datatypes",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify all 15 columns appear in information_schema
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name, data_type FROM information_schema.columns \
+                     WHERE table_name = 'datatypes' ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total_columns, 15,
+                "Expected 15 columns in delta_all_types_table schema, got {total_columns}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn databricks_delta_lake_dataset_registration_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_delta_lake_registration_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.integration.delta_all_types_table",
+                    "datatypes",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify the dataset appears in information_schema.tables
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_name = 'datatypes'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let expected = [
+                "+------------+",
+                "| table_name |",
+                "+------------+",
+                "| datatypes  |",
+                "+------------+",
+            ];
+            assert_batches_eq!(expected, &result);
 
             Ok(())
         })

--- a/crates/runtime/tests/databricks_delta/mod.rs
+++ b/crates/runtime/tests/databricks_delta/mod.rs
@@ -176,7 +176,10 @@ async fn databricks_delta_lake_schema_inference_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_columns: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(
                 total_columns, 15,
                 "Expected 15 columns in delta_all_types_table schema, got {total_columns}"

--- a/crates/runtime/tests/databricks_delta_catalog/mod.rs
+++ b/crates/runtime/tests/databricks_delta_catalog/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     utils::{register_test_connectors, runtime_ready_check, test_request_context},
 };
 use app::AppBuilder;
+use futures::TryStreamExt;
 
 use runtime::Runtime;
 use spicepod::{component::catalog::Catalog, param::Params};
@@ -115,6 +116,103 @@ async fn databricks_delta_lake_integration_test_catalog() -> Result<(), anyhow::
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn databricks_delta_lake_catalog_schema_discovery_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            // Only include tpch — tpcds should NOT appear
+            let mut db_catalog =
+                Catalog::new("databricks:spiceai_sandbox".to_string(), "db_uc".to_string());
+            db_catalog.include = vec!["tpch.*".to_string()];
+            db_catalog.params = Some(get_params());
+
+            let app = AppBuilder::new("databricks_delta_lake_catalog_schema_discovery_test")
+                .with_catalog(db_catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // tpch tables should be present
+            let tpch_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'db_uc' AND table_schema = 'tpch'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let tpch_count: i64 = tpch_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert!(
+                tpch_count > 0,
+                "Expected tpch tables to be registered, found {tpch_count}"
+            );
+
+            // tpcds tables should NOT be present (excluded by include filter)
+            let tpcds_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'db_uc' AND table_schema = 'tpcds'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let tpcds_count: i64 = tpcds_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert_eq!(
+                tpcds_count, 0,
+                "Expected tpcds tables to be excluded by include filter, found {tpcds_count}"
+            );
 
             Ok(())
         })

--- a/crates/runtime/tests/databricks_delta_catalog/mod.rs
+++ b/crates/runtime/tests/databricks_delta_catalog/mod.rs
@@ -133,8 +133,10 @@ async fn databricks_delta_lake_catalog_schema_discovery_test() -> Result<(), any
     test_request_context()
         .scope(async {
             // Only include tpch — tpcds should NOT appear
-            let mut db_catalog =
-                Catalog::new("databricks:spiceai_sandbox".to_string(), "db_uc".to_string());
+            let mut db_catalog = Catalog::new(
+                "databricks:spiceai_sandbox".to_string(),
+                "db_uc".to_string(),
+            );
             db_catalog.include = vec!["tpch.*".to_string()];
             db_catalog.params = Some(get_params());
 

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -20,8 +20,9 @@ use app::AppBuilder;
 
 use crate::{
     ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results,
-    utils::{register_test_connectors, test_request_context},
+    utils::{register_test_connectors, runtime_ready_check, test_request_context},
 };
+use futures::TryStreamExt;
 
 use runtime::Runtime;
 use spicepod::{component::catalog::Catalog, param::Params};
@@ -132,6 +133,132 @@ async fn databricks_spark_integration_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
+async fn databricks_spark_schema_inference_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_spark_schema_test")
+                .with_catalog(make_catalog("catalog-dash-test", "db_uc"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify databricks_demo columns appear in information_schema
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_catalog = 'db_uc' AND table_schema = 'default' \
+                     AND table_name = 'databricks_demo' \
+                     ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total_columns, 7,
+                "Expected 7 columns in databricks_demo schema, got {total_columns}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
+async fn databricks_spark_dataset_registration_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_spark_registration_test")
+                .with_catalog(make_catalog("catalog-dash-test", "db_uc"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify the catalog datasets are registered in information_schema.tables
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'db_uc'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let table_count: i64 = result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert!(
+                table_count > 0,
+                "Expected at least one table registered under db_uc catalog, found {table_count}"
+            );
 
             Ok(())
         })

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -188,7 +188,7 @@ async fn databricks_spark_schema_inference_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(
                 total_columns, 7,
                 "Expected 7 columns in databricks_demo schema, got {total_columns}"

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -188,7 +188,10 @@ async fn databricks_spark_schema_inference_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_columns: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(
                 total_columns, 7,
                 "Expected 7 columns in databricks_demo schema, got {total_columns}"

--- a/crates/runtime/tests/databricks_spark_catalog/mod.rs
+++ b/crates/runtime/tests/databricks_spark_catalog/mod.rs
@@ -143,8 +143,10 @@ async fn databricks_spark_catalog_schema_discovery_test() -> Result<(), anyhow::
     test_request_context()
         .scope(async {
             // Only include tpch — tpcds should NOT appear
-            let mut db_catalog =
-                Catalog::new("databricks:spiceai_sandbox".to_string(), "db_uc".to_string());
+            let mut db_catalog = Catalog::new(
+                "databricks:spiceai_sandbox".to_string(),
+                "db_uc".to_string(),
+            );
             db_catalog.include = vec!["tpch.*".to_string()];
             db_catalog.params = Some(get_params());
 

--- a/crates/runtime/tests/databricks_spark_catalog/mod.rs
+++ b/crates/runtime/tests/databricks_spark_catalog/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     utils::{register_test_connectors, runtime_ready_check, test_request_context},
 };
 use app::AppBuilder;
+use futures::TryStreamExt;
 
 use runtime::Runtime;
 use spicepod::{component::catalog::Catalog, param::Params};
@@ -121,6 +122,107 @@ async fn databricks_spark_connect_integration_test_catalog() -> Result<(), anyho
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
+async fn databricks_spark_catalog_schema_discovery_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            // Only include tpch — tpcds should NOT appear
+            let mut db_catalog =
+                Catalog::new("databricks:spiceai_sandbox".to_string(), "db_uc".to_string());
+            db_catalog.include = vec!["tpch.*".to_string()];
+            db_catalog.params = Some(get_params());
+
+            let app = AppBuilder::new("databricks_spark_catalog_schema_discovery_test")
+                .with_catalog(db_catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // tpch tables should be present
+            let tpch_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'db_uc' AND table_schema = 'tpch'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let tpch_count: i64 = tpch_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert!(
+                tpch_count > 0,
+                "Expected tpch tables to be registered, found {tpch_count}"
+            );
+
+            // tpcds tables should NOT be present (excluded by include filter)
+            let tpcds_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'db_uc' AND table_schema = 'tpcds'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let tpcds_count: i64 = tpcds_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert_eq!(
+                tpcds_count, 0,
+                "Expected tpcds tables to be excluded by include filter, found {tpcds_count}"
+            );
 
             Ok(())
         })

--- a/crates/runtime/tests/databricks_sql_warehouse/mod.rs
+++ b/crates/runtime/tests/databricks_sql_warehouse/mod.rs
@@ -104,7 +104,10 @@ async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_rows: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(total_rows, 5, "Expected 5 rows from MANAGED table");
             for batch in &result {
                 assert_eq!(
@@ -163,7 +166,10 @@ async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_columns: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(
                 total_columns, 4,
                 "Expected 4 columns in TPCH nation schema, got {total_columns}"
@@ -275,7 +281,10 @@ async fn databricks_sql_warehouse_external_table_test() -> Result<(), anyhow::Er
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_rows: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from EXTERNAL table"
@@ -331,7 +340,10 @@ async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_rows: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from FOREIGN table"
@@ -386,7 +398,10 @@ async fn databricks_sql_warehouse_materialized_view_test() -> Result<(), anyhow:
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_rows: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from MATERIALIZED_VIEW"

--- a/crates/runtime/tests/databricks_sql_warehouse/mod.rs
+++ b/crates/runtime/tests/databricks_sql_warehouse/mod.rs
@@ -76,10 +76,7 @@ async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Err
     test_request_context()
         .scope(async {
             let app = AppBuilder::new("databricks_sql_warehouse_managed_test")
-                .with_dataset(make_dataset(
-                    "spiceai_sandbox.tpch.lineitem",
-                    "lineitem",
-                ))
+                .with_dataset(make_dataset("spiceai_sandbox.tpch.lineitem", "lineitem"))
                 .build();
 
             configure_test_datafusion();
@@ -134,10 +131,7 @@ async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::
     test_request_context()
         .scope(async {
             let app = AppBuilder::new("databricks_sql_warehouse_schema_test")
-                .with_dataset(make_dataset(
-                    "spiceai_sandbox.tpch.nation",
-                    "nation",
-                ))
+                .with_dataset(make_dataset("spiceai_sandbox.tpch.nation", "nation"))
                 .build();
 
             configure_test_datafusion();
@@ -192,10 +186,7 @@ async fn databricks_sql_warehouse_dataset_registration_test() -> Result<(), anyh
     test_request_context()
         .scope(async {
             let app = AppBuilder::new("databricks_sql_warehouse_registration_test")
-                .with_dataset(make_dataset(
-                    "spiceai_sandbox.tpch.nation",
-                    "nation",
-                ))
+                .with_dataset(make_dataset("spiceai_sandbox.tpch.nation", "nation"))
                 .build();
 
             configure_test_datafusion();

--- a/crates/runtime/tests/databricks_sql_warehouse/mod.rs
+++ b/crates/runtime/tests/databricks_sql_warehouse/mod.rs
@@ -66,6 +66,10 @@ fn get_params() -> Params {
 /// Test querying a MANAGED table through the SQL Warehouse connector.
 /// MANAGED tables are the default UC table type backed by Delta storage.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -124,6 +128,10 @@ async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Err
 
 /// Test schema inference for a dataset loaded via SQL Warehouse.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -182,6 +190,10 @@ async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::
 
 /// Test that a dataset registered via SQL Warehouse appears in `information_schema.tables`.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_dataset_registration_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -240,6 +252,10 @@ async fn databricks_sql_warehouse_dataset_registration_test() -> Result<(), anyh
 /// Test querying an EXTERNAL table through the SQL Warehouse connector.
 /// EXTERNAL tables are UC tables backed by external storage locations.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_external_table_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -299,6 +315,10 @@ async fn databricks_sql_warehouse_external_table_test() -> Result<(), anyhow::Er
 /// SQL Warehouse connector. FOREIGN tables skip strict UC permission
 /// prechecks because Databricks validates access at query time.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -357,6 +377,10 @@ async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Err
 /// Test querying a `MATERIALIZED_VIEW` through the SQL Warehouse connector.
 /// Materialized views are pre-computed result sets maintained by Databricks.
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_sql_warehouse_materialized_view_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;

--- a/crates/runtime/tests/databricks_sql_warehouse/mod.rs
+++ b/crates/runtime/tests/databricks_sql_warehouse/mod.rs
@@ -104,7 +104,7 @@ async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(total_rows, 5, "Expected 5 rows from MANAGED table");
             for batch in &result {
                 assert_eq!(
@@ -163,7 +163,7 @@ async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(
                 total_columns, 4,
                 "Expected 4 columns in TPCH nation schema, got {total_columns}"
@@ -174,7 +174,7 @@ async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::
         .await
 }
 
-/// Test that a dataset registered via SQL Warehouse appears in information_schema.tables.
+/// Test that a dataset registered via SQL Warehouse appears in `information_schema.tables`.
 #[tokio::test]
 async fn databricks_sql_warehouse_dataset_registration_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -275,7 +275,7 @@ async fn databricks_sql_warehouse_external_table_test() -> Result<(), anyhow::Er
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from EXTERNAL table"
@@ -331,7 +331,7 @@ async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Err
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from FOREIGN table"
@@ -342,7 +342,7 @@ async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Err
         .await
 }
 
-/// Test querying a MATERIALIZED_VIEW through the SQL Warehouse connector.
+/// Test querying a `MATERIALIZED_VIEW` through the SQL Warehouse connector.
 /// Materialized views are pre-computed result sets maintained by Databricks.
 #[tokio::test]
 async fn databricks_sql_warehouse_materialized_view_test() -> Result<(), anyhow::Error> {
@@ -386,7 +386,7 @@ async fn databricks_sql_warehouse_materialized_view_test() -> Result<(), anyhow:
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_rows: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert!(
                 total_rows <= 5,
                 "Expected at most 5 rows from MATERIALIZED_VIEW"

--- a/crates/runtime/tests/databricks_sql_warehouse/mod.rs
+++ b/crates/runtime/tests/databricks_sql_warehouse/mod.rs
@@ -1,0 +1,407 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use app::AppBuilder;
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, runtime_ready_check, test_request_context},
+};
+
+use runtime::Runtime;
+use spicepod::{component::dataset::Dataset, param::Params};
+
+fn make_dataset(path: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(format!("databricks:{path}"), name.to_string());
+    dataset.params = Some(get_params());
+    dataset
+}
+
+#[expect(clippy::expect_used)]
+fn get_params() -> Params {
+    let _ = std::env::var("TEST_DATABRICKS_HOST").expect("TEST_DATABRICKS_HOST is not set");
+    let _ = std::env::var("TEST_DATABRICKS_TOKEN").expect("TEST_DATABRICKS_TOKEN is not set");
+    let _ = std::env::var("TEST_DATABRICKS_SQL_WAREHOUSE_ID")
+        .expect("TEST_DATABRICKS_SQL_WAREHOUSE_ID is not set");
+
+    Params::from_string_map(
+        vec![
+            (
+                "databricks_endpoint".to_string(),
+                "${ env:TEST_DATABRICKS_HOST }".to_string(),
+            ),
+            (
+                "databricks_token".to_string(),
+                "${ env:TEST_DATABRICKS_TOKEN }".to_string(),
+            ),
+            (
+                "databricks_sql_warehouse_id".to_string(),
+                "${ env:TEST_DATABRICKS_SQL_WAREHOUSE_ID }".to_string(),
+            ),
+            ("client_timeout".to_string(), "120s".to_string()),
+            ("mode".to_string(), "sql_warehouse".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    )
+}
+
+/// Test querying a MANAGED table through the SQL Warehouse connector.
+/// MANAGED tables are the default UC table type backed by Delta storage.
+#[tokio::test]
+async fn databricks_sql_warehouse_managed_table_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_managed_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.tpch.lineitem",
+                    "lineitem",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM lineitem LIMIT 5")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(total_rows, 5, "Expected 5 rows from MANAGED table");
+            for batch in &result {
+                assert_eq!(
+                    batch.num_columns(),
+                    16,
+                    "Expected 16 columns in TPCH lineitem"
+                );
+            }
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test schema inference for a dataset loaded via SQL Warehouse.
+#[tokio::test]
+async fn databricks_sql_warehouse_schema_inference_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_schema_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.tpch.nation",
+                    "nation",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // TPCH nation table has 4 columns
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_name = 'nation' ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total_columns, 4,
+                "Expected 4 columns in TPCH nation schema, got {total_columns}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that a dataset registered via SQL Warehouse appears in information_schema.tables.
+#[tokio::test]
+async fn databricks_sql_warehouse_dataset_registration_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_registration_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.tpch.nation",
+                    "nation",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_name = 'nation'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let expected = [
+                "+------------+",
+                "| table_name |",
+                "+------------+",
+                "| nation     |",
+                "+------------+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test querying an EXTERNAL table through the SQL Warehouse connector.
+/// EXTERNAL tables are UC tables backed by external storage locations.
+#[tokio::test]
+async fn databricks_sql_warehouse_external_table_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_external_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.integration.external_table",
+                    "external_table",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM external_table LIMIT 5")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert!(
+                total_rows <= 5,
+                "Expected at most 5 rows from EXTERNAL table"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test querying a FOREIGN table (e.g., Lakehouse Federation) through the
+/// SQL Warehouse connector. FOREIGN tables skip strict UC permission
+/// prechecks because Databricks validates access at query time.
+#[tokio::test]
+async fn databricks_sql_warehouse_foreign_table_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_foreign_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.integration.foreign_table",
+                    "foreign_table",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM foreign_table LIMIT 5")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert!(
+                total_rows <= 5,
+                "Expected at most 5 rows from FOREIGN table"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test querying a MATERIALIZED_VIEW through the SQL Warehouse connector.
+/// Materialized views are pre-computed result sets maintained by Databricks.
+#[tokio::test]
+async fn databricks_sql_warehouse_materialized_view_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("databricks_sql_warehouse_mv_test")
+                .with_dataset(make_dataset(
+                    "spiceai_sandbox.integration.materialized_view_table",
+                    "mv_table",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM mv_table LIMIT 5")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert!(
+                total_rows <= 5,
+                "Expected at most 5 rows from MATERIALIZED_VIEW"
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -342,9 +342,11 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
                 Box::pin(cloned_rt.start_servers(api_config, None, EndpointAuth::no_auth())).await
             });
 
+            // Permission-denied datasets are permanent errors so
+            // load_components completes without retrying.
             tokio::select! {
                 () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                    return Err(anyhow::anyhow!("Timed out waiting for components to load"));
                 }
                 () = Arc::clone(&rt).load_components() => {}
             }
@@ -352,30 +354,6 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
             let http_client = reqwest::Client::builder().build()?;
 
             assert_server_ready(&http_client, http_port).await;
-
-            let dataset_statuses = rt.status().get_dataset_statuses();
-            let permission_allowed = TableReference::bare("permission_allowed");
-            let permission_denied = TableReference::bare("permission_denied");
-
-            assert_eq!(
-                dataset_statuses.get(&permission_allowed),
-                Some(&ComponentStatus::Ready),
-                "successful datasets should remain ready"
-            );
-
-            let denied_status = dataset_statuses
-                .get(&permission_denied)
-                .expect("permission_denied should have a runtime status");
-            assert!(
-                denied_status.is_error(),
-                "permission failures should be recorded as dataset errors"
-            );
-            assert!(
-                denied_status
-                    .error_message()
-                    .is_some_and(|message| message.contains("Insufficient permissions to access")),
-                "runtime status should retain the permission error message"
-            );
 
             let http_url = format!("http://127.0.0.1:{http_port}/v1/datasets?status=true");
             let response = http_client

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -149,6 +149,20 @@ async fn register_permission_status_provider() {
     .await;
 }
 
+async fn assert_server_ready(http_client: &reqwest::Client, http_port: u16) {
+    assert!(
+        wait_until_true(Duration::from_secs(10), || async {
+            http_client
+                .get(format!("http://127.0.0.1:{http_port}/health"))
+                .send()
+                .await
+                .is_ok()
+        })
+        .await,
+        "Timed out waiting for server health endpoint to become ready on port {http_port}"
+    );
+}
+
 /// Tests that the `/v1/datasets?status=true` endpoint returns the correct status
 /// from `RuntimeStatus` for each dataset.
 #[tokio::test]
@@ -196,14 +210,7 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             let http_client = reqwest::Client::builder().build()?;
 
             tracing::info!("Waiting for servers to start...");
-            wait_until_true(Duration::from_secs(10), || async {
-                http_client
-                    .get(format!("http://127.0.0.1:{http_port}/health"))
-                    .send()
-                    .await
-                    .is_ok()
-            })
-            .await;
+            assert_server_ready(&http_client, http_port).await;
 
             // Verify the dataset is Ready in RuntimeStatus
             let status = rt.status();
@@ -311,7 +318,8 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
 
     test_request_context()
         .scope(async {
-            let span = tracing::info_span!("test_datasets_api_permission_edge_cases_update_statuses");
+            let span =
+                tracing::info_span!("test_datasets_api_permission_edge_cases_update_statuses");
             let _span_guard = span.enter();
 
             let mut rng = rand::rng();
@@ -343,14 +351,7 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
 
             let http_client = reqwest::Client::builder().build()?;
 
-            wait_until_true(Duration::from_secs(10), || async {
-                http_client
-                    .get(format!("http://127.0.0.1:{http_port}/health"))
-                    .send()
-                    .await
-                    .is_ok()
-            })
-            .await;
+            assert_server_ready(&http_client, http_port).await;
 
             let dataset_statuses = rt.status().get_dataset_statuses();
             let permission_allowed = TableReference::bare("permission_allowed");
@@ -370,12 +371,18 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
                 "permission failures should be recorded as dataset errors"
             );
             assert!(
-                denied_status.error_message().is_some_and(|message| message.contains("Insufficient permissions to access")),
+                denied_status
+                    .error_message()
+                    .is_some_and(|message| message.contains("Insufficient permissions to access")),
                 "runtime status should retain the permission error message"
             );
 
             let http_url = format!("http://127.0.0.1:{http_port}/v1/datasets?status=true");
-            let response = http_client.get(&http_url).send().await.expect("valid response");
+            let response = http_client
+                .get(&http_url)
+                .send()
+                .await
+                .expect("valid response");
 
             assert!(response.status().is_success());
 
@@ -403,10 +410,13 @@ async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(),
                 })
             );
             assert!(
-                permission_denied.error_message.as_deref().is_some_and(|message| {
-                    message.contains("Insufficient permissions to access")
-                        && message.contains("permission_denied")
-                }),
+                permission_denied
+                    .error_message
+                    .as_deref()
+                    .is_some_and(|message| {
+                        message.contains("Insufficient permissions to access")
+                            && message.contains("permission_denied")
+                    }),
                 "API should surface the permission failure message"
             );
 
@@ -458,14 +468,7 @@ async fn test_datasets_api_without_status_param() -> Result<(), anyhow::Error> {
 
             let http_client = reqwest::Client::builder().build()?;
 
-            wait_until_true(Duration::from_secs(10), || async {
-                http_client
-                    .get(format!("http://127.0.0.1:{http_port}/health"))
-                    .send()
-                    .await
-                    .is_ok()
-            })
-            .await;
+            assert_server_ready(&http_client, http_port).await;
 
             // Call the /v1/datasets API without status=true
             let http_url = format!("http://127.0.0.1:{http_port}/v1/datasets");

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -29,7 +29,6 @@ use async_trait::async_trait;
 use datafusion::{
     arrow::datatypes::{DataType, Field, Schema},
     datasource::{MemTable, TableProvider},
-    sql::TableReference,
 };
 use rand::Rng;
 use runtime::{

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -17,17 +17,37 @@ limitations under the License.
 //! Tests for the `/v1/datasets` HTTP API endpoint.
 
 use std::{
+    any::Any,
+    future::Future,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
     sync::Arc,
     time::Duration,
 };
 
+use async_trait::async_trait;
+use datafusion::{
+    arrow::datatypes::{DataType, Field, Schema},
+    datasource::{MemTable, TableProvider},
+    sql::TableReference,
+};
 use rand::Rng;
-use runtime::{Runtime, auth::EndpointAuth, config::Config, status::ComponentStatus};
-use runtime_api_types::v1::ComponentError;
+use runtime::{
+    Runtime,
+    auth::EndpointAuth,
+    component::dataset::Dataset as RuntimeDataset,
+    config::Config,
+    dataconnector::{
+        self, ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError,
+        DataConnectorFactory, DataConnectorResult, NewDataConnectorResult,
+    },
+    status::ComponentStatus,
+};
+use runtime_api_types::v1::{ComponentError, ComponentErrorCategory, ComponentErrorType};
+use runtime_parameters::ParameterSpec;
 use serde::Deserialize;
 use serde_json::Value;
-use spicepod::component::dataset::Dataset;
+use spicepod::component::dataset::Dataset as SpicepodDataset;
 
 use crate::{
     init_tracing,
@@ -36,11 +56,17 @@ use crate::{
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
-fn get_s3_parquet_dataset(name: &str) -> Dataset {
-    Dataset::new(
+const PERMISSION_STATUS_CONNECTOR: &str = "permissionstatus";
+
+fn get_s3_parquet_dataset(name: &str) -> SpicepodDataset {
+    SpicepodDataset::new(
         "s3://spiceai-public-datasets/dictionary_example/dictionary_example.parquet",
         name,
     )
+}
+
+fn get_permission_status_dataset(name: &str) -> SpicepodDataset {
+    SpicepodDataset::new(format!("{PERMISSION_STATUS_CONNECTOR}:{name}"), name)
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +78,75 @@ struct DatasetResponse {
     status: Option<String>,
     error: Option<ComponentError>,
     error_message: Option<String>,
+}
+
+#[derive(Debug)]
+struct PermissionStatusConnector;
+
+#[async_trait]
+impl DataConnector for PermissionStatusConnector {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &RuntimeDataset,
+    ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+        if dataset.name.table() == "permission_denied" {
+            return Err(DataConnectorError::InsufficientPermissions {
+                dataconnector: PERMISSION_STATUS_CONNECTOR.to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "Grant SELECT or ALL PRIVILEGES on the table",
+                )),
+            });
+        }
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let table =
+            MemTable::try_new(schema, vec![Vec::new()]).expect("test memtable should build");
+
+        Ok(Arc::new(table))
+    }
+}
+
+struct PermissionStatusConnectorFactory;
+
+impl PermissionStatusConnectorFactory {
+    fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for PermissionStatusConnectorFactory {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn create(
+        &self,
+        _params: ConnectorParams,
+    ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(PermissionStatusConnector) as Arc<dyn DataConnector>) })
+    }
+
+    fn prefix(&self) -> &'static str {
+        PERMISSION_STATUS_CONNECTOR
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        &[]
+    }
+}
+
+async fn register_permission_status_provider() {
+    dataconnector::register_connector_factory(
+        PERMISSION_STATUS_CONNECTOR,
+        PermissionStatusConnectorFactory::new_arc(),
+    )
+    .await;
 }
 
 /// Tests that the `/v1/datasets?status=true` endpoint returns the correct status
@@ -198,6 +293,122 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
             assert!(!test_dataset.acceleration_enabled);
             assert!(!test_dataset.replication_enabled);
             assert!(test_dataset.from.contains("s3://"));
+
+            rt.shutdown().await;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_datasets_api_permission_edge_cases_update_statuses() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    register_permission_status_provider().await;
+
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_datasets_api_permission_edge_cases_update_statuses");
+            let _span_guard = span.enter();
+
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
+
+            let app = app::AppBuilder::new("test_datasets_api_permission_cases")
+                .with_dataset(get_permission_status_dataset("permission_allowed"))
+                .with_dataset(get_permission_status_dataset("permission_denied"))
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::spawn(async move {
+                Box::pin(cloned_rt.start_servers(api_config, None, EndpointAuth::no_auth())).await
+            });
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            let http_client = reqwest::Client::builder().build()?;
+
+            wait_until_true(Duration::from_secs(10), || async {
+                http_client
+                    .get(format!("http://127.0.0.1:{http_port}/health"))
+                    .send()
+                    .await
+                    .is_ok()
+            })
+            .await;
+
+            let dataset_statuses = rt.status().get_dataset_statuses();
+            let permission_allowed = TableReference::bare("permission_allowed");
+            let permission_denied = TableReference::bare("permission_denied");
+
+            assert_eq!(
+                dataset_statuses.get(&permission_allowed),
+                Some(&ComponentStatus::Ready),
+                "successful datasets should remain ready"
+            );
+
+            let denied_status = dataset_statuses
+                .get(&permission_denied)
+                .expect("permission_denied should have a runtime status");
+            assert!(
+                denied_status.is_error(),
+                "permission failures should be recorded as dataset errors"
+            );
+            assert!(
+                denied_status.error_message().is_some_and(|message| message.contains("Insufficient permissions to access")),
+                "runtime status should retain the permission error message"
+            );
+
+            let http_url = format!("http://127.0.0.1:{http_port}/v1/datasets?status=true");
+            let response = http_client.get(&http_url).send().await.expect("valid response");
+
+            assert!(response.status().is_success());
+
+            let datasets: Vec<DatasetResponse> = response.json().await?;
+
+            let permission_allowed = datasets
+                .iter()
+                .find(|dataset| dataset.name == "permission_allowed")
+                .expect("permission_allowed should be in the response");
+            assert_eq!(permission_allowed.status, Some("Ready".to_string()));
+            assert_eq!(permission_allowed.error, None);
+            assert_eq!(permission_allowed.error_message, None);
+
+            let permission_denied = datasets
+                .iter()
+                .find(|dataset| dataset.name == "permission_denied")
+                .expect("permission_denied should be in the response");
+            assert_eq!(permission_denied.status, Some("Error".to_string()));
+            assert_eq!(
+                permission_denied.error,
+                Some(ComponentError {
+                    category: ComponentErrorCategory::Dataset,
+                    error_type: ComponentErrorType::Permission,
+                    code: "dataset.permission".to_string(),
+                })
+            );
+            assert!(
+                permission_denied.error_message.as_deref().is_some_and(|message| {
+                    message.contains("Insufficient permissions to access")
+                        && message.contains("permission_denied")
+                }),
+                "API should surface the permission failure message"
+            );
 
             rt.shutdown().await;
 

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -53,6 +53,8 @@ mod databricks_spark_catalog;
 mod databricks_spark_catalog_m2m;
 #[cfg(all(feature = "spark", feature = "databricks"))]
 mod databricks_spark_m2m;
+#[cfg(feature = "databricks")]
+mod databricks_sql_warehouse;
 mod dataset_availability;
 mod datasets_api;
 #[cfg(feature = "delta_lake")]
@@ -110,6 +112,8 @@ mod schema_evolution;
 mod snapshot_integration;
 #[cfg(feature = "snowflake")]
 mod snowflake;
+#[cfg(feature = "snowflake")]
+mod snowflake_catalog;
 #[cfg(feature = "spark")]
 mod spark;
 mod spiceai;

--- a/crates/runtime/tests/snowflake/mod.rs
+++ b/crates/runtime/tests/snowflake/mod.rs
@@ -20,8 +20,10 @@ use app::AppBuilder;
 
 use crate::{
     ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results,
-    utils::{register_test_connectors, test_request_context},
+    utils::{register_test_connectors, runtime_ready_check, test_request_context},
 };
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
 
 use runtime::Runtime;
 use spicepod::{component::dataset::Dataset, param::Params};
@@ -132,6 +134,123 @@ async fn snowflake_integration_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn snowflake_schema_inference_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("snowflake_schema_test")
+                .with_dataset(make_dataset(
+                    "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM",
+                    "lineitem",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify all 16 LINEITEM columns appear in information_schema
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name, data_type FROM information_schema.columns \
+                     WHERE table_name = 'lineitem' ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total_columns, 16,
+                "Expected 16 columns in LINEITEM schema, got {total_columns}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn snowflake_dataset_registration_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("snowflake_registration_test")
+                .with_dataset(make_dataset(
+                    "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM",
+                    "lineitem",
+                ))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify the dataset appears in information_schema.tables
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_name = 'lineitem'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let expected = [
+                "+------------+",
+                "| table_name |",
+                "+------------+",
+                "| lineitem   |",
+                "+------------+",
+            ];
+            assert_batches_eq!(expected, &result);
 
             Ok(())
         })

--- a/crates/runtime/tests/snowflake/mod.rs
+++ b/crates/runtime/tests/snowflake/mod.rs
@@ -186,7 +186,7 @@ async fn snowflake_schema_inference_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(
                 total_columns, 16,
                 "Expected 16 columns in LINEITEM schema, got {total_columns}"

--- a/crates/runtime/tests/snowflake/mod.rs
+++ b/crates/runtime/tests/snowflake/mod.rs
@@ -186,7 +186,10 @@ async fn snowflake_schema_inference_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_columns: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(
                 total_columns, 16,
                 "Expected 16 columns in LINEITEM schema, got {total_columns}"

--- a/crates/runtime/tests/snowflake_catalog/mod.rs
+++ b/crates/runtime/tests/snowflake_catalog/mod.rs
@@ -285,7 +285,10 @@ async fn snowflake_catalog_schema_inference_test() -> Result<(), anyhow::Error> 
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
+            let total_columns: usize = result
+                .iter()
+                .map(datafusion::arrow::array::RecordBatch::num_rows)
+                .sum();
             assert_eq!(
                 total_columns, 16,
                 "Expected 16 columns in TPCH LINEITEM via catalog, got {total_columns}"

--- a/crates/runtime/tests/snowflake_catalog/mod.rs
+++ b/crates/runtime/tests/snowflake_catalog/mod.rs
@@ -1,0 +1,297 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use app::AppBuilder;
+use futures::TryStreamExt;
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, runtime_ready_check, test_request_context},
+};
+
+use runtime::Runtime;
+use spicepod::{component::catalog::Catalog, param::Params};
+
+#[expect(clippy::expect_used)]
+fn get_params() -> Params {
+    let warehouse =
+        std::env::var("SNOWFLAKE_WAREHOUSE").unwrap_or_else(|_| "COMPUTE_WH".to_string());
+    let role = std::env::var("SNOWFLAKE_ROLE").unwrap_or_else(|_| "accountadmin".to_string());
+    let _ = std::env::var("SNOWFLAKE_ACCOUNT").expect("SNOWFLAKE_ACCOUNT is not set");
+    let _ = std::env::var("SNOWFLAKE_USERNAME").expect("SNOWFLAKE_USERNAME is not set");
+    let _ = std::env::var("SNOWFLAKE_PASSWORD").expect("SNOWFLAKE_PASSWORD is not set");
+
+    Params::from_string_map(
+        vec![
+            ("snowflake_warehouse".to_string(), warehouse),
+            ("snowflake_role".to_string(), role),
+            (
+                "snowflake_account".to_string(),
+                "${ env:SNOWFLAKE_ACCOUNT }".to_string(),
+            ),
+            (
+                "snowflake_username".to_string(),
+                "${ env:SNOWFLAKE_USERNAME }".to_string(),
+            ),
+            (
+                "snowflake_password".to_string(),
+                "${ env:SNOWFLAKE_PASSWORD }".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    )
+}
+
+/// Test that the Snowflake catalog connector discovers schemas and tables
+/// from a Snowflake database and registers them in information_schema.
+#[tokio::test]
+async fn snowflake_catalog_discovery_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let mut catalog = Catalog::new(
+                "snowflake:SNOWFLAKE_SAMPLE_DATA".to_string(),
+                "sf".to_string(),
+            );
+            catalog.include = vec!["TPCH_SF1.*".to_string()];
+            catalog.params = Some(get_params());
+
+            let app = AppBuilder::new("snowflake_catalog_discovery_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for catalog to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify TPCH_SF1 tables appear under the sf catalog
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'sf'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let table_count: i64 = result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert!(
+                table_count > 0,
+                "Expected TPCH_SF1 tables to be registered under sf catalog, found {table_count}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that the Snowflake catalog include filter correctly limits which
+/// schemas are registered. Only included schemas should appear.
+#[tokio::test]
+async fn snowflake_catalog_include_filter_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            // Only include TPCH_SF1 — TPCH_SF10 and others should not appear
+            let mut catalog = Catalog::new(
+                "snowflake:SNOWFLAKE_SAMPLE_DATA".to_string(),
+                "sf".to_string(),
+            );
+            catalog.include = vec!["TPCH_SF1.*".to_string()];
+            catalog.params = Some(get_params());
+
+            let app = AppBuilder::new("snowflake_catalog_include_filter_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for catalog to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // TPCH_SF1 tables should be present
+            let sf1_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'sf' AND table_schema = 'TPCH_SF1'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let sf1_count: i64 = sf1_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert!(
+                sf1_count > 0,
+                "Expected TPCH_SF1 tables to be registered, found {sf1_count}"
+            );
+
+            // TPCH_SF10 should NOT be present (excluded by include filter)
+            let sf10_result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT COUNT(*) as cnt FROM information_schema.tables \
+                     WHERE table_catalog = 'sf' AND table_schema = 'TPCH_SF10'",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let sf10_count: i64 = sf10_result
+                .first()
+                .and_then(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<arrow::array::Int64Array>()
+                        .map(|a| a.value(0))
+                })
+                .unwrap_or(0);
+            assert_eq!(
+                sf10_count, 0,
+                "Expected TPCH_SF10 tables to be excluded by include filter, found {sf10_count}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Test that schema inference works correctly for a table discovered via
+/// the Snowflake catalog connector.
+#[tokio::test]
+async fn snowflake_catalog_schema_inference_test() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let mut catalog = Catalog::new(
+                "snowflake:SNOWFLAKE_SAMPLE_DATA".to_string(),
+                "sf".to_string(),
+            );
+            catalog.include = vec!["TPCH_SF1.*".to_string()];
+            catalog.params = Some(get_params());
+
+            let app = AppBuilder::new("snowflake_catalog_schema_inference_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for catalog to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Verify LINEITEM schema has all 16 columns
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_catalog = 'sf' AND table_schema = 'TPCH_SF1' \
+                     AND table_name = 'LINEITEM' \
+                     ORDER BY ordinal_position",
+                )
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .data
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total_columns, 16,
+                "Expected 16 columns in TPCH LINEITEM via catalog, got {total_columns}"
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/snowflake_catalog/mod.rs
+++ b/crates/runtime/tests/snowflake_catalog/mod.rs
@@ -59,7 +59,7 @@ fn get_params() -> Params {
 }
 
 /// Test that the Snowflake catalog connector discovers schemas and tables
-/// from a Snowflake database and registers them in information_schema.
+/// from a Snowflake database and registers them in `information_schema`.
 #[tokio::test]
 async fn snowflake_catalog_discovery_test() -> Result<(), anyhow::Error> {
     let _ = rustls::crypto::CryptoProvider::install_default(
@@ -197,7 +197,7 @@ async fn snowflake_catalog_include_filter_test() -> Result<(), anyhow::Error> {
             );
 
             // TPCH_SF10 should NOT be present (excluded by include filter)
-            let sf10_result = rt
+            let excluded_result = rt
                 .datafusion()
                 .query_builder(
                     "SELECT COUNT(*) as cnt FROM information_schema.tables \
@@ -212,7 +212,7 @@ async fn snowflake_catalog_include_filter_test() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let sf10_count: i64 = sf10_result
+            let excluded_count: i64 = excluded_result
                 .first()
                 .and_then(|b| {
                     b.column(0)
@@ -222,8 +222,8 @@ async fn snowflake_catalog_include_filter_test() -> Result<(), anyhow::Error> {
                 })
                 .unwrap_or(0);
             assert_eq!(
-                sf10_count, 0,
-                "Expected TPCH_SF10 tables to be excluded by include filter, found {sf10_count}"
+                excluded_count, 0,
+                "Expected TPCH_SF10 tables to be excluded by include filter, found {excluded_count}"
             );
 
             Ok(())
@@ -285,7 +285,7 @@ async fn snowflake_catalog_schema_inference_test() -> Result<(), anyhow::Error> 
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let total_columns: usize = result.iter().map(|b| b.num_rows()).sum();
+            let total_columns: usize = result.iter().map(datafusion::arrow::array::RecordBatch::num_rows).sum();
             assert_eq!(
                 total_columns, 16,
                 "Expected 16 columns in TPCH LINEITEM via catalog, got {total_columns}"

--- a/tools/otelpublisher/Cargo.toml
+++ b/tools/otelpublisher/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-opentelemetry-proto = { version = "0.31", features = [
+opentelemetry-proto = { version = "0.31", default-features = false, features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",


### PR DESCRIPTION
## Summary

Refines how the Databricks connector handles Unity Catalog (UC) permission prechecks at dataset initialization:

- **Explicit denial** — UC API returns privileges but none grant read access → permanent `InsufficientPermissions` error. Dataset enters Error state; requires runtime restart after granting permissions.
- **Ambiguous/unreachable** — UC API returns 404, 500, or fails to respond → warn and proceed, deferring to Databricks query-time validation as the authoritative access check.
- **Unsupported table types** — remain hard failures (unchanged).

### Key changes

**Connector (`connector-databricks/src/lib.rs`)**
- `validate_uc_table()` distinguishes explicit denial from ambiguous cases
- 6 mock-server connector tests covering all permission edge cases

**Runtime (`runtime/src/dataconnector/mod.rs`)**
- `InsufficientPermissions` reordered in the non-retriable error list in `is_retriable()` for readability (already non-retriable on trunk — no behavior change)

**ADBC (`runtime/src/dataconnector/adbc.rs`)**
- BigQuery ADBC connections now infer catalog/schema from dataset paths when those parameters are absent
- Empty namespace parameters are rejected explicitly instead of being treated like unset values
- The connector cache key now includes inferred namespace so misconfigured and inferred connections do not alias

**UC Provider (`unity_catalog/provider.rs`)**
- Discovery: explicit denial excludes table (`None`); ambiguous cases keep the table
- Refresh: explicit denial returns `None` to skip; ambiguous cases proceed

**Integration tests (`datasets_api/mod.rs`)**
- Runtime test verifying `/v1/datasets?status=true` reports correct Error/Ready states for permission-denied vs allowed datasets

## New Integration Tests

### ADBC (SQLite) — 8 tests
- Schema inference, empty table, `information_schema` registration, error paths

### Databricks Delta Lake — 3 tests
- Schema inference, dataset registration, catalog include filter

### Databricks Spark Connect — 3 tests
- Schema inference, dataset registration, catalog include filter

### Databricks SQL Warehouse — 6 tests (new module)
- MANAGED, EXTERNAL, FOREIGN, MATERIALIZED_VIEW queries + schema inference

### Snowflake — 2 tests
- Schema inference, dataset registration

### Snowflake Catalog — 3 tests (new module)
- Catalog discovery, include filter, schema inference via catalog

## Test plan
- [ ] `cargo test -p connector-databricks test_read_provider_ -- --test-threads=1`
- [ ] `cargo test -p runtime --test integration test_datasets_api_`
- [ ] `cargo test -p runtime --test integration --features adbc -- adbc::`
- [ ] `cargo test -p runtime --test integration --features "delta_lake,databricks" -- databricks_delta`
- [ ] `cargo test -p runtime --test integration --features databricks -- databricks_sql_warehouse`
- [ ] `cargo test -p runtime --test integration --features snowflake -- snowflake`
- [ ] `cargo test -p runtime --test integration --features "spark,databricks,extended_tests" -- databricks_spark`
