### PR TITLE
Upgrade datafusion-table-providers to 4e8b2b0 (comprehensive pushdown support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.4.2"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=e1318d3f7530234356caa87ba59e4bbc05dbe72a#e1318d3f7530234356caa87ba59e4bbc05dbe72a"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=bda2122883a184ab8e23b2af2728fefc6631f21a#bda2122883a184ab8e23b2af2728fefc6631f21a"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -6157,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d1b911a5ed7c5a814572b3ce86b65e15129d6fe5#d1b911a5ed7c5a814572b3ce86b65e15129d6fe5"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4e8b2b0bd0f0f39f47810a25883a1951c92247a6#4e8b2b0bd0f0f39f47810a25883a1951c92247a6"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -8314,8 +8314,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9457,7 +9457,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -13971,7 +13971,7 @@ checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
  "hashbrown 0.5.0",
- "parking_lot 0.12.5",
+ "parking_lot 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -14509,8 +14509,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14544,7 +14544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -17318,7 +17318,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17980,7 +17980,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ datafusion-common-runtime = "52.0.0"
 datafusion-datasource = "52.0.0"
 datafusion-execution = "52.0.0"
 datafusion-expr = "52.0.0"
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e1318d3f7530234356caa87ba59e4bbc05dbe72a", features = ["sql"] } # SHA format (short vs full) must match to what datafusion-table-providers use for datafusion-federation
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "bda2122883a184ab8e23b2af2728fefc6631f21a", features = ["sql"] } # SHA format (short vs full) must match to what datafusion-table-providers use for datafusion-federation
 datafusion-functions = "52.0.0"
 datafusion-functions-json = "0.52"
 datafusion-physical-expr = "52.0.0"
@@ -395,7 +395,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c434c7b5a4e1ddb3137f1cea8da1006c514ae889" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d1b911a5ed7c5a814572b3ce86b65e15129d6fe5" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4e8b2b0bd0f0f39f47810a25883a1951c92247a6" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "729428c650a0d0fe2a10662e35d14250505140a2" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "729428c650a0d0fe2a10662e35d14250505140a2" } # spiceai-52.5


### PR DESCRIPTION
## Summary

Upgrade `datafusion-table-providers` from `d1b911a5` to `4e8b2b0bd0f0f39f47810a25883a1951c92247a6` and align `datafusion-federation` to `bda2122883a184ab8e23b2af2728fefc6631f21a` (matching the new TP's dependency).

## What's new in this TP version

[datafusion-contrib/datafusion-table-providers#615](https://github.com/datafusion-contrib/datafusion-table-providers/pull/615) adds comprehensive pushdown support for all SQL providers:

- **Sort pushdown** (`try_pushdown_sort`): push ORDER BY into generated SQL
- **Limit pushdown** (`with_fetch` / `fetch` / `supports_limit_pushdown`): push LIMIT into SQL
- **Filter pushdown** (`handle_child_pushdown_result`): physical filter pushdown converting PhysicalExpr predicates into SQL WHERE conditions
- Uses `Unparser` for dialect-aware SQL generation (identifier quoting, operator support, type casting)
- Adds `dialect` field to `SqlExec` and threads it from `SqlTable` through all connector exec types (SQLiteSqlExec, MySQLSQLExec, DuckSqlExec, AdbcSqlExec, ClickHouse)
- Replaces `.expect()` with proper error handling in all 4 connector filter pushdown implementations

## Changes

- `Cargo.toml`: Updated `datafusion-table-providers` and `datafusion-federation` git revisions
- `Cargo.lock`: Updated lockfile

## Verification

`cargo check` passes cleanly across the full workspace.