### PR TITLE
Improve `ready_state: on_schema_resolved`

### DIFF
--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -174,7 +174,7 @@ mod tests {
     /// fallback (source) table reference so federation generates fully-qualified SQL.
     #[tokio::test]
     async fn test_dynamic_table_ref_uses_fallback_before_load() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
         assert!(!refresher.initial_load_completed());
 
         let table = DynamicSQLTable {
@@ -194,7 +194,7 @@ mod tests {
     /// accelerated layer's table reference so queries target the local engine.
     #[tokio::test]
     async fn test_dynamic_table_ref_uses_accelerated_after_load() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
         refresher.set_initial_load_completed(true);
 
         let table = DynamicSQLTable {

--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -14,18 +14,53 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::any::Any;
 use std::sync::Arc;
 
 use super::AcceleratedTable;
-use crate::component::dataset::acceleration::ZeroResultsAction;
+use crate::component::dataset::{ReadyState, acceleration::ZeroResultsAction};
 use data_components::poly::PolyTableProvider;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion_federation::{
-    FederatedTableProviderAdaptor, FederatedTableSource, sql::SQLTableSource,
+    FederatedTableProviderAdaptor, FederatedTableSource,
+    sql::{MultiPartTableReference, SQLTable, SQLTableSource},
 };
 use provider::AcceleratedTableFederationProvider;
 
 mod provider;
+
+/// A [`SQLTable`] that dynamically switches the remote table reference based on
+/// whether the initial acceleration load has completed.
+///
+/// During initial load, queries are federated to the original source (e.g. Databricks)
+/// using `fallback_table_ref`. After load, they target the accelerated layer (e.g. DuckDB)
+/// using `accelerated_table_ref`.
+#[derive(Debug)]
+struct DynamicSQLTable {
+    fallback_table_ref: MultiPartTableReference,
+    accelerated_table_ref: MultiPartTableReference,
+    schema: SchemaRef,
+    refresher: Arc<crate::accelerated_table::refresh::Refresher>,
+}
+
+impl SQLTable for DynamicSQLTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_reference(&self) -> MultiPartTableReference {
+        if self.refresher.initial_load_completed() {
+            self.accelerated_table_ref.clone()
+        } else {
+            self.fallback_table_ref.clone()
+        }
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
 
 impl AcceleratedTable {
     #[must_use]
@@ -37,26 +72,78 @@ impl AcceleratedTable {
                 .clone(),
         );
 
-        let remote_table_name = accelerated_table_federation_provider
+        let accelerated_table_ref = accelerated_table_federation_provider
             .get_table_source()?
             .as_any()
             .downcast_ref::<SQLTableSource>()
             .map(SQLTableSource::table_reference)?;
 
+        // Try to get the federated source's (e.g. Databricks) SQLTableSource so that during
+        // initial load we can federate queries with the correct fully-qualified table reference.
+        let fallback = self.federated.try_table_provider_sync().and_then(|tp| {
+            tp.as_any()
+                .downcast_ref::<FederatedTableProviderAdaptor>()
+                .and_then(|adaptor| {
+                    adaptor
+                        .source
+                        .as_any()
+                        .downcast_ref::<SQLTableSource>()
+                        .map(|s| (s.federation_provider(), s.table_reference()))
+                })
+        });
+
         let enabled =
             self.zero_results_action != ZeroResultsAction::UseSource && !self.disable_federation;
 
-        let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
-            enabled,
-            Some(accelerated_table_federation_provider),
-            self.refresher(),
-        ));
+        // Only fall back to the federated source during initial load for ready states that
+        // are designed to serve queries before acceleration completes. The default `OnLoad`
+        // state must NOT federate during initial load — it returns "Acceleration not ready".
+        let fallback_during_initial_load = matches!(
+            self.ready_state,
+            ReadyState::OnSchemaResolved | ReadyState::OnRegistration
+        );
 
-        Some(Arc::new(SQLTableSource::new_with_schema(
-            fed_provider,
-            remote_table_name,
-            Arc::clone(&self.schema()),
-        )))
+        let table_source: Arc<dyn FederatedTableSource> = match fallback {
+            Some((fb_provider, fb_table_ref)) if fb_table_ref != accelerated_table_ref => {
+                // Federated source uses a different (typically fully-qualified) table reference.
+                // Use a dynamic table that presents the correct reference during each phase.
+                let dynamic_table: Arc<dyn SQLTable> = Arc::new(DynamicSQLTable {
+                    fallback_table_ref: fb_table_ref,
+                    accelerated_table_ref,
+                    schema: Arc::clone(&self.schema()),
+                    refresher: self.refresher(),
+                });
+                let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
+                    enabled,
+                    fallback_during_initial_load,
+                    Some(accelerated_table_federation_provider),
+                    Some(fb_provider),
+                    self.refresher(),
+                ));
+                Arc::new(SQLTableSource::new_with_table(
+                    fed_provider as Arc<_>,
+                    dynamic_table,
+                ))
+            }
+            fallback_same_ref => {
+                // No useful fallback source or same table reference — use the simple path.
+                let fb_provider = fallback_same_ref.map(|(p, _)| p);
+                let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
+                    enabled,
+                    fallback_during_initial_load,
+                    Some(accelerated_table_federation_provider),
+                    fb_provider,
+                    self.refresher(),
+                ));
+                Arc::new(SQLTableSource::new_with_schema(
+                    fed_provider as Arc<_>,
+                    accelerated_table_ref,
+                    Arc::clone(&self.schema()),
+                ))
+            }
+        };
+
+        Some(table_source)
     }
 
     #[must_use]

