### PR TITLE
Upgrade datafusion-table-providers with MongoDB SRV support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6125,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139#64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=fded3b402f8d4145fa82b77a446842b1ba063321#fded3b402f8d4145fa82b77a446842b1ba063321"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -11705,9 +11705,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803dd859e8afa084c255a8effd8000ff86f7c8076a50cd6d8c99e8f3496f75c2"
+checksum = "2c5941683db2ab2697f71e58dc0319024e808d3b28e7cf20f4bfb445fe54a30b"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -11754,9 +11754,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973ef3dd3dbc6f6e65bbdecfd9ec5e781b9e7493b0f369a7c62e35d8e5ae2c8"
+checksum = "47021a12bbf0dffde9c890fa2d36ff6ae342c532016226b04a42301b2b912660"
 dependencies = [
  "macro_magic",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ linkme = "0.3.35"
 logos = "0.16.1"
 mailparse = "0.16.1"
 moka = { version = "0.12", features = ["future"] }
-mongodb = { version = "3.5.1", features = ["openssl-tls"] }
+mongodb = { version = "3.5.2", features = ["openssl-tls"] }
 mysql_async = { version = "0.36.2", features = ["native-tls-tls", "chrono"] }
 nix = "0.30"
 num_cpus = "1.16"
@@ -394,7 +394,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "64da4a7d9dbfd2fc1c111d2bf7cb70590f74d139" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "fded3b402f8d4145fa82b77a446842b1ba063321" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "869b1a0245244accfcc725de82e95ec7e604349a" } # spiceai-52.5

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -128,7 +128,7 @@ const IGNORED_IF_URI: &[&str] = &[
     "srv",
 ];
 
-/// Returns `true` if the host looks like a MongoDB SRV endpoint
+/// Returns `true` if the host looks like a `MongoDB` SRV endpoint
 /// (e.g. `cluster0.abc123.mongodb.net`).
 fn is_srv_host(host: &str) -> bool {
     let normalized = host.trim_end_matches('.').to_ascii_lowercase();
@@ -169,8 +169,9 @@ impl DataConnectorFactory for MongoDBFactory {
                     .map(|s| s.expose_secret().to_string());
                 let srv_provided = params.parameters.get("srv").ok().is_some();
 
-                if let Some(ref h) = host {
-                    if is_srv_host(h) {
+                if let Some(ref h) = host
+                    && is_srv_host(h)
+                {
                         if !srv_provided {
                             params
                                 .parameters
@@ -183,7 +184,6 @@ impl DataConnectorFactory for MongoDBFactory {
                                 component = params.component
                             );
                         }
-                    }
                 }
             }
 
@@ -325,5 +325,36 @@ impl DataConnector for MongoDB {
                     connector_component: ConnectorComponent::from(dataset),
                 })?,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_srv_host_basic() {
+        assert!(is_srv_host("cluster0.abc123.mongodb.net"));
+        assert!(is_srv_host("my-cluster.xyz.mongodb.net"));
+    }
+
+    #[test]
+    fn test_is_srv_host_case_insensitive() {
+        assert!(is_srv_host("Cluster0.ABC123.MongoDB.Net"));
+        assert!(is_srv_host("CLUSTER0.ABC123.MONGODB.NET"));
+        assert!(is_srv_host("cluster0.abc123.MongoDB.NET"));
+    }
+
+    #[test]
+    fn test_is_srv_host_trailing_dot() {
+        assert!(is_srv_host("cluster0.abc123.mongodb.net."));
+    }
+
+    #[test]
+    fn test_is_srv_host_non_srv() {
+        assert!(!is_srv_host("localhost"));
+        assert!(!is_srv_host("192.168.1.1"));
+        assert!(!is_srv_host("mongo.example.com"));
+        assert!(!is_srv_host("mongodb.net")); // bare domain, no subdomain
     }
 }

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -172,18 +172,18 @@ impl DataConnectorFactory for MongoDBFactory {
                 if let Some(ref h) = host
                     && is_srv_host(h)
                 {
-                        if !srv_provided {
-                            params
-                                .parameters
-                                .insert("srv".to_string(), "true".to_string().into());
-                        }
+                    if !srv_provided {
+                        params
+                            .parameters
+                            .insert("srv".to_string(), "true".to_string().into());
+                    }
 
-                        if params.parameters.get("port").ok().is_some() {
-                            tracing::warn!(
-                                "The 'port' parameter is ignored for SRV host '{h}' on the {component}. mongodb+srv:// uses DNS SRV records for host/port discovery.",
-                                component = params.component
-                            );
-                        }
+                    if params.parameters.get("port").ok().is_some() {
+                        tracing::warn!(
+                            "The 'port' parameter is ignored for SRV host '{h}' on the {component}. mongodb+srv:// uses DNS SRV records for host/port discovery.",
+                            component = params.component
+                        );
+                    }
                 }
             }
 

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -100,6 +100,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("direct_connection")
         .description("Whether to connect directly to a single MongoDB host instead of discovering the topology. Accepts 'true' or 'false'.")
         .is_boolean(),
