### PR TITLE
Fix BigQuery ADBC namespace resolution and OTEL log noise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,18 +4364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13039,7 +13027,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
- "tracing",
 ]
 
 [[package]]
@@ -13048,13 +13035,9 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "base64 0.22.1",
- "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
@@ -14448,21 +14431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
-dependencies = [
- "bitflags 2.10.0",
- "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15080,15 +15048,6 @@ name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -21024,12 +20983,6 @@ dependencies = [
  "thiserror 1.0.69",
  "ug 0.5.0",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,14 +223,14 @@ opentelemetry = { version = "0.31", default-features = false, features = [
     "metrics",
     "trace",
 ] }
-opentelemetry-http = { version = "0.31", features = ["reqwest-rustls"] }
+opentelemetry-http = { version = "0.31", default-features = false, features = ["reqwest-rustls"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
     "metrics",
     "grpc-tonic",
     "http-proto",
     "reqwest-rustls",
 ] }
-opentelemetry-prometheus = "0.31"
+opentelemetry-prometheus = { version = "0.31", default-features = false }
 opentelemetry-zipkin = { version = "0.31", default-features = false, features = [
     "reqwest",
     "reqwest-rustls",

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -90,37 +90,40 @@ const INTERNAL_COMPONENTS: &[&str] = &[
 ];
 
 const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,delta_kernel::listed_log_files=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
-const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off";
+const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off,opentelemetry=warn";
 
 fn specific_env_filter(filter: &str) -> String {
     format!("{OFF_FILTERS},{filter}")
 }
 
+fn env_filter_string(v: &LogVerbosity) -> String {
+    fn internal_components(level: &str) -> String {
+        INTERNAL_COMPONENTS
+            .iter()
+            .map(|component| format!("{component}={level}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    match v {
+        LogVerbosity::Default => format!(
+            "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},WARN",
+            internal_components("INFO")
+        ),
+        LogVerbosity::Verbose => format!(
+            "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},INFO",
+            internal_components("DEBUG")
+        ),
+        LogVerbosity::VeryVerbose => {
+            format!("{},{OFF_FILTERS},DEBUG", internal_components("TRACE"))
+        }
+        LogVerbosity::Specific(filter) => specific_env_filter(filter),
+    }
+}
+
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {
-        fn internal_components(level: &str) -> String {
-            INTERNAL_COMPONENTS
-                .iter()
-                .map(|component| format!("{component}={level}"))
-                .collect::<Vec<_>>()
-                .join(",")
-        }
-
-        match v {
-            LogVerbosity::Default => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},WARN",
-                internal_components("INFO")
-            )),
-            LogVerbosity::Verbose => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},INFO",
-                internal_components("DEBUG")
-            )),
-            LogVerbosity::VeryVerbose => EnvFilter::new(format!(
-                "{},{OFF_FILTERS},DEBUG",
-                internal_components("TRACE")
-            )),
-            LogVerbosity::Specific(filter) => EnvFilter::new(specific_env_filter(&filter)),
-        }
+        EnvFilter::new(env_filter_string(&v))
     }
 }
 
