### PR TITLE
fix: handle non-2xx GitHub API responses in release script (fixes #6566)

### DIFF
--- a/.github/scripts/github_release.py
+++ b/.github/scripts/github_release.py
@@ -27,6 +27,18 @@ def getReleaseByTag(owner, repo, tag):
     if releaseInfo.status_code == 404:
         return None
 
+    if not releaseInfo.ok:
+        # Non-2xx responses (e.g. transient 5xx, 403 rate limit) return an
+        # error payload that lacks the keys callers expect ("id", "assets",
+        # "upload_url"). Treat as missing so callers can retry/skip cleanly
+        # instead of crashing on KeyError downstream.
+        print(f"Failed to fetch release for tag {tag}: HTTP {releaseInfo.status_code}")
+        try:
+            print(releaseInfo.json())
+        except ValueError:
+            print(releaseInfo.text)
+        return None
+
     return releaseInfo.json()
 
 def getUploadUrl(artifactPath, originalUploadUrl):
@@ -133,11 +145,12 @@ def actionDelete(args):
         return
 
     # Step 2: For each artifact, see if it already exists as an asset on the release
+    assets = releaseInfo.get("assets", [])
     for artifact in args.artifact:
         filename = os.path.basename(artifact)
         print(f"Deleting -> {filename}")
 
-        for asset in releaseInfo["assets"]:
+        for asset in assets:
             if asset["name"] == filename:
                 deleteAsset(args.owner, args.repo, asset["id"])
 

--- a/.github/scripts/test_github_release.py
+++ b/.github/scripts/test_github_release.py
@@ -1,0 +1,130 @@
+"""Unit tests for github_release.py."""
+import os
+import sys
+import unittest
+from unittest import mock
+
+# github_release exits at import time if GITHUB_TOKEN is missing.
+os.environ.setdefault("GITHUB_TOKEN", "test-token")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import github_release  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_data=None, text=""):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._json_data = json_data
+        self.text = text
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("No JSON body")
+        return self._json_data
+
+
+class GetReleaseByTagTests(unittest.TestCase):
+    @mock.patch("github_release.requests.get")
+    def test_returns_release_dict_on_200(self, mock_get):
+        release = {"id": 1, "assets": [], "upload_url": "https://example/{?name,label}"}
+        mock_get.return_value = FakeResponse(200, release)
+
+        self.assertEqual(github_release.getReleaseByTag("o", "r", "v1.0"), release)
+
+    @mock.patch("github_release.requests.get")
+    def test_returns_none_on_404(self, mock_get):
+        mock_get.return_value = FakeResponse(404, {"message": "Not Found"})
+
+        self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
+
+    @mock.patch("github_release.requests.get")
+    def test_returns_none_on_5xx(self, mock_get):
+        # Regression for #6566: a 5xx response previously fell through to
+        # callers, which would then crash on KeyError("assets").
+        mock_get.return_value = FakeResponse(500, {"message": "Internal Server Error"})
+
+        self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
+
+    @mock.patch("github_release.requests.get")
+    def test_returns_none_on_rate_limit(self, mock_get):
+        mock_get.return_value = FakeResponse(403, {"message": "rate limit exceeded"})
+
+        self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
+
+    @mock.patch("github_release.requests.get")
+    def test_returns_none_when_error_body_is_not_json(self, mock_get):
+        mock_get.return_value = FakeResponse(502, json_data=None, text="Bad Gateway")
+
+        self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
+
+
+class ActionDeleteTests(unittest.TestCase):
+    def _args(self, artifacts=None):
+        return mock.Mock(
+            owner="o",
+            repo="r",
+            tag="v1.0",
+            artifact=artifacts or ["./release/x.tar.gz"],
+        )
+
+    @mock.patch("github_release.deleteAsset")
+    @mock.patch("github_release.getReleaseByTag")
+    def test_no_release_skips_silently(self, mock_get, mock_delete):
+        mock_get.return_value = None
+
+        github_release.actionDelete(self._args())
+
+        mock_delete.assert_not_called()
+
+    @mock.patch("github_release.deleteAsset")
+    @mock.patch("github_release.getReleaseByTag")
+    def test_release_without_assets_key_does_not_raise(self, mock_get, mock_delete):
+        # Regression for #6566: the release payload occasionally arrives
+        # without an "assets" key, which previously raised KeyError mid-loop
+        # and aborted the release workflow.
+        mock_get.return_value = {"id": 1, "tag_name": "v1.0"}
+
+        github_release.actionDelete(self._args())
+
+        mock_delete.assert_not_called()
+
+    @mock.patch("github_release.deleteAsset")
+    @mock.patch("github_release.getReleaseByTag")
+    def test_release_with_empty_assets(self, mock_get, mock_delete):
+        mock_get.return_value = {"id": 1, "assets": []}
+
+        github_release.actionDelete(self._args())
+
+        mock_delete.assert_not_called()
+
+    @mock.patch("github_release.deleteAsset")
+    @mock.patch("github_release.getReleaseByTag")
+    def test_release_with_matching_asset_is_deleted(self, mock_get, mock_delete):
+        mock_get.return_value = {
+            "id": 1,
+            "assets": [
+                {"id": 100, "name": "x.tar.gz"},
+                {"id": 101, "name": "y.tar.gz"},
+            ],
+        }
+
+        github_release.actionDelete(self._args(["./release/x.tar.gz"]))
+
+        mock_delete.assert_called_once_with("o", "r", 100)
+
+    @mock.patch("github_release.deleteAsset")
+    @mock.patch("github_release.getReleaseByTag")
+    def test_release_with_no_matching_asset_does_not_delete(self, mock_get, mock_delete):
+        mock_get.return_value = {
+            "id": 1,
+            "assets": [{"id": 101, "name": "y.tar.gz"}],
+        }
+
+        github_release.actionDelete(self._args(["./release/x.tar.gz"]))
+
+        mock_delete.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_github_release.py
+++ b/.github/scripts/test_github_release.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import unittest
-from unittest import mock
+import unittest.mock
 
 # github_release exits at import time if GITHUB_TOKEN is missing.
 os.environ.setdefault("GITHUB_TOKEN", "test-token")
