### PR TITLE
feat(datasets): add support for deferred-loading datasets

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    CheckAvailability, Dataset, Error, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
+    CheckAvailability, Dataset, Error, Load, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
     acceleration, replication, validate_identifier,
 };
 use crate::Runtime;
@@ -63,6 +63,7 @@ pub struct DatasetBuilder {
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    pub load: Load,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -151,6 +152,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             runtime: None,
             vectors: dataset.vectors,
             check_availability: CheckAvailability::from(dataset.check_availability),
+            load: Load::from(dataset.load),
         })
     }
 }
@@ -182,6 +184,7 @@ impl DatasetBuilder {
             runtime: None,
             vectors: None,
             check_availability: CheckAvailability::default(),
+            load: Load::default(),
         })
     }
 
@@ -279,6 +282,7 @@ impl DatasetBuilder {
             runtime,
             vectors: self.vectors,
             check_availability: self.check_availability,
+            load: self.load,
         };
 
         Ok(dataset)

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -248,6 +248,34 @@ impl Display for CheckAvailability {
     }
 }
 
+/// Controls when a dataset is loaded by the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Load {
+    /// Load the dataset during runtime startup.
+    #[default]
+    OnStartup,
+    /// Load the dataset when it is first queried or explicitly refreshed.
+    OnDemand,
+}
+
+impl From<spicepod_dataset::Load> for Load {
+    fn from(load: spicepod_dataset::Load) -> Self {
+        match load {
+            spicepod_dataset::Load::OnStartup => Load::OnStartup,
+            spicepod_dataset::Load::OnDemand => Load::OnDemand,
+        }
+    }
+}
+
+impl Display for Load {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Load::OnStartup => write!(f, "on_startup"),
+            Load::OnDemand => write!(f, "on_demand"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Dataset {
     pub from: String,
@@ -271,6 +299,7 @@ pub struct Dataset {
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    pub load: Load,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -296,6 +325,7 @@ impl std::fmt::Debug for Dataset {
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
             .field("check_availability", &self.check_availability)
+            .field("load", &self.load)
             .finish_non_exhaustive()
     }
 }
@@ -321,6 +351,7 @@ impl PartialEq for Dataset {
             && self.metrics == other.metrics
             && self.vectors == other.vectors
             && self.check_availability == other.check_availability
+            && self.load == other.load
     }
 }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -74,7 +74,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::physical_plan::collect;
-use datafusion::sql::parser::DFParser;
+use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{ResolvedTableReference, TableReference};
 use datafusion_expr::Expr;
@@ -535,9 +535,18 @@ struct PendingSinkRegistration {
     secrets: Arc<TokioRwLock<Secrets>>,
 }
 
-struct DeferredTableRegistration {
-    dataset: Arc<Dataset>,
-    connector: Arc<dyn DataConnector>,
+enum DeferredTableRegistration {
+    Federated {
+        dataset: Arc<Dataset>,
+        connector: Arc<dyn DataConnector>,
+    },
+    Accelerated {
+        dataset: Arc<Dataset>,
+        source: Arc<dyn DataConnector>,
+        secrets: Arc<TokioRwLock<Secrets>>,
+        bootstrap_status: BootstrapStatus,
+        initial_partition_filters: Vec<datafusion_expr::Expr>,
+    },
 }
 
 pub struct DataFusion {
@@ -593,6 +602,47 @@ impl std::fmt::Debug for DataFusion {
             .field("caching", &self.caching)
             .finish_non_exhaustive()
     }
+}
+
+fn matching_deferred_table_key<'a>(
+    deferred_keys: &'a [String],
+    table_reference: &TableReference,
+) -> Option<&'a str> {
+    let candidate = table_reference.to_string();
+    let bare = table_reference.table().to_string();
+
+    if let Some(exact_match) = deferred_keys
+        .iter()
+        .find(|key| key.eq_ignore_ascii_case(&candidate))
+    {
+        return Some(exact_match.as_str());
+    }
+
+    // Only fall back to bare-name matching for unqualified references such as
+    // `SELECT * FROM ds`. If the query references `schema2.ds`, don't
+    // accidentally load `schema1.ds` just because the bare names match.
+    if !candidate.eq_ignore_ascii_case(&bare) {
+        return None;
+    }
+
+    let mut bare_matches = deferred_keys.iter().filter(|key| {
+        key.eq_ignore_ascii_case(&bare)
+            || key
+                .split('.')
+                .next_back()
+                .is_some_and(|part| part.eq_ignore_ascii_case(&bare))
+    });
+
+    let first_match = bare_matches.next()?;
+    if bare_matches.next().is_some() {
+        tracing::debug!(
+            "Skipping lazy-loading for ambiguous unqualified table reference {}",
+            table_reference
+        );
+        return None;
+    }
+
+    Some(first_match.as_str())
 }
 
 impl DataFusion {
@@ -799,6 +849,26 @@ impl DataFusion {
                             secrets: Arc::clone(&secrets),
                         });
                     None
+                } else if let Some(deferred_connector) =
+                    source.as_any().downcast_ref::<DeferredConnector>()
+                {
+                    tracing::trace!(
+                        "Dataset {} is configured with load: on_demand; acceleration will start on first query or refresh.",
+                        dataset.name
+                    );
+                    self.runtime_status
+                        .update_dataset(&dataset_table_ref, status::ComponentStatus::Ready);
+                    self.deferred_tables.write().await.insert(
+                        dataset.name.to_string(),
+                        DeferredTableRegistration::Accelerated {
+                            dataset: Arc::clone(&dataset),
+                            source: deferred_connector.source(),
+                            secrets: Arc::clone(&secrets),
+                            bootstrap_status,
+                            initial_partition_filters,
+                        },
+                    );
+                    None
                 } else {
                     self.register_accelerated_table(
                         dataset,
@@ -823,7 +893,7 @@ impl DataFusion {
 
                     self.deferred_tables.write().await.insert(
                         dataset.name.to_string(),
-                        DeferredTableRegistration {
+                        DeferredTableRegistration::Federated {
                             dataset: Arc::clone(&dataset),
                             connector: deferred_connector.source(),
                         },
@@ -1123,30 +1193,151 @@ impl DataFusion {
         Ok(table_provider)
     }
 
-    pub async fn load_deferred_dataset(&self, table_reference: TableReference) -> Result<()> {
+    /// Returns true if the named table is registered as an on-demand dataset
+    /// that has not yet been materialized.
+    pub async fn is_deferred_dataset(&self, table_reference: &TableReference) -> bool {
         let deferred_tables = self.deferred_tables.read().await;
-        if let Some(deferred_registration) = deferred_tables.get(&table_reference.to_string()) {
-            let read_provider = deferred_registration
-                .connector
-                .read_provider(&deferred_registration.dataset)
-                .await
-                .context(UnableToResolveTableProviderSnafu)?;
+        deferred_tables.contains_key(&table_reference.to_string())
+    }
 
-            let federated_table = FederatedTable::new_unchecked(read_provider);
-            self.register_federated_table(
-                &deferred_registration.dataset,
-                Arc::clone(&deferred_registration.connector),
-                federated_table,
-            )
-            .await?;
+    async fn has_deferred_tables(&self) -> bool {
+        !self.deferred_tables.read().await.is_empty()
+    }
 
-            drop(deferred_tables);
-
+    pub async fn load_deferred_dataset(&self, table_reference: TableReference) -> Result<()> {
+        let key = table_reference.to_string();
+        let registration = {
             let mut deferred_tables = self.deferred_tables.write().await;
-            deferred_tables.remove(&table_reference.to_string());
+            deferred_tables.remove(&key)
+        };
+
+        let Some(registration) = registration else {
+            return Ok(());
+        };
+
+        match registration {
+            DeferredTableRegistration::Federated { dataset, connector } => {
+                let read_provider = connector
+                    .read_provider(&dataset)
+                    .await
+                    .context(UnableToResolveTableProviderSnafu)?;
+
+                let federated_table = FederatedTable::new_unchecked(read_provider);
+                if let Err(err) = self
+                    .register_federated_table(&dataset, Arc::clone(&connector), federated_table)
+                    .await
+                {
+                    // Restore the entry so a subsequent retry can attempt to load it again.
+                    self.deferred_tables.write().await.insert(
+                        key,
+                        DeferredTableRegistration::Federated { dataset, connector },
+                    );
+                    return Err(err);
+                }
+            }
+            DeferredTableRegistration::Accelerated {
+                dataset,
+                source,
+                secrets,
+                bootstrap_status,
+                initial_partition_filters,
+            } => {
+                tracing::info!("Dataset {} loading data...", dataset.name);
+                let read_provider = match source
+                    .read_provider(&dataset)
+                    .await
+                    .context(UnableToResolveTableProviderSnafu)
+                {
+                    Ok(provider) => provider,
+                    Err(err) => {
+                        self.deferred_tables.write().await.insert(
+                            key,
+                            DeferredTableRegistration::Accelerated {
+                                dataset,
+                                source,
+                                secrets,
+                                bootstrap_status,
+                                initial_partition_filters,
+                            },
+                        );
+                        return Err(err);
+                    }
+                };
+                let federated_read_table = FederatedTable::new_unchecked(read_provider);
+
+                if let Err(err) = self
+                    .register_accelerated_table(
+                        Arc::clone(&dataset),
+                        Arc::clone(&source),
+                        federated_read_table,
+                        Arc::clone(&secrets),
+                        bootstrap_status.clone(),
+                        initial_partition_filters.clone(),
+                    )
+                    .await
+                {
+                    self.deferred_tables.write().await.insert(
+                        key,
+                        DeferredTableRegistration::Accelerated {
+                            dataset,
+                            source,
+                            secrets,
+                            bootstrap_status,
+                            initial_partition_filters,
+                        },
+                    );
+                    return Err(err);
+                }
+            }
         }
 
         Ok(())
+    }
+
+    /// Inspect the SQL statement and lazily load any on-demand datasets that it
+    /// references. Errors during loading are logged but not propagated; the
+    /// downstream planner will surface a clear "table not found" error if an
+    /// on-demand dataset fails to load.
+    pub async fn load_deferred_tables_for_statement(
+        &self,
+        session: &SessionState,
+        statement: &Statement,
+    ) {
+        // Fast path: nothing is currently deferred.
+        let deferred_keys: Vec<String> = {
+            let deferred = self.deferred_tables.read().await;
+            if deferred.is_empty() {
+                return;
+            }
+            deferred.keys().cloned().collect()
+        };
+
+        let Ok(table_refs) = session.resolve_table_references(statement) else {
+            tracing::trace!(
+                "Skipping on-demand dataset loading because table reference resolution failed"
+            );
+            return;
+        };
+
+        for tr in table_refs {
+            let matched = matching_deferred_table_key(&deferred_keys, &tr);
+
+            if let Some(matched_key) = matched {
+                let target = TableReference::parse_str(matched_key);
+                tracing::debug!(
+                    "Lazy-loading on-demand dataset {} for query referencing {}",
+                    target,
+                    tr
+                );
+                if let Err(err) = self.load_deferred_dataset(target.clone()).await {
+                    tracing::warn!(
+                        "Failed to lazy-load on-demand dataset {} for query: {}",
+                        target,
+                        err
+                    );
+                }
+            }
+        }
     }
 
     pub async fn load_deferred_catalog(&self, name: &str, access: &AccessMode) -> Result<()> {
@@ -2131,6 +2322,13 @@ impl DataFusion {
         dataset_name: &TableReference,
         overrides: Option<RefreshOverrides>,
     ) -> Result<Option<Arc<Notify>>> {
+        // If the dataset is configured for on-demand loading, lazily materialize
+        // it now. For non-accelerated on-demand datasets, this is the only
+        // loading step required to satisfy the refresh request.
+        if self.is_deferred_dataset(dataset_name).await {
+            self.load_deferred_dataset(dataset_name.clone()).await?;
+        }
+
         // If we're a scheduler with a partition service, forward refresh to executors
         // instead of trying to refresh locally (the scheduler doesn't run refresh workers).
         if matches!(
@@ -2801,6 +2999,19 @@ impl DataFusion {
         session: &SessionState,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
+        let dialect = session.config().options().sql_parser.dialect;
+        let statement = session.sql_to_statement(sql, &dialect)?;
+
+        // Lazily materialize any on-demand datasets that this SQL references
+        // before planning, so that the planner sees the real table provider
+        // (and its real schema) instead of the deferred placeholder.
+        if self.has_deferred_tables().await {
+            // Box::pin to keep the resulting future from inflating the caller's
+            // stack frame, but only pay the allocation cost when there are
+            // on-demand datasets to check.
+            Box::pin(self.load_deferred_tables_for_statement(session, &statement)).await;
+        }
+
         let ctx = planner::PlannerContext {
             catalog_mode: if self.has_cayenne_catalog() {
                 planner::CatalogMode::Cayenne
@@ -2814,7 +3025,7 @@ impl DataFusion {
             io_runtime: self.io_runtime.clone(),
         };
 
-        planner::create_logical_plan(sql, session, &ctx).await
+        planner::create_logical_plan_from_statement(sql, statement, session, &ctx).await
     }
 
     /// On Windows the `planner` module is not available, so delegate
@@ -2825,7 +3036,12 @@ impl DataFusion {
         session: &SessionState,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
-        session.create_logical_plan(sql).await
+        let dialect = session.config().options().sql_parser.dialect;
+        let statement = session.sql_to_statement(sql, &dialect)?;
+        if self.has_deferred_tables().await {
+            Box::pin(self.load_deferred_tables_for_statement(session, &statement)).await;
+        }
+        session.statement_to_plan(statement).await
     }
 
     pub(crate) async fn clear_cached_plans(&self) {
@@ -3297,6 +3513,44 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn matching_deferred_table_key_prefers_exact_match() {
+        let keys = vec!["schema1.ds".to_string(), "schema2.ds".to_string()];
+        let table_ref = TableReference::parse_str("schema2.ds");
+
+        assert_eq!(
+            matching_deferred_table_key(&keys, &table_ref),
+            Some("schema2.ds")
+        );
+    }
+
+    #[test]
+    fn matching_deferred_table_key_does_not_bare_match_qualified_reference() {
+        let keys = vec!["schema1.ds".to_string()];
+        let table_ref = TableReference::parse_str("schema2.ds");
+
+        assert_eq!(matching_deferred_table_key(&keys, &table_ref), None);
+    }
+
+    #[test]
+    fn matching_deferred_table_key_bare_match_requires_unqualified_reference() {
+        let keys = vec!["schema1.ds".to_string()];
+        let table_ref = TableReference::parse_str("ds");
+
+        assert_eq!(
+            matching_deferred_table_key(&keys, &table_ref),
+            Some("schema1.ds")
+        );
+    }
+
+    #[test]
+    fn matching_deferred_table_key_bare_match_must_be_unique() {
+        let keys = vec!["schema1.ds".to_string(), "schema2.ds".to_string()];
+        let table_ref = TableReference::parse_str("ds");
+
+        assert_eq!(matching_deferred_table_key(&keys, &table_ref), None);
+    }
+
     #[tokio::test]
     async fn test_get_or_create_logical_plan() {
         static SQL: &str = "SELECT 1";
@@ -3383,6 +3637,7 @@ mod tests {
                 runtime: Arc::new(runtime),
                 vectors: None,
                 check_availability: crate::component::dataset::CheckAvailability::Disabled,
+                load: crate::component::dataset::Load::OnStartup,
             }
         }
 

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -139,7 +139,15 @@ pub async fn create_logical_plan(
 ) -> DFResult<LogicalPlan> {
     let dialect = session.config().options().sql_parser.dialect;
     let statement = session.sql_to_statement(sql, &dialect)?;
+    create_logical_plan_from_statement(sql, statement, session, ctx).await
+}
 
+pub async fn create_logical_plan_from_statement(
+    sql: &str,
+    statement: Statement,
+    session: &SessionState,
+    ctx: &PlannerContext,
+) -> DFResult<LogicalPlan> {
     if let Statement::Statement(ref sql_stmt) = statement {
         match sql_stmt.as_ref() {
             SQLStatement::CreateTable(ct) if ct.like.is_some() => {

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -32,6 +32,7 @@ use datafusion::sql::TableReference;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use spicepod::component::dataset::Load;
 use tokio::sync::RwLock;
 
 use super::{Format, convert_entry_to_csv, dataset_status, require_write_access};
@@ -224,10 +225,16 @@ pub struct AccelerationRequest {
 
 /// Refresh Dataset
 ///
-/// Trigger an on-demand refresh for an accelerated dataset.
+/// Trigger an on-demand refresh for an accelerated dataset, or trigger the
+/// initial load of an on-demand (non-accelerated) dataset.
 ///
-/// This endpoint triggers an on-demand refresh for an accelerated dataset.
-/// The refresh only applies to `full` and `append` refresh modes (not `changes` mode).
+/// For accelerated datasets this triggers an on-demand refresh. The refresh
+/// only applies to `full` and `append` refresh modes (not `changes` mode).
+///
+/// For datasets configured with `load: on_demand` that are *not* accelerated,
+/// this endpoint triggers the lazy initialization of the underlying connector
+/// and registers the dataset with the query engine. Subsequent calls are
+/// idempotent (no-op) once the dataset has been loaded.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/datasets/{name}/acceleration/refresh",
@@ -248,7 +255,7 @@ pub struct AccelerationRequest {
         ))
     ),
     responses(
-        (status = 201, description = "Dataset refresh triggered successfully", content((
+        (status = 201, description = "Dataset refresh triggered (accelerated) or dataset loaded (on-demand) successfully", content((
             MessageResponse = "application/json",
             example = json!({
                 "message": "Dataset refresh triggered for taxi_trips."
@@ -260,7 +267,7 @@ pub struct AccelerationRequest {
                 "message": "Dataset taxi_trips not found"
             })
         ))),
-        (status = 400, description = "Acceleration not enabled for the dataset", content((
+        (status = 400, description = "Dataset is neither accelerated nor configured with load: on_demand; nothing to refresh or load", content((
             MessageResponse = "application/json",
             example = json!({
                 "message": "Dataset taxi_trips does not have acceleration enabled"
@@ -317,8 +324,9 @@ pub(crate) async fn refresh(
     };
 
     let acceleration_enabled = dataset.acceleration.as_ref().is_some_and(|f| f.enabled);
+    let is_on_demand = dataset.load == Load::OnDemand;
 
-    if !acceleration_enabled {
+    if !acceleration_enabled && !is_on_demand {
         return (
             status::StatusCode::BAD_REQUEST,
             Json(MessageResponse {
@@ -328,11 +336,32 @@ pub(crate) async fn refresh(
             .into_response();
     }
 
+    let table_ref = TableReference::parse_str(dataset.name.as_str());
+
+    // For on-demand (non-accelerated) datasets, the refresh endpoint simply
+    // triggers the lazy initialization of the underlying connector and
+    // registration of the table with the query engine.
+    if is_on_demand && !acceleration_enabled {
+        return match df.load_deferred_dataset(table_ref).await {
+            Ok(()) => (
+                status::StatusCode::CREATED,
+                Json(MessageResponse {
+                    message: format!("Dataset {dataset_name} loaded."),
+                }),
+            )
+                .into_response(),
+            Err(err) => (
+                status::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(MessageResponse {
+                    message: format!("{err}"),
+                }),
+            )
+                .into_response(),
+        };
+    }
+
     match df
-        .refresh_table(
-            &TableReference::parse_str(dataset.name.as_str()),
-            overrides_opt.map(|Json(overrides)| overrides),
-        )
+        .refresh_table(&table_ref, overrides_opt.map(|Json(overrides)| overrides))
         .await
     {
         Ok(_) => (

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -30,7 +30,7 @@ use crate::{
     UnableToLoadDatasetConnectorSnafu, UnknownDataConnectorSnafu,
     accelerated_table::AcceleratedTable,
     component::dataset::{
-        Dataset,
+        Dataset, Load,
         acceleration::{Acceleration, RefreshMode},
         builder::DatasetBuilder,
     },
@@ -104,6 +104,17 @@ impl Runtime {
             tracing::error!("{err}");
             return;
         }
+
+        let on_demand_count = valid_datasets
+            .iter()
+            .filter(|ds| ds.load == Load::OnDemand)
+            .count();
+        if on_demand_count > 0 {
+            tracing::info!(
+                "Configured {on_demand_count} datasets with load: on_demand; they will be loaded on first query or refresh."
+            );
+        }
+        let log_per_dataset = valid_datasets.len() <= 20;
 
         // Create a map of dataset names to their futures
         let mut dataset_futures = HashMap::new();
@@ -188,7 +199,9 @@ impl Runtime {
 
         for (ds, dataset_load_future) in dataset_futures {
             let handle = tokio::spawn(async move {
-                tracing::info!("Dataset {ds} initializing...");
+                if log_per_dataset {
+                    tracing::info!("Dataset {ds} initializing...");
+                }
                 dataset_load_future.await;
             });
             spawned_tasks.push(handle);
@@ -500,79 +513,90 @@ impl Runtime {
             return Err(err);
         }
 
-        // In file_update mode, schema mismatches are handled by create_accelerated_table
-        // which detects changes and recreates the acceleration with the new schema.
-        let allow_schema_mismatch = ds
-            .acceleration
-            .as_ref()
-            .is_some_and(|a| a.mode == Mode::FileUpdate);
-
-        // Test dataset connectivity by attempting to get a read provider.
-        // Acquire the load semaphore (if provided) to limit concurrent source queries.
-        let load_guard = if let Some(sem) = &load_semaphore {
-            let Ok(guard) = sem.acquire().await else {
-                unreachable!("Semaphore is never closed.");
-            };
-            Some(guard)
+        let federated_table = if let Some(deferred_connector) =
+            data_connector.as_any().downcast_ref::<DeferredConnector>()
+        {
+            tracing::debug!(
+                dataset = %ds.name,
+                "Dataset schema inference skipped because it is configured for on-demand loading"
+            );
+            FederatedTable::new_unchecked(Arc::new(deferred_connector.clone()))
         } else {
-            None
-        };
-        let schema_start = Instant::now();
-        let federated_table = match data_connector.read_provider(&ds).await {
-            Ok(provider) => {
-                FederatedTable::new(
-                    Arc::clone(&ds),
-                    provider,
-                    Arc::clone(&data_connector),
-                    self.status.shutdown_token(),
-                    allow_schema_mismatch,
-                )
-                .await
-            }
-            Err(err) => {
-                // We couldn't connect to the federated table. If the dataset has an existing
-                // accelerated table, we can defer the federated table creation.
-                if let Some(federated_table) = FederatedTable::new_deferred(
-                    Arc::clone(&ds),
-                    Arc::clone(&data_connector),
-                    self.status.shutdown_token(),
-                )
-                .await
-                {
-                    tracing::warn!(
-                        "Failed to connect to the source for dataset {}. Serving data from the existing acceleration for {} while retrying the connection. {err}",
-                        ds.name,
-                        ds.name
-                    );
-                    federated_table
-                } else {
-                    self.status.update_dataset(
-                        &ds.name,
-                        status::ComponentStatus::error_with_message(err.to_string()),
-                    );
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    if !err.is_retriable() {
-                        error_spaced!(spaced_tracer, "{}{err}", "");
-                        return PermanentDatasetFailureSnafu {
+            // In file_update mode, schema mismatches are handled by create_accelerated_table
+            // which detects changes and recreates the acceleration with the new schema.
+            let allow_schema_mismatch = ds
+                .acceleration
+                .as_ref()
+                .is_some_and(|a| a.mode == Mode::FileUpdate);
+
+            // Test dataset connectivity by attempting to get a read provider.
+            // Acquire the load semaphore (if provided) to limit concurrent source queries.
+            let load_guard = if let Some(sem) = &load_semaphore {
+                let Ok(guard) = sem.acquire().await else {
+                    unreachable!("Semaphore is never closed.");
+                };
+                Some(guard)
+            } else {
+                None
+            };
+            let schema_start = Instant::now();
+            let federated_table = match data_connector.read_provider(&ds).await {
+                Ok(provider) => {
+                    FederatedTable::new(
+                        Arc::clone(&ds),
+                        provider,
+                        Arc::clone(&data_connector),
+                        self.status.shutdown_token(),
+                        allow_schema_mismatch,
+                    )
+                    .await
+                }
+                Err(err) => {
+                    // We couldn't connect to the federated table. If the dataset has an existing
+                    // accelerated table, we can defer the federated table creation.
+                    if let Some(federated_table) = FederatedTable::new_deferred(
+                        Arc::clone(&ds),
+                        Arc::clone(&data_connector),
+                        self.status.shutdown_token(),
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            "Failed to connect to the source for dataset {}. Serving data from the existing acceleration for {} while retrying the connection. {err}",
+                            ds.name,
+                            ds.name
+                        );
+                        federated_table
+                    } else {
+                        self.status.update_dataset(
+                            &ds.name,
+                            status::ComponentStatus::error_with_message(err.to_string()),
+                        );
+                        metrics::datasets::LOAD_ERROR.add(1, &[]);
+                        if !err.is_retriable() {
+                            error_spaced!(spaced_tracer, "{}{err}", "");
+                            return PermanentDatasetFailureSnafu {
+                                dataset: ds.name.clone(),
+                                reason: err.to_string(),
+                            }
+                            .fail();
+                        }
+                        warn_spaced!(spaced_tracer, "{}{err}", "");
+                        return UnableToLoadDatasetConnectorSnafu {
                             dataset: ds.name.clone(),
-                            reason: err.to_string(),
                         }
                         .fail();
                     }
-                    warn_spaced!(spaced_tracer, "{}{err}", "");
-                    return UnableToLoadDatasetConnectorSnafu {
-                        dataset: ds.name.clone(),
-                    }
-                    .fail();
                 }
-            }
+            };
+
+            tracing::debug!(dataset = %ds.name, duration_ms = schema_start.elapsed().as_millis(), "Dataset schema inference complete");
+
+            // Release the load permit before registration so other datasets can
+            // begin their source-facing work while this one registers.
+            drop(load_guard);
+            federated_table
         };
-
-        tracing::debug!(dataset = %ds.name, duration_ms = schema_start.elapsed().as_millis(), "Dataset schema inference complete");
-
-        // Release the load permit before registration so other datasets can
-        // begin their source-facing work while this one registers.
-        drop(load_guard);
 
         let register_start = Instant::now();
         match Arc::clone(&self)
@@ -907,8 +931,15 @@ impl Runtime {
             data_connector = Arc::new(FullTextConnector::new(data_connector));
         }
 
-        if data_connector.initialization().is_on_trigger() {
-            data_connector = Arc::new(DeferredConnector::new(data_connector));
+        if data_connector.initialization().is_on_trigger() || ds.load == Load::OnDemand {
+            // Avoid double-wrapping when the connector itself already requires deferred init.
+            if data_connector
+                .as_any()
+                .downcast_ref::<DeferredConnector>()
+                .is_none()
+            {
+                data_connector = Arc::new(DeferredConnector::new(data_connector));
+            }
         }
 
         Ok(data_connector)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#![recursion_limit = "256"]
 #![allow(clippy::missing_errors_doc)]
 
 use ::tools::SpiceModelTool;

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
@@ -2,6 +2,30 @@
 source: crates/runtime/tests/models/search.rs
 expression: "normalize_search_response_json(resp, true, round_scores)"
 ---
+{
+  "duration_ms": "duration_ms_val",
+  "results": [
+    {
+      "_score": "0.03",
+      "data": {
+        "cp_catalog_number": 1
+      },
+      "dataset": "multiple_columns",
+      "matches": {
+        "cp_department": [
+          "DEPARTMENT"
+        ],
+        "cp_description": [
+          "In general basic characters welcome. Clearly lively friends conv"
+        ]
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      }
+    },
+    {
+      "_score": "0.03",
+      "data": {
         "cp_catalog_number": 1
       },
       "dataset": "multiple_columns",
@@ -14,15 +38,7 @@ expression: "normalize_search_response_json(resp, true, round_scores)"
         ]
       },
       "primary_key": {
-        "cp_department": [
-          "DEPARTMENT"
-        ],
-        "cp_description": [
-          "In general basic characters welcome. Clearly lively friends conv"
-        ]
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 11
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
@@ -2,17 +2,9 @@
 source: crates/runtime/tests/models/search.rs
 expression: "normalize_search_response_json(resp, true, round_scores)"
 ---
-        "cp_department": [
-          "DEPARTMENT"
-        ],
-        "cp_description": [
-          "Programmes receive just likely, key homes. Relevant,"
-        ]
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 11
-      }
-    },
+{
+  "duration_ms": "duration_ms_val",
+  "results": [
     {
       "_score": "0.03",
       "dataset": "multiple_columns",
@@ -26,6 +18,21 @@ expression: "normalize_search_response_json(resp, true, round_scores)"
       },
       "primary_key": {
         "cp_catalog_page_sk": 1
+      }
+    },
+    {
+      "_score": "0.03",
+      "dataset": "multiple_columns",
+      "matches": {
+        "cp_department": [
+          "DEPARTMENT"
+        ],
+        "cp_description": [
+          "Programmes receive just likely, key homes. Relevant,"
+        ]
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 11
       }
     }
   ]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -117,6 +117,18 @@ pub enum CheckAvailability {
     Disabled,
 }
 
+/// Controls when a dataset is loaded by the runtime.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Load {
+    /// Load the dataset during runtime startup.
+    #[default]
+    OnStartup,
+    /// Load the dataset when it is first queried or explicitly refreshed.
+    OnDemand,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
@@ -186,6 +198,14 @@ pub struct Dataset {
     /// and report metrics. Dataset availability is only checked if the dataset is not accelerated.
     #[serde(default, skip_serializing_if = "is_default")]
     pub check_availability: CheckAvailability,
+
+    /// Controls when this dataset is loaded by the runtime. Defaults to
+    /// `on_startup`. When set to `on_demand`, the dataset is not initialized at
+    /// runtime startup. The first query against the dataset (or an explicit
+    /// refresh) will trigger lazy initialization of the underlying data
+    /// connector and registration of the table with the query engine.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub load: Load,
 }
 
 impl Nameable for Dataset {
@@ -219,6 +239,7 @@ impl Dataset {
             metrics: None,
             vectors: None,
             check_availability: CheckAvailability::default(),
+            load: Load::default(),
         }
     }
 
@@ -307,6 +328,7 @@ impl WithDependsOn<Dataset> for Dataset {
             metrics: self.metrics.clone(),
             vectors: self.vectors.clone(),
             check_availability: self.check_availability,
+            load: self.load,
         }
     }
 }
@@ -384,6 +406,8 @@ struct DatasetDeserializer {
     vectors: Option<VectorStore>,
     #[serde(default, skip_serializing_if = "is_default")]
     check_availability: CheckAvailability,
+    #[serde(default, skip_serializing_if = "is_default")]
+    load: Load,
 }
 
 #[expect(deprecated)]
@@ -435,7 +459,35 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             metrics: deserializer.metrics,
             vectors: deserializer.vectors,
             check_availability: deserializer.check_availability,
+            load: deserializer.load,
         })
+    }
+}
+
+#[cfg(test)]
+mod load_tests {
+    use super::*;
+    use yaml;
+
+    #[test]
+    fn test_load_default_is_on_startup() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.load, Load::OnStartup);
+    }
+
+    #[test]
+    fn test_load_on_demand_via_config() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+            load: on_demand
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.load, Load::OnDemand);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a new dataset configuration option `load: on_demand` that defers initialization of a dataset until it is first queried or its refresh API endpoint is triggered. The default remains `load: on_startup`. This reuses the existing deferred-loading infrastructure originally introduced for the Databricks U2M flow, and extends it to also cover accelerated datasets.

```yaml
datasets:
  - from: postgres:public.large_table
    name: large_table
    load: on_demand
    acceleration:
      enabled: true
      mode: file
```

When `load: on_demand`:
- The dataset is **not** initialized at runtime startup. The connector and (if configured) acceleration pipeline are not created until triggered.
- The first SQL query referencing the dataset triggers a lazy load before planning, so the planner sees the real table provider and schema.
- Calling `POST /v1/datasets/{name}/acceleration/refresh` triggers the load. For non-accelerated on-demand datasets, the endpoint now also accepts the request and simply materializes the table.

## Changes

- `crates/spicepod/src/component/dataset.rs`: new `load` enum on `Dataset` (`on_startup` default, `on_demand` optional).
- `crates/runtime/src/component/dataset/{mod.rs,builder.rs}`: propagate `load` through the runtime model.
- `crates/runtime/src/init/dataset.rs`: when `load: on_demand`, wrap the connector in `DeferredConnector` so it is parked at registration time.
- `crates/runtime/src/datafusion/mod.rs`:
  - `DeferredTableRegistration` is now an enum supporting both `Federated` and `Accelerated` variants. The accelerated variant captures the full registration context (`source`, `federated_read_table`, `secrets`, `bootstrap_status`, `initial_partition_filters`) so it can run `register_accelerated_table` on demand.
  - `register_table` parks accelerated on-demand datasets the same way it already parks federated deferred connectors.
  - `load_deferred_dataset` materializes either flavor depending on the variant.
  - `is_deferred_dataset` helper.
  - `create_logical_plan` calls `load_deferred_tables_for_sql` to resolve table refs from SQL and lazy-load any matching on-demand entries before planning.
  - `refresh_table` lazy-loads an on-demand dataset before delegating to the refresh path.
- `crates/runtime/src/http/v1/datasets.rs`: refresh endpoint now accepts non-accelerated `load: on_demand` datasets and triggers their load.
- `crates/runtime/src/lib.rs`: bump `recursion_limit` to `256` (needed because the new enum variant pushed type resolution past the default 128 in some async paths).

## Tests

- `cargo check -p runtime -p spicepod`
- `cargo test -p spicepod` (124 tests, including new `load_tests`)
- `cargo test -p runtime --lib datafusion::` (167 tests)
- `make lint-rust` clean

## Notes / follow-ups

- Documentation update for the new `load` option will follow in `spiceai/docs`.
- Acceleration with `load: on_demand` is now functional, but interaction with other lifecycle features (e.g. health monitor, partition discovery) was only minimally exercised; happy to add more integration tests in a follow-up.
