### PR TITLE
feat(mysql): add mysql_zero_date_behavior parameter (null|error)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d7fae5f0167e2c7e1c7f34fd1e0c54c383c5a1b0#d7fae5f0167e2c7e1c7f34fd1e0c54c383c5a1b0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=faaaf61c1fbd66064500bcc2c908b95235b2fc9d#faaaf61c1fbd66064500bcc2c908b95235b2fc9d"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -8310,8 +8310,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9445,7 +9445,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -13992,8 +13992,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.16.1",
- "parking_lot 0.12.5",
+ "hashbrown 0.5.0",
+ "parking_lot 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -14532,7 +14532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14566,7 +14566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -17392,7 +17392,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,7 +416,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "f9443aba33172331918845db9b4abcf1a9a3e1fd" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "f9443aba33172331918845db9b4abcf1a9a3e1fd" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d7fae5f0167e2c7e1c7f34fd1e0c54c383c5a1b0" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "faaaf61c1fbd66064500bcc2c908b95235b2fc9d" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e6bcc66785319e08f530b07c2e1fa029ff14a2db" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e6bcc66785319e08f530b07c2e1fa029ff14a2db" } # spiceai-52.5

--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::sqlparser::dialect::MySqlDialect;
 use datafusion_table_providers::mysql::MySQLTableFactory;
+use datafusion_table_providers::sql::arrow_sql_gen::mysql::MysqlZeroDateBehavior;
 use datafusion_table_providers::sql::db_connection_pool::{
     Error as DbConnectionPoolError, dbconnection,
     mysqlpool::{self, MySQLConnectionPool},
@@ -127,6 +128,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("time_zone")
         .description("The time zone to use for the connection. Default is '+00:00' (UTC).")
         .help_link(MYSQL_DOCS),
+    ParameterSpec::component("zero_date_behavior")
+        .description(
+            "How to handle the MySQL '0000-00-00' / '0000-00-00 00:00:00' zero-date sentinel for DATE/DATETIME/TIMESTAMP columns. \
+             'null' (default) coerces zero dates to NULL and reports such columns as nullable in the Arrow schema. \
+             'error' fails the scan when a zero date is encountered and honors the source NOT NULL constraint exactly.",
+        )
+        .default("null")
+        .one_of_ignore_ascii_case(&["null", "error"])
+        .help_link(MYSQL_DOCS),
 ];
 
 // https://github.com/apache/datafusion-sqlparser-rs/blob/87d19073/src/keywords.rs#L1053
@@ -179,6 +189,19 @@ impl DataConnectorFactory for MySQLFactory {
                 );
             }
 
+            let zero_date_behavior = match params
+                .parameters
+                .get("zero_date_behavior")
+                .ok()
+                .map(|s| s.expose_secret().to_ascii_lowercase())
+                .as_deref()
+            {
+                Some("error") => MysqlZeroDateBehavior::Error,
+                // `one_of_ignore_ascii_case` validation has already rejected anything other
+                // than "null" / "error"; default + any other value falls through to Null.
+                _ => MysqlZeroDateBehavior::Null,
+            };
+
             if let Some(time_zone) = params.parameters.get("time_zone").expose().ok() {
                 // "LOCAL_SYSTEM" value must be replaced with the actual system time zone information.
                 if time_zone.to_uppercase() == "LOCAL_SYSTEM" {
@@ -199,7 +222,7 @@ impl DataConnectorFactory for MySQLFactory {
             }
 
             let pool = match MySQLConnectionPool::new(params.parameters.to_secret_map()).await {
-                Ok(pool) => Arc::new(pool),
+                Ok(pool) => Arc::new(pool.with_zero_date_behavior(zero_date_behavior)),
                 Err(error) => match error {
                     mysqlpool::Error::InvalidUsernameOrPassword => {
                         return Err(


### PR DESCRIPTION
## Summary

Adds a new `mysql_zero_date_behavior` parameter to the MySQL data connector that controls how MySQL's `'0000-00-00'` / `'0000-00-00 00:00:00'` zero-date sentinel is handled for `DATE` / `DATETIME` / `TIMESTAMP` columns:

- `null` *(default)* — coerce zero dates to `NULL`; widen affected columns to nullable in the Arrow schema. Restores pre-regression behavior.
- `error` — fail the scan loudly with a column-named error; honor the source `NOT NULL` constraint exactly.

## Change

Adds a new connector parameter:

```yaml
datasets:
  - from: mysql:my_db.my_table
    name: my_table
    params:
      mysql_zero_date_behavior: null    # default — coerce to NULL
      # mysql_zero_date_behavior: error  # opt-in strict mode
```

The parameter is parsed in `MySQLFactory::create` and applied via `MySQLConnectionPool::with_zero_date_behavior`, which is plumbed through `MySQLConnection::query_arrow` and `MySQLConnection::get_schema` in `datafusion-table-providers` ([PR #633](https://github.com/datafusion-contrib/datafusion-table-providers/pull/633), already merged on `spiceai-52`).

Default is `null`, so all existing deployments restore the pre-regression silent-coerce behavior with **zero spicepod changes**.

## Bumps

- `datafusion-table-providers` rev → `faaaf61c1fbd66064500bcc2c908b95235b2fc9d` (spiceai-52, includes [PR #633](https://github.com/datafusion-contrib/datafusion-table-providers/pull/633))

## Verification

Built locally and tested end-to-end against MySQL 8.4 with `sql_mode=''` and the problematic schema:

```sql
CREATE TABLE some_table (
  id INT PRIMARY KEY,
  name VARCHAR(50) NOT NULL,
  date_created TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
  date_modified DATE      NOT NULL DEFAULT '0000-00-00'
);
INSERT INTO some_table VALUES
  (1, 'alice', '2024-01-15 10:00:00', '2024-01-15'),
  (2, 'bob',   '0000-00-00 00:00:00', '0000-00-00'),
  (3, 'carol', '2024-03-20 14:30:00', '2024-03-20');
```

| Mode | `DESCRIBE some_table` | `SELECT * ORDER BY id` |
|---|---|---|
| Default (`null`) | `id`/`name` → `NO`, `date_created`/`date_modified` → `YES` | 3 rows; bob's row returns NULL for both date columns |
| `error` | All four columns → `NO` (source-exact) | Errors with `Encountered MySQL zero date '0000-00-00' in column 'date_created' but mysql_zero_date_behavior is set to 'error'.` |
| `error` + `WHERE id != 2` | (same) | 2 rows succeed (predicate pushdown skips the bad row in MySQL) |

Pre-fix, the default-mode query failed with the regression error.

`cargo check`, `cargo clippy -p connector-mysql -- -D warnings`, and `cargo fmt --check` all clean.