@@ -25,20 +25,20 @@ class FakeResponse:
 
 
 class GetReleaseByTagTests(unittest.TestCase):
-    @mock.patch("github_release.requests.get")
+    @unittest.mock.patch("github_release.requests.get")
     def test_returns_release_dict_on_200(self, mock_get):
         release = {"id": 1, "assets": [], "upload_url": "https://example/{?name,label}"}
         mock_get.return_value = FakeResponse(200, release)
 
         self.assertEqual(github_release.getReleaseByTag("o", "r", "v1.0"), release)
 
-    @mock.patch("github_release.requests.get")
+    @unittest.mock.patch("github_release.requests.get")
     def test_returns_none_on_404(self, mock_get):
         mock_get.return_value = FakeResponse(404, {"message": "Not Found"})
 
         self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
 
-    @mock.patch("github_release.requests.get")
+    @unittest.mock.patch("github_release.requests.get")
     def test_returns_none_on_5xx(self, mock_get):
         # Regression for #6566: a 5xx response previously fell through to
         # callers, which would then crash on KeyError("assets").
@@ -46,13 +46,13 @@ class GetReleaseByTagTests(unittest.TestCase):
 
         self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
 
-    @mock.patch("github_release.requests.get")
+    @unittest.mock.patch("github_release.requests.get")
     def test_returns_none_on_rate_limit(self, mock_get):
         mock_get.return_value = FakeResponse(403, {"message": "rate limit exceeded"})
 
         self.assertIsNone(github_release.getReleaseByTag("o", "r", "v1.0"))
 
-    @mock.patch("github_release.requests.get")
+    @unittest.mock.patch("github_release.requests.get")
     def test_returns_none_when_error_body_is_not_json(self, mock_get):
         mock_get.return_value = FakeResponse(502, json_data=None, text="Bad Gateway")
 
@@ -61,15 +61,15 @@ class GetReleaseByTagTests(unittest.TestCase):
 
 class ActionDeleteTests(unittest.TestCase):
     def _args(self, artifacts=None):
