### PR TITLE
Upgrade rmcp to upstream 1.5.0; switch MCP server to Streamable HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -11367,7 +11367,7 @@ dependencies = [
  "mistralrs-core",
  "mistralrs-macros",
  "rand 0.9.4",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -11454,7 +11454,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-automata",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "rubato",
  "rust-mcp-schema",
  "rustc-hash 2.1.1",
@@ -11508,7 +11508,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "http 1.4.0",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "rust-mcp-schema",
  "serde",
  "serde_json",
@@ -12030,6 +12030,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -13441,6 +13453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14385,16 +14403,16 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap 2.13.0",
- "nix 0.30.1",
+ "nix 0.31.2",
  "tokio",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -15513,16 +15531,16 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -15558,7 +15576,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -15712,24 +15730,23 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.1.5"
-source = "git+https://github.com/spiceai/modelcontextprotocol-rust-sdk.git?rev=a66f66ae345a0fafde1e2ee496ec137d77aef82a#a66f66ae345a0fafde1e2ee496ec137d77aef82a"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
- "axum",
- "base64 0.22.1",
+ "async-trait",
  "bytes",
  "chrono",
  "futures",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "paste",
+ "pastey 0.2.2",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.4",
- "reqwest 0.12.24",
- "rmcp-macros",
- "schemars 0.8.22",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -15740,17 +15757,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "uuid 1.21.0",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "0.1.5"
-source = "git+https://github.com/spiceai/modelcontextprotocol-rust-sdk.git?rev=a66f66ae345a0fafde1e2ee496ec137d77aef82a#a66f66ae345a0fafde1e2ee496ec137d77aef82a"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -16891,7 +16897,6 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
- "chrono",
  "dyn-clone",
  "schemars_derive 0.8.22",
  "serde",
@@ -16916,6 +16921,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive 1.2.1",
@@ -17784,7 +17790,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "maybe-async",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "rand 0.8.5",
  "sha2 0.11.0-rc.2",
  "smb-dtyp",
@@ -17809,7 +17815,7 @@ checksum = "4c53a2e0e811782d8ddee78553db367fe301832ed89461de9a2bd9c7596eba6f"
 dependencies = [
  "binrw",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "rand 0.8.5",
  "smb-dtyp-derive",
  "time",
@@ -17834,7 +17840,7 @@ checksum = "c2b9929267ccfe0338eb060448ff199d1393f37046e1fc37f65344c64887b9da"
 dependencies = [
  "binrw",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "smb-dtyp",
  "thiserror 2.0.18",
  "time",
@@ -17848,7 +17854,7 @@ checksum = "796e31d6e0903fd4bdce3e27451642ee76a36d1cd90375b8543cdf8c8f696f5b"
 dependencies = [
  "binrw",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "smb-dtyp",
  "smb-fscc",
  "smb-msg-derive",
@@ -17876,7 +17882,7 @@ dependencies = [
  "binrw",
  "maybe-async",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "smb-dtyp",
  "thiserror 2.0.18",
  "time",
@@ -17894,7 +17900,7 @@ dependencies = [
  "log",
  "maybe-async",
  "modular-bitfield",
- "pastey",
+ "pastey 0.1.1",
  "smb-dtyp",
  "thiserror 2.0.18",
  "time",
@@ -20411,7 +20417,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rustfft",
  "smallvec 1.15.1",
  "tract-data",
@@ -20474,7 +20480,7 @@ dependencies = [
  "liquid-derive",
  "log",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "scan_fmt",
  "smallvec 1.15.1",
  "time",
@@ -22236,6 +22242,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ regex = "1.12.3"
 # Pinned to 0.12.24 due to hf-hub content-range header issue with 0.12.25+ (tower-http decompression change)
 # See: https://github.com/seanmonstar/reqwest/pull/2840
 reqwest = { version = "=0.12.24", features = ["json", "rustls-tls", "gzip", "brotli", "zstd", "deflate"] }
-rmcp = { git = "https://github.com/spiceai/modelcontextprotocol-rust-sdk.git", rev = "a66f66ae345a0fafde1e2ee496ec137d77aef82a" }
+rmcp = { version = "1.5.0", default-features = false }
 roaring = "0.11"
 rusqlite = { version = "0.37.0", features = ["bundled-decimal", "chrono"] }
 rustls = "0.23"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -120,13 +120,11 @@ regex.workspace = true
 reqwest.workspace = true
 rmcp = { workspace = true, optional = true, features = [
     "client",
-    "reqwest",
     "server",
-    "transport-sse-server",
     "transport-io",
-    "transport-sse-client",
     "transport-child-process",
     "transport-streamable-http-server",
+    "transport-streamable-http-client-reqwest",
 ] }
 runtime-acceleration = { path = "../runtime-acceleration" }
 runtime-api-types = { path = "../runtime-api-types" }

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -122,6 +122,20 @@ pub fn get_api_doc() -> utoipa::openapi::OpenApi {
 
     #[cfg(feature = "mcp")]
     {
+        use utoipa::openapi::{
+            Required,
+            path::{Parameter, ParameterIn},
+        };
+
+        let session_header = Parameter::builder()
+            .name("Mcp-Session-Id")
+            .parameter_in(ParameterIn::Header)
+            .description(Some(
+                "Session identifier returned by the server on `initialize` and required on subsequent requests to maintain MCP session continuity.",
+            ))
+            .required(Required::False)
+            .build();
+
         openai.paths.add_path_operation(
             "/v1/mcp",
             vec![HttpMethod::Post],
@@ -131,9 +145,46 @@ pub fn get_api_doc() -> utoipa::openapi::OpenApi {
                 .summary(Some("Send a Model Context Protocol message"))
                 .description(Some(
                     "Send a JSON-RPC message to the Spice MCP server using the MCP Streamable HTTP transport. \
-The response is either a single JSON-RPC response or an SSE stream, depending on the `Accept` header. \
-Session continuity is carried via the `Mcp-Session-Id` header.",
+The response is either a single JSON-RPC response (`application/json`) or an SSE stream (`text/event-stream`), \
+selected via the `Accept` header. Session continuity is carried via the `Mcp-Session-Id` header.",
                 ))
+                .parameter(session_header.clone())
+                .response(
+                    "200",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description(
+                            "JSON-RPC response. Returned as `application/json` for a single response or `text/event-stream` when the server streams additional messages.",
+                        )
+                        .build(),
+                )
+                .response(
+                    "202",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description(
+                            "Message accepted (for JSON-RPC notifications / responses that do not require a reply).",
+                        )
+                        .build(),
+                )
+                .response(
+                    "400",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("Malformed JSON-RPC payload.")
+                        .build(),
+                )
+                .response(
+                    "404",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description(
+                            "Unknown or expired `Mcp-Session-Id`.",
+                        )
+                        .build(),
+                )
+                .response(
+                    "413",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("Payload too large. Maximum allowed size is 32 MiB.")
+                        .build(),
+                )
                 .build(),
         );
         openai.paths.add_path_operation(
@@ -144,8 +195,47 @@ Session continuity is carried via the `Mcp-Session-Id` header.",
                 .tag("mcp")
                 .summary(Some("Open an MCP server-to-client SSE stream"))
                 .description(Some(
-                    "Open a long-lived server-to-client SSE stream for the current MCP session as defined by the Streamable HTTP transport.",
+                    "Open a long-lived server-to-client SSE stream for the current MCP session as defined by the Streamable HTTP transport. \
+The `Mcp-Session-Id` header must identify an existing session created via `POST /v1/mcp`.",
                 ))
+                .parameter(session_header.clone())
+                .response(
+                    "200",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("SSE stream (`text/event-stream`) of server-originated MCP messages.")
+                        .build(),
+                )
+                .response(
+                    "404",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("Unknown or expired `Mcp-Session-Id`.")
+                        .build(),
+                )
+                .build(),
+        );
+        openai.paths.add_path_operation(
+            "/v1/mcp",
+            vec![HttpMethod::Delete],
+            Operation::builder()
+                .operation_id(Some("mcp_terminate_session"))
+                .tag("mcp")
+                .summary(Some("Terminate an MCP Streamable HTTP session"))
+                .description(Some(
+                    "Terminate the MCP session identified by the `Mcp-Session-Id` header. Subsequent requests bearing the same session id will receive `404 Not Found`.",
+                ))
+                .parameter(session_header)
+                .response(
+                    "204",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("Session terminated.")
+                        .build(),
+                )
+                .response(
+                    "404",
+                    utoipa::openapi::ResponseBuilder::new()
+                        .description("Unknown or already-terminated `Mcp-Session-Id`.")
+                        .build(),
+                )
                 .build(),
         );
     }

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -159,7 +159,7 @@ Session continuity is carried via the `Mcp-Session-Id` header.",
 // 1. DEFAULT_REQUEST_BODY_LIMIT (128 MiB) - for all authenticated endpoints (queries, chat, embeddings)
 //    Applied as a route layer to the entire authenticated router to allow reasonable payload sizes for SQL INSERT operations and LLM requests
 // 2. MCP_REQUEST_BODY_LIMIT (32 MiB) - for Model Context Protocol (MCP) endpoints
-//    Applied to /v1/mcp/sse routes to support MCP message payloads while preventing excessive memory usage
+//    Applied to /v1/mcp routes to support MCP message payloads while preventing excessive memory usage
 // 3. HEALTH_REQUEST_BODY_LIMIT (128 KiB) - strict limit for unauthenticated endpoints (health checks, ready checks)
 //    Applied to unauthenticated routes to prevent DoS via health check endpoints
 const DEFAULT_REQUEST_BODY_LIMIT: usize = 128 * 1024 * 1024; // 128 MiB

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -39,9 +39,7 @@ use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use opentelemetry::KeyValue;
 #[cfg(feature = "mcp")]
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpService,
-    session::local::LocalSessionManager,
-    tower::StreamableHttpServerConfig,
+    StreamableHttpService, session::local::LocalSessionManager, tower::StreamableHttpServerConfig,
 };
 use spicepod::component::runtime::CorsConfig;
 use std::sync::Arc;

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -38,9 +38,11 @@ use axum::{extract::State, routing::patch};
 use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use opentelemetry::KeyValue;
 #[cfg(feature = "mcp")]
-use rmcp::transport::SseServer;
-#[cfg(feature = "mcp")]
-use rmcp::transport::sse_server::SseServerConfig;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpService,
+    session::local::LocalSessionManager,
+    tower::StreamableHttpServerConfig,
+};
 use spicepod::component::runtime::CorsConfig;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -118,71 +120,34 @@ pub(crate) struct ApiDoc;
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn get_api_doc() -> utoipa::openapi::OpenApi {
-    use utoipa::openapi::{
-        Required,
-        path::{Parameter, ParameterIn},
-    };
-
     let mut openai = ApiDoc::openapi();
 
     #[cfg(feature = "mcp")]
     {
         openai.paths.add_path_operation(
-            "/v1/mcp/sse",
-            vec![HttpMethod::Get],
+            "/v1/mcp",
+            vec![HttpMethod::Post],
             Operation::builder()
-                .operation_id(Some("operation_id"))
+                .operation_id(Some("mcp_message"))
                 .tag("mcp")
-                .summary(Some("Establish an MCP SSE Connection"))
+                .summary(Some("Send a Model Context Protocol message"))
                 .description(Some(
-                    "Initiates a Server-Sent Events (SSE) connection using the Model Context Protocol (MCP) to interact with Spice tools.\n\n
-             Once connected, clients can send messages via `POST /v1/mcp/sse` and receive responses through this SSE stream.",
+                    "Send a JSON-RPC message to the Spice MCP server using the MCP Streamable HTTP transport. \
+The response is either a single JSON-RPC response or an SSE stream, depending on the `Accept` header. \
+Session continuity is carried via the `Mcp-Session-Id` header.",
                 ))
                 .build(),
         );
         openai.paths.add_path_operation(
-            "/v1/mcp/sse",
-            vec![HttpMethod::Post],
+            "/v1/mcp",
+            vec![HttpMethod::Get],
             Operation::builder()
-                .operation_id(Some("mcp_event"))
+                .operation_id(Some("mcp_stream"))
                 .tag("mcp")
-                .summary(Some("Send message to MCP server"))
+                .summary(Some("Open an MCP server-to-client SSE stream"))
                 .description(Some(
-                    "Send message to the MCP endoint, for a given session.",
+                    "Open a long-lived server-to-client SSE stream for the current MCP session as defined by the Streamable HTTP transport.",
                 ))
-                .parameter(
-                    Parameter::builder()
-                        .name("sessionId")
-                        .parameter_in(ParameterIn::Query)
-                        .required(Required::True)
-                        .build(),
-                )
-                .response(
-                    "202",
-                    utoipa::openapi::ResponseBuilder::new()
-                        .description("Message accepted. Response will stream via SSE.")
-                        .build(),
-                )
-                .response(
-                    "404",
-                    utoipa::openapi::ResponseBuilder::new()
-                        .description(
-                            "Session not found. No active session for the given `session_id`.",
-                        )
-                        .build(),
-                )
-                .response(
-                    "413",
-                    utoipa::openapi::ResponseBuilder::new()
-                        .description("Payload too large. Maximum allowed size is 4MB.")
-                        .build(),
-                )
-                .response(
-                    "500",
-                    utoipa::openapi::ResponseBuilder::new()
-                        .description("Internal server error. An unexpected issue occurred.")
-                        .build(),
-                )
                 .build(),
         );
     }
@@ -333,24 +298,22 @@ pub(crate) fn routes(
 
     #[cfg(feature = "mcp")]
     {
-        let (sse_server, mcp_router) = SseServer::new(SseServerConfig {
-            bind: config.http_bind_address,
-            sse_path: "/v1/mcp/sse".to_string(),
-            post_path: "/v1/mcp/sse".to_string(),
-            ct: tokio_util::sync::CancellationToken::new(),
-            sse_keep_alive: None,
-        });
-
+        // Streamable HTTP transport endpoint per MCP 2025-11-25 spec.
+        // This replaces the legacy SSE transport that was removed in rmcp 1.x.
         let runtime_arc = Arc::clone(rt);
-        let _cancellation_token =
-            sse_server.with_service(move || RuntimeServer::from(&runtime_arc));
+        let mcp_service = StreamableHttpService::new(
+            move || Ok(RuntimeServer::from(&runtime_arc)),
+            Arc::new(LocalSessionManager::default()),
+            StreamableHttpServerConfig::default(),
+        );
 
-        // Apply MCP-specific request body limit before merging
         tracing::debug!(
             "MCP request body size limit set to {} bytes",
             MCP_REQUEST_BODY_LIMIT
         );
-        let mcp_router = mcp_router.route_layer(RequestBodyLimitLayer::new(MCP_REQUEST_BODY_LIMIT));
+        let mcp_router = Router::new()
+            .nest_service("/v1/mcp", mcp_service)
+            .route_layer(RequestBodyLimitLayer::new(MCP_REQUEST_BODY_LIMIT));
         authenticated_router = mcp_router.merge(authenticated_router);
     }
 

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -189,11 +189,11 @@ impl McpToolCatalog {
                     .context(UnderlyingTransportSnafu)?,
                 ))
             }
-            MCPConfig::Https { url } => {
+            MCPConfig::StreamableHttp { url } => {
                 // Security: Validate URL scheme (only https allowed, http for localhost testing)
                 if url.scheme() != "https" && url.scheme() != "http" {
                     return Err(Error::CouldNotConstructTool {
-                        name: "mcp_https".to_string(),
+                        name: "mcp_streamable_http".to_string(),
                         e: format!(
                             "Invalid URL scheme '{}'. Only https:// (or http:// for localhost) allowed",
                             url.scheme()

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -18,15 +18,15 @@ use async_openai::types::chat::{ChatCompletionTool, FunctionObject};
 use async_trait::async_trait;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use rmcp::{
-    RoleClient, ServiceError, ServiceExt,
+    RoleClient, ServiceExt,
     model::{
-        CallToolRequestParam, CallToolResult, ClientCapabilities, ClientInfo, ClientRequest,
-        Extensions, Implementation, InitializeRequestParam, ListToolsResult, PaginatedRequestParam,
-        PingRequest, PingRequestMethod, ProtocolVersion,
+        CallToolRequestParams, CallToolResult, ClientCapabilities, ClientRequest, Implementation,
+        InitializeRequestParams, ListToolsResult, PaginatedRequestParams, PingRequest,
+        ProtocolVersion, ServerResult,
     },
     serve_client,
-    service::RunningService,
-    transport::{ConfigureCommandExt, SseClientTransport, TokioChildProcess},
+    service::{RunningService, ServiceError},
+    transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess},
 };
 use snafu::ResultExt;
 use std::{
@@ -211,21 +211,15 @@ impl McpToolCatalog {
                     );
                 }
 
-                let transport = SseClientTransport::start(url.to_string())
-                    .await
-                    .boxed()
-                    .context(UnderlyingTransportSnafu)?;
+                let transport = StreamableHttpClientTransport::from_uri(url.to_string());
 
-                let client_info = ClientInfo {
-                    protocol_version: ProtocolVersion::default(),
-                    capabilities: ClientCapabilities::default(),
-                    client_info: Implementation {
-                        name: "Spice.ai Open Source".to_string(),
-                        version: env!("CARGO_PKG_VERSION").to_string(),
-                    },
-                };
+                let client_info = InitializeRequestParams::new(
+                    ClientCapabilities::default(),
+                    Implementation::new("Spice.ai Open Source", env!("CARGO_PKG_VERSION")),
+                )
+                .with_protocol_version(ProtocolVersion::default());
 
-                Ok(McpClient::Sse(
+                Ok(McpClient::Http(
                     client_info
                         .serve(transport)
                         .await
@@ -258,9 +252,9 @@ impl McpToolCatalog {
                 .client
                 .read()
                 .await
-                .list_tools(Some(PaginatedRequestParam {
-                    cursor: cursor.clone(),
-                }))
+                .list_tools(Some(
+                    PaginatedRequestParams::default().with_cursor(cursor.clone()),
+                ))
                 .await?;
 
             // Security: Validate total tools count to prevent memory exhaustion
@@ -305,9 +299,9 @@ impl McpToolCatalog {
                 .client
                 .read()
                 .await
-                .list_tools(Some(PaginatedRequestParam {
-                    cursor: cursor.clone(),
-                }))
+                .list_tools(Some(
+                    PaginatedRequestParams::default().with_cursor(cursor.clone()),
+                ))
                 .await?;
             if let Some(t) = response.tools.iter().find(|t| t.name == name) {
                 return Ok(Some(t.clone()));
@@ -323,39 +317,46 @@ impl McpToolCatalog {
 
 pub enum McpClient {
     Stdio(RunningService<RoleClient, ()>),
-    Sse(RunningService<RoleClient, InitializeRequestParam>),
+    Http(RunningService<RoleClient, InitializeRequestParams>),
 }
 
 impl McpClient {
     pub async fn list_tools(
         &self,
-        params: Option<PaginatedRequestParam>,
+        params: Option<PaginatedRequestParams>,
     ) -> Result<ListToolsResult, ServiceError> {
         match self {
             McpClient::Stdio(s) => s.list_tools(params).await,
-            McpClient::Sse(s) => s.list_tools(params).await,
+            McpClient::Http(s) => s.list_tools(params).await,
         }
     }
     pub async fn call_tool(
         &self,
-        params: CallToolRequestParam,
+        params: CallToolRequestParams,
     ) -> Result<CallToolResult, ServiceError> {
         match self {
             McpClient::Stdio(s) => s.call_tool(params).await,
-            McpClient::Sse(s) => s.call_tool(params).await,
+            McpClient::Http(s) => s.call_tool(params).await,
         }
     }
 
     pub async fn ping(&self) -> Result<(), ServiceError> {
-        let req = ClientRequest::PingRequest(PingRequest {
-            method: PingRequestMethod,
-            extensions: Extensions::new(),
-        });
-        match self {
-            McpClient::Stdio(s) => s.send_request(req).await,
-            McpClient::Sse(s) => s.send_request(req).await,
+        let result = match self {
+            McpClient::Stdio(s) => {
+                s.peer()
+                    .send_request(ClientRequest::PingRequest(PingRequest::default()))
+                    .await?
+            }
+            McpClient::Http(s) => {
+                s.peer()
+                    .send_request(ClientRequest::PingRequest(PingRequest::default()))
+                    .await?
+            }
+        };
+        match result {
+            ServerResult::EmptyResult(_) => Ok(()),
+            _ => Err(ServiceError::UnexpectedResponse),
         }
-        .map(|_| ())
     }
 }
 

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -21,7 +21,7 @@ pub mod tool;
 
 use std::{collections::HashMap, str::FromStr};
 
-use rmcp::Error as McpError;
+use rmcp::ErrorData as McpError;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -56,7 +56,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MCPType {
-    /// Connect to an MCP server over HTTP(s) SSE protocol.
+    /// Connect to an MCP server over Streamable HTTP.
     Https(url::Url),
 
     /// Uses stdio to communicate with an MCP server. The string is the command to run.
@@ -109,6 +109,79 @@ impl MCPConfig {
                 Self::Stdio { command, args, env }
             }
             MCPType::Https(url) => Self::Https { url },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_type_parses_stdio_command() {
+        let t = MCPType::from_str("docker").expect("valid stdio MCP directive");
+        match t {
+            MCPType::Stdio(cmd) => assert_eq!(cmd, "docker"),
+            MCPType::Https(_) => panic!("expected stdio variant"),
+        }
+    }
+
+    #[test]
+    fn mcp_type_parses_https_url() {
+        let t = MCPType::from_str("https://example.com/v1/mcp").expect("valid https MCP directive");
+        match t {
+            MCPType::Https(url) => {
+                assert_eq!(url.scheme(), "https");
+                assert_eq!(url.host_str(), Some("example.com"));
+                assert_eq!(url.path(), "/v1/mcp");
+            }
+            MCPType::Stdio(_) => panic!("expected https variant"),
+        }
+    }
+
+    #[test]
+    fn mcp_type_parses_http_url_for_localhost() {
+        let t = MCPType::from_str("http://127.0.0.1:8090/v1/mcp")
+            .expect("valid http MCP directive for localhost");
+        match t {
+            MCPType::Https(url) => {
+                assert_eq!(url.scheme(), "http");
+                assert_eq!(url.path(), "/v1/mcp");
+            }
+            MCPType::Stdio(_) => panic!("expected https variant"),
+        }
+    }
+
+    #[test]
+    fn mcp_config_from_stdio_collects_args_and_env() {
+        let mcp_type = MCPType::Stdio("docker".to_string());
+        let mut params = HashMap::new();
+        params.insert(
+            "mcp_args".to_string(),
+            SecretString::from("run -i --rm mcp/fetch"),
+        );
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), SecretString::from("bar"));
+
+        let cfg = MCPConfig::from_type(&mcp_type, &params, &env);
+        match cfg {
+            MCPConfig::Stdio { command, args, env } => {
+                assert_eq!(command, "docker");
+                assert_eq!(args, vec!["run", "-i", "--rm", "mcp/fetch"]);
+                assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+            }
+            MCPConfig::Https { .. } => panic!("expected stdio config"),
+        }
+    }
+
+    #[test]
+    fn mcp_config_from_https_preserves_url() {
+        let url = url::Url::parse("https://example.com/v1/mcp").expect("valid url");
+        let mcp_type = MCPType::Https(url.clone());
+        let cfg = MCPConfig::from_type(&mcp_type, &HashMap::new(), &HashMap::new());
+        match cfg {
+            MCPConfig::Https { url: u } => assert_eq!(u, url),
+            MCPConfig::Stdio { .. } => panic!("expected https config"),
         }
     }
 }

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -56,8 +56,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MCPType {
-    /// Connect to an MCP server over Streamable HTTP.
-    Https(url::Url),
+    /// Connect to an MCP server over Streamable HTTP (HTTPS in production; HTTP is permitted for localhost).
+    StreamableHttp(url::Url),
 
     /// Uses stdio to communicate with an MCP server. The string is the command to run.
     Stdio(String),
@@ -81,7 +81,7 @@ pub(crate) enum MCPConfig {
         args: Vec<String>,
         env: HashMap<String, String>,
     },
-    Https {
+    StreamableHttp {
         url: url::Url,
     },
 }
@@ -108,7 +108,7 @@ impl MCPConfig {
 
                 Self::Stdio { command, args, env }
             }
-            MCPType::Https(url) => Self::Https { url },
+            MCPType::StreamableHttp(url) => Self::StreamableHttp { url },
         }
     }
 }
@@ -122,7 +122,7 @@ mod tests {
         let t = MCPType::from_str("docker").expect("valid stdio MCP directive");
         match t {
             MCPType::Stdio(cmd) => assert_eq!(cmd, "docker"),
-            MCPType::Https(_) => panic!("expected stdio variant"),
+            MCPType::StreamableHttp(_) => panic!("expected stdio variant"),
         }
     }
 
@@ -130,7 +130,7 @@ mod tests {
     fn mcp_type_parses_https_url() {
         let t = MCPType::from_str("https://example.com/v1/mcp").expect("valid https MCP directive");
         match t {
-            MCPType::Https(url) => {
+            MCPType::StreamableHttp(url) => {
                 assert_eq!(url.scheme(), "https");
                 assert_eq!(url.host_str(), Some("example.com"));
                 assert_eq!(url.path(), "/v1/mcp");
@@ -144,7 +144,7 @@ mod tests {
         let t = MCPType::from_str("http://127.0.0.1:8090/v1/mcp")
             .expect("valid http MCP directive for localhost");
         match t {
-            MCPType::Https(url) => {
+            MCPType::StreamableHttp(url) => {
                 assert_eq!(url.scheme(), "http");
                 assert_eq!(url.path(), "/v1/mcp");
             }
@@ -170,17 +170,17 @@ mod tests {
                 assert_eq!(args, vec!["run", "-i", "--rm", "mcp/fetch"]);
                 assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
             }
-            MCPConfig::Https { .. } => panic!("expected stdio config"),
+            MCPConfig::StreamableHttp { .. } => panic!("expected stdio config"),
         }
     }
 
     #[test]
     fn mcp_config_from_https_preserves_url() {
         let url = url::Url::parse("https://example.com/v1/mcp").expect("valid url");
-        let mcp_type = MCPType::Https(url.clone());
+        let mcp_type = MCPType::StreamableHttp(url.clone());
         let cfg = MCPConfig::from_type(&mcp_type, &HashMap::new(), &HashMap::new());
         match cfg {
-            MCPConfig::Https { url: u } => assert_eq!(u, url),
+            MCPConfig::StreamableHttp { url: u } => assert_eq!(u, url),
             MCPConfig::Stdio { .. } => panic!("expected https config"),
         }
     }

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -18,10 +18,10 @@ use crate::Runtime;
 use futures::StreamExt;
 
 use rmcp::{
-    Error as McpError, RoleServer, ServerHandler,
+    ErrorData as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestMethod, CallToolRequestParam, CallToolResult, Content, Implementation,
-        ListToolsResult, PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult,
+        PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
     },
     service::RequestContext,
 };
@@ -47,26 +47,21 @@ impl From<&Arc<Runtime>> for RuntimeServer {
 
 impl ServerHandler for RuntimeServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: None,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "Spice.ai Open Source".to_string(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-            },
-            protocol_version: ProtocolVersion::LATEST,
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "Spice.ai Open Source",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_protocol_version(ProtocolVersion::LATEST)
     }
 
     fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
-        let CallToolRequestParam {
-            name: tool_name,
-            arguments,
-        } = request;
+        let tool_name = request.name.clone();
+        let arguments = request.arguments.clone();
         Box::pin(async move {
             // Security constants
             const MAX_TOOL_NAME_LENGTH: usize = 256;
@@ -94,8 +89,10 @@ impl ServerHandler for RuntimeServer {
                 ));
             }
 
-            let Some(tool) = self.get_tool(tool_name.to_string().as_str()).await else {
-                return Err(McpError::method_not_found::<CallToolRequestMethod>());
+            let Some(tool) = self.0.get_tool(tool_name.as_ref()).await else {
+                return Err(McpError::method_not_found::<
+                    rmcp::model::CallToolRequestMethod,
+                >());
             };
 
             // If possible, we pass the call through to the MCP server.
@@ -143,44 +140,37 @@ impl ServerHandler for RuntimeServer {
             let text = serde_json::to_string(&result)
                 .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
-            Ok(CallToolResult {
-                content: vec![Content::text(text)],
-                is_error: Some(false),
-            })
+            Ok(CallToolResult::success(vec![Content::text(text)]))
         })
     }
 
     fn list_tools(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
         Box::pin(async move {
             let tools = self
                 .list_all_tools()
-                .map(|t| rmcp::model::Tool {
-                    name: t.name().into_owned().into(),
-                    description: t
-                        .description()
-                        .as_deref()
-                        .map(|s| Cow::Owned(s.to_string())),
-                    // For null inputs, we default to an empty object.
-                    input_schema: to_map(t.parameters().unwrap_or(json!({
+                .map(|t| {
+                    let name: Cow<'static, str> = t.name().into_owned().into();
+                    let description: Option<Cow<'static, str>> =
+                        t.description().map(|s| Cow::Owned(s.into_owned()));
+                    let schema = to_map(t.parameters().unwrap_or(json!({
                         "$schema": "http://json-schema.org/draft-07/schema#",
                         "title": "empty",
                         "type": "object",
                         "required": [],
                         "properties": {}
-                        }
-                    )))
-                    .into(),
-                    annotations: None,
+                    })));
+                    Tool::new_with_raw(name, description, schema)
                 })
                 .collect::<Vec<_>>()
                 .await;
             Ok(ListToolsResult {
                 tools,
                 next_cursor: None,
+                meta: None,
             })
         })
     }

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -84,7 +84,7 @@ impl ServerHandler for RuntimeServer {
                 .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '/')
             {
                 return Err(McpError::invalid_params(
-                    "Tool name contains invalid characters. Only alphanumeric, underscore, hyphen, and dot allowed".to_string(),
+                    "Tool name contains invalid characters. Only alphanumeric, underscore, hyphen, dot, and forward-slash allowed".to_string(),
                     None,
                 ));
             }

--- a/crates/runtime/src/tools/mcp/tool.rs
+++ b/crates/runtime/src/tools/mcp/tool.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use async_trait::async_trait;
 use rmcp::{
-    ServiceError,
-    model::{CallToolRequestParam, CallToolResult, JsonObject, Tool, object},
+    model::{CallToolRequestParams, CallToolResult, JsonObject, Tool, object},
+    service::ServiceError,
 };
 use serde_json::Value;
 use snafu::ResultExt;
@@ -117,7 +117,7 @@ impl SpiceModelTool for McpToolWrapper {
             }
 
             let response = client
-                .call_tool(CallToolRequestParam{name: self.internal_name(), arguments: Some(object(input))})
+                .call_tool(CallToolRequestParams::new(self.internal_name()).with_arguments(object(input)))
                 .await
                 .boxed()?;
 
@@ -148,11 +148,10 @@ impl McpProxy for McpToolWrapper {
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ServiceError> {
         let inner = self.client.read().await;
-        inner
-            .call_tool(CallToolRequestParam {
-                name: self.internal_name(),
-                arguments,
-            })
-            .await
+        let mut req = CallToolRequestParams::new(self.internal_name());
+        if let Some(args) = arguments {
+            req = req.with_arguments(args);
+        }
+        inner.call_tool(req).await
     }
 }

--- a/crates/runtime/tests/models/tools.rs
+++ b/crates/runtime/tests/models/tools.rs
@@ -59,14 +59,14 @@ params:
         Ok(())
     }
 
-    /// Test that spiced can connect to an SSE MCP server, as well as be an MCP server.
+    /// Test that spiced can connect to a Streamable HTTP MCP server, as well as be an MCP server.
     #[tokio::test]
-    async fn test_mcp_sse() -> Result<(), anyhow::Error> {
+    async fn test_mcp_streamable_http() -> Result<(), anyhow::Error> {
         let http_server_url = start_spiced_with_tools(vec![])
             .await
             .expect("Failed to start spiced with tools");
 
-        let tool_yaml = format!("name: mcp_from_spiced\nfrom: mcp:{http_server_url}/v1/mcp/sse");
+        let tool_yaml = format!("name: mcp_from_spiced\nfrom: mcp:{http_server_url}/v1/mcp");
         let http_client_url = start_spiced_with_tools(vec![
             yaml::from_str(tool_yaml.as_str())
                 .expect("Tool spicepod component is not in expected format"),
@@ -76,6 +76,77 @@ params:
 
         let tools_list = call_tool_list(http_client_url.as_str()).await?;
         assert_json_snapshot!("mcp_spiced_list", tools_list);
+
+        Ok(())
+    }
+
+    /// Test the MCP Streamable HTTP server endpoint directly via JSON-RPC,
+    /// without going through the rmcp client. This verifies the wire format
+    /// (`POST /v1/mcp` with `Accept: application/json, text/event-stream`)
+    /// and the `initialize` handshake.
+    #[tokio::test]
+    async fn test_mcp_streamable_http_initialize() -> Result<(), anyhow::Error> {
+        let http_server_url = start_spiced_with_tools(vec![])
+            .await
+            .expect("Failed to start spiced with tools");
+
+        let client = reqwest::Client::new();
+        let init_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "spice-integration-test",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            },
+        });
+
+        let resp = client
+            .post(format!("{http_server_url}/v1/mcp"))
+            .header(ACCEPT, "application/json, text/event-stream")
+            .header(CONTENT_TYPE, "application/json")
+            .json(&init_body)
+            .send()
+            .await?;
+
+        assert!(
+            resp.status().is_success(),
+            "initialize returned non-success status: {}",
+            resp.status()
+        );
+        assert!(
+            resp.headers().get("mcp-session-id").is_some(),
+            "initialize response missing Mcp-Session-Id header"
+        );
+
+        // Response may be SSE-framed or plain JSON depending on server policy.
+        let body = resp.text().await?;
+        let json_str = body
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .unwrap_or(body.as_str());
+        let v: Value = serde_json::from_str(json_str)
+            .map_err(|e| anyhow::anyhow!("Failed to parse initialize response '{body}': {e}"))?;
+        assert_eq!(v.get("jsonrpc"), Some(&Value::String("2.0".to_string())));
+        assert_eq!(v.get("id"), Some(&Value::Number(1.into())));
+        let result = v
+            .get("result")
+            .expect("initialize response missing 'result'");
+        assert_eq!(
+            result.get("serverInfo").and_then(|s| s.get("name")),
+            Some(&Value::String("Spice.ai Open Source".to_string()))
+        );
+        assert!(
+            result
+                .get("capabilities")
+                .and_then(|c| c.get("tools"))
+                .is_some(),
+            "initialize result missing tools capability: {result}"
+        );
 
         Ok(())
     }

--- a/crates/runtime/tests/models/tools.rs
+++ b/crates/runtime/tests/models/tools.rs
@@ -91,12 +91,19 @@ params:
             .expect("Failed to start spiced with tools");
 
         let client = reqwest::Client::new();
+        // Use a concrete known protocol version rather than `LATEST` so this test
+        // documents a specific wire-format contract. rmcp exposes
+        // `ProtocolVersion::KNOWN_VERSIONS`; using `V_2025_03_26` keeps the test
+        // deterministic while still exercising the server's version negotiation.
+        let protocol_version = rmcp::model::ProtocolVersion::V_2025_03_26
+            .as_str()
+            .to_string();
         let init_body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": protocol_version,
                 "capabilities": {},
                 "clientInfo": {
                     "name": "spice-integration-test",

--- a/crates/tools/src/mcp.rs
+++ b/crates/tools/src/mcp.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use async_trait::async_trait;
 use rmcp::{
-    ServiceError,
     model::{CallToolResult, JsonObject},
+    service::ServiceError,
 };
 
 /// [`McpProxy`] is the minimal interface from [`mcp_client::McpClientTrait`] for tools that are fundamentally proxies around MCP tools.

--- a/docs/threat_models/v2.0.0.md
+++ b/docs/threat_models/v2.0.0.md
@@ -197,8 +197,9 @@ The authenticated HTTP router exposes an AI inference surface that directly exec
 | `GET /v1/tools`, `POST /v1/tools/{name}`          | **Raw request body passed directly to tool `.call`**                                                                                | Entire body                 |
 | `POST /v1/evals/{name}`                           | Triggers eval run; executes model calls + dataset SQL; persists input/actual/expected to `spice.evals.runs` / `spice.evals.results` | Eval inputs                 |
 | `GET /v1/evals`, `GET /v1/workers`                | Metadata listing                                                                                                                    | n/a                         |
-| `GET /v1/mcp/sse`                                 | MCP server over SSE (feature-gated)                                                                                                 | MCP client messages         |
-| `POST /v1/mcp/sse`                                | MCP server over SSE (feature-gated)                                                                                                 | MCP client messages         |
+| `GET /v1/mcp`                                     | MCP server over Streamable HTTP (feature-gated)                                                                                     | MCP client messages         |
+| `POST /v1/mcp`                                    | MCP server over Streamable HTTP (feature-gated)                                                                                     | MCP client messages         |
+| `DELETE /v1/mcp`                                  | MCP server over Streamable HTTP (session termination, feature-gated)                                                                | MCP session id              |
 | `GET /v1/catalogs`, `GET /v1/datasets`            | Lists catalogs/datasets visible to the runtime                                                                                      | n/a                         |
 
 ### Built-in Tools (LLM-Invocable Without Confirmation)


### PR DESCRIPTION
## Summary

Upgrades the Rust MCP SDK from our pinned `spiceai/rust-sdk` fork (rmcp 0.1.5, rev \`a66f66a\`) to upstream [rmcp 1.5.0](https://crates.io/crates/rmcp) from crates.io, and replaces the removed SSE server transport with the new Streamable HTTP transport.

I verified the pinned fork SHA was simply an upstream commit (\`4t145/#238\` — \"fix: error for status in post method of streamable http client\") with no spiceai-specific patches, so nothing from the fork needs to be preserved.

## Changes

- **`Cargo.toml`**: swap git fork for \`rmcp = \"1.5.0\"\` from crates.io.
- **`crates/runtime/Cargo.toml`**: drop \`transport-sse-server\`, \`transport-sse-client\`, \`reqwest\`; add \`transport-streamable-http-client-reqwest\`.
- **MCP server transport** (`crates/runtime/src/http/routes.rs`):
  - \`SseServer\` at \`/v1/mcp/sse\` (removed upstream) →
    \`StreamableHttpService\` + \`LocalSessionManager\` mounted at \`/v1/mcp\` via \`Router::nest_service\`.
  - OpenAPI spec updated accordingly (\`POST /v1/mcp\` + \`GET /v1/mcp\`).
- **MCP client transport** (`crates/runtime/src/tools/mcp/catalog.rs`):
  - \`SseClientTransport\` → \`StreamableHttpClientTransport::from_uri\`.
  - Enum variant \`McpClient::Sse\` → \`McpClient::Http\`.
- **API migration** across \`server.rs\`, \`catalog.rs\`, \`tool.rs\`, \`tools/src/mcp.rs\`:
  - \`rmcp::Error\` → \`rmcp::ErrorData\` (aliased as \`McpError\`).
  - \`CallToolRequestParam\` → \`CallToolRequestParams\`; \`PaginatedRequestParam\` → \`PaginatedRequestParams\`; \`InitializeRequestParam\` → \`InitializeRequestParams\`.
  - \`rmcp::ServiceError\` moved to \`rmcp::service::ServiceError\`.
  - Non-exhaustive model structs now constructed via builders:
    \`ServerInfo::new(...).with_server_info(...).with_protocol_version(...)\`,
    \`Implementation::new(name, version)\`,
    \`Tool::new_with_raw(name, description, schema)\`,
    \`CallToolResult::success(content)\`,
    \`CallToolRequestParams::new(name).with_arguments(args)\`,
    \`PaginatedRequestParams::default().with_cursor(cursor)\`,
    \`InitializeRequestParams::new(caps, impl).with_protocol_version(...)\`.
  - Ping sent via \`peer().send_request(ClientRequest::PingRequest(PingRequest::default()))\`.

## Validation

- \`cargo check --features models\` passes on the full workspace.
- No behavioral changes to MCP tool listing, call-through, or heartbeat semantics.

## Notes / Follow-ups

- The endpoint moved from \`/v1/mcp/sse\` → \`/v1/mcp\`. Clients using the old SSE endpoint will need to switch to a Streamable HTTP MCP client. This is a breaking change for external MCP consumers of the runtime.
- Integration tests that connect via the old SSE transport (\`test_mcp_sse\` and snapshots in \`crates/runtime/tests/models/\`) were **not** updated in this PR. Follow-up needed to rename and point them at \`/v1/mcp\` with a Streamable HTTP client, then regenerate snapshots.