--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -100,45 +100,28 @@ impl AcceleratedTable {
         // state must NOT federate during initial load — it returns "Acceleration not ready".
         let fallback_during_initial_load = matches!(self.ready_state, ReadyState::OnSchemaResolved);
 
-        let table_source: Arc<dyn FederatedTableSource> = match fallback {
-            Some((fb_provider, fb_table_ref)) if fb_table_ref != accelerated_table_ref => {
-                // Federated source uses a different (typically fully-qualified) table reference.
-                // Use a dynamic table that presents the correct reference during each phase.
-                let dynamic_table: Arc<dyn SQLTable> = Arc::new(DynamicSQLTable {
-                    fallback_table_ref: fb_table_ref,
-                    accelerated_table_ref,
-                    schema: Arc::clone(&self.schema()),
-                    refresher: self.refresher(),
-                });
-                let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
-                    enabled,
-                    fallback_during_initial_load,
-                    Some(accelerated_table_federation_provider),
-                    Some(fb_provider),
-                    self.refresher(),
-                ));
-                Arc::new(SQLTableSource::new_with_table(
-                    fed_provider as Arc<_>,
-                    dynamic_table,
-                ))
-            }
-            fallback_same_ref => {
-                // No useful fallback source or same table reference — use the simple path.
-                let fb_provider = fallback_same_ref.map(|(p, _)| p);
-                let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
-                    enabled,
-                    fallback_during_initial_load,
-                    Some(accelerated_table_federation_provider),
-                    fb_provider,
-                    self.refresher(),
-                ));
-                Arc::new(SQLTableSource::new_with_schema(
-                    fed_provider as Arc<_>,
-                    accelerated_table_ref,
-                    Arc::clone(&self.schema()),
-                ))
-            }
+        let (fb_provider, fallback_table_ref) = match fallback {
+            Some((p, fb_ref)) => (Some(p), fb_ref),
+            None => (None, accelerated_table_ref.clone()),
         };
+
+        let dynamic_table: Arc<dyn SQLTable> = Arc::new(DynamicSQLTable {
+            fallback_table_ref,
+            accelerated_table_ref,
+            schema: Arc::clone(&self.schema()),
+            refresher: self.refresher(),
+        });
+        let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
+            enabled,
+            fallback_during_initial_load,
+            Some(accelerated_table_federation_provider),
+            fb_provider,
+            self.refresher(),
+        ));
+        let table_source: Arc<dyn FederatedTableSource> = Arc::new(SQLTableSource::new_with_table(
+            fed_provider as Arc<_>,
+            dynamic_table,
+        ));
 
         Some(table_source)
     }

--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -34,7 +34,7 @@ mod provider;
 /// whether the initial acceleration load has completed.
 ///
 /// During initial load, queries are federated to the original source (e.g. Databricks)
