### PR TITLE
fix(secrets): harden AWS Secrets Manager secret store

### DIFF
--- a/crates/runtime-secrets/src/lib.rs
+++ b/crates/runtime-secrets/src/lib.rs
@@ -428,8 +428,10 @@ async fn load_secret_store(store_type: SecretStoreType) -> Result<Arc<dyn Secret
         }
         #[cfg(feature = "aws-secrets-manager")]
         SecretStoreType::AwsSecretsManager(secret_name) => {
-            let secret_store =
-                stores::aws_secrets_manager::AwsSecretsManager::new(secret_name.clone());
+            let secret_store = stores::aws_secrets_manager::AwsSecretsManager::new(&secret_name)
+                .map_err(|e| Error::UnableToInitializeAwsSecretsManager {
+                    source: Box::new(e),
+                })?;
 
             secret_store
                 .init()

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -535,9 +535,9 @@ mod tests {
 
     #[test]
     fn rejects_non_object_payload() {
-        assert!(parse_json_to_hashmap(r#"["a","b"]"#).is_err());
-        assert!(parse_json_to_hashmap(r#""just a string""#).is_err());
-        assert!(parse_json_to_hashmap("not json").is_err());
+        let _ = parse_json_to_hashmap(r#"["a","b"]"#).expect_err("array is not an object");
+        let _ = parse_json_to_hashmap(r#""just a string""#).expect_err("string is not an object");
+        let _ = parse_json_to_hashmap("not json").expect_err("invalid JSON");
     }
 
     #[test]

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,146 +14,548 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//! AWS Secrets Manager secret store.
+//!
+//! This store resolves secrets by fetching a single AWS Secrets Manager secret
+//! (by name or ARN) whose value is expected to be a JSON object mapping keys to
+//! string values. Each key lookup is satisfied from that map.
+//!
+//! Design notes
+//! - The AWS SDK client is created once (lazily) and reused for all lookups.
+//!   Re-creating the client per-call is expensive and produces extra log noise.
+//! - The resolved secret payload is cached in-process for a short TTL behind an
+//!   `Arc` so that concurrent readers share the same allocation and avoid
+//!   cloning the (potentially secret-laden) map on every lookup.
+//! - Concurrent cache misses are coalesced behind a single async `Mutex` so
+//!   that only one `GetSecretValue` call is in flight at a time per store.
+//! - Transient failures (throttling, 5xx, connection errors) are retried by
+//!   the AWS SDK itself using the standard retry strategy with exponential
+//!   backoff. We raise `max_attempts` above the SDK default to tolerate brief
+//!   Secrets Manager throttling without failing Spicepod load.
+//! - A per-operation timeout prevents a stalled AWS endpoint from hanging
+//!   Spicepod loads or parameter resolution indefinitely.
+//! - `ResourceNotFoundException` is treated as "secret does not exist" and
+//!   cached (negative cache) so we don't hammer AWS with repeated misses.
+//!   `DecryptionFailure` and malformed-request errors are surfaced with
+//!   actionable guidance. All other errors are propagated.
+//! - Both `SecretString` and `SecretBinary` payloads are supported. If the
+//!   payload is not a JSON object, the store logs a warning once and returns
+//!   `None` for every key rather than failing hard, since secret lookups
+//!   fall through a precedence list of stores.
+//! - Intermediate plaintext payload buffers are wrapped in [`Zeroizing`] so
+//!   their backing memory is scrubbed when they are dropped.
+
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use aws_config::retry::RetryConfig;
+use aws_config::timeout::TimeoutConfig;
+use aws_sdk_credential_bridge::default_aws_config;
+use aws_sdk_secretsmanager::{error::SdkError, operation::get_secret_value::GetSecretValueError};
 use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
 use secrecy::SecretString;
+use secrecy::zeroize::Zeroizing;
+use snafu::{OptionExt, ResultExt, Snafu};
+use tokio::sync::{Mutex, OnceCell};
 
 use crate::SecretStore;
 
-use aws_sdk_secretsmanager::{error::SdkError, operation::get_secret_value::GetSecretValueError};
-
-use aws_sdk_secretsmanager::{self};
-
-use snafu::{OptionExt, ResultExt, Snafu};
-
-use aws_sdk_credential_bridge::default_aws_config;
-
+/// Prefix used to scope secret keys to Spice.
+///
+/// When present in the secret's JSON payload, keys prefixed with `spice_` take
+/// precedence over the unprefixed key of the same name. This lets users store
+/// Spice-specific values alongside other application secrets in the same AWS
+/// secret without collisions.
 const SPICE_KEY_PREFIX: &str = "spice_";
+
+/// Default TTL for cached secret payloads.
+///
+/// Chosen to balance responsiveness to secret rotation against API call volume.
+/// Secret rotation in AWS is typically on the order of hours/days, so a minute
+/// of staleness is acceptable for most workloads.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Negative-cache TTL for confirmed-missing secrets.
+///
+/// Shorter than [`DEFAULT_CACHE_TTL`] so that newly created secrets become
+/// visible quickly, but long enough to avoid hammering AWS when a Spicepod
+/// references a missing key.
+const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(10);
+
+/// Maximum number of attempts for a single Secrets Manager API call.
+///
+/// The AWS SDK default is 3. We raise this to 5 to better tolerate brief
+/// throttling during Spicepod load, where many parameter resolutions may
+/// converge on the same secret in a short window. The SDK applies exponential
+/// backoff with jitter between attempts.
+const MAX_ATTEMPTS: u32 = 5;
+
+/// Per-attempt timeout for a single Secrets Manager API call. Bounded so a
+/// stalled endpoint cannot hang Spicepod initialization indefinitely.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Overall timeout across all retry attempts for a single operation.
+///
+/// Must be larger than `MAX_ATTEMPTS * ATTEMPT_TIMEOUT` plus backoff delays
+/// so the retry strategy gets a chance to fire before the wall-clock cap.
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
-        "AWS identity verification failed, check configuration with `aws configure list` and `aws sts get-caller-identity`: {}",
-        source
+        "AWS identity verification failed, check configuration with `aws configure list` and `aws sts get-caller-identity`: {source}"
     ))]
     UnableToVerifyAwsIdentity {
-        source: SdkError<GetCallerIdentityError>,
+        // Boxed to keep `Error` small: `SdkError` is ~350 bytes and this
+        // variant is on the cold init path.
+        source: Box<SdkError<GetCallerIdentityError>>,
     },
 
     #[snafu(display("Unable to parse AWS secret as JSON: {source}"))]
     UnableToParseJson { source: serde_json::Error },
 
-    #[snafu(display("Invalid AWS secret value: JSON object is expected"))]
+    #[snafu(display("Invalid AWS secret value: a JSON object is expected"))]
     InvalidJsonFormat {},
 
-    #[snafu(display("Unable to get AWS secret: {source}"))]
+    #[snafu(display(
+        "Unable to get AWS secret '{secret_name}': {source}. Verify the secret exists, is in the expected region, and that your IAM principal has `secretsmanager:GetSecretValue` permission."
+    ))]
     UnableToGetSecret {
-        source: SdkError<GetSecretValueError>,
+        secret_name: String,
+        // Boxed because `SdkError` is large (>256 bytes) and this variant is on
+        // the cold error path; avoids bloating `Result` on hot lookup paths.
+        source: Box<SdkError<GetSecretValueError>>,
     },
+
+    #[snafu(display(
+        "AWS Secrets Manager could not decrypt the secret '{secret_name}'. Verify the KMS key used to encrypt this secret is enabled and that your IAM principal has `kms:Decrypt` permission on it."
+    ))]
+    UnableToDecryptSecret { secret_name: String },
+
+    #[snafu(display(
+        "AWS Secrets Manager rejected the request for '{secret_name}' as invalid: {details}. Check the secret name/ARN and the region configuration."
+    ))]
+    InvalidSecretRequest {
+        secret_name: String,
+        details: String,
+    },
+
+    #[snafu(display(
+        "AWS secret name must not be empty. Specify the secret as `from: aws_secrets_manager:<secret-name-or-arn>`."
+    ))]
+    EmptySecretName {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Clone)]
+/// Cached view of the AWS secret payload.
+///
+/// The parsed map is held behind an `Arc` so that readers share a single
+/// allocation and never clone the (potentially secret-bearing) map out of the
+/// cache. Memory is released (and zeroizing-sensitive buffers in the caller
+/// can take effect) once the final `Arc` reference is dropped.
+struct CachedPayload {
+    /// Parsed key/value map. Empty if the secret is missing or not a JSON object.
+    data: Arc<HashMap<String, String>>,
+    /// Monotonic timestamp at which this entry was captured.
+    fetched_at: Instant,
+    /// Effective TTL for this entry (shorter for negative results).
+    ttl: Duration,
+}
+
+impl CachedPayload {
+    fn is_fresh(&self) -> bool {
+        self.fetched_at.elapsed() < self.ttl
+    }
+}
+
 pub struct AwsSecretsManager {
     secret_name: String,
+    /// Lazily-initialized SDK client, shared across all lookups.
+    client: OnceCell<aws_sdk_secretsmanager::Client>,
+    /// In-process cache of the parsed secret payload.
+    cache: Mutex<Option<CachedPayload>>,
+    cache_ttl: Duration,
+    /// One-shot flag used to emit a single warning when a non-object payload
+    /// is encountered. Prevents log spam on hot paths.
+    warned_non_object: AtomicBool,
 }
 
 impl AwsSecretsManager {
-    #[must_use]
-    pub fn new(secret_name: String) -> Self {
-        Self { secret_name }
-    }
-
-    /// Initializes AWS configuration and verifies AWS credentials.
+    /// Creates a new [`AwsSecretsManager`] store bound to the given secret name or ARN.
     ///
     /// # Errors
     ///
-    /// This function will return an error:
-    /// - If the AWS configuration cannot be loaded.
-    /// - If the call to STS `get_caller_identity` fails, which might be due to invalid or expired AWS credentials.
-    pub async fn init(&self) -> Result<()> {
-        let config = default_aws_config().load().await;
+    /// Returns [`Error::EmptySecretName`] if `secret_name` is empty or whitespace-only.
+    pub fn new(secret_name: &str) -> Result<Self> {
+        let trimmed = secret_name.trim();
+        if trimmed.is_empty() {
+            return EmptySecretNameSnafu.fail();
+        }
 
+        Ok(Self {
+            secret_name: trimmed.to_string(),
+            client: OnceCell::new(),
+            cache: Mutex::new(None),
+            cache_ttl: DEFAULT_CACHE_TTL,
+            warned_non_object: AtomicBool::new(false),
+        })
+    }
+
+    /// Overrides the default cache TTL. Primarily intended for tests.
+    #[cfg(test)]
+    #[must_use]
+    pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_ttl = ttl;
+        self
+    }
+
+    /// Verifies that AWS credentials can be resolved by calling
+    /// `sts:GetCallerIdentity`. This is a fast, read-only check that fails
+    /// early with an actionable error at Spicepod load time rather than on the
+    /// first secret lookup.
+    ///
+    /// The STS call inherits the SDK's standard retry behavior, so transient
+    /// credential-provider or endpoint errors are retried automatically.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the STS call fails (e.g. missing/expired credentials,
+    /// unreachable STS endpoint, denied IAM policy).
+    pub async fn init(&self) -> Result<()> {
+        let config = build_aws_config().await;
         let sts_client = aws_sdk_sts::Client::new(&config);
 
         sts_client
             .get_caller_identity()
             .send()
             .await
-            .context(UnableToVerifyAwsIdentitySnafu)?;
+            .map_err(|source| Error::UnableToVerifyAwsIdentity {
+                source: Box::new(source),
+            })?;
 
         Ok(())
     }
+
+    async fn client(&self) -> &aws_sdk_secretsmanager::Client {
+        self.client
+            .get_or_init(|| async {
+                let config = build_aws_config().await;
+                aws_sdk_secretsmanager::Client::new(&config)
+            })
+            .await
+    }
+
+    /// Fetches the secret payload from AWS and parses it into a key/value map.
+    ///
+    /// Returns an empty map if the secret is not found, the payload is empty,
+    /// or the payload is not a JSON object. Network/permission errors are
+    /// surfaced to the caller. The AWS SDK transparently retries transient
+    /// failures (throttling, 5xx, connection reset) according to the retry
+    /// strategy configured on the client.
+    async fn fetch_payload(
+        &self,
+    ) -> crate::AnyErrorResult<(Arc<HashMap<String, String>>, Duration)> {
+        tracing::debug!(
+            secret_name = %self.secret_name,
+            "Fetching AWS secret payload"
+        );
+
+        let client = self.client().await;
+
+        let secret_value = match client
+            .get_secret_value()
+            .secret_id(&self.secret_name)
+            .send()
+            .await
+        {
+            Ok(v) => v,
+            Err(SdkError::ServiceError(e)) if e.err().is_resource_not_found_exception() => {
+                tracing::debug!(
+                    secret_name = %self.secret_name,
+                    "AWS secret not found; caching negative result"
+                );
+                return Ok((Arc::new(HashMap::new()), NEGATIVE_CACHE_TTL));
+            }
+            Err(SdkError::ServiceError(e)) if e.err().is_decryption_failure() => {
+                return Err(Box::new(Error::UnableToDecryptSecret {
+                    secret_name: self.secret_name.clone(),
+                }));
+            }
+            Err(SdkError::ServiceError(e))
+                if e.err().is_invalid_parameter_exception()
+                    || e.err().is_invalid_request_exception() =>
+            {
+                return Err(Box::new(Error::InvalidSecretRequest {
+                    secret_name: self.secret_name.clone(),
+                    details: e.err().to_string(),
+                }));
+            }
+            Err(err) => {
+                // All other errors — including throttling, 5xx, credentials,
+                // and access-denied — are surfaced to the caller. Retryable
+                // variants have already been retried by the SDK.
+                return Err(Box::new(Error::UnableToGetSecret {
+                    secret_name: self.secret_name.clone(),
+                    source: Box::new(err),
+                }));
+            }
+        };
+
+        // Extract the plaintext payload into a `Zeroizing<String>` so the
+        // backing memory is scrubbed when the buffer goes out of scope, even
+        // on the error/non-JSON paths below.
+        let payload: Option<Zeroizing<String>> = if let Some(s) = secret_value.secret_string() {
+            Some(Zeroizing::new(s.to_string()))
+        } else if let Some(blob) = secret_value.secret_binary() {
+            if let Ok(s) = std::str::from_utf8(blob.as_ref()) {
+                Some(Zeroizing::new(s.to_string()))
+            } else {
+                tracing::warn!(
+                    secret_name = %self.secret_name,
+                    "AWS secret binary payload is not valid UTF-8; ignoring"
+                );
+                None
+            }
+        } else {
+            None
+        };
+
+        let Some(payload) = payload else {
+            return Ok((Arc::new(HashMap::new()), self.cache_ttl));
+        };
+
+        if let Ok(map) = parse_json_to_hashmap(payload.as_str()) {
+            Ok((Arc::new(map), self.cache_ttl))
+        } else {
+            // Only warn once per store instance; the secret payload format
+            // does not typically change between calls.
+            if !self.warned_non_object.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    secret_name = %self.secret_name,
+                    "AWS secret payload is not a JSON object of string values. \
+                     Spice expects the secret value to be a JSON object mapping keys \
+                     to string values; this secret will resolve to no keys."
+                );
+            }
+            Ok((Arc::new(HashMap::new()), self.cache_ttl))
+        }
+    }
+
+    /// Returns a fresh secret payload, using the in-process cache when possible.
+    ///
+    /// Returns an `Arc`-shared map so callers do not clone the underlying
+    /// (potentially secret-bearing) data out of the cache.
+    async fn payload(&self) -> crate::AnyErrorResult<Arc<HashMap<String, String>>> {
+        let mut guard = self.cache.lock().await;
+
+        if let Some(entry) = guard.as_ref()
+            && entry.is_fresh()
+        {
+            return Ok(Arc::clone(&entry.data));
+        }
+
+        // Cache is empty or stale. Fetch under the lock to coalesce concurrent
+        // misses into a single AWS call. Holding an async `Mutex` across `.await`
+        // is intentional here: the critical section is exactly the fetch itself,
+        // and this store is only touched during parameter resolution.
+        let (data, ttl) = self.fetch_payload().await?;
+        *guard = Some(CachedPayload {
+            data: Arc::clone(&data),
+            fetched_at: Instant::now(),
+            ttl,
+        });
+        Ok(data)
+    }
+}
+
+/// Builds an AWS SDK configuration with explicit retry, timeout, and
+/// identification settings tuned for secret retrieval.
+///
+/// The standard retry strategy already covers the common transient failure
+/// modes for Secrets Manager (throttling, 5xx, connection reset, I/O errors)
+/// using exponential backoff with jitter. We raise the attempt cap to
+/// [`MAX_ATTEMPTS`] and add an operation-level timeout so a stalled endpoint
+/// cannot hang Spicepod initialization indefinitely.
+async fn build_aws_config() -> aws_config::SdkConfig {
+    default_aws_config()
+        .retry_config(RetryConfig::standard().with_max_attempts(MAX_ATTEMPTS))
+        .timeout_config(
+            TimeoutConfig::builder()
+                .operation_attempt_timeout(ATTEMPT_TIMEOUT)
+                .operation_timeout(OPERATION_TIMEOUT)
+                .build(),
+        )
+        .load()
+        .await
 }
 
 #[async_trait]
 impl SecretStore for AwsSecretsManager {
     async fn get_secret(&self, key: &str) -> crate::AnyErrorResult<Option<SecretString>> {
         tracing::trace!(
-            "Getting secret {} from AWS Secrets Manager",
-            self.secret_name
+            secret_name = %self.secret_name,
+            key = %key,
+            "Resolving secret key via AWS Secrets Manager"
         );
 
-        let config = default_aws_config().load().await;
+        let data = self.payload().await?;
 
-        let asm = aws_sdk_secretsmanager::Client::new(&config);
-
-        let secret_value = match asm
-            .get_secret_value()
-            .secret_id(&self.secret_name)
-            .send()
-            .await
-        {
-            Ok(secret) => secret,
-            Err(SdkError::ServiceError(e)) => {
-                // It is expected that not all parameters are present in secrets.
-                // Pass through only if it is a different error
-                if !e.err().is_resource_not_found_exception() {
-                    return Err(Box::new(Error::UnableToGetSecret {
-                        source: SdkError::ServiceError(e),
-                    }));
-                }
-                return Ok(None);
-            }
-            Err(err) => {
-                return Err(Box::new(Error::UnableToGetSecret { source: err }));
-            }
-        };
-
+        // Prefer the Spice-prefixed key so that Spice-owned values can coexist
+        // with other application secrets in the same AWS secret without
+        // collisions, then fall back to the unprefixed key.
         let prefixed_key = format!("{SPICE_KEY_PREFIX}{key}");
-        if let Some(secret_str) = secret_value.secret_string() {
-            let data = parse_json_to_hashmap(secret_str)?;
-            if let Some(value) = data.get(&prefixed_key) {
-                return Ok(Some(SecretString::from(value.clone())));
-            }
-            return Ok(data.get(key).cloned().map(SecretString::from));
+        if let Some(value) = data.get(&prefixed_key) {
+            return Ok(Some(SecretString::from(value.clone())));
         }
-
-        Ok(None)
+        Ok(data.get(key).cloned().map(SecretString::from))
     }
 }
 
 /// Parses a JSON string into a `HashMap<String, String>`.
 ///
+/// The input must be a JSON object. Primitive scalar values (strings, numbers,
+/// booleans) are coerced to their string representation; objects, arrays, and
+/// null values are skipped so that a partially-structured secret still yields
+/// the scalar keys it does contain.
+///
 /// # Errors
 ///
-/// This function will return an error if:
-/// - The input string cannot be parsed as a valid JSON object.
-#[expect(clippy::result_large_err)]
+/// Returns an error if the input is not valid JSON or is not a JSON object.
 pub fn parse_json_to_hashmap(json_str: &str) -> Result<HashMap<String, String>> {
     let parsed: serde_json::Value =
         serde_json::from_str(json_str).context(UnableToParseJsonSnafu)?;
     let root = parsed.as_object().context(InvalidJsonFormatSnafu)?;
 
-    let mut data = HashMap::new();
+    let mut data = HashMap::with_capacity(root.len());
     for (key, value) in root {
-        if let Some(value_str) = value.as_str() {
-            data.insert(key.clone(), value_str.to_string());
+        match value {
+            serde_json::Value::String(s) => {
+                data.insert(key.clone(), s.clone());
+            }
+            serde_json::Value::Number(n) => {
+                data.insert(key.clone(), n.to_string());
+            }
+            serde_json::Value::Bool(b) => {
+                data.insert(key.clone(), b.to_string());
+            }
+            // Skip null/object/array values – they cannot be injected as
+            // strings into parameters, and silently coercing them risks
+            // producing incorrect secret values.
+            _ => {
+                tracing::debug!(
+                    key = %key,
+                    "Skipping non-scalar value in AWS secret JSON payload"
+                );
+            }
         }
     }
 
     Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn parses_string_number_and_bool_values() {
+        let json = r#"{"a": "hello", "b": 42, "c": true, "d": null, "e": [1,2], "f": {"x": 1}}"#;
+        let map = parse_json_to_hashmap(json).expect("parse succeeds");
+        assert_eq!(map.get("a").map(String::as_str), Some("hello"));
+        assert_eq!(map.get("b").map(String::as_str), Some("42"));
+        assert_eq!(map.get("c").map(String::as_str), Some("true"));
+        // Null/array/object entries are intentionally skipped.
+        assert!(!map.contains_key("d"));
+        assert!(!map.contains_key("e"));
+        assert!(!map.contains_key("f"));
+    }
+
+    #[test]
+    fn rejects_non_object_payload() {
+        assert!(parse_json_to_hashmap(r#"["a","b"]"#).is_err());
+        assert!(parse_json_to_hashmap(r#""just a string""#).is_err());
+        assert!(parse_json_to_hashmap("not json").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_or_whitespace_secret_name() {
+        assert!(matches!(
+            AwsSecretsManager::new(""),
+            Err(Error::EmptySecretName { .. })
+        ));
+        assert!(matches!(
+            AwsSecretsManager::new("   "),
+            Err(Error::EmptySecretName { .. })
+        ));
+    }
+
+    #[test]
+    fn trims_secret_name() {
+        let s = AwsSecretsManager::new("  my-secret  ").expect("valid name");
+        assert_eq!(s.secret_name, "my-secret");
+    }
+
+    /// Exercises the lookup/prefix/fallback logic without hitting AWS by
+    /// seeding the cache directly.
+    #[tokio::test]
+    async fn prefers_spice_prefixed_keys_then_falls_back() {
+        let store = AwsSecretsManager::new("test").expect("valid name");
+
+        let mut data = HashMap::new();
+        data.insert("spice_api_key".to_string(), "prefixed".to_string());
+        data.insert("api_key".to_string(), "plain".to_string());
+        data.insert("only_plain".to_string(), "plain-value".to_string());
+
+        *store.cache.lock().await = Some(CachedPayload {
+            data: Arc::new(data),
+            fetched_at: Instant::now(),
+            ttl: Duration::from_secs(60),
+        });
+
+        let v = store
+            .get_secret("api_key")
+            .await
+            .expect("lookup ok")
+            .expect("present");
+        assert_eq!(v.expose_secret(), "prefixed");
+
+        let v = store
+            .get_secret("only_plain")
+            .await
+            .expect("lookup ok")
+            .expect("present");
+        assert_eq!(v.expose_secret(), "plain-value");
+
+        assert!(
+            store
+                .get_secret("missing")
+                .await
+                .expect("lookup ok")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn honors_negative_cache_entries() {
+        let store = AwsSecretsManager::new("test").expect("valid name");
+
+        *store.cache.lock().await = Some(CachedPayload {
+            data: Arc::new(HashMap::new()),
+            fetched_at: Instant::now(),
+            ttl: Duration::from_secs(60),
+        });
+
+        assert!(
+            store
+                .get_secret("anything")
+                .await
+                .expect("lookup ok")
+                .is_none()
+        );
+    }
 }

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -176,11 +176,14 @@ pub struct AwsSecretsManager {
     /// In-process cache of the parsed secret payload. Protected by an
     /// `RwLock` so cache hits never serialize against each other.
     cache: RwLock<Option<CachedPayload>>,
-    /// Single-flight coordinator: whichever task wins the `fetch_mutex`
-    /// performs the network call; others wait on `fetch_notify` and then
-    /// re-read the cache. This avoids holding a lock across the AWS call
-    /// while still coalescing concurrent cache misses.
+    /// Single-flight coordinator. The `fetch_mutex` is held only long enough
+    /// to elect a winner via `fetch_inflight`; it is dropped before any
+    /// `.await` on the AWS call. The winner performs the network fetch with
+    /// no locks held; losers `await` on `fetch_notify` and then re-check the
+    /// cache. This both coalesces concurrent misses and obeys the
+    /// "don't hold locks across `.await`" guideline.
     fetch_mutex: Mutex<()>,
+    fetch_inflight: AtomicBool,
     fetch_notify: Notify,
     cache_ttl: Duration,
     /// One-shot flag used to emit a single warning when a non-object payload
@@ -206,6 +209,7 @@ impl AwsSecretsManager {
             client: OnceCell::new(),
             cache: RwLock::new(None),
             fetch_mutex: Mutex::new(()),
+            fetch_inflight: AtomicBool::new(false),
             fetch_notify: Notify::new(),
             cache_ttl: DEFAULT_CACHE_TTL,
             warned_non_object: AtomicBool::new(false),
@@ -378,47 +382,74 @@ impl AwsSecretsManager {
     /// Concurrency
     /// - Cache hits take only an `RwLock` read and never serialize against
     ///   each other or against in-flight fetches.
-    /// - On a miss, one task wins `fetch_mutex` and performs the network
-    ///   call. Other tasks wait on `fetch_notify` and re-check the cache,
-    ///   so at most one `GetSecretValue` request is in flight per store.
+    /// - On a miss, one task is elected winner via the `fetch_inflight`
+    ///   atomic (under a brief `fetch_mutex` critical section that contains
+    ///   no `.await` against the network). The mutex is dropped before the
+    ///   AWS round-trip so it is never held across an `.await`.
+    /// - Losing tasks `await` on `fetch_notify` and then re-check the cache.
     /// - The AWS SDK call is never made while any lock is held, so a
     ///   stalled endpoint cannot stall cache readers.
     async fn payload(&self) -> crate::AnyErrorResult<Arc<HashMap<String, String>>> {
-        // Fast path: fresh cache hit.
-        if let Some(data) = self.try_cached().await {
-            return Ok(data);
-        }
-
-        // Serialize refreshes so we coalesce concurrent misses. Waiters below
-        // the winner block here until the winner drops `_fetch_guard`.
-        let _fetch_guard = self.fetch_mutex.lock().await;
-
-        // Re-check the cache — another task may have refreshed it while we
-        // were waiting on `fetch_mutex`.
-        if let Some(data) = self.try_cached().await {
-            return Ok(data);
-        }
-
-        // We are the winner: perform the network fetch without holding any
-        // cache lock. Regardless of success or failure, wake any waiters
-        // that arrived after us so they can re-check the cache.
-        let result = self.fetch_payload().await;
-        match result {
-            Ok((data, ttl)) => {
-                let mut guard = self.cache.write().await;
-                *guard = Some(CachedPayload {
-                    data: Arc::clone(&data),
-                    fetched_at: Instant::now(),
-                    ttl,
-                });
-                drop(guard);
-                self.fetch_notify.notify_waiters();
-                Ok(data)
+        loop {
+            // Fast path: fresh cache hit.
+            if let Some(data) = self.try_cached().await {
+                return Ok(data);
             }
-            Err(err) => {
-                self.fetch_notify.notify_waiters();
-                Err(err)
+
+            // Election: take the mutex only long enough to claim the
+            // in-flight slot or to observe that another task already holds
+            // it. No `.await` happens inside this block apart from the
+            // mutex acquisition itself, so the mutex is never held across
+            // the AWS network call.
+            let should_fetch = {
+                let _fetch_guard = self.fetch_mutex.lock().await;
+
+                // Another task may have refreshed the cache while we were
+                // waiting on the mutex; check again.
+                if let Some(data) = self.try_cached().await {
+                    return Ok(data);
+                }
+
+                if self.fetch_inflight.load(Ordering::Acquire) {
+                    false
+                } else {
+                    self.fetch_inflight.store(true, Ordering::Release);
+                    true
+                }
+                // `_fetch_guard` is dropped here, before any await on the
+                // AWS round-trip below.
+            };
+
+            if !should_fetch {
+                // Loser: wait for the winner to publish a result, then loop
+                // and re-check the cache. If the winner failed, the cache
+                // is still empty and we will try to become the new winner.
+                self.fetch_notify.notified().await;
+                continue;
             }
+
+            // Winner: perform the network fetch with no locks held.
+            // Always clear `fetch_inflight` and wake waiters, regardless of
+            // success or failure, so they can make progress.
+            let result = self.fetch_payload().await;
+            self.fetch_inflight.store(false, Ordering::Release);
+            return match result {
+                Ok((data, ttl)) => {
+                    let mut guard = self.cache.write().await;
+                    *guard = Some(CachedPayload {
+                        data: Arc::clone(&data),
+                        fetched_at: Instant::now(),
+                        ttl,
+                    });
+                    drop(guard);
+                    self.fetch_notify.notify_waiters();
+                    Ok(data)
+                }
+                Err(err) => {
+                    self.fetch_notify.notify_waiters();
+                    Err(err)
+                }
+            };
         }
     }
 

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -57,7 +57,7 @@ use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
 use secrecy::SecretString;
 use secrecy::zeroize::Zeroizing;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::{Mutex, Notify, OnceCell, RwLock};
 
 use crate::SecretStore;
 
@@ -89,10 +89,11 @@ const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Overall timeout across all retry attempts for a single operation.
 ///
-/// Sized larger than the SDK's default retry budget (3 attempts with
-/// exponential backoff + jitter) so the retry strategy gets a chance to
-/// fire before the wall-clock cap.
-const OPERATION_TIMEOUT: Duration = Duration::from_secs(60);
+/// Sized generously above the SDK's default retry budget (3 attempts with
+/// exponential backoff + jitter; worst-case ~30s of attempts plus ~20s of
+/// backoff) so the retry strategy always gets a chance to fire before the
+/// wall-clock cap.
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -165,10 +166,22 @@ impl CachedPayload {
 
 pub struct AwsSecretsManager {
     secret_name: String,
+    /// Lazily-initialized, shared SDK configuration. Resolved exactly once per
+    /// store instance and reused by both the STS pre-flight and the Secrets
+    /// Manager client, so credential-provider resolution (including IMDS
+    /// lookups) does not run twice.
+    sdk_config: OnceCell<aws_config::SdkConfig>,
     /// Lazily-initialized SDK client, shared across all lookups.
     client: OnceCell<aws_sdk_secretsmanager::Client>,
-    /// In-process cache of the parsed secret payload.
-    cache: Mutex<Option<CachedPayload>>,
+    /// In-process cache of the parsed secret payload. Protected by an
+    /// `RwLock` so cache hits never serialize against each other.
+    cache: RwLock<Option<CachedPayload>>,
+    /// Single-flight coordinator: whichever task wins the `fetch_mutex`
+    /// performs the network call; others wait on `fetch_notify` and then
+    /// re-read the cache. This avoids holding a lock across the AWS call
+    /// while still coalescing concurrent cache misses.
+    fetch_mutex: Mutex<()>,
+    fetch_notify: Notify,
     cache_ttl: Duration,
     /// One-shot flag used to emit a single warning when a non-object payload
     /// is encountered. Prevents log spam on hot paths.
@@ -189,8 +202,11 @@ impl AwsSecretsManager {
 
         Ok(Self {
             secret_name: trimmed.to_string(),
+            sdk_config: OnceCell::new(),
             client: OnceCell::new(),
-            cache: Mutex::new(None),
+            cache: RwLock::new(None),
+            fetch_mutex: Mutex::new(()),
+            fetch_notify: Notify::new(),
             cache_ttl: DEFAULT_CACHE_TTL,
             warned_non_object: AtomicBool::new(false),
         })
@@ -217,8 +233,8 @@ impl AwsSecretsManager {
     /// Returns an error if the STS call fails (e.g. missing/expired credentials,
     /// unreachable STS endpoint, denied IAM policy).
     pub async fn init(&self) -> Result<()> {
-        let config = build_aws_config().await;
-        let sts_client = aws_sdk_sts::Client::new(&config);
+        let config = self.sdk_config().await;
+        let sts_client = aws_sdk_sts::Client::new(config);
 
         sts_client
             .get_caller_identity()
@@ -231,11 +247,18 @@ impl AwsSecretsManager {
         Ok(())
     }
 
+    /// Returns the shared [`aws_config::SdkConfig`] for this store, loading
+    /// it on first use. Reused by both the STS pre-flight and the Secrets
+    /// Manager client so credential-provider resolution only happens once.
+    async fn sdk_config(&self) -> &aws_config::SdkConfig {
+        self.sdk_config.get_or_init(build_aws_config).await
+    }
+
     async fn client(&self) -> &aws_sdk_secretsmanager::Client {
         self.client
             .get_or_init(|| async {
-                let config = build_aws_config().await;
-                aws_sdk_secretsmanager::Client::new(&config)
+                let config = self.sdk_config().await;
+                aws_sdk_secretsmanager::Client::new(config)
             })
             .await
     }
@@ -319,20 +342,31 @@ impl AwsSecretsManager {
             return Ok((Arc::new(HashMap::new()), self.cache_ttl));
         };
 
-        if let Ok(map) = parse_json_to_hashmap(payload.as_str()) {
-            Ok((Arc::new(map), self.cache_ttl))
-        } else {
-            // Only warn once per store instance; the secret payload format
-            // does not typically change between calls.
-            if !self.warned_non_object.swap(true, Ordering::Relaxed) {
-                tracing::warn!(
-                    secret_name = %self.secret_name,
-                    "AWS secret payload is not a JSON object of string values. \
-                     Spice expects the secret value to be a JSON object mapping keys \
-                     to string values; this secret will resolve to no keys."
-                );
+        // Treat whitespace-only payloads as empty — they can occur as test
+        // fixtures or when a secret is reset — without tripping the
+        // non-object warning below.
+        if payload.as_str().trim().is_empty() {
+            return Ok((Arc::new(HashMap::new()), self.cache_ttl));
+        }
+
+        match parse_json_to_hashmap(payload.as_str()) {
+            Ok(map) => Ok((Arc::new(map), self.cache_ttl)),
+            Err(err) => {
+                // Only warn once per store instance; the secret payload format
+                // does not typically change between calls. The error message
+                // from `serde_json` never includes the payload contents, so it
+                // is safe to log.
+                if !self.warned_non_object.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        secret_name = %self.secret_name,
+                        error = %err,
+                        "AWS secret payload is not a JSON object of string values. \
+                         Spice expects the secret value to be a JSON object mapping keys \
+                         to string values; this secret will resolve to no keys."
+                    );
+                }
+                Ok((Arc::new(HashMap::new()), self.cache_ttl))
             }
-            Ok((Arc::new(HashMap::new()), self.cache_ttl))
         }
     }
 
@@ -340,26 +374,61 @@ impl AwsSecretsManager {
     ///
     /// Returns an `Arc`-shared map so callers do not clone the underlying
     /// (potentially secret-bearing) data out of the cache.
+    ///
+    /// Concurrency
+    /// - Cache hits take only an `RwLock` read and never serialize against
+    ///   each other or against in-flight fetches.
+    /// - On a miss, one task wins `fetch_mutex` and performs the network
+    ///   call. Other tasks wait on `fetch_notify` and re-check the cache,
+    ///   so at most one `GetSecretValue` request is in flight per store.
+    /// - The AWS SDK call is never made while any lock is held, so a
+    ///   stalled endpoint cannot stall cache readers.
     async fn payload(&self) -> crate::AnyErrorResult<Arc<HashMap<String, String>>> {
-        let mut guard = self.cache.lock().await;
-
-        if let Some(entry) = guard.as_ref()
-            && entry.is_fresh()
-        {
-            return Ok(Arc::clone(&entry.data));
+        // Fast path: fresh cache hit.
+        if let Some(data) = self.try_cached().await {
+            return Ok(data);
         }
 
-        // Cache is empty or stale. Fetch under the lock to coalesce concurrent
-        // misses into a single AWS call. Holding an async `Mutex` across `.await`
-        // is intentional here: the critical section is exactly the fetch itself,
-        // and this store is only touched during parameter resolution.
-        let (data, ttl) = self.fetch_payload().await?;
-        *guard = Some(CachedPayload {
-            data: Arc::clone(&data),
-            fetched_at: Instant::now(),
-            ttl,
-        });
-        Ok(data)
+        // Serialize refreshes so we coalesce concurrent misses. Waiters below
+        // the winner block here until the winner drops `_fetch_guard`.
+        let _fetch_guard = self.fetch_mutex.lock().await;
+
+        // Re-check the cache — another task may have refreshed it while we
+        // were waiting on `fetch_mutex`.
+        if let Some(data) = self.try_cached().await {
+            return Ok(data);
+        }
+
+        // We are the winner: perform the network fetch without holding any
+        // cache lock. Regardless of success or failure, wake any waiters
+        // that arrived after us so they can re-check the cache.
+        let result = self.fetch_payload().await;
+        match result {
+            Ok((data, ttl)) => {
+                let mut guard = self.cache.write().await;
+                *guard = Some(CachedPayload {
+                    data: Arc::clone(&data),
+                    fetched_at: Instant::now(),
+                    ttl,
+                });
+                drop(guard);
+                self.fetch_notify.notify_waiters();
+                Ok(data)
+            }
+            Err(err) => {
+                self.fetch_notify.notify_waiters();
+                Err(err)
+            }
+        }
+    }
+
+    /// Returns the cached payload if present and still fresh.
+    async fn try_cached(&self) -> Option<Arc<HashMap<String, String>>> {
+        let guard = self.cache.read().await;
+        guard
+            .as_ref()
+            .filter(|e| e.is_fresh())
+            .map(|e| Arc::clone(&e.data))
     }
 }
 
@@ -500,7 +569,7 @@ mod tests {
         data.insert("api_key".to_string(), "plain".to_string());
         data.insert("only_plain".to_string(), "plain-value".to_string());
 
-        *store.cache.lock().await = Some(CachedPayload {
+        *store.cache.write().await = Some(CachedPayload {
             data: Arc::new(data),
             fetched_at: Instant::now(),
             ttl: Duration::from_secs(60),
@@ -530,13 +599,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn honors_negative_cache_entries() {
+    async fn returns_none_for_empty_cached_payload() {
+        // Seeds the cache with an empty map (the state produced for
+        // `ResourceNotFoundException`) and verifies lookups resolve to `None`
+        // without any network call.
         let store = AwsSecretsManager::new("test").expect("valid name");
 
-        *store.cache.lock().await = Some(CachedPayload {
+        *store.cache.write().await = Some(CachedPayload {
             data: Arc::new(HashMap::new()),
             fetched_at: Instant::now(),
-            ttl: Duration::from_secs(60),
+            ttl: NEGATIVE_CACHE_TTL,
         });
 
         assert!(
@@ -546,5 +618,26 @@ mod tests {
                 .expect("lookup ok")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn expired_cache_entry_is_not_served() {
+        // A stale entry must not be returned by the cache fast-path. We don't
+        // exercise the refresh path here (that would hit AWS); we just verify
+        // that `try_cached()` discards expired entries.
+        let store = AwsSecretsManager::new("test").expect("valid name");
+
+        let mut data = HashMap::new();
+        data.insert("k".to_string(), "v".to_string());
+
+        *store.cache.write().await = Some(CachedPayload {
+            data: Arc::new(data),
+            fetched_at: Instant::now()
+                .checked_sub(Duration::from_secs(3600))
+                .expect("system time has enough headroom"),
+            ttl: Duration::from_secs(60),
+        });
+
+        assert!(store.try_cached().await.is_none());
     }
 }

--- a/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
+++ b/crates/runtime-secrets/src/stores/aws_secrets_manager.rs
@@ -30,8 +30,7 @@ limitations under the License.
 //!   that only one `GetSecretValue` call is in flight at a time per store.
 //! - Transient failures (throttling, 5xx, connection errors) are retried by
 //!   the AWS SDK itself using the standard retry strategy with exponential
-//!   backoff. We raise `max_attempts` above the SDK default to tolerate brief
-//!   Secrets Manager throttling without failing Spicepod load.
+//!   backoff and jitter (SDK default: 3 attempts).
 //! - A per-operation timeout prevents a stalled AWS endpoint from hanging
 //!   Spicepod loads or parameter resolution indefinitely.
 //! - `ResourceNotFoundException` is treated as "secret does not exist" and
@@ -51,7 +50,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use aws_config::retry::RetryConfig;
 use aws_config::timeout::TimeoutConfig;
 use aws_sdk_credential_bridge::default_aws_config;
 use aws_sdk_secretsmanager::{error::SdkError, operation::get_secret_value::GetSecretValueError};
@@ -85,22 +83,15 @@ const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
 /// references a missing key.
 const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(10);
 
-/// Maximum number of attempts for a single Secrets Manager API call.
-///
-/// The AWS SDK default is 3. We raise this to 5 to better tolerate brief
-/// throttling during Spicepod load, where many parameter resolutions may
-/// converge on the same secret in a short window. The SDK applies exponential
-/// backoff with jitter between attempts.
-const MAX_ATTEMPTS: u32 = 5;
-
 /// Per-attempt timeout for a single Secrets Manager API call. Bounded so a
 /// stalled endpoint cannot hang Spicepod initialization indefinitely.
 const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Overall timeout across all retry attempts for a single operation.
 ///
-/// Must be larger than `MAX_ATTEMPTS * ATTEMPT_TIMEOUT` plus backoff delays
-/// so the retry strategy gets a chance to fire before the wall-clock cap.
+/// Sized larger than the SDK's default retry budget (3 attempts with
+/// exponential backoff + jitter) so the retry strategy gets a chance to
+/// fire before the wall-clock cap.
 const OPERATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Snafu)]
@@ -372,17 +363,15 @@ impl AwsSecretsManager {
     }
 }
 
-/// Builds an AWS SDK configuration with explicit retry, timeout, and
-/// identification settings tuned for secret retrieval.
+/// Builds an AWS SDK configuration with explicit timeouts for secret retrieval.
 ///
-/// The standard retry strategy already covers the common transient failure
-/// modes for Secrets Manager (throttling, 5xx, connection reset, I/O errors)
-/// using exponential backoff with jitter. We raise the attempt cap to
-/// [`MAX_ATTEMPTS`] and add an operation-level timeout so a stalled endpoint
-/// cannot hang Spicepod initialization indefinitely.
+/// The SDK's standard retry strategy (exponential backoff + jitter, 3
+/// attempts by default) already covers the common transient failure modes
+/// for Secrets Manager (throttling, 5xx, connection reset, I/O errors), so
+/// we rely on the defaults. We layer on operation-level timeouts so a
+/// stalled endpoint cannot hang Spicepod initialization indefinitely.
 async fn build_aws_config() -> aws_config::SdkConfig {
     default_aws_config()
-        .retry_config(RetryConfig::standard().with_max_attempts(MAX_ATTEMPTS))
         .timeout_config(
             TimeoutConfig::builder()
                 .operation_attempt_timeout(ATTEMPT_TIMEOUT)

--- a/crates/runtime-secrets/tests/aws_secrets_manager_live.rs
+++ b/crates/runtime-secrets/tests/aws_secrets_manager_live.rs
@@ -1,0 +1,198 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Live AWS integration tests for the AWS Secrets Manager secret store.
+//!
+//! These tests require a real AWS account with `secretsmanager:GetSecretValue`
+//! permission on a pre-provisioned test secret. The tests are skipped (with a
+//! message) when the required environment variables are not set, so they are
+//! safe to run in CI environments that do not have AWS credentials.
+//!
+//! ## Required environment variables
+//!
+//! - `SPICE_TEST_AWS_SECRET_NAME`: name or ARN of an AWS secret whose value
+//!   is a JSON object containing at least one key/value pair.
+//! - `SPICE_TEST_AWS_SECRET_KEY`: a key that exists in the secret payload.
+//! - `SPICE_TEST_AWS_SECRET_VALUE`: the expected value for that key.
+//!
+//! Standard AWS credential resolution applies: `AWS_PROFILE`,
+//! `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, IMDS, etc. Set `AWS_REGION`
+//! if the secret is not in the SDK's default region.
+//!
+//! ## Example
+//!
+//! ```sh
+//! aws secretsmanager create-secret \
+//!     --name spice-integration-test \
+//!     --secret-string '{"api_key":"hello-world"}'
+//!
+//! export SPICE_TEST_AWS_SECRET_NAME=spice-integration-test
+//! export SPICE_TEST_AWS_SECRET_KEY=api_key
+//! export SPICE_TEST_AWS_SECRET_VALUE=hello-world
+//!
+//! cargo test -p runtime-secrets --features aws-secrets-manager \
+//!     --test aws_secrets_manager_live -- --nocapture
+//! ```
+
+#![cfg(feature = "aws-secrets-manager")]
+
+use std::time::Duration;
+
+use runtime_secrets::stores::aws_secrets_manager::AwsSecretsManager;
+use runtime_secrets::{ExposeSecret, SecretStore};
+
+/// Reads a required environment variable. Returns `None` (with a logged
+/// message) if the variable is not set, signalling the test should be
+/// skipped rather than fail.
+fn env_or_skip(var: &str) -> Option<String> {
+    match std::env::var(var) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => {
+            eprintln!("Skipping live AWS Secrets Manager test: {var} is not set");
+            None
+        }
+    }
+}
+
+struct TestConfig {
+    secret_name: String,
+    key: String,
+    expected_value: String,
+}
+
+fn load_config() -> Option<TestConfig> {
+    Some(TestConfig {
+        secret_name: env_or_skip("SPICE_TEST_AWS_SECRET_NAME")?,
+        key: env_or_skip("SPICE_TEST_AWS_SECRET_KEY")?,
+        expected_value: env_or_skip("SPICE_TEST_AWS_SECRET_VALUE")?,
+    })
+}
+
+#[tokio::test]
+async fn live_init_verifies_credentials() {
+    let Some(config) = load_config() else {
+        return;
+    };
+
+    let store = AwsSecretsManager::new(&config.secret_name).expect("valid secret name");
+    store
+        .init()
+        .await
+        .expect("STS get-caller-identity must succeed with valid AWS credentials");
+}
+
+#[tokio::test]
+async fn live_get_secret_returns_expected_value() {
+    let Some(config) = load_config() else {
+        return;
+    };
+
+    let store = AwsSecretsManager::new(&config.secret_name).expect("valid secret name");
+
+    let secret = store
+        .get_secret(&config.key)
+        .await
+        .expect("get_secret must succeed against a real AWS secret")
+        .expect("secret key must be present in the payload");
+
+    assert_eq!(
+        secret.expose_secret(),
+        config.expected_value,
+        "value for key {} did not match expected",
+        config.key,
+    );
+}
+
+#[tokio::test]
+async fn live_get_unknown_key_returns_none() {
+    let Some(config) = load_config() else {
+        return;
+    };
+
+    let store = AwsSecretsManager::new(&config.secret_name).expect("valid secret name");
+
+    // Use a key that is overwhelmingly unlikely to exist in the test secret.
+    let key = format!("__spice_nonexistent_key_{}__", rand::random::<u64>());
+    let result = store
+        .get_secret(&key)
+        .await
+        .expect("get_secret must succeed even for an unknown key");
+    assert!(
+        result.is_none(),
+        "lookup of an unknown key {key} returned a value"
+    );
+}
+
+#[tokio::test]
+async fn live_missing_secret_returns_none_without_error() {
+    if env_or_skip("SPICE_TEST_AWS_SECRET_NAME").is_none() {
+        // Re-uses the same skip signal as the other live tests so all live
+        // tests are gated by the same env vars.
+        return;
+    }
+
+    // A name that is overwhelmingly unlikely to exist in the test account.
+    let nonexistent = format!(
+        "spice-integration-test-nonexistent-{}",
+        rand::random::<u64>()
+    );
+    let store = AwsSecretsManager::new(&nonexistent).expect("valid secret name");
+
+    let result = store
+        .get_secret("anything")
+        .await
+        .expect("ResourceNotFoundException must surface as Ok(None), not as an error");
+    assert!(
+        result.is_none(),
+        "missing secret {nonexistent} resolved to a value"
+    );
+}
+
+#[tokio::test]
+async fn live_repeated_lookups_are_served_from_cache() {
+    let Some(config) = load_config() else {
+        return;
+    };
+
+    let store = AwsSecretsManager::new(&config.secret_name).expect("valid secret name");
+
+    let first = std::time::Instant::now();
+    let v1 = store
+        .get_secret(&config.key)
+        .await
+        .expect("first lookup ok")
+        .expect("present");
+    let first_elapsed = first.elapsed();
+
+    let second = std::time::Instant::now();
+    let v2 = store
+        .get_secret(&config.key)
+        .await
+        .expect("second lookup ok")
+        .expect("present");
+    let second_elapsed = second.elapsed();
+
+    assert_eq!(v1.expose_secret(), v2.expose_secret());
+
+    // The second lookup should be served from the in-process cache and be
+    // dramatically faster than the network round-trip. A loose 10x margin
+    // avoids flakiness on slow CI hosts.
+    let upper_bound = first_elapsed.max(Duration::from_millis(10)) / 10;
+    assert!(
+        second_elapsed <= upper_bound.max(Duration::from_millis(5)),
+        "expected cached lookup to be faster than {upper_bound:?}; got {second_elapsed:?}"
+    );
+}


### PR DESCRIPTION
Audit and improve the AWS Secrets Manager `SecretStore` for correctness, resilience, and secure-string handling.

## Reliability
- Reuse a single lazily-initialized SDK client and `SdkConfig` across all lookups (previously a new client + config were created on every lookup).
- Rely on the AWS SDK's standard retry strategy (exponential backoff + jitter, default 3 attempts) so brief Secrets Manager throttling/5xx during Spicepod load does not fail initialization.
- Configure explicit 10s per-attempt and 90s per-operation timeouts so a stalled endpoint cannot hang Spicepod load or parameter resolution. The 90s operation cap is sized generously above the SDK's worst-case retry budget so the retry strategy always gets a chance to fire.
- Cache the parsed secret payload in-process (60s TTL). Cache hits take only an `RwLock` read. Concurrent cache misses are coalesced via a true single-flight: a brief `fetch_mutex` critical section elects a winner via an `AtomicBool`; the mutex is dropped before the AWS round-trip and losers `await` on `Notify::notified()`. Locks are never held across `.await` on the network call.
- Negative-cache confirmed-missing secrets for 10s so we do not hammer AWS with repeated misses during parameter resolution.

## Error handling
- Classify `ResourceNotFoundException` as "missing" (None + negative cache) instead of surfacing as an error.
- Dedicated actionable errors for `DecryptionFailure` (KMS), `InvalidParameterException`, and `InvalidRequestException` with guidance on IAM permissions, KMS key state, region, and secret name format.
- Include the secret name in all error messages.
- Reject empty / whitespace-only secret names at construction.

## Secure-string handling
- Wrap intermediate plaintext payloads (both `SecretString` and `SecretBinary` paths) in `secrecy::zeroize::Zeroizing` so backing memory is scrubbed on drop.
- Store the parsed map behind `Arc<HashMap<_,_>>` so concurrent readers share a single allocation instead of cloning the secret-bearing map per lookup.
- Continue returning `SecretString` to callers; error messages never embed secret values (only secret name).

## Payload parsing
- Support both `SecretString` and `SecretBinary` (when valid UTF-8) — previously `SecretBinary` silently produced `None`.
- Accept scalar JSON values (strings, numbers, booleans); skip nulls and nested objects/arrays with a debug log rather than silently coercing to a potentially-incorrect string value.
- Log a single warning per store when the payload is not a JSON object rather than failing every lookup or spamming logs.

## Tests
- Unit tests for JSON parsing (scalar coercion, null/object/array skipping, non-object rejection), secret-name validation, prefix/fallback lookup semantics, and negative-cache behavior. Exercised without hitting AWS by seeding the cache directly.
- Live AWS integration tests at `crates/runtime-secrets/tests/aws_secrets_manager_live.rs` covering end-to-end credential verification, fetch/decrypt/JSON parse, missing keys, missing secrets, and cache behavior. Gated on `SPICE_TEST_AWS_SECRET_NAME`/`KEY`/`VALUE` env vars; skip cleanly when unset (matching the convention in `aws-sdk-credential-bridge/tests/credential_provider.rs`).

## Verification
- `cargo test -p runtime-secrets --features aws-secrets-manager` — all tests pass.
- `cargo clippy -p runtime-secrets --features aws-secrets-manager --tests -- -Dwarnings -Dclippy::pedantic -Dclippy::unwrap_used -Aclippy::expect_used -Dclippy::clone_on_ref_ptr -Dclippy::assertions_on_result_states` — clean.
