### PR TITLE
Fix ubuntu mirror configuration

### DIFF
--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -56,29 +56,16 @@ runs:
         if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
           sudo cp /etc/apt/sources.list.d/ubuntu.sources \
                   /etc/apt/sources.list.d/ubuntu.sources.bak
-          # deb822 stanzas are separated by blank lines. For the archive
-          # stanza (identified by archive.ubuntu.com; not security.ubuntu.com),
-          # replace the URIs line with the full space-separated mirror list so
-          # apt fails over through them in order.
-          # NOTE: match only on “archive.ubuntu.com” — the previous regex
-          # ([a-z]+\.)?archive\.ubuntu\.com caused mawk to greedily consume
-          # “archive.” into the optional group, leaving the rest unmatched.
-          sudo awk -v mirrors="$ALL_MIRRORS" '
-            BEGIN { RS = ""; ORS = "\n\n" }
-            {
-              if ($0 ~ /archive\.ubuntu\.com/) {
-                sub(/URIs:[^\n]*/, "URIs: " mirrors)
-              }
-              print
-            }
-          ' /etc/apt/sources.list.d/ubuntu.sources.bak \
-            | sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null
+          # Ubuntu's default deb822 file has separate archive and security
+          # stanzas. Replace only the archive URIs line and leave the
+          # security stanza untouched.
+          sudo sed -i -E \
+            -e "s|^URIs:[[:space:]]*https?://archive\.ubuntu\.com/ubuntu/?$|URIs: ${ALL_MIRRORS}|" \
+            /etc/apt/sources.list.d/ubuntu.sources
           # Fail loudly if the substitution had no effect. Check that the
-          # primary Pittsburgh mirror is now in the file — archive.ubuntu.com
-          # will still appear there as an intentional fallback in ALL_MIRRORS,
-          # so checking for its absence would be a false negative.
+          # primary Pittsburgh mirror is now in the file.
           if ! grep -q 'mirror\.pit\.teraswitch\.com' /etc/apt/sources.list.d/ubuntu.sources; then
-            echo "ERROR: configure-apt: Pittsburgh mirror not found in ubuntu.sources after substitution — awk may have failed to match" >&2
+            echo "ERROR: configure-apt: Pittsburgh mirror not found in ubuntu.sources after substitution" >&2
             echo "--- current ubuntu.sources URIs ---" >&2
             grep '^URIs:' /etc/apt/sources.list.d/ubuntu.sources >&2 || true
             exit 1

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -57,19 +57,28 @@ runs:
           sudo cp /etc/apt/sources.list.d/ubuntu.sources \
                   /etc/apt/sources.list.d/ubuntu.sources.bak
           # deb822 stanzas are separated by blank lines. For the archive
-          # stanza (matches archive.ubuntu.com; not security.ubuntu.com),
-          # replace the URIs line with the full space-separated mirror
-          # list so apt fails over through them in order.
+          # stanza (identified by archive.ubuntu.com; not security.ubuntu.com),
+          # replace the URIs line with the full space-separated mirror list so
+          # apt fails over through them in order.
+          # NOTE: match only on “archive.ubuntu.com” — the previous regex
+          # ([a-z]+\.)?archive\.ubuntu\.com caused mawk to greedily consume
+          # “archive.” into the optional group, leaving the rest unmatched.
           sudo awk -v mirrors="$ALL_MIRRORS" '
             BEGIN { RS = ""; ORS = "\n\n" }
             {
-              if ($0 ~ /URIs:[[:space:]]*https?:\/\/([a-z]+\.)?archive\.ubuntu\.com/) {
+              if ($0 ~ /archive\.ubuntu\.com/) {
                 sub(/URIs:[^\n]*/, "URIs: " mirrors)
               }
               print
             }
           ' /etc/apt/sources.list.d/ubuntu.sources.bak \
             | sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null
+          # Fail loudly if the substitution had no effect (archive.ubuntu.com
+          # still present means the awk condition did not match).
+          if grep -q 'archive\.ubuntu\.com' /etc/apt/sources.list.d/ubuntu.sources; then
+            echo "ERROR: configure-apt: archive.ubuntu.com still present in ubuntu.sources after mirror substitution" >&2
+            exit 1
+          fi
         fi
         if [ -f /etc/apt/sources.list ]; then
           sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -73,10 +73,14 @@ runs:
             }
           ' /etc/apt/sources.list.d/ubuntu.sources.bak \
             | sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null
