### PR TITLE
Add connect_timeout/client_timeout params to Databricks sql_warehouse mode

### DIFF
--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -160,7 +160,9 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         .description("The execution mode for running queries: 'spark_connect', 'delta_lake', or 'sql_warehouse'.")
         .default("spark_connect"),
     ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for object store client."),
+        .description("HTTP client request timeout. In 'delta_lake' mode, applies to the object store client. In 'sql_warehouse' mode, applies per-HTTP-call (statement submit, status poll, chunk fetch) — set to the longest expected single call, not total query duration. Accepts durations like '30s' or '5m'. Default: 30s."),
+    ParameterSpec::runtime("connect_timeout")
+        .description("Timeout for establishing TCP/TLS connections to the Databricks API. Applies in 'sql_warehouse' mode. Accepts durations like '10s'. Default: 10s."),
     ParameterSpec::component("cluster_id").description("The ID of the compute cluster in Databricks to use for the query. Only valid when mode is spark_connect."),
     ParameterSpec::component("use_ssl").description("Use a TLS connection to connect to the Databricks Spark Connect endpoint.").default("true"),
 
@@ -1228,7 +1230,9 @@ pub const CATALOG_PARAMETERS: &[ParameterSpec] = &[
         .description("The execution mode for querying against Databricks.")
         .default("spark_connect"),
     ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for object store client."),
+        .description("HTTP client request timeout. In 'delta_lake' mode, applies to the object store client. In 'sql_warehouse' mode, applies per-HTTP-call (statement submit, status poll, chunk fetch) — set to the longest expected single call, not total query duration. Accepts durations like '30s' or '5m'. Default: 30s."),
+    ParameterSpec::runtime("connect_timeout")
+        .description("Timeout for establishing TCP/TLS connections to the Databricks API. Applies in 'sql_warehouse' mode. Accepts durations like '10s'. Default: 10s."),
     ParameterSpec::component("cluster_id").description("The ID of the compute cluster in Databricks to use for the query. Only valid when mode is spark_connect."),
     ParameterSpec::component("use_ssl").description("Use a TLS connection to connect to the Databricks Spark Connect endpoint.").default("true"),
     ParameterSpec::component("sql_warehouse_id")

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -56,8 +56,11 @@ use util::{
 };
 
 use crate::resilient_http::{
-    RetryConfig, configure_client_builder, send_request_with_retry_and_concurrency_limit,
+    DEFAULT_HTTP_CONNECT_TIMEOUT, DEFAULT_HTTP_REQUEST_TIMEOUT, RetryConfig,
+    configure_client_builder_with_timeouts, send_request_with_retry_and_concurrency_limit,
 };
+#[cfg(test)]
+use crate::resilient_http::configure_client_builder;
 use crate::schema_discovery::{
     DatasetPermissions, NoPermissionsCheck, PermissionCheckResult, SchemaProbeResult,
     discover_schema,
@@ -105,6 +108,15 @@ pub struct SqlWarehouseConfig {
     /// the connector so subsequent queries fail immediately without issuing
     /// further HTTP requests.
     pub disable_on_permanent_error: bool,
+
+    /// Timeout for establishing TCP/TLS connections to the SQL Warehouse API.
+    pub connect_timeout: std::time::Duration,
+
+    /// Per-request wall-clock timeout for every HTTP call (statement submit,
+    /// status poll, and result-chunk fetch). Must be set to the longest
+    /// expected single HTTP call, not the total query duration — the overall
+    /// query duration is bounded by `statement_max_retries` × backoff.
+    pub request_timeout: std::time::Duration,
 }
 
 impl Default for SqlWarehouseConfig {
@@ -115,6 +127,8 @@ impl Default for SqlWarehouseConfig {
             backoff_method: BackoffMethod::Fibonacci,
             statement_max_retries: SQL_WAREHOUSE_DEFAULT_STATEMENT_MAX_RETRIES,
             disable_on_permanent_error: true,
+            connect_timeout: DEFAULT_HTTP_CONNECT_TIMEOUT,
+            request_timeout: DEFAULT_HTTP_REQUEST_TIMEOUT,
         }
     }
 }
@@ -604,10 +618,14 @@ impl SqlWarehouseApi {
         metrics: Arc<DatabricksMetrics>,
         request_semaphore: Arc<Semaphore>,
     ) -> Result<Self, Error> {
-        let client = configure_client_builder(ClientBuilder::new())
-            .user_agent(super::user_agent())
-            .build()
-            .context(ClientBuildFailedSnafu)?;
+        let client = configure_client_builder_with_timeouts(
+            ClientBuilder::new(),
+            config.connect_timeout,
+            config.request_timeout,
+        )
+        .user_agent(super::user_agent())
+        .build()
+        .context(ClientBuildFailedSnafu)?;
 
         Ok(Self {
             client,

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -55,12 +55,12 @@ use util::{
     format_datafusion_error,
 };
 
+#[cfg(test)]
+use crate::resilient_http::configure_client_builder;
 use crate::resilient_http::{
     DEFAULT_HTTP_CONNECT_TIMEOUT, DEFAULT_HTTP_REQUEST_TIMEOUT, RetryConfig,
     configure_client_builder_with_timeouts, send_request_with_retry_and_concurrency_limit,
 };
-#[cfg(test)]
-use crate::resilient_http::configure_client_builder;
 use crate::schema_discovery::{
     DatasetPermissions, NoPermissionsCheck, PermissionCheckResult, SchemaProbeResult,
     discover_schema,

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -22,8 +22,8 @@ use std::sync::atomic::AtomicU64;
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 use util::retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder};
-pub const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-pub const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 const DEFAULT_HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 const DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST: usize = 16;
@@ -217,7 +217,7 @@ pub fn configure_client_builder(builder: ClientBuilder) -> ClientBuilder {
 /// Like [`configure_client_builder`] but lets the caller override the connect
 /// and per-request timeouts. Pool and keepalive settings remain at their
 /// defaults.
-pub fn configure_client_builder_with_timeouts(
+pub(crate) fn configure_client_builder_with_timeouts(
     builder: ClientBuilder,
     connect_timeout: Duration,
     request_timeout: Duration,

--- a/crates/data_components/src/resilient_http.rs
+++ b/crates/data_components/src/resilient_http.rs
@@ -22,8 +22,8 @@ use std::sync::atomic::AtomicU64;
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 use util::retry_strategy::{Backoff, BackoffMethod, RetryBackoffBuilder};
-const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 const DEFAULT_HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 const DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST: usize = 16;
@@ -207,9 +207,24 @@ pub fn enable_supported_compression(builder: ClientBuilder) -> ClientBuilder {
 }
 
 pub fn configure_client_builder(builder: ClientBuilder) -> ClientBuilder {
+    configure_client_builder_with_timeouts(
+        builder,
+        DEFAULT_HTTP_CONNECT_TIMEOUT,
+        DEFAULT_HTTP_REQUEST_TIMEOUT,
+    )
+}
+
+/// Like [`configure_client_builder`] but lets the caller override the connect
+/// and per-request timeouts. Pool and keepalive settings remain at their
+/// defaults.
+pub fn configure_client_builder_with_timeouts(
+    builder: ClientBuilder,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> ClientBuilder {
     enable_supported_compression(builder)
-        .connect_timeout(DEFAULT_HTTP_CONNECT_TIMEOUT)
-        .timeout(DEFAULT_HTTP_REQUEST_TIMEOUT)
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
         .pool_idle_timeout(DEFAULT_HTTP_POOL_IDLE_TIMEOUT)
         .pool_max_idle_per_host(DEFAULT_HTTP_POOL_MAX_IDLE_PER_HOST)
         .tcp_keepalive(DEFAULT_HTTP_TCP_KEEPALIVE)

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -268,7 +268,7 @@ bedrock = []
 clickhouse = ["db_connection_pool/clickhouse", "data_components/clickhouse"]
 cosmosdb = ["data_components/cosmosdb"]
 cuda = ["llms/cuda"]
-databricks = ["data_components/databricks"]
+databricks = ["data_components/databricks", "dep:duration-parse"]
 debezium = ["kafka", "data_components/debezium"]
 default = [
     "keyring-secret-store",

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -475,6 +475,22 @@ pub fn build_sql_warehouse_config(params: &Parameters) -> SqlWarehouseConfig {
             }
         }
     }
+    if let Some(v) = params.get("connect_timeout").expose().ok() {
+        match duration_parse::parse_duration(v) {
+            Ok(d) => config.connect_timeout = d,
+            Err(e) => {
+                tracing::warn!(parameter = "connect_timeout", value = v, error = %e, "Invalid Databricks SQL Warehouse config value; using default");
+            }
+        }
+    }
+    if let Some(v) = params.get("client_timeout").expose().ok() {
+        match duration_parse::parse_duration(v) {
+            Ok(d) => config.request_timeout = d,
+            Err(e) => {
+                tracing::warn!(parameter = "client_timeout", value = v, error = %e, "Invalid Databricks SQL Warehouse config value; using default");
+            }
+        }
+    }
 
     config
 }
@@ -675,6 +691,8 @@ mod tests {
             ("backoff_method", "exponential"),
             ("statement_max_retries", "21"),
             ("disable_on_permanent_error", "false"),
+            ("connect_timeout", "5s"),
+            ("client_timeout", "2m"),
         ]);
 
         let config = build_sql_warehouse_config(&params);
@@ -687,6 +705,8 @@ mod tests {
         );
         assert_eq!(config.statement_max_retries, 21);
         assert!(!config.disable_on_permanent_error);
+        assert_eq!(config.connect_timeout, std::time::Duration::from_secs(5));
+        assert_eq!(config.request_timeout, std::time::Duration::from_secs(120));
     }
 
     #[test]
@@ -697,6 +717,8 @@ mod tests {
             ("backoff_method", "quadratic"),
             ("statement_max_retries", "bad"),
             ("disable_on_permanent_error", "maybe"),
+            ("connect_timeout", "not-a-duration"),
+            ("client_timeout", ""),
         ]);
 
         let config = build_sql_warehouse_config(&params);
@@ -713,5 +735,7 @@ mod tests {
             config.disable_on_permanent_error,
             defaults.disable_on_permanent_error
         );
+        assert_eq!(config.connect_timeout, defaults.connect_timeout);
+        assert_eq!(config.request_timeout, defaults.request_timeout);
     }
 }

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -78,7 +78,9 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         .description("The execution mode for querying against Databricks.")
         .default("spark_connect"),
     ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for object store client."),
+        .description("HTTP client request timeout. In 'delta_lake' mode, applies to the object store client. In 'sql_warehouse' mode, applies per-HTTP-call (statement submit, status poll, chunk fetch) — set to the longest expected single call, not total query duration. Accepts durations like '30s' or '5m'. Default: 30s."),
+    ParameterSpec::runtime("connect_timeout")
+        .description("Timeout for establishing TCP/TLS connections to the Databricks API. Applies in 'sql_warehouse' mode. Accepts durations like '10s'. Default: 10s."),
     ParameterSpec::component("cluster_id").description("The ID of the compute cluster in Databricks to use for the query. Only valid when mode is spark_connect."),
     ParameterSpec::component("use_ssl").description("Use a TLS connection to connect to the Databricks Spark Connect endpoint.").default("true"),
     ParameterSpec::component("sql_warehouse_id")
@@ -737,5 +739,28 @@ mod tests {
         );
         assert_eq!(config.connect_timeout, defaults.connect_timeout);
         assert_eq!(config.request_timeout, defaults.request_timeout);
+    }
+
+    /// Regression test: every runtime param consumed by
+    /// [`build_sql_warehouse_config`] must be declared in [`PARAMETERS`],
+    /// otherwise `Parameters::try_new` strips the key before it reaches
+    /// `build_sql_warehouse_config` and the override is silently ignored.
+    #[test]
+    fn test_sql_warehouse_config_params_are_declared_in_parameters_spec() {
+        let expected = [
+            "max_concurrent_requests",
+            "http_max_retries",
+            "backoff_method",
+            "statement_max_retries",
+            "disable_on_permanent_error",
+            "connect_timeout",
+            "client_timeout",
+        ];
+        for name in expected {
+            assert!(
+                PARAMETERS.iter().any(|p| p.name == name),
+                "parameter `{name}` is consumed by build_sql_warehouse_config but not declared in PARAMETERS; Parameters::try_new would strip it"
+            );
+        }
     }
 }

