### PR TITLE
Run make install on spiceai-macos with setup-spiceio

### DIFF
--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -18,12 +18,31 @@ concurrency:
 jobs:
   make_install:
     name: make install*
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
+
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
+      - name: Set up sccache
+        if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''
+        uses: ./.github/actions/setup-sccache
+        with:
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
 
       - name: Set up make
         uses: ./.github/actions/setup-make
@@ -55,3 +74,19 @@ jobs:
       - name: make install-odbc
         run: |
           make install-odbc
+
+      - name: Show sccache stats
+        if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''
+        run: sccache --show-stats
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: spiceio-makefile-targets-logs
+          path: ${{ runner.temp }}/spiceio.log
+          if-no-files-found: ignore


### PR DESCRIPTION
Switches the `make install*` job in `makefile_targets.yml` from `spiceai-dev-runners` to `spiceai-macos`, and wires in `setup-spiceio` + `setup-sccache` with matching cleanup (kill spiceio pid, upload logs, show sccache stats), following the pattern used in `features.yml` and `pr-develop.yml`.