### PR TITLE
fix: Map Utf8/LargeUtf8 to STRING in Databricks/Spark SQL dialects

### DIFF
--- a/crates/data-connectors/connector-odbc/src/lib.rs
+++ b/crates/data-connectors/connector-odbc/src/lib.rs
@@ -99,6 +99,8 @@ fn databricks_dialect() -> CustomDialect {
     CustomDialectBuilder::new()
         .with_identifier_quote_style('`')
         .with_interval_style(IntervalStyle::MySQL)
+        .with_utf8_cast_dtype(datafusion::sql::sqlparser::ast::DataType::String(None))
+        .with_large_utf8_cast_dtype(datafusion::sql::sqlparser::ast::DataType::String(None))
         .build()
 }
 

--- a/crates/data_components/src/databricks/dialect.rs
+++ b/crates/data_components/src/databricks/dialect.rs
@@ -55,6 +55,16 @@ impl Dialect for DatabricksDialect {
         IntervalStyle::MySQL
     }
 
+    /// Databricks/Spark SQL uses STRING for UTF8 strings.
+    fn utf8_cast_dtype(&self) -> ast::DataType {
+        ast::DataType::String(None)
+    }
+
+    /// Databricks/Spark SQL uses STRING for large UTF8 strings.
+    fn large_utf8_cast_dtype(&self) -> ast::DataType {
+        ast::DataType::String(None)
+    }
+
     /// Override scalar functions to translate `DataFusion` functions to Spark SQL equivalents.
     fn scalar_function_to_sql_overrides(
         &self,
@@ -145,6 +155,24 @@ mod tests {
         let dialect = create_dialect();
         assert_eq!(dialect.identifier_quote_style("test"), Some('`'));
         assert_eq!(dialect.identifier_quote_style("column_name"), Some('`'));
+    }
+
+    #[test]
+    fn test_dialect_strings_overrides() -> datafusion::common::Result<()> {
+        let dialect = create_dialect();
+        let unparser = Unparser::new(&dialect);
+
+        // utf8_cast_dtype: STRING instead of VARCHAR
+        let expr = datafusion::logical_expr::cast(datafusion::prelude::col("a"), datafusion::arrow::datatypes::DataType::Utf8);
+        let actual = format!("{}", unparser.expr_to_sql(&expr)?);
+        assert_eq!(actual, "CAST(`a` AS STRING)");
+
+        // large_utf8_cast_dtype: STRING instead of TEXT
+        let expr = datafusion::logical_expr::cast(datafusion::prelude::col("a"), datafusion::arrow::datatypes::DataType::LargeUtf8);
+        let actual = format!("{}", unparser.expr_to_sql(&expr)?);
+        assert_eq!(actual, "CAST(`a` AS STRING)");
+
+        Ok(())
     }
 
     #[test]

--- a/crates/data_components/src/databricks/dialect.rs
+++ b/crates/data_components/src/databricks/dialect.rs
@@ -163,12 +163,18 @@ mod tests {
         let unparser = Unparser::new(&dialect);
 
         // utf8_cast_dtype: STRING instead of VARCHAR
-        let expr = datafusion::logical_expr::cast(datafusion::prelude::col("a"), datafusion::arrow::datatypes::DataType::Utf8);
+        let expr = datafusion::logical_expr::cast(
+            datafusion::prelude::col("a"),
+            datafusion::arrow::datatypes::DataType::Utf8,
+        );
         let actual = format!("{}", unparser.expr_to_sql(&expr)?);
         assert_eq!(actual, "CAST(`a` AS STRING)");
 
         // large_utf8_cast_dtype: STRING instead of TEXT
-        let expr = datafusion::logical_expr::cast(datafusion::prelude::col("a"), datafusion::arrow::datatypes::DataType::LargeUtf8);
+        let expr = datafusion::logical_expr::cast(
+            datafusion::prelude::col("a"),
+            datafusion::arrow::datatypes::DataType::LargeUtf8,
+        );
         let actual = format!("{}", unparser.expr_to_sql(&expr)?);
         assert_eq!(actual, "CAST(`a` AS STRING)");
 

--- a/crates/data_components/src/spark_connect/federation.rs
+++ b/crates/data_components/src/spark_connect/federation.rs
@@ -70,6 +70,8 @@ impl SQLExecutor for SparkConnectTableProvider {
             CustomDialectBuilder::new()
                 .with_interval_style(datafusion::sql::unparser::dialect::IntervalStyle::SQLStandard)
                 .with_identifier_quote_style('`')
+                .with_utf8_cast_dtype(datafusion::sql::sqlparser::ast::DataType::String(None))
+                .with_large_utf8_cast_dtype(datafusion::sql::sqlparser::ast::DataType::String(None))
                 .build(),
         )
     }


### PR DESCRIPTION
## 📝 Summary

Databricks/Spark SQL uses `STRING` for text types. DataFusion's defaults map `Utf8` to `VARCHAR` (which requires a length in Databricks) and `LargeUtf8` to `TEXT` (unsupported), causing tpcds_q15 and tpcds_q62 to fail:

- `[DATATYPE_MISSING_SIZE] DataType "VARCHAR" requires a length parameter`
- `[UNSUPPORTED_DATATYPE] Unsupported data type "TEXT"`

Override `utf8_cast_dtype` and `large_utf8_cast_dtype` to return `STRING` in:
- `DatabricksDialect` (SQL Warehouse path)
- Spark Connect federation dialect
- ODBC `databricks_dialect`

## 🔗 Related

Fixes #10405

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I've also reviewed if it is easy to share single dialect but it is not straightforward => not worth doing this now.
