### PR TITLE
fix: error on MSSQL/Oracle timestamp nanosecond overflow

### DIFF
--- a/crates/data_components/src/mssql/convert.rs
+++ b/crates/data_components/src/mssql/convert.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use datafusion_table_providers::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder;
+use snafu::OptionExt;
 use tiberius::{ColumnType, Row, numeric::Numeric, xml::XmlData};
 use uuid::Uuid;
 
@@ -147,8 +148,12 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                     };
                     let v = row.get::<NaiveDateTime, usize>(i);
                     match v {
-                        Some(v) => builder
-                            .append_value(v.and_utc().timestamp_nanos_opt().unwrap_or_default()),
+                        Some(v) => {
+                            // DATETIME2 supports years 0001-9999, but Arrow's nanosecond
+                            // timestamps only cover ~1677-2262. Error on overflow rather
+                            // than silently defaulting to epoch 0.
+                            builder.append_value(naive_datetime_to_nanos(v)?);
+                        }
                         None => builder.append_null(),
                     }
                 }
@@ -166,9 +171,10 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                     let v = row.get::<DateTime<chrono::FixedOffset>, usize>(i);
                     match v {
                         Some(v) => {
-                            let utc_value = v.with_timezone(&chrono::Utc);
-                            builder
-                                .append_value(utc_value.timestamp_nanos_opt().unwrap_or_default());
+                            // See DATETIME2 comment: DATETIMEOFFSET also supports
+                            // years 0001-9999, so we reject overflow instead of silently
+                            // returning epoch 0.
+                            builder.append_value(datetime_to_nanos(v)?);
                         }
                         None => builder.append_null(),
                     }
@@ -307,6 +313,24 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
         .map_err(|err| super::Error::FailedToBuildRecordBatch { source: err })
 }
 
