### PR TITLE
fix(model2vec): report missing local model paths

### DIFF
--- a/crates/llms/src/embeddings/mod.rs
+++ b/crates/llms/src/embeddings/mod.rs
@@ -91,6 +91,11 @@ pub enum Error {
     ModelDoesNotExist { model_name: String },
 
     #[snafu(display(
+        "The specified local model path '{path}' does not exist. Verify the path and try again."
+    ))]
+    LocalModelPathDoesNotExist { path: String },
+
+    #[snafu(display(
         "The specified model, '{from}', does not support executing the task '{task}'. Select a different model or task, and try again."
     ))]
     UnsupportedTaskForModel { from: String, task: String },

--- a/crates/llms/src/model2vec.rs
+++ b/crates/llms/src/model2vec.rs
@@ -149,6 +149,10 @@ fn local_model_path(name: &str) -> Result<Option<PathBuf>, super::embeddings::Er
             });
         };
 
+        // Trim leading path separators so `~//foo` doesn't silently resolve to `/foo`
+        // via PathBuf::join's absolute-path override.
+        let home_relative_path = home_relative_path.trim_start_matches(['/', '\\']);
+
         return Ok(Some(home_dir.join(home_relative_path)));
     }
 
@@ -308,6 +312,15 @@ mod tests {
                 .expect("home-relative model path should resolve")
                 .expect("home-relative model path should be treated as local"),
             home_dir_path.join("model")
+        );
+
+        // Leading separators after `~/` must not silently resolve to an absolute path
+        // outside the home directory.
+        assert_eq!(
+            local_model_path("~//tmp/model")
+                .expect("home-relative model path should resolve")
+                .expect("home-relative model path should be treated as local"),
+            home_dir_path.join("tmp/model")
         );
     }
 

