### PR TITLE
fix: delegate update() in UpsertDedupTableProvider to inner provider

### DIFF
--- a/crates/runtime/src/dataaccelerator/upsert_dedup.rs
+++ b/crates/runtime/src/dataaccelerator/upsert_dedup.rs
@@ -169,6 +169,15 @@ impl TableProvider for UpsertDedupTableProvider {
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         self.inner.delete_from(state, filters).await
     }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        self.inner.update(state, assignments, filters).await
+    }
 }
 
 /// An execution plan that applies deduplication to batches before passing them downstream.


### PR DESCRIPTION
## Summary
- `UpsertDedupTableProvider` is a wrapper `TableProvider` that applies batch deduplication on insert before passing data to the underlying accelerator. It correctly delegated `scan`, `insert_into`, and `delete_from` to the inner provider, but was missing the `update()` delegation.
- In local (non-distributed) mode, DataFusion routes `UPDATE` statements through `TableProvider::update()`. When the inner provider is a Cayenne table (which supports `UPDATE`), the missing delegation caused the call to fall through to DataFusion's default implementation, returning a "not implemented" error instead of executing the update.
- This is the same class of bug as PR #10048, which previously fixed `UpsertDedupTableProvider`'s missing `update()` but was lost in a subsequent rewrite.

## Fix
Add the `update()` method to `UpsertDedupTableProvider`'s `TableProvider` impl, delegating directly to `self.inner.update()`. Update operations don't need batch deduplication (they modify existing rows rather than inserting new ones), so a straight delegation is correct.

## Test plan
- `cargo check -p runtime --lib` passes
- `cargo clippy -p runtime --lib -- -D warnings` passes
- `cargo fmt --check -p runtime` passes
- Performance impact: none (adds a delegation method, no additional overhead)