### PR TITLE
fix(cdc): emit ready signal on caught-up Kafka/Debezium streams (#5201)

### DIFF
--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -26,6 +26,26 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use snafu::prelude::*;
 
+/// A stream of [`ChangeEnvelope`] items produced by a CDC connector.
+///
+/// # Readiness contract
+///
+/// It is the responsibility of each connector implementation to indicate when
+/// the dataset can be considered ready for queries by producing at least one
+/// [`ChangeEnvelope`] with [`ChangeEnvelope::is_dataset_ready`] returning
+/// `true`. The runtime treats the dataset as not ready and rejects queries
+/// (with `AccelerationNotReady`) until that signal arrives.
+///
+/// Connectors MUST emit a ready signal even when the source has no new data
+/// (e.g. on restart with an already-populated accelerator, or against a quiet
+/// topic). For sources that may stay quiet indefinitely, use
+/// [`build_ready_signal_envelope`] to emit a zero-row, no-op envelope as soon
+/// as the connector determines it has caught up to the source (for example,
+/// when Kafka consumer lag reaches zero, or when a Postgres logical
+/// replication slot resumes from an existing position).
+///
+/// Failing to honor this contract causes the runtime to wait for an event
+/// that may never arrive — see <https://github.com/spiceai/spiceai/issues/5201>.
 pub type ChangesStream = BoxStream<'static, Result<ChangeEnvelope, StreamError>>;
 
 #[derive(Debug, Snafu)]
@@ -131,10 +151,68 @@ impl ChangeEnvelope {
         }
     }
 
+    /// Returns `true` if processing this envelope means the dataset can be
+    /// marked ready for queries.
+    ///
+    /// See the [`ChangesStream`] documentation for the connector readiness
+    /// contract.
     #[must_use]
     pub fn is_dataset_ready(&self) -> bool {
         self.is_dataset_ready
     }
+}
+
+/// A [`CommitChange`] implementation that does nothing. Useful when emitting
+/// synthetic envelopes (e.g. ready signals) that have no underlying source
+/// offset to commit.
+pub struct NoOpCommitter;
+
+#[async_trait]
+impl CommitChange for NoOpCommitter {
+    async fn commit(&self) -> Result<(), CommitError> {
+        Ok(())
+    }
+}
+
+/// Construct an empty [`ChangeEnvelope`] whose only job is to flip
+/// `is_dataset_ready=true`. The batch contains zero rows and uses a no-op
+/// committer.
+///
+/// Connectors should emit one of these envelopes once they consider
+/// themselves caught up to the source if no real change events are available
+/// to carry the ready signal. See the [`ChangesStream`] documentation for the
+/// readiness contract.
+pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope, ChangeBatchError> {
+    // Build zero-row versions of each dataset column.
+    let empty_data_columns: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .map(|f| arrow::array::new_empty_array(f.data_type()))
+        .collect();
+    let data_struct = StructArray::new(schema.fields().clone(), empty_data_columns, None);
+
+    let op_array: ArrayRef = Arc::new(StringArray::from(Vec::<&str>::new()));
+    let pk_field = Arc::new(Field::new("item", DataType::Utf8, false));
+    let pk_list = ListArray::new(
+        Arc::clone(&pk_field),
+        OffsetBuffer::new(vec![0i32].into()),
+        Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef,
+        None,
+    );
+
+    let wrapper_schema = Arc::new(changes_schema(schema));
+    let record = RecordBatch::try_new(
+        wrapper_schema,
+        vec![op_array, Arc::new(pk_list), Arc::new(data_struct)],
+    )
+    .context(ArrowSnafu)?;
+    let batch = ChangeBatch::try_new(record)?;
+
+    Ok(ChangeEnvelope::new(
+        Box::new(NoOpCommitter),
+        batch,
+        true, // is_dataset_ready
+    ))
 }
 
 /// The Arrow schema that represents a `ChangeEvent`

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::kafka::MessageBatchCommitter;
+use crate::kafka::{MessageBatchCommitter, inject_ready_signal_on_caught_up};
 use crate::{
     cdc::{self, ChangeEnvelope, ChangesStream},
     debezium::{
@@ -101,7 +101,8 @@ impl DebeziumKafka {
         let schema = Arc::clone(&self.schema);
         let primary_keys = self.primary_keys.clone();
         let consumer = self.consumer;
-        let stream = self
+        let metrics = Arc::clone(self.consumer.metrics());
+        let inner = self
             .consumer
             .stream_json::<ChangeEventKey, ChangeEvent>()
             .chunks_timeout(self.batching.0, self.batching.1)
@@ -131,7 +132,11 @@ impl DebeziumKafka {
                 Ok(ChangeEnvelope::new(Box::new(committer), rb, true))
             });
 
-        Box::pin(stream)
+        Box::pin(inject_ready_signal_on_caught_up(
+            inner,
+            metrics,
+            Arc::clone(&self.schema),
+        ))
     }
 }
 

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -36,9 +36,10 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use snafu::prelude::*;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use std::{any::Any, sync::Arc};
+use tokio::sync::Notify;
 use tokio_stream::StreamExt;
 use tonic::async_trait;
 