--- a/crates/llms/src/model2vec.rs
+++ b/crates/llms/src/model2vec.rs
@@ -24,8 +24,9 @@ use cache::CacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
 use model2vec_rs::model::StaticModel;
 use std::fmt::{Debug, Formatter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use util::home_dir::home_dir;
 
 /// A wrapper around the `model2vec` library for generating text embeddings.
 ///
@@ -76,13 +77,25 @@ impl Model2Vec {
         embed_max_token_length: Option<usize>,
         embed_custom_batch_size: Option<usize>,
     ) -> Result<Self, super::embeddings::Error> {
-        if looks_like_local_model_path(name) && !Path::new(name).exists() {
-            return Err(LocalModelPathDoesNotExist {
-                path: name.to_string(),
-            });
-        }
+        let name = if let Some(local_model_path) = local_model_path(name)? {
+            match local_model_path.try_exists() {
+                Ok(true) => local_model_path.to_string_lossy().into_owned(),
+                Ok(false) => {
+                    return Err(LocalModelPathDoesNotExist {
+                        path: name.to_string(),
+                    });
+                }
+                Err(source) => {
+                    return Err(FailedToInstantiateEmbeddingModel {
+                        source: source.into(),
+                    });
+                }
+            }
+        } else {
+            name.to_string()
+        };
 
-        let model = StaticModel::from_pretrained(name, hf_token, normalize, subfolder)
+        let model = StaticModel::from_pretrained(&name, hf_token, normalize, subfolder)
             .map_err(|e| FailedToInstantiateEmbeddingModel { source: e.into() })?;
 
         let model2vec = Self {
@@ -119,6 +132,24 @@ fn looks_like_local_model_path(name: &str) -> bool {
         || name.starts_with("..\\")
         || name.starts_with("~/")
         || name.starts_with("~\\")
+}
+
+fn local_model_path(name: &str) -> Result<Option<PathBuf>, super::embeddings::Error> {
+    if let Some(home_relative_path) = name.strip_prefix("~/").or_else(|| name.strip_prefix("~\\")) {
+        let Some(home_dir) = home_dir() else {
+            return Err(LocalModelPathDoesNotExist {
+                path: name.to_string(),
+            });
+        };
+
+        return Ok(Some(home_dir.join(home_relative_path)));
+    }
+
+    if looks_like_local_model_path(name) {
+        return Ok(Some(Path::new(name).to_path_buf()));
+    }
+
+    Ok(None)
 }
 
 impl Debug for Model2Vec {
@@ -235,7 +266,9 @@ mod tests {
             .as_nanos();
         let missing_path = std::env::temp_dir().join(format!("missing-model2vec-{suffix}"));
         assert!(
-            !missing_path.exists(),
+            !missing_path
+                .try_exists()
+                .expect("test path check should not fail"),
             "test path should not exist before model loading"
         );
         let missing_path = missing_path.to_string_lossy().into_owned();
@@ -246,6 +279,28 @@ mod tests {
         assert!(
             matches!(err, Error::LocalModelPathDoesNotExist { path } if path == missing_path),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn expands_home_directory_model_paths() {
+        let Some(home_dir_path) = home_dir() else {
+            return;
+        };
+
+        assert_eq!(
+            local_model_path("~/model")
+                .expect("home-relative model path should resolve")
+                .expect("home-relative model path should be treated as local"),
+            home_dir_path.join("model")
+        );
+
+        #[cfg(windows)]
+        assert_eq!(
+            local_model_path("~\\model")
+                .expect("home-relative model path should resolve")
+                .expect("home-relative model path should be treated as local"),
+            home_dir_path.join("model")
         );
     }
 

--- a/crates/llms/src/model2vec.rs
+++ b/crates/llms/src/model2vec.rs
@@ -24,6 +24,7 @@ use cache::CacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
 use model2vec_rs::model::StaticModel;
 use std::fmt::{Debug, Formatter};
+use std::io::{Error as IoError, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use util::home_dir::home_dir;
@@ -137,8 +138,14 @@ fn looks_like_local_model_path(name: &str) -> bool {
 fn local_model_path(name: &str) -> Result<Option<PathBuf>, super::embeddings::Error> {
     if let Some(home_relative_path) = name.strip_prefix("~/").or_else(|| name.strip_prefix("~\\")) {
         let Some(home_dir) = home_dir() else {
-            return Err(LocalModelPathDoesNotExist {
-                path: name.to_string(),
+            return Err(FailedToInstantiateEmbeddingModel {
+                source: IoError::new(
+                    ErrorKind::NotFound,
+                    format!(
+                        "Unable to resolve home directory while expanding local model path '{name}'"
+                    ),
+                )
+                .into(),
             });
         };
 
@@ -246,7 +253,7 @@ mod tests {
     use async_openai::types::embeddings::EmbeddingInput;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::looks_like_local_model_path;
+    use super::{home_dir, local_model_path, looks_like_local_model_path};
 
     #[test]
     fn detects_local_model_paths() {
@@ -277,7 +284,7 @@ mod tests {
             .expect_err("missing local model path should fail before Hugging Face lookup");
 
         assert!(
-            matches!(err, Error::LocalModelPathDoesNotExist { path } if path == missing_path),
+            matches!(err, Error::LocalModelPathDoesNotExist { ref path } if path == &missing_path),
             "unexpected error: {err}"
         );
     }

--- a/crates/llms/src/model2vec.rs
+++ b/crates/llms/src/model2vec.rs
@@ -15,13 +15,16 @@ limitations under the License.
 */
 
 use crate::embeddings::Embed;
-use crate::embeddings::Error::{FailedToInstantiateEmbeddingModel, UnsupportedEmbeddingInput};
+use crate::embeddings::Error::{
+    FailedToInstantiateEmbeddingModel, LocalModelPathDoesNotExist, UnsupportedEmbeddingInput,
+};
 use async_openai::types::embeddings::EmbeddingInput;
 use async_trait::async_trait;
 use cache::CacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
 use model2vec_rs::model::StaticModel;
 use std::fmt::{Debug, Formatter};
+use std::path::Path;
 use std::sync::Arc;
 
 /// A wrapper around the `model2vec` library for generating text embeddings.
@@ -73,6 +76,12 @@ impl Model2Vec {
         embed_max_token_length: Option<usize>,
         embed_custom_batch_size: Option<usize>,
     ) -> Result<Self, super::embeddings::Error> {
+        if looks_like_local_model_path(name) && !Path::new(name).exists() {
+            return Err(LocalModelPathDoesNotExist {
+                path: name.to_string(),
+            });
+        }
+
         let model = StaticModel::from_pretrained(name, hf_token, normalize, subfolder)
             .map_err(|e| FailedToInstantiateEmbeddingModel { source: e.into() })?;
 
@@ -99,6 +108,17 @@ impl Model2Vec {
         self.cache = cache;
         self
     }
+}
+
+fn looks_like_local_model_path(name: &str) -> bool {
+    let path = Path::new(name);
+    path.is_absolute()
+        || name.starts_with("./")
+        || name.starts_with("../")
+        || name.starts_with(".\\")
+        || name.starts_with("..\\")
+        || name.starts_with("~/")
+        || name.starts_with("~\\")
 }
 
 impl Debug for Model2Vec {
@@ -190,8 +210,44 @@ impl Embed for Model2Vec {
 #[cfg(test)]
 mod tests {
     use crate::embeddings::Embed;
+    use crate::embeddings::Error;
     use crate::model2vec::Model2Vec;
     use async_openai::types::embeddings::EmbeddingInput;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::looks_like_local_model_path;
+
+    #[test]
+    fn detects_local_model_paths() {
+        assert!(looks_like_local_model_path("/tmp/model"));
+        assert!(looks_like_local_model_path("//tmp/model"));
+        assert!(looks_like_local_model_path("./model"));
+        assert!(looks_like_local_model_path("../model"));
+        assert!(looks_like_local_model_path("~/model"));
+        assert!(!looks_like_local_model_path("minishlab/potion-base-8M"));
+    }
+
+    #[test]
+    fn missing_local_model_path_returns_specific_error() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        let missing_path = std::env::temp_dir().join(format!("missing-model2vec-{suffix}"));
+        assert!(
+            !missing_path.exists(),
+            "test path should not exist before model loading"
+        );
+        let missing_path = missing_path.to_string_lossy().into_owned();
+
+        let err = Model2Vec::from_params(&missing_path, None, None, None, None, None, None)
+            .expect_err("missing local model path should fail before Hugging Face lookup");
+
+        assert!(
+            matches!(err, Error::LocalModelPathDoesNotExist { path } if path == missing_path),
+            "unexpected error: {err}"
+        );
+    }
 
     #[expect(dead_code)]
     async fn test_embed() {


### PR DESCRIPTION
## 📝 Summary

- Detect model2vec identifiers that are clearly local filesystem paths before calling `model2vec-rs`.
- Return a specific local-path-not-found embedding error instead of allowing a missing path to be treated as a Hugging Face model id.
- Add unit coverage for local path detection and the missing-path error.

## 🔗 Related

Closes #7023

## 🚨 Breaking Changes

None.

## 📚 Docs

No docs changes required; this corrects an error path.

## 👀 Notes for Reviewers

Validation:
- `cargo fmt -p llms -- --check`
- `git diff --check`

I also attempted `cargo test -p llms --no-default-features --features local_embed model2vec::tests -- --nocapture`, but Cargo began fetching large workspace git submodules unrelated to this package, including Apache Spark through `spark-connect-rs`. Re-running with `--offline` confirms the local blocker is the missing `core/spark` submodule fetch.