-/// using `fallback_table_ref`. After load, they target the accelerated layer (e.g. DuckDB)
+/// using `fallback_table_ref`. After load, they target the accelerated layer (e.g. `DuckDB`)
 /// using `accelerated_table_ref`.
 #[derive(Debug)]
 struct DynamicSQLTable {

--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -98,10 +98,7 @@ impl AcceleratedTable {
         // Only fall back to the federated source during initial load for ready states that
         // are designed to serve queries before acceleration completes. The default `OnLoad`
         // state must NOT federate during initial load — it returns "Acceleration not ready".
-        let fallback_during_initial_load = matches!(
-            self.ready_state,
-            ReadyState::OnSchemaResolved | ReadyState::OnRegistration
-        );
+        let fallback_during_initial_load = matches!(self.ready_state, ReadyState::OnSchemaResolved);
 
         let table_source: Arc<dyn FederatedTableSource> = match fallback {
             Some((fb_provider, fb_table_ref)) if fb_table_ref != accelerated_table_ref => {
@@ -155,5 +152,58 @@ impl AcceleratedTable {
             )),
             None => self,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provider::make_refresher;
+
+    fn table_ref(name: &str) -> MultiPartTableReference {
+        MultiPartTableReference::from(datafusion::sql::TableReference::bare(name))
+    }
+
+    fn full_table_ref(catalog: &str, schema: &str, table: &str) -> MultiPartTableReference {
+        MultiPartTableReference::from(datafusion::sql::TableReference::full(
+            catalog, schema, table,
+        ))
+    }
+
+    /// Before initial load completes, `DynamicSQLTable` should present the
+    /// fallback (source) table reference so federation generates fully-qualified SQL.
+    #[tokio::test]
+    async fn test_dynamic_table_ref_uses_fallback_before_load() {
+        let refresher = make_refresher();
+        assert!(!refresher.initial_load_completed());
+
+        let table = DynamicSQLTable {
+            fallback_table_ref: full_table_ref("cat", "sch", "remote"),
+            accelerated_table_ref: table_ref("local"),
+            schema: Arc::new(datafusion::arrow::datatypes::Schema::empty()),
+            refresher,
+        };
+
+        assert_eq!(
+            table.table_reference(),
+            full_table_ref("cat", "sch", "remote")
+        );
+    }
+
+    /// After initial load completes, `DynamicSQLTable` should present the
+    /// accelerated layer's table reference so queries target the local engine.
+    #[tokio::test]
+    async fn test_dynamic_table_ref_uses_accelerated_after_load() {
+        let refresher = make_refresher();
+        refresher.set_initial_load_completed(true);
+
+        let table = DynamicSQLTable {
+            fallback_table_ref: full_table_ref("cat", "sch", "remote"),
+            accelerated_table_ref: table_ref("local"),
+            schema: Arc::new(datafusion::arrow::datatypes::Schema::empty()),
+            refresher,
+        };
+
+        assert_eq!(table.table_reference(), table_ref("local"));
     }
 }

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -22,28 +22,49 @@ use datafusion_federation::{FederationAnalyzerForLogicalPlan, FederationProvider
 #[derive(Debug)]
 pub struct AcceleratedTableFederationProvider {
     enabled: bool,
+    /// If true, federate queries to the source during initial load (for `on_schema_resolved` /
+    /// `on_registration` ready states). If false (default `on_load`), return `None` so that
+    /// `AcceleratedTable::scan()` can surface the "Acceleration not ready" error.
+    fallback_during_initial_load: bool,
+    /// Federation provider for the accelerated layer (e.g. DuckDB). Used post-load.
     provider: Option<Arc<dyn FederationProvider>>,
+    /// Federation provider for the federated source (e.g. Databricks). Used during initial load
+    /// to ensure queries are federated correctly while acceleration is being populated.
+    fallback_provider: Option<Arc<dyn FederationProvider>>,
     refresher: Arc<crate::accelerated_table::refresh::Refresher>,
 }
 
 impl AcceleratedTableFederationProvider {
     pub fn new(
         enabled: bool,
+        fallback_during_initial_load: bool,
         provider: Option<Arc<dyn FederationProvider>>,
+        fallback_provider: Option<Arc<dyn FederationProvider>>,
         refresher: Arc<crate::accelerated_table::refresh::Refresher>,
     ) -> Self {
         Self {
             enabled,
+            fallback_during_initial_load,
             provider,
+            fallback_provider,
             refresher,
         }
     }
 
     fn federation_provider(&self) -> Option<Arc<dyn FederationProvider>> {
-        // If the initial load has completed and this provider is enabled, we can use the accelerated table federation provider.
-        match (self.enabled, self.refresher.initial_load_completed()) {
-            (true, true) => self.provider.clone(),
-            _ => None,
+        if self.refresher.initial_load_completed() {
+            // Post-load: use the accelerated provider (e.g. DuckDB) if federation is enabled.
+            if self.enabled {
+                self.provider.clone()
+            } else {
+                None
+            }
+        } else if self.fallback_during_initial_load {
+            // on_schema_resolved / on_registration: federate to the source during initial load.
+            self.fallback_provider.clone()
+        } else {
+            // on_load (default): don't federate; let AcceleratedTable::scan() return "not ready".
+            None
         }
     }
 }
@@ -54,16 +75,10 @@ impl FederationProvider for AcceleratedTableFederationProvider {
     }
 
     fn compute_context(&self) -> Option<String> {
-        if !self.enabled {
-            return None;
-        }
         self.federation_provider().and_then(|x| x.compute_context())
     }
 
     fn analyzer(&self, plan: &LogicalPlan) -> Option<FederationAnalyzerForLogicalPlan> {
-        if !self.enabled {
-            return None;
-        }
         self.federation_provider()?.analyzer(plan)
     }
 }

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -83,7 +83,7 @@ pub(super) fn make_refresher()
     let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
     let mem_table = Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![]])?);
     let federated = Arc::new(FederatedTable::Immediate(
-        mem_table.clone() as Arc<dyn datafusion::datasource::TableProvider>
+        Arc::clone(&mem_table) as Arc<dyn datafusion::datasource::TableProvider>
     ));
     Ok(Arc::new(Refresher::new(
         crate::status::RuntimeStatus::new(),

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -26,7 +26,7 @@ pub struct AcceleratedTableFederationProvider {
     /// `on_registration` ready states). If false (default `on_load`), return `None` so that
     /// `AcceleratedTable::scan()` can surface the "Acceleration not ready" error.
     fallback_during_initial_load: bool,
-    /// Federation provider for the accelerated layer (e.g. DuckDB). Used post-load.
+    /// Federation provider for the accelerated layer (e.g. `DuckDB`). Used post-load.
     provider: Option<Arc<dyn FederationProvider>>,
     /// Federation provider for the federated source (e.g. Databricks). Used during initial load
     /// to ensure queries are federated correctly while acceleration is being populated.
@@ -164,7 +164,7 @@ mod tests {
         assert_eq!(provider.compute_context(), Some("fallback".to_string()));
     }
 
-    /// Pre-load + fallback disabled (on_load default) → no federation.
+    /// Pre-load + fallback disabled (`on_load` default) → no federation.
     #[tokio::test]
     async fn test_pre_load_fallback_disabled_returns_none() {
         let refresher = make_refresher();
@@ -180,7 +180,7 @@ mod tests {
         assert!(provider.compute_context().is_none());
     }
 
-    /// Post-load + enabled → federate to accelerated layer (e.g. DuckDB).
+    /// Post-load + enabled → federate to accelerated layer (e.g. `DuckDB`).
     #[tokio::test]
     async fn test_post_load_enabled_uses_accelerated_provider() {
         let refresher = make_refresher();

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -52,15 +52,14 @@ impl AcceleratedTableFederationProvider {
     }
 
     fn federation_provider(&self) -> Option<Arc<dyn FederationProvider>> {
+        if !self.enabled {
+            return None;
+        }
         if self.refresher.initial_load_completed() {
-            // Post-load: use the accelerated provider (e.g. DuckDB) if federation is enabled.
-            if self.enabled {
-                self.provider.clone()
-            } else {
-                None
-            }
+            // Post-load: use the accelerated provider (e.g. DuckDB).
+            self.provider.clone()
         } else if self.fallback_during_initial_load {
-            // on_schema_resolved / on_registration: federate to the source during initial load.
+            // on_schema_resolved: federate to the source during initial load.
             self.fallback_provider.clone()
         } else {
             // on_load (default): don't federate; let AcceleratedTable::scan() return "not ready".
@@ -70,7 +69,8 @@ impl AcceleratedTableFederationProvider {
 }
 
 #[cfg(test)]
-pub(super) fn make_refresher() -> Arc<crate::accelerated_table::refresh::Refresher> {
+pub(super) fn make_refresher()
+-> datafusion::common::Result<Arc<crate::accelerated_table::refresh::Refresher>> {
     use crate::accelerated_table::refresh::{Refresh, Refresher};
     use crate::component::dataset::acceleration::RefreshMode;
     use crate::federated_table::FederatedTable;
@@ -81,11 +81,11 @@ pub(super) fn make_refresher() -> Arc<crate::accelerated_table::refresh::Refresh
     use tokio::sync::{Mutex, RwLock};
 
     let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
-    let mem_table = Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![]]).unwrap());
+    let mem_table = Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![]])?);
     let federated = Arc::new(FederatedTable::Immediate(
         mem_table.clone() as Arc<dyn datafusion::datasource::TableProvider>
     ));
-    Arc::new(Refresher::new(
+    Ok(Arc::new(Refresher::new(
         crate::status::RuntimeStatus::new(),
         TableReference::bare("test"),
         federated,
@@ -95,7 +95,7 @@ pub(super) fn make_refresher() -> Arc<crate::accelerated_table::refresh::Refresh
         None,
         Handle::current(),
         Arc::new(Mutex::new(())),
-    ))
+    )))
 }
 
 impl FederationProvider for AcceleratedTableFederationProvider {
@@ -150,7 +150,7 @@ mod tests {
     /// Pre-load + fallback enabled → federate to source (e.g. Databricks).
     #[tokio::test]
     async fn test_pre_load_fallback_enabled_uses_fallback_provider() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
         assert!(!refresher.initial_load_completed());
 
         let provider = AcceleratedTableFederationProvider::new(
@@ -167,7 +167,7 @@ mod tests {
     /// Pre-load + fallback disabled (`on_load` default) → no federation.
     #[tokio::test]
     async fn test_pre_load_fallback_disabled_returns_none() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
 
         let provider = AcceleratedTableFederationProvider::new(
             true,
@@ -180,10 +180,26 @@ mod tests {
         assert!(provider.compute_context().is_none());
     }
 
+    /// Pre-load + federation disabled → no federation even when fallback is configured.
+    #[tokio::test]
+    async fn test_pre_load_federation_disabled_returns_none() {
+        let refresher = make_refresher().expect("make_refresher");
+
+        let provider = AcceleratedTableFederationProvider::new(
+            false,
+            true,
+            Some(accelerated()),
+            Some(fallback()),
+            refresher,
+        );
+
+        assert!(provider.compute_context().is_none());
+    }
+
     /// Post-load + enabled → federate to accelerated layer (e.g. `DuckDB`).
     #[tokio::test]
     async fn test_post_load_enabled_uses_accelerated_provider() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
         refresher.set_initial_load_completed(true);
 
         let provider = AcceleratedTableFederationProvider::new(
@@ -200,7 +216,7 @@ mod tests {
     /// Post-load + disabled → no federation.
     #[tokio::test]
     async fn test_post_load_disabled_returns_none() {
-        let refresher = make_refresher();
+        let refresher = make_refresher().expect("make_refresher");
         refresher.set_initial_load_completed(true);
 
         let provider = AcceleratedTableFederationProvider::new(

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -69,6 +69,35 @@ impl AcceleratedTableFederationProvider {
     }
 }
 
+#[cfg(test)]
+pub(super) fn make_refresher() -> Arc<crate::accelerated_table::refresh::Refresher> {
+    use crate::accelerated_table::refresh::{Refresh, Refresher};
+    use crate::component::dataset::acceleration::RefreshMode;
+    use crate::federated_table::FederatedTable;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::catalog::MemTable;
+    use datafusion::common::TableReference;
+    use tokio::runtime::Handle;
+    use tokio::sync::{Mutex, RwLock};
+
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+    let mem_table = Arc::new(MemTable::try_new(Arc::clone(&schema), vec![vec![]]).unwrap());
+    let federated = Arc::new(FederatedTable::Immediate(
+        mem_table.clone() as Arc<dyn datafusion::datasource::TableProvider>
+    ));
+    Arc::new(Refresher::new(
+        crate::status::RuntimeStatus::new(),
+        TableReference::bare("test"),
+        federated,
+        None,
+        Arc::new(RwLock::new(Refresh::new(RefreshMode::Full))),
+        mem_table,
+        None,
+        Handle::current(),
+        Arc::new(Mutex::new(())),
+    ))
+}
+
 impl FederationProvider for AcceleratedTableFederationProvider {
     fn name(&self) -> &'static str {
         "FederationProviderForAcceleratedDataset"
@@ -80,5 +109,108 @@ impl FederationProvider for AcceleratedTableFederationProvider {
 
     fn analyzer(&self, plan: &LogicalPlan) -> Option<FederationAnalyzerForLogicalPlan> {
         self.federation_provider()?.analyzer(plan)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockFederationProvider {
+        context: &'static str,
+    }
+
+    impl FederationProvider for MockFederationProvider {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn compute_context(&self) -> Option<String> {
+            Some(self.context.to_string())
+        }
+
+        fn analyzer(&self, _: &LogicalPlan) -> Option<FederationAnalyzerForLogicalPlan> {
+            None
+        }
+    }
+
+    fn accelerated() -> Arc<dyn FederationProvider> {
+        Arc::new(MockFederationProvider {
+            context: "accelerated",
+        })
+    }
+
+    fn fallback() -> Arc<dyn FederationProvider> {
+        Arc::new(MockFederationProvider {
+            context: "fallback",
+        })
+    }
+
+    /// Pre-load + fallback enabled → federate to source (e.g. Databricks).
+    #[tokio::test]
+    async fn test_pre_load_fallback_enabled_uses_fallback_provider() {
+        let refresher = make_refresher();
+        assert!(!refresher.initial_load_completed());
+
+        let provider = AcceleratedTableFederationProvider::new(
+            true,
+            true,
+            Some(accelerated()),
+            Some(fallback()),
+            refresher,
+        );
+
+        assert_eq!(provider.compute_context(), Some("fallback".to_string()));
+    }
+
+    /// Pre-load + fallback disabled (on_load default) → no federation.
+    #[tokio::test]
+    async fn test_pre_load_fallback_disabled_returns_none() {
+        let refresher = make_refresher();
+
+        let provider = AcceleratedTableFederationProvider::new(
+            true,
+            false,
+            Some(accelerated()),
+            Some(fallback()),
+            refresher,
+        );
+
+        assert!(provider.compute_context().is_none());
+    }
+
+    /// Post-load + enabled → federate to accelerated layer (e.g. DuckDB).
+    #[tokio::test]
+    async fn test_post_load_enabled_uses_accelerated_provider() {
+        let refresher = make_refresher();
+        refresher.set_initial_load_completed(true);
+
+        let provider = AcceleratedTableFederationProvider::new(
+            true,
+            true,
+            Some(accelerated()),
+            Some(fallback()),
+            refresher,
+        );
+
+        assert_eq!(provider.compute_context(), Some("accelerated".to_string()));
+    }
+
+    /// Post-load + disabled → no federation.
+    #[tokio::test]
+    async fn test_post_load_disabled_returns_none() {
+        let refresher = make_refresher();
+        refresher.set_initial_load_completed(true);
+
+        let provider = AcceleratedTableFederationProvider::new(
+            false,
+            false,
+            Some(accelerated()),
+            Some(fallback()),
+            refresher,
+        );
+
+        assert!(provider.compute_context().is_none());
     }
 }

--- a/crates/runtime/tests/ready_state/snapshots/integration__ready_state__test_ready_state_on_schema_resolved_federated_duckdb_acceleration.snap
+++ b/crates/runtime/tests/ready_state/snapshots/integration__ready_state__test_ready_state_on_schema_resolved_federated_duckdb_acceleration.snap
@@ -2,11 +2,15 @@
 source: crates/runtime/tests/ready_state/mod.rs
 expression: explain_str
 ---
-+---------------+----------------------------------------------------------------+
-| plan_type     | plan                                                           |
-+---------------+----------------------------------------------------------------+
-| logical_plan  | TableScan: federated_on_schema_resolved_duckdb projection=[id] |
-| physical_plan | BytesProcessedExec                                             |
-|               |   DataSourceExec: partitions=1, partition_sizes=[1]            |
-|               |                                                                |
-+---------------+----------------------------------------------------------------+
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                 |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Federated                                                                                                                                                                            |
+|               |  Projection: federated_on_schema_resolved_duckdb.id                                                                                                                                  |
+|               |   TableScan: federated_on_schema_resolved_duckdb projection=[id]                                                                                                                     |
+| physical_plan | SchemaCastScanExec                                                                                                                                                                   |
+|               |   CooperativeExec                                                                                                                                                                    |
+|               |     BytesProcessedExec                                                                                                                                                               |
+|               |       VirtualExecutionPlan name=mock_sql_executor compute_context=mock_context base_sql=SELECT "federated_on_schema_resolved_duckdb"."id" FROM "federated_on_schema_resolved_duckdb" |
+|               |                                                                                                                                                                                      |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## 📝 Summary

For accelerated datasets with `on_schema_resolved` ready states, queries arriving during initial load are now federated to the source using the correct fully-qualified table - new `DynamicSQLTable` struct is added to handle such cases properly.

Plus tests.