### PR TITLE
fix(cli): suppress banner for all JSON-producing cloud subcommands (fixes #10498)

### DIFF
--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -193,14 +193,39 @@ fn is_json_output(cmd: &Commands) -> bool {
             cloud::CloudCommands::Deployments(x) => x.output == OutputFormat::Json,
             cloud::CloudCommands::Inspect(x) => x.output == OutputFormat::Json,
             cloud::CloudCommands::ApiKeys(x) => x.output == OutputFormat::Json,
+            cloud::CloudCommands::Metrics(x) => x.output == OutputFormat::Json,
+            cloud::CloudCommands::Logs(x) => x.output == OutputFormat::Json,
+            cloud::CloudCommands::Deploy(x) => x.output == OutputFormat::Json,
+            cloud::CloudCommands::Rollback(x) => x.output == OutputFormat::Json,
             cloud::CloudCommands::Secrets(cloud::SecretsCommands::List(x)) => {
+                x.output == OutputFormat::Json
+            }
+            cloud::CloudCommands::Secrets(cloud::SecretsCommands::Set(x)) => {
                 x.output == OutputFormat::Json
             }
             cloud::CloudCommands::Secrets(cloud::SecretsCommands::Get(x)) => {
                 x.output == OutputFormat::Json
             }
+            cloud::CloudCommands::Secrets(cloud::SecretsCommands::Delete(x)) => {
+                x.output == OutputFormat::Json
+            }
+            cloud::CloudCommands::Create(cloud::CreateCommands::App(x)) => {
+                x.output == OutputFormat::Json
+            }
+            cloud::CloudCommands::Create(cloud::CreateCommands::Deployment(x)) => {
+                x.output == OutputFormat::Json
+            }
             cloud::CloudCommands::Get(cloud::GetCommands::App(x)) => x.output == OutputFormat::Json,
-            _ => false,
+            cloud::CloudCommands::Update(cloud::UpdateCommands::App(x)) => {
+                x.output == OutputFormat::Json
+            }
+            cloud::CloudCommands::Delete(cloud::DeleteCommands::App(x)) => {
+                x.output == OutputFormat::Json
+            }
+            cloud::CloudCommands::Login(_)
+            | cloud::CloudCommands::Logout
+            | cloud::CloudCommands::Link(_)
+            | cloud::CloudCommands::Unlink => false,
         },
         _ => false,
     }
