### PR TITLE
feat(postgres): support inline PEM sslrootcert

### DIFF
--- a/crates/data-connectors/connector-postgres/src/lib.rs
+++ b/crates/data-connectors/connector-postgres/src/lib.rs
@@ -126,7 +126,7 @@ const PARAMETERS: &[ParameterSpec] = &[
         .help_link(POSTGRES_DOCS),
     ParameterSpec::component("sslrootcert")
         .description(
-            "Path to a PEM-encoded CA certificate used when sslmode is verify-ca/verify-full.",
+            "Path to, or inline PEM content for, a CA certificate used when sslmode is verify-ca/verify-full.",
         )
         .help_link(POSTGRES_DOCS),
     ParameterSpec::component("connection_pool_min_idle")

--- a/crates/runtime/src/catalogconnector/postgres.rs
+++ b/crates/runtime/src/catalogconnector/postgres.rs
@@ -45,7 +45,8 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("port").description("The PostgreSQL port number."),
     ParameterSpec::component("db").description("The PostgreSQL database name."),
     ParameterSpec::component("sslmode").description("The SSL mode for the connection."),
-    ParameterSpec::component("sslrootcert").description("The path to the SSL root certificate."),
+    ParameterSpec::component("sslrootcert")
+        .description("The path to, or inline PEM content for, the SSL root certificate."),
 ];
 
 /// A catalog connector for `PostgreSQL`, providing access to schemas and tables

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -88,7 +88,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("user").secret(),
     ParameterSpec::component("pass").secret(),
     ParameterSpec::component("sslmode"),
-    ParameterSpec::component("sslrootcert"),
+    ParameterSpec::component("sslrootcert")
+        .description("The path to, or inline PEM content for, the SSL root certificate."),
     ParameterSpec::component("connection_pool_min")
         .description("The minimum number of connections to keep open in the pool, lazily created when requested.")
         .default("5"),


### PR DESCRIPTION
## Summary
- Bump `datafusion-table-providers` to include inline `pg_sslrootcert` PEM support from datafusion-contrib/datafusion-table-providers#634
- Update Postgres connector/catalog/accelerator parameter descriptions to document path or inline PEM content

## Testing
- `cargo update -p datafusion-table-providers`
- `cargo check -p data_components --features postgres` ✅
- `cargo check -p connector-postgres` started and compiled through `runtime` dependencies, but hit the 240s local timeout before completion
