### PR TITLE
Bump datafusion-table-providers (#10375)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6109,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=246441ec5bd564e4fe26b7dfc47f3e06d70e5814#246441ec5bd564e4fe26b7dfc47f3e06d70e5814"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5790adcfac5578331a9cadfe1e2e88d1eb8f0565#5790adcfac5578331a9cadfe1e2e88d1eb8f0565"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,7 +407,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "f9443aba33172331918845db9b4abcf1a9a3e1fd" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "f9443aba33172331918845db9b4abcf1a9a3e1fd" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "246441ec5bd564e4fe26b7dfc47f3e06d70e5814" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5790adcfac5578331a9cadfe1e2e88d1eb8f0565" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "729428c650a0d0fe2a10662e35d14250505140a2" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "729428c650a0d0fe2a10662e35d14250505140a2" } # spiceai-52.5


### PR DESCRIPTION
## 📝 Summary

bring https://github.com/spiceai/spiceai/pull/10375 to trunk

Bump datafusion-table-providers to https://github.com/datafusion-contrib/datafusion-table-providers/commit/5790adcfac5578331a9cadfe1e2e88d1eb8f0565