--- a/docs/features/databricks-resilience.md
+++ b/docs/features/databricks-resilience.md
@@ -8,13 +8,17 @@ The Databricks connector includes resilience controls, Unity Catalog awareness, 
 
 When using `mode: sql_warehouse`, the connector exposes parameters to tune HTTP retry behavior and concurrency limits for the Databricks SQL Statements API.
 
-| Parameter                    | Type    | Default     | Description                                                                                                              |
-| ---------------------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `max_concurrent_requests`    | integer | `8`         | Maximum number of concurrent HTTP requests to the SQL Warehouse API. Controls a semaphore that gates all outbound calls. |
-| `http_max_retries`           | integer | `3`         | Maximum number of HTTP-level retries for transient failures (429 rate-limit, 5xx server errors).                         |
-| `backoff_method`             | string  | `fibonacci` | Backoff strategy for transient HTTP retries. One of `fibonacci` or `exponential`.                                        |
-| `statement_max_retries`      | integer | `14`        | Maximum number of poll retries when waiting for an async SQL statement to complete (PENDING/RUNNING states).             |
-| `disable_on_permanent_error` | boolean | `true`      | When `true`, non-retryable HTTP errors (401, 403, 404) permanently disable the connector to prevent a thundering herd.   |
+| Parameter                    | Type     | Default     | Description                                                                                                              |
+| ---------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `max_concurrent_requests`    | integer  | `8`         | Maximum number of concurrent HTTP requests to the SQL Warehouse API. Controls a semaphore that gates all outbound calls. |
+| `http_max_retries`           | integer  | `3`         | Maximum number of HTTP-level retries for transient failures (429 rate-limit, 5xx server errors).                         |
+| `backoff_method`             | string   | `fibonacci` | Backoff strategy for transient HTTP retries. One of `fibonacci` or `exponential`.                                        |
+| `statement_max_retries`      | integer  | `14`        | Maximum number of poll retries when waiting for an async SQL statement to complete (PENDING/RUNNING states).             |
+| `disable_on_permanent_error` | boolean  | `true`      | When `true`, non-retryable HTTP errors (401, 403, 404) permanently disable the connector to prevent a thundering herd.   |
+| `connect_timeout`            | duration | `10s`       | Timeout for establishing TCP/TLS connections to the Databricks API. Accepts durations like `10s` or `500ms`.             |
+| `client_timeout`             | duration | `30s`       | Per-HTTP-call wall-clock timeout (statement submit, status poll, chunk fetch). See note below — set to the longest expected single call, **not** total query duration. |
+
+> **Note on `client_timeout` semantics.** In `sql_warehouse` mode `client_timeout` bounds every individual HTTP call, including large result-chunk downloads. Set it to the longest expected single call (e.g., the slowest chunk fetch), not the total query wall-clock. Total query duration is still bounded by `statement_max_retries` × poll backoff. If you have large result sets over slow links, the default 30s may be too short for chunk downloads — raise it to `2m` or higher. The same parameter name is used in `delta_lake` mode but there it controls the object-store HTTP client instead.
 
 #### Example
 
