### PR TITLE
Fix physical codec decode ambiguity for empty protobuf messages

### DIFF
--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -198,7 +198,18 @@ message MetricsResponse {
     bytes otlp_metrics = 2;
 }
 
-// Physical plan
+// Physical plan — wrapper with oneof to unambiguously tag each node type.
+// Without this, empty proto3 messages (BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode with an empty schema)
+// are wire-identical to each other and making decoding unreliable.
+message SpicePhysicalPlanNode {
+    oneof node {
+        SchemaCastScanExecNode schema_cast_scan = 1;
+        BytesProcessedExecNode bytes_processed = 2;
+        CayenneAccelerationExecNode cayenne_acceleration = 3;
+        UdtfExecNode udtf = 4;
+    }
+}
+
 message SchemaCastScanExecNode {
     bytes schema = 1;
 }

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -31,7 +31,8 @@ use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
 use runtime_proto::{
-    BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode, UdtfExecNode,
+    BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode,
+    SpicePhysicalPlanNode, UdtfExecNode, spice_physical_plan_node,
 };
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -77,93 +78,100 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             return Ok(plan);
         }
 
-        if let Ok(node) = SchemaCastScanExecNode::decode(buf)
-            && !node.schema.is_empty()
-        {
-            let schema = datafusion_common::Schema::decode(&*node.schema)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let wrapper = SpicePhysicalPlanNode::decode(buf)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-            let exec = Arc::new(SchemaCastScanExec::new(
-                Arc::clone(&inputs[0]),
-                Arc::new(Schema::try_from(&schema)?),
-            ));
+        match wrapper.node {
+            Some(spice_physical_plan_node::Node::SchemaCastScan(node)) => {
+                let schema = datafusion_common::Schema::decode(&*node.schema)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-            Ok(exec)
-        } else if BytesProcessedExecNode::decode(buf).is_ok() {
-            Ok(Arc::new(
+                let exec = Arc::new(SchemaCastScanExec::new(
+                    Arc::clone(&inputs[0]),
+                    Arc::new(Schema::try_from(&schema)?),
+                ));
+
+                Ok(exec)
+            }
+            Some(spice_physical_plan_node::Node::BytesProcessed(_)) => Ok(Arc::new(
                 BytesProcessedExec::new(
                     Arc::clone(&inputs[0]),
                     Arc::new(Box::new(track_bytes_processed)),
                 )
                 .fallback_to_new_context(),
-            ))
-        } else if CayenneAccelerationExecNode::decode(buf).is_ok() {
-            #[cfg(not(windows))]
-            {
-                Ok(Arc::new(CayenneAccelerationExec::new(Arc::clone(
-                    &inputs[0],
-                ))))
+            )),
+            Some(spice_physical_plan_node::Node::CayenneAcceleration(_)) => {
+                #[cfg(not(windows))]
+                {
+                    Ok(Arc::new(CayenneAccelerationExec::new(Arc::clone(
+                        &inputs[0],
+                    ))))
+                }
+                #[cfg(windows)]
+                {
+                    exec_err!("CayenneAccelerationExec is not supported on Windows")
+                }
             }
-            #[cfg(windows)]
-            {
-                exec_err!("CayenneAccelerationExec is not supported on Windows")
+            Some(spice_physical_plan_node::Node::Udtf(node)) => {
+                // Decode the UdtfExec by re-invoking the UDTF
+                let runtime = self.runtime()?;
+                let Some(args) = node.args else {
+                    return exec_err!("UdtfExecNode missing args");
+                };
+
+                // Re-invoke the UDTF to get the TableProvider
+                let table_provider = SpiceLogicalCodec::invoke_udtf(args.clone(), &runtime)?;
+
+                // Get the execution plan from the TableProvider using the runtime's session state
+                let session_state = runtime.df.ctx.state();
+                // NOTE: The codec deserialization API is synchronous, but DataFusion's
+                // TableProvider::scan is async. To reconstruct the physical plan we must
+                // synchronously wait for the scan to complete. This path is only taken during
+                // plan deserialization on executor startup, so the blocking cost is acceptable.
+                let inner_plan = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async {
+                        table_provider.scan(&session_state, None, &[], None).await
+                    })
+                })?;
+
+                Ok(Arc::new(UdtfExec::new(args, inner_plan)))
             }
-        } else if let Ok(node) = UdtfExecNode::decode(buf) {
-            // Decode the UdtfExec by re-invoking the UDTF
-            let runtime = self.runtime()?;
-            let Some(args) = node.args else {
-                return exec_err!("UdtfExecNode missing args");
-            };
-
-            // Re-invoke the UDTF to get the TableProvider
-            let table_provider = SpiceLogicalCodec::invoke_udtf(args.clone(), &runtime)?;
-
-            // Get the execution plan from the TableProvider using the runtime's session state
-            let session_state = runtime.df.ctx.state();
-            // NOTE: The codec deserialization API is synchronous, but DataFusion's
-            // TableProvider::scan is async. To reconstruct the physical plan we must
-            // synchronously wait for the scan to complete. This path is only taken during
-            // plan deserialization on executor startup, so the blocking cost is acceptable.
-            let inner_plan = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current()
-                    .block_on(async { table_provider.scan(&session_state, None, &[], None).await })
-            })?;
-
-            Ok(Arc::new(UdtfExec::new(args, inner_plan)))
-        } else {
-            exec_err!("Cannot deserialize unknown execution plan")
+            None => exec_err!("Cannot deserialize unknown execution plan"),
         }
     }
 
     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
