### PR TITLE
feat(rerank): add task_history tracing to rerank UDTF

### DIFF
--- a/crates/runtime/src/search/rerank.rs
+++ b/crates/runtime/src/search/rerank.rs
@@ -932,9 +932,6 @@ impl ExecutionPlan for RerankExec {
         let input_is_nested = self.input_is_nested;
         let model_name = self.reranker.model_name().unwrap_or("unknown").to_string();
 
-        let span =
-            tracing::span!(target: "task_history", tracing::Level::INFO, "rerank", input = %query);
-
         let stream = futures::stream::once(async move {
             // 1. Execute the child plan and collect candidate batches.
             tracing::debug!(document = %document, "RerankExec: collecting candidate batches..");
@@ -947,8 +944,13 @@ impl ExecutionPlan for RerankExec {
                 batches = truncate_batches(batches, DEFAULT_MAX_CANDIDATES);
             }
 
-            tracing::info!(target: "task_history", model = %model_name, document = %document, candidates = total, "labels");
             tracing::debug!(candidates = total, document = %document, "RerankExec: collected candidate batches");
+
+            // Start the task_history span after candidate collection so `execution_duration_ms` measures only
+            // the reranker work (extract docs → API call → sort), not the child plan execution which has its own traces.
+            let span = tracing::span!(target: "task_history", tracing::Level::INFO, "rerank", input = %query);
+            async {
+            tracing::info!(target: "task_history", model = %model_name, document = %document, candidates = total, "labels");
 
             // 2. Concatenate into a single batch for the reranker.
             let concatenated = if batches.is_empty() {
@@ -1031,7 +1033,8 @@ impl ExecutionPlan for RerankExec {
                 .inspect_err(|e| {
                     tracing::error!(target: "task_history", "{e}");
                 })
-        }.instrument(span));
+            }.instrument(span).await
+        });
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&self.output_schema),

--- a/crates/runtime/src/search/rerank.rs
+++ b/crates/runtime/src/search/rerank.rs
@@ -63,6 +63,7 @@ use datafusion_expr::{LogicalPlanBuilder, ScalarFunctionArgs, ScalarUDFImpl};
 use futures::TryStreamExt;
 use llms::rerank::{LlmRerank, LlmStrategy, Rerank, RerankerModelStore};
 use tokio::sync::RwLock;
+use tracing::Instrument;
 
 use crate::datafusion::{DataFusion, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use crate::embeddings::udtf::VECTOR_SEARCH_UDTF_NAME;
@@ -929,6 +930,10 @@ impl ExecutionPlan for RerankExec {
         let reranker = Arc::clone(&self.reranker);
         let rerank_limit = self.rerank_limit;
         let input_is_nested = self.input_is_nested;
+        let model_name = self.reranker.model_name().unwrap_or("unknown").to_string();
+
+        let span =
+            tracing::span!(target: "task_history", tracing::Level::INFO, "rerank", input = %query);
 
         let stream = futures::stream::once(async move {
             // 1. Execute the child plan and collect candidate batches.
@@ -942,6 +947,7 @@ impl ExecutionPlan for RerankExec {
                 batches = truncate_batches(batches, DEFAULT_MAX_CANDIDATES);
             }
 
+            tracing::info!(target: "task_history", model = %model_name, document = %document, candidates = total, "labels");
             tracing::debug!(candidates = total, document = %document, "RerankExec: collected candidate batches");
 
             // 2. Concatenate into a single batch for the reranker.
@@ -1016,7 +1022,16 @@ impl ExecutionPlan for RerankExec {
 
             // 7. Sort by rerank_score DESC, apply output limit.
             sort_by_rerank_score_desc(&unsorted, rerank_limit)
-        });
+                .inspect(|batch| {
+                    tracing::info!(target: "task_history", rows_produced = batch.num_rows(), "labels");
+                    let preview = batch.slice(0, batch.num_rows().min(3));
+                    let captured_output = crate::datafusion::query::write_to_json_string(&[preview]).unwrap_or_default();
+                    tracing::info!(target: "task_history", captured_output = %captured_output);
+                })
+                .inspect_err(|e| {
+                    tracing::error!(target: "task_history", "{e}");
+                })
+        }.instrument(span));
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&self.output_schema),


### PR DESCRIPTION
## 📝 Summary

Adds `runtime.task_history` tracing to the `rerank()` UDTF, matching the conventions used by `search`, `text_embed`, and `ai_completion`.

<img width="1225" height="662" alt="image" src="https://github.com/user-attachments/assets/c84aa087-8487-4def-8e5e-fd5c378e4740" />


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
