### PR TITLE
fix(cluster): forward register_object_stores through connector wrappers

### DIFF
--- a/crates/runtime/src/dataconnector/deferred.rs
+++ b/crates/runtime/src/dataconnector/deferred.rs
@@ -65,6 +65,16 @@ impl DataConnector for DeferredConnector {
         Ok(Arc::new(self.clone()))
     }
 
+    async fn register_object_stores(
+        &self,
+        dataset: &Dataset,
+        runtime_env: &Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+    ) -> super::DataConnectorResult<()> {
+        self.inner
+            .register_object_stores(dataset, runtime_env)
+            .await
+    }
+
     fn initialization(&self) -> ComponentInitialization {
         ComponentInitialization::OnTrigger
     }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -223,6 +223,16 @@ impl DataConnector for EmbeddingConnector {
         self.inner_connector.metadata_provider(dataset).await
     }
 
+    async fn register_object_stores(
+        &self,
+        dataset: &Dataset,
+        runtime_env: &Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+    ) -> DataConnectorResult<()> {
+        self.inner_connector
+            .register_object_stores(dataset, runtime_env)
+            .await
+    }
+
     fn initialization(&self) -> ComponentInitialization {
         self.inner_connector.initialization()
     }

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -123,6 +123,16 @@ impl DataConnector for FullTextConnector {
         self.inner_connector.metadata_provider(dataset).await
     }
 
+    async fn register_object_stores(
+        &self,
+        dataset: &Dataset,
+        runtime_env: &Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+    ) -> DataConnectorResult<()> {
+        self.inner_connector
+            .register_object_stores(dataset, runtime_env)
+            .await
+    }
+
     fn initialization(&self) -> ComponentInitialization {
         self.inner_connector.initialization()
     }


### PR DESCRIPTION
## Summary

Wrappers around `DataConnector` — `EmbeddingConnector`, `FullTextConnector`, and `DeferredConnector` — were inheriting the default no-op `register_object_stores` trait impl. On cluster executors, `get_dataconnector_from_dataset` wraps the underlying connector when a dataset has embeddings, full-text columns, or deferred initialization, so `executor_bind_object_stores` ended up calling the wrapper's no-op impl instead of the inner connector's impl.

The result: object stores were silently never registered for affected datasets (e.g. a Databricks `delta_lake` dataset with embeddings), and the executor fell back to a default-region S3 client when DataFusion later asked the runtime env for a store, surfacing as `BareRedirect` against buckets outside `us-east-1`.

This is a regression caught after #10414 / #10436 added connector-driven object store registration on executors — the wrappers were not updated to forward the new hook.

## Change

Forward `register_object_stores` from each wrapper (`EmbeddingConnector`, `FullTextConnector`, `DeferredConnector`) to its inner connector.

## Repro

Spicepod on a cluster with at least one Databricks delta_lake dataset that has embeddings configured, e.g.:

```yaml
datasets:
  - from: databricks:catalog.schema.amazon_reviews_embed
    name: amazon_reviews
    params:
      databricks_aws_access_key_id: ${ secrets:... }
      databricks_aws_region: us-west-2
      databricks_aws_secret_access_key: ${ secrets:... }
      databricks_endpoint: ...
      databricks_token: ${ secrets:... }
      mode: delta_lake
    columns:
      - name: review_body
        embeddings:
          - from: hf_static_mrl
            vector_size: 1024
```

Before: Ballista task on executor fails with `BareRedirect` because the executor falls back to the default-region S3 client.

After: Executor uses the Databricks connector's configured AWS region/credentials, request goes to the right region, no redirect.