-        if let Some(concrete) = node.as_any().downcast_ref::<SchemaCastScanExec>() {
+        let wrapper = if let Some(concrete) = node.as_any().downcast_ref::<SchemaCastScanExec>() {
             let mut schema_buf = vec![];
             let serialized_schema = datafusion_common::Schema::try_from(concrete.schema())?;
             serialized_schema
                 .encode(&mut schema_buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-            let node = SchemaCastScanExecNode { schema: schema_buf };
-            node.encode(buf)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            SpicePhysicalPlanNode {
+                node: Some(spice_physical_plan_node::Node::SchemaCastScan(
+                    SchemaCastScanExecNode { schema: schema_buf },
+                )),
+            }
         } else if node.as_any().downcast_ref::<BytesProcessedExec>().is_some() {
-            let node = BytesProcessedExecNode {};
-            node.encode(buf)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            SpicePhysicalPlanNode {
+                node: Some(spice_physical_plan_node::Node::BytesProcessed(
+                    BytesProcessedExecNode {},
+                )),
+            }
         } else if let Some(udtf_exec) = node.as_any().downcast_ref::<UdtfExec>() {
-            // Serialize the UdtfExec with its args and schema
             let mut schema_buf = vec![];
             let serialized_schema = datafusion_common::Schema::try_from(udtf_exec.schema())?;
             serialized_schema
                 .encode(&mut schema_buf)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-            let node = UdtfExecNode {
-                args: Some(udtf_exec.args().clone()),
-                schema: schema_buf,
-            };
-            node.encode(buf)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            SpicePhysicalPlanNode {
+                node: Some(spice_physical_plan_node::Node::Udtf(UdtfExecNode {
+                    args: Some(udtf_exec.args().clone()),
+                    schema: schema_buf,
+                })),
+            }
         } else {
             #[cfg(not(windows))]
             if node
@@ -171,9 +179,11 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 .downcast_ref::<CayenneAccelerationExec>()
                 .is_some()
             {
-                let node = CayenneAccelerationExecNode {};
-                node.encode(buf)
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                SpicePhysicalPlanNode {
+                    node: Some(spice_physical_plan_node::Node::CayenneAcceleration(
+                        CayenneAccelerationExecNode {},
+                    )),
+                }
             } else {
                 return self.inner.try_encode(node, buf);
             }
@@ -181,7 +191,11 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             {
                 return self.inner.try_encode(node, buf);
             }
-        }
+        };
+
+        wrapper
+            .encode(buf)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         Ok(())
     }

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -77,7 +77,9 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             return Ok(plan);
         }
 
-        if let Ok(node) = SchemaCastScanExecNode::decode(buf) {
+        if let Ok(node) = SchemaCastScanExecNode::decode(buf)
+            && !node.schema.is_empty()
+        {
             let schema = datafusion_common::Schema::decode(&*node.schema)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
 


### PR DESCRIPTION
## 📝 Summary

Fix physical codec decode ambiguity for empty protobuf messages

Problem

`BytesProcessedExecNode` is empty proto3 messages (zero bytes when encoded). In proto3,  any message can be decoded from an empty buffer — all fields take their default values. The physical codec decode chain tries each message type in order:

```
SchemaCastScanExecNode::decode(buf)   ← checked first
BytesProcessedExecNode::decode(buf)
CayenneAccelerationExecNode::decode(buf)
UdtfExecNode::decode(buf)
```

When `buf` is empty (from a serialized `BytesProcessedExec`), `SchemaCastScanExecNode::decode` succeeds with `schema: vec![]`, producing a `SchemaCastScanExec` with **0 columns**. Downstream operators then fail:

>PhysicalExpr Column references column '_score' at index 4 but input schema only has 0 columns: []


This affects any distributed query whose physical plan contains a `BytesProcessedExec` node — for example distributed `rrf` queries.

### Coordinator plan (correct)

```
SortExec(TopK, fetch=10) [_score@4 DESC]
  BytesProcessedExec                    ← empty proto message
    UdtfExec (rrf / vector_search)
```

### Executor plan after decode (broken, before fix)

```
SortExec(TopK, fetch=10) [_score@4 DESC]
  SchemaCastScanExec (schema: [])       ← ghost node, 0 columns! Must be BytesProcessedExec
    UdtfExec (rrf / vector_search)
```

`SortExec` references `_score@4` but `SchemaCastScanExec` reports 0 columns → crash.

## Fix

Wrap all custom physical plan node types in a `SpicePhysicalPlanNode` message with a `oneof` discriminator:

```protobuf
message SpicePhysicalPlanNode {
    oneof node {
        SchemaCastScanExecNode schema_cast_scan = 1;
        BytesProcessedExecNode bytes_processed = 2;
        CayenneAccelerationExecNode cayenne_acceleration = 3;
        UdtfExecNode udtf = 4;
    }
}
```

Each variant is now unambiguously tagged on the wire — no decode-chain guessing. The codec encodes/decodes `SpicePhysicalPlanNode` and `match`es on the `oneof` variant directly.
