### PR TITLE
fix: Map LargeUtf8 to VARCHAR in Athena ODBC dialect

### DIFF
--- a/crates/data-connectors/connector-odbc/src/lib.rs
+++ b/crates/data-connectors/connector-odbc/src/lib.rs
@@ -106,6 +106,7 @@ fn athena_dialect() -> CustomDialect {
     CustomDialectBuilder::new()
         .with_interval_style(IntervalStyle::MySQL)
         .with_date_field_extract_style(DateFieldExtractStyle::Extract)
+        .with_large_utf8_cast_dtype(datafusion::sql::sqlparser::ast::DataType::Varchar(None))
         .build()
 }
 
@@ -318,6 +319,29 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::common::Result;
+    use datafusion::logical_expr::cast;
+    use datafusion::prelude::col;
+    use datafusion::sql::unparser::Unparser;
+
+    #[test]
+    fn test_athena_dialect_overrides() -> Result<()> {
+        let dialect = athena_dialect();
+        let unparser = Unparser::new(&dialect);
+
+        // large_utf8_cast_dtype: VARCHAR instead of TEXT
+        let expr = cast(col("a"), DataType::LargeUtf8);
+        let actual = format!("{}", unparser.expr_to_sql(&expr)?);
+        assert_eq!(actual, "CAST(a AS VARCHAR)");
+
+        // utf8_cast_dtype: VARCHAR
+        let expr = cast(col("a"), DataType::Utf8);
+        let actual = format!("{}", unparser.expr_to_sql(&expr)?);
+        assert_eq!(actual, "CAST(a AS VARCHAR)");
+
+        Ok(())
+    }
 
     #[test]
     fn test_odbc_driver_is_file() {


### PR DESCRIPTION
## 📝 Summary

Athena (Trino) doesn't support the `TEXT` type which is used by DataFusion as default `CustomDialect` type mapping for `LargeUtf8`

Fix by setting `.with_large_utf8_cast_dtype(Varchar(None))` on the Athena dialect so both `Utf8` and `LargeUtf8` map to `VARCHAR

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/10404

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