+/// Convert a [`NaiveDateTime`] (interpreted as UTC) to nanoseconds since epoch.
+/// Returns [`super::Error::FailedToConvertTimestampToNanos`] if the value is outside
+/// the i64 nanosecond range (~1677-2262).
+fn naive_datetime_to_nanos(v: NaiveDateTime) -> super::Result<i64> {
+    v.and_utc()
+        .timestamp_nanos_opt()
+        .context(super::FailedToConvertTimestampToNanosSnafu { v: v.to_string() })
+}
+
+/// Convert a [`DateTime`] with a fixed offset to nanoseconds since epoch (UTC).
+/// Returns [`super::Error::FailedToConvertTimestampToNanos`] if the value is outside
+/// the i64 nanosecond range (~1677-2262).
+fn datetime_to_nanos(v: DateTime<chrono::FixedOffset>) -> super::Result<i64> {
+    v.with_timezone(&chrono::Utc)
+        .timestamp_nanos_opt()
+        .context(super::FailedToConvertTimestampToNanosSnafu { v: v.to_string() })
+}
+
 pub(crate) fn map_column_type_to_arrow_type(
     column_type: ColumnType,
     decimal_precision: Option<u8>,
@@ -395,5 +419,96 @@ fn get_column_precision_and_scale(
     match field.data_type() {
         DataType::Decimal128(precision, scale) => Some((*precision, *scale)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{FixedOffset, NaiveDate, TimeZone};
+
+    #[test]
+    fn test_naive_datetime_to_nanos_in_range() {
+        // Year 2020 is well within the i64 nanosecond range.
+        let v = NaiveDate::from_ymd_opt(2020, 1, 1)
+            .expect("valid date")
+            .and_hms_opt(12, 34, 56)
+            .expect("valid time");
+        let nanos = naive_datetime_to_nanos(v).expect("in-range timestamp should convert");
+        assert_eq!(
+            nanos,
+            v.and_utc().timestamp_nanos_opt().expect("chrono nanos")
+        );
+    }
+
+    #[test]
+    fn test_naive_datetime_to_nanos_overflow_errors_not_silent() {
+        // Year 2300 overflows the i64 nanosecond range. Previously `unwrap_or_default()`
+        // silently returned 0 (epoch 1970-01-01), corrupting query results. The fix
+        // returns an error instead.
+        let v = NaiveDate::from_ymd_opt(2300, 1, 1)
+            .expect("valid date")
+            .and_hms_opt(0, 0, 0)
+            .expect("valid time");
+
+        let result = naive_datetime_to_nanos(v);
+
+        match result {
+            Err(super::super::Error::FailedToConvertTimestampToNanos { v: msg }) => {
+                assert!(
+                    msg.contains("2300"),
+                    "error should mention the offending value, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected FailedToConvertTimestampToNanos, got {other:?}"),
+            Ok(nanos) => panic!(
+                "expected error for year-2300 timestamp, but got nanos={nanos} \
+                 (this indicates the bug has regressed — out-of-range timestamps \
+                 are silently converting to epoch 0 again)"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_datetime_to_nanos_in_range() {
+        let offset = FixedOffset::east_opt(3600).expect("valid offset");
+        let v = offset
+            .with_ymd_and_hms(2020, 1, 1, 12, 34, 56)
+            .single()
+            .expect("valid datetime");
+        let nanos = datetime_to_nanos(v).expect("in-range timestamp should convert");
+        assert_eq!(
+            nanos,
+            v.with_timezone(&chrono::Utc)
+                .timestamp_nanos_opt()
+                .expect("chrono nanos")
+        );
+    }
+
+    #[test]
+    fn test_datetime_to_nanos_overflow_errors_not_silent() {
+        // Year 2300 with a non-zero offset still overflows i64 nanoseconds.
+        let offset = FixedOffset::east_opt(3600).expect("valid offset");
+        let v = offset
+            .with_ymd_and_hms(2300, 1, 1, 0, 0, 0)
+            .single()
+            .expect("valid datetime");
+
+        let result = datetime_to_nanos(v);
+
+        match result {
+            Err(super::super::Error::FailedToConvertTimestampToNanos { v: msg }) => {
+                assert!(
+                    msg.contains("2300"),
+                    "error should mention the offending value, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected FailedToConvertTimestampToNanos, got {other:?}"),
+            Ok(nanos) => panic!(
+                "expected error for year-2300 DATETIMEOFFSET, but got nanos={nanos} \
+                 (this indicates the bug has regressed — out-of-range timestamps \
+                 are silently converting to epoch 0 again)"
+            ),
+        }
     }
 }

--- a/crates/data_components/src/mssql/mod.rs
+++ b/crates/data_components/src/mssql/mod.rs
@@ -74,6 +74,11 @@ pub enum Error {
     FailedToDowncastBuilder { mssql_type: String },
 
     #[snafu(display(
+        "Failed to convert SQL Server timestamp {v} to Arrow nanosecond timestamp: value is outside the supported range (~1677-2262)"
+    ))]
+    FailedToConvertTimestampToNanos { v: String },
+
+    #[snafu(display(
         "Failed to generate SQL for SQL Server query: {}",
         format_datafusion_error(source)
     ))]

--- a/crates/data_components/src/oracle/convert.rs
+++ b/crates/data_components/src/oracle/convert.rs
@@ -323,13 +323,7 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         chrono::DateTime<FixedOffset>,
                         row,
                         idx,
-                        |v: chrono::DateTime<FixedOffset>| {
-                            // Normalize to UTC before converting to nanos timestamp
-                            let utc_value = v.with_timezone(&chrono::Utc);
-                            Ok::<_, super::Error>(
-                                utc_value.timestamp_nanos_opt().unwrap_or_default(),
-                            )
-                        }
+                        fixed_offset_to_nanos
                     );
                 }
                 (DataType::Binary, _) => {
@@ -382,6 +376,19 @@ fn big_decimal_to_i128(decimal: &bigdecimal::BigDecimal, scale: i8) -> Option<i1
 
     bigdecimal::BigDecimal::from_f32(10f32.powi(i32::from(scale)))
         .and_then(|scale| (decimal * scale).to_i128())
+}
+
+/// Convert an Oracle `TIMESTAMP WITH TIME ZONE` value to nanoseconds since epoch (UTC).
+/// Returns an error if the value is outside the i64 nanosecond range (~1677-2262).
+/// Previously used `unwrap_or_default()` which silently converted out-of-range
+/// timestamps to epoch 0 (1970-01-01 UTC), corrupting query results.
+fn fixed_offset_to_nanos(v: chrono::DateTime<FixedOffset>) -> super::Result<i64> {
+    let utc_value = v.with_timezone(&chrono::Utc);
+    utc_value
+        .timestamp_nanos_opt()
+        .context(FailedToConvertNaiveDateTimeToNanosSnafu {
+            v: utc_value.naive_utc(),
+        })
 }
 
 #[cfg(test)]
@@ -459,6 +466,56 @@ mod tests {
                 Some(expected.clone()),
                 "Failed mapping for column {name}: {oracle_type} -> {expected:?}",
             );
+        }
+    }
+
+    #[test]
+    fn test_fixed_offset_to_nanos_in_range() {
+        use chrono::TimeZone;
+
+        let offset = FixedOffset::east_opt(3600).expect("valid offset");
+        let v = offset
+            .with_ymd_and_hms(2020, 1, 1, 12, 34, 56)
+            .single()
+            .expect("valid datetime");
+        let nanos = fixed_offset_to_nanos(v).expect("in-range timestamp should convert");
+        assert_eq!(
+            nanos,
+            v.with_timezone(&chrono::Utc)
+                .timestamp_nanos_opt()
+                .expect("chrono nanos")
+        );
+    }
+
+    #[test]
+    fn test_fixed_offset_to_nanos_overflow_errors_not_silent() {
+        use chrono::TimeZone;
+
+        // Year 2300 overflows i64 nanoseconds. Previously `unwrap_or_default()`
+        // silently returned 0 (epoch 1970-01-01), corrupting query results for
+        // Oracle `TIMESTAMP WITH TIME ZONE` values outside ~1677-2262.
+        let offset = FixedOffset::east_opt(3600).expect("valid offset");
+        let v = offset
+            .with_ymd_and_hms(2300, 6, 15, 12, 0, 0)
+            .single()
+            .expect("valid datetime");
+
+        let result = fixed_offset_to_nanos(v);
+
+        match result {
+            Err(super::super::Error::FailedToConvertNaiveDateTimeToNanos { v: offending }) => {
+                assert_eq!(
+                    offending.date().format("%Y").to_string(),
+                    "2300",
+                    "error should carry the offending value"
+                );
+            }
+            Err(other) => panic!("expected FailedToConvertNaiveDateTimeToNanos, got {other:?}"),
+            Ok(nanos) => panic!(
+                "expected error for year-2300 TIMESTAMP WITH TIME ZONE, but got \
+                 nanos={nanos} (this indicates the bug has regressed — \
+                 out-of-range timestamps are silently converting to epoch 0)"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary
The MSSQL `DATETIME2` and `DATETIMEOFFSET` paths and the Oracle `TIMESTAMP WITH TIME ZONE` path used `.timestamp_nanos_opt().unwrap_or_default()` to convert `chrono` values to Arrow nanosecond timestamps. When the input falls outside the i64 nanosecond range (~1677-09-21 to 2262-04-11), `timestamp_nanos_opt()` returns `None` and `unwrap_or_default()` silently substitutes `0`, which Arrow interprets as `1970-01-01 UTC`.

`DATETIME2` and `DATETIMEOFFSET` support years 0001-9999, and Oracle's `TIMESTAMP` types do as well — so any out-of-range value was being silently rewritten to epoch 0 in query results. This is the same class of bug fixed for the Turso connector in #10282.

## Fix
Replace the silent default with a typed error in both connectors:

- **MSSQL** (`crates/data_components/src/mssql/`): adds a new `FailedToConvertTimestampToNanos` error variant. `Datetime2` and `DatetimeOffsetn` now route through small `naive_datetime_to_nanos` / `datetime_to_nanos` helpers that return `Err` on overflow.
- **Oracle** (`crates/data_components/src/oracle/convert.rs`): extracts the WITH TIME ZONE conversion into a `fixed_offset_to_nanos` helper that reuses the existing `FailedToConvertNaiveDateTimeToNanos` variant — matching the WITHOUT TIME ZONE / LTZ paths, which already error correctly.

Behavior for in-range timestamps is unchanged. Out-of-range timestamps now surface a descriptive error instead of corrupting the result.

## Test plan
- Added regression tests in `crates/data_components/src/mssql/convert.rs::tests` covering the in-range happy path and the out-of-range overflow case for both `DATETIME2` (NaiveDateTime) and `DATETIMEOFFSET` (DateTime<FixedOffset>).
- Added regression tests in `crates/data_components/src/oracle/convert.rs::tests` covering the in-range and overflow cases for `TIMESTAMP WITH TIME ZONE`.
- All new tests pass: `cargo test -p data_components --features mssql,oracle --lib`.
- `cargo fmt --all -- --check` passes.
- `cargo clippy -p data_components --features mssql,oracle --lib` and `--tests` pass under the project's pedantic lint set.
- Performance impact: none (single helper call per row, identical work to the prior path on the happy path).