### PR TITLE
fix: add missing NULL check on Timestamp path in append refresh

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -2526,9 +2526,7 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![Arc::new(TimestampNanosecondArray::from(vec![
-                None,
-                None,
-                None,
+                None, None, None,
             ]))],
         )
         .expect("batch");

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -1422,7 +1422,7 @@ impl RefreshTask {
                     reason: "Failed to get the latest timestamp during incremental appending. Failed to convert the value of the time column to a timestamp. Verify the column is a timestamp.",
                 })?;
 
-            if array.is_empty() {
+            if array.is_empty() || array.is_null(0) {
                 return Ok(None);
             }
 
@@ -2514,5 +2514,27 @@ mod tests {
             .downcast_ref::<Int32Array>()
             .expect("id column should be Int32");
         assert_eq!(id_col.value(0), 4, "remaining row should be id=4");
+    }
+
+    #[tokio::test]
+    async fn test_max_timestamp_df_timestamp_ns_all_null_returns_none() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "t",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(TimestampNanosecondArray::from(vec![
+                None,
+                None,
+                None,
+            ]))],
+        )
+        .expect("batch");
+        let mem = Arc::new(
+            MemTable::try_new(schema, vec![vec![batch]]).expect("mem table should be created"),
+        ) as Arc<dyn TableProvider>;
+        assert_eq!(collect_numeric_from_max_df(&mem, "t").await, None);
     }
 }


### PR DESCRIPTION
## Summary
- The Timestamp branch in `timestamp_nanos_for_append_query` checked `is_empty()` but not `is_null(0)` before calling `value(0)` on the result of `MAX(time_column)`
- When all rows have NULL timestamps, `value(0)` silently returns `0` (epoch 1970-01-01), causing the incremental append refresh to build a `WHERE time_column > '1970-01-01'` filter instead of returning `None`
- The Int64 and UInt64 branches in the same function already had the `is_null(0)` guard — this aligns the Timestamp branch with that pattern

## Fix
Added `|| array.is_null(0)` to the existing `is_empty()` check on the Timestamp path (line 1425), mirroring the pattern at lines 1378 and 1406.

## Test plan
- Added regression test `test_max_timestamp_df_timestamp_ns_all_null_returns_none` that creates a table with all-NULL timestamp values and verifies `collect_numeric_from_max_df` returns `None`
- `cargo clippy -p runtime` passes
- `cargo test -p runtime --lib accelerated_table::refresh_task::tests` passes
- Performance impact: none (single branch condition added)