### PR TITLE
docs(copilot): flag missing wrapper delegation when adding default trait methods

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -491,6 +491,24 @@ export PATH="$PATH:$HOME/.spice/bin"
 - `docs/PRINCIPLES.md`, `docs/EXTENSIBILITY.md`, `docs/dev/style_guide.md`, `docs/dev/error_handling.md`
 - `CONTRIBUTING.md`, `Makefile`, `Cargo.toml`, `crates/runtime/src/lib.rs`
 
+## Trait Evolution & Wrapper Delegation (CRITICAL)
+
+When **adding a new method to a trait** — especially one with a default implementation — audit every wrapper/decorator implementation of that trait and ensure each one **forwards the call to its inner instance**. Default impls are silent traps for wrappers: they compile cleanly but no-op the behavior, causing regressions that often only surface in specific runtime configurations (e.g. cluster executors, accelerated tables, embedded/full-text wrappers).
+
+This pattern caused real regressions, e.g. [#10460](https://github.com/spiceai/spiceai/pull/10460): `register_object_stores` was added to `DataConnector` with a no-op default impl, but `EmbeddingConnector`, `FullTextConnector`, and `DeferredConnector` were not updated to forward it. On cluster executors, object stores were silently never registered for affected datasets, causing `BareRedirect` errors against non-default-region S3 buckets.
+
+**Reviewer checklist when a PR adds or changes a trait method:**
+
+1. **Identify all wrapper/decorator impls** of the trait. Common Spice traits with wrappers include (non-exhaustive):
+   - `DataConnector` — wrapped by `EmbeddingConnector`, `FullTextConnector`, `DeferredConnector`
+   - `TableProvider` — wrapped by `AcceleratedTable`, `FederatedTable`, view providers, sink providers
+   - `Read`, `ReadWrite`, `Catalog`, `SecretStore`, `Chat`, `Embed`, `Nql` — check for newtype/decorator wrappers in `data_components/`, `runtime/`, `llms/`, `model_components/`, `search/`
+   - Search by ripgrep: `rg -n "impl\s+(\w+\s+for\s+)?<TraitName>\b" crates/`
+2. **For every wrapper, verify the new method is explicitly implemented and delegates to the inner type.** Inheriting the default impl is almost always a bug for wrappers — even when the default is a no-op, since the wrapper's inner connector may have meaningful behavior.
+3. **Flag PRs that add a defaulted trait method without touching corresponding wrapper impls.** Ask the author to confirm each wrapper has been audited, or to add explicit forwarding impls.
+4. **Prefer no default impl on traits with known wrappers** when the correct behavior cannot be "do nothing". Forcing implementors to write the method makes wrappers visible at compile time. If a default is necessary for backward compatibility, leave a comment on the trait method pointing wrapper authors at the forwarding requirement.
+5. **Call out missing test coverage**: regressions of this kind typically escape unit tests because the default impl compiles. Suggest an integration or cluster/executor test that exercises the wrapped path when feasible.
+
 ## Gotchas
 
 1. Don't use `stream!` macro


### PR DESCRIPTION
## Summary

Updates `.github/copilot-instructions.md` to teach the Copilot PR reviewer to catch a recurring class of regression: adding a method (especially a defaulted one) to a trait that has wrapper/decorator implementations, without forwarding the call from each wrapper to its inner instance.

The default impl compiles silently in the wrapper but no-ops the behavior, so the regression typically only surfaces in specific runtime configurations (cluster executors, accelerated tables, embedded/full-text wrappers, etc.).

## Motivating example

[#10460](https://github.com/spiceai/spiceai/pull/10460) \u2014 `register_object_stores` was added to `DataConnector` with a no-op default impl, but `EmbeddingConnector`, `FullTextConnector`, and `DeferredConnector` were not updated. On cluster executors, object stores were silently never registered for affected datasets, surfacing as `BareRedirect` against non-default-region S3 buckets.

## Change

Adds a **Trait Evolution & Wrapper Delegation (CRITICAL)** section with:

- A non-exhaustive catalog of Spice traits that have known wrappers (`DataConnector`, `TableProvider`, `Read`/`ReadWrite`, `Catalog`, `SecretStore`, `Chat`, `Embed`, `Nql`).
- A ripgrep query to enumerate impls.
- A 5-step reviewer checklist: identify wrappers \u2192 verify each forwards \u2192 flag missing forwarding impls \u2192 prefer no default impl when "do nothing" is wrong \u2192 call out missing test coverage on the wrapped path.

Docs-only change; no runtime impact.