### PR TITLE
feat(otel): add metric name prefix at runtime.telemetry.metric_prefix

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -887,6 +887,13 @@
           "description": "Aggregation temporality preference for exported metrics.\n\nDefaults to `delta`, which is required by Datadog and recommended for\nmost push-based OTLP backends (`CloudWatch`, New Relic, etc.). Set to\n`cumulative` when forwarding to an `OTel` collector that feeds Prometheus\nor another cumulative-native backend. See [`OtelTemporality`] for\ndetails.",
           "$ref": "#/$defs/OtelTemporality",
           "default": "delta"
+        },
+        "prefix": {
+          "description": "Optional prefix prepended to every exported metric name.\n\nUseful for namespacing Spice metrics in shared backends so they don't\ncollide with metrics from other services. For example, with\n`prefix: \"spiceai.\"` the runtime metric `query_duration_ms` is exported\nas `spiceai.query_duration_ms`.\n\nThe prefix is applied via an `OpenTelemetry` `View` on the runtime's\n`MeterProvider`, so it affects every metric reader attached to that\nprovider (the `otel_exporter` push reader, the Prometheus scrape\nendpoint, and the cluster on-demand OTLP reader). In practice users\ntypically enable only one of these at a time, so the prefix appears on\nexactly the destination they configured it for.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -567,12 +567,15 @@ pub async fn run(args: Args) -> Result<()> {
             std::collections::HashMap::new()
         };
 
+        let metric_prefix = telemetry_config.get().and_then(|c| c.metric_prefix.clone());
+
         init_metrics(
             &rt.datafusion(),
             prometheus_registry.clone(),
             otel_config,
             resolved_otel_headers,
             metrics_reader,
+            metric_prefix,
         )
         .context(UnableToInitializeMetricsSnafu)?;
     }
