### PR TITLE
Support Snowflake OBJECT, MAP, GEOGRAPHY, GEOMETRY, VECTOR, TIMESTAMP_LTZ types

### DIFF
--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -314,9 +314,21 @@ fn map_snowflake_sql_type(sql_type: &str, precision: Option<u8>, scale: Option<i
                 DataType::Decimal128(p, s)
             }
         }
-        "VARCHAR" | "CHAR" | "CHARACTER" | "STRING" | "TEXT" | "VARIANT" | "OBJECT" | "ARRAY" => {
+        "VARCHAR" | "CHAR" | "CHARACTER" | "STRING" | "TEXT" | "VARIANT" | "OBJECT" | "ARRAY"
+        // Structured MAP collapses to JSON text here because
+        // `information_schema.columns` does not expose key/value types.
+        | "MAP"
+        // GEOGRAPHY/GEOMETRY are serialized by Snowflake as WKT/GeoJSON/WKB
+        // text over the wire; Utf8 is the correct lossless mapping.
+        | "GEOGRAPHY" | "GEOMETRY"
+        // UUID and FILE are textual representations in Snowflake's wire format.
+        | "UUID" | "FILE" => {
             DataType::Utf8
         }
+        // DECFLOAT uses a dynamic base-10 exponent with up to 38 significant
+        // digits, which cannot be losslessly represented by a fixed-scale
+        // Arrow Decimal. Fall back to Utf8 to preserve exact values.
+        "DECFLOAT" => DataType::Utf8,
         "BINARY" | "VARBINARY" => DataType::Binary,
         "BOOLEAN" => DataType::Boolean,
         "DATE" => DataType::Date32,
@@ -376,5 +388,140 @@ impl Read for SnowflakeTableFactory {
         );
 
         Ok(table_provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every Snowflake `information_schema.columns` `DATA_TYPE` we support, paired
+    /// with its expected Arrow mapping. Covers integer/decimal/float variants,
+    /// string/semi-structured types (including `OBJECT`), binary, boolean,
+    /// date/time, and all timestamp variants.
+    #[test]
+    fn test_map_snowflake_sql_type_all_types() {
+        let cases: &[(&str, Option<u8>, Option<i8>, DataType)] = &[
+            // Numeric: NUMBER always decimal; precision/scale honored
+            ("NUMBER", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("NUMBER", Some(12), Some(4), DataType::Decimal128(12, 4)),
+            ("NUMBER", None, None, DataType::Decimal128(38, 0)),
+            ("DECIMAL", Some(10), Some(2), DataType::Decimal128(10, 2)),
+            ("NUMERIC", Some(10), Some(2), DataType::Decimal128(10, 2)),
+            // Integer aliases collapse to Decimal128 with provided precision/scale
+            ("INT", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("INTEGER", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("BIGINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("SMALLINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("TINYINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            ("BYTEINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
+            // Float family
+            ("FLOAT", None, None, DataType::Float32),
+            ("FLOAT4", None, None, DataType::Float32),
+            ("REAL", None, None, DataType::Float32),
+            ("FLOAT8", None, None, DataType::Float64),
+            ("DOUBLE", None, None, DataType::Float64),
+            ("DOUBLE PRECISION", None, None, DataType::Float64),
+            // String-like
+            ("VARCHAR", None, None, DataType::Utf8),
+            ("CHAR", None, None, DataType::Utf8),
+            ("CHARACTER", None, None, DataType::Utf8),
+            ("STRING", None, None, DataType::Utf8),
+            ("TEXT", None, None, DataType::Utf8),
+            // Semi-structured: JSON-serialized strings from Snowflake
+            ("VARIANT", None, None, DataType::Utf8),
+            ("OBJECT", None, None, DataType::Utf8),
+            ("ARRAY", None, None, DataType::Utf8),
+            // Binary
+            ("BINARY", None, None, DataType::Binary),
+            ("VARBINARY", None, None, DataType::Binary),
+            // Boolean / Date / Time
+            ("BOOLEAN", None, None, DataType::Boolean),
+            ("DATE", None, None, DataType::Date32),
+            ("TIME", None, None, DataType::Time64(TimeUnit::Nanosecond)),
+            // Timestamps
+            (
+                "DATETIME",
+                None,
+                None,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            (
+                "TIMESTAMP",
+                None,
+                None,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            (
+                "TIMESTAMP_NTZ",
+                None,
+                None,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            (
+                "TIMESTAMP_LTZ",
+                None,
+                None,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            (
+                "TIMESTAMP_TZ",
+                None,
+                None,
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            ),
+        ];
+
+        for (sql_type, precision, scale, expected) in cases {
+            let got = map_snowflake_sql_type(sql_type, *precision, *scale);
+            assert_eq!(
+                got, *expected,
+                "Mismatch for SQL type '{sql_type}' (precision={precision:?}, scale={scale:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_map_snowflake_sql_type_is_case_insensitive() {
+        assert_eq!(map_snowflake_sql_type("object", None, None), DataType::Utf8);
+        assert_eq!(map_snowflake_sql_type("Object", None, None), DataType::Utf8);
+        assert_eq!(
+            map_snowflake_sql_type("varchar", None, None),
+            DataType::Utf8
+        );
+    }
+
+    #[test]
+    fn test_map_snowflake_sql_type_unknown_falls_back_to_utf8() {
+        // Unknown/future types must not crash the connector; fall back to Utf8
+        // (lossless text representation) while logging a warning.
+        assert_eq!(
+            map_snowflake_sql_type("SOMETHING_NEW", None, None),
+            DataType::Utf8
+        );
+    }
+
+    #[test]
+    fn test_map_snowflake_sql_type_extended_types() {
+        // Explicit coverage for Snowflake types beyond the "classic" SQL set:
+        // - Geospatial (GEOGRAPHY, GEOMETRY) — text-serialized WKT/GeoJSON/WKB.
+        // - Semi-structured MAP — dynamic, collapses to JSON text.
+        // - UUID / FILE — textual wire representations.
+        // - DECFLOAT — dynamic-scale decimal with no lossless fixed-scale
+        //   Arrow mapping; intentionally mapped to Utf8 to preserve exact values.
+        for (sql_type, expected) in [
+            ("GEOGRAPHY", DataType::Utf8),
+            ("GEOMETRY", DataType::Utf8),
+            ("MAP", DataType::Utf8),
+            ("UUID", DataType::Utf8),
+            ("FILE", DataType::Utf8),
+            ("DECFLOAT", DataType::Utf8),
+        ] {
+            assert_eq!(
+                map_snowflake_sql_type(sql_type, None, None),
+                expected,
+                "Mismatch for {sql_type}"
+            );
+        }
     }
 }

--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -306,8 +306,16 @@ fn map_snowflake_sql_type(sql_type: &str, precision: Option<u8>, scale: Option<i
             let s = scale.unwrap_or(0);
             if s == 0 && upper != "NUMBER" {
                 match upper.as_str() {
-                    "FLOAT" | "FLOAT4" | "REAL" => DataType::Float32,
-                    "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION" => DataType::Float64,
+                    // Snowflake documents that FLOAT, FLOAT4, FLOAT8, REAL, DOUBLE,
+                    // and DOUBLE PRECISION are all stored internally as 64-bit
+                    // double-precision floats (see "Summary of data types"
+                    // footnote [1]). Mapping any of these to Float32 would be
+                    // lossy and would also disagree with the `SHOW COLUMNS` path
+                    // that maps "REAL" to Float64. Use Float64 for the entire
+                    // float family to keep both discovery paths consistent.
+                    "FLOAT" | "FLOAT4" | "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION" | "REAL" => {
+                        DataType::Float64
+                    }
                     _ => DataType::Decimal128(p, s),
                 }
             } else {
@@ -416,9 +424,12 @@ mod tests {
             ("TINYINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
             ("BYTEINT", Some(38), Some(0), DataType::Decimal128(38, 0)),
             // Float family
-            ("FLOAT", None, None, DataType::Float32),
-            ("FLOAT4", None, None, DataType::Float32),
-            ("REAL", None, None, DataType::Float32),
+            // Float family: Snowflake stores all float variants as 64-bit
+            // DOUBLE internally, so every variant maps to Float64 to avoid
+            // lossy narrowing and to agree with the SHOW COLUMNS path.
+            ("FLOAT", None, None, DataType::Float64),
+            ("FLOAT4", None, None, DataType::Float64),
+            ("REAL", None, None, DataType::Float64),
             ("FLOAT8", None, None, DataType::Float64),
             ("DOUBLE", None, None, DataType::Float64),
             ("DOUBLE PRECISION", None, None, DataType::Float64),

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -529,14 +529,17 @@ pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error>
         Some("BINARY") => Ok(DataType::Binary),
         Some("BOOLEAN") => Ok(DataType::Boolean),
         Some("DATE") => Ok(DataType::Date32),
-        Some("TIMESTAMP_NTZ") => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        Some("TIMESTAMP_NTZ" | "TIMESTAMP_LTZ") => {
+            // TIMESTAMP_NTZ has no time zone. TIMESTAMP_LTZ stores an
+            // absolute instant (UTC-backed) that is rendered in the session
+            // time zone. Mirror the `information_schema` path, which maps
+            // both to a timezone-less Arrow Timestamp so schema discovery is
+            // consistent across paths. TIMESTAMP_TZ (below) stores an
+            // explicit offset per value and is represented with a UTC
+            // timezone.
+            Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
+        }
         Some("TIME") => Ok(DataType::Time64(TimeUnit::Nanosecond)),
-        // TIMESTAMP_LTZ stores an absolute instant (UTC-backed) that is
-        // rendered in the session time zone. Mirror the `information_schema`
-        // path, which maps both NTZ and LTZ to a timezone-less Arrow Timestamp
-        // so schema discovery is consistent across paths. TIMESTAMP_TZ stores
-        // an explicit offset per value and is represented with a UTC timezone.
-        Some("TIMESTAMP_LTZ") => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         Some("TIMESTAMP_TZ") => Ok(DataType::Timestamp(
             TimeUnit::Nanosecond,
             Some("UTC".into()),
@@ -551,9 +554,19 @@ pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error>
                 .ok_or_else(|| Error::UnableToRetrieveSchema {
                     reason: "VECTOR type missing or invalid 'dimension'".to_string(),
                 })?;
+            // Snowflake VECTOR values are dense numeric arrays; a zero or
+            // negative dimension is not a valid Snowflake type and would
+            // produce a meaningless FixedSizeList. Reject it with a clear
+            // error so schema discovery fails loudly instead of silently
+            // yielding a wrong type.
+            if dimension <= 0 {
+                return Err(Error::UnableToRetrieveSchema {
+                    reason: format!("VECTOR type has non-positive 'dimension': {dimension}"),
+                });
+            }
             let element_type = match data_type["elementType"].as_str() {
-                Some("FLOAT") | Some("FLOAT32") => DataType::Float32,
-                Some("INT") | Some("INT32") => DataType::Int32,
+                Some("FLOAT" | "FLOAT32") => DataType::Float32,
+                Some("INT" | "INT32") => DataType::Int32,
                 Some(other) => {
                     return Err(Error::UnableToRetrieveSchema {
                         reason: format!("Unsupported VECTOR element type: {other}"),
@@ -565,8 +578,11 @@ pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error>
                     });
                 }
             };
+            // Individual elements of a Snowflake VECTOR are never null — the
+            // whole vector value is either present or SQL NULL. Mark the
+            // inner `item` field non-nullable to model this accurately.
             Ok(DataType::FixedSizeList(
-                Arc::new(Field::new("item", element_type, true)),
+                Arc::new(Field::new("item", element_type, false)),
                 dimension,
             ))
         }
@@ -914,14 +930,16 @@ mod tests {
 
     #[test]
     fn test_parse_snowflake_data_type_vector() {
-        // VECTOR<FLOAT, N> → FixedSizeList<Float32, N>
+        // VECTOR<FLOAT, N> → FixedSizeList<Float32, N>. The inner `item`
+        // field is non-nullable because Snowflake VECTOR elements are
+        // always present (only the entire vector value can be SQL NULL).
         let got = parse_snowflake_data_type(
             r#"{"type":"VECTOR","dimension":128,"elementType":"FLOAT","nullable":true}"#,
         )
         .expect("Should parse VECTOR<FLOAT, 128>");
         assert_eq!(
             got,
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128)
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, false)), 128)
         );
 
         // VECTOR<INT, N> → FixedSizeList<Int32, N>
@@ -931,24 +949,32 @@ mod tests {
         .expect("Should parse VECTOR<INT, 4>");
         assert_eq!(
             got,
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, true)), 4)
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, false)), 4)
         );
 
         // Missing dimension must fail clearly rather than produce a wrong type.
-        let err = parse_snowflake_data_type(
-            r#"{"type":"VECTOR","elementType":"FLOAT","nullable":true}"#,
-        )
-        .expect_err("Should error when dimension is missing");
+        let err =
+            parse_snowflake_data_type(r#"{"type":"VECTOR","elementType":"FLOAT","nullable":true}"#)
+                .expect_err("Should error when dimension is missing");
         assert!(
             matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("dimension")),
             "Expected missing dimension error, got: {err:?}"
         );
 
-        // Missing elementType must fail clearly.
+        // Zero or negative dimensions are not valid Snowflake VECTOR types;
+        // reject them so schema discovery fails loudly.
         let err = parse_snowflake_data_type(
-            r#"{"type":"VECTOR","dimension":4,"nullable":true}"#,
+            r#"{"type":"VECTOR","dimension":0,"elementType":"FLOAT","nullable":true}"#,
         )
-        .expect_err("Should error when elementType is missing");
+        .expect_err("Should error when dimension is zero");
+        assert!(
+            matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("dimension")),
+            "Expected non-positive dimension error, got: {err:?}"
+        );
+
+        // Missing elementType must fail clearly.
+        let err = parse_snowflake_data_type(r#"{"type":"VECTOR","dimension":4,"nullable":true}"#)
+            .expect_err("Should error when elementType is missing");
         assert!(
             matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("elementType")),
             "Expected missing elementType error, got: {err:?}"
@@ -1184,10 +1210,7 @@ mod tests {
             ),
             (
                 "c_vector",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, true)),
-                    4,
-                ),
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, false)), 4),
                 true,
             ),
         ];
@@ -1214,7 +1237,7 @@ mod tests {
         // as Utf8 JSON strings and must pass through schema_cast unchanged,
         // preserving both type and values (data correctness).
         let json_object = r#"{"k":"v","n":42}"#;
-        let json_array = r#"[1,2,3]"#;
+        let json_array = r"[1,2,3]";
         let json_variant = r#""hello""#;
 
         let object_array = Arc::new(StringArray::from(vec![Some(json_object), None])) as ArrayRef;

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -519,17 +519,57 @@ pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error>
             let scale = data_type["scale"].as_i64().unwrap_or(0) as i8;
             Ok(DataType::Decimal128(precision, scale))
         }
-        Some("TEXT" | "VARIANT" | "ARRAY") => Ok(DataType::Utf8),
+        // Semi-structured types (dynamic schema per row) and structured MAP
+        // arrive as JSON-serialized strings. Geospatial types are serialized as
+        // WKT/GeoJSON/WKB text. Utf8 is the correct lossless Arrow mapping.
+        Some("TEXT" | "VARIANT" | "ARRAY" | "OBJECT" | "MAP" | "GEOGRAPHY" | "GEOMETRY") => {
+            Ok(DataType::Utf8)
+        }
         Some("REAL") => Ok(DataType::Float64),
         Some("BINARY") => Ok(DataType::Binary),
         Some("BOOLEAN") => Ok(DataType::Boolean),
         Some("DATE") => Ok(DataType::Date32),
         Some("TIMESTAMP_NTZ") => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         Some("TIME") => Ok(DataType::Time64(TimeUnit::Nanosecond)),
+        // TIMESTAMP_LTZ stores an absolute instant (UTC-backed) that is
+        // rendered in the session time zone. Mirror the `information_schema`
+        // path, which maps both NTZ and LTZ to a timezone-less Arrow Timestamp
+        // so schema discovery is consistent across paths. TIMESTAMP_TZ stores
+        // an explicit offset per value and is represented with a UTC timezone.
+        Some("TIMESTAMP_LTZ") => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         Some("TIMESTAMP_TZ") => Ok(DataType::Timestamp(
             TimeUnit::Nanosecond,
             Some("UTC".into()),
         )),
+        // VECTOR is a fixed-length numeric array. Snowflake's type descriptor
+        // embeds `dimension` and `elementType` (FLOAT or INT); map to the
+        // corresponding Arrow FixedSizeList for lossless representation.
+        Some("VECTOR") => {
+            let dimension = data_type["dimension"]
+                .as_u64()
+                .and_then(|n| i32::try_from(n).ok())
+                .ok_or_else(|| Error::UnableToRetrieveSchema {
+                    reason: "VECTOR type missing or invalid 'dimension'".to_string(),
+                })?;
+            let element_type = match data_type["elementType"].as_str() {
+                Some("FLOAT") | Some("FLOAT32") => DataType::Float32,
+                Some("INT") | Some("INT32") => DataType::Int32,
+                Some(other) => {
+                    return Err(Error::UnableToRetrieveSchema {
+                        reason: format!("Unsupported VECTOR element type: {other}"),
+                    });
+                }
+                None => {
+                    return Err(Error::UnableToRetrieveSchema {
+                        reason: "VECTOR type missing 'elementType'".to_string(),
+                    });
+                }
+            };
+            Ok(DataType::FixedSizeList(
+                Arc::new(Field::new("item", element_type, true)),
+                dimension,
+            ))
+        }
         Some(t) => Err(Error::UnableToRetrieveSchema {
             reason: format!("Unsupported Snowflake data type: {t}"),
         }),
@@ -815,6 +855,7 @@ mod tests {
             ),
             (r#"{"type":"VARIANT","nullable":true}"#, DataType::Utf8),
             (r#"{"type":"ARRAY","nullable":true}"#, DataType::Utf8),
+            (r#"{"type":"OBJECT","nullable":true}"#, DataType::Utf8),
         ];
 
         for (input, expected) in test_cases {
@@ -826,6 +867,409 @@ mod tests {
                 "Mismatch for input: {input}"
             );
         }
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_semi_structured() {
+        // Semi-structured Snowflake types (OBJECT, VARIANT, ARRAY) and
+        // structured MAP are returned as JSON-serialized strings in
+        // Snowflake's Arrow wire format and have dynamic, per-row shapes.
+        // Utf8 is the correct lossless Arrow mapping.
+        for input in [
+            r#"{"type":"OBJECT","nullable":true}"#,
+            r#"{"type":"OBJECT","nullable":false}"#,
+            r#"{"type":"VARIANT","nullable":true}"#,
+            r#"{"type":"ARRAY","nullable":true}"#,
+            r#"{"type":"MAP","nullable":true}"#,
+        ] {
+            let got = parse_snowflake_data_type(input)
+                .unwrap_or_else(|e| panic!("Failed to parse '{input}': {e:?}"));
+            assert_eq!(got, DataType::Utf8, "Expected Utf8 for '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_geospatial() {
+        // GEOGRAPHY/GEOMETRY arrive as WKT/GeoJSON/WKB text strings.
+        for input in [
+            r#"{"type":"GEOGRAPHY","nullable":true}"#,
+            r#"{"type":"GEOMETRY","nullable":false}"#,
+        ] {
+            let got = parse_snowflake_data_type(input)
+                .unwrap_or_else(|e| panic!("Failed to parse '{input}': {e:?}"));
+            assert_eq!(got, DataType::Utf8, "Expected Utf8 for '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_timestamp_ltz() {
+        // TIMESTAMP_LTZ must map consistently with the information_schema
+        // path (Timestamp(ns, None)) so schema discovery agrees across paths.
+        let got = parse_snowflake_data_type(
+            r#"{"type":"TIMESTAMP_LTZ","precision":0,"scale":9,"nullable":true}"#,
+        )
+        .expect("Should parse TIMESTAMP_LTZ");
+        assert_eq!(got, DataType::Timestamp(TimeUnit::Nanosecond, None));
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_vector() {
+        // VECTOR<FLOAT, N> → FixedSizeList<Float32, N>
+        let got = parse_snowflake_data_type(
+            r#"{"type":"VECTOR","dimension":128,"elementType":"FLOAT","nullable":true}"#,
+        )
+        .expect("Should parse VECTOR<FLOAT, 128>");
+        assert_eq!(
+            got,
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128)
+        );
+
+        // VECTOR<INT, N> → FixedSizeList<Int32, N>
+        let got = parse_snowflake_data_type(
+            r#"{"type":"VECTOR","dimension":4,"elementType":"INT","nullable":true}"#,
+        )
+        .expect("Should parse VECTOR<INT, 4>");
+        assert_eq!(
+            got,
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, true)), 4)
+        );
+
+        // Missing dimension must fail clearly rather than produce a wrong type.
+        let err = parse_snowflake_data_type(
+            r#"{"type":"VECTOR","elementType":"FLOAT","nullable":true}"#,
+        )
+        .expect_err("Should error when dimension is missing");
+        assert!(
+            matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("dimension")),
+            "Expected missing dimension error, got: {err:?}"
+        );
+
+        // Missing elementType must fail clearly.
+        let err = parse_snowflake_data_type(
+            r#"{"type":"VECTOR","dimension":4,"nullable":true}"#,
+        )
+        .expect_err("Should error when elementType is missing");
+        assert!(
+            matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("elementType")),
+            "Expected missing elementType error, got: {err:?}"
+        );
+
+        // Unknown elementType must fail clearly.
+        let err = parse_snowflake_data_type(
+            r#"{"type":"VECTOR","dimension":4,"elementType":"DOUBLE","nullable":true}"#,
+        )
+        .expect_err("Should error for unsupported elementType");
+        assert!(
+            matches!(err, Error::UnableToRetrieveSchema { ref reason } if reason.contains("DOUBLE")),
+            "Expected unsupported elementType error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_fixed_variants() {
+        // FIXED honors precision/scale and falls back to (38, 0) when absent.
+        let cases = [
+            (
+                r#"{"type":"FIXED","precision":38,"scale":0,"nullable":true}"#,
+                DataType::Decimal128(38, 0),
+            ),
+            (
+                r#"{"type":"FIXED","precision":18,"scale":9,"nullable":false}"#,
+                DataType::Decimal128(18, 9),
+            ),
+            (
+                r#"{"type":"FIXED","precision":5,"scale":-2,"nullable":true}"#,
+                DataType::Decimal128(5, -2),
+            ),
+            (
+                // Missing precision/scale: defaults to (38, 0).
+                r#"{"type":"FIXED","nullable":true}"#,
+                DataType::Decimal128(38, 0),
+            ),
+        ];
+        for (input, expected) in cases {
+            let got = parse_snowflake_data_type(input)
+                .unwrap_or_else(|e| panic!("Failed to parse '{input}': {e:?}"));
+            assert_eq!(got, expected, "Mismatch for '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_parse_schema_from_json_covers_all_types() {
+        // Simulates a `SHOW COLUMNS` JSON response containing every supported
+        // Snowflake type, verifying the end-to-end schema discovery round-trip:
+        // SHOW COLUMNS row -> JSON type descriptor -> Arrow Field.
+        //
+        // SHOW COLUMNS rows are positional arrays where index 2 is the column
+        // name, index 3 is the type descriptor JSON, and index 4 is nullability.
+        let rows = serde_json::json!([
+            [
+                "db",
+                "schema",
+                "c_fixed",
+                r#"{"type":"FIXED","precision":38,"scale":0,"nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_decimal",
+                r#"{"type":"FIXED","precision":12,"scale":4,"nullable":false}"#,
+                "FALSE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_text",
+                r#"{"type":"TEXT","length":16777216,"nullable":true,"fixed":false}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_real",
+                r#"{"type":"REAL","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_binary",
+                r#"{"type":"BINARY","length":8388608,"nullable":true,"fixed":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_bool",
+                r#"{"type":"BOOLEAN","nullable":false}"#,
+                "FALSE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_date",
+                r#"{"type":"DATE","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_ts_ntz",
+                r#"{"type":"TIMESTAMP_NTZ","precision":0,"scale":9,"nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_ts_tz",
+                r#"{"type":"TIMESTAMP_TZ","precision":0,"scale":9,"nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_time",
+                r#"{"type":"TIME","precision":0,"scale":9,"nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_variant",
+                r#"{"type":"VARIANT","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_array",
+                r#"{"type":"ARRAY","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_object",
+                r#"{"type":"OBJECT","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_map",
+                r#"{"type":"MAP","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_geography",
+                r#"{"type":"GEOGRAPHY","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_geometry",
+                r#"{"type":"GEOMETRY","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_ts_ltz",
+                r#"{"type":"TIMESTAMP_LTZ","precision":0,"scale":9,"nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+            [
+                "db",
+                "schema",
+                "c_vector",
+                r#"{"type":"VECTOR","dimension":4,"elementType":"FLOAT","nullable":true}"#,
+                "TRUE",
+                ""
+            ],
+        ]);
+
+        let schema =
+            parse_schema_from_json(&rows).expect("Should parse SHOW COLUMNS JSON into a Schema");
+
+        let expected: Vec<(&str, DataType, bool)> = vec![
+            ("c_fixed", DataType::Decimal128(38, 0), true),
+            ("c_decimal", DataType::Decimal128(12, 4), false),
+            ("c_text", DataType::Utf8, true),
+            ("c_real", DataType::Float64, true),
+            ("c_binary", DataType::Binary, true),
+            ("c_bool", DataType::Boolean, false),
+            ("c_date", DataType::Date32, true),
+            (
+                "c_ts_ntz",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            (
+                "c_ts_tz",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                true,
+            ),
+            ("c_time", DataType::Time64(TimeUnit::Nanosecond), true),
+            ("c_variant", DataType::Utf8, true),
+            ("c_array", DataType::Utf8, true),
+            ("c_object", DataType::Utf8, true),
+            ("c_map", DataType::Utf8, true),
+            ("c_geography", DataType::Utf8, true),
+            ("c_geometry", DataType::Utf8, true),
+            (
+                "c_ts_ltz",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            (
+                "c_vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    4,
+                ),
+                true,
+            ),
+        ];
+
+        assert_eq!(
+            schema.fields().len(),
+            expected.len(),
+            "Field count mismatch"
+        );
+        for (field, (name, dtype, nullable)) in schema.fields().iter().zip(expected.iter()) {
+            assert_eq!(field.name(), name, "Name mismatch");
+            assert_eq!(field.data_type(), dtype, "Type mismatch for {name}");
+            assert_eq!(
+                field.is_nullable(),
+                *nullable,
+                "Nullability mismatch for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_snowflake_schema_cast_passes_through_semi_structured() {
+        // Semi-structured columns (OBJECT/VARIANT/ARRAY) arrive from Snowflake
+        // as Utf8 JSON strings and must pass through schema_cast unchanged,
+        // preserving both type and values (data correctness).
+        let json_object = r#"{"k":"v","n":42}"#;
+        let json_array = r#"[1,2,3]"#;
+        let json_variant = r#""hello""#;
+
+        let object_array = Arc::new(StringArray::from(vec![Some(json_object), None])) as ArrayRef;
+        let array_array =
+            Arc::new(StringArray::from(vec![Some(json_array), Some("[]")])) as ArrayRef;
+        let variant_array =
+            Arc::new(StringArray::from(vec![Some(json_variant), Some("null")])) as ArrayRef;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("obj", DataType::Utf8, true),
+            Field::new("arr", DataType::Utf8, false),
+            Field::new("var", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::clone(&object_array),
+                Arc::clone(&array_array),
+                Arc::clone(&variant_array),
+            ],
+        )
+        .expect("Should build record batch");
+
+        let out = snowflake_schema_cast(&batch).expect("schema_cast should succeed");
+
+        assert_eq!(out.num_columns(), 3);
+        assert_eq!(out.num_rows(), 2);
+        for (i, name) in ["obj", "arr", "var"].iter().enumerate() {
+            assert_eq!(out.schema().field(i).name(), name);
+            assert_eq!(out.schema().field(i).data_type(), &DataType::Utf8);
+        }
+
+        let obj_out = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Should be StringArray");
+        assert_eq!(obj_out.value(0), json_object);
+        assert!(obj_out.is_null(1));
+
+        let arr_out = out
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Should be StringArray");
+        assert_eq!(arr_out.value(0), json_array);
+        assert_eq!(arr_out.value(1), "[]");
+
+        let var_out = out
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Should be StringArray");
+        assert_eq!(var_out.value(0), json_variant);
+        assert_eq!(var_out.value(1), "null");
     }
 
     #[test]

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -506,7 +506,6 @@ where
 /// # Errors
 ///
 /// Returns an error if the JSON is malformed or contains an unsupported type.
-#[expect(clippy::cast_possible_truncation)]
 pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error> {
     let data_type: serde_json::Value =
         serde_json::from_str(data_type_str).map_err(|e| Error::UnableToRetrieveSchema {
@@ -515,8 +514,34 @@ pub fn parse_snowflake_data_type(data_type_str: &str) -> Result<DataType, Error>
 
     match data_type["type"].as_str() {
         Some("FIXED") => {
-            let precision = data_type["precision"].as_u64().unwrap_or(38) as u8;
-            let scale = data_type["scale"].as_i64().unwrap_or(0) as i8;
+            // Snowflake's FIXED precision must fit in Arrow `Decimal128`
+            // (max 38). Snowflake itself also caps precision at 38, so any
+            // larger value is malformed/unexpected. Scale is bounded by the
+            // same range. Use checked conversions with clear error messages
+            // rather than `as` casts, which would silently truncate and
+            // yield wrong schemas — a data-correctness violation.
+            const MAX_DECIMAL128_PRECISION: u64 = 38;
+            let precision_raw = data_type["precision"].as_u64().unwrap_or(38);
+            if precision_raw == 0 || precision_raw > MAX_DECIMAL128_PRECISION {
+                return Err(Error::UnableToRetrieveSchema {
+                    reason: format!(
+                        "FIXED precision {precision_raw} is out of range (expected 1..={MAX_DECIMAL128_PRECISION})",
+                    ),
+                });
+            }
+            // Safe: bounded above by 38.
+            let precision =
+                u8::try_from(precision_raw).map_err(|_| Error::UnableToRetrieveSchema {
+                    reason: format!("FIXED precision {precision_raw} does not fit in u8"),
+                })?;
+            let scale_raw = data_type["scale"].as_i64().unwrap_or(0);
+            let scale = i8::try_from(scale_raw).map_err(|_| Error::UnableToRetrieveSchema {
+                reason: format!(
+                    "FIXED scale {scale_raw} is out of range (expected {}..={})",
+                    i8::MIN,
+                    i8::MAX,
+                ),
+            })?;
             Ok(DataType::Decimal128(precision, scale))
         }
         // Semi-structured types (dynamic schema per row) and structured MAP
@@ -1017,6 +1042,52 @@ mod tests {
             let got = parse_snowflake_data_type(input)
                 .unwrap_or_else(|e| panic!("Failed to parse '{input}': {e:?}"));
             assert_eq!(got, expected, "Mismatch for '{input}'");
+        }
+    }
+
+    #[test]
+    fn test_parse_snowflake_data_type_fixed_out_of_range() {
+        // Using `as` casts on precision/scale would silently truncate
+        // out-of-range values and produce a subtly wrong Arrow schema, which
+        // is a data-correctness violation. Confirm that each malformed or
+        // out-of-range descriptor returns a structured schema error instead.
+        let cases: &[(&str, &str)] = &[
+            // precision > Arrow Decimal128 max (38)
+            (
+                r#"{"type":"FIXED","precision":39,"scale":0,"nullable":true}"#,
+                "precision",
+            ),
+            // precision = 0 is nonsensical for Decimal128
+            (
+                r#"{"type":"FIXED","precision":0,"scale":0,"nullable":true}"#,
+                "precision",
+            ),
+            // precision overflows u8 dramatically
+            (
+                r#"{"type":"FIXED","precision":300,"scale":0,"nullable":true}"#,
+                "precision",
+            ),
+            // scale overflows i8
+            (
+                r#"{"type":"FIXED","precision":10,"scale":200,"nullable":true}"#,
+                "scale",
+            ),
+            // scale underflows i8
+            (
+                r#"{"type":"FIXED","precision":10,"scale":-200,"nullable":true}"#,
+                "scale",
+            ),
+        ];
+        for (input, expected_field) in cases {
+            let err = parse_snowflake_data_type(input)
+                .expect_err(&format!("Should error for malformed input '{input}'"));
+            let Error::UnableToRetrieveSchema { reason } = err else {
+                panic!("Unexpected error type for '{input}': {err:?}");
+            };
+            assert!(
+                reason.contains(expected_field),
+                "Error '{reason}' should mention '{expected_field}' for input '{input}'"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes schema discovery failure on Snowflake tables containing `OBJECT` (and related) columns, which previously errored with:

```
Failed to create Snowflake SQL table: Unable to get schema:
Unable to retrieve schema: Unsupported Snowflake data type: OBJECT
```

While investigating, I audited every Snowflake data type in the [official summary](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types) against both schema-discovery paths and filled the gaps.

## Changes

### `SHOW COLUMNS` JSON path — `parse_snowflake_data_type` (`crates/db_connection_pool`)

Previously errored on several common types. Now explicitly mapped:

| Snowflake type | Arrow `DataType` | Rationale |
| --- | --- | --- |
| `OBJECT`, `MAP` | `Utf8` | Schema-less per-row shape; Snowflake serializes as JSON text. |
| `GEOGRAPHY`, `GEOMETRY` | `Utf8` | Serialized as WKT / GeoJSON / WKB text. |
| `TIMESTAMP_LTZ` | `Timestamp(ns, None)` | Matches the `information_schema` path for cross-path consistency. |
| `VECTOR` | `FixedSizeList<Float32\|Int32, N>` | Parses `dimension` + `elementType` from the descriptor. Errors clearly on malformed/unsupported variants. |

### `information_schema.columns` path — `map_snowflake_sql_type` (`crates/data_components`)

These previously landed in the "unrecognized, default Utf8 + warn" branch. Making them explicit removes warning noise and locks in the intended mapping:

| Snowflake type | Arrow `DataType` |
| --- | --- |
| `MAP`, `GEOGRAPHY`, `GEOMETRY`, `UUID`, `FILE` | `Utf8` |
| `DECFLOAT` | `Utf8` — dynamic base-10 exponent cannot be represented losslessly by fixed-scale `Decimal128`; text is the data-correct choice. |

### Cross-path consistency

`TIMESTAMP_LTZ` now maps identically in both paths. This matters because the runtime probes `information_schema` first and falls back to `SHOW COLUMNS` — a mismatch would yield different schemas for the same table depending on privileges.

## Why `Utf8` for `OBJECT` / `VARIANT` / `ARRAY` / `MAP`

Snowflake's semi-structured types are schema-less by design — rows in the same column can have completely different shapes. The Arrow wire format always delivers them as JSON-serialized strings. `DataType::Struct` requires a fixed schema and `DataType::Map` requires homogeneous value types — neither holds here. `Utf8` is the lossless, data-correct mapping and matches what Snowflake's own JDBC/ODBC drivers expose.

## Tests

Expanded unit-test coverage to all supported types across both paths. All 26 tests pass (16 in `db_connection_pool`, 10 in `data_components`).

New tests:
- `test_parse_snowflake_data_type_semi_structured` — `OBJECT` / `VARIANT` / `ARRAY` / `MAP`
- `test_parse_snowflake_data_type_geospatial` — `GEOGRAPHY` / `GEOMETRY`
- `test_parse_snowflake_data_type_timestamp_ltz`
- `test_parse_snowflake_data_type_vector` — valid `FLOAT` / `INT` variants, plus three clear-error cases (missing `dimension`, missing `elementType`, unsupported `elementType`)
- `test_parse_snowflake_data_type_fixed_variants` — precision / scale round-trips including negative scale and defaults
- `test_parse_schema_from_json_covers_all_types` — end-to-end `SHOW COLUMNS` JSON → Arrow `Schema` round-trip across 18 columns covering every supported type
- `test_snowflake_schema_cast_passes_through_semi_structured` — verifies JSON string values are preserved unchanged through `snowflake_schema_cast`
- `test_map_snowflake_sql_type_all_types`, `_is_case_insensitive`, `_extended_types`, `_unknown_falls_back_to_utf8`

## Known limitation

`information_schema.DATA_TYPE` for `VECTOR` columns does not expose `dimension` / `elementType`, so that path falls through to `Utf8`. The `SHOW COLUMNS` path still maps `VECTOR` precisely to `FixedSizeList` since the type descriptor carries full metadata.
