### PR TITLE
Add helm lint CI

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,33 @@
+name: pr - helm-lint
+
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - 'deploy/chart/**'
+  merge_group:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+
+jobs:
+  lint-helm:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+
+      - name: Lint Helm chart
+        run: helm lint deploy/chart/

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -9,17 +9,11 @@ on:
       - feature-*
     paths:
       - 'deploy/chart/**'
-  merge_group:
-    branches:
-      - trunk
-      - release-*
-      - release/*
-      - feature-*
 
 jobs:
   lint-helm:
     name: Helm Lint
-    runs-on: ubuntu-latest
+    runs-on: spiceai-macos
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically lint Helm charts on pull requests and merge groups. This helps ensure that any changes to the Helm chart in the `deploy/chart/` directory are validated for correctness before being merged.

**CI/CD Improvements:**

* Added a `.github/workflows/helm-lint.yml` workflow that runs `helm lint` on changes to the Helm chart for pull requests.