### PR TITLE
Jeadie/26 04 16/spice sql

### DIFF
--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -127,5 +127,3 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         custom_headers: args.custom_headers.clone(),
     }
 }
-
-

--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -91,7 +91,7 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         .map_or_else(
             || {
                 if let Some(region) = ctx.cloud_region() {
-                    format!("https://{region}-flight.spiceai.io")
+                    format!("https://{region}-prod-aws-flight.spiceai.io")
                 } else {
                     "http://localhost:50051".to_string()
                 }
@@ -127,3 +127,5 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         custom_headers: args.custom_headers.clone(),
     }
 }
+
+

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -122,7 +122,7 @@ impl RuntimeContext {
         }
 
         if let Some(region) = cloud {
-            ctx.http_endpoint = format!("https://{region}-data.spiceai.io");
+            ctx.http_endpoint = format!("https://{region}-prod-aws-data.spiceai.io");
             ctx.cloud_region = Some(region.to_string());
         }
 
@@ -889,7 +889,10 @@ mod tests {
             .expect("with_args should succeed");
 
         assert!(ctx.is_cloud());
-        assert_eq!(ctx.http_endpoint(), "https://us-east-1-data.spiceai.io");
+        assert_eq!(
+            ctx.http_endpoint(),
+            "https://us-east-1-prod-aws-data.spiceai.io"
+        );
         assert_eq!(ctx.cloud_region(), Some("us-east-1"));
     }
 
@@ -1007,7 +1010,10 @@ mod tests {
         .expect("with_args should succeed");
 
         assert!(ctx.is_cloud());
-        assert_eq!(ctx.http_endpoint(), "https://us-west-2-data.spiceai.io");
+        assert_eq!(
+            ctx.http_endpoint(),
+            "https://us-west-2-prod-aws-data.spiceai.io"
+        );
     }
 
     #[test]
@@ -1022,7 +1028,10 @@ mod tests {
         .expect("with_args should succeed");
 
         assert!(ctx.is_cloud());
-        assert_eq!(ctx.http_endpoint(), "https://us-west-2-data.spiceai.io");
+        assert_eq!(
+            ctx.http_endpoint(),
+            "https://us-west-2-prod-aws-data.spiceai.io"
+        );
         assert_eq!(ctx.api_key(), Some("cloud-api-key-12345"));
     }
 
@@ -1069,7 +1078,10 @@ mod tests {
             .expect("with_args should succeed");
 
         // Cloud mode socket address should strip https://
-        assert_eq!(ctx.http_socket_address(), "us-east-1-data.spiceai.io");
+        assert_eq!(
+            ctx.http_socket_address(),
+            "us-east-1-prod-aws-data.spiceai.io"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 📝 Summary

Fix this bug
```shell
>>  spice sql --api-key <api_key>  --cloud us-west-2
Spice.ai OSS CLI v2.0.0-unstable (20a732ed27)
ERROR SQL REPL error: Connection failed to spiced at 'https://us-west-2-flight.spiceai.io': transport error. Check if the Spice runtime is running, endpoint including port is correct, and TLS config (if used) is valid.
```