@@ -160,6 +161,16 @@ pub struct KafkaMetrics {
     pub records_consumed: AtomicU64,
     /// Total bytes consumed
     pub bytes_consumed: AtomicU64,
+    /// Set to true the first time the rdkafka stats callback fires with at
+    /// least one valid partition. Until this flips, `records_lag == 0` only
+    /// means "we haven't observed any stats yet", not "the consumer is
+    /// caught up".
+    pub has_received_stats: AtomicBool,
+    /// Notified by the stats callback whenever the consumer is observed to
+    /// be caught up (received at least one valid stats sample with
+    /// `total_lag == 0`). Used by CDC connectors to emit a synthetic
+    /// ready-signal envelope on quiet topics without polling.
+    pub caught_up: Notify,
 }
 
 struct KafkaConsumerContext {
@@ -189,6 +200,24 @@ impl KafkaMetrics {
     pub fn update_bytes_consumed(&self, bytes: u64) {
         self.bytes_consumed.store(bytes, Ordering::Relaxed);
     }
+
+    /// Returns true once the consumer has received at least one statistics
+    /// callback that reported valid partitions and the most recent total lag
+    /// across those partitions is zero.
+    ///
+    /// Uses Acquire ordering on `has_received_stats` so that an observer that
+    /// sees the flag set is guaranteed to also see the matching Release-stored
+    /// `records_lag` value from the same stats callback (and not a stale
+    /// default 0).
+    ///
+    /// Used by CDC connectors to decide when to emit a synthetic
+    /// `is_dataset_ready=true` envelope on quiet topics. See the
+    /// [`crate::cdc::ChangesStream`] readiness contract.
+    #[must_use]
+    pub fn is_caught_up(&self) -> bool {
+        self.has_received_stats.load(Ordering::Acquire)
+            && self.records_lag.load(Ordering::Relaxed) == 0
+    }
 }
 
 impl rdkafka::ClientContext for KafkaConsumerContext {
@@ -210,7 +239,21 @@ impl rdkafka::ClientContext for KafkaConsumerContext {
 
         // Update total lag only if we have valid partitions to avoid misleading data
         if has_valid_partitions {
+            // Pair these stores with the Acquire load in `is_caught_up`:
+            // store the lag first (Relaxed is sufficient since the Release
+            // store below acts as the release fence), then publish the
+            // "stats received" flag with Release so any observer that sees
+            // the flag set also sees this exact lag value.
             self.metrics.update_records_lag(total_lag);
+            self.metrics
+                .has_received_stats
+                .store(true, Ordering::Release);
+            if total_lag == 0 {
+                // Wake any task waiting on `KafkaMetrics::caught_up` (e.g.
+                // the CDC ready-signal wrapper). Cheap and idempotent: if no
+                // one is waiting, the permit is stored for the next waiter.
+                self.metrics.caught_up.notify_one();
+            }
         }
 
         self.metrics
@@ -599,7 +642,8 @@ impl Kafka {
         let schema = Arc::clone(&self.schema);
         let flatten_json = self.flatten_json.clone();
         let consumer = self.consumer;
-        let stream = self
+        let metrics = Arc::clone(self.consumer.metrics());
+        let inner = self
             .consumer
             .stream_json::<serde_json::Value, serde_json::Value>()
             .chunks_timeout(self.batching.0, self.batching.1)
@@ -627,7 +671,11 @@ impl Kafka {
                 change_batch.map(|rb| ChangeEnvelope::new(Box::new(committer), rb, true))
             });
 
-        Box::pin(stream)
+        Box::pin(inject_ready_signal_on_caught_up(
+            inner,
+            metrics,
+            Arc::clone(&self.schema),
+        ))
     }
 }
 
@@ -694,6 +742,84 @@ impl TableProvider for Kafka {
             &self.schema,
             projection,
         )?)))
