### PR TITLE
fix: delegate update and delete_from in IndexedTableProvider and EmbeddingTable

### DIFF
--- a/crates/runtime-datafusion-index/src/provider.rs
+++ b/crates/runtime-datafusion-index/src/provider.rs
@@ -158,4 +158,23 @@ impl TableProvider for IndexedTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.underlying.insert_into(state, input, insert_op).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.underlying.delete_from(state, filters).await
+    }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.underlying
+            .update(state, assignments, filters)
+            .await
+    }
 }

--- a/crates/runtime-datafusion-index/src/provider.rs
+++ b/crates/runtime-datafusion-index/src/provider.rs
@@ -173,8 +173,6 @@ impl TableProvider for IndexedTableProvider {
         assignments: Vec<(String, Expr)>,
         filters: Vec<Expr>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.underlying
-            .update(state, assignments, filters)
-            .await
+        self.underlying.update(state, assignments, filters).await
     }
 }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -992,6 +992,23 @@ impl TableProvider for EmbeddingTable {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.base_table.insert_into(state, input, overwrite).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.base_table.delete_from(state, filters).await
+    }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.base_table.update(state, assignments, filters).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `IndexedTableProvider` and `EmbeddingTable` both delegate `insert_into` to the underlying provider but omit `update` and `delete_from`, causing those operations to fall through to DataFusion's default "not supported" error
- Since these wrappers form the outermost layer of the registered provider chain (`IndexedTableProvider` → `EmbeddingTable` → `AcceleratedTable`), the missing delegations block UPDATE and DELETE for all indexed or embedding-augmented tables, even when the underlying accelerator (DuckDB, Cayenne, etc.) fully supports them

## Fix
Added `delete_from` and `update` method delegations to both `IndexedTableProvider` and `EmbeddingTable`, forwarding calls to `self.underlying` / `self.base_table` respectively — matching the existing `insert_into` pattern.

## Test plan
- `cargo check -p runtime-datafusion-index -p runtime` passes
- Existing tests continue to pass
- Performance impact: none (simple delegation, no new logic)