-        return mock.Mock(
+        return unittest.mock.Mock(
             owner="o",
             repo="r",
             tag="v1.0",
             artifact=artifacts or ["./release/x.tar.gz"],
         )
 
-    @mock.patch("github_release.deleteAsset")
-    @mock.patch("github_release.getReleaseByTag")
+    @unittest.mock.patch("github_release.deleteAsset")
+    @unittest.mock.patch("github_release.getReleaseByTag")
     def test_no_release_skips_silently(self, mock_get, mock_delete):
         mock_get.return_value = None
 
@@ -77,8 +77,8 @@ class ActionDeleteTests(unittest.TestCase):
 
         mock_delete.assert_not_called()
 
-    @mock.patch("github_release.deleteAsset")
-    @mock.patch("github_release.getReleaseByTag")
+    @unittest.mock.patch("github_release.deleteAsset")
+    @unittest.mock.patch("github_release.getReleaseByTag")
     def test_release_without_assets_key_does_not_raise(self, mock_get, mock_delete):
         # Regression for #6566: the release payload occasionally arrives
         # without an "assets" key, which previously raised KeyError mid-loop
@@ -89,8 +89,8 @@ class ActionDeleteTests(unittest.TestCase):
 
         mock_delete.assert_not_called()
 
-    @mock.patch("github_release.deleteAsset")
-    @mock.patch("github_release.getReleaseByTag")
+    @unittest.mock.patch("github_release.deleteAsset")
+    @unittest.mock.patch("github_release.getReleaseByTag")
     def test_release_with_empty_assets(self, mock_get, mock_delete):
         mock_get.return_value = {"id": 1, "assets": []}
 
@@ -98,8 +98,8 @@ class ActionDeleteTests(unittest.TestCase):
 
         mock_delete.assert_not_called()
 
-    @mock.patch("github_release.deleteAsset")
-    @mock.patch("github_release.getReleaseByTag")
+    @unittest.mock.patch("github_release.deleteAsset")
+    @unittest.mock.patch("github_release.getReleaseByTag")
     def test_release_with_matching_asset_is_deleted(self, mock_get, mock_delete):
         mock_get.return_value = {
             "id": 1,
@@ -113,8 +113,8 @@ class ActionDeleteTests(unittest.TestCase):
 
         mock_delete.assert_called_once_with("o", "r", 100)
 
-    @mock.patch("github_release.deleteAsset")
-    @mock.patch("github_release.getReleaseByTag")
+    @unittest.mock.patch("github_release.deleteAsset")
+    @unittest.mock.patch("github_release.getReleaseByTag")
     def test_release_with_no_matching_asset_does_not_delete(self, mock_get, mock_delete):
         mock_get.return_value = {
             "id": 1,

--- a/.github/workflows/release_script_test.yml
+++ b/.github/workflows/release_script_test.yml
@@ -1,0 +1,48 @@
+---
+name: Release Script Tests
+
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+    paths:
+      - '.github/scripts/github_release.py'
+      - '.github/scripts/test_github_release.py'
+      - '.github/workflows/release_script_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/scripts/github_release.py'
+      - '.github/scripts/test_github_release.py'
+      - '.github/workflows/release_script_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-github-release-script:
+    name: Unit tests for github_release.py
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run tests
+        env:
+          GITHUB_TOKEN: test-token
+        run: python .github/scripts/test_github_release.py -v


### PR DESCRIPTION
## Summary
Fixes #6566.

The release workflow occasionally fails mid-publish with
`KeyError: 'assets'` in `actionDelete`. Root cause: `getReleaseByTag`
only treated HTTP 404 as "release missing" and returned the raw JSON
for every other non-2xx status. When the GitHub API returns a transient
5xx, 403 rate limit, or similar, that response body is an error dict
(e.g. `{"message": "...", "documentation_url": "..."}`) without the
`assets`/`id`/`upload_url` keys callers depend on, so the next access
crashes the script and aborts the release.

## Changes
- `getReleaseByTag` now treats any non-2xx response (other than 404) as
  missing, logs the status and body, and returns `None`. Existing "no
  release" branches in `actionUpload` / `actionDelete` already handle
  that cleanly.
- `actionDelete` reads `assets` via `.get("assets", [])` so a release
  payload that lacks the key (e.g. a freshly created release) does not
  abort iteration with `KeyError`.
- New `.github/scripts/test_github_release.py` covers 200/404/5xx/403
  and non-JSON error bodies in `getReleaseByTag`, and exercises
  `actionDelete` against missing-release, missing-`assets`-key, empty
  assets, matching asset, and non-matching asset cases. The
  missing-`assets`-key test is the regression test for this bug — it
  fails on the original code.
- Small `release_script_test.yml` workflow runs the tests on PRs that
  touch the script (path-scoped, no other workloads triggered).

## Test plan
- [x] Added regression test for `KeyError: 'assets'`
- [x] Added edge case tests (5xx, 403, non-JSON body, empty assets,
      matching/non-matching asset names)
- [x] Verified regression test fails on the unfixed code (4 of 10 tests
      red without the patch)
- [x] All 10 tests pass with the fix
- [ ] CI green on PR

## Checklist
- [x] Root cause identified and fixed
- [x] Regression tests added
- [x] Edge cases covered
- [x] No snapshot deletions
- [x] No worktree paths or unrelated changes