-          # Fail loudly if the substitution had no effect (archive.ubuntu.com
-          # still present means the awk condition did not match).
-          if grep -q 'archive\.ubuntu\.com' /etc/apt/sources.list.d/ubuntu.sources; then
-            echo "ERROR: configure-apt: archive.ubuntu.com still present in ubuntu.sources after mirror substitution" >&2
+          # Fail loudly if the substitution had no effect. Check that the
+          # primary Pittsburgh mirror is now in the file — archive.ubuntu.com
+          # will still appear there as an intentional fallback in ALL_MIRRORS,
+          # so checking for its absence would be a false negative.
+          if ! grep -q 'mirror\.pit\.teraswitch\.com' /etc/apt/sources.list.d/ubuntu.sources; then
+            echo "ERROR: configure-apt: Pittsburgh mirror not found in ubuntu.sources after substitution — awk may have failed to match" >&2
+            echo "--- current ubuntu.sources URIs ---" >&2
+            grep '^URIs:' /etc/apt/sources.list.d/ubuntu.sources >&2 || true
             exit 1
           fi
         fi

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -63,9 +63,9 @@ runs:
             -e "s|^URIs:[[:space:]]*https?://archive\.ubuntu\.com/ubuntu/?$|URIs: ${ALL_MIRRORS}|" \
             /etc/apt/sources.list.d/ubuntu.sources
           # Fail loudly if the substitution had no effect. Check that the
-          # primary Pittsburgh mirror is now in the file.
-          if ! grep -q 'mirror\.pit\.teraswitch\.com' /etc/apt/sources.list.d/ubuntu.sources; then
-            echo "ERROR: configure-apt: Pittsburgh mirror not found in ubuntu.sources after substitution" >&2
+          # configured primary mirror is now in the file.
+          if ! grep -Fq "${PRIMARY}" /etc/apt/sources.list.d/ubuntu.sources; then
+            echo "ERROR: configure-apt: primary mirror ${PRIMARY} not found in ubuntu.sources after substitution" >&2
             echo "--- current ubuntu.sources URIs ---" >&2
             grep '^URIs:' /etc/apt/sources.list.d/ubuntu.sources >&2 || true
             exit 1

--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -86,3 +86,24 @@ runs:
         echo "apt primary archive mirror: ${PRIMARY}"
         echo "deb822 mirror failover list: ${ALL_MIRRORS}"
         echo "apt retry policy installed at /etc/apt/apt.conf.d/99-spice-retries"
+
+    - name: Verify apt mirror configuration (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "=== /etc/apt/apt.conf.d/99-spice-retries ==="
+        cat /etc/apt/apt.conf.d/99-spice-retries
+
+        echo "=== Active URIs in ubuntu.sources (deb822) ==="
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          grep '^URIs:' /etc/apt/sources.list.d/ubuntu.sources
+        else
+          echo "not present"
+        fi
+
+        echo "=== Active archive lines in sources.list (classic) ==="
+        if [ -f /etc/apt/sources.list ]; then
+          grep 'archive\.ubuntu\.com' /etc/apt/sources.list | grep -v '^#' || true
+        else
+          echo "not present"
+        fi


### PR DESCRIPTION
This pull request updates the logic for configuring and verifying the Ubuntu APT mirror setup in the GitHub Actions workflow. The main improvements are a safer and more targeted method for updating the `ubuntu.sources` file and the addition of a verification step to ensure the configuration is correct.

**APT mirror configuration improvements:**

* Replaced the previous `awk`-based approach for updating the `URIs` line in `ubuntu.sources` with a more precise `sed` command. This change ensures that only the archive stanza is modified, leaving the security stanza untouched. It also adds a check to fail loudly if the primary mirror is not found after the substitution.

**Verification enhancements:**

* Added a new step to print the contents of `/etc/apt/apt.conf.d/99-spice-retries`, the active `URIs` lines in `ubuntu.sources`, and the active archive lines in `sources.list` for easier debugging and verification of the APT mirror configuration.