+    ParameterSpec::component("srv")
+        .description("Use mongodb+srv:// connection scheme for DNS SRV record discovery. Auto-detected for .mongodb.net hosts. Accepts 'true' or 'false'. Defaults to 'false'.")
+        .is_boolean(),
     ParameterSpec::component("time_zone")
         .description("Time zone to use for interpreting and returning timestamp values (e.g., 'UTC', 'America/Los_Angeles')."),
     ParameterSpec::component("unnest_depth")
@@ -122,7 +125,15 @@ const IGNORED_IF_URI: &[&str] = &[
     "pass",
     "auth_source",
     "direct_connection",
+    "srv",
 ];
+
+/// Returns `true` if the host looks like a MongoDB SRV endpoint
+/// (e.g. `cluster0.abc123.mongodb.net`).
+fn is_srv_host(host: &str) -> bool {
+    let normalized = host.trim_end_matches('.').to_ascii_lowercase();
+    normalized.ends_with(".mongodb.net")
+}
 
 impl DataConnectorFactory for MongoDBFactory {
     fn as_any(&self) -> &dyn Any {
@@ -148,6 +159,31 @@ impl DataConnectorFactory for MongoDBFactory {
                         parameters = ignored.join(", "),
                         component = params.component
                     );
+                }
+            } else {
+                // Auto-detect SRV from the host parameter unless the user already set it.
+                let host = params
+                    .parameters
+                    .get("host")
+                    .ok()
+                    .map(|s| s.expose_secret().to_string());
+                let srv_provided = params.parameters.get("srv").ok().is_some();
+
+                if let Some(ref h) = host {
+                    if is_srv_host(h) {
+                        if !srv_provided {
+                            params
+                                .parameters
+                                .insert("srv".to_string(), "true".to_string().into());
+                        }
+
+                        if params.parameters.get("port").ok().is_some() {
+                            tracing::warn!(
+                                "The 'port' parameter is ignored for SRV host '{h}' on the {component}. mongodb+srv:// uses DNS SRV records for host/port discovery.",
+                                component = params.component
+                            );
+                        }
+                    }
                 }
             }
 

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -219,7 +219,7 @@ pub enum OpenOption {
 async fn acceleration_connection(
     source: &dyn AccelerationSource,
     #[cfg_attr(
-        not(any(feature = "duckdb", feature = "sqlite")),
+        not(any(feature = "duckdb", feature = "sqlite", feature = "turso")),
         expect(unused_variables)
     )]
     open_option: OpenOption,

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -218,7 +218,10 @@ pub enum OpenOption {
 
 async fn acceleration_connection(
     source: &dyn AccelerationSource,
-    #[cfg_attr(not(any(feature = "duckdb", feature = "sqlite")), expect(unused_variables))]
+    #[cfg_attr(
+        not(any(feature = "duckdb", feature = "sqlite")),
+        expect(unused_variables)
+    )]
     open_option: OpenOption,
 ) -> Result<AccelerationConnection> {
     let acceleration_settings = source.acceleration().context(AccelerationNotEnabledSnafu)?;

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -218,6 +218,7 @@ pub enum OpenOption {
 
 async fn acceleration_connection(
     source: &dyn AccelerationSource,
+    #[cfg_attr(not(any(feature = "duckdb", feature = "sqlite")), expect(unused_variables))]
     open_option: OpenOption,
 ) -> Result<AccelerationConnection> {
     let acceleration_settings = source.acceleration().context(AccelerationNotEnabledSnafu)?;

--- a/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/mod.rs
@@ -21,7 +21,9 @@ use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption}
 mod duckdb;
 
 pub struct CachingEngineSys {
+    #[cfg_attr(not(feature = "duckdb"), expect(dead_code))]
     dataset_name: String,
+    #[cfg_attr(not(feature = "duckdb"), expect(dead_code))]
     acceleration_connection: AccelerationConnection,
 }
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -60,6 +60,12 @@ const CHECKPOINT_TABLE_NAME: &str = "spice_sys_dataset_checkpoint";
 ))]
 const SCHEMA_MIGRATION_01_STMT: &str =
     "ALTER TABLE spice_sys_dataset_checkpoint ADD COLUMN IF NOT EXISTS schema_json TEXT";