@@ -489,5 +492,12 @@ mod tests {
     #[test]
     fn specific_filter_keeps_off_filters() {
         assert_eq!(specific_env_filter("trace"), format!("{OFF_FILTERS},trace"));
+    }
+
+    #[test]
+    fn verbose_filter_suppresses_opentelemetry_info() {
+        assert!(env_filter_string(&LogVerbosity::Default).contains("opentelemetry=warn"));
+        assert!(env_filter_string(&LogVerbosity::Verbose).contains("opentelemetry=warn"));
+        assert!(!env_filter_string(&LogVerbosity::VeryVerbose).contains("opentelemetry=warn"));
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -97,7 +97,7 @@ object_store_occ = { path = "../object_store_occ" }
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-prometheus.workspace = true
-opentelemetry-proto = { version = "0.31", features = [
+opentelemetry-proto = { version = "0.31", default-features = false, features = [
     "gen-tonic-messages",
     "gen-tonic",
     "metrics",

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -55,9 +55,7 @@ pub enum Error {
     ))]
     InvalidPoolParameter { name: String, value: String },
 
-    #[snafu(display(
-        "Invalid value for parameter '{name}': expected a non-empty string"
-    ))]
+    #[snafu(display("Invalid value for parameter 'adbc_{name}': expected a non-empty string"))]
     InvalidEmptyParameter { name: String },
 
     #[snafu(display("Failed to load ADBC driver '{driver_location}': {source}"))]
@@ -367,16 +365,13 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let connection_namespace = resolve_connection_namespace(
-            &driver_name_owned,
-            &params.component,
-            &params.parameters,
-        )
-        .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
-            dataconnector: "adbc".to_string(),
-            connector_component: params.component.clone(),
-            source: Box::new(e),
-        })?;
+        let connection_namespace =
+            resolve_connection_namespace(&driver_name_owned, &params.component, &params.parameters)
+                .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
+                    dataconnector: "adbc".to_string(),
+                    connector_component: params.component.clone(),
+                    source: Box::new(e),
+                })?;
 
         let conn_options = build_conn_options(
             connection_namespace.catalog.as_deref(),
@@ -796,8 +791,18 @@ fn infer_bigquery_namespace_from_path(path: &str) -> ConnectionNamespace {
 
 fn connection_namespace_for_cache_key(params: &ConnectorParams) -> ConnectionNamespace {
     let explicit = ConnectionNamespace {
-        catalog: params.parameters.get("catalog").expose().ok().map(String::from),
-        schema: params.parameters.get("schema").expose().ok().map(String::from),
+        catalog: params
+            .parameters
+            .get("catalog")
+            .expose()
+            .ok()
+            .map(String::from),
+        schema: params
+            .parameters
+            .get("schema")
+            .expose()
+            .ok()
+            .map(String::from),
     };
 
     if params.parameters.get("driver").expose().ok() != Some("bigquery") {
@@ -1422,7 +1427,10 @@ mod tests {
         let parameters = Parameters::new(
             vec![
                 ("driver".to_string(), SecretString::from("bigquery")),
-                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
             ],
             "adbc",
             PARAMETERS,
@@ -1448,7 +1456,10 @@ mod tests {
         let parameters = Parameters::new(
             vec![
                 ("driver".to_string(), SecretString::from("bigquery")),
-                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
                 (
                     "catalog".to_string(),
                     SecretString::from("configured-project"),
@@ -1482,7 +1493,10 @@ mod tests {
         let parameters = Parameters::new(
             vec![
                 ("driver".to_string(), SecretString::from("bigquery")),
-                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
                 ("schema".to_string(), SecretString::from("")),
             ],
             "adbc",
@@ -1498,7 +1512,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Invalid value for parameter 'schema': expected a non-empty string"
+            "Invalid value for parameter 'adbc_schema': expected a non-empty string"
         );
     }
 
@@ -1513,7 +1527,10 @@ mod tests {
             let parameters = Parameters::new(
                 vec![
                     ("driver".to_string(), SecretString::from("bigquery")),
-                    ("uri".to_string(), SecretString::from("bigquery:///my_project")),
+                    (
+                        "uri".to_string(),
+                        SecretString::from("bigquery:///my_project"),
+                    ),
                 ],
                 "adbc",
                 PARAMETERS,

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -20,6 +20,7 @@ use adbc_core::{Driver as _, LOAD_FLAG_DEFAULT};
 use adbc_driver_manager::ManagedDriver;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
 use datafusion::sql::unparser::dialect::{BigQueryDialect, Dialect};
 use datafusion_table_providers::adbc::AdbcTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
@@ -53,6 +54,11 @@ pub enum Error {
         "Invalid value for parameter '{name}': expected a positive integer, got '{value}'"
     ))]
     InvalidPoolParameter { name: String, value: String },
+
+    #[snafu(display(
+        "Invalid value for parameter '{name}': expected a non-empty string"
+    ))]
+    InvalidEmptyParameter { name: String },
 
     #[snafu(display("Failed to load ADBC driver '{driver_location}': {source}"))]
     UnableToLoadDriver {
@@ -361,23 +367,28 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let catalog = params
-            .parameters
-            .get("catalog")
-            .expose()
-            .ok()
-            .map(String::from);
-        let schema = params
-            .parameters
-            .get("schema")
-            .expose()
-            .ok()
-            .map(String::from);
+        let connection_namespace = resolve_connection_namespace(
+            &driver_name_owned,
+            &params.component,
+            &params.parameters,
+        )
+        .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
+            dataconnector: "adbc".to_string(),
+            connector_component: params.component.clone(),
+            source: Box::new(e),
+        })?;
 
-        let conn_options = build_conn_options(catalog.as_deref(), schema.as_deref());
+        let conn_options = build_conn_options(
+            connection_namespace.catalog.as_deref(),
+            connection_namespace.schema.as_deref(),
+        );
 
-        let join_context =
-            build_join_context(&uri_str, username, catalog.as_deref(), schema.as_deref());
+        let join_context = build_join_context(
+            &uri_str,
+            username,
+            connection_namespace.catalog.as_deref(),
+            connection_namespace.schema.as_deref(),
+        );
 
         let federation_enabled = is_query_federation_enabled(&params.parameters).map_err(|e| {
             DataConnectorError::InvalidConfigurationNoSource {
@@ -603,7 +614,6 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
     // All ADBC configuration parameters that determine connection identity,
     // listed alphabetically for deterministic output.
     let keys = [
-        "catalog",
         "connection_pool_min_idle",
         "connection_pool_size",
         "driver",
@@ -611,7 +621,6 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
         "driver_path",
         "password",
         "query_federation",
-        "schema",
         "uri",
         "username",
     ];
@@ -624,6 +633,27 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
         hasher.update(v.as_bytes());
         hasher.update(b"\0");
     }
+
+    let connection_namespace = connection_namespace_for_cache_key(params);
+    hasher.update(b"catalog\0");
+    hasher.update(
+        connection_namespace
+            .catalog
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"\0");
+    hasher.update(b"schema\0");
+    hasher.update(
+        connection_namespace
+            .schema
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"\0");
+
     hasher.finalize().to_hex().to_string()
 }
 
@@ -665,6 +695,120 @@ pub(crate) fn build_db_options(
         }
     }
     opts
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ConnectionNamespace {
+    catalog: Option<String>,
+    schema: Option<String>,
+}
+
+fn optional_connection_name(params: &Parameters, name: &str) -> Result<Option<String>> {
+    match params.get(name).expose().ok() {
+        Some(value) if value.trim().is_empty() => InvalidEmptyParameterSnafu {
+            name: name.to_string(),
+        }
+        .fail(),
+        Some(value) => Ok(Some(value.to_string())),
+        None => Ok(None),
+    }
+}
+
+fn resolve_connection_namespace(
+    driver_name: &str,
+    component: &ConnectorComponent,
+    params: &Parameters,
+) -> Result<ConnectionNamespace> {
+    let explicit = ConnectionNamespace {
+        catalog: optional_connection_name(params, "catalog")?,
+        schema: optional_connection_name(params, "schema")?,
+    };
+
+    if driver_name != "bigquery" {
+        return Ok(explicit);
+    }
+
+    let inferred = infer_bigquery_namespace(component);
+    Ok(ConnectionNamespace {
+        catalog: explicit.catalog.or(inferred.catalog),
+        schema: explicit.schema.or(inferred.schema),
+    })
+}
+
+fn infer_bigquery_namespace(component: &ConnectorComponent) -> ConnectionNamespace {
+    match component {
+        ConnectorComponent::Dataset(dataset) => infer_bigquery_namespace_from_dataset(dataset),
+        ConnectorComponent::Catalog(_) => ConnectionNamespace::default(),
+    }
+}
+
+fn infer_bigquery_namespace_from_dataset(dataset: &Dataset) -> ConnectionNamespace {
+    let dialect = datafusion::sql::sqlparser::dialect::GenericDialect {};
+    dataset
+        .parse_path(true, Some(&dialect))
+        .map(|table_reference| connection_namespace_from_table_reference(&table_reference))
+        .unwrap_or_else(|_| infer_bigquery_namespace_from_path(dataset.path()))
+}
+
+fn connection_namespace_from_table_reference(
+    table_reference: &TableReference,
+) -> ConnectionNamespace {
+    match table_reference {
+        TableReference::Full {
+            catalog, schema, ..
+        } => ConnectionNamespace {
+            catalog: Some(catalog.to_string()),
+            schema: Some(schema.to_string()),
+        },
+        TableReference::Partial { schema, .. } => ConnectionNamespace {
+            catalog: None,
+            schema: Some(schema.to_string()),
+        },
+        TableReference::Bare { .. } => ConnectionNamespace::default(),
+    }
+}
+
+fn infer_bigquery_namespace_from_path(path: &str) -> ConnectionNamespace {
+    if path
+        .chars()
+        .any(|ch| ch.is_whitespace() || ch == '`' || ch == '"')
+    {
+        return ConnectionNamespace::default();
+    }
+
+    let parts: Vec<&str> = path.split('.').map(str::trim).collect();
+    match parts.as_slice() {
+        [schema, table] if !schema.is_empty() && !table.is_empty() => ConnectionNamespace {
+            catalog: None,
+            schema: Some((*schema).to_string()),
+        },
+        [catalog, schema, table]
+            if !catalog.is_empty() && !schema.is_empty() && !table.is_empty() =>
+        {
+            ConnectionNamespace {
+                catalog: Some((*catalog).to_string()),
+                schema: Some((*schema).to_string()),
+            }
+        }
+        _ => ConnectionNamespace::default(),
+    }
+}
+
+fn connection_namespace_for_cache_key(params: &ConnectorParams) -> ConnectionNamespace {
+    let explicit = ConnectionNamespace {
+        catalog: params.parameters.get("catalog").expose().ok().map(String::from),
+        schema: params.parameters.get("schema").expose().ok().map(String::from),
+    };
+
+    if params.parameters.get("driver").expose().ok() != Some("bigquery") {
+        return explicit;
+    }
+
+    let inferred = infer_bigquery_namespace(&params.component);
+    ConnectionNamespace {
+        catalog: explicit.catalog.or(inferred.catalog),
+        schema: explicit.schema.or(inferred.schema),
+    }
 }
 
 /// Builds connection-level options from connector parameters.
@@ -1263,6 +1407,131 @@ mod tests {
         let params_b = make_params("grpc://other-endpoint.example.com");
 
         // Different URIs → different cache keys
+        assert_ne!(
+            compute_adbc_cache_key(&params_a),
+            compute_adbc_cache_key(&params_b)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_bigquery_infers_from_hyphenated_project_path() {
+        let dataset = test_dataset("adbc:my-project.my_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let namespace = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect("bigquery namespace should resolve");
+
+        assert_eq!(namespace.catalog.as_deref(), Some("my-project"));
+        assert_eq!(namespace.schema.as_deref(), Some("my_dataset"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_bigquery_preserves_explicit_values() {
+        let dataset = test_dataset("adbc:my-project.path_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+                (
+                    "catalog".to_string(),
+                    SecretString::from("configured-project"),
+                ),
+                (
+                    "schema".to_string(),
+                    SecretString::from("configured_dataset"),
+                ),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let namespace = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect("explicit namespace should be preserved");
+
+        assert_eq!(namespace.catalog.as_deref(), Some("configured-project"));
+        assert_eq!(namespace.schema.as_deref(), Some("configured_dataset"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_connection_namespace_rejects_empty_schema() {
+        let dataset = test_dataset("adbc:my_dataset.my_table", "my_table").await;
+
+        use secrecy::SecretString;
+
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                ("uri".to_string(), SecretString::from("bigquery:///my-project")),
+                ("schema".to_string(), SecretString::from("")),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let err = resolve_connection_namespace(
+            "bigquery",
+            &ConnectorComponent::from(&dataset),
+            &parameters,
+        )
+        .expect_err("empty schema should be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid value for parameter 'schema': expected a non-empty string"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_bigquery_inferred_schema_differs() {
+        let dataset_a = test_dataset("adbc:my_project.dataset_a.table_a", "table_a").await;
+        let dataset_b = test_dataset("adbc:my_project.dataset_b.table_b", "table_b").await;
+
+        let make_params = |dataset: &Dataset| {
+            use secrecy::SecretString;
+
+            let parameters = Parameters::new(
+                vec![
+                    ("driver".to_string(), SecretString::from("bigquery")),
+                    ("uri".to_string(), SecretString::from("bigquery:///my_project")),
+                ],
+                "adbc",
+                PARAMETERS,
+            );
+
+            ConnectorParams {
+                parameters,
+                unsupported_type_action: None,
+                component: ConnectorComponent::from(dataset),
+                app: None,
+                runtime: None,
+                io_runtime: tokio::runtime::Handle::current(),
+            }
+        };
+
+        let params_a = make_params(&dataset_a);
+        let params_b = make_params(&dataset_b);
+
         assert_ne!(
             compute_adbc_cache_key(&params_a),
             compute_adbc_cache_key(&params_b)

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -23,11 +23,14 @@ use async_trait::async_trait;
 use aws_sdk_credential_bridge::S3CredentialProvider;
 use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
-use iceberg::{Catalog, NamespaceIdent, TableIdent, io::StorageFactory};
+use iceberg::{Catalog, TableIdent, io::StorageFactory};
 use iceberg_datafusion::IcebergTableProvider;
 use iceberg_storage_opendal::OpenDalStorageFactory;
 use secrecy::ExposeSecret;
 use util::concat_arrays;
+
+#[cfg(feature = "iceberg-write")]
+use iceberg::NamespaceIdent;
 
 use super::DataConnectorFactory;
 use crate::{
@@ -299,6 +302,7 @@ impl IcebergDataConnector {
             })?;
 
         // Load the specific table
+    #[cfg(feature = "iceberg-write")]
         let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -302,7 +302,7 @@ impl IcebergDataConnector {
             })?;
 
         // Load the specific table
-    #[cfg(feature = "iceberg-write")]
+        #[cfg(feature = "iceberg-write")]
         let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 

--- a/tools/otelpublisher/Cargo.toml
+++ b/tools/otelpublisher/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-opentelemetry-proto = { version = "0.31", features = [
+opentelemetry-proto = { version = "0.31", default-features = false, features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",


### PR DESCRIPTION
## 📝 Summary

- fix BigQuery ADBC namespace resolution by inferring the connection catalog/schema from dataset paths, rejecting empty namespace parameters, and including the resolved namespace in the connector cache key
- reduce noisy `INFO opentelemetry` meter-provider logs by disabling unneeded OpenTelemetry default features and suppressing the `opentelemetry` target in normal and verbose `spiced` logging

## 👀 Notes for Reviewers

- `opentelemetry-prometheus 0.31.0` still enables upstream OpenTelemetry internal logs in its dependency graph, so the runtime filter change is what prevents `MeterProvider.GlobalSet` from surfacing in standard `spiced` logs
- file-level diagnostics are clean for the edited Rust files; a targeted `cargo test -p spiced --lib verbose_filter_suppresses_opentelemetry_info -- --exact` was started but timed out during compilation before reaching the test
