### PR TITLE
feat(cluster): consolidate distributed state into cluster.json

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -190,7 +190,7 @@ utoipa-swagger-ui = { version = ">=8.1.1", features = [
 ], optional = true }
 
 gethostname.workspace = true
-uuid = { workspace = true, features = ["v7"] }
+uuid = { workspace = true, features = ["v4", "v7"] }
 workers = { path = "../workers" }
 x509-certificate.workspace = true
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -18,7 +18,7 @@ use crate::cluster::DistributedNode;
 use crate::cluster::ExecutorRegistry;
 use crate::cluster::PartitionManager;
 use crate::cluster::ResolvedClusterConfig;
-use crate::cluster::partition;
+use crate::cluster::{ClusterStateStore, SchedulerHeartbeatStore};
 use crate::config::ClusterRole;
 use crate::config::Config;
 use crate::datafusion::udf::register_udfs;
@@ -251,56 +251,76 @@ impl RuntimeBuilder {
                     .as_ref()
                     .and_then(|app| app.runtime.scheduler.clone())
                 {
-                    match partition::build_partition_metadata_store(
-                        io_runtime.clone(),
+                    match crate::cluster::scheduler_registry::build_object_store_internal(
                         Arc::clone(&secrets),
+                        io_runtime.clone(),
+                        &scheduler_config.state_location,
                         &scheduler_config,
                     )
                     .await
                     {
-                        Ok(store) => {
-                            let partition_manager =
-                                Arc::new(PartitionManager::new(Arc::clone(&store)));
+                        Ok((store, base_prefix)) => {
+                            let cluster_state =
+                                Arc::new(ClusterStateStore::new(Arc::clone(&store), &base_prefix));
+                            let heartbeats = Arc::new(SchedulerHeartbeatStore::new(
+                                Arc::clone(&store),
+                                &base_prefix,
+                            ));
+                            let accelerations_partitions = Arc::new(
+                                PartitionManager::accelerations(Arc::clone(&cluster_state)),
+                            );
+                            let catalog_partitions =
+                                Arc::new(PartitionManager::catalog(Arc::clone(&cluster_state)));
 
                             Some(DistributedNode::Scheduler {
                                 peers: Arc::new(RwLock::new(HashMap::new())),
                                 // Initialized later when scheduler registry starts
                                 job_executor: Arc::new(RwLock::new(None)),
                                 executor_registry: Arc::new(ExecutorRegistry::new(
-                                    Arc::clone(&partition_manager),
-                                    Arc::new(
-                                        PartitionManager::new(Arc::clone(&store))
-                                            .with_prefix("catalog/partitions/"),
-                                    ),
+                                    Arc::clone(&accelerations_partitions),
+                                    Arc::clone(&catalog_partitions),
                                 )),
-                                partition_manager,
+                                cluster_state,
+                                heartbeats,
+                                accelerations_partitions,
+                                catalog_partitions,
                             })
                         }
                         Err(e) => {
                             tracing::error!(
-                                "Failed to initialize partition metadata store for scheduler: {e}"
+                                "Failed to initialize cluster state store for scheduler: {e}"
                             );
                             None
                         }
                     }
                 } else {
                     tracing::warn!(
-                        "'--role scheduler' was specified but no `runtime.scheduler` field was found in spicepod.yaml. Using in-memory partition store."
+                        "'--role scheduler' was specified but no `runtime.scheduler` field was found in spicepod.yaml. Using in-memory cluster state."
                     );
                     let store: Arc<dyn object_store::ObjectStore> =
                         Arc::new(object_store::memory::InMemory::new());
-                    let partition_manager = Arc::new(PartitionManager::new(Arc::clone(&store)));
+                    let cluster_state = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+                    if let Err(err) = cluster_state.bootstrap().await {
+                        tracing::warn!(
+                            "Failed to bootstrap in-memory cluster state document; will retry: {err}"
+                        );
+                    }
+                    let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+                    let accelerations_partitions =
+                        Arc::new(PartitionManager::accelerations(Arc::clone(&cluster_state)));
+                    let catalog_partitions =
+                        Arc::new(PartitionManager::catalog(Arc::clone(&cluster_state)));
                     Some(DistributedNode::Scheduler {
                         peers: Arc::new(RwLock::new(HashMap::new())),
                         job_executor: Arc::new(RwLock::new(None)),
                         executor_registry: Arc::new(ExecutorRegistry::new(
-                            Arc::clone(&partition_manager),
-                            Arc::new(
-                                PartitionManager::new(Arc::clone(&store))
-                                    .with_prefix("catalog/partitions/"),
-                            ),
+                            Arc::clone(&accelerations_partitions),
+                            Arc::clone(&catalog_partitions),
                         )),
-                        partition_manager,
+                        cluster_state,
+                        heartbeats,
+                        accelerations_partitions,
+                        catalog_partitions,
                     })
                 }
             }

--- a/crates/runtime/src/cluster/cluster_state.rs
+++ b/crates/runtime/src/cluster/cluster_state.rs
@@ -1,0 +1,663 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Single-document cluster state stored at `cluster.json`.
+//!
+//! This module holds [`ClusterState`] (the schema for the document), the
+//! [`ClusterStateStore`] wrapper that performs OCC reads/writes, and the
+//! [`mutate`](ClusterStateStore::mutate) abstraction that all writers go
+//! through.
+//!
+//! Layout reminder: every non-job piece of distributed state lives in this
+//! one document — registered schedulers (without per-tick heartbeat data),
+//! accelerated table partition metadata, and catalog/federated table
+//! partition metadata. Heartbeats live in `heartbeats/{id}.json` and are
+//! managed by [`crate::cluster::heartbeat::SchedulerHeartbeatStore`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, ObjectStore, PutMode, PutOptions, UpdateVersion};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use uuid::Uuid;
+
+use crate::cluster::partition::TablePartitionMetadata;
+
+/// Current schema version for `cluster.json`. Bump if the on-disk shape
+/// changes; readers reject unknown versions.
+pub const CLUSTER_STATE_SCHEMA_VERSION: u32 = 1;
+
+/// Maximum number of conditional-write attempts for [`ClusterStateStore::mutate`].
+/// Bumped from the 5 used per-table in the old layout because the document is
+/// now shared across all schedulers and partition operations.
+const MAX_MUTATE_ATTEMPTS: usize = 8;
+
+/// Logical scheduler identifier (`host:port` style, stable across restarts).
+pub type SchedulerId = String;
+/// Normalized table name as produced by [`crate::cluster::partition::metadata::normalized_table_name`].
+pub type NormalizedTableName = String;
+
+/// The full distributed cluster state, persisted as a single OCC document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClusterState {
+    pub schema_version: u32,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+
+    /// All currently registered schedulers (heartbeats live in a separate
+    /// per-scheduler file).
+    #[serde(default)]
+    pub schedulers: HashMap<SchedulerId, SchedulerEntry>,
+
+    /// Partition metadata for accelerated tables.
+    #[serde(default)]
+    pub accelerations: HashMap<NormalizedTableName, TablePartitionMetadata>,
+
+    /// Partition metadata for catalog/federated tables.
+    #[serde(default)]
+    pub catalog: HashMap<NormalizedTableName, TablePartitionMetadata>,
+}
+
+impl ClusterState {
+    fn new(now_ms: u64) -> Self {
+        Self {
+            schema_version: CLUSTER_STATE_SCHEMA_VERSION,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+            schedulers: HashMap::new(),
+            accelerations: HashMap::new(),
+            catalog: HashMap::new(),
+        }
+    }
+}
+
+/// One scheduler's registration. The `instance_id` is regenerated on every
+/// process start so that takeover and heartbeat ownership stay safe even
+/// though heartbeats live in a separate file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SchedulerEntry {
+    pub scheduler_id: SchedulerId,
+    pub instance_id: Uuid,
+    pub advertise_address: String,
+    pub grpc_address: String,
+    pub http_address: String,
+    pub started_at_ms: u64,
+    pub ttl_ms: u64,
+    pub build_version: String,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+/// Which partition submap a [`ClusterStateStore`] mutation should operate on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PartitionScope {
+    Acceleration,
+    Catalog,
+}
+
+impl PartitionScope {
+    pub(crate) fn map_mut(
+        self,
+        state: &mut ClusterState,
+    ) -> &mut HashMap<NormalizedTableName, TablePartitionMetadata> {
+        match self {
+            PartitionScope::Acceleration => &mut state.accelerations,
+            PartitionScope::Catalog => &mut state.catalog,
+        }
+    }
+
+    pub(crate) fn map(
+        self,
+        state: &ClusterState,
+    ) -> &HashMap<NormalizedTableName, TablePartitionMetadata> {
+        match self {
+            PartitionScope::Acceleration => &state.accelerations,
+            PartitionScope::Catalog => &state.catalog,
+        }
+    }
+
+    #[expect(dead_code, reason = "useful for diagnostics; kept for symmetry")]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            PartitionScope::Acceleration => "acceleration",
+            PartitionScope::Catalog => "catalog",
+        }
+    }
+}
+
+/// Outcome a mutator returns to [`ClusterStateStore::mutate`].
+#[derive(Debug)]
+pub enum MutationOutcome {
+    /// The mutator detected its desired change is already present. The
+    /// store will only return [`MutateOk::AlreadySatisfied`] after
+    /// confirming this against a freshly-read state — `NoChange` against a
+    /// stale cached snapshot will trigger a fresh read and a re-run.
+    NoChange,
+    /// Commit the mutated state.
+    Apply,
+    /// Mutator detected an unrecoverable condition; surface this error to
+    /// the caller without writing.
+    Abort(MutateError),
+}
+
+/// Result of a successful [`ClusterStateStore::mutate`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutateOk {
+    /// A new revision was committed.
+    Committed,
+    /// The mutator returned [`MutationOutcome::NoChange`] against fresh
+    /// state — the change was already present, no write was issued.
+    AlreadySatisfied,
+}
+
+#[derive(Debug, Snafu)]
+pub enum MutateError {
+    #[snafu(display("Cluster document is missing at {path}"))]
+    ClusterDocMissing { path: String },
+
+    #[snafu(display(
+        "Concurrent modification on cluster document at {path}; gave up after {attempts} attempts"
+    ))]
+    ConcurrentModification { path: String, attempts: usize },
+
+    #[snafu(display("Failed to read cluster document at {path}: {source}"))]
+    Read {
+        path: String,
+        source: ObjectStoreError,
+    },
+
+    #[snafu(display("Failed to write cluster document at {path}: {source}"))]
+    Write {
+        path: String,
+        source: ObjectStoreError,
+    },
+
+    #[snafu(display("Failed to (de)serialize cluster document at {path}: {source}"))]
+    Serde {
+        path: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Cluster document at {path} has unsupported schema version {found}"))]
+    UnsupportedSchemaVersion { path: String, found: u32 },
+
+    #[snafu(display("Failed to read system clock: {source}"))]
+    Clock { source: std::time::SystemTimeError },
+
+    /// Caller-supplied condition (e.g. scheduler-id conflict).
+    #[snafu(display("{message}"))]
+    Conflict { message: String },
+}
+
+pub type Result<T, E = MutateError> = std::result::Result<T, E>;
+
+#[derive(Clone, Debug)]
+struct CachedState {
+    value: Arc<ClusterState>,
+    version: UpdateVersion,
+}
+
+/// OCC-protected store for the single `cluster.json` document.
+///
+/// All writes go through [`Self::mutate`]. Readers can use [`Self::read`]
+/// for a fresh fetch or [`Self::read_cached`] for the in-memory snapshot
+/// (returned as an `Arc` so query routing doesn't pay a deep clone).
+#[derive(Debug)]
+pub struct ClusterStateStore {
+    store: Arc<dyn ObjectStore>,
+    /// Full path of the cluster document, e.g. `prefix/cluster.json`.
+    path: Path,
+    cache: RwLock<Option<CachedState>>,
+}
+
+impl ClusterStateStore {
+    #[must_use]
+    pub fn new(store: Arc<dyn ObjectStore>, base_prefix: &str) -> Self {
+        let path = if base_prefix.is_empty() {
+            Path::from("cluster.json")
+        } else {
+            Path::from(format!(
+                "{}/cluster.json",
+                base_prefix.trim_end_matches('/')
+            ))
+        };
+        Self {
+            store,
+            path,
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Returns the full object-store path of the cluster document.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Idempotent first-writer-wins create. Should be called exactly once
+    /// per scheduler at startup; subsequent calls are no-ops.
+    pub async fn bootstrap(&self) -> Result<()> {
+        let now_ms = now_ms()?;
+        let state = ClusterState::new(now_ms);
+        let payload = serde_json::to_vec(&state).context(SerdeSnafu {
+            path: self.path.to_string(),
+        })?;
+
+        match self
+            .store
+            .put_opts(
+                &self.path,
+                payload.into(),
+                PutOptions::from(PutMode::Create),
+            )
+            .await
+        {
+            Ok(result) => {
+                let version = UpdateVersion::from(result);
+                self.update_cache(state, version);
+                Ok(())
+            }
+            Err(ObjectStoreError::AlreadyExists { .. }) => Ok(()),
+            Err(source) => Err(MutateError::Write {
+                path: self.path.to_string(),
+                source,
+            }),
+        }
+    }
+
+    /// Forces a fresh read from the object store. Updates the cached `Arc`.
+    pub async fn read(&self) -> Result<Arc<ClusterState>> {
+        let (state, version) = self.fetch().await?;
+        let arc = Arc::new(state);
+        *self.cache.write() = Some(CachedState {
+            value: Arc::clone(&arc),
+            version,
+        });
+        Ok(arc)
+    }
+
+    /// Returns the in-memory snapshot if any has been observed so far.
+    /// Cheap (Arc clone) and IO-free.
+    #[must_use]
+    pub fn read_cached(&self) -> Option<Arc<ClusterState>> {
+        self.cache.read().as_ref().map(|c| Arc::clone(&c.value))
+    }
+
+    /// Returns the cached `Arc` if present, otherwise fetches.
+    pub async fn read_or_cached(&self) -> Result<Arc<ClusterState>> {
+        if let Some(arc) = self.read_cached() {
+            return Ok(arc);
+        }
+        self.read().await
+    }
+
+    /// Centralised OCC mutation. See module docs and the project plan
+    /// (`plans/consolidate-cluster-state-into-cluster-json.md`) for the
+    /// full semantics. Key invariants:
+    ///
+    /// - The mutator must be pure and IO-free; it will be re-run on
+    ///   conflicts and on stale-cache verification.
+    /// - [`MutationOutcome::NoChange`] returned against a cached
+    ///   snapshot is *not* trusted: the store forces one fresh read and
+    ///   re-invokes the mutator before declaring `AlreadySatisfied`.
+    /// - [`MutationOutcome::Apply`] starts from cache (fast path), then
+    ///   on `Conflict` re-reads and re-runs against the fresh state.
+    /// - `NotFound` mid-flight is *not* auto-bootstrapped; it is
+    ///   surfaced as [`MutateError::ClusterDocMissing`].
+    pub async fn mutate<F>(&self, mut mutator: F) -> Result<MutateOk>
+    where
+        F: FnMut(&mut ClusterState) -> MutationOutcome,
+    {
+        // Track whether the next mutator invocation will run against a
+        // cached (potentially stale) snapshot. If so, a `NoChange` result
+        // must be re-confirmed against a fresh read before being trusted.
+        let mut state_arc: Arc<ClusterState>;
+        let mut current_version: UpdateVersion;
+        let mut used_cache: bool;
+        if let Some(cached) = self.cached_pair() {
+            state_arc = cached.0;
+            current_version = cached.1;
+            used_cache = true;
+        } else {
+            let (state, version) = self.fetch().await?;
+            current_version = version.clone();
+            state_arc = Arc::new(state);
+            *self.cache.write() = Some(CachedState {
+                value: Arc::clone(&state_arc),
+                version,
+            });
+            used_cache = false;
+        }
+
+        let mut backoff = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_MUTATE_ATTEMPTS))
+            .build();
+        let mut attempts = 0usize;
+
+        loop {
+            attempts += 1;
+            let mut draft = (*state_arc).clone();
+            match mutator(&mut draft) {
+                MutationOutcome::Abort(err) => return Err(err),
+                MutationOutcome::NoChange => {
+                    if used_cache {
+                        // Cached state may be stale; verify against fresh read.
+                        let (fresh, fresh_version) = self.fetch().await?;
+                        current_version = fresh_version.clone();
+                        state_arc = Arc::new(fresh);
+                        *self.cache.write() = Some(CachedState {
+                            value: Arc::clone(&state_arc),
+                            version: fresh_version,
+                        });
+                        used_cache = false;
+                        continue;
+                    }
+                    return Ok(MutateOk::AlreadySatisfied);
+                }
+                MutationOutcome::Apply => {
+                    draft.updated_at_ms = now_ms()?;
+                    let payload = serde_json::to_vec(&draft).context(SerdeSnafu {
+                        path: self.path.to_string(),
+                    })?;
+                    match self
+                        .store
+                        .put_opts(
+                            &self.path,
+                            payload.into(),
+                            PutOptions::from(PutMode::Update(current_version.clone())),
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            let new_version = UpdateVersion::from(result);
+                            let new_arc = Arc::new(draft);
+                            *self.cache.write() = Some(CachedState {
+                                value: Arc::clone(&new_arc),
+                                version: new_version,
+                            });
+                            return Ok(MutateOk::Committed);
+                        }
+                        Err(ObjectStoreError::NotFound { .. }) => {
+                            return Err(MutateError::ClusterDocMissing {
+                                path: self.path.to_string(),
+                            });
+                        }
+                        Err(ObjectStoreError::Precondition { .. }) => {
+                            // Conflict: refresh and retry.
+                            let Some(delay) = backoff.next_duration() else {
+                                return Err(MutateError::ConcurrentModification {
+                                    path: self.path.to_string(),
+                                    attempts,
+                                });
+                            };
+                            tokio::time::sleep(delay).await;
+                            let (fresh, fresh_version) = self.fetch().await?;
+                            current_version = fresh_version.clone();
+                            state_arc = Arc::new(fresh);
+                            *self.cache.write() = Some(CachedState {
+                                value: Arc::clone(&state_arc),
+                                version: fresh_version,
+                            });
+                            used_cache = false;
+                        }
+                        Err(source) => {
+                            return Err(MutateError::Write {
+                                path: self.path.to_string(),
+                                source,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn cached_pair(&self) -> Option<(Arc<ClusterState>, UpdateVersion)> {
+        self.cache
+            .read()
+            .as_ref()
+            .map(|c| (Arc::clone(&c.value), c.version.clone()))
+    }
+
+    fn update_cache(&self, value: ClusterState, version: UpdateVersion) {
+        *self.cache.write() = Some(CachedState {
+            value: Arc::new(value),
+            version,
+        });
+    }
+
+    async fn fetch(&self) -> Result<(ClusterState, UpdateVersion)> {
+        let result = match self.store.get(&self.path).await {
+            Ok(r) => r,
+            Err(ObjectStoreError::NotFound { .. }) => {
+                return Err(MutateError::ClusterDocMissing {
+                    path: self.path.to_string(),
+                });
+            }
+            Err(source) => {
+                return Err(MutateError::Read {
+                    path: self.path.to_string(),
+                    source,
+                });
+            }
+        };
+
+        let version = UpdateVersion {
+            e_tag: result.meta.e_tag.clone(),
+            version: result.meta.version.clone(),
+        };
+        let bytes = result.bytes().await.map_err(|source| MutateError::Read {
+            path: self.path.to_string(),
+            source,
+        })?;
+        let state: ClusterState = serde_json::from_slice(&bytes).context(SerdeSnafu {
+            path: self.path.to_string(),
+        })?;
+
+        if state.schema_version != CLUSTER_STATE_SCHEMA_VERSION {
+            return Err(MutateError::UnsupportedSchemaVersion {
+                path: self.path.to_string(),
+                found: state.schema_version,
+            });
+        }
+
+        Ok((state, version))
+    }
+}
+
+pub(crate) fn now_ms() -> Result<u64> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context(ClockSnafu)?;
+    Ok(u64::try_from(now.as_millis()).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn store() -> Arc<dyn ObjectStore> {
+        Arc::new(InMemory::new())
+    }
+
+    fn entry(id: &str, instance: Uuid) -> SchedulerEntry {
+        SchedulerEntry {
+            scheduler_id: id.to_string(),
+            instance_id: instance,
+            advertise_address: id.to_string(),
+            grpc_address: id.to_string(),
+            http_address: id.to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn bootstrap_is_idempotent() {
+        let store = store();
+        let s = ClusterStateStore::new(Arc::clone(&store), "");
+        s.bootstrap().await.expect("first bootstrap");
+        // Mutate to bump revision so we can detect overwrites.
+        let id = Uuid::new_v4();
+        s.mutate(|cs| {
+            cs.schedulers.insert("a".to_string(), entry("a", id));
+            MutationOutcome::Apply
+        })
+        .await
+        .expect("insert ok");
+
+        // Second bootstrap should not overwrite.
+        let s2 = ClusterStateStore::new(Arc::clone(&store), "");
+        s2.bootstrap().await.expect("second bootstrap");
+        let read = s2.read().await.expect("read");
+        assert!(read.schedulers.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn mutate_apply_writes_new_revision() {
+        let s = ClusterStateStore::new(store(), "");
+        s.bootstrap().await.expect("bootstrap");
+        let id = Uuid::new_v4();
+        let result = s
+            .mutate(|cs| {
+                cs.schedulers.insert("a".to_string(), entry("a", id));
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("mutate");
+        assert_eq!(result, MutateOk::Committed);
+        let read = s.read().await.expect("read");
+        assert!(read.schedulers.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn mutate_no_change_against_fresh_state_skips_write() {
+        let s = ClusterStateStore::new(store(), "");
+        s.bootstrap().await.expect("bootstrap");
+        // Force a fresh fetch first so the cache is current.
+        s.read().await.expect("read");
+        let result = s
+            .mutate(|_cs| MutationOutcome::NoChange)
+            .await
+            .expect("mutate");
+        assert_eq!(result, MutateOk::AlreadySatisfied);
+    }
+
+    #[tokio::test]
+    async fn mutate_no_change_from_stale_cache_forces_fresh_read() {
+        let store = store();
+        let a = ClusterStateStore::new(Arc::clone(&store), "");
+        let b = ClusterStateStore::new(Arc::clone(&store), "");
+        a.bootstrap().await.expect("bootstrap");
+        // Prime A's cache.
+        a.read().await.expect("read");
+        // B mutates the doc behind A's back.
+        let id = Uuid::new_v4();
+        b.mutate(|cs| {
+            cs.schedulers.insert("a".to_string(), entry("a", id));
+            MutationOutcome::Apply
+        })
+        .await
+        .expect("b mutate");
+
+        // A's mutator decides "already inserted" based on stale cache —
+        // verify the store re-runs the mutator against fresh state and
+        // the second pass actually applies the change.
+        let calls = AtomicUsize::new(0);
+        let new_id = Uuid::new_v4();
+        let result = a
+            .mutate(|cs| {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    // Pretend "already done" using stale view.
+                    MutationOutcome::NoChange
+                } else {
+                    cs.schedulers.insert("b".to_string(), entry("b", new_id));
+                    MutationOutcome::Apply
+                }
+            })
+            .await
+            .expect("mutate");
+        assert_eq!(result, MutateOk::Committed);
+        assert!(calls.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn mutate_conflict_then_effective_no_op() {
+        let store = store();
+        let a = ClusterStateStore::new(Arc::clone(&store), "");
+        let b = ClusterStateStore::new(Arc::clone(&store), "");
+        a.bootstrap().await.expect("bootstrap");
+        a.read().await.expect("read a");
+        b.read().await.expect("read b");
+
+        let id = Uuid::new_v4();
+        // B applies a change A is also about to make.
+        b.mutate(|cs| {
+            cs.schedulers.insert("a".to_string(), entry("a", id));
+            MutationOutcome::Apply
+        })
+        .await
+        .expect("b mutate");
+
+        // A tries to add the same scheduler. After the first attempt
+        // conflicts, the re-run sees the entry already present and
+        // returns NoChange against fresh state -> AlreadySatisfied.
+        let result = a
+            .mutate(|cs| {
+                if cs.schedulers.contains_key("a") {
+                    MutationOutcome::NoChange
+                } else {
+                    cs.schedulers.insert("a".to_string(), entry("a", id));
+                    MutationOutcome::Apply
+                }
+            })
+            .await
+            .expect("a mutate");
+        assert_eq!(result, MutateOk::AlreadySatisfied);
+    }
+
+    #[tokio::test]
+    async fn mutate_returns_error_on_mid_flight_doc_missing() {
+        let store = store();
+        let s = ClusterStateStore::new(Arc::clone(&store), "");
+        // No bootstrap -> first mutate sees missing doc.
+        let err = s
+            .mutate(|_| MutationOutcome::Apply)
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, MutateError::ClusterDocMissing { .. }));
+    }
+
+    #[tokio::test]
+    async fn read_cached_returns_arc_pointer_clone() {
+        let s = ClusterStateStore::new(store(), "");
+        s.bootstrap().await.expect("bootstrap");
+        s.read().await.expect("read");
+        let a = s.read_cached().expect("cached");
+        let b = s.read_cached().expect("cached");
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+}

--- a/crates/runtime/src/cluster/executor_registry.rs
+++ b/crates/runtime/src/cluster/executor_registry.rs
@@ -533,12 +533,20 @@ mod tests {
     use object_store::memory::InMemory;
 
     use super::*;
+    use crate::cluster::ClusterStateStore;
+    use crate::cluster::PartitionScope;
+
+    fn test_partition_manager() -> PartitionManager {
+        let store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let cs = Arc::new(ClusterStateStore::new(store, ""));
+        PartitionManager::new(cs, PartitionScope::Acceleration)
+    }
 
     #[tokio::test]
     async fn test_register_unregister() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(test_partition_manager()),
+            Arc::new(test_partition_manager()),
         );
         let (tx, _rx) = mpsc::channel(1);
 
@@ -556,8 +564,8 @@ mod tests {
     #[tokio::test]
     async fn test_reconnect_replaces_connection() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(test_partition_manager()),
+            Arc::new(test_partition_manager()),
         );
         let (tx1, _rx1) = mpsc::channel(1);
         let (tx2, _rx2) = mpsc::channel(1);
@@ -572,8 +580,8 @@ mod tests {
     #[tokio::test]
     async fn test_request_metrics_empty_registry() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(test_partition_manager()),
+            Arc::new(test_partition_manager()),
         );
         let result = registry.request_metrics_from_all().await;
         assert!(result.is_ok());
@@ -583,8 +591,8 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_executors() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(test_partition_manager()),
+            Arc::new(test_partition_manager()),
         );
         let (tx1, _rx1) = mpsc::channel(1);
         let (tx2, _rx2) = mpsc::channel(1);
@@ -613,8 +621,8 @@ mod tests {
     #[tokio::test]
     async fn test_unregister_nonexistent() {
         let registry = ExecutorRegistry::new(
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
-            Arc::new(PartitionManager::new(Arc::new(InMemory::new()))),
+            Arc::new(test_partition_manager()),
+            Arc::new(test_partition_manager()),
         );
         let (tx, _rx) = mpsc::channel(1);
 

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -1,0 +1,450 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Per-scheduler heartbeat files at `heartbeats/{scheduler_id}.json`.
+//!
+//! Heartbeats live outside [`crate::cluster::cluster_state::ClusterState`]
+//! so that the high-frequency write path does not contend with partition
+//! and membership writes against the single cluster document.
+//!
+//! Each heartbeat file carries the writer's `instance_id`. A heartbeat
+//! whose `instance_id` does not match the corresponding entry in
+//! `cluster.json` is treated as orphan and ignored — this lets a fresh
+//! process safely take over a crashed predecessor's `scheduler_id` even
+//! though the underlying object store has no conditional-delete primitive.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, ObjectStore, PutMode, PutOptions};
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use uuid::Uuid;
+
+use crate::cluster::cluster_state::{ClusterState, SchedulerId};
+
+/// Tolerated clock skew between schedulers when judging heartbeat
+/// freshness, in milliseconds.
+pub const CLOCK_SKEW_TOLERANCE_MS: u64 = 5_000;
+
+/// Maximum write retries for a single heartbeat write. Heartbeats live in
+/// per-scheduler files so contention is essentially impossible in steady
+/// state; retries handle the bootstrap race only.
+const MAX_HEARTBEAT_ATTEMPTS: usize = 5;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to read heartbeat at {path}: {source}"))]
+    Read {
+        path: String,
+        source: ObjectStoreError,
+    },
+    #[snafu(display("Failed to write heartbeat at {path}: {source}"))]
+    Write {
+        path: String,
+        source: ObjectStoreError,
+    },
+    #[snafu(display("Failed to delete heartbeat at {path}: {source}"))]
+    Delete {
+        path: String,
+        source: ObjectStoreError,
+    },
+    #[snafu(display("Failed to list heartbeats at {prefix}: {source}"))]
+    List {
+        prefix: String,
+        source: ObjectStoreError,
+    },
+    #[snafu(display("Failed to (de)serialize heartbeat: {source}"))]
+    Serde { source: serde_json::Error },
+    #[snafu(display("Heartbeat write for {scheduler_id} exhausted retries: {source}"))]
+    RetryExhausted {
+        scheduler_id: String,
+        source: ObjectStoreError,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// On-disk heartbeat record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SchedulerHeartbeat {
+    pub scheduler_id: SchedulerId,
+    /// Must match the `instance_id` of the corresponding entry in
+    /// `cluster.json`. Mismatched heartbeats are filtered out as
+    /// orphans by [`SchedulerHeartbeatStore::list_alive`].
+    pub instance_id: Uuid,
+    pub last_heartbeat_ms: u64,
+    pub ttl_ms: u64,
+}
+
+impl SchedulerHeartbeat {
+    /// Returns true if this heartbeat is older than its TTL plus the
+    /// configured clock-skew tolerance.
+    #[must_use]
+    pub fn is_stale(&self, now_ms: u64) -> bool {
+        now_ms.saturating_sub(self.last_heartbeat_ms)
+            > self.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS)
+    }
+}
+
+/// Object-store-backed heartbeat store.
+///
+/// No internal cache: the discovery tick and the reaper both want a
+/// fresh view, the file count is bounded by the number of schedulers,
+/// and skipping the cache eliminates the "ghost key after delete" edge
+/// case that exists in [`object_store_occ::ObjectState::refresh`].
+#[derive(Debug)]
+pub struct SchedulerHeartbeatStore {
+    store: Arc<dyn ObjectStore>,
+    /// e.g. `prefix/heartbeats/` or `heartbeats/`. Always ends with `/`.
+    prefix: String,
+}
+
+impl SchedulerHeartbeatStore {
+    #[must_use]
+    pub fn new(store: Arc<dyn ObjectStore>, base_prefix: &str) -> Self {
+        let trimmed = base_prefix.trim_end_matches('/');
+        let prefix = if trimmed.is_empty() {
+            "heartbeats/".to_string()
+        } else {
+            format!("{trimmed}/heartbeats/")
+        };
+        Self { store, prefix }
+    }
+
+    /// Returns the full path for a given scheduler id.
+    #[must_use]
+    pub fn path_for(&self, scheduler_id: &str) -> Path {
+        Path::from(format!("{}{}.json", self.prefix, scheduler_id))
+    }
+
+    /// Writes (or overwrites) the heartbeat for a scheduler.
+    pub async fn heartbeat(
+        &self,
+        scheduler_id: &str,
+        instance_id: Uuid,
+        now_ms: u64,
+        ttl_ms: u64,
+    ) -> Result<()> {
+        let beat = SchedulerHeartbeat {
+            scheduler_id: scheduler_id.to_string(),
+            instance_id,
+            last_heartbeat_ms: now_ms,
+            ttl_ms,
+        };
+        let payload = serde_json::to_vec(&beat).context(SerdeSnafu)?;
+        let path = self.path_for(scheduler_id);
+
+        let mut backoff = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_HEARTBEAT_ATTEMPTS))
+            .build();
+
+        let mut last_err: Option<ObjectStoreError> = None;
+        loop {
+            match self
+                .store
+                .put_opts(
+                    &path,
+                    payload.clone().into(),
+                    PutOptions::from(PutMode::Overwrite),
+                )
+                .await
+            {
+                Ok(_) => return Ok(()),
+                Err(source) => {
+                    let Some(delay) = backoff.next_duration() else {
+                        return Err(Error::RetryExhausted {
+                            scheduler_id: scheduler_id.to_string(),
+                            source: last_err.unwrap_or(source),
+                        });
+                    };
+                    tracing::debug!(
+                        scheduler_id,
+                        path = %path,
+                        error = %source,
+                        retry_in_ms = delay.as_millis(),
+                        "Heartbeat write failed, retrying"
+                    );
+                    last_err = Some(source);
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    /// Reads the heartbeat for a scheduler, if any.
+    pub async fn read(&self, scheduler_id: &str) -> Result<Option<SchedulerHeartbeat>> {
+        let path = self.path_for(scheduler_id);
+        match self.store.get(&path).await {
+            Ok(result) => {
+                let bytes = result.bytes().await.map_err(|source| Error::Read {
+                    path: path.to_string(),
+                    source,
+                })?;
+                let beat: SchedulerHeartbeat =
+                    serde_json::from_slice(&bytes).context(SerdeSnafu)?;
+                Ok(Some(beat))
+            }
+            Err(ObjectStoreError::NotFound { .. }) => Ok(None),
+            Err(source) => Err(Error::Read {
+                path: path.to_string(),
+                source,
+            }),
+        }
+    }
+
+    /// Best-effort delete; missing files are tolerated.
+    pub async fn delete(&self, scheduler_id: &str) -> Result<()> {
+        let path = self.path_for(scheduler_id);
+        match self.store.delete(&path).await {
+            Ok(()) | Err(ObjectStoreError::NotFound { .. }) => Ok(()),
+            Err(source) => Err(Error::Delete {
+                path: path.to_string(),
+                source,
+            }),
+        }
+    }
+
+    /// Lists every heartbeat present in the store. Always performs a
+    /// fresh `list` + `get`; never reads from a cache.
+    pub async fn list_all(&self) -> Result<HashMap<SchedulerId, SchedulerHeartbeat>> {
+        let prefix_path = Path::from(self.prefix.trim_end_matches('/'));
+        let mut stream = self.store.list(Some(&prefix_path));
+        let mut paths = Vec::new();
+        while let Some(meta) = stream.next().await {
+            let meta = meta.map_err(|source| Error::List {
+                prefix: self.prefix.clone(),
+                source,
+            })?;
+            paths.push(meta.location);
+        }
+
+        let mut out = HashMap::with_capacity(paths.len());
+        for path in paths {
+            let path_str = path.to_string();
+            let Some(rest) = path_str.strip_prefix(&self.prefix) else {
+                continue;
+            };
+            let Some(id) = rest.strip_suffix(".json") else {
+                continue;
+            };
+            match self.store.get(&path).await {
+                Ok(result) => {
+                    let bytes = result.bytes().await.map_err(|source| Error::Read {
+                        path: path_str.clone(),
+                        source,
+                    })?;
+                    match serde_json::from_slice::<SchedulerHeartbeat>(&bytes) {
+                        Ok(beat) => {
+                            out.insert(id.to_string(), beat);
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                path = %path_str,
+                                error = %err,
+                                "Skipping unparseable heartbeat file"
+                            );
+                        }
+                    }
+                }
+                Err(ObjectStoreError::NotFound { .. }) => {
+                    // Concurrent delete during list; skip.
+                }
+                Err(source) => {
+                    return Err(Error::Read {
+                        path: path_str,
+                        source,
+                    });
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Returns the heartbeats that are (a) registered in `cluster_state`,
+    /// (b) carry the matching `instance_id`, and (c) are not stale.
+    pub async fn list_alive(
+        &self,
+        now_ms: u64,
+        cluster_state: &ClusterState,
+    ) -> Result<HashMap<SchedulerId, SchedulerHeartbeat>> {
+        let all = self.list_all().await?;
+        let mut alive = HashMap::with_capacity(all.len());
+        for (id, beat) in all {
+            let Some(entry) = cluster_state.schedulers.get(&id) else {
+                continue;
+            };
+            if entry.instance_id != beat.instance_id {
+                continue;
+            }
+            if beat.is_stale(now_ms) {
+                continue;
+            }
+            alive.insert(id, beat);
+        }
+        Ok(alive)
+    }
+}
+
+/// Convenience: small jittered sleep helper used by callers that schedule
+/// the reaper task with random offset.
+#[must_use]
+pub fn jitter(base: Duration, randomization_factor: f64) -> Duration {
+    let nanos = u128_to_f64(base.as_nanos());
+    let factor = 1.0 + (rand::random::<f64>() - 0.5) * 2.0 * randomization_factor;
+    let jittered = (nanos * factor).max(0.0);
+    Duration::from_nanos(f64_to_u64(jittered))
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "jitter only needs approximate nanosecond precision"
+)]
+fn u128_to_f64(value: u128) -> f64 {
+    value as f64
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "jittered value is clamped to >= 0 and bounded by base duration"
+)]
+fn f64_to_u64(value: f64) -> u64 {
+    value as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::cluster_state::{
+        ClusterState, ClusterStateStore, MutationOutcome, SchedulerEntry,
+    };
+    use object_store::memory::InMemory;
+
+    fn entry(id: &str, instance: Uuid) -> SchedulerEntry {
+        SchedulerEntry {
+            scheduler_id: id.to_string(),
+            instance_id: instance,
+            advertise_address: id.to_string(),
+            grpc_address: id.to_string(),
+            http_address: id.to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        }
+    }
+
+    async fn cluster_with(entries: &[SchedulerEntry]) -> ClusterState {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cs = ClusterStateStore::new(store, "");
+        cs.bootstrap().await.expect("bootstrap");
+        cs.mutate(|s| {
+            for e in entries {
+                s.schedulers.insert(e.scheduler_id.clone(), e.clone());
+            }
+            MutationOutcome::Apply
+        })
+        .await
+        .expect("mutate");
+        (*cs.read().await.expect("read")).clone()
+    }
+
+    #[tokio::test]
+    async fn heartbeat_writes_then_reads_back() {
+        let s = SchedulerHeartbeatStore::new(Arc::new(InMemory::new()), "");
+        let id = Uuid::new_v4();
+        s.heartbeat("a", id, 1000, 30_000).await.expect("write");
+        let read = s.read("a").await.expect("read").expect("present");
+        assert_eq!(read.scheduler_id, "a");
+        assert_eq!(read.instance_id, id);
+        assert_eq!(read.last_heartbeat_ms, 1000);
+    }
+
+    #[tokio::test]
+    async fn list_alive_filters_stale() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = SchedulerHeartbeatStore::new(Arc::clone(&store), "");
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        s.heartbeat("a", id_a, 100_000, 30_000).await.expect("a");
+        s.heartbeat("b", id_b, 1_000, 30_000).await.expect("b"); // stale
+
+        let cluster = cluster_with(&[entry("a", id_a), entry("b", id_b)]).await;
+        let alive = s.list_alive(100_000, &cluster).await.expect("list");
+        assert!(alive.contains_key("a"));
+        assert!(!alive.contains_key("b"));
+    }
+
+    #[tokio::test]
+    async fn list_alive_filters_orphan_instance_id() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = SchedulerHeartbeatStore::new(Arc::clone(&store), "");
+        let cluster_id = Uuid::new_v4();
+        let other_id = Uuid::new_v4();
+        s.heartbeat("a", other_id, 100_000, 30_000)
+            .await
+            .expect("a");
+
+        let cluster = cluster_with(&[entry("a", cluster_id)]).await;
+        let alive = s.list_alive(100_000, &cluster).await.expect("list");
+        assert!(!alive.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn list_all_evicts_deleted_keys() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = SchedulerHeartbeatStore::new(Arc::clone(&store), "");
+        let id = Uuid::new_v4();
+        s.heartbeat("a", id, 1, 1).await.expect("a");
+        s.heartbeat("b", id, 1, 1).await.expect("b");
+        s.delete("a").await.expect("delete");
+        let all = s.list_all().await.expect("list");
+        assert!(!all.contains_key("a"));
+        assert!(all.contains_key("b"));
+    }
+
+    #[tokio::test]
+    async fn delete_then_read_returns_none() {
+        let s = SchedulerHeartbeatStore::new(Arc::new(InMemory::new()), "");
+        let id = Uuid::new_v4();
+        s.heartbeat("a", id, 1, 1).await.expect("write");
+        s.delete("a").await.expect("delete");
+        assert!(s.read("a").await.expect("read").is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_heartbeats_for_same_id_converge() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s1 = SchedulerHeartbeatStore::new(Arc::clone(&store), "");
+        let s2 = SchedulerHeartbeatStore::new(Arc::clone(&store), "");
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let f1 = s1.heartbeat("a", id1, 100, 30_000);
+        let f2 = s2.heartbeat("a", id2, 200, 30_000);
+        let (r1, r2) = tokio::join!(f1, f2);
+        r1.expect("h1");
+        r2.expect("h2");
+        let read = s1.read("a").await.expect("read").expect("present");
+        // Last writer wins; either id is acceptable.
+        assert!(read.instance_id == id1 || read.instance_id == id2);
+    }
+}

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -92,8 +92,18 @@ pub enum DistributedNode {
         /// Registry of connected executors for `FlightSQL`.
         executor_registry: Arc<ExecutorRegistry>,
 
-        /// Manager for accelerated table partition metadata (initialized when scheduler config is available)
-        partition_manager: Arc<PartitionManager>,
+        /// Shared cluster state document used by both partition managers
+        /// and the scheduler registry.
+        cluster_state: Arc<ClusterStateStore>,
+
+        /// Heartbeat store, owned alongside the cluster state.
+        heartbeats: Arc<SchedulerHeartbeatStore>,
+
+        /// Manager for accelerated table partition metadata.
+        accelerations_partitions: Arc<AccelerationsPartitions>,
+
+        /// Manager for catalog/federated table partition metadata.
+        catalog_partitions: Arc<CatalogPartitions>,
     },
     Executor {
         /// Partition assignments for this runtime (executor) for each table.
@@ -393,21 +403,32 @@ fn update_scheduler_pollers(
     *known_schedulers = next_schedulers;
 }
 
+mod cluster_state;
 mod composite_flight_service;
 mod control_stream_client;
 pub mod datafusion;
 pub(crate) mod executor_registry;
+mod heartbeat;
 pub mod metrics_collector;
 pub mod partition;
-mod scheduler_registry;
+mod reaper;
+pub(crate) mod scheduler_registry;
 mod servers;
 mod service;
 
+pub use cluster_state::{
+    CLUSTER_STATE_SCHEMA_VERSION, ClusterState as SpiceClusterState, ClusterStateStore,
+    MutateError, MutateOk, MutationOutcome, PartitionScope, SchedulerEntry,
+};
 pub use control_stream_client::ControlStreamManager;
 pub use executor_registry::{ExecutorRegistry, FederatedPartitionProvider};
-pub use partition::{PartitionManager, PartitionMetadata, TablePartitionMetadata};
-pub use scheduler_registry::start_scheduler_registry;
-pub use scheduler_registry::{SchedulerPeers, SchedulerRecord};
+pub use heartbeat::{CLOCK_SKEW_TOLERANCE_MS, SchedulerHeartbeat, SchedulerHeartbeatStore};
+pub use partition::{
+    AccelerationsPartitions, CatalogPartitions, PartitionManager, PartitionMetadata,
+    TablePartitionMetadata,
+};
+pub use reaper::{Reaper, ReaperOutcome};
+pub use scheduler_registry::{SchedulerPeers, start_scheduler_registry};
 pub use servers::{start_executor_flight_server, start_internal_cluster_server};
 pub use service::{ClusterServiceImpl, ExecutorControlStreamRegistry};
 
@@ -887,16 +908,33 @@ pub(crate) async fn initialize_cluster_scheduler_future(
         let registry_shutdown_for_task = registry_shutdown.clone();
         let peers = Arc::clone(&scheduler_peers);
         let self_ref = Arc::clone(rt);
+        let cluster_state = rt.cluster_state();
+        let heartbeats = rt.scheduler_heartbeats();
         let scheduler_registry_fut = self_for_task
             .start_runtime_task(
                 CLUSTER_SCHEDULER_REGISTRY,
                 Some(registry_shutdown_for_task),
                 async move {
-                    start_scheduler_registry(self_ref, &config, registry_shutdown.clone(), peers)
-                        .await
-                        .map_err(|err| crate::Error::FailedToRegisterScheduler {
-                            source: Box::new(err),
-                        })
+                    let (Some(cluster_state), Some(heartbeats)) = (cluster_state, heartbeats)
+                    else {
+                        return Err(crate::Error::FailedToRegisterScheduler {
+                            source: Box::new(std::io::Error::other(
+                                "cluster state store not initialized for scheduler role",
+                            )),
+                        });
+                    };
+                    start_scheduler_registry(
+                        self_ref,
+                        &config,
+                        registry_shutdown.clone(),
+                        peers,
+                        cluster_state,
+                        heartbeats,
+                    )
+                    .await
+                    .map_err(|err| crate::Error::FailedToRegisterScheduler {
+                        source: Box::new(err),
+                    })
                 },
             )
             .await;

--- a/crates/runtime/src/cluster/partition/manager.rs
+++ b/crates/runtime/src/cluster/partition/manager.rs
@@ -14,14 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::time::SystemTime;
-use std::{collections::HashMap, sync::Arc};
+//! Partition metadata wrappers backed by [`ClusterStateStore`].
+//!
+//! The cluster's accelerated and catalog/federated partition metadata
+//! both live as submaps inside the single `cluster.json` document. This
+//! module exposes a [`PartitionManager`] type parameterised by
+//! [`PartitionScope`] so that call sites get a typed, scope-specific
+//! handle (`AccelerationsPartitions` / `CatalogPartitions`) without
+//! duplicating method bodies. Both type aliases point at the same
+//! struct; the only difference is the scope passed at construction.
+
+use std::sync::Arc;
+use std::{collections::HashMap, time::SystemTime};
 
 use datafusion::sql::TableReference;
-use object_store::ObjectStore;
-use object_store_occ::{InsertResult, ObjectState, WriteResult};
 use snafu::prelude::*;
 
+use crate::cluster::cluster_state::{
+    ClusterStateStore, MutateError, MutateOk, MutationOutcome, PartitionScope,
+};
 use crate::cluster::partition::metadata::PartitionValue;
 
 use super::metadata::{PartitionMetadata, TablePartitionMetadata, normalized_table_name};
@@ -29,10 +40,7 @@ use super::metadata::{PartitionMetadata, TablePartitionMetadata, normalized_tabl
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to access partition metadata for table {table}: {source}"))]
-    MetadataAccess {
-        table: String,
-        source: object_store_occ::Error,
-    },
+    MetadataAccess { table: String, source: MutateError },
 
     #[snafu(display("Failed to get current time: {source}"))]
     SystemTime { source: std::time::SystemTimeError },
@@ -48,17 +56,6 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-static PARTITION_PREFIX: &str = "accelerations/partitions/";
-
-/// Manages partition metadata for accelerated tables in object storage.
-///
-/// Uses optimistic concurrency control to safely coordinate partition assignments
-/// across multiple schedulers without locks.
-#[derive(Debug)]
-pub struct PartitionManager {
-    state: ObjectState<TablePartitionMetadata>,
-}
 
 /// Result of copying partition assignments from one table to another.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,21 +91,58 @@ impl AllocationResult {
     }
 }
 
+/// A single (table, partition, executor) assignment, used by the
+/// batched [`PartitionManager::apply_assignments`] API.
+#[derive(Debug, Clone)]
+pub struct AssignmentRequest {
+    pub table: TableReference,
+    pub partition_value: PartitionValue,
+    pub executor_id: String,
+}
+
+/// Partition metadata manager bound to one [`PartitionScope`] of the
+/// shared cluster document.
+///
+/// Construct via [`PartitionManager::accelerations`] or
+/// [`PartitionManager::catalog`] (or via the [`AccelerationsPartitions`]
+/// / [`CatalogPartitions`] type aliases for clarity at call sites).
+#[derive(Debug, Clone)]
+pub struct PartitionManager {
+    cluster: Arc<ClusterStateStore>,
+    scope: PartitionScope,
+}
+
+/// Type alias used at scheduler/executor wiring sites for clarity.
+pub type AccelerationsPartitions = PartitionManager;
+/// Type alias used at scheduler/executor wiring sites for clarity.
+pub type CatalogPartitions = PartitionManager;
+
 impl PartitionManager {
-    /// Creates a new partition manager with the given object store.
-    ///
-    /// All partition metadata will be stored under the "partitions/" prefix.
     #[must_use]
-    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
-        Self {
-            state: ObjectState::new(store).with_prefix(PARTITION_PREFIX),
-        }
+    pub fn new(cluster: Arc<ClusterStateStore>, scope: PartitionScope) -> Self {
+        Self { cluster, scope }
+    }
+
+    /// Convenience constructor for the acceleration scope.
+    #[must_use]
+    pub fn accelerations(cluster: Arc<ClusterStateStore>) -> Self {
+        Self::new(cluster, PartitionScope::Acceleration)
+    }
+
+    /// Convenience constructor for the catalog/federated scope.
+    #[must_use]
+    pub fn catalog(cluster: Arc<ClusterStateStore>) -> Self {
+        Self::new(cluster, PartitionScope::Catalog)
     }
 
     #[must_use]
-    pub fn with_prefix(mut self, prefix: &str) -> Self {
-        self.state = self.state.with_prefix(prefix);
-        self
+    pub fn scope(&self) -> PartitionScope {
+        self.scope
+    }
+
+    #[must_use]
+    pub fn cluster_state(&self) -> &Arc<ClusterStateStore> {
+        &self.cluster
     }
 
     /// Get partition metadata for a table from object store.
@@ -117,79 +151,113 @@ impl PartitionManager {
         table: &TableReference,
     ) -> Result<Option<TablePartitionMetadata>> {
         let key = normalized_table_name(table);
-        self.state
-            .get(&key)
+        let snap = self
+            .cluster
+            .read()
             .await
-            .context(MetadataAccessSnafu { table: key })
+            .context(MetadataAccessSnafu { table: key.clone() })?;
+        Ok(self.scope.map(&snap).get(&key).cloned())
     }
 
-    /// Get partition metadata from local cache (may be stale).
+    /// Get partition metadata from the most recent in-memory snapshot.
+    /// Cheap; no IO; never returns stale-deletes (snapshot is whole-doc).
     #[must_use]
     pub fn get_cached_table_metadata(
         &self,
         table: &TableReference,
     ) -> Option<TablePartitionMetadata> {
         let key = normalized_table_name(table);
-        self.state.get_cached(&key)
+        let snap = self.cluster.read_cached()?;
+        self.scope.map(&snap).get(&key).cloned()
     }
 
     /// Initialize partition metadata for a table with the given partition expression SQL strings.
     ///
-    /// If the file already exists, this is a no-op and returns `Ok(false)`.
+    /// Returns `Ok(true)` if a new entry was created, `Ok(false)` if one already existed.
     pub async fn initialize_metadata(
         &self,
         table: &TableReference,
         partition_expressions: Vec<String>,
     ) -> Result<bool> {
-        // If its cached, can avoid insert operation. Optimisation to reduce object store calls.
         if self.get_cached_table_metadata(table).is_some() {
             return Ok(false);
         }
+
         let key = normalized_table_name(table);
         let now_ms = now_ms()?;
         let metadata = TablePartitionMetadata::new(table, now_ms, partition_expressions);
-
-        match self
-            .state
-            .insert(&key, &metadata)
+        let scope = self.scope;
+        let key_for_closure = key.clone();
+        let metadata_for_closure = metadata.clone();
+        let mut created = false;
+        let res = self
+            .cluster
+            .mutate(|state| {
+                let map = scope.map_mut(state);
+                if map.contains_key(&key_for_closure) {
+                    created = false;
+                    MutationOutcome::NoChange
+                } else {
+                    map.insert(key_for_closure.clone(), metadata_for_closure.clone());
+                    created = true;
+                    MutationOutcome::Apply
+                }
+            })
             .await
-            .context(MetadataAccessSnafu { table: key.clone() })?
-        {
-            InsertResult::Ok => Ok(true),
-            InsertResult::AlreadyExists => Ok(false),
+            .context(MetadataAccessSnafu { table: key.clone() })?;
+        match res {
+            MutateOk::Committed => Ok(created),
+            MutateOk::AlreadySatisfied => Ok(false),
         }
     }
 
     /// Update partition metadata with discovered partitions, all marked as unassigned.
-    ///
-    /// This replaces the partitions list with the provided partition values.
-    /// If `partition_expressions` is non-empty, it also sets the SQL expression strings
-    /// (only when currently empty, to avoid overwriting values set during table creation).
     pub async fn set_unassigned_partitions(
         &self,
         table: &TableReference,
         partition_values: Vec<HashMap<String, String>>,
         partition_expressions: Vec<String>,
     ) -> Result<()> {
-        let now_ms = now_ms()?;
-
-        let mut metadata = self
-            .get_table_metadata(table)
-            .await?
-            .unwrap_or_else(|| TablePartitionMetadata::new(table, now_ms, partition_expressions));
-
-        metadata.partitions = partition_values
-            .into_iter()
-            .map(PartitionMetadata::new)
-            .collect();
-        metadata.updated_at = now_ms;
-
-        self.write_metadata(table, metadata).await
+        let key = normalized_table_name(table);
+        let scope = self.scope;
+        let table_clone = table.clone();
+        self.cluster
+            .mutate(|state| {
+                let now_ms = match crate::cluster::cluster_state::now_ms() {
+                    Ok(v) => u128::from(v),
+                    Err(e) => return MutationOutcome::Abort(e),
+                };
+                let map = scope.map_mut(state);
+                let entry = map.entry(key.clone()).or_insert_with(|| {
+                    TablePartitionMetadata::new(&table_clone, now_ms, partition_expressions.clone())
+                });
+                if entry.partition_expressions.is_empty() && !partition_expressions.is_empty() {
+                    entry
+                        .partition_expressions
+                        .clone_from(&partition_expressions);
+                }
+                entry.partitions = partition_values
+                    .iter()
+                    .cloned()
+                    .map(PartitionMetadata::new)
+                    .collect();
+                entry.updated_at = now_ms;
+                MutationOutcome::Apply
+            })
+            .await
+            .map_err(|e| match e {
+                MutateError::ConcurrentModification { .. } => {
+                    Error::ConcurrentModification { table: key }
+                }
+                other => Error::MetadataAccess {
+                    table: key,
+                    source: other,
+                },
+            })?;
+        Ok(())
     }
 
     /// Allocates unassigned partitions to an executor.
-    ///
-    /// Uses OCC to atomically update metadata.
     pub async fn allocate_partitions(
         &self,
         table: &TableReference,
@@ -197,137 +265,206 @@ impl PartitionManager {
         limit: usize,
     ) -> Result<AllocationResult> {
         let key = normalized_table_name(table);
-        let mut backoff = util::fibonacci_backoff::FibonacciBackoffBuilder::new()
-            .max_retries(Some(5))
-            .build();
+        let scope = self.scope;
 
-        loop {
-            let now_ms = now_ms()?;
-            let mut metadata = self
-                .get_table_metadata(table)
-                .await?
-                .ok_or_else(|| Error::TableMetadataNotFound { table: key.clone() })?;
+        let mut captured: Option<AllocationResult> = None;
+        let executor = executor_id.to_string();
+        let key_for_err = key.clone();
+        let res = self
+            .cluster
+            .mutate(|state| {
+                let now_ms = match crate::cluster::cluster_state::now_ms() {
+                    Ok(v) => u128::from(v),
+                    Err(e) => return MutationOutcome::Abort(e),
+                };
+                let map = scope.map_mut(state);
+                let Some(metadata) = map.get_mut(&key) else {
+                    return MutationOutcome::Abort(MutateError::Conflict {
+                        message: format!("no partition metadata for table {key}"),
+                    });
+                };
 
-            let mut result = AllocationResult {
-                newly_assigned: vec![],
-                previously_assigned: metadata
+                let previously_assigned: Vec<PartitionValue> = metadata
                     .partitions
                     .iter()
-                    .filter_map(|p| {
-                        if p.is_assigned_to(executor_id) {
-                            Some(p.partition_value.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect(),
-            };
-            let mut changes = false;
-
-            for partition in &mut metadata.partitions {
-                if result.count() >= limit {
-                    break;
-                }
-
-                if !partition.is_assigned() {
-                    partition.assign_to(executor_id.to_string(), now_ms);
-                    result
-                        .newly_assigned
-                        .push(partition.partition_value.clone());
-                    changes = true;
-                }
-            }
-
-            if !changes {
-                return Ok(result);
-            }
-
-            metadata.updated_at = now_ms;
-
-            match self.write_metadata(table, metadata).await {
-                Ok(()) => return Ok(result),
-                Err(Error::ConcurrentModification { .. }) => {
-                    if let Some(delay) = backoff.next_duration() {
-                        tokio::time::sleep(delay).await;
-                        continue;
+                    .filter(|p| p.is_assigned_to(&executor))
+                    .map(|p| p.partition_value.clone())
+                    .collect();
+                let mut newly_assigned: Vec<PartitionValue> = Vec::new();
+                let mut total = previously_assigned.len();
+                let mut changes = false;
+                for partition in &mut metadata.partitions {
+                    if total >= limit {
+                        break;
                     }
-                    return Err(Error::ConcurrentModification { table: key.clone() });
+                    if !partition.is_assigned() {
+                        partition.assign_to(executor.clone(), now_ms);
+                        newly_assigned.push(partition.partition_value.clone());
+                        total += 1;
+                        changes = true;
+                    }
                 }
-                Err(e) => return Err(e),
-            }
-        }
+
+                let result = AllocationResult {
+                    previously_assigned,
+                    newly_assigned,
+                };
+                captured = Some(result);
+
+                if changes {
+                    metadata.updated_at = now_ms;
+                    MutationOutcome::Apply
+                } else {
+                    MutationOutcome::NoChange
+                }
+            })
+            .await
+            .map_err(|e| match e {
+                MutateError::ConcurrentModification { .. } => Error::ConcurrentModification {
+                    table: key_for_err.clone(),
+                },
+                MutateError::Conflict { message } if message.contains("no partition metadata") => {
+                    Error::TableMetadataNotFound {
+                        table: key_for_err.clone(),
+                    }
+                }
+                other => Error::MetadataAccess {
+                    table: key_for_err.clone(),
+                    source: other,
+                },
+            })?;
+
+        let _ = res;
+        captured.ok_or_else(|| Error::TableMetadataNotFound { table: key_for_err })
     }
 
-    /// Assigns a partition to an executor in the metadata store.
+    /// Assigns a single partition to an executor. Most callers should
+    /// prefer [`Self::apply_assignments`] for batching.
     pub async fn assign_partition(
         &self,
         table: &TableReference,
         partition_value: &PartitionValue,
         executor_id: &str,
     ) -> Result<()> {
-        let key = normalized_table_name(table);
-        let mut backoff = util::fibonacci_backoff::FibonacciBackoffBuilder::new()
-            .max_retries(Some(5))
-            .build();
+        let assignments = vec![AssignmentRequest {
+            table: table.clone(),
+            partition_value: partition_value.clone(),
+            executor_id: executor_id.to_string(),
+        }];
+        let mut not_found: Option<(String, String)> = None;
+        self.apply_assignments_inner(&assignments, &mut not_found)
+            .await?;
+        if let Some((tbl, part)) = not_found {
+            return Err(Error::PartitionNotFound {
+                table: tbl,
+                partition: part,
+            });
+        }
+        Ok(())
+    }
 
-        loop {
-            let now_ms = now_ms()?;
-            let mut metadata = self
-                .get_table_metadata(table)
-                .await?
-                .ok_or_else(|| Error::TableMetadataNotFound { table: key.clone() })?;
+    /// Atomically apply many `(table, partition, executor)` assignments
+    /// in a single cluster-document write. Existing assignments to the
+    /// same `(table, partition)` are overwritten with the new executor.
+    /// Partition rows that don't yet exist are created so that callers
+    /// can use this both for "first-time assignment" and "reassign".
+    pub async fn apply_assignments(&self, assignments: &[AssignmentRequest]) -> Result<()> {
+        let mut not_found: Option<(String, String)> = None;
+        self.apply_assignments_inner(assignments, &mut not_found)
+            .await
+    }
 
-            let mut updated = false;
-            for partition in &mut metadata.partitions {
-                if partition.partition_value == *partition_value {
-                    partition.assign_to(executor_id.to_string(), now_ms);
-                    updated = true;
-                    break;
-                }
-            }
+    async fn apply_assignments_inner(
+        &self,
+        assignments: &[AssignmentRequest],
+        not_found_out: &mut Option<(String, String)>,
+    ) -> Result<()> {
+        if assignments.is_empty() {
+            return Ok(());
+        }
+        let scope = self.scope;
+        let assignments_owned: Vec<_> = assignments.to_vec();
+        // Captured by the mutator on the failure path so the surfaced
+        // error can name the exact table (and partition) that broke the
+        // batch instead of guessing from `assignments[0]`.
+        let mut missing_key: Option<(String, String)> = None;
 
-            if !updated {
-                return Err(Error::PartitionNotFound {
-                    table: key.clone(),
-                    partition: format!("{partition_value:?}"),
-                });
-            }
-
-            metadata.updated_at = now_ms;
-
-            match self.write_metadata(table, metadata).await {
-                Ok(()) => return Ok(()),
-                Err(Error::ConcurrentModification { .. }) => {
-                    if let Some(delay) = backoff.next_duration() {
-                        tokio::time::sleep(delay).await;
-                        continue;
+        let res = self
+            .cluster
+            .mutate(|state| {
+                let now_ms = match crate::cluster::cluster_state::now_ms() {
+                    Ok(v) => u128::from(v),
+                    Err(e) => return MutationOutcome::Abort(e),
+                };
+                let map = scope.map_mut(state);
+                let mut changes = false;
+                for assignment in &assignments_owned {
+                    let key = normalized_table_name(&assignment.table);
+                    let Some(metadata) = map.get_mut(&key) else {
+                        missing_key =
+                            Some((key.clone(), format!("{:?}", assignment.partition_value)));
+                        return MutationOutcome::Abort(MutateError::Conflict {
+                            message: format!("no partition metadata for table {key}"),
+                        });
+                    };
+                    if let Some(partition) = metadata
+                        .partitions
+                        .iter_mut()
+                        .find(|p| p.partition_value == assignment.partition_value)
+                    {
+                        if !partition.is_assigned_to(&assignment.executor_id) {
+                            partition.assigned_executors.clear();
+                            partition.assign_to(assignment.executor_id.clone(), now_ms);
+                            changes = true;
+                        }
+                    } else {
+                        let mut p = PartitionMetadata::new(assignment.partition_value.clone());
+                        p.assign_to(assignment.executor_id.clone(), now_ms);
+                        metadata.add_partition(p);
+                        changes = true;
                     }
-                    return Err(Error::ConcurrentModification { table: key.clone() });
+                    metadata.updated_at = now_ms;
                 }
-                Err(e) => return Err(e),
+                if changes {
+                    MutationOutcome::Apply
+                } else {
+                    MutationOutcome::NoChange
+                }
+            })
+            .await;
+
+        match res {
+            Ok(_) => Ok(()),
+            Err(MutateError::ConcurrentModification { .. }) => {
+                let table = missing_key
+                    .as_ref()
+                    .map(|(t, _)| t.clone())
+                    .or_else(|| assignments.first().map(|a| normalized_table_name(&a.table)))
+                    .unwrap_or_default();
+                Err(Error::ConcurrentModification { table })
             }
+            Err(MutateError::Conflict { .. }) => {
+                if let Some((tbl, part)) = missing_key {
+                    *not_found_out = Some((tbl.clone(), part));
+                    Err(Error::TableMetadataNotFound { table: tbl })
+                } else {
+                    Err(Error::MetadataAccess {
+                        table: String::from("<batch>"),
+                        source: MutateError::Conflict {
+                            message: "unexpected conflict from mutator".to_string(),
+                        },
+                    })
+                }
+            }
+            Err(other) => Err(Error::MetadataAccess {
+                table: missing_key.map_or_else(|| String::from("<batch>"), |(t, _)| t),
+                source: other,
+            }),
         }
     }
 
-    /// List all tables with partition metadata.
-    pub async fn list_tables(&self) -> Result<Vec<String>> {
-        self.state.list_keys().await.context(MetadataAccessSnafu {
-            table: String::from("<list>"),
-        })
-    }
-
-    /// Refresh the local cache from object store.
-    pub async fn refresh(&self) -> Result<()> {
-        self.state.refresh().await.context(MetadataAccessSnafu {
-            table: String::from("<refresh>"),
-        })
-    }
-
-    /// Adds new partitions to a table's metadata and assigns each to its
-    /// respective executor in a single OCC write. If a partition already exists,
-    /// it is assigned (or left as-is if already assigned to the same executor).
-    ///
-    /// `assignments` is a list of (`partition_value`, `executor_id`) tuples.
+    /// Adds new partitions to a table's metadata and assigns each to
+    /// its respective executor in a single OCC write.
     pub async fn add_and_assign_partitions(
         &self,
         table: &TableReference,
@@ -336,116 +473,124 @@ impl PartitionManager {
         if assignments.is_empty() {
             return Ok(());
         }
-
-        let key = normalized_table_name(table);
-        let mut backoff = util::fibonacci_backoff::FibonacciBackoffBuilder::new()
-            .max_retries(Some(5))
-            .build();
-
-        loop {
-            let now_ms = now_ms()?;
-            let mut metadata = self
-                .get_table_metadata(table)
-                .await?
-                .ok_or_else(|| Error::TableMetadataNotFound { table: key.clone() })?;
-
-            let mut changes = false;
-
-            for &(partition_value, executor_id) in assignments {
-                let existing = metadata
-                    .partitions
-                    .iter_mut()
-                    .find(|p| p.partition_value == *partition_value);
-
-                if let Some(p) = existing {
-                    if !p.is_assigned_to(executor_id) {
-                        p.assign_to(executor_id.to_string(), now_ms);
-                        changes = true;
-                    }
-                } else {
-                    let mut new_partition = PartitionMetadata::new(partition_value.clone());
-                    new_partition.assign_to(executor_id.to_string(), now_ms);
-                    metadata.add_partition(new_partition);
-                    changes = true;
-                }
-            }
-
-            if !changes {
-                return Ok(());
-            }
-
-            metadata.updated_at = now_ms;
-
-            match self.write_metadata(table, metadata).await {
-                Ok(()) => return Ok(()),
-                Err(Error::ConcurrentModification { .. }) => {
-                    if let Some(delay) = backoff.next_duration() {
-                        tokio::time::sleep(delay).await;
-                        continue;
-                    }
-                    return Err(Error::ConcurrentModification { table: key.clone() });
-                }
-                Err(e) => return Err(e),
-            }
-        }
-    }
-
-    /// Copy partition-to-executor assignments from one table to another.
-    ///
-    /// Creates (or overwrites) the target table's metadata with the same
-    /// partition expressions, partition values, and executor assignments
-    /// as the source table. This ensures `DoPut` write-through routes data
-    /// to the same executors for both tables.
-    ///
-    /// If the source table has no partition metadata, this is a no-op because
-    /// the source exists but is unpartitioned and there is nothing to copy.
-    pub async fn copy_assignments(
-        &self,
-        source_table: &TableReference,
-        target_table: &TableReference,
-    ) -> Result<CopyAssignmentsResult> {
-        let Some(source_metadata) = self.get_table_metadata(source_table).await? else {
-            return Ok(CopyAssignmentsResult::NoSourceMetadata);
-        };
-
-        let assigned_count = source_metadata
-            .partitions
+        let requests: Vec<AssignmentRequest> = assignments
             .iter()
-            .filter(|p| p.is_assigned())
-            .count();
-
-        let now_ms = now_ms()?;
-        let mut target_metadata = source_metadata;
-        target_metadata.table_name = normalized_table_name(target_table);
-        target_metadata.updated_at = now_ms;
-
-        self.write_metadata(target_table, target_metadata).await?;
-
-        if assigned_count == 0 {
-            Ok(CopyAssignmentsResult::NoAssignments)
-        } else {
-            Ok(CopyAssignmentsResult::Copied {
-                partition_count: assigned_count,
+            .map(|(pv, executor)| AssignmentRequest {
+                table: table.clone(),
+                partition_value: (*pv).clone(),
+                executor_id: (*executor).to_string(),
             })
-        }
+            .collect();
+        self.apply_assignments(&requests).await
     }
 
-    /// Write metadata using `insert_or_update` with conflict handling.
-    pub(crate) async fn write_metadata(
+    /// Replace this table's metadata wholesale (atomic OCC write). Used
+    /// by callers that compute the new metadata externally and just need
+    /// to persist it.
+    pub async fn write_metadata(
         &self,
         table: &TableReference,
         metadata: TablePartitionMetadata,
     ) -> Result<()> {
         let key = normalized_table_name(table);
-        match self
-            .state
-            .insert_or_update(&key, &metadata)
+        let scope = self.scope;
+        let key_for_err = key.clone();
+        self.cluster
+            .mutate(|state| {
+                let map = scope.map_mut(state);
+                map.insert(key.clone(), metadata.clone());
+                MutationOutcome::Apply
+            })
             .await
-            .context(MetadataAccessSnafu { table: key.clone() })?
-        {
-            WriteResult::Inserted | WriteResult::Updated => Ok(()),
-            WriteResult::Conflict { .. } => Err(Error::ConcurrentModification { table: key }),
+            .map_err(|e| match e {
+                MutateError::ConcurrentModification { .. } => {
+                    Error::ConcurrentModification { table: key_for_err }
+                }
+                other => Error::MetadataAccess {
+                    table: key_for_err,
+                    source: other,
+                },
+            })?;
+        Ok(())
+    }
+
+    /// List all tables (in this scope) with partition metadata.
+    pub async fn list_tables(&self) -> Result<Vec<String>> {
+        match self.cluster.read().await {
+            Ok(snap) => Ok(self.scope.map(&snap).keys().cloned().collect()),
+            Err(MutateError::ClusterDocMissing { .. }) => Ok(Vec::new()),
+            Err(other) => Err(Error::MetadataAccess {
+                table: String::from("<list>"),
+                source: other,
+            }),
         }
+    }
+
+    /// Refresh the local cache from object store.
+    pub async fn refresh(&self) -> Result<()> {
+        match self.cluster.read().await {
+            Ok(_) | Err(MutateError::ClusterDocMissing { .. }) => Ok(()),
+            Err(other) => Err(Error::MetadataAccess {
+                table: String::from("<refresh>"),
+                source: other,
+            }),
+        }
+    }
+
+    /// Copy partition assignments from one table to another atomically
+    /// (read + write happen inside a single OCC mutation).
+    pub async fn copy_assignments(
+        &self,
+        source_table: &TableReference,
+        target_table: &TableReference,
+    ) -> Result<CopyAssignmentsResult> {
+        let scope = self.scope;
+        let source_key = normalized_table_name(source_table);
+        let target_key = normalized_table_name(target_table);
+
+        let mut outcome: Option<CopyAssignmentsResult> = None;
+        let res = self
+            .cluster
+            .mutate(|state| {
+                let now_ms = match crate::cluster::cluster_state::now_ms() {
+                    Ok(v) => u128::from(v),
+                    Err(e) => return MutationOutcome::Abort(e),
+                };
+                let map = scope.map_mut(state);
+                let Some(source_meta) = map.get(&source_key).cloned() else {
+                    outcome = Some(CopyAssignmentsResult::NoSourceMetadata);
+                    return MutationOutcome::NoChange;
+                };
+                let assigned_count = source_meta
+                    .partitions
+                    .iter()
+                    .filter(|p| p.is_assigned())
+                    .count();
+                let mut target_meta = source_meta;
+                target_meta.table_name.clone_from(&target_key);
+                target_meta.updated_at = now_ms;
+                map.insert(target_key.clone(), target_meta);
+                outcome = Some(if assigned_count == 0 {
+                    CopyAssignmentsResult::NoAssignments
+                } else {
+                    CopyAssignmentsResult::Copied {
+                        partition_count: assigned_count,
+                    }
+                });
+                MutationOutcome::Apply
+            })
+            .await
+            .map_err(|e| match e {
+                MutateError::ConcurrentModification { .. } => Error::ConcurrentModification {
+                    table: target_key.clone(),
+                },
+                other => Error::MetadataAccess {
+                    table: target_key.clone(),
+                    source: other,
+                },
+            })?;
+        let _ = res;
+        Ok(outcome.unwrap_or(CopyAssignmentsResult::NoSourceMetadata))
     }
 }
 
@@ -460,25 +605,28 @@ fn now_ms() -> Result<u128> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cluster::cluster_state::ClusterStateStore;
     use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+    use object_store::ObjectStore;
     use object_store::memory::InMemory;
 
-    fn test_manager() -> PartitionManager {
-        PartitionManager::new(Arc::new(InMemory::new())).with_prefix("test/")
+    async fn test_manager() -> PartitionManager {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cs = Arc::new(ClusterStateStore::new(store, ""));
+        cs.bootstrap().await.expect("bootstrap");
+        PartitionManager::accelerations(cs)
     }
 
     #[tokio::test]
     async fn copy_assignments_copies_metadata() {
-        let pm = test_manager();
+        let pm = test_manager().await;
         let source = TableReference::parse_str("catalog.schema.source");
         let target = TableReference::parse_str("catalog.schema.target");
 
-        // Initialize source with partition expressions
         pm.initialize_metadata(&source, vec!["region".to_string()])
             .await
             .expect("should initialize");
 
-        // Add a partition and assign it
         let pv = HashMap::from([("region".to_string(), "us-east-1".to_string())]);
         pm.set_unassigned_partitions(&source, vec![pv], vec![])
             .await
@@ -489,14 +637,12 @@ mod tests {
             .await
             .expect("should assign");
 
-        // Copy assignments
         let result = pm
             .copy_assignments(&source, &target)
             .await
             .expect("should copy");
         assert_eq!(result, CopyAssignmentsResult::Copied { partition_count: 1 });
 
-        // Verify target has the same metadata
         let target_meta = pm
             .get_table_metadata(&target)
             .await
@@ -514,29 +660,26 @@ mod tests {
 
     #[tokio::test]
     async fn copy_assignments_noop_when_source_missing() {
-        let pm = test_manager();
+        let pm = test_manager().await;
         let source = TableReference::parse_str("catalog.schema.missing");
         let target = TableReference::parse_str("catalog.schema.target");
 
-        // Missing source metadata is a no-op (source exists but is unpartitioned).
         let result = pm
             .copy_assignments(&source, &target)
             .await
             .expect("should be a no-op for missing source metadata");
         assert_eq!(result, CopyAssignmentsResult::NoSourceMetadata);
 
-        // Target should have no metadata since nothing was copied.
         let target_meta = pm.get_table_metadata(&target).await.expect("should get");
         assert!(target_meta.is_none());
     }
 
     #[tokio::test]
     async fn copy_assignments_overwrites_existing_target() {
-        let pm = test_manager();
+        let pm = test_manager().await;
         let source = TableReference::parse_str("catalog.schema.source");
         let target = TableReference::parse_str("catalog.schema.target");
 
-        // Initialize both
         pm.initialize_metadata(&source, vec!["region".to_string()])
             .await
             .expect("should initialize source");
@@ -544,13 +687,11 @@ mod tests {
             .await
             .expect("should initialize target");
 
-        // Add partition to source
         let pv = HashMap::from([("region".to_string(), "eu-west-1".to_string())]);
         pm.set_unassigned_partitions(&source, vec![pv], vec![])
             .await
             .expect("should set partitions");
 
-        // Copy should overwrite target
         let result = pm
             .copy_assignments(&source, &target)
             .await
@@ -577,20 +718,14 @@ mod tests {
         let partial = TableReference::partial(SPICE_DEFAULT_SCHEMA, "my_table");
         let full = TableReference::full(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, "my_table");
 
-        assert_eq!(
-            normalized_table_name(&bare),
-            normalized_table_name(&full),
-            "bare and full should produce the same key"
-        );
+        assert_eq!(normalized_table_name(&bare), normalized_table_name(&full));
         assert_eq!(
             normalized_table_name(&partial),
-            normalized_table_name(&full),
-            "partial and full should produce the same key"
+            normalized_table_name(&full)
         );
         assert_eq!(
             normalized_table_name(&bare),
-            normalized_table_name(&partial),
-            "bare and partial should produce the same key"
+            normalized_table_name(&partial)
         );
     }
 
@@ -613,22 +748,19 @@ mod tests {
 
     #[tokio::test]
     async fn fully_qualified_and_bare_resolve_to_same_partition() {
-        let pm = test_manager();
+        let pm = test_manager().await;
         let bare = TableReference::bare("my_table");
         let full = TableReference::full(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, "my_table");
 
-        // Initialize with bare name
         pm.initialize_metadata(&bare, vec!["org_id".to_string()])
             .await
             .expect("should initialize");
 
-        // Set partitions using bare name
         let pv = HashMap::from([("org_id".to_string(), "test_org_name".to_string())]);
         pm.set_unassigned_partitions(&bare, vec![pv], vec![])
             .await
             .expect("should set partitions");
 
-        // Look up using fully qualified name — should find the same metadata
         let meta_via_full = pm
             .get_table_metadata(&full)
             .await
@@ -637,14 +769,12 @@ mod tests {
 
         assert_eq!(meta_via_full.partitions.len(), 1);
 
-        // Assign using fully qualified name
         let partition_value: PartitionValue =
             HashMap::from([("org_id".to_string(), "test_org_name".to_string())]);
         pm.assign_partition(&full, &partition_value, "executor-1")
             .await
             .expect("should assign via fully qualified ref");
 
-        // Verify assignment is visible via bare name
         let meta_via_bare = pm
             .get_table_metadata(&bare)
             .await
@@ -652,5 +782,63 @@ mod tests {
             .expect("bare lookup should see assignment made with fully qualified name");
 
         assert!(meta_via_bare.partitions[0].is_assigned_to("executor-1"));
+    }
+
+    #[tokio::test]
+    async fn acceleration_and_catalog_share_no_state() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cs = Arc::new(ClusterStateStore::new(store, ""));
+        cs.bootstrap().await.expect("bootstrap");
+        let acc = PartitionManager::accelerations(Arc::clone(&cs));
+        let cat = PartitionManager::catalog(Arc::clone(&cs));
+        let table = TableReference::bare("t");
+
+        acc.initialize_metadata(&table, vec!["region".to_string()])
+            .await
+            .expect("init");
+        let pv = HashMap::from([("region".to_string(), "us-east-1".to_string())]);
+        acc.set_unassigned_partitions(&table, vec![pv.clone()], vec![])
+            .await
+            .expect("set");
+        acc.assign_partition(&table, &pv, "exec-1")
+            .await
+            .expect("assign");
+
+        // Catalog scope should not see the acceleration assignment.
+        assert!(cat.get_table_metadata(&table).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn apply_assignments_writes_once_for_many_partitions() {
+        let pm = test_manager().await;
+        let table = TableReference::bare("t");
+        pm.initialize_metadata(&table, vec!["region".to_string()])
+            .await
+            .expect("init");
+        let values: Vec<HashMap<String, String>> = (0..50)
+            .map(|i| HashMap::from([("region".to_string(), format!("r-{i}"))]))
+            .collect();
+        pm.set_unassigned_partitions(&table, values.clone(), vec![])
+            .await
+            .expect("set");
+
+        let requests: Vec<AssignmentRequest> = values
+            .iter()
+            .map(|pv| AssignmentRequest {
+                table: table.clone(),
+                partition_value: pv.clone(),
+                executor_id: "exec-1".to_string(),
+            })
+            .collect();
+        pm.apply_assignments(&requests).await.expect("apply");
+
+        let meta = pm
+            .get_table_metadata(&table)
+            .await
+            .expect("get")
+            .expect("present");
+        for p in meta.partitions {
+            assert!(p.is_assigned_to("exec-1"));
+        }
     }
 }

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -18,7 +18,10 @@ mod discovery;
 pub mod executor_selection;
 mod manager;
 mod metadata;
-pub use manager::CopyAssignmentsResult;
+pub use manager::{
+    AccelerationsPartitions, AllocationResult, AssignmentRequest, CatalogPartitions,
+    CopyAssignmentsResult, PartitionManager,
+};
 pub mod scheduler_task;
 mod startup;
 pub(crate) mod write_through;
@@ -27,23 +30,17 @@ use std::collections::HashMap;
 
 use datafusion::sql::TableReference;
 use datafusion_expr::Expr;
-pub use manager::PartitionManager;
 pub use metadata::{
     PartitionMetadata, PartitionValue, TablePartitionMetadata, partition_value_to_bytes,
 };
 use snafu::Snafu;
 pub use startup::{
-    accelerated_tables, build_partition_metadata_store, executor_request_initial_partitions,
-    initialize_partition_metadata, validate_partition_keys,
+    accelerated_tables, executor_request_initial_partitions, initialize_partition_metadata,
+    validate_partition_keys,
 };
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to build object store for partition metadata: {source}"))]
-    ObjectStoreBuild {
-        source: crate::cluster::scheduler_registry::Error,
-    },
-
     #[snafu(display("Failed to initialize partition metadata for table {table}: {source}"))]
     PartitionMetadataInit {
         table: String,

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -19,51 +19,25 @@ use std::{
     sync::Arc,
 };
 
-use app::{App, spicepod::component::runtime::Scheduler as SchedulerConfig};
+use app::App;
 
 use datafusion::{execution::FunctionRegistry, logical_expr::Expr, sql::TableReference};
 use datafusion_proto::bytes::Serializeable;
-use object_store::ObjectStore;
-use object_store::prefix::PrefixStore;
 use runtime_proto::{
     AllocateInitialPartitionsRequest, cluster_service_client::ClusterServiceClient,
 };
-use runtime_secrets::Secrets;
 use snafu::prelude::*;
 use spicepod::partitioning::PartitionedBy;
-use tokio::{runtime::Handle, sync::RwLock};
 use tonic::transport::Channel;
 
-use super::{PartitionManager, Result};
+use super::PartitionManager;
 use crate::{
     cluster::partition::{
-        MissingPartitionKeysSnafu, ObjectStoreBuildSnafu, PartitionAllocationRequestSnafu,
-        PartitionExpressionDeserializationSnafu, discovery,
+        MissingPartitionKeysSnafu, PartitionAllocationRequestSnafu,
+        PartitionExpressionDeserializationSnafu, Result, discovery,
     },
     datafusion::DataFusion,
 };
-
-/// Builds an object store for partition metadata from scheduler configuration.
-pub async fn build_partition_metadata_store(
-    io_runtime: Handle,
-    secrets: Arc<RwLock<Secrets>>,
-    config: &SchedulerConfig,
-) -> Result<Arc<dyn ObjectStore>> {
-    let (store, prefix) = crate::cluster::scheduler_registry::build_object_store_internal(
-        secrets,
-        io_runtime,
-        &config.state_location,
-        config,
-    )
-    .await
-    .context(ObjectStoreBuildSnafu)?;
-
-    if prefix.is_empty() {
-        Ok(store)
-    } else {
-        Ok(Arc::new(PrefixStore::new(store, prefix)))
-    }
-}
 
 /// Initialize acceleration partition metadata for all accelerated tables on scheduler startup.
 ///

--- a/crates/runtime/src/cluster/reaper.rs
+++ b/crates/runtime/src/cluster/reaper.rs
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Reaper that evicts dead schedulers from `cluster.json`.
+//!
+//! Heartbeat files are deliberately *not* deleted by the reaper. Object
+//! stores have no conditional-delete primitive, so deleting after a
+//! takeover would race the new process's freshly written heartbeat.
+//! Orphan heartbeats (those whose `instance_id` no longer matches any
+//! entry in `cluster.json`) are filtered out at read time by
+//! [`crate::cluster::heartbeat::SchedulerHeartbeatStore::list_alive`],
+//! so leaving them in place is harmless.
+
+use std::sync::Arc;
+
+use snafu::Snafu;
+use uuid::Uuid;
+
+use crate::cluster::cluster_state::{
+    ClusterStateStore, MutateError, MutateOk, MutationOutcome, SchedulerId,
+};
+use crate::cluster::heartbeat::{self, CLOCK_SKEW_TOLERANCE_MS, SchedulerHeartbeatStore};
+
+/// Errors that can be raised during a single reaper tick.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to read cluster state in reaper: {source}"))]
+    ClusterRead { source: MutateError },
+
+    #[snafu(display("Failed to mutate cluster state in reaper: {source}"))]
+    ClusterMutate { source: MutateError },
+
+    #[snafu(display("Failed to list scheduler heartbeats in reaper: {source}"))]
+    ListHeartbeats { source: heartbeat::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Outcome of one reaper tick.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReaperOutcome {
+    pub evicted: Vec<SchedulerId>,
+    pub skipped: Vec<SchedulerId>,
+}
+
+#[derive(Debug)]
+pub struct Reaper {
+    cluster: Arc<ClusterStateStore>,
+    heartbeats: Arc<SchedulerHeartbeatStore>,
+}
+
+impl Reaper {
+    #[must_use]
+    pub fn new(cluster: Arc<ClusterStateStore>, heartbeats: Arc<SchedulerHeartbeatStore>) -> Self {
+        Self {
+            cluster,
+            heartbeats,
+        }
+    }
+
+    /// Run a single reap pass. Returns the set of scheduler ids that
+    /// were evicted from `cluster.json` and any candidates that were
+    /// skipped because of an `instance_id` mismatch (likely takeover).
+    pub async fn tick(&self, now_ms: u64) -> Result<ReaperOutcome> {
+        let snapshot = self
+            .cluster
+            .read()
+            .await
+            .map_err(|source| Error::ClusterRead { source })?;
+        let heartbeats = self
+            .heartbeats
+            .list_all()
+            .await
+            .map_err(|source| Error::ListHeartbeats { source })?;
+
+        // Build the (id -> instance_id we observed as stale-or-missing) map.
+        let mut stale: Vec<(SchedulerId, Uuid)> = Vec::new();
+        for (id, entry) in &snapshot.schedulers {
+            match heartbeats.get(id) {
+                Some(beat) if beat.instance_id == entry.instance_id => {
+                    if beat.is_stale(now_ms) {
+                        stale.push((id.clone(), entry.instance_id));
+                    }
+                }
+                Some(_) => {
+                    // Heartbeat carries a different instance_id (orphan or
+                    // mid-takeover). Don't reap.
+                }
+                None => {
+                    // No heartbeat at all. Only reap if the entry has
+                    // had time to publish its first heartbeat.
+                    let grace = entry.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
+                    if now_ms.saturating_sub(entry.started_at_ms) > grace {
+                        stale.push((id.clone(), entry.instance_id));
+                    }
+                }
+            }
+        }
+
+        let mut outcome = ReaperOutcome::default();
+        for (id, observed_instance) in stale {
+            let id_for_closure = id.clone();
+            let res = self
+                .cluster
+                .mutate(|state| match state.schedulers.get(&id_for_closure) {
+                    Some(entry) if entry.instance_id == observed_instance => {
+                        state.schedulers.remove(&id_for_closure);
+                        MutationOutcome::Apply
+                    }
+                    _ => MutationOutcome::NoChange,
+                })
+                .await
+                .map_err(|source| Error::ClusterMutate { source })?;
+            match res {
+                MutateOk::Committed => {
+                    tracing::info!(
+                        scheduler_id = %id,
+                        instance_id = %observed_instance,
+                        "Reaped stale scheduler"
+                    );
+                    outcome.evicted.push(id);
+                }
+                MutateOk::AlreadySatisfied => {
+                    outcome.skipped.push(id);
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::cluster_state::{MutationOutcome, SchedulerEntry};
+    use crate::cluster::heartbeat::SchedulerHeartbeatStore;
+    use object_store::ObjectStore;
+    use object_store::memory::InMemory;
+    use std::collections::HashMap;
+
+    fn entry(id: &str, instance: Uuid, started_at_ms: u64, ttl_ms: u64) -> SchedulerEntry {
+        SchedulerEntry {
+            scheduler_id: id.to_string(),
+            instance_id: instance,
+            advertise_address: id.to_string(),
+            grpc_address: id.to_string(),
+            http_address: id.to_string(),
+            started_at_ms,
+            ttl_ms,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        }
+    }
+
+    async fn setup() -> (Arc<ClusterStateStore>, Arc<SchedulerHeartbeatStore>) {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cs = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        cs.bootstrap().await.expect("bootstrap");
+        let hb = Arc::new(SchedulerHeartbeatStore::new(store, ""));
+        (cs, hb)
+    }
+
+    async fn add_entry(cs: &ClusterStateStore, e: SchedulerEntry) {
+        cs.mutate(|s| {
+            s.schedulers.insert(e.scheduler_id.clone(), e.clone());
+            MutationOutcome::Apply
+        })
+        .await
+        .expect("mutate");
+    }
+
+    #[tokio::test]
+    async fn reaps_scheduler_with_stale_heartbeat() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 0, 30_000)).await;
+        hb.heartbeat("a", id, 1_000, 30_000).await.expect("hb");
+
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let out = r.tick(1_000_000).await.expect("tick");
+        assert_eq!(out.evicted, vec!["a".to_string()]);
+        let snap = cs.read().await.expect("read");
+        assert!(!snap.schedulers.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn reaps_scheduler_with_missing_heartbeat_after_grace_period() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 0, 30_000)).await;
+        // No heartbeat written.
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let out = r.tick(1_000_000).await.expect("tick");
+        assert_eq!(out.evicted, vec!["a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn does_not_reap_scheduler_with_fresh_heartbeat() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 0, 30_000)).await;
+        hb.heartbeat("a", id, 999_000, 30_000).await.expect("hb");
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let out = r.tick(1_000_000).await.expect("tick");
+        assert!(out.evicted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn does_not_reap_recently_registered_scheduler_without_heartbeat() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 990_000, 30_000)).await;
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let out = r.tick(1_000_000).await.expect("tick");
+        assert!(out.evicted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reaper_skips_when_instance_id_does_not_match() {
+        let (cs, hb) = setup().await;
+        let old = Uuid::new_v4();
+        let new = Uuid::new_v4();
+        // cluster.json carries the new (post-takeover) instance id.
+        add_entry(&cs, entry("a", new, 999_000, 30_000)).await;
+        // Heartbeat file still carries the old instance id (orphan
+        // about to be overwritten by the new process).
+        hb.heartbeat("a", old, 1_000, 30_000).await.expect("hb");
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let out = r.tick(1_000_000).await.expect("tick");
+        assert!(out.evicted.is_empty());
+        let snap = cs.read().await.expect("read");
+        assert!(snap.schedulers.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_reapers_idempotent() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 0, 30_000)).await;
+        hb.heartbeat("a", id, 1_000, 30_000).await.expect("hb");
+        let r1 = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let r2 = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        let (o1, o2) = tokio::join!(r1.tick(1_000_000), r2.tick(1_000_000));
+        let o1 = o1.expect("o1");
+        let o2 = o2.expect("o2");
+        let total: Vec<_> = o1
+            .evicted
+            .iter()
+            .chain(o2.evicted.iter())
+            .cloned()
+            .collect();
+        // Eviction should happen exactly once across the two reapers.
+        assert_eq!(total, vec!["a".to_string()]);
+        // The other reaper either skipped (saw entry, mutator returned
+        // NoChange against fresh state) or saw nothing-to-do because the
+        // first reaper had already committed by the time it read the
+        // cluster snapshot.
+        assert!(o1.skipped.len() + o2.skipped.len() <= 1);
+    }
+
+    #[tokio::test]
+    async fn reaper_does_not_delete_heartbeat_files() {
+        let (cs, hb) = setup().await;
+        let id = Uuid::new_v4();
+        add_entry(&cs, entry("a", id, 0, 30_000)).await;
+        hb.heartbeat("a", id, 1_000, 30_000).await.expect("hb");
+        let r = Reaper::new(Arc::clone(&cs), Arc::clone(&hb));
+        r.tick(1_000_000).await.expect("tick");
+        // Heartbeat file is still present (orphan now, but not deleted
+        // by the reaper).
+        let beat = hb.read("a").await.expect("read");
+        assert!(beat.is_some());
+    }
+}

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -14,37 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//! Scheduler-side registration loop, discovery, and reaper wiring.
+//!
+//! All non-job distributed state now lives in a single document
+//! (`cluster.json`) and per-scheduler heartbeats live in
+//! `heartbeats/{id}.json`. See
+//! `plans/consolidate-cluster-state-into-cluster-json.md`.
+
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use app::spicepod::component::runtime::Scheduler as SchedulerConfig;
 use aws_sdk_credential_bridge::object_store_builder::S3ObjectStoreBuilder;
 use datafusion::execution::object_store::ObjectStoreRegistry;
-use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectStore, PutMode, PutOptions};
-use object_store_occ::{InsertResult, ObjectState, UpdateResult};
+use object_store::ObjectStore;
 use runtime_object_store::registry::SpiceObjectStoreRegistry;
 use runtime_parameters::{ParameterSpec, Parameters};
 use runtime_secrets::{Secrets, get_params_with_secrets};
-use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use url::Url;
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use uuid::Uuid;
 
 use crate::Runtime;
+use crate::cluster::cluster_state::{
+    self, ClusterStateStore, MutateError, MutationOutcome, SchedulerEntry,
+};
+use crate::cluster::heartbeat::{self, CLOCK_SKEW_TOLERANCE_MS, SchedulerHeartbeatStore};
+use crate::cluster::reaper::Reaper;
 use crate::metrics::cluster as cluster_metrics;
 
-const CLUSTER_SCHEMA_VERSION: u32 = 1;
-const SCHEDULER_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_TTL_MS: u64 = 30_000;
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_DIVISOR: u64 = 3;
-const CLOCK_SKEW_TOLERANCE_MS: u64 = 5_000;
-const MAX_CONDITIONAL_ATTEMPTS: usize = 5;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -84,47 +89,24 @@ pub enum Error {
     #[snafu(display("Missing scheduler advertise address for registration"))]
     MissingAdvertiseAddress,
 
-    #[snafu(display("Failed to read scheduler state from object store: {source}"))]
-    ObjectStoreRead { source: ObjectStoreError },
+    #[snafu(display("Failed to access cluster state: {source}"))]
+    ClusterState { source: MutateError },
 
-    #[snafu(display("Failed to write scheduler state to object store: {source}"))]
-    ObjectStoreWrite { source: ObjectStoreError },
-
-    #[snafu(display("Failed to serialize scheduler state: {source}"))]
-    SerializeState { source: serde_json::Error },
+    #[snafu(display("Failed to access scheduler heartbeats: {source}"))]
+    Heartbeat { source: heartbeat::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SchedulerRecord {
-    pub schema_version: u32,
-    pub advertise_address: String,
-    pub grpc_address: String,
-    pub http_address: String,
-    pub started_at_ms: u64,
-    pub last_heartbeat_ms: u64,
-    pub ttl_ms: u64,
-    pub build_version: String,
-    #[serde(default)]
-    pub labels: HashMap<String, String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ClusterMetadata {
-    schema_version: u32,
-    created_at_ms: u64,
-}
-
-pub type SchedulerPeers = HashMap<String, SchedulerRecord>;
+pub type SchedulerPeers = HashMap<String, SchedulerEntry>;
 
 struct SchedulerRegistryRunner {
-    store: Arc<dyn ObjectStore>,
-    state: ObjectState<SchedulerRecord>,
+    cluster: Arc<ClusterStateStore>,
+    heartbeats: Arc<SchedulerHeartbeatStore>,
+    reaper: Reaper,
     scheduler_id: String,
-    metadata_path: Path,
-    record_path: Path,
-    record: SchedulerRecord,
+    instance_id: Uuid,
+    entry: SchedulerEntry,
     peers: Arc<RwLock<SchedulerPeers>>,
 }
 
@@ -133,10 +115,9 @@ pub async fn start_scheduler_registry(
     config: &SchedulerConfig,
     cancel: CancellationToken,
     peers: Arc<RwLock<SchedulerPeers>>,
+    cluster: Arc<ClusterStateStore>,
+    heartbeats: Arc<SchedulerHeartbeatStore>,
 ) -> Result<()> {
-    let (store, base_prefix) =
-        build_object_store(rt.as_ref(), &config.state_location, config).await?;
-
     let datafusion = rt.datafusion();
     let advertise_host = datafusion
         .cluster_config
@@ -149,7 +130,27 @@ pub async fn start_scheduler_registry(
         rt.datafusion().cluster_config.node_bind_address().port()
     );
 
-    // Initialize job executor for async SQL queries
+    let instance_id = Uuid::new_v4();
+    let now = now_ms()?;
+    let entry = SchedulerEntry {
+        scheduler_id: scheduler_id.clone(),
+        instance_id,
+        advertise_address: scheduler_id.clone(),
+        grpc_address: format!(
+            "{advertise_host}:{}",
+            rt.config().flight_bind_address.port()
+        ),
+        http_address: format!("{advertise_host}:{}", rt.config().http_bind_address.port()),
+        started_at_ms: now,
+        ttl_ms: DEFAULT_TTL_MS,
+        build_version: env!("CARGO_PKG_VERSION").to_string(),
+        labels: HashMap::new(),
+    };
+
+    // Initialize job executor for async SQL queries. Reuses the raw
+    // (store, base_prefix) pair behind ClusterStateStore.
+    let (store, base_prefix) =
+        build_object_store(rt.as_ref(), &config.state_location, config).await?;
     let job_store = crate::jobs::JobStore::new(
         Arc::clone(&store),
         base_prefix.clone(),
@@ -162,80 +163,71 @@ pub async fn start_scheduler_registry(
         config.state_location
     );
 
-    let record = SchedulerRecord {
-        schema_version: SCHEDULER_SCHEMA_VERSION,
-        advertise_address: scheduler_id.clone(),
-        grpc_address: format!(
-            "{advertise_host}:{}",
-            rt.config().flight_bind_address.port()
-        ),
-        http_address: format!("{advertise_host}:{}", rt.config().http_bind_address.port()),
-        started_at_ms: now_ms()?,
-        last_heartbeat_ms: now_ms()?,
-        ttl_ms: DEFAULT_TTL_MS,
-        build_version: env!("CARGO_PKG_VERSION").to_string(),
-        labels: HashMap::new(),
-    };
+    let reaper = Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats));
 
-    let runner = SchedulerRegistryRunner::new(
-        store,
-        &base_prefix,
+    let runner = SchedulerRegistryRunner {
+        cluster,
+        heartbeats,
+        reaper,
         scheduler_id,
-        record,
-        Arc::clone(&peers),
-    );
+        instance_id,
+        entry,
+        peers,
+    };
 
     runner.run(cancel).await
 }
 
 impl SchedulerRegistryRunner {
-    fn new(
-        store: Arc<dyn ObjectStore>,
-        base_prefix: &str,
-        scheduler_id: String,
-        record: SchedulerRecord,
-        peers: Arc<RwLock<SchedulerPeers>>,
-    ) -> Self {
-        let metadata_path = join_path(base_prefix, "metadata/cluster.json");
-        let record_path = join_path(base_prefix, &format!("schedulers/{scheduler_id}.json"));
-        let schedulers_prefix = format!("{}/schedulers/", base_prefix.trim_end_matches('/'));
-        let state: ObjectState<SchedulerRecord> =
-            ObjectState::new(Arc::clone(&store)).with_prefix(schedulers_prefix);
-
-        Self {
-            store,
-            state,
-            scheduler_id,
-            metadata_path,
-            record_path,
-            record,
-            peers,
-        }
-    }
-
-    async fn run(mut self, cancel: CancellationToken) -> Result<()> {
-        self.ensure_cluster_metadata().await?;
-        self.bootstrap_record().await?;
+    async fn run(self, cancel: CancellationToken) -> Result<()> {
+        self.cluster.bootstrap().await.context(ClusterStateSnafu)?;
+        self.register_self().await?;
 
         let heartbeat_interval =
-            Duration::from_millis(self.record.ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
-        let mut heartbeat = tokio::time::interval(heartbeat_interval);
-        let mut discovery = tokio::time::interval(DISCOVERY_INTERVAL);
+            Duration::from_millis(self.entry.ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
+        let reaper_interval = Duration::from_millis(self.entry.ttl_ms);
+        let reaper_jittered = heartbeat::jitter(reaper_interval, 0.2);
+        let mut heartbeat_tick = tokio::time::interval(heartbeat_interval);
+        let mut discovery_tick = tokio::time::interval(DISCOVERY_INTERVAL);
+        let mut reaper_tick = tokio::time::interval(reaper_jittered);
+
+        // Run an initial discovery so peers are populated promptly.
+        if let Err(err) = self.refresh_peers().await {
+            tracing::warn!("Initial scheduler discovery failed: {err}");
+        }
 
         loop {
             tokio::select! {
                 () = cancel.cancelled() => {
-                    self.delete_record().await;
+                    self.shutdown().await;
                     break;
                 }
-                _ = heartbeat.tick() => {
-                    if let Err(err) = self.heartbeat().await {
+                _ = heartbeat_tick.tick() => {
+                    if let Err(err) = self.send_heartbeat().await {
                         tracing::warn!("Scheduler heartbeat failed: {err}");
                     }
                 }
-                _ = discovery.tick() => {
+                _ = discovery_tick.tick() => {
                     if let Err(err) = self.refresh_peers().await {
                         tracing::warn!("Scheduler discovery failed: {err}");
+                    }
+                }
+                _ = reaper_tick.tick() => {
+                    match now_ms() {
+                        Ok(now) => match self.reaper.tick(now).await {
+                            Ok(out) if !out.evicted.is_empty() => {
+                                tracing::info!(
+                                    evicted = ?out.evicted,
+                                    skipped = ?out.skipped,
+                                    "Reaper tick"
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(err) => tracing::warn!("Reaper tick failed: {err}"),
+                        },
+                        Err(err) => tracing::warn!(
+                            "Skipping reaper tick because current time is unavailable: {err}"
+                        ),
                     }
                 }
             }
@@ -244,126 +236,104 @@ impl SchedulerRegistryRunner {
         Ok(())
     }
 
-    async fn ensure_cluster_metadata(&self) -> Result<()> {
-        let metadata = ClusterMetadata {
-            schema_version: CLUSTER_SCHEMA_VERSION,
-            created_at_ms: now_ms()?,
-        };
-        let payload = serde_json::to_vec(&metadata).context(SerializeStateSnafu)?;
+    async fn register_self(&self) -> Result<()> {
+        let observed = self
+            .heartbeats
+            .read(&self.scheduler_id)
+            .await
+            .context(HeartbeatSnafu)?;
+        let observed_instance = observed.as_ref().map(|b| b.instance_id);
 
-        let put_result = self
-            .store
-            .put_opts(
-                &self.metadata_path,
-                payload.into(),
-                PutOptions::from(PutMode::Create),
-            )
+        let entry = self.entry.clone();
+        let scheduler_id = self.scheduler_id.clone();
+        let instance_id = self.instance_id;
+
+        let now = now_ms()?;
+
+        let res = self
+            .cluster
+            .mutate(|state| {
+                if let Some(existing) = state.schedulers.get(&scheduler_id) {
+                    // Allow takeover only if (a) the heartbeat we
+                    // observed matches the existing entry's
+                    // instance_id (so we are taking over the
+                    // incarnation we judged stale), AND (b) that
+                    // observation is in fact stale, OR there is no
+                    // heartbeat at all and the existing entry has
+                    // had time to publish one.
+                    let observed_matches =
+                        observed_instance.is_none_or(|i| i == existing.instance_id);
+                    let stale_or_missing = if let Some(beat) = observed.as_ref() {
+                        beat.is_stale(now)
+                    } else {
+                        let grace = existing.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
+                        now.saturating_sub(existing.started_at_ms) > grace
+                    };
+                    if observed_matches && stale_or_missing {
+                        state.schedulers.insert(scheduler_id.clone(), entry.clone());
+                        MutationOutcome::Apply
+                    } else if existing.instance_id == instance_id {
+                        // Re-register on top of our own (e.g. retry).
+                        MutationOutcome::NoChange
+                    } else {
+                        MutationOutcome::Abort(MutateError::Conflict {
+                            message: format!("scheduler id {scheduler_id} is already registered"),
+                        })
+                    }
+                } else {
+                    state.schedulers.insert(scheduler_id.clone(), entry.clone());
+                    MutationOutcome::Apply
+                }
+            })
             .await;
 
-        match put_result {
-            Ok(_) | Err(ObjectStoreError::AlreadyExists { .. }) => Ok(()),
-            Err(err) => Err(Error::ObjectStoreWrite { source: err }),
-        }
-    }
-
-    async fn bootstrap_record(&mut self) -> Result<()> {
-        match self
-            .state
-            .insert(&self.scheduler_id, &self.record)
-            .await
-            .map_err(|e| e.into_object_store("scheduler_registry"))
-            .context(ObjectStoreWriteSnafu)?
-        {
-            InsertResult::Ok => return Ok(()),
-            InsertResult::AlreadyExists => {}
-        }
-
-        // Record exists - check if stale
-        let existing = self
-            .state
-            .get(&self.scheduler_id)
-            .await
-            .map_err(|e| e.into_object_store("scheduler_registry"))
-            .context(ObjectStoreReadSnafu)?
-            .ok_or_else(|| Error::SchedulerIdConflict {
-                scheduler_id: self.scheduler_id.clone(),
-            })?;
-
-        if !record_is_stale(&existing, now_ms()?) {
-            return Err(Error::SchedulerIdConflict {
-                scheduler_id: self.scheduler_id.clone(),
-            });
-        }
-
-        // Stale record - overwrite it
-        self.conditional_update().await
-    }
-
-    async fn heartbeat(&mut self) -> Result<()> {
-        self.record.last_heartbeat_ms = now_ms()?;
-        self.conditional_update().await
-    }
-
-    async fn conditional_update(&mut self) -> Result<()> {
-        let mut backoff = FibonacciBackoffBuilder::new()
-            .max_retries(Some(MAX_CONDITIONAL_ATTEMPTS))
-            .build();
-
-        loop {
-            match self
-                .state
-                .update(&self.scheduler_id, &self.record)
-                .await
-                .map_err(|e| e.into_object_store("scheduler_registry"))
-                .context(ObjectStoreWriteSnafu)?
-            {
-                UpdateResult::Ok => return Ok(()),
-                UpdateResult::NotFound => {
-                    // Record was deleted - re-insert
-                    let _ = self.state.insert(&self.scheduler_id, &self.record).await;
-                    return Ok(());
-                }
-                UpdateResult::Conflict { .. } => {
-                    // ETag mismatch - state.update() already refreshed cache with current value
-                    let Some(delay) = backoff.next_duration() else {
-                        return Err(Error::ObjectStoreWrite {
-                            source: ObjectStoreError::Precondition {
-                                path: self.scheduler_id.clone(),
-                                source: Box::new(std::io::Error::other(
-                                    "Conditional update failed after retries",
-                                )),
-                            },
-                        });
-                    };
-                    tokio::time::sleep(delay).await;
-                }
+        match res {
+            Ok(_) => {}
+            Err(MutateError::Conflict { .. }) => {
+                return Err(Error::SchedulerIdConflict {
+                    scheduler_id: self.scheduler_id.clone(),
+                });
             }
+            Err(other) => return Err(Error::ClusterState { source: other }),
         }
+
+        // Write our first heartbeat so peers see liveness on next discovery.
+        self.heartbeats
+            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
+            .await
+            .context(HeartbeatSnafu)?;
+        Ok(())
+    }
+
+    async fn send_heartbeat(&self) -> Result<()> {
+        let now = now_ms()?;
+        self.heartbeats
+            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
+            .await
+            .context(HeartbeatSnafu)
     }
 
     async fn refresh_peers(&self) -> Result<()> {
-        self.state
-            .refresh()
-            .await
-            .map_err(|e| e.into_object_store("scheduler_registry"))
-            .context(ObjectStoreReadSnafu)?;
-
+        let snap = self.cluster.read().await.context(ClusterStateSnafu)?;
         let now = now_ms()?;
-        let records: HashMap<String, SchedulerRecord> = self
-            .state
-            .cached_entries()
-            .into_iter()
-            .filter(|(_, record)| !record_is_stale(record, now))
-            .map(|(_, record)| (record.advertise_address.clone(), record))
-            .collect();
+        let alive = self
+            .heartbeats
+            .list_alive(now, &snap)
+            .await
+            .context(HeartbeatSnafu)?;
+
+        let mut next: HashMap<String, SchedulerEntry> = HashMap::new();
+        for (id, entry) in &snap.schedulers {
+            if alive.contains_key(id) || id == &self.scheduler_id {
+                next.insert(id.clone(), entry.clone());
+            }
+        }
 
         let mut peers = self.peers.write().await;
         let previous: HashSet<String> = peers.keys().cloned().collect();
-        let next: HashSet<String> = records.keys().cloned().collect();
-
-        let added: Vec<_> = next.difference(&previous).cloned().collect();
-        let removed: Vec<_> = previous.difference(&next).cloned().collect();
-
+        let next_keys: HashSet<String> = next.keys().cloned().collect();
+        let added: Vec<_> = next_keys.difference(&previous).cloned().collect();
+        let removed: Vec<_> = previous.difference(&next_keys).cloned().collect();
         if !added.is_empty() || !removed.is_empty() {
             tracing::info!(
                 "Scheduler membership updated; added={}, removed={}",
@@ -371,18 +341,29 @@ impl SchedulerRegistryRunner {
                 removed.len()
             );
         }
-
-        *peers = records;
-
-        // Record cluster scheduler count metric
+        *peers = next;
         cluster_metrics::set_scheduler_count(&self.scheduler_id, peers.len() as u64);
-
         Ok(())
     }
 
-    async fn delete_record(&self) {
-        if let Err(err) = self.store.delete(&self.record_path).await {
-            tracing::warn!("Failed to delete scheduler record: {err}");
+    async fn shutdown(&self) {
+        let scheduler_id = self.scheduler_id.clone();
+        let instance_id = self.instance_id;
+        if let Err(err) = self
+            .cluster
+            .mutate(|state| match state.schedulers.get(&scheduler_id) {
+                Some(entry) if entry.instance_id == instance_id => {
+                    state.schedulers.remove(&scheduler_id);
+                    MutationOutcome::Apply
+                }
+                _ => MutationOutcome::NoChange,
+            })
+            .await
+        {
+            tracing::warn!("Failed to remove scheduler entry on shutdown: {err}");
+        }
+        if let Err(err) = self.heartbeats.delete(&self.scheduler_id).await {
+            tracing::warn!("Failed to delete heartbeat on shutdown: {err}");
         }
     }
 }
@@ -420,7 +401,7 @@ pub(super) async fn build_object_store(
     .await
 }
 
-pub(super) async fn build_object_store_internal(
+pub async fn build_object_store_internal(
     secrets: Arc<RwLock<Secrets>>,
     io_runtime: Handle,
     state_location: &str,
@@ -431,9 +412,6 @@ pub(super) async fn build_object_store_internal(
     })?;
 
     if url.scheme() == "file" {
-        // For file:// URLs, reconstruct the local filesystem path.
-        // `file://.data/scheduler-state` → host=".data", path="/scheduler-state" → ".data/scheduler-state"
-        // `file:///absolute/path`        → host=None,    path="/absolute/path"   → "/absolute/path"
         let local_path = match url.host_str() {
             Some(host) => {
                 let path_suffix = url.path().trim_start_matches('/');
@@ -451,10 +429,6 @@ pub(super) async fn build_object_store_internal(
             source: Box::new(e),
         })?;
 
-        // Use `LocalConditionalPut` instead of plain `LocalFileSystem` because
-        // `LocalFileSystem` returns `NotImplemented` for `PutMode::Update`.
-        // The scheduler registry heartbeats and job store state transitions
-        // both rely on conditional puts (ETag-based OCC).
         let store: Arc<dyn ObjectStore> = Arc::new(
             object_store_occ::LocalConditionalPut::new(&local_path).map_err(|e| {
                 Error::LocalFileSystemInit {
@@ -464,7 +438,6 @@ pub(super) async fn build_object_store_internal(
             })?,
         );
 
-        // The store is rooted at `local_path`, so the base prefix is empty.
         return Ok((store, String::new()));
     }
 
@@ -523,32 +496,54 @@ async fn build_s3_parameters(
     }
 }
 
-fn join_path(prefix: &str, suffix: &str) -> Path {
-    if prefix.is_empty() {
-        Path::from(suffix)
-    } else {
-        Path::from(format!("{prefix}/{suffix}"))
-    }
-}
-
-fn record_is_stale(record: &SchedulerRecord, now_ms: u64) -> bool {
-    now_ms.saturating_sub(record.last_heartbeat_ms)
-        > record.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS)
-}
-
 fn now_ms() -> Result<u64> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|source| Error::ObjectStoreRead {
-            source: ObjectStoreError::Generic {
-                store: "scheduler_registry",
-                source: Box::new(source),
-            },
-        })?;
-    u64::try_from(now.as_millis()).map_err(|source| Error::ObjectStoreRead {
-        source: ObjectStoreError::Generic {
-            store: "scheduler_registry",
-            source: Box::new(source),
-        },
-    })
+    cluster_state::now_ms().map_err(|source| Error::ClusterState { source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    #[tokio::test]
+    async fn registry_runner_basic_register_and_shutdown() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+        };
+        runner.register_self().await.expect("register");
+
+        let snap = cluster.read().await.expect("read");
+        assert!(snap.schedulers.contains_key("test:50051"));
+        let beat = heartbeats.read("test:50051").await.expect("read hb");
+        assert!(beat.is_some());
+
+        runner.shutdown().await;
+        let snap = cluster.read().await.expect("read");
+        assert!(!snap.schedulers.contains_key("test:50051"));
+        let beat = heartbeats.read("test:50051").await.expect("read hb");
+        assert!(beat.is_none());
+    }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -775,8 +775,40 @@ impl Runtime {
     pub fn partition_manager(&self) -> Option<Arc<PartitionManager>> {
         match self.distributed.as_ref() {
             Some(DistributedNode::Scheduler {
-                partition_manager, ..
-            }) => Some(Arc::clone(partition_manager)),
+                accelerations_partitions,
+                ..
+            }) => Some(Arc::clone(accelerations_partitions)),
+            _ => None,
+        }
+    }
+
+    /// Returns the catalog/federated partition manager (scheduler only).
+    #[must_use]
+    pub fn catalog_partition_manager(&self) -> Option<Arc<PartitionManager>> {
+        match self.distributed.as_ref() {
+            Some(DistributedNode::Scheduler {
+                catalog_partitions, ..
+            }) => Some(Arc::clone(catalog_partitions)),
+            _ => None,
+        }
+    }
+
+    /// Returns the shared cluster state store (scheduler only).
+    #[must_use]
+    pub fn cluster_state(&self) -> Option<Arc<crate::cluster::ClusterStateStore>> {
+        match self.distributed.as_ref() {
+            Some(DistributedNode::Scheduler { cluster_state, .. }) => {
+                Some(Arc::clone(cluster_state))
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the scheduler heartbeat store (scheduler only).
+    #[must_use]
+    pub fn scheduler_heartbeats(&self) -> Option<Arc<crate::cluster::SchedulerHeartbeatStore>> {
+        match self.distributed.as_ref() {
+            Some(DistributedNode::Scheduler { heartbeats, .. }) => Some(Arc::clone(heartbeats)),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

Distributed scheduler state lived across four kinds of files: `metadata/cluster.json`, `schedulers/{id}.json`, `accelerations/partitions/{table}.json`, and `catalog/partitions/{table}.json`. This PR consolidates all of them into a single OCC-protected document at `cluster.json`, and moves heartbeats out into per-scheduler files at `heartbeats/{id}.json` so the high-frequency write path doesn't contend with everything else.

Discovery becomes a single `cluster.json` read instead of N prefix lists. Job state (`jobs/`) is unchanged.

## Layout

```
{base_prefix}/
├── cluster.json                   # NEW: schedulers + accelerations + catalog (OCC)
├── heartbeats/
│   └── {scheduler_id}.json        # NEW: heartbeat-only, frequent writes
└── jobs/                          # unchanged
    ├── {job_id}.json
    └── {job_id}/chunk_*.arrow
```

Removed: `metadata/cluster.json`, `schedulers/{id}.json`, `accelerations/partitions/*.json`, `catalog/partitions/*.json`.

## `cluster.json` schema (v1)

```jsonc
{
  "schema_version": 1,                  // u32, currently 1
  "created_at_ms":  1776849553512,      // u64, ms since epoch, set on bootstrap
  "updated_at_ms":  1776849732709,      // u64, ms since epoch, refreshed on every commit

  // Registered schedulers, keyed by scheduler_id (= node-bind-address `host:port`).
  // Heartbeats live in heartbeats/{scheduler_id}.json, NOT here.
  "schedulers": {
    "127.0.0.1:50071": {
      "scheduler_id":      "127.0.0.1:50071",
      "instance_id":       "0d8a78b9-d455-4a2e-a40d-9f0e73a1ae5b",  // UUID, regenerated every process start
      "advertise_address": "127.0.0.1:50071",
      "grpc_address":      "127.0.0.1:51071",
      "http_address":      "127.0.0.1:18090",
      "started_at_ms":     1776849732606,
      "ttl_ms":            30000,
      "build_version":     "2.0.0-unstable",
      "labels":            {}             // HashMap<String, String>, defaults to {}
    }
  },

  // Partition metadata for accelerated tables, keyed by normalized table name
  // ("catalog.schema.table", lowercased, defaults filled in).
  "accelerations": {
    "spice.public.taxi_trips": {
      "table_name":             "spice.public.taxi_trips",
      "schema_version":         1,
      "updated_at":             1776849732606,                       // u128 ms since epoch
      "partition_expressions":  ["bucket(3, c_nationkey)"],          // Vec<String>, original SQL exprs
      "partitions": [
        {
          "partition_value":      { "expr0": "0" },                  // HashMap<String, String>
          "assigned_executors":   ["127.0.0.1:52071"],                // Vec<String>, defaults to []
          "last_assigned_at":     1776849732606                       // u128, omitted if never assigned
        }
      ]
    }
  },

  // Same shape as `accelerations`, for catalog/federated tables.
  "catalog": {}
}
```

All three top-level maps default to `{}` when missing on read. `labels` and `assigned_executors` default to empty; `last_assigned_at` is omitted when `None`.

`heartbeats/{scheduler_id}.json` is a separate document so the high-frequency heartbeat write path doesn't contend with cluster mutations:

```jsonc
{
  "scheduler_id":      "127.0.0.1:50071",
  "instance_id":       "0d8a78b9-d455-4a2e-a40d-9f0e73a1ae5b",  // must match cluster.json entry; mismatches are filtered as orphans
  "last_heartbeat_ms": 1776849733511,
  "ttl_ms":            30000
}
```

## Design notes

- `ClusterStateStore::mutate` is the only write path. On `Conflict` it refetches and re-runs the closure. `NoChange` returned against a stale cached snapshot is verified against a fresh read before returning `AlreadySatisfied` (the "check whether the change is already applied on conflict and re-read" semantics requested in design review). `NotFound` mid-flight is surfaced, never silently re-bootstrapped.
- `SchedulerEntry` and `SchedulerHeartbeat` carry an `instance_id` (UUID per process). The takeover decision happens inside the OCC closure on `cluster.json`, eliminating the TOCTOU window between "observe stale heartbeat" and "overwrite entry".
- Reaper removes a dead scheduler from `cluster.json` only when the `instance_id` it observed still matches. It does **not** delete heartbeat files (object store has no conditional delete, and orphans are filtered out by `list_alive`).
- Membership RPC keeps reading the pre-filtered in-memory `peers` map, not raw `cluster.read_cached()`, so executor failover latency stays at one discovery interval rather than `discovery + reaper`.
- `PartitionManager` is parameterised by `PartitionScope::{Acceleration, Catalog}`; two type aliases (`AccelerationsPartitions`, `CatalogPartitions`) document scope at call sites.
- New `apply_assignments(&[AssignmentRequest])` batches many `(table, partition, executor)` updates into one cluster-document write — the previous per-partition write loop in `scheduler_task::commit_assignments` would amplify badly against the now-shared document.
- Executor disconnect on a reaped scheduler is unchanged: the existing `fetch_scheduler_membership` poll feeds `ControlStreamManager`, no proto changes.

## Migration — clean break

Pre-RC, no readers for the old layout. **Operators of distributed deployments must wipe** `metadata/`, `schedulers/`, `accelerations/`, and `catalog/` under `runtime.scheduler.state_location` before upgrading. **Do NOT wipe `jobs/`** — job state is unchanged and contains user-visible async query results. The new `heartbeats/` prefix is intentionally distinct from the old `schedulers/` prefix so leftover legacy files cannot break heartbeat listing.

## Tests

Unit tests cover:

- `mutate` apply / NoChange-against-fresh / NoChange-from-stale-cache-forces-fresh-read / conflict-effective-no-op / mid-flight `NotFound` / `Arc` snapshot identity.
- Heartbeat `list_alive` filtering for both stale and orphan `instance_id`; `list_all_evicts_deleted_keys`; concurrent heartbeats convergence.
- Reaper: stale heartbeat / missing heartbeat after grace / fresh heartbeat / recently-registered without heartbeat / `instance_id` mismatch / concurrent idempotency / `reaper_does_not_delete_heartbeat_files`.
- Partition wrappers: ported all `copy_assignments_*` and `table_key_*` tests; added `acceleration_and_catalog_share_no_state` and `apply_assignments_writes_once_for_many_partitions`.
- `registry_runner_basic_register_and_shutdown`.

Manual end-to-end with two file-backed schedulers against `/tmp/spice-cluster-state`:

- Layout: only `cluster.json` + `heartbeats/<id>.json` are created. `cluster.json` mtime changes only on membership/partition writes; heartbeat mtimes update independently.
- Two-scheduler discovery: each sees the other within one discovery interval.
- Graceful shutdown: entry removed from `cluster.json` and heartbeat file deleted within ~1s.
- SIGKILL: entry stays in `cluster.json` until reaper fires (~ttl + jitter ≈ 30–36s); reaper logs `Reaped stale scheduler`; orphan heartbeat is left in place.
- Takeover after reap: fresh process registers with new `instance_id`; orphan heartbeat is overwritten.
- Takeover during the reaper window with a still-fresh heartbeat: registration correctly refused with `Scheduler registration record already exists … and is still active`, matching pre-existing semantics.

`make lint-rust` ✅

