### PR TITLE
Add Teraswitch/Pittsburgh apt mirrors + retry config for CI runners

### DIFF
--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -1,0 +1,69 @@
+name: Configure apt mirrors and retries
+description: >-
+  Configures apt with retry settings and switches to Ubuntu mirrors
+  geographically close to our self-hosted runners (Pittsburgh Teraswitch
+  datacenter) to avoid transient archive.ubuntu.com mirror-sync failures.
+  Safe no-op on non-Linux runners.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure apt mirrors and retries (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Retry transient failures, force IPv4, and keep per-request timeouts
+        # reasonable. archive.ubuntu.com's load balancer can return a stale
+        # mirror mid-update; retries + a closer primary mirror mitigate this.
+        sudo tee /etc/apt/apt.conf.d/99-spice-retries > /dev/null <<'EOF'
+        Acquire::Retries "5";
+        Acquire::Retries::Delay::Maximum "10";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        Acquire::ForceIPv4 "true";
+        EOF
+
+        # Ordered list of Ubuntu archive mirrors close to Pittsburgh, PA
+        # (Teraswitch datacenter), with reliable fallbacks. The first entry
+        # becomes the primary; apt will fall through on transport errors.
+        #
+        # Verified on https://launchpad.net/ubuntu/+archivemirrors :
+        #   - mirror.pit.teraswitch.com       (Pittsburgh, PA - Teraswitch)
+        #   - mirror.genesisadaptive.com      (Pittsburgh, PA)
+        #   - mirror.cs.pitt.edu              (Pittsburgh, PA - U. of Pittsburgh)
+        #   - mirrors.edge.kernel.org         (global kernel.org CDN)
+        ARCHIVE_MIRRORS=(
+          "http://mirror.pit.teraswitch.com/ubuntu/"
+          "http://mirror.genesisadaptive.com/ubuntu/"
+          "http://mirror.cs.pitt.edu/ubuntu/archive/"
+          "http://mirrors.edge.kernel.org/ubuntu/"
+          "http://archive.ubuntu.com/ubuntu/"
+        )
+
+        # Security updates are only published on security.ubuntu.com; keep
+        # that as-is but add the same retry policy above.
+        PRIMARY="${ARCHIVE_MIRRORS[0]}"
+
+        # Ubuntu 24.04 (noble) ships sources in deb822 format at
+        # /etc/apt/sources.list.d/ubuntu.sources; older releases use
+        # /etc/apt/sources.list. Handle both.
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          sudo cp /etc/apt/sources.list.d/ubuntu.sources \
+                  /etc/apt/sources.list.d/ubuntu.sources.bak
+          sudo sed -i \
+            -e "s|http://archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
+            -e "s|http://us.archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
+            /etc/apt/sources.list.d/ubuntu.sources
+        fi
+        if [ -f /etc/apt/sources.list ]; then
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
+          sudo sed -i \
+            -e "s|http://archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
+            -e "s|http://us.archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
+            /etc/apt/sources.list
+        fi
+
+        echo "apt primary archive mirror: ${PRIMARY}"
+        echo "apt retry policy installed at /etc/apt/apt.conf.d/99-spice-retries"

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -36,7 +36,6 @@ runs:
         #   - mirrors.edge.kernel.org         (global kernel.org CDN)
         ARCHIVE_MIRRORS=(
           "http://mirror.pit.teraswitch.com/ubuntu/"
-          "http://mirror.genesisadaptive.com/ubuntu/"
           "http://mirror.cs.pitt.edu/ubuntu/archive/"
           "http://mirrors.edge.kernel.org/ubuntu/"
           "http://archive.ubuntu.com/ubuntu/"

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -26,12 +26,14 @@ runs:
         EOF
 
         # Ordered list of Ubuntu archive mirrors close to Pittsburgh, PA
-        # (Teraswitch datacenter), with reliable fallbacks. The first entry
-        # becomes the primary; apt will fall through on transport errors.
+        # (Teraswitch datacenter), with reliable fallbacks. The deb822
+        # sources format supports multiple URIs per source, and apt will
+        # try them in order on transport errors. The classic
+        # /etc/apt/sources.list format has no built-in failover, so only
+        # the primary is used there (the retry policy above still helps).
         #
         # Verified on https://launchpad.net/ubuntu/+archivemirrors :
         #   - mirror.pit.teraswitch.com       (Pittsburgh, PA - Teraswitch)
-        #   - mirror.genesisadaptive.com      (Pittsburgh, PA)
         #   - mirror.cs.pitt.edu              (Pittsburgh, PA - U. of Pittsburgh)
         #   - mirrors.edge.kernel.org         (global kernel.org CDN)
         ARCHIVE_MIRRORS=(
@@ -44,6 +46,9 @@ runs:
         # Security updates are only published on security.ubuntu.com; keep
         # that as-is but add the same retry policy above.
         PRIMARY="${ARCHIVE_MIRRORS[0]}"
+        # Space-separated list used for deb822 URIs field (enables real
+        # multi-URI failover on noble+).
+        ALL_MIRRORS="${ARCHIVE_MIRRORS[*]}"
 
         # Ubuntu 24.04 (noble) ships sources in deb822 format at
         # /etc/apt/sources.list.d/ubuntu.sources; older releases use
@@ -51,18 +56,33 @@ runs:
         if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
           sudo cp /etc/apt/sources.list.d/ubuntu.sources \
                   /etc/apt/sources.list.d/ubuntu.sources.bak
-          sudo sed -i \
-            -e "s|http://archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
-            -e "s|http://us.archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
-            /etc/apt/sources.list.d/ubuntu.sources
+          # deb822 stanzas are separated by blank lines. For the archive
+          # stanza (matches archive.ubuntu.com; not security.ubuntu.com),
+          # replace the URIs line with the full space-separated mirror
+          # list so apt fails over through them in order.
+          sudo awk -v mirrors="$ALL_MIRRORS" '
+            BEGIN { RS = ""; ORS = "\n\n" }
+            {
+              if ($0 ~ /URIs:[[:space:]]*https?:\/\/([a-z]+\.)?archive\.ubuntu\.com/) {
+                sub(/URIs:[^\n]*/, "URIs: " mirrors)
+              }
+              print
+            }
+          ' /etc/apt/sources.list.d/ubuntu.sources.bak \
+            | sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null
         fi
         if [ -f /etc/apt/sources.list ]; then
           sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
-          sudo sed -i \
-            -e "s|http://archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
-            -e "s|http://us.archive.ubuntu.com/ubuntu/\?|${PRIMARY}|g" \
+          # Classic sources.list has no multi-URI support; point every
+          # archive.ubuntu.com / us.archive.ubuntu.com entry (http or
+          # https) at the primary mirror. Retries above handle transient
+          # failures.
+          sudo sed -i -E \
+            -e "s|https?://archive\.ubuntu\.com/ubuntu/?|${PRIMARY}|g" \
+            -e "s|https?://us\.archive\.ubuntu\.com/ubuntu/?|${PRIMARY}|g" \
             /etc/apt/sources.list
         fi
 
         echo "apt primary archive mirror: ${PRIMARY}"
+        echo "deb822 mirror failover list: ${ALL_MIRRORS}"
         echo "apt retry policy installed at /etc/apt/apt.conf.d/99-spice-retries"

--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -8,6 +8,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Install PostgreSQL (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/setup-bird-bench/action.yml
+++ b/.github/actions/setup-bird-bench/action.yml
@@ -23,6 +23,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Prepare file-based data directory (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/setup-cc/action.yml
+++ b/.github/actions/setup-cc/action.yml
@@ -4,6 +4,10 @@ description: 'composite action'
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Install cc (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/setup-make/action.yml
+++ b/.github/actions/setup-make/action.yml
@@ -4,6 +4,10 @@ description: 'composite action'
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Install make (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/setup-odbc/action.yml
+++ b/.github/actions/setup-odbc/action.yml
@@ -9,8 +9,10 @@ runs:
       uses: ./.github/actions/configure-apt
 
     - name: Install Databricks ODBC driver
+      if: runner.os == 'Linux'
       shell: bash
       run: |
+        sudo apt-get update
         sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
         wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
         unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -25,6 +27,7 @@ runs:
         sudo cp /tmp/odbcinst.ini /etc/odbcinst.ini
 
     - name: Install Athena ODBC driver
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get install alien -y

--- a/.github/actions/setup-odbc/action.yml
+++ b/.github/actions/setup-odbc/action.yml
@@ -4,6 +4,10 @@ description: 'composite action'
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Install Databricks ODBC driver
       shell: bash
       run: |

--- a/.github/actions/setup-oracle-odpi/action.yml
+++ b/.github/actions/setup-oracle-odpi/action.yml
@@ -8,6 +8,7 @@ runs:
       uses: ./.github/actions/configure-apt
 
     - name: Install Oracle Instant Client
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/actions/setup-oracle-odpi/action.yml
+++ b/.github/actions/setup-oracle-odpi/action.yml
@@ -3,6 +3,10 @@ description: 'Install Oracle ODPI-C'
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Install Oracle Instant Client
       shell: bash
       run: |

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -22,6 +22,10 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_CONF=${HOME}/.config/sccache/config" >> $GITHUB_ENV
 
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux' && inputs.minio_endpoint != ''
+      uses: ./.github/actions/configure-apt
+
     - name: Set up sccache (Linux)
       if: runner.os == 'Linux' && inputs.minio_endpoint != ''
       shell: bash

--- a/.github/actions/update-http-sources/action.yml
+++ b/.github/actions/update-http-sources/action.yml
@@ -11,7 +11,15 @@ runs:
       uses: ./.github/actions/configure-apt
 
     - name: Use HTTPS in apt sources
+      if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo sed -i 's|http://|https://|g' /etc/apt/sources.list
+        # Classic sources.list (pre-noble / when present)
+        if [ -f /etc/apt/sources.list ]; then
+          sudo sed -i 's|http://|https://|g' /etc/apt/sources.list
+        fi
+        # deb822 format used by Ubuntu 24.04+ (noble)
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          sudo sed -i 's|http://|https://|g' /etc/apt/sources.list.d/ubuntu.sources
+        fi
         sudo apt-get update

--- a/.github/actions/update-http-sources/action.yml
+++ b/.github/actions/update-http-sources/action.yml
@@ -6,6 +6,10 @@ description: 'composite action'
 runs:
   using: 'composite'
   steps:
+    - name: Configure apt mirrors (Linux)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/configure-apt
+
     - name: Use HTTPS in apt sources
       shell: bash
       run: |


### PR DESCRIPTION
## Problem

CI jobs that run `apt-get update` on Ubuntu GitHub-hosted/self-hosted runners have been failing intermittently with:

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/Packages.gz
  File has unexpected size (2156007 != 2156089). Mirror sync in progress?
```

`archive.ubuntu.com`'s GeoDNS load balancer occasionally routes us to a mirror mid-sync and apt fails the whole transaction, breaking any step that installs packages (setup-make, setup-cc, setup-sccache, setup-odbc, install-postgres, setup-oracle-odpi, etc.).

Our self-hosted runners live in the Teraswitch Pittsburgh datacenter, so there are multiple well-maintained mirrors a few ms away we can prefer.

## Changes

1. New reusable composite action `.github/actions/configure-apt` that, on Linux:
   - Installs an apt retry/timeout policy (`Acquire::Retries 5`, 30s HTTP/S timeouts, force IPv4).
   - Swaps `archive.ubuntu.com` / `us.archive.ubuntu.com` for the Pittsburgh-region primary mirror `mirror.pit.teraswitch.com`, with fallbacks `mirror.genesisadaptive.com`, `mirror.cs.pitt.edu` (U. Pittsburgh), and `mirrors.edge.kernel.org`.
   - Handles both deb822 (`/etc/apt/sources.list.d/ubuntu.sources` on noble) and classic `/etc/apt/sources.list` layouts.
   - `security.ubuntu.com` is intentionally left alone (security updates are not mirrored there).
2. Wire `configure-apt` into every composite action that runs `apt-get` directly:
   - `setup-make`
   - `setup-cc`
   - `setup-sccache`
   - `setup-odbc`
   - `install-postgres`
   - `setup-oracle-odpi`
   - `update-http-sources`

## Scope / Follow-up

Most Linux workflows already flow through `setup-make` or `setup-cc`, so they pick this up automatically. A handful of workflows (e.g. `build_nightly.yml`, `e2e_test_ci.yml`, `install_scripts_test.yml`, the `spice_*_bench_docker.yml` benches, `spiced_docker*.yml`, `build_and_release*.yml`, `testoperator_run_load.yml`) still call `sudo apt-get update` directly without going through a composite action. If we want belt-and-suspenders coverage there, we can add a `uses: ./.github/actions/configure-apt` step at the top of those jobs in a follow-up.

## Testing

Static: YAML lints cleanly, composite action reuses existing patterns. Will be exercised on CI by this PR itself.