### PR TITLE
fix(ci): fix Bedrock runner mismatch and snapshot auto-merge failure

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -59,8 +59,8 @@ runs:
             if [[ -z "${BODY}" ]]; then
               BODY="Automated snapshot update from workflow run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
             fi
-            gh pr create --title "${{ inputs.title }}" --body "${BODY}" --base develop --head ${BRANCH_NAME} --label kind/bug
-            gh pr merge --squash --auto ${BRANCH_NAME}
+            gh pr create --title "${{ inputs.title }}" --body "${BODY}" --base trunk --head ${BRANCH_NAME} --label kind/bug
+            gh pr merge --squash --auto ${BRANCH_NAME} || echo "Auto-merge not available for this branch; PR created and requires manual merge."
           fi
         fi
       env:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -357,7 +357,7 @@ jobs:
     name: Test Bedrock Models
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' || github.event_name == 'schedule' }}
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 


### PR DESCRIPTION
- Change test-bedrock job to run on spiceai-macos so the macOS-built test binary is executed on a compatible runner (was spiceai-dev-runners, a Linux x86_64 host, causing a binary format/arch mismatch)
- Make gh pr merge --auto a non-fatal step in push-snap-changes action; auto-merge requires branch protection rules