### PR TITLE
ci: bump test archive upload compression-level to 1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -151,8 +151,8 @@ jobs:
           name: integration-test-archive
           path: ./integration.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Upload retention OOM test archive
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -161,8 +161,8 @@ jobs:
           name: integration-retention-oom-test-archive
           path: ./retention_oom.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Upload AWS SDK test archive
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -171,8 +171,8 @@ jobs:
           name: integration-aws-sdk-test-archive
           path: ./integration_aws_sdk.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Upload AWS SDK credential bridge test archive
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -181,8 +181,8 @@ jobs:
           name: integration-aws-sdk-credential-bridge-test-archive
           path: ./integration_aws_sdk_credential_bridge.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Upload partition table test archive
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -191,8 +191,8 @@ jobs:
           name: integration-partition-table-test-archive
           path: ./partition_table_test.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Upload data components test archive
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -201,8 +201,8 @@ jobs:
           name: integration-data-components-test-archive
           path: ./data_components_hadoop.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
   test:
     name: Integration Tests (part ${{ matrix.label }})

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -117,8 +117,8 @@ jobs:
           name: llms-integration-test-binary
           path: ./llms_integration_test
           retention-days: 3
-          # Test binary is already a compact native binary; skip artifact zip compression.
-          compression-level: 0
+          # Test binary is already a compact native binary; use minimal artifact zip compression.
+          compression-level: 1
 
   test:
     runs-on: ${{ matrix.target.runner }}

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -135,8 +135,8 @@ jobs:
           name: ai-integration-test-archive
           path: ./integration.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -448,8 +448,8 @@ jobs:
           name: ai-integration-test-archive-extended
           path: ./integration-extended.tar.zst
           retention-days: 3
-          # Archive is already zstd-compressed; skip artifact zip compression.
-          compression-level: 0
+          # Archive is already zstd-compressed; use minimal artifact zip compression.
+          compression-level: 1
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''


### PR DESCRIPTION
The `integration_models` workflow uploads the nextest archive (already zstd-compressed) with `compression-level: 0`, which skips the artifact zip wrapper compression entirely. Bump it to `1` (fastest) so the artifact still gets minimal zip-level compression without meaningfully increasing upload time.

Only touches `.github/workflows/integration_models.yml`.