### PR TITLE
fix(delta_lake): register object stores on cluster executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,9 +4016,11 @@ dependencies = [
  "linkme",
  "paste",
  "runtime",
+ "secrecy",
  "snafu",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/data-connectors/connector-delta-lake/Cargo.toml
+++ b/crates/data-connectors/connector-delta-lake/Cargo.toml
@@ -14,6 +14,8 @@ datafusion.workspace = true
 linkme.workspace = true
 paste.workspace = true
 runtime = { path = "../../runtime" }
+secrecy.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+url.workspace = true

--- a/crates/data-connectors/connector-delta-lake/src/lib.rs
+++ b/crates/data-connectors/connector-delta-lake/src/lib.rs
@@ -19,6 +19,8 @@ use data_components::Read;
 use data_components::delta_lake::DeltaTableFactory;
 use datafusion::config::TableParquetOptions;
 use datafusion::datasource::TableProvider;
+use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::execution::runtime_env::RuntimeEnv;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::build_table_parquet_options;
 use runtime::dataconnector::{
@@ -26,6 +28,7 @@ use runtime::dataconnector::{
     DataConnectorResult, NewDataConnectorResult,
 };
 use runtime::parameters::{ParameterSpec, Parameters};
+use secrecy::ExposeSecret;
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
@@ -35,11 +38,13 @@ use tokio::runtime::Handle;
 #[derive(Debug)]
 pub struct DeltaLake {
     delta_table_factory: DeltaTableFactory,
+    /// Retained so `register_object_stores` can encode the AWS/Azure/GCS
+    /// params into the executor's object store registry URL fragment.
+    params: Parameters,
 }
 
 impl DeltaLake {
     #[must_use]
-    #[expect(clippy::needless_pass_by_value)]
     pub fn new(
         params: Parameters,
         io_runtime: Handle,
@@ -48,6 +53,7 @@ impl DeltaLake {
         Self {
             delta_table_factory: DeltaTableFactory::new(params.to_secret_map(), io_runtime)
                 .with_table_parquet_options(table_parquet_options),
+            params,
         }
     }
 }
@@ -183,6 +189,101 @@ impl DataConnector for DeltaLake {
                 source: e,
             }),
         }
+    }
+
+    /// Registers the underlying object store (S3/Azure/GCS) on the executor's
+    /// `RuntimeEnv` so decoded `ParquetSource` plans, which lose their
+    /// per-scan `parquet_file_reader_factory` during proto round-trip, can
+    /// resolve the bucket via `runtime_env().object_store(url)` with the
+    /// correct region/credentials.
+    ///
+    /// Without this, executors fall back to a default S3 store with no region
+    /// set, which surfaces as `Received redirect without LOCATION` against
+    /// buckets outside `us-east-1`.
+    async fn register_object_stores(
+        &self,
+        dataset: &Dataset,
+        runtime_env: &Arc<RuntimeEnv>,
+    ) -> DataConnectorResult<()> {
+        let storage_location = dataset.path();
+
+        // Delta tables backed by a local filesystem (file://, file paths,
+        // or relative paths like `my_delta_table`) don't need an object
+        // store registration. Match the listing connector's behavior:
+        // emit a warning so misconfigured cluster setups are diagnosable,
+        // then no-op rather than failing executor startup.
+        let parsed = match url::Url::parse(storage_location) {
+            Ok(parsed) => parsed,
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                tracing::warn!(
+                    "Dataset {} delta_lake path `{}` is not an absolute URL; \
+                     skipping cluster object store registration. Cluster \
+                     executors will not be able to resolve this path without \
+                     a shared mount.",
+                    dataset.name,
+                    storage_location,
+                );
+                return Ok(());
+            }
+            Err(source) => {
+                return Err(DataConnectorError::UnableToConnectInternal {
+                    dataconnector: "delta_lake".to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(source),
+                });
+            }
+        };
+
+        if parsed.scheme() == "file" {
+            tracing::warn!(
+                "Dataset {} has a file:// scheme and may not be resolvable on cluster executors without a shared mount.",
+                dataset.name,
+            );
+            return Ok(());
+        }
+
+        // Encode the connector's storage params as the URL fragment so
+        // `SpiceObjectStoreRegistry::get_store` can build the right object
+        // store. `storage_registry_params` returns just the AWS/Azure/GCS
+        // entries with their prefixed names rewritten to the registry's
+        // canonical names.
+        let storage_params = self.params.storage_registry_params();
+        if storage_params.is_empty() {
+            // Nothing connector-specific to register; leave the default
+            // registry behavior in place.
+            return Ok(());
+        }
+
+        let mut parsed = parsed;
+        let mut fragment_builder = url::form_urlencoded::Serializer::new(String::new());
+        for (key, value) in storage_params {
+            fragment_builder.append_pair(&key, value.expose_secret());
+        }
+        parsed.set_fragment(Some(fragment_builder.finish().as_str()));
+
+        let listing_url = ListingTableUrl::parse(parsed).map_err(|source| {
+            DataConnectorError::UnableToConnectInternal {
+                dataconnector: "delta_lake".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: Box::new(source),
+            }
+        })?;
+
+        runtime_env.object_store(&listing_url).map_err(|source| {
+            DataConnectorError::UnableToConnectInternal {
+                dataconnector: "delta_lake".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: Box::new(source),
+            }
+        })?;
+
+        let mut redacted = <ListingTableUrl as AsRef<url::Url>>::as_ref(&listing_url).clone();
+        redacted.set_fragment(None);
+        tracing::debug!(
+            "Configured object storage for Delta Lake Dataset {} ({redacted})",
+            dataset.name,
+        );
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Problem

