### PR TITLE
fix(s3): quiet AWS SDK credential probe when no region is configured

### DIFF
--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -245,7 +245,12 @@ async fn load_sdk_config_from_env(
 
                     Ok(None)
                 } else {
-                    tracing::warn!(
+                    // Proceeding without authentication anyway: log at debug. The bridge
+                    // doesn't know whether the caller actually needs AWS credentials, so
+                    // callers with that context (e.g. the S3 connector when `region` is
+                    // explicitly configured) should warn themselves based on whether
+                    // `get_sdk_config()` returns `None` after this call.
+                    tracing::debug!(
                         "Non-retryable AWS credentials error, proceeding without authentication: {err}"
                     );
                     Ok(None)

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -211,7 +211,12 @@ impl DataConnectorFactory for S3Factory {
                         .expose()
                         .ok()
                         .map(ToString::to_string);
-                    // Initialize global AWS SDK for default credential chain.
+                    // Always probe the default AWS credential chain so env-only setups
+                    // (IRSA, EC2 IMDS, AWS_ACCESS_KEY_ID/AWS_REGION env vars, etc.) keep
+                    // working when the user did not put `region` into spicepod params.
+                    // The bridge logs internal probe failures at debug level, so we only
+                    // surface a WARN here when the user explicitly configured a `region`
+                    // (signalling AWS auth intent) but no credentials were resolved.
                     if let Err(err) = aws_sdk_credential_bridge::get_or_init_sdk_config_with_region(
                         region.as_deref(),
                     )
@@ -219,6 +224,12 @@ impl DataConnectorFactory for S3Factory {
                     {
                         tracing::warn!(
                             "Unable to initialize AWS credentials for S3 connector: {err}"
+                        );
+                    } else if region.is_some()
+                        && aws_sdk_credential_bridge::get_sdk_config().is_none()
+                    {
+                        tracing::warn!(
+                            "S3 connector configured with `region` but no AWS credentials were resolved from the environment; falling back to anonymous access. Set `auth: public` to silence this warning, or configure AWS credentials (env vars, ~/.aws/credentials, IAM role)."
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

Closes #10505.

When the S3 data connector loads a dataset without an explicit `region` parameter (e.g. the quickstart's public `s3://spiceai-demo-datasets/...`), the eager AWS credential probe surfaced a misleading WARN on every `spice run` for hosts with no AWS configuration:

```
WARN aws_sdk_credential_bridge: Non-retryable AWS credentials error, proceeding without authentication: the credentials provider was not properly configured
```

We still need to probe the AWS chain at registration time so the global SDK config cache is populated for env-only setups (IRSA, EC2 IMDS, `AWS_ACCESS_KEY_ID` + `AWS_REGION`, etc.) where the user did not set `region` in spicepod params. Skipping the probe outright would regress those flows by causing the object-store registry to fall back to anonymous access.

Instead:

- Downgrade the bridge's internal "non-retryable, proceeding without authentication" log from WARN to DEBUG. The bridge already returns `Ok(None)` and proceeds — it can't tell whether the caller actually needed credentials, so it shouldn't decide log severity.
- In the S3 connector, after probing, only emit a connector-specific WARN when the user explicitly configured `region` (signalling AWS intent) but no credentials were resolved. The message names the connector and tells the user how to silence it (`auth: public`) or how to configure credentials.

## Manual testing

| Case | Before | After |
|---|---|---|
| Public S3, no region, no AWS env (the issue repro) | misleading bridge WARN | silent ✅ |
| Public S3, `s3_region` set, no AWS env | misleading bridge WARN | clear connector WARN naming connector + remediation ✅ |
| env-only AWS creds (`AWS_ACCESS_KEY_ID` + `AWS_REGION`), no region in params, `s3_auth: iam_role` | works | works (creds attached, S3 returns `InvalidAccessKeyId` for fake key — proves request was signed) ✅ |

Verified against the exact repro from the issue (quickstart-style spicepod, all `AWS_*` env vars unset). No `aws_sdk_credential_bridge` WARN; dataset registers and loads.