### PR TITLE
Add versioned release install workflow coverage

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -198,9 +198,13 @@ jobs:
           echo "CLI Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $cli_version"
           echo "Runtime Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $runtime_version"
 
-          if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
-            echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
-            exit 1
+          if [[ "$cli_version" != v1.11.* ]]; then
+            if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
+              echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+              exit 1
+            fi
+          else
+            echo "::warning::Skipping CLI version check: v1.11.x CLI does not self-upgrade"
           fi
 
           if [[ "$runtime_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
@@ -351,28 +355,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
-          spice install "$PREVIOUS_STABLE_VERSION"
+          previous_stable_version="${{ env.PREVIOUS_STABLE_VERSION }}"
+          spice install "$previous_stable_version"
 
       - name: check previous stable Spice runtime version
         shell: wsl-bash {0}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
           LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          previous_stable_version="${{ env.PREVIOUS_STABLE_VERSION }}"
           version=$(spice version 2>&1)
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
           echo "Latest Release Version: $LATEST_RELEASE_VERSION"
-          echo "CLI Version after spice install $PREVIOUS_STABLE_VERSION: $cli_version"
-          echo "Runtime Version after spice install $PREVIOUS_STABLE_VERSION: $runtime_version"
+          echo "CLI Version after spice install $previous_stable_version: $cli_version"
+          echo "Runtime Version after spice install $previous_stable_version: $runtime_version"
 
           if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "CLI version $cli_version changed unexpectedly after spice install $PREVIOUS_STABLE_VERSION."
+            echo "CLI version $cli_version changed unexpectedly after spice install $previous_stable_version."
             exit 1
           fi
 
-          if [[ "$runtime_version" != "$PREVIOUS_STABLE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $PREVIOUS_STABLE_VERSION."
+          if [[ "$runtime_version" != "$previous_stable_version"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $previous_stable_version."
             exit 1
           fi
 
@@ -382,26 +388,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
-          spice upgrade "$PREVIEW_UPGRADE_VERSION"
+          preview_upgrade_version="${{ env.PREVIEW_UPGRADE_VERSION }}"
+          spice upgrade "$preview_upgrade_version"
 
       - name: check preview Spice cli and runtime version
         shell: wsl-bash {0}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
+          preview_upgrade_version="${{ env.PREVIEW_UPGRADE_VERSION }}"
           version=$(spice version 2>&1)
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "CLI Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $cli_version"
-          echo "Runtime Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $runtime_version"
+          echo "CLI Version after spice upgrade $preview_upgrade_version: $cli_version"
+          echo "Runtime Version after spice upgrade $preview_upgrade_version: $runtime_version"
 
-          if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
-            echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
-            exit 1
+          if [[ "$cli_version" != v1.11.* ]]; then
+            if [[ "$cli_version" != "$preview_upgrade_version"* ]]; then
+              echo "CLI version $cli_version does not match the requested version $preview_upgrade_version."
+              exit 1
+            fi
+          else
+            echo "::warning::Skipping CLI version check: v1.11.x CLI does not self-upgrade"
           fi
 
-          if [[ "$runtime_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+          if [[ "$runtime_version" != "$preview_upgrade_version"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $preview_upgrade_version."
             exit 1
           fi
 

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -21,6 +21,10 @@ on:
       - 'install/Install.ps1'
       - '.github/workflows/e2e_test_release_install.yml'
 
+env:
+  PREVIOUS_STABLE_VERSION: v1.11.4
+  PREVIEW_UPGRADE_VERSION: v2.0.0-rc.2
+
 jobs:
   test-install:
     name: install on ${{ matrix.name }}
@@ -76,6 +80,25 @@ jobs:
         run: |
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
+      - name: resolve latest Spice release version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          auth_args=()
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            auth_args=(-H "Authorization: token $GITHUB_TOKEN")
+          fi
+
+          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+
+          if [ -z "$release_version" ]; then
+            echo "Failed to resolve latest Spice release version"
+            exit 1
+          fi
+
+          mkdir -p "$HOME/.spice"
+          echo "$release_version" > "$HOME/.spice/latest_release_version.txt"
+
       - name: check installation
         run: |
           spice version
@@ -97,29 +120,105 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
           version=$(spice version 2>&1)
           # CLI version may include commit hash like "v1.11.0 (f2e8ad5)" - extract just the version
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
-          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | xargs)
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" -H "Authorization: token $GITHUB_TOKEN" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
-          release_version_with_models="${release_version}+models"
-
-          echo "Release Version: $release_version"
+          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
           echo "CLI Version: $cli_version"
           echo "Runtime Version: $runtime_version"
 
-          # CLI does not have '+models' suffix, so compare base versions
-          if [ "$cli_version" != "$release_version" ]; then
-            echo "CLI version $cli_version does not match the latest release version $release_version."
+          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "CLI version $cli_version does not match the latest release version $LATEST_RELEASE_VERSION."
             exit 1
           fi
 
-          # Runtime has '+models' suffix
-          if [ "$runtime_version" != "$release_version_with_models" ]; then
-            echo "Runtime version $runtime_version does not match the latest release version $release_version_with_models."
+          # v1 runtimes may include '+models'; compare by release prefix.
+          if [[ "$runtime_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the latest release version $LATEST_RELEASE_VERSION."
             exit 1
           fi
+
+      - name: stop Spice runtime before version-targeted tests
+        run: |
+          pkill -x spiced || true
+          pkill -x spice || true
+
+          for _ in $(seq 1 30); do
+            if ! pgrep -x spiced >/dev/null 2>&1 && ! pgrep -x spice >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Spice runtime failed to stop"
+          exit 1
+
+      - name: install previous stable Spice runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spice install "$PREVIOUS_STABLE_VERSION"
+
+      - name: check previous stable Spice runtime version
+        run: |
+          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          version=$(spice version 2>&1)
+          cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
+
+          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
+          echo "CLI Version after spice install $PREVIOUS_STABLE_VERSION: $cli_version"
+          echo "Runtime Version after spice install $PREVIOUS_STABLE_VERSION: $runtime_version"
+
+          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "CLI version $cli_version changed unexpectedly after spice install $PREVIOUS_STABLE_VERSION."
+            exit 1
+          fi
+
+          if [[ "$runtime_version" != "$PREVIOUS_STABLE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $PREVIOUS_STABLE_VERSION."
+            exit 1
+          fi
+
+      - name: upgrade Spice cli and runtime to preview release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spice upgrade "$PREVIEW_UPGRADE_VERSION"
+
+      - name: check preview Spice cli and runtime version
+        run: |
+          version=$(spice version 2>&1)
+          cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
+
+          echo "CLI Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $cli_version"
+          echo "Runtime Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $runtime_version"
+
+          if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
+            echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+            exit 1
+          fi
+
+          if [[ "$runtime_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+            exit 1
+          fi
+
+      - name: restart Spice runtime after preview upgrade
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd app
+          spice run &
+
+      - name: wait for preview Spice runtime healthy
+        run: |
+          bash -c 'while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done' || false
+        timeout-minutes: 1
 
   # Test Windows with WSL - runtime runs in WSL, not native Windows
   test-install-windows-wsl:
@@ -158,6 +257,28 @@ jobs:
           export PATH="$HOME/.spice/bin:$PATH"
           spice version
 
+      - name: resolve latest Spice release version
+        shell: wsl-bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+
+          auth_args=()
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            auth_args=(-H "Authorization: token $GITHUB_TOKEN")
+          fi
+
+          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+
+          if [ -z "$release_version" ]; then
+            echo "Failed to resolve latest Spice release version"
+            exit 1
+          fi
+
+          mkdir -p "$HOME/.spice"
+          echo "$release_version" > "$HOME/.spice/latest_release_version.txt"
+
       - name: start Spice runtime and wait for healthy
         shell: wsl-bash {0}
         env:
@@ -185,31 +306,125 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
+          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
           version=$(spice version 2>&1)
           # CLI version may include commit hash like "v1.11.0 (f2e8ad5)" - extract just the version
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
-          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | xargs)
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          # Use bash array for optional curl args to avoid quoting issues
-          auth_args=()
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            auth_args=(-H "Authorization: token $GITHUB_TOKEN")
-          fi
-          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | jq -r '.tag_name')"
-          release_version_with_models="${release_version}+models"
-
-          echo "Release Version: $release_version"
+          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
           echo "CLI Version: $cli_version"
           echo "Runtime Version: $runtime_version"
 
-          # CLI does not have '+models' suffix, so compare base versions
-          if [ "$cli_version" != "$release_version" ]; then
-            echo "CLI version $cli_version does not match the latest release version $release_version."
+          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "CLI version $cli_version does not match the latest release version $LATEST_RELEASE_VERSION."
             exit 1
           fi
 
-          # Runtime has '+models' suffix
-          if [ "$runtime_version" != "$release_version_with_models" ]; then
-            echo "Runtime version $runtime_version does not match the latest release version $release_version_with_models."
+          # v1 runtimes may include '+models'; compare by release prefix.
+          if [[ "$runtime_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the latest release version $LATEST_RELEASE_VERSION."
             exit 1
           fi
+
+      - name: stop Spice runtime before version-targeted tests
+        shell: wsl-bash {0}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+
+          pkill -x spiced || true
+          pkill -x spice || true
+
+          for i in $(seq 1 30); do
+            if ! pgrep -x spiced >/dev/null 2>&1 && ! pgrep -x spice >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Spice runtime failed to stop"
+          exit 1
+
+      - name: install previous stable Spice runtime
+        shell: wsl-bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          spice install "$PREVIOUS_STABLE_VERSION"
+
+      - name: check previous stable Spice runtime version
+        shell: wsl-bash {0}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          version=$(spice version 2>&1)
+          cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
+
+          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
+          echo "CLI Version after spice install $PREVIOUS_STABLE_VERSION: $cli_version"
+          echo "Runtime Version after spice install $PREVIOUS_STABLE_VERSION: $runtime_version"
+
+          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+            echo "CLI version $cli_version changed unexpectedly after spice install $PREVIOUS_STABLE_VERSION."
+            exit 1
+          fi
+
+          if [[ "$runtime_version" != "$PREVIOUS_STABLE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $PREVIOUS_STABLE_VERSION."
+            exit 1
+          fi
+
+      - name: upgrade Spice cli and runtime to preview release
+        shell: wsl-bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          spice upgrade "$PREVIEW_UPGRADE_VERSION"
+
+      - name: check preview Spice cli and runtime version
+        shell: wsl-bash {0}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          version=$(spice version 2>&1)
+          cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
+          runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
+
+          echo "CLI Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $cli_version"
+          echo "Runtime Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $runtime_version"
+
+          if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
+            echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+            exit 1
+          fi
+
+          if [[ "$runtime_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
+            echo "Runtime version $runtime_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+            exit 1
+          fi
+
+      - name: restart Spice runtime after preview upgrade
+        shell: wsl-bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          cd app
+          spice run &
+
+      - name: wait for preview Spice runtime healthy
+        shell: wsl-bash {0}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          for i in $(seq 1 60); do
+            if [ "$(curl -s http://localhost:8090/health)" = "ok" ]; then
+              echo "Spice runtime is healthy"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Spice runtime failed to start"
+          exit 1
+        timeout-minutes: 2

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -417,7 +417,7 @@ jobs:
             exit 1
           fi
 
-      - name: restart Spice runtime after preview upgrade
+      - name: restart Spice runtime after preview upgrade and wait for healthy
         shell: wsl-bash {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -426,10 +426,6 @@ jobs:
           cd app
           spice run &
 
-      - name: wait for preview Spice runtime healthy
-        shell: wsl-bash {0}
-        run: |
-          export PATH="$HOME/.spice/bin:$PATH"
           for i in $(seq 1 60); do
             if [ "$(curl -s http://localhost:8090/health)" = "ok" ]; then
               echo "Spice runtime is healthy"

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -54,13 +54,6 @@ jobs:
       - name: checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-      # The aarch64 runner does not have any tools pre-installed
-      - name: Install missing tools
-        if: matrix.target_os == 'linux' && matrix.target_arch == 'aarch64'
-        run: |
-          sudo apt-get update
-          sudo apt install jq -y
-
       - name: install Spice (https://install.spiceai.org)
         if: github.event_name == 'workflow_dispatch' && inputs.install_script_branch == ''
         env:
@@ -81,6 +74,7 @@ jobs:
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
       - name: resolve latest Spice release version
+        id: resolve_latest_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -89,15 +83,14 @@ jobs:
             auth_args=(-H "Authorization: token $GITHUB_TOKEN")
           fi
 
-          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+          release_version="$(curl -fsSL "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("tag_name", ""))')"
 
           if [ -z "$release_version" ]; then
             echo "Failed to resolve latest Spice release version"
             exit 1
           fi
 
-          mkdir -p "$HOME/.spice"
-          echo "$release_version" > "$HOME/.spice/latest_release_version.txt"
+          echo "version=$release_version" >> "$GITHUB_OUTPUT"
 
       - name: check installation
         run: |
@@ -117,29 +110,30 @@ jobs:
         timeout-minutes: 1
 
       - name: check Spice cli and runtime version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          latest_release_version="${{ steps.resolve_latest_release.outputs.version }}"
           version=$(spice version 2>&1)
           # CLI version may include commit hash like "v1.11.0 (f2e8ad5)" - extract just the version
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
+          echo "Latest Release Version: $latest_release_version"
           echo "CLI Version: $cli_version"
           echo "Runtime Version: $runtime_version"
 
-          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "CLI version $cli_version does not match the latest release version $LATEST_RELEASE_VERSION."
+          if [[ "$cli_version" != "$latest_release_version" ]]; then
+            echo "CLI version $cli_version does not match the latest release version $latest_release_version."
             exit 1
           fi
 
-          # v1 runtimes may include '+models'; compare by release prefix.
-          if [[ "$runtime_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the latest release version $LATEST_RELEASE_VERSION."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$latest_release_version"|"$latest_release_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the latest release version $latest_release_version."
+              exit 1
+              ;;
+          esac
 
       - name: stop Spice runtime before version-targeted tests
         run: |
@@ -164,24 +158,29 @@ jobs:
 
       - name: check previous stable Spice runtime version
         run: |
-          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          latest_release_version="${{ steps.resolve_latest_release.outputs.version }}"
+          previous_stable_version="${{ env.PREVIOUS_STABLE_VERSION }}"
           version=$(spice version 2>&1)
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
-          echo "CLI Version after spice install $PREVIOUS_STABLE_VERSION: $cli_version"
-          echo "Runtime Version after spice install $PREVIOUS_STABLE_VERSION: $runtime_version"
+          echo "Latest Release Version: $latest_release_version"
+          echo "CLI Version after spice install $previous_stable_version: $cli_version"
+          echo "Runtime Version after spice install $previous_stable_version: $runtime_version"
 
-          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "CLI version $cli_version changed unexpectedly after spice install $PREVIOUS_STABLE_VERSION."
+          if [[ "$cli_version" != "$latest_release_version" ]]; then
+            echo "CLI version $cli_version changed unexpectedly after spice install $previous_stable_version."
             exit 1
           fi
 
-          if [[ "$runtime_version" != "$PREVIOUS_STABLE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $PREVIOUS_STABLE_VERSION."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$previous_stable_version"|"$previous_stable_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the requested version $previous_stable_version."
+              exit 1
+              ;;
+          esac
 
       - name: upgrade Spice cli and runtime to preview release
         env:
@@ -191,26 +190,31 @@ jobs:
 
       - name: check preview Spice cli and runtime version
         run: |
+          preview_upgrade_version="${{ env.PREVIEW_UPGRADE_VERSION }}"
           version=$(spice version 2>&1)
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "CLI Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $cli_version"
-          echo "Runtime Version after spice upgrade $PREVIEW_UPGRADE_VERSION: $runtime_version"
+          echo "CLI Version after spice upgrade $preview_upgrade_version: $cli_version"
+          echo "Runtime Version after spice upgrade $preview_upgrade_version: $runtime_version"
 
           if [[ "$cli_version" != v1.11.* ]]; then
-            if [[ "$cli_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
-              echo "CLI version $cli_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
+            if [[ "$cli_version" != "$preview_upgrade_version" ]]; then
+              echo "CLI version $cli_version does not match the requested version $preview_upgrade_version."
               exit 1
             fi
           else
             echo "::warning::Skipping CLI version check: v1.11.x CLI does not self-upgrade"
           fi
 
-          if [[ "$runtime_version" != "$PREVIEW_UPGRADE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $PREVIEW_UPGRADE_VERSION."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$preview_upgrade_version"|"$preview_upgrade_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the requested version $preview_upgrade_version."
+              exit 1
+              ;;
+          esac
 
       - name: restart Spice runtime after preview upgrade
         env:
@@ -224,6 +228,22 @@ jobs:
           bash -c 'while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done' || false
         timeout-minutes: 1
 
+      - name: cleanup Spice runtime
+        if: ${{ always() }}
+        run: |
+          pkill -x spiced || true
+          pkill -x spice || true
+
+          for _ in $(seq 1 30); do
+            if ! pgrep -x spiced >/dev/null 2>&1 && ! pgrep -x spice >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Spice runtime failed to stop"
+          exit 1
+
   # Test Windows with WSL - runtime runs in WSL, not native Windows
   test-install-windows-wsl:
     name: install on Windows x64 (WSL)
@@ -236,7 +256,7 @@ jobs:
         uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
           distribution: Ubuntu-22.04
-          additional-packages: curl jq
+          additional-packages: curl
 
       - name: install Spice (https://install.spiceai.org)
         if: github.event_name == 'workflow_dispatch' && inputs.install_script_branch == ''
@@ -262,26 +282,24 @@ jobs:
           spice version
 
       - name: resolve latest Spice release version
-        shell: wsl-bash {0}
+        id: resolve_latest_release
+        shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export PATH="$HOME/.spice/bin:$PATH"
+          $headers = @{}
+          if ($env:GITHUB_TOKEN) {
+            $headers.Authorization = "token $env:GITHUB_TOKEN"
+          }
 
-          auth_args=()
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            auth_args=(-H "Authorization: token $GITHUB_TOKEN")
-          fi
+          $response = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/spiceai/spiceai/releases/latest"
+          $releaseVersion = $response.tag_name
 
-          release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" "${auth_args[@]}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+          if ([string]::IsNullOrWhiteSpace($releaseVersion)) {
+            throw "Failed to resolve latest Spice release version"
+          }
 
-          if [ -z "$release_version" ]; then
-            echo "Failed to resolve latest Spice release version"
-            exit 1
-          fi
-
-          mkdir -p "$HOME/.spice"
-          echo "$release_version" > "$HOME/.spice/latest_release_version.txt"
+          "version=$releaseVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: start Spice runtime and wait for healthy
         shell: wsl-bash {0}
@@ -306,30 +324,31 @@ jobs:
 
       - name: check Spice cli and runtime version
         shell: wsl-bash {0}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
-          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          latest_release_version="${{ steps.resolve_latest_release.outputs.version }}"
           version=$(spice version 2>&1)
           # CLI version may include commit hash like "v1.11.0 (f2e8ad5)" - extract just the version
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
+          echo "Latest Release Version: $latest_release_version"
           echo "CLI Version: $cli_version"
           echo "Runtime Version: $runtime_version"
 
-          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "CLI version $cli_version does not match the latest release version $LATEST_RELEASE_VERSION."
+          if [[ "$cli_version" != "$latest_release_version" ]]; then
+            echo "CLI version $cli_version does not match the latest release version $latest_release_version."
             exit 1
           fi
 
-          # v1 runtimes may include '+models'; compare by release prefix.
-          if [[ "$runtime_version" != "$LATEST_RELEASE_VERSION"* ]]; then
-            echo "Runtime version $runtime_version does not match the latest release version $LATEST_RELEASE_VERSION."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$latest_release_version"|"$latest_release_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the latest release version $latest_release_version."
+              exit 1
+              ;;
+          esac
 
       - name: stop Spice runtime before version-targeted tests
         shell: wsl-bash {0}
@@ -362,25 +381,29 @@ jobs:
         shell: wsl-bash {0}
         run: |
           export PATH="$HOME/.spice/bin:$PATH"
-          LATEST_RELEASE_VERSION="$(cat "$HOME/.spice/latest_release_version.txt")"
+          latest_release_version="${{ steps.resolve_latest_release.outputs.version }}"
           previous_stable_version="${{ env.PREVIOUS_STABLE_VERSION }}"
           version=$(spice version 2>&1)
           cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | awk '{print $1}')
           runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | awk '{print $1}')
 
-          echo "Latest Release Version: $LATEST_RELEASE_VERSION"
+          echo "Latest Release Version: $latest_release_version"
           echo "CLI Version after spice install $previous_stable_version: $cli_version"
           echo "Runtime Version after spice install $previous_stable_version: $runtime_version"
 
-          if [[ "$cli_version" != "$LATEST_RELEASE_VERSION"* ]]; then
+          if [[ "$cli_version" != "$latest_release_version" ]]; then
             echo "CLI version $cli_version changed unexpectedly after spice install $previous_stable_version."
             exit 1
           fi
 
-          if [[ "$runtime_version" != "$previous_stable_version"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $previous_stable_version."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$previous_stable_version"|"$previous_stable_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the requested version $previous_stable_version."
+              exit 1
+              ;;
+          esac
 
       - name: upgrade Spice cli and runtime to preview release
         shell: wsl-bash {0}
@@ -404,7 +427,7 @@ jobs:
           echo "Runtime Version after spice upgrade $preview_upgrade_version: $runtime_version"
 
           if [[ "$cli_version" != v1.11.* ]]; then
-            if [[ "$cli_version" != "$preview_upgrade_version"* ]]; then
+            if [[ "$cli_version" != "$preview_upgrade_version" ]]; then
               echo "CLI version $cli_version does not match the requested version $preview_upgrade_version."
               exit 1
             fi
@@ -412,10 +435,14 @@ jobs:
             echo "::warning::Skipping CLI version check: v1.11.x CLI does not self-upgrade"
           fi
 
-          if [[ "$runtime_version" != "$preview_upgrade_version"* ]]; then
-            echo "Runtime version $runtime_version does not match the requested version $preview_upgrade_version."
-            exit 1
-          fi
+          case "$runtime_version" in
+            "$preview_upgrade_version"|"$preview_upgrade_version+models")
+              ;;
+            *)
+              echo "Runtime version $runtime_version does not match the requested version $preview_upgrade_version."
+              exit 1
+              ;;
+          esac
 
       - name: restart Spice runtime after preview upgrade and wait for healthy
         shell: wsl-bash {0}
@@ -436,3 +463,21 @@ jobs:
           echo "Spice runtime failed to start"
           exit 1
         timeout-minutes: 2
+
+      - name: cleanup Spice runtime
+        if: ${{ always() }}
+        shell: wsl-bash {0}
+        run: |
+          export PATH="$HOME/.spice/bin:$PATH"
+          pkill -x spiced || true
+          pkill -x spice || true
+
+          for i in $(seq 1 30); do
+            if ! pgrep -x spiced >/dev/null 2>&1 && ! pgrep -x spice >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Spice runtime failed to stop"
+          exit 1


### PR DESCRIPTION
## Summary
- extend the release install E2E workflow to validate the latest published install path before targeted version tests
- add explicit coverage for `spice install v1.11.4` and `spice upgrade v2.0.0-rc.2` in both Unix and Windows WSL jobs
- verify CLI/runtime versions after each transition and restart the runtime after the preview upgrade

## Testing
- validated `.github/workflows/e2e_test_release_install.yml` with workspace diagnostics
- did not run the GitHub Actions workflow locally