@@ -33,6 +37,8 @@ catalogs:
       backoff_method: exponential
       statement_max_retries: '20'
       disable_on_permanent_error: 'true'
+      connect_timeout: 10s
+      client_timeout: 2m
 ```
 
 ### Shared Concurrency Semaphore


### PR DESCRIPTION
## Summary

The Databricks `sql_warehouse` mode built its reqwest client via `configure_client_builder()` with hard-coded 10s connect and 30s per-request timeouts, with no user-facing override. Other connectors (`delta_lake` mode, `https`, `s3`, `gcs`, `abfs`, `elasticsearch`) expose `client_timeout` and/or `connect_timeout`, so this was a consistency gap.

The 30s per-request default was also a real correctness risk: reqwest's \`.timeout()\` applies to every HTTP call *including result-chunk downloads*. For large result sets over slow links, a single chunk fetch can exceed 30s and be aborted mid-stream.

## Changes

- Add \`connect_timeout\` and \`request_timeout\` to \`SqlWarehouseConfig\`, defaulting to the existing constants (no behavior change for existing users).
- Add \`configure_client_builder_with_timeouts\` in \`resilient_http.rs\`; keep \`configure_client_builder\` as a thin wrapper.
- Parse \`connect_timeout\` and \`client_timeout\` (duration strings like \`30s\`, \`5m\`) in \`build_sql_warehouse_config\`.
- Register \`ParameterSpec\` entries on the Databricks connector (both connector and catalog parameter blocks), with descriptions that note mode-specific semantics.
- Gate \`duration-parse\` behind the \`databricks\` runtime feature.
- Extend unit tests to cover valid and invalid duration overrides.

## Usage

\`\`\`yaml
datasets:
  - from: databricks:my_catalog.my_schema.sales
    name: sales
    params:
      mode: sql_warehouse
      databricks_endpoint: https://dbc-xxxx.cloud.databricks.com
      databricks_sql_warehouse_id: \${secrets:DBX_WAREHOUSE_ID}
      databricks_token: \${secrets:DBX_TOKEN}
      connect_timeout: 10s
      client_timeout: 2m           # per-HTTP-call, not total query duration
      statement_max_retries: \"20\"
      http_max_retries: \"5\"
      backoff_method: exponential
\`\`\`

## Notes

- In \`sql_warehouse\` mode \`client_timeout\` applies per-HTTP-call (statement submit, status poll, chunk fetch), not to total query duration — overall query time is still bounded by \`statement_max_retries\` × backoff. The param description calls this out.
- In \`delta_lake\` mode, \`client_timeout\` continues to control the object store client (unchanged).
- Defaults preserved: 10s connect / 30s request.

## Tests

Extended \`test_build_sql_warehouse_config_parses_valid_overrides\` and \`test_build_sql_warehouse_config_uses_defaults_for_invalid_values\` to cover the two new params.