@@ -718,10 +721,42 @@ fn init_metrics(
     otel_config: Option<&app::spicepod::component::runtime::OtelExporterConfig>,
     resolved_otel_headers: std::collections::HashMap<String, String>,
     metrics_reader: Option<runtime::metrics_reader::MetricsReader>,
+    metric_prefix: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let resource = Resource::builder().build();
 
     let mut provider_builder = SdkMeterProvider::builder().with_resource(resource);
+
+    // Optional metric name prefix (e.g. "spiceai.") configured under
+    // `runtime.telemetry.metric_prefix`. Applied via an OTel View on the
+    // MeterProvider, so the rename happens once at the SDK layer and is
+    // observed by every reader attached below (Prometheus scrape, cluster
+    // on-demand OTLP, OTEL push). The prefix is intentionally placed at the
+    // telemetry level rather than under any single exporter because
+    // OpenTelemetry 0.31's SDK does not support per-reader name transforms.
+    if let Some(prefix) = metric_prefix.filter(|p| !p.is_empty()) {
+        tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");
+        provider_builder = provider_builder.with_view(
+            move |instrument: &opentelemetry_sdk::metrics::Instrument| {
+                let new_name = format!("{prefix}{}", instrument.name());
+                match opentelemetry_sdk::metrics::Stream::builder()
+                    .with_name(new_name.clone())
+                    .build()
+                {
+                    Ok(stream) => Some(stream),
+                    Err(e) => {
+                        tracing::warn!(
+                            instrument = %instrument.name(),
+                            new_name = %new_name,
+                            error = %e,
+                            "Failed to apply OTEL metric prefix; instrument will keep its original name"
+                        );
+                        None
+                    }
+                }
+            },
+        );
+    }
 
     // Case 1: Prometheus scrape
     if let Some(registry) = registry {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -329,8 +329,31 @@ pub struct TelemetryConfig {
     pub enabled: bool,
     #[serde(default)]
     pub user_agent_collection: UserAgentCollection,
+    /// Custom key/value attributes attached to telemetry metrics emitted by
+    /// spiced. Applied as OpenTelemetry resource attributes on the runtime's
+    /// `MeterProvider`, so they appear as dimensions on every metric exported
+    /// via the Prometheus scrape endpoint, the cluster on-demand OTLP reader,
+    /// and the `otel_exporter` push exporter, and as labels on anonymous
+    /// usage telemetry. Currently does not affect tracing spans or logs.
+    /// Example: `{ environment: prod, region: us-west-2, team: data-platform }`.
     #[serde(default)]
     pub properties: HashMap<String, String>,
+    /// Optional prefix prepended to every exported metric name.
+    ///
+    /// Useful for namespacing Spice metrics in shared backends (e.g. Datadog,
+    /// Grafana Cloud) so they don't collide with metrics from other services.
+    /// For example, with `metric_prefix: "spiceai."` the runtime metric
+    /// `query_duration_ms` is exported as `spiceai.query_duration_ms`.
+    ///
+    /// The prefix is applied via an `OpenTelemetry` `View` on the runtime's
+    /// `MeterProvider`, so it affects every metric reader attached to that
+    /// provider — the Prometheus scrape endpoint (`--metrics`), the cluster
+    /// on-demand OTLP reader, and the `otel_exporter` push reader.
+    /// `OpenTelemetry` 0.31's SDK does not support per-reader name transforms,
+    /// so this knob is intentionally placed at the telemetry level rather
+    /// than under any single exporter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric_prefix: Option<String>,
     /// Optional configuration for pushing metrics to an OpenTelemetry collector
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub otel_exporter: Option<OtelExporterConfig>,
@@ -342,6 +365,7 @@ impl Default for TelemetryConfig {
             enabled: true,
             user_agent_collection: UserAgentCollection::default(),
             properties: HashMap::new(),
+            metric_prefix: None,
             otel_exporter: None,
         }
     }
@@ -1573,6 +1597,29 @@ mod tests {
             result.is_err(),
             "unknown temporality value must fail to parse"
         );
+    }
+
+    #[test]
+    fn test_metric_prefix_default_is_none() {
+        let yaml = r"
+            telemetry:
+                otel_exporter:
+                    endpoint: otel-collector
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.telemetry.metric_prefix, None);
+    }
+
+    #[test]
+    fn test_metric_prefix_parsing() {
+        let yaml = r#"
+            telemetry:
+                metric_prefix: "spiceai."
+                otel_exporter:
+                    endpoint: otel-collector
+        "#;
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.telemetry.metric_prefix.as_deref(), Some("spiceai."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an optional `metric_prefix` field to `runtime.telemetry` that prepends a configurable string to every exported metric name. Useful for namespacing Spice metrics in shared backends (e.g. Datadog, Grafana Cloud, New Relic) so they don't collide with metrics from other services in the same project/account.

## Example

```yaml
runtime:
  telemetry:
    metric_prefix: "spiceai."
    otel_exporter:
      endpoint: https://otlp.us3.datadoghq.com/v1/metrics
      headers:
        DD-API-KEY: ${secrets:dd_api_key}
```

With this config, the runtime metric `query_duration_ms` is exported as `spiceai.query_duration_ms`. Defaults to `None` (no prefix).

## Why `runtime.telemetry.metric_prefix` and not `otel_exporter.prefix`?

The prefix is implemented via an OpenTelemetry `View` on the runtime's `SdkMeterProvider`:

```rust
provider_builder = provider_builder.with_view(move |i: &Instrument| {
    Stream::builder().with_name(format!("{prefix}{}", i.name())).build()...
});
```

OpenTelemetry 0.31's Rust SDK does **not** provide a way to apply per-reader name transforms:

- `opentelemetry_sdk::metrics::data::Metric` fields are `pub(crate)`, so a wrapping `PushMetricExporter` cannot construct or mutate metric names.
- `opentelemetry_otlp::MetricsClient` is `pub(crate)`, so we cannot substitute a custom OTLP transport that mutates the protobuf payload.
- Views are configured on the `SdkMeterProvider` and apply to **all** attached readers (Prometheus scrape, cluster on-demand OTLP, OTLP push) equally.

So in practice this prefix affects every metric reader the runtime has enabled. To avoid misleading users into thinking the field scopes to a single exporter, it lives at the `telemetry` level rather than under `otel_exporter`.

## Error handling

If a `Stream` build ever fails for a renamed instrument (e.g. invalid name characters), the original instrument name is preserved and a `tracing::warn!` is emitted with the instrument name, attempted new name, and the underlying error — instead of silently dropping the prefix.

## Validation

- `cargo test -p spicepod --lib` — 117 passed (115 prior + 2 new for default-is-none and parsing).
- `cargo check -p spiced` — clean.
- `cargo clippy -p spiced --no-deps` — clean.
- Schema regenerated via `cargo run -p spicepodschema .schema/spicepod.schema.json`.

## Related

- #10347 — auth headers
- #10412 — default delta temporality
- #10416 — telemetry.properties as resource attributes