### PR TITLE
fix: Increase throughput test default ready_wait from 30s to 300s (fixes #8207)

### DIFF
--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -53,7 +53,7 @@ on:
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true
-        default: '30'
+        default: '300'
         type: string
       concurrency_count:
         description: 'How many concurrent client connections to use?'


### PR DESCRIPTION
## Summary
Fixes #8207

**Root cause:** The throughput workflow's `ready_wait` input defaults to 30 seconds, which is insufficient for tests that load data from external sources like MongoDB. When triggered manually via the GitHub UI (rather than through the testoperator dispatch mechanism which correctly specifies `ready_wait: 600`), the low default causes "Spiced instance not ready within 30s" failures.

## Changes
- Increased the `ready_wait` workflow input default from `'30'` to `'300'` (5 minutes) in `testoperator_run_throughput.yml`

This aligns the default with a reasonable timeout for real-world spicepod configurations. The dispatch mechanism already specifies per-test timeouts (e.g., 600s for mongodb-arrow), so this change only affects manual UI triggers.

## Test plan
- [ ] The throughput workflow default is now 300s for manual triggers
- [ ] Dispatch YAML configs continue to override with their specific `ready_wait` values
- [ ] No impact on existing automated dispatches (they always specify `ready_wait` explicitly)

## Checklist
- [x] Root cause identified and fixed
- [x] No snapshot deletions
- [x] Lint clean