### PR TITLE
Enable filter pushdown for `vector_search` UDTF

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -46,7 +46,8 @@ use datafusion::{
 };
 
 use datafusion_expr::{
-    LogicalPlanBuilder, ScalarFunctionArgs, ScalarUDFImpl, binary_expr, col, ident,
+    LogicalPlanBuilder, ScalarFunctionArgs, ScalarUDFImpl, TableProviderFilterPushDown,
+    binary_expr, col, ident,
 };
 #[cfg(any(feature = "s3_vectors", feature = "elasticsearch"))]
 use futures::FutureExt;
@@ -60,7 +61,7 @@ use search::generation::util::get_primary_keys;
 use std::{
     any::Any,
     cmp::min,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, LazyLock, Weak},
 };
 
@@ -771,6 +772,33 @@ impl TableProvider for VectorSearchUDTFProvider {
         TableType::View
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        let schema = self.underlying.schema();
+        let base_field_names: HashSet<&str> =
+            schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+        filters
+            .iter()
+            .map(|f| {
+                // Only push down filters whose columns all exist in the underlying table.
+                // Filters on computed columns (e.g. _score) are not pushable.
+                let pushable = f
+                    .column_refs()
+                    .iter()
+                    .all(|c| base_field_names.contains(c.name()));
+
+                Ok(if pushable {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                })
+            })
+            .collect()
+    }
+
     async fn scan(
         &self,
         state: &dyn Session,
@@ -894,12 +922,24 @@ fn alias_value_to_match(
 }
 
 #[cfg(test)]
-mod parser_tests {
-    use super::VectorSearchTableFunc;
+mod tests {
+    use crate::embeddings::udtf::VectorSearchUDTFProvider;
+    use crate::model::EmbeddingModelStore;
+
+    use super::{VectorSearchTableFunc, VectorSearchTableFuncArgs};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::catalog::TableProvider;
+    use datafusion::datasource::MemTable;
     use datafusion::prelude::Expr;
     use datafusion::scalar::ScalarValue;
+    use datafusion::sql::TableReference;
+    use datafusion_expr::TableProviderFilterPushDown;
     use datafusion_expr::expr::ScalarFunction;
+    use datafusion_expr::{col, lit};
+    use search::SEARCH_SCORE_COLUMN_NAME;
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use tokio::sync::RwLock;
 
     fn lit_utf8(s: &str) -> Expr {
         Expr::Literal(ScalarValue::Utf8(Some(s.to_string())), None)
@@ -946,5 +986,118 @@ mod parser_tests {
         let q = Expr::ScalarFunction(ScalarFunction::new_udf(Arc::clone(&make_array), vec![]));
         let err = VectorSearchTableFunc::parse_query_arg(Some(&q)).expect_err("expected rejection");
         assert!(err.to_string().contains("at least one query string"));
+    }
+
+    /// Create a minimal `VectorSearchUDTFProvider` with the given underlying schema for testing.
+    fn make_provider(schema: Schema) -> VectorSearchUDTFProvider {
+        let schema = Arc::new(schema);
+        let underlying: Arc<dyn TableProvider> =
+            Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![]]).expect("valid MemTable"));
+        VectorSearchUDTFProvider {
+            args: VectorSearchTableFuncArgs {
+                tbl: TableReference::bare("test_table"),
+                query: "test query".to_string(),
+                queries: vec!["test query".to_string()],
+                column: None,
+                limit: Some(5),
+                include_score: Some(true),
+            },
+            underlying,
+            embedded_columns: HashMap::new(),
+            embedding_models: Arc::new(RwLock::new(EmbeddingModelStore::default())),
+        }
+    }
+
+    #[test]
+    fn test_filter_pushdown_base_column() {
+        let provider = make_provider(Schema::new(vec![
+            Field::new("review_date", DataType::Date32, false),
+            Field::new("review_body", DataType::Utf8, false),
+        ]));
+
+        let filter = col("review_date").gt(lit("2015-08-30"));
+        let result = provider
+            .supports_filters_pushdown(&[&filter])
+            .expect("pushdown check should succeed");
+
+        assert_eq!(result, vec![TableProviderFilterPushDown::Exact]);
+    }
+
+    #[test]
+    fn test_filter_pushdown_computed_column_unsupported() {
+        let provider = make_provider(Schema::new(vec![Field::new(
+            "review_date",
+            DataType::Date32,
+            false,
+        )]));
+
+        let filter = col(SEARCH_SCORE_COLUMN_NAME).gt(lit(0.5));
+        let result = provider
+            .supports_filters_pushdown(&[&filter])
+            .expect("pushdown check should succeed");
+
+        assert_eq!(result, vec![TableProviderFilterPushDown::Unsupported]);
+    }
+
+    #[test]
+    fn test_filter_pushdown_mixed_filters() {
+        let provider = make_provider(Schema::new(vec![
+            Field::new("review_date", DataType::Date32, false),
+            Field::new("star_rating", DataType::Int32, false),
+        ]));
+
+        let base_filter = col("review_date").gt(lit("2015-08-30"));
+        let score_filter = col(SEARCH_SCORE_COLUMN_NAME).gt(lit(0.5));
+        let multi_base_filter = col("star_rating").gt_eq(lit(4));
+
+        let result = provider
+            .supports_filters_pushdown(&[&base_filter, &score_filter, &multi_base_filter])
+            .expect("pushdown check should succeed");
+
+        assert_eq!(
+            result,
+            vec![
+                TableProviderFilterPushDown::Exact,
+                TableProviderFilterPushDown::Unsupported,
+                TableProviderFilterPushDown::Exact,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filter_pushdown_mixed_column_expr_unsupported() {
+        let provider = make_provider(Schema::new(vec![Field::new(
+            "review_date",
+            DataType::Date32,
+            false,
+        )]));
+
+        // A filter referencing both a base column and a computed column should not be pushed down.
+        let filter = col("review_date")
+            .gt(lit("2015-08-30"))
+            .and(col(SEARCH_SCORE_COLUMN_NAME).gt(lit(0.5)));
+        let result = provider
+            .supports_filters_pushdown(&[&filter])
+            .expect("pushdown check should succeed");
+
+        assert_eq!(result, vec![TableProviderFilterPushDown::Unsupported]);
+    }
+
+    #[test]
+    fn test_filter_pushdown_constant_expr_exact() {
+        let provider = make_provider(Schema::new(vec![Field::new(
+            "review_date",
+            DataType::Date32,
+            false,
+        )]));
+
+        // A constant expression with no column refs (e.g. `WHERE true`) references no computed
+        // columns, so it is safe to push down — consistent with EmbeddingTable behavior.
+        let filter = lit(true);
+        let result = provider
+            .supports_filters_pushdown(&[&filter])
+            .expect("pushdown check should succeed");
+
+        assert_eq!(result, vec![TableProviderFilterPushDown::Exact]);
     }
 }

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -1100,11 +1100,9 @@ fn alias_value_to_match(
 
 #[cfg(test)]
 mod tests {
-    use super::{VectorSearchTableFunc, closest_column};
+    use super::{VectorSearchTableFunc, VectorSearchTableFuncArgs, closest_column};
     use crate::embeddings::udtf::VectorSearchUDTFProvider;
     use crate::model::EmbeddingModelStore;
-
-    use super::{VectorSearchTableFunc, VectorSearchTableFuncArgs};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::catalog::TableProvider;
     use datafusion::datasource::MemTable;
@@ -1210,6 +1208,7 @@ mod tests {
                 column: None,
                 limit: Some(5),
                 include_score: Some(true),
+                distance_metric: None,
             },
             underlying,
             embedded_columns: HashMap::new(),


### PR DESCRIPTION
## 📝 Summary

Implements `supports_filters_pushdown` on `VectorSearchUDTFProvider` so that WHERE predicates on base table columns are pushed down into the underlying scan before cosine similarity is computed.

Previously, the default `supports_filters_pushdown` returned `Unsupported` for all filters, meaning every `vector_search` query performed a full table scan regardless of WHERE clauses. 

There is already the following existing filter-handling code in `scan()`.

https://github.com/spiceai/spiceai/blob/655a1336790f6fc0d089552942e7cfccc5ab6aea/crates/runtime/src/embeddings/udtf.rs#L807-L809

### Changes
- Add `supports_filters_pushdown` that returns `Exact` for filters referencing only base table columns, `Unsupported` for computed columns (e.g. `_score`)
- Add unit tests for base column, computed column, mixed, and constant expression filters

### Impact
Filters now act as pre-filters (top-K within the filtered set) rather than post-filters, which is what users except IMO

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