In distributed Ballista mode (1 scheduler + N executors), Delta Lake datasets backed by S3 buckets outside `us-east-1` fail with:

```
Task <N> failed: DataFusion error: Parquet error: External: Generic S3 error: Error performing GET https://<bucket>.s3.us-east-1.amazonaws.com/... - Received redirect without LOCATION, this normally indicates an incorrectly configured region
```

even though the spicepod sets `delta_lake_aws_region` correctly.

## Cause

Decoded `ParquetSource` plans on executors lose their per-scan `parquet_file_reader_factory` during proto round-trip and fall back to `runtime_env().object_store(url)`. The runtime calls `DataConnector::register_object_stores` for each dataset on executor startup (`crates/runtime/src/cluster/mod.rs:1812`) to populate that registry. The `delta_lake` connector did not implement it, so executors built a default S3 store with no region configured.

## Fix

Mirror the `databricks` connector's existing implementation:

- Retain the connector `Parameters` on `DeltaLake` (in addition to passing them to `DeltaTableFactory`).
- Implement `register_object_stores`: parse `dataset.path()` as the storage URL, encode the AWS/Azure/GCS subset of params via `Parameters::storage_registry_params()` into the URL fragment, and call `runtime_env.object_store(&listing_url)` so `SpiceObjectStoreRegistry::get_store` builds and caches a properly-configured S3/Azure/GCS store on each executor.
- No-op early when the connector has no storage params, preserving today's behavior for credential-less setups.

## Audit of other connectors

Already covered (via `ListingTableConnector::register_object_stores`): `s3`, `gcs`, `abfs`, `file`, `https` (structured), `nfs`, `smb`, `sftp`, `ftp`. Plus `databricks` (own impl).

Same bug, follow-up needed: `glue` (delegates to `S3::read_provider` from `read_provider` only, so the outer connector's no-op `register_object_stores` runs on the executor).

Different shape — needs more than this fix: `iceberg` (custom `IcebergTableProvider` + `s3_*` params not in `storage_registry_params()`), `ducklake` (DuckDB-backed), `sharepoint`, `github`, `https` (text mode).

Doesn't apply: SQL pushdown / Flight stream connectors (`snowflake`, `postgres`, `mysql`, `mssql`, `oracle`, `clickhouse`, `dremio`, `spark`, `flightsql`, `mongodb`, `elasticsearch`, `odbc`, `scylladb`, `kafka`, `debezium`, `dynamodb`, `imap`, `graphql`, `git`, `localpod`, `memory`, `sink`, `spiceai`).

## Testing

- `cargo build -p connector-delta-lake` ✅
- `cargo clippy -p connector-delta-lake --no-deps -- -D warnings` ✅
- `make lint-rust` (running)
- Manual repro pending against the Databricks Unity Catalog-managed S3 bucket from the original report.