### PR TITLE
feat(otel): default OTLP push exporter to delta temporality

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -882,11 +882,36 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "temporality": {
+          "description": "Aggregation temporality preference for exported metrics.\n\nDefaults to `delta`, which is required by Datadog and recommended for\nmost push-based OTLP backends (`CloudWatch`, New Relic, etc.). Set to\n`cumulative` when forwarding to an `OTel` collector that feeds Prometheus\nor another cumulative-native backend. See [`OtelTemporality`] for\ndetails.",
+          "$ref": "#/$defs/OtelTemporality",
+          "default": "delta"
         }
       },
       "additionalProperties": false,
       "required": [
         "endpoint"
+      ]
+    },
+    "OtelTemporality": {
+      "description": "Aggregation temporality preference for the OTEL metrics push exporter.\n\nControls how counter and histogram values are encoded on the wire:\n\n- **`Delta`** (default): each export contains the change since the previous\n  export. Required by Datadog's OTLP intake and recommended by AWS\n  `CloudWatch`, New Relic, and most push-based `SaaS` backends. Aligns with the\n  `OpenTelemetry` guidance for push exporters.\n- **`Cumulative`**: each export carries the running total since process\n  start. Use this for `OTel` collectors that downstream into Prometheus or\n  other pull-based / cumulative-native backends.\n- **`LowMemory`**: counters use cumulative, histograms use delta. Reduces\n  the SDK's in-process state for histogram-heavy workloads.\n\nThis setting only affects the OTLP push exporter; the runtime's Prometheus\nscrape endpoint always exposes cumulative metrics regardless of this value.",
+      "oneOf": [
+        {
+          "description": "Delta temporality. Default — required by Datadog and recommended for\npush-based backends.",
+          "type": "string",
+          "const": "delta"
+        },
+        {
+          "description": "Cumulative temporality. Use for `OTel` collectors that downstream into\nPrometheus or other cumulative-native backends.",
+          "type": "string",
+          "const": "cumulative"
+        },
+        {
+          "description": "Counters use cumulative, histograms use delta.",
+          "type": "string",
+          "const": "low_memory"
+        }
       ]
     },
     "TaskHistory": {
@@ -4318,7 +4343,11 @@
         "fetch_content": {
           "description": "Whether to fetch file content. Set to 'true' to include file content in the 'content' column.",
           "type": "string",
-          "default": "false"
+          "default": "false",
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "cache_path": {
           "description": "Custom path for the local Git repository cache. If not specified, uses system temp directory.",
@@ -4332,6 +4361,105 @@
         "max_file_bytes": {
           "description": "Maximum size (bytes) for an individual file when fetching content. Files larger than this value are skipped. Default: 524288. Maximum: 5242880 (5 MiB).",
           "type": "string"
+        },
+        "git_username": {
+          "description": "Username for HTTP(S) basic authentication.",
+          "type": "string"
+        },
+        "git_password": {
+          "description": "Password or personal access token for HTTP(S) basic authentication.",
+          "type": "string",
+          "x-secret": true
+        },
+        "git_token": {
+          "description": "Personal access token used for HTTP(S) authentication. Equivalent to providing a username of 'x-access-token' with the token as the password.",
+          "type": "string",
+          "x-secret": true
+        },
+        "git_ssh_key": {
+          "description": "Absolute path to an SSH private key used to authenticate to the remote repository.",
+          "type": "string"
+        },
+        "git_ssh_passphrase": {
+          "description": "Passphrase for the SSH private key identified by 'ssh_key'.",
+          "type": "string",
+          "x-secret": true
+        },
+        "git_ssh_use_agent": {
+          "description": "When 'true', attempt to authenticate via the running ssh-agent when no explicit ssh_key is provided. Defaults to 'true'.",
+          "type": "string",
+          "default": "true",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "enable_lfs": {
+          "description": "Whether to fetch git-lfs objects after clone/fetch. Requires the 'git-lfs' CLI to be available on PATH.",
+          "type": "string",
+          "default": "false",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "max_concurrent_requests": {
+          "description": "Maximum number of concurrent Git network operations (clone/fetch) across datasets that share the same repository URL.",
+          "type": "string",
+          "default": "4"
+        },
+        "git_max_retries": {
+          "description": "Maximum number of retries when the connector encounters a transient error cloning or fetching from the remote.",
+          "type": "string",
+          "default": "3"
+        },
+        "backoff_method": {
+          "description": "Backoff strategy for retries on transient errors.",
+          "type": "string",
+          "default": "exponential",
+          "enum": [
+            "exponential",
+            "fibonacci"
+          ]
+        },
+        "disable_on_permanent_error": {
+          "description": "When true, a permanent error (authentication failure, access denied) will disable the connector to prevent a thundering herd of failed requests.",
+          "type": "string",
+          "default": "true",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "git_include": {
+          "description": "**DEPRECATED**: Rename 'git_include' to 'include'.\n\n[deprecated] Use unprefixed 'include'.",
+          "type": "string",
+          "deprecated": true
+        },
+        "git_fetch_content": {
+          "description": "**DEPRECATED**: Rename 'git_fetch_content' to 'fetch_content'.\n\n[deprecated] Use unprefixed 'fetch_content'.",
+          "type": "string",
+          "deprecated": true
+        },
+        "git_cache_path": {
+          "description": "**DEPRECATED**: Rename 'git_cache_path' to 'cache_path'.\n\n[deprecated] Use unprefixed 'cache_path'.",
+          "type": "string",
+          "deprecated": true
+        },
+        "git_max_files": {
+          "description": "**DEPRECATED**: Rename 'git_max_files' to 'max_files'.\n\n[deprecated] Use unprefixed 'max_files'.",
+          "type": "string",
+          "deprecated": true
+        },
+        "git_max_file_bytes": {
+          "description": "**DEPRECATED**: Rename 'git_max_file_bytes' to 'max_file_bytes'.\n\n[deprecated] Use unprefixed 'max_file_bytes'.",
+          "type": "string",
+          "deprecated": true
+        },
+        "git_enable_lfs": {
+          "description": "**DEPRECATED**: Rename 'git_enable_lfs' to 'enable_lfs'.\n\n[deprecated] Use unprefixed 'enable_lfs'.",
+          "type": "string",
+          "deprecated": true
         }
       },
       "additionalProperties": true
@@ -4926,6 +5054,33 @@
           "description": "Number of items per page for query-parameter pagination. Must be a positive integer greater than 0. Used to expand {limit} in pagination_query_params and to detect the last page (fewer results than page_size = done).",
           "type": "string"
         },
+        "auth_token_url": {
+          "description": "OAuth2 token endpoint URL. When set together with http_auth_refresh_token, the connector exchanges the refresh token for short-lived access tokens (RFC 6749 §6) and attaches 'Authorization: Bearer <token>' to all data requests. Applies to JSON API endpoints only.",
+          "type": "string"
+        },
+        "http_auth_refresh_token": {
+          "description": "OAuth2 refresh token exchanged against auth_token_url to obtain access tokens. Required when auth_token_url is set.",
+          "type": "string",
+          "x-secret": true
+        },
+        "http_auth_client_id": {
+          "description": "OAuth2 client_id presented to the token endpoint. Required for confidential clients; optional for public clients. Paired with http_auth_client_secret.",
+          "type": "string",
+          "x-secret": true
+        },
+        "http_auth_client_secret": {
+          "description": "OAuth2 client_secret presented to the token endpoint. Required when the client is confidential; must be set together with http_auth_client_id.",
+          "type": "string",
+          "x-secret": true
+        },
+        "auth_scopes": {
+          "description": "Space-separated OAuth2 scopes to request when refreshing. Omit to inherit the scopes bound to the refresh token. Optional.",
+          "type": "string"
+        },
+        "auth_client_auth": {
+          "description": "How client credentials are sent to the token endpoint: 'basic' (HTTP Basic header, default per RFC 6749 §2.3.1) or 'body' (client_id/client_secret in the form body). Case-insensitive.",
+          "type": "string"
+        },
         "file_format": {
           "type": "string"
         },
@@ -5189,6 +5344,33 @@
         },
         "pagination_page_size": {
           "description": "Number of items per page for query-parameter pagination. Must be a positive integer greater than 0. Used to expand {limit} in pagination_query_params and to detect the last page (fewer results than page_size = done).",
+          "type": "string"
+        },
+        "auth_token_url": {
+          "description": "OAuth2 token endpoint URL. When set together with http_auth_refresh_token, the connector exchanges the refresh token for short-lived access tokens (RFC 6749 §6) and attaches 'Authorization: Bearer <token>' to all data requests. Applies to JSON API endpoints only.",
+          "type": "string"
+        },
+        "http_auth_refresh_token": {
+          "description": "OAuth2 refresh token exchanged against auth_token_url to obtain access tokens. Required when auth_token_url is set.",
+          "type": "string",
+          "x-secret": true
+        },
+        "http_auth_client_id": {
+          "description": "OAuth2 client_id presented to the token endpoint. Required for confidential clients; optional for public clients. Paired with http_auth_client_secret.",
+          "type": "string",
+          "x-secret": true
+        },
+        "http_auth_client_secret": {
+          "description": "OAuth2 client_secret presented to the token endpoint. Required when the client is confidential; must be set together with http_auth_client_id.",
+          "type": "string",
+          "x-secret": true
+        },
+        "auth_scopes": {
+          "description": "Space-separated OAuth2 scopes to request when refreshing. Omit to inherit the scopes bound to the refresh token. Optional.",
+          "type": "string"
+        },
+        "auth_client_auth": {
+          "description": "How client credentials are sent to the token endpoint: 'basic' (HTTP Basic header, default per RFC 6749 §2.3.1) or 'body' (client_id/client_secret in the form body). Case-insensitive.",
           "type": "string"
         },
         "file_format": {

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -759,6 +759,7 @@ fn init_metrics(
                     endpoint = %config.endpoint,
                     protocol = protocol,
                     push_interval = %config.push_interval,
+                    temporality = ?config.temporality,
                     "OTEL metrics exporter enabled"
                 );
             }

--- a/crates/runtime/src/otel_push_exporter.rs
+++ b/crates/runtime/src/otel_push_exporter.rs
@@ -160,7 +160,16 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Re-export the config from spicepod for convenience
-pub use spicepod::component::runtime::OtelExporterConfig;
+pub use spicepod::component::runtime::{OtelExporterConfig, OtelTemporality};
+
+/// Map a spicepod-level [`OtelTemporality`] preference to the OpenTelemetry SDK enum.
+fn map_temporality(t: OtelTemporality) -> Temporality {
+    match t {
+        OtelTemporality::Delta => Temporality::Delta,
+        OtelTemporality::Cumulative => Temporality::Cumulative,
+        OtelTemporality::LowMemory => Temporality::LowMemory,
+    }
+}
 
 /// Creates a [`PeriodicReader`] for pushing metrics to an OTEL collector.
 ///
@@ -189,7 +198,7 @@ pub use spicepod::component::runtime::OtelExporterConfig;
 /// # Example
 ///
 /// ```ignore
-/// use runtime::otel_push_exporter::{create_otel_periodic_reader, OtelExporterConfig};
+/// use runtime::otel_push_exporter::{create_otel_periodic_reader, OtelExporterConfig, OtelTemporality};
 /// use std::collections::HashMap;
 ///
 /// let config = OtelExporterConfig {
@@ -198,6 +207,7 @@ pub use spicepod::component::runtime::OtelExporterConfig;
 ///     push_interval: "30s".to_string(),
 ///     metrics: vec![],
 ///     headers: HashMap::new(),
+///     temporality: OtelTemporality::Delta,
 /// };
 ///
 /// let otel_reader = create_otel_periodic_reader(&config, HashMap::new())?;
@@ -224,19 +234,21 @@ pub fn create_otel_periodic_reader(
             })?;
 
     let protocol = if config.is_http() { "http" } else { "grpc" };
+    let temporality = map_temporality(config.temporality);
     tracing::info!(
         endpoint = %config.endpoint,
         protocol = protocol,
         push_interval_secs = push_interval.as_secs(),
         metrics_filter = ?config.metrics,
         num_headers = resolved_headers.len(),
+        temporality = ?config.temporality,
         "Creating OTEL metrics periodic reader"
     );
 
     let inner_exporter = if config.is_http() {
-        create_http_exporter(&config.endpoint, resolved_headers)?
+        create_http_exporter(&config.endpoint, resolved_headers, temporality)?
     } else {
-        create_grpc_exporter(&config.grpc_endpoint(), &resolved_headers)?
+        create_grpc_exporter(&config.grpc_endpoint(), &resolved_headers, temporality)?
     };
 
     // Wrap with filtering exporter
@@ -252,11 +264,13 @@ pub fn create_otel_periodic_reader(
 fn create_grpc_exporter(
     endpoint: &str,
     headers: &HashMap<String, String>,
+    temporality: Temporality,
 ) -> Result<MetricExporter> {
     let mut builder = MetricExporter::builder()
         .with_tonic()
         .with_endpoint(endpoint)
-        .with_protocol(Protocol::Grpc);
+        .with_protocol(Protocol::Grpc)
+        .with_temporality(temporality);
 
     if !headers.is_empty() {
         let mut metadata = tonic::metadata::MetadataMap::new();
@@ -283,6 +297,7 @@ fn create_grpc_exporter(
 fn create_http_exporter(
     endpoint: &str,
     headers: HashMap<String, String>,
+    temporality: Temporality,
 ) -> Result<MetricExporter> {
     // For HTTP, the endpoint should include the /v1/metrics path
     let full_endpoint = if endpoint.ends_with("/v1/metrics") {
@@ -303,7 +318,8 @@ fn create_http_exporter(
         .with_http()
         .with_http_client(http_client)
         .with_endpoint(full_endpoint)
-        .with_protocol(Protocol::HttpBinary);
+        .with_protocol(Protocol::HttpBinary)
+        .with_temporality(temporality);
 
     if !headers.is_empty() {
         builder = builder.with_headers(headers);
@@ -469,7 +485,11 @@ mod tests {
             ("X-Custom".to_string(), "value".to_string()),
         ]);
         // HTTP exporter with headers should build successfully
-        let result = create_http_exporter("http://localhost:4318/v1/metrics", headers);
+        let result = create_http_exporter(
+            "http://localhost:4318/v1/metrics",
+            headers,
+            Temporality::Delta,
+        );
         assert!(
             result.is_ok(),
             "HTTP exporter with headers should build: {result:?}"
@@ -479,7 +499,11 @@ mod tests {
     #[test]
     fn test_create_http_exporter_without_headers() {
         let headers = HashMap::new();
-        let result = create_http_exporter("http://localhost:4318/v1/metrics", headers);
+        let result = create_http_exporter(
+            "http://localhost:4318/v1/metrics",
+            headers,
+            Temporality::Delta,
+        );
         assert!(
             result.is_ok(),
             "HTTP exporter without headers should build: {result:?}"
@@ -495,7 +519,7 @@ mod tests {
             ("api-key".to_string(), "test-key".to_string()),
             ("x-custom-header".to_string(), "value".to_string()),
         ]);
-        let result = create_grpc_exporter("http://localhost:4317", &headers);
+        let result = create_grpc_exporter("http://localhost:4317", &headers, Temporality::Delta);
         assert!(
             result.is_ok(),
             "gRPC exporter with valid headers should build: {result:?}"
@@ -507,7 +531,7 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
         let _guard = rt.enter();
         let headers = HashMap::new();
-        let result = create_grpc_exporter("http://localhost:4317", &headers);
+        let result = create_grpc_exporter("http://localhost:4317", &headers, Temporality::Delta);
         assert!(
             result.is_ok(),
             "gRPC exporter without headers should build: {result:?}"
@@ -521,7 +545,7 @@ mod tests {
         let _guard = rt.enter();
         // gRPC metadata keys must be lowercase ASCII
         let headers = HashMap::from([("Invalid Key With Spaces".to_string(), "value".to_string())]);
-        let result = create_grpc_exporter("http://localhost:4317", &headers);
+        let result = create_grpc_exporter("http://localhost:4317", &headers, Temporality::Delta);
         assert!(result.is_err());
         let err = result.expect_err("should fail with invalid metadata key");
         let msg = err.to_string();

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -166,6 +166,37 @@ fn default_otel_push_interval() -> String {
     "60s".to_string()
 }
 
+/// Aggregation temporality preference for the OTEL metrics push exporter.
+///
+/// Controls how counter and histogram values are encoded on the wire:
+///
+/// - **`Delta`** (default): each export contains the change since the previous
+///   export. Required by Datadog's OTLP intake and recommended by AWS
+///   `CloudWatch`, New Relic, and most push-based `SaaS` backends. Aligns with the
+///   `OpenTelemetry` guidance for push exporters.
+/// - **`Cumulative`**: each export carries the running total since process
+///   start. Use this for `OTel` collectors that downstream into Prometheus or
+///   other pull-based / cumulative-native backends.
+/// - **`LowMemory`**: counters use cumulative, histograms use delta. Reduces
+///   the SDK's in-process state for histogram-heavy workloads.
+///
+/// This setting only affects the OTLP push exporter; the runtime's Prometheus
+/// scrape endpoint always exposes cumulative metrics regardless of this value.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub enum OtelTemporality {
+    /// Delta temporality. Default — required by Datadog and recommended for
+    /// push-based backends.
+    #[default]
+    Delta,
+    /// Cumulative temporality. Use for `OTel` collectors that downstream into
+    /// Prometheus or other cumulative-native backends.
+    Cumulative,
+    /// Counters use cumulative, histograms use delta.
+    LowMemory,
+}
+
 /// Configuration for pushing metrics to an OpenTelemetry collector.
 ///
 /// The protocol is inferred from the endpoint:
@@ -226,6 +257,16 @@ pub struct OtelExporterConfig {
     /// Values support secret replacement syntax (e.g., `${secrets:api_key}`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub headers: HashMap<String, String>,
+
+    /// Aggregation temporality preference for exported metrics.
+    ///
+    /// Defaults to `delta`, which is required by Datadog and recommended for
+    /// most push-based OTLP backends (`CloudWatch`, New Relic, etc.). Set to
+    /// `cumulative` when forwarding to an `OTel` collector that feeds Prometheus
+    /// or another cumulative-native backend. See [`OtelTemporality`] for
+    /// details.
+    #[serde(default)]
+    pub temporality: OtelTemporality,
 }
 
 impl OtelExporterConfig {
@@ -1477,6 +1518,61 @@ mod tests {
         assert_eq!(otel_config.endpoint, "otel-collector");
         assert!(!otel_config.is_http()); // gRPC: bare hostname
         assert_eq!(otel_config.push_interval, "60s"); // default
+        assert_eq!(otel_config.temporality, OtelTemporality::Delta); // default
+    }
+
+    #[test]
+    fn test_otel_exporter_temporality_default_is_delta() {
+        let yaml = r"
+            telemetry:
+                otel_exporter:
+                    endpoint: otel-collector
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        let otel_config = runtime
+            .telemetry
+            .otel_exporter
+            .expect("otel_exporter should be present");
+        assert_eq!(otel_config.temporality, OtelTemporality::Delta);
+    }
+
+    #[test]
+    fn test_otel_exporter_temporality_parsing() {
+        for (raw, expected) in [
+            ("delta", OtelTemporality::Delta),
+            ("cumulative", OtelTemporality::Cumulative),
+            ("low_memory", OtelTemporality::LowMemory),
+        ] {
+            let yaml = format!(
+                "
+            telemetry:
+                otel_exporter:
+                    endpoint: otel-collector
+                    temporality: {raw}
+        "
+            );
+            let runtime: Runtime = yaml::from_str(&yaml).expect("Failed to parse Runtime");
+            let otel_config = runtime
+                .telemetry
+                .otel_exporter
+                .expect("otel_exporter should be present");
+            assert_eq!(otel_config.temporality, expected, "raw={raw}");
+        }
+    }
+
+    #[test]
+    fn test_otel_exporter_temporality_invalid_rejected() {
+        let yaml = r"
+            telemetry:
+                otel_exporter:
+                    endpoint: otel-collector
+                    temporality: nonsense
+        ";
+        let result: Result<Runtime, _> = yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "unknown temporality value must fail to parse"
+        );
     }
 
     #[test]
@@ -1487,6 +1583,7 @@ mod tests {
             push_interval: "30s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let duration = config
             .push_interval_duration()
@@ -1499,6 +1596,7 @@ mod tests {
             push_interval: "5m".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let duration = config_minutes
             .push_interval_duration()
@@ -1511,6 +1609,7 @@ mod tests {
             push_interval: "1h".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let duration = config_hours
             .push_interval_duration()
@@ -1524,6 +1623,7 @@ mod tests {
             push_interval: "500ms".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let duration = config_ms
             .push_interval_duration()
@@ -1539,6 +1639,7 @@ mod tests {
             push_interval: "0s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let result = config.push_interval_duration();
         assert!(result.is_err());
@@ -1556,6 +1657,7 @@ mod tests {
             push_interval: "invalid".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         let result = config.push_interval_duration();
         let _ = result.expect_err("Expected an error for invalid push_interval");
@@ -1580,6 +1682,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert!(!grpc_bare.is_http());
 
@@ -1590,6 +1693,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert!(!grpc_port.is_http());
 
@@ -1600,6 +1704,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert!(http_scheme.is_http());
 
@@ -1610,6 +1715,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert!(https_config.is_http());
 
@@ -1620,6 +1726,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert!(http_path.is_http());
     }
@@ -1633,6 +1740,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert_eq!(bare.grpc_endpoint(), "http://otel-collector:4317");
 
@@ -1643,6 +1751,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert_eq!(with_port.grpc_endpoint(), "http://otel-collector:9090");
 
@@ -1653,6 +1762,7 @@ mod tests {
             push_interval: "60s".to_string(),
             metrics: vec![],
             headers: HashMap::new(),
+            temporality: OtelTemporality::default(),
         };
         assert_eq!(localhost.grpc_endpoint(), "http://localhost:4317");
     }

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -99,6 +99,7 @@ runtime:
       enabled: true
       endpoint: http://localhost:4317
       push_interval: 60s
+      temporality: delta # delta (default, required by Datadog), cumulative, or low_memory
       metrics:
         - runtime.query_duration_ms
         - runtime.memory_usage_bytes


### PR DESCRIPTION
## Summary

The OTLP push exporter previously used the OpenTelemetry SDK default of **cumulative** aggregation temporality. This is incompatible with several push-based OTLP backends — most notably **Datadog**, whose intake silently drops cumulative counter and histogram datapoints (returning HTTP 2xx) so metrics like `query_duration_ms` and `query_executions` never appear in the UI even though the export request "succeeds".

This PR makes the push exporter default to **delta** temporality and adds a config field to opt out.

## Changes

- New `OtelTemporality` enum (`delta`, `cumulative`, `low_memory`) and a `temporality` field on `OtelExporterConfig`.
- Default is `delta` — required by Datadog, recommended by AWS CloudWatch / New Relic / most push-based OTLP backends, and aligned with OpenTelemetry's guidance for push exporters.
- Plumbed through to both the HTTP and gRPC exporter builders via `MetricExporter::with_temporality(...)`.
- Active temporality is logged at startup so misconfiguration is visible.
- Spicepod JSON schema regenerated and the all-fields example fixture updated.

## Behavior change

This is a behavior change for anyone currently using the OTLP push exporter and relying on cumulative temporality (e.g. forwarding to a collector that downstreams into Prometheus). They can opt back in:

```yaml
runtime:
  telemetry:
    otel_exporter:
      endpoint: ...
      temporality: cumulative   # delta (default) | cumulative | low_memory
```

The runtime's built-in **Prometheus scrape endpoint** is unaffected and continues to expose cumulative metrics regardless of this setting.

## Validation

Manually validated end-to-end against `https://otlp.us3.datadoghq.com`:

- **Before** (cumulative default): runtime exports succeed (HTTP 200), but `query_duration_ms`, `query_execution_duration_ms`, `query_executions`, `query_processed_bytes`, etc. are all silently dropped by Datadog and never appear in Metrics Explorer. Only gauge-shaped instruments like `query_active_count` show up.
- **After** (delta default): all of the above metrics appear in Datadog Metrics Explorer with correct values, no `Failed to export metrics` warnings across multiple push intervals.

Startup log now includes `temporality=Delta` (or whatever was configured):

```
INFO runtime::otel_push_exporter: Creating OTEL metrics periodic reader endpoint=https://otlp.us3.datadoghq.com/v1/metrics protocol="http" push_interval_secs=30 metrics_filter=[] num_headers=1 temporality=Delta
```

## Tests

- 3 new spicepod parsing tests: default-is-delta, all three values parse, unknown value is rejected.
- All existing `otel_exporter` tests in `crates/spicepod` (20) and `crates/runtime` (13) updated to pass the new field / argument and continue to pass.
- `make lint-rust` clean.

## Follow-up to

Builds on #10347 (auth headers support).