@@ -342,4 +367,95 @@ fn run_cli(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).expect("failed to parse CLI args")
+    }
+
+    fn is_json(args: &[&str]) -> bool {
+        is_json_output(&parse(args).command)
+    }
+
+    #[test]
+    fn cloud_metrics_json_output_suppresses_banner() {
+        assert!(is_json(&[
+            "spice", "cloud", "metrics", "--app", "org/app", "--output", "json",
+        ]));
+    }
+
+    #[test]
+    fn cloud_metrics_table_output_keeps_banner() {
+        assert!(!is_json(&["spice", "cloud", "metrics", "--app", "org/app"]));
+        assert!(!is_json(&[
+            "spice", "cloud", "metrics", "--app", "org/app", "--output", "table",
+        ]));
+    }
+
+    #[test]
+    fn cloud_all_json_producing_subcommands_suppress_banner() {
+        // Every cloud subcommand whose execute_* fn writes JSON when --output=json
+        // must cause the banner to be suppressed, otherwise piping to `jq` breaks.
+        let json_producing: &[&[&str]] = &[
+            &["spice", "cloud", "whoami", "--output", "json"],
+            &["spice", "cloud", "apps", "--output", "json"],
+            &["spice", "cloud", "regions", "--output", "json"],
+            &["spice", "cloud", "images", "--output", "json"],
+            &["spice", "cloud", "deployments", "--output", "json"],
+            &["spice", "cloud", "inspect", "--output", "json"],
+            &["spice", "cloud", "api-keys", "--output", "json"],
+            &["spice", "cloud", "metrics", "--output", "json"],
+            &["spice", "cloud", "logs", "--output", "json"],
+            &["spice", "cloud", "deploy", "--output", "json"],
+            &["spice", "cloud", "rollback", "--output", "json"],
+            &["spice", "cloud", "secrets", "list", "--output", "json"],
+            &[
+                "spice", "cloud", "secrets", "set", "name", "value", "--output", "json",
+            ],
+            &[
+                "spice", "cloud", "secrets", "get", "name", "--output", "json",
+            ],
+            &[
+                "spice", "cloud", "secrets", "delete", "name", "--output", "json",
+            ],
+            &[
+                "spice", "cloud", "create", "app", "name", "--output", "json",
+            ],
+            &["spice", "cloud", "create", "deployment", "--output", "json"],
+            &[
+                "spice", "cloud", "get", "app", "org/app", "--output", "json",
+            ],
+            &["spice", "cloud", "update", "app", "--output", "json"],
+            &[
+                "spice", "cloud", "delete", "app", "org/app", "--yes", "--output", "json",
+            ],
+        ];
+        for argv in json_producing {
+            assert!(
+                is_json(argv),
+                "expected --output=json to suppress banner for: {argv:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn non_json_commands_keep_banner() {
+        // Commands without --output=json should not suppress the banner.
+        assert!(!is_json(&["spice", "cloud", "login"]));
+        assert!(!is_json(&["spice", "cloud", "logout"]));
+        assert!(!is_json(&["spice", "cloud", "unlink"]));
+        assert!(!is_json(&["spice", "datasets"]));
+        assert!(!is_json(&["spice", "pods"]));
+    }
+
+    #[test]
+    fn non_cloud_json_output_suppresses_banner() {
+        assert!(is_json(&["spice", "datasets", "--output", "json"]));
+        assert!(is_json(&["spice", "pods", "--output", "json"]));
+        assert!(is_json(&["spice", "status", "--output", "json"]));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #10498

The CLI banner (`Spice.ai OSS CLI v...`) was prepended to stdout for several cloud subcommands that produce JSON output, breaking pipes like:

```
spice cloud metrics --app org/app --output=json | jq '.'
```

**Root cause:** `is_json_output` in `bin/spice/src/main.rs` only enumerated a subset of cloud subcommands (Whoami, Apps, Regions, Images, Deployments, Inspect, ApiKeys, Secrets::List, Secrets::Get, Get::App) and fell through to `_ => false` for everything else. Subcommands like `Metrics`, `Logs`, `Deploy`, `Rollback`, `Secrets::Set/Delete`, `Create::App/Deployment`, `Update::App`, and `Delete::App` all honor `--output=json` in their `execute_*` fns (via `write_json`), but the banner check never treated them as JSON-producing.

## Changes

`bin/spice/src/main.rs`
- Extend the `Commands::Cloud` arm of `is_json_output` to cover every subcommand whose `execute_*` fn calls `write_json`.
- Replace the `_ => false` catch-all with an explicit list of non-JSON variants (`Login`, `Logout`, `Link`, `Unlink`). The match is now exhaustive, so adding a new cloud subcommand will fail to compile until a banner-suppression decision is made explicitly.

## Test plan
- [x] Added unit test for the original repro (cloud metrics + --output=json)
- [x] Added unit tests covering all cloud subcommands that produce JSON
- [x] Added unit tests covering cloud subcommands that do NOT produce JSON
- [x] Added unit tests covering non-cloud JSON commands (datasets/pods/status)
- [x] cargo fmt -p spice -- --check passes
- [x] cargo clippy -p spice --lib --bins with full strict deny-list passes
- [x] cargo clippy -p spice --tests with strict deny-list passes
- [x] cargo test -p spice passes (79 lib tests + 5 new bin tests)

## Checklist
- [x] Root cause identified and fixed
- [x] Regression test added (the original scenario)
- [x] Edge cases covered
- [x] No snapshot deletions
- [x] Lint clean