+    }
+}
+
+/// Wraps an inner Kafka-derived `ChangesStream` and emits a single synthetic
+/// `is_dataset_ready=true` [`ChangeEnvelope`] (built via
+/// [`cdc::build_ready_signal_envelope`]) once the underlying consumer reports
+/// it has caught up to the source (`KafkaMetrics::caught_up` is notified by
+/// the stats callback when `total_lag == 0`). The wrapper stops watching
+/// after the first ready signal (whether emitted by the wrapper or carried
+/// by a real change envelope).
+///
+/// This satisfies the [`cdc::ChangesStream`] readiness contract for quiet
+/// topics where no actual change events are available to flip the
+/// `is_dataset_ready` flag (e.g. on restart against an already-populated
+/// accelerator). See <https://github.com/spiceai/spiceai/issues/5201>.
+pub(crate) fn inject_ready_signal_on_caught_up<S>(
+    inner: S,
+    metrics: Arc<KafkaMetrics>,
+    schema: SchemaRef,
+) -> impl Stream<Item = Result<ChangeEnvelope, cdc::StreamError>>
+where
+    S: Stream<Item = Result<ChangeEnvelope, cdc::StreamError>> + Send + 'static,
+{
+    async_stream::stream! {
+        let mut inner = Box::pin(inner);
+        let mut ready_emitted = false;
+
+        loop {
+            tokio::select! {
+                biased;
+                next = inner.next() => match next {
+                    Some(item) => {
+                        if !ready_emitted
+                            && let Ok(ref env) = item
+                            && env.is_dataset_ready()
+                        {
+                            ready_emitted = true;
+                        }
+                        yield item;
+                    }
+                    None => break,
+                },
+                () = metrics.caught_up.notified(), if !ready_emitted => {
+                    // Re-check under the same memory ordering as the
+                    // notifier; `notified()` may wake spuriously if the
+                    // notifier raced with another waiter.
+                    if metrics.is_caught_up() {
+                        match cdc::build_ready_signal_envelope(&schema) {
+                            Ok(env) => {
+                                ready_emitted = true;
+                                tracing::debug!(
+                                    "Kafka consumer reports zero lag; emitting synthetic ready signal envelope"
+                                );
+                                yield Ok(env);
+                            }
+                            Err(e) => {
+                                // Building the envelope is schema-driven and
+                                // therefore deterministic: a failure here
+                                // will repeat on every wake-up. Surface it
+                                // as a stream error and stop the synthetic
+                                // ready-signal path so we don't spam logs
+                                // forever — the inner stream still runs and
+                                // can deliver readiness via a real envelope
+                                // if any change event ever arrives.
+                                tracing::error!(
+                                    "Failed to build Kafka ready-signal envelope; \
+                                     synthetic readiness disabled for this stream: {e}"
+                                );
+                                ready_emitted = true;
+                                yield Err(cdc::StreamError::Arrow(format!(
+                                    "failed to build Kafka ready-signal envelope: {e}"
+                                )));
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -899,6 +1025,75 @@ mod tests {
             batch.record.num_rows(),
             1025,
             "1025 rows should not be truncated to 1024"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ready_signal_emitted_when_caught_up_on_quiet_stream() {
+        // Inner stream that produces nothing (quiet topic).
+        let inner = futures::stream::pending::<Result<ChangeEnvelope, cdc::StreamError>>();
+
+        let metrics = Arc::new(KafkaMetrics::default());
+        // Simulate a stats callback observing zero lag: flip the flag and
+        // notify the wrapper.
+        metrics
+            .has_received_stats
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        metrics.caught_up.notify_one();
+
+        let schema = test_schema();
+        let stream = inject_ready_signal_on_caught_up(inner, Arc::clone(&metrics), schema);
+
+        // Should yield a ready envelope essentially immediately.
+        let next = tokio::time::timeout(Duration::from_secs(1), Box::pin(stream).next())
+            .await
+            .expect("ready envelope should be emitted promptly after notification")
+            .expect("stream produced an item")
+            .expect("item is Ok");
+
+        assert!(next.is_dataset_ready(), "envelope must flag dataset ready");
+        assert_eq!(
+            next.change_batch.record.num_rows(),
+            0,
+            "ready signal envelope must carry zero rows"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ready_signal_not_emitted_before_stats_received() {
+        let inner = futures::stream::pending::<Result<ChangeEnvelope, cdc::StreamError>>();
+
+        let metrics = Arc::new(KafkaMetrics::default());
+        // No stats callback yet — nothing notified, has_received_stats=false.
+
+        let schema = test_schema();
+        let stream = inject_ready_signal_on_caught_up(inner, Arc::clone(&metrics), schema);
+
+        let res = tokio::time::timeout(Duration::from_millis(500), Box::pin(stream).next()).await;
+        assert!(
+            res.is_err(),
+            "no ready envelope must be emitted before stats are received"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn spurious_notify_without_caught_up_does_not_emit() {
+        // Verifies the re-check guard inside the wrapper: a stale notify
+        // permit must not cause a false ready signal if the consumer is no
+        // longer caught up.
+        let inner = futures::stream::pending::<Result<ChangeEnvelope, cdc::StreamError>>();
+
+        let metrics = Arc::new(KafkaMetrics::default());
+        // Notify but leave has_received_stats=false (e.g. callback never ran).
+        metrics.caught_up.notify_one();
+
+        let schema = test_schema();
+        let stream = inject_ready_signal_on_caught_up(inner, Arc::clone(&metrics), schema);
+
+        let res = tokio::time::timeout(Duration::from_millis(500), Box::pin(stream).next()).await;
+        assert!(
+            res.is_err(),
+            "spurious notify without is_caught_up must not produce a ready envelope"
         );
     }
 }

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -201,8 +201,10 @@ async fn start_inner(
     // the dataset ready without having to wait for the first WAL change. On
     // quiet sources that wait could be indefinite.
     let skip_bootstrap_ready: Option<ChangesStream> = if bootstrap_stream.is_none() {
-        let envelope = build_ready_signal_envelope(&schema).map_err(|e| Error::SchemaMismatch {
-            message: e.to_string(),
+        let envelope = crate::cdc::build_ready_signal_envelope(&schema).map_err(|e| {
+            Error::SchemaMismatch {
+                message: e.to_string(),
+            }
         })?;
         Some(Box::pin(futures::stream::once(async move { Ok(envelope) })))
     } else {
@@ -231,57 +233,6 @@ async fn start_inner(
         (None, Some(ready)) => Box::pin(ready.chain(wal_stream)),
         (None, None) => wal_stream,
     })
-}
-
-/// Construct an empty `ChangeEnvelope` whose only job is to flip
-/// `is_dataset_ready=true`. Zero-row batch, no-op committer.
-fn build_ready_signal_envelope(
-    schema: &SchemaRef,
-) -> std::result::Result<crate::cdc::ChangeEnvelope, StreamError> {
-    use arrow::array::{ArrayRef, ListArray, RecordBatch, StringArray, StructArray};
-    use arrow::buffer::OffsetBuffer;
-    use arrow::datatypes::{DataType, Field};
-
-    // Build zero-row versions of each dataset column.
-    let empty_data_columns: Vec<ArrayRef> = schema
-        .fields()
-        .iter()
-        .map(|f| arrow::array::new_empty_array(f.data_type()))
-        .collect();
-    let data_struct = StructArray::new(schema.fields().clone(), empty_data_columns, None);
-
-    let op_array: ArrayRef = Arc::new(StringArray::from(Vec::<&str>::new()));
-    let pk_field = Arc::new(Field::new("item", DataType::Utf8, false));
-    let pk_list = ListArray::new(
-        Arc::clone(&pk_field),
-        OffsetBuffer::new(vec![0i32].into()),
-        Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef,
-        None,
-    );
-
-    let wrapper_schema = Arc::new(crate::cdc::changes_schema(schema));
-    let record = RecordBatch::try_new(
-        wrapper_schema,
-        vec![op_array, Arc::new(pk_list), Arc::new(data_struct)],
-    )
-    .map_err(|e| StreamError::External(format!("ready-signal batch: {e}")))?;
-    let batch = crate::cdc::ChangeBatch::try_new(record)
-        .map_err(|e| StreamError::External(format!("ready-signal batch validation: {e}")))?;
-
-    Ok(crate::cdc::ChangeEnvelope::new(
-        Box::new(NoOpCommitter),
-        batch,
-        true, // is_dataset_ready
-    ))
-}
-
-struct NoOpCommitter;
-
-#[async_trait::async_trait]
-impl crate::cdc::CommitChange for NoOpCommitter {
-    async fn commit(&self) -> std::result::Result<(), crate::cdc::CommitError> {
-        Ok(())
-    }
 }
 
 fn stream_error(err: &Error) -> StreamError {


### PR DESCRIPTION
Fixes #5201. Closely related to #7057.

## Problem

When a CDC dataset (Kafka or Debezium connector) is restarted with file-mode acceleration and `refresh_mode: changes`, the dataset would never transition to **Ready** if the source topic had no new events past the last committed offset. Queries against the dataset would fail with:

```
External(AccelerationNotReady { dataset_name: "<name>" })
```

Root cause: the readiness signal is normally piggy-backed on the first incoming `ChangeEnvelope`. On a quiet topic after restart, no envelope arrives, so the dataset never flips to Ready.

## Fix

Make each Kafka-backed `changes` connector responsible for emitting its own readiness signal once the consumer reports it has caught up to the source.

- Promote `build_ready_signal_envelope` and `NoOpCommitter` to public helpers in `data_components::cdc` so any changes connector can reuse them. Document the readiness contract on `ChangesStream` for future implementations.
- Add `KafkaMetrics::has_received_stats` (set by the rdkafka stats callback when at least one valid partition is observed) and a `tokio::sync::Notify` (`caught_up`) signalled when total_lag drops to zero. Expose `is_caught_up()`.
- Wrap `Kafka::stream_changes()` and `DebeziumKafka::stream_changes()` in `inject_ready_signal_on_caught_up`, an event-driven `async_stream` wrapper that yields a single synthetic ready envelope the moment `caught_up` is notified, with a defensive `is_caught_up()` re-check to ignore spurious wake-ups.

The implementation is event-driven (no polling), so warm-restart-to-Ready is bounded by rdkafka's stats interval (~1 s) plus consumer-group join time, not by any fixed timeout in our code.

## Verification

Manual repro using cookbook `cdc-debezium`:
- **Before fix:** dataset stuck in initialising indefinitely after restart, queries return `AccelerationNotReady`.
- **After fix:** restart-to-Ready is **~2.25 s** on a warm broker; subsequent queries succeed and incremental Postgres inserts continue to propagate via Debezium → Kafka → SQLite acceleration.

## Tests

New unit tests in `crates/data_components/src/kafka.rs`:
- `ready_signal_emitted_when_caught_up_on_quiet_stream` — wrapper emits a ready envelope on a pending inner stream after `caught_up` notification.
- `ready_signal_not_emitted_before_stats_received` — `has_received_stats` gate prevents default-zero-lag false positives at startup.
- `spurious_notify_without_caught_up_does_not_emit` — re-check guard ignores stale notify permits.

`make lint-rust` clean.

## Out of scope

- DynamoDB streams connector — the same readiness contract applies but the lag-detection mechanism is different; deferred to a follow-up.
- The runtime `delay_initial_ready` logic in `crates/runtime/src/datafusion/mod.rs` is intentionally untouched. Each connector now owns its own readiness determination per the documented `ChangesStream` contract.
