### PR TITLE
Update test_github_workflows snapshot

### DIFF
--- a/crates/runtime/tests/github/snapshots/integration__github__workflows_list_data.snap
+++ b/crates/runtime/tests/github/snapshots/integration__github__workflows_list_data.snap
@@ -2,17 +2,17 @@
 source: crates/runtime/tests/github/mod.rs
 expression: pretty_batches
 ---
-+---------------------------------------+-------------------------------------------------+
-| name                                  | path                                            |
-+---------------------------------------+-------------------------------------------------+
-| spiced_docker                         | .github/workflows/spiced_docker.yml             |
-| Check for forbidden licenses          | .github/workflows/license_check.yml             |
-| .github/workflows/codeql-analysis.yml | .github/workflows/codeql-analysis.yml           |
-| build_and_release                     | .github/workflows/build_and_release.yml         |
-| pr                                    | .github/workflows/pr.yml                        |
-| E2E Test CI                           | .github/workflows/e2e_test_ci.yml               |
-| E2E Test Release Installation         | .github/workflows/e2e_test_release_install.yml  |
-| Generate Acknowledgements             | .github/workflows/generate_acknowledgements.yml |
-| check all features                    | .github/workflows/features.yml                  |
-| Test types support                    | .github/workflows/types_check.yml               |
-+---------------------------------------+-------------------------------------------------+
++-------------------------------+-------------------------------------------------+
+| name                          | path                                            |
++-------------------------------+-------------------------------------------------+
+| spiced_docker                 | .github/workflows/spiced_docker.yml             |
+| Check for forbidden licenses  | .github/workflows/license_check.yml             |
+| CodeQL                        | .github/workflows/codeql-analysis.yml           |
+| build_and_release             | .github/workflows/build_and_release.yml         |
+| pr                            | .github/workflows/pr.yml                        |
+| E2E Test CI                   | .github/workflows/e2e_test_ci.yml               |
+| E2E Test Release Installation | .github/workflows/e2e_test_release_install.yml  |
+| Generate Acknowledgements     | .github/workflows/generate_acknowledgements.yml |
+| check all features            | .github/workflows/features.yml                  |
+| Test types support            | .github/workflows/types_check.yml               |
++-------------------------------+-------------------------------------------------+


### PR DESCRIPTION
Regenerate insta snapshot for the `workflows_list_data` test.

The CodeQL workflow name changed from its file path (`.github/workflows/codeql-analysis.yml`) to `CodeQL`, causing the snapshot to be outdated.