+#[cfg(any(
+    feature = "sqlite",
+    feature = "duckdb",
+    feature = "postgres-accel",
+    feature = "turso"
+))]
 const REFRESH_SQL_MIGRATION_STMT: &str =
     "ALTER TABLE spice_sys_dataset_checkpoint ADD COLUMN IF NOT EXISTS refresh_sql TEXT";
 
@@ -108,6 +114,7 @@ impl DatasetCheckpointer for DatasetCheckpoint {
 pub struct DatasetCheckpoint {
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
+    #[cfg_attr(not(feature = "duckdb"), expect(dead_code))]
     snapshot_behavior: SnapshotBehavior,
 }
 
@@ -272,6 +279,15 @@ impl DatasetCheckpoint {
         }
     }
 
+    #[cfg_attr(
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
+        expect(unused_variables)
+    )]
     pub async fn checkpoint(&self, schema: &SchemaRef, refresh_sql: Option<&str>) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -44,9 +44,9 @@ use crate::{
     config::ClusterRole,
     datafusion::{DataFusion, request_context_extension::get_current_datafusion},
     dataupdate::{StreamingDataUpdate, UpdateType},
-    timing::TimedStream,
 };
 use runtime_request_context::{AsyncMarker, RequestContext};
+use telemetry::timing::TimedStream;
 
 use super::{
     Service, flightsql, flightsql::prepared_statement_query, metrics,

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -44,9 +44,9 @@ use crate::{
     config::ClusterRole,
     datafusion::{DataFusion, request_context_extension::get_current_datafusion},
     dataupdate::{StreamingDataUpdate, UpdateType},
+    timing::TimedStream,
 };
 use runtime_request_context::{AsyncMarker, RequestContext};
-use telemetry::timing::TimedStream;
 
 use super::{
     Service, flightsql, flightsql::prepared_statement_query, metrics,

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -442,7 +442,7 @@ pub(crate) async fn acceleration(
 }
 
 fn dataset_properties(ds: &Dataset) -> HashMap<String, Value> {
-    #[cfg_attr(not(feature = "models"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "models"), expect(unused_mut))]
     let mut properties = HashMap::new();
 
     #[cfg(not(feature = "models"))]

--- a/crates/runtime/src/token_providers/databricks.rs
+++ b/crates/runtime/src/token_providers/databricks.rs
@@ -365,8 +365,11 @@ impl DatabricksU2MTokenProvider {
 // Token Provider Helper Functions
 // ============================================================================
 
+#[cfg(feature = "databricks")]
 use crate::parameters::Parameters;
+#[cfg(feature = "databricks")]
 use token_provider::StaticTokenProvider;
+#[cfg(feature = "databricks")]
 use token_provider::registry::TokenProviderRegistry;
 
 /// Build auth credentials from parameters.


### PR DESCRIPTION
## Changes

- Upgrade `datafusion-table-providers` to [fded3b4](https://github.com/datafusion-contrib/datafusion-table-providers/commit/fded3b402f8d4145fa82b77a446842b1ba063321) (spiceai-52 branch, cherry-pick of [#602](https://github.com/datafusion-contrib/datafusion-table-providers/pull/602))
- Upgrade `mongodb` crate from 3.5.1 to 3.5.2
- Auto-detect SRV endpoints: when the `host` parameter ends with `.mongodb.net`, the connector automatically uses `mongodb+srv://` scheme (no explicit parameter needed)
- Warn when `port` is specified alongside an SRV host (SRV uses DNS discovery)
- `connection_string` with `mongodb+srv://` continues to work as before

## Upstream changes (datafusion-table-providers)

- `mongodb+srv://` SRV connection format support via `srv` parameter in URI builder
- `tables()` method on `MongoDBConnection` for listing collections
- MongoDB Python bindings re-enabled
- Unit tests for SRV connection URI building