### PR TITLE
Add TPC-H SF100 s3[parquet]-duckdb[file] benchmark spicepod

### DIFF
--- a/test/spicepods/tpch/sf100/accelerated/s3[parquet]-duckdb[file].yaml
+++ b/test/spicepods/tpch/sf100/accelerated/s3[parquet]-duckdb[file].yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: Spicepod
+name: s3[parquet]-duckdb[file]
+datasets:
+  - from: s3://benchmarks/tpch_sf100/customer.parquet
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf100/lineitem.parquet
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/nation.parquet
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/orders.parquet
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/part.parquet
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/partsupp.parquet
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/region.parquet
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf100/supplier.parquet
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration


### PR DESCRIPTION
Adds a new TPC-H SF100 benchmark spicepod using S3 parquet sources accelerated with DuckDB in file mode and no `duckdb_memory_limit` configured.

This complements the existing variants:
- `s3[parquet]-duckdb[memory].yaml`
- `file[parquet]-duckdb[file]-64gib.yaml`

filling the gap for an S3-sourced, file-mode DuckDB acceleration benchmark with no memory cap.

## Changes

- `test/spicepods/tpch/sf100/accelerated/s3[parquet]-duckdb[file].yaml`: New spicepod with all 8 TPC-H tables, S3 parquet `from`, and `acceleration: { engine: duckdb, mode: file }`.
