### PR TITLE
test(runtime): add containerized integration tests for hashicorp_vault store

### DIFF
--- a/crates/runtime/tests/hashicorp_vault/common.rs
+++ b/crates/runtime/tests/hashicorp_vault/common.rs
@@ -1,0 +1,205 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Container helpers for the `hashicorp_vault` integration tests.
+//!
+//! These spin up a single-node Vault dev server (KV v2 mounted at the
+//! default `secret/` path) and provide thin REST helpers for writing a
+//! KV value and configuring `AppRole` auth, mirroring the manual flow we
+//! used while bringing the secret store up.
+
+use std::time::Duration;
+
+use bollard::secret::HealthConfig;
+use serde_json::{Value, json};
+use tracing::instrument;
+
+use crate::docker::{ContainerRunnerBuilder, RunningContainer};
+
+pub const VAULT_ROOT_TOKEN: &str = "spice-vault-it-root";
+const VAULT_DOCKER_CONTAINER: &str = "runtime-integration-test-vault";
+/// Pinned to a recent Vault Enterprise/OSS image; using a tagged version
+/// keeps the test reproducible if upstream bumps the `latest` tag.
+const VAULT_IMAGE: &str = "hashicorp/vault:1.18";
+
+#[instrument]
+pub async fn start_vault_docker_container(
+    port: u16,
+) -> Result<RunningContainer<'static>, anyhow::Error> {
+    let container_name = format!("{VAULT_DOCKER_CONTAINER}-{port}");
+    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
+
+    let running_container = ContainerRunnerBuilder::new(container_name)
+        .image(VAULT_IMAGE.to_string())
+        .add_port_binding(8200, port)
+        .add_env_var("VAULT_DEV_ROOT_TOKEN_ID", VAULT_ROOT_TOKEN)
+        .add_env_var("VAULT_DEV_LISTEN_ADDRESS", "0.0.0.0:8200")
+        .healthcheck(HealthConfig {
+            // Use Vault's own status command so we wait for the dev
+            // server to be unsealed and ready, not just for the TCP
+            // socket to be open.
+            test: Some(vec![
+                "CMD-SHELL".to_string(),
+                format!(
+                    "VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN={VAULT_ROOT_TOKEN} \
+                     vault status >/dev/null 2>&1"
+                ),
+            ]),
+            interval: Some(250_000_000), // 250ms
+            timeout: Some(500_000_000),  // 500ms
+            retries: Some(20),
+            start_period: Some(500_000_000), // 500ms
+            start_interval: None,
+        })
+        .build()?
+        .run(None)
+        .await?;
+
+    // Wait an extra beat for the dev-mode KV mount provisioning to
+    // settle. Vault accepts requests as soon as the listener is up but
+    // the default `secret/` mount is created asynchronously by
+    // `vault server -dev`.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(running_container)
+}
+
+fn vault_address(port: u16) -> String {
+    format!("http://127.0.0.1:{port}")
+}
+
+fn client() -> Result<reqwest::Client, anyhow::Error> {
+    Ok(reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()?)
+}
+
+/// Write a KV v2 secret at `secret/<path>`. The `data` map becomes the
+/// `data.data` payload — i.e. the same shape `vault kv put` produces.
+pub async fn write_kv_v2_secret(
+    port: u16,
+    token: &str,
+    path: &str,
+    data: serde_json::Map<String, Value>,
+) -> Result<(), anyhow::Error> {
+    let url = format!("{}/v1/secret/data/{path}", vault_address(port));
+    let resp = client()?
+        .post(&url)
+        .header("X-Vault-Token", token)
+        .json(&json!({ "data": data }))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("vault kv put {url} failed: {status}: {body}");
+    }
+    Ok(())
+}
+
+/// Approle credentials — the equivalent of the local `approle.env`
+/// produced by the demo `setup.sh`.
+pub struct AppRoleCreds {
+    pub role_id: String,
+    pub secret_id: String,
+}
+
+/// Enable the `AppRole` auth backend, install a read-only policy for the
+/// demo path, and mint a `role_id` / `secret_id` pair.
+pub async fn configure_approle(
+    port: u16,
+    token: &str,
+    role_name: &str,
+    policy_path: &str,
+) -> Result<AppRoleCreds, anyhow::Error> {
+    let addr = vault_address(port);
+    let http = client()?;
+
+    // Idempotent: enable approle if not already enabled. Vault returns
+    // 400 with `path is already in use at approle/` on a second call.
+    let enable_resp = http
+        .post(format!("{addr}/v1/sys/auth/approle"))
+        .header("X-Vault-Token", token)
+        .json(&json!({ "type": "approle" }))
+        .send()
+        .await?;
+    let enable_status = enable_resp.status();
+    if !enable_status.is_success() && enable_status.as_u16() != 400 {
+        let body = enable_resp.text().await.unwrap_or_default();
+        anyhow::bail!("vault enable approle failed: {enable_status}: {body}");
+    }
+
+    // Policy granting read on the KV v2 data path.
+    let policy_doc =
+        format!("path \"secret/data/{policy_path}\" {{ capabilities = [\"read\"] }}\n");
+    let policy_resp = http
+        .put(format!("{addr}/v1/sys/policies/acl/spice-it"))
+        .header("X-Vault-Token", token)
+        .json(&json!({ "policy": policy_doc }))
+        .send()
+        .await?;
+    if !policy_resp.status().is_success() {
+        let status = policy_resp.status();
+        let body = policy_resp.text().await.unwrap_or_default();
+        anyhow::bail!("vault policy write failed: {status}: {body}");
+    }
+
+    // Create the role bound to that policy.
+    let role_resp = http
+        .post(format!("{addr}/v1/auth/approle/role/{role_name}"))
+        .header("X-Vault-Token", token)
+        .json(&json!({
+            "token_policies": "spice-it",
+            "token_ttl":     "1h",
+            "token_max_ttl": "4h",
+        }))
+        .send()
+        .await?;
+    if !role_resp.status().is_success() {
+        let status = role_resp.status();
+        let body = role_resp.text().await.unwrap_or_default();
+        anyhow::bail!("vault role create failed: {status}: {body}");
+    }
+
+    let role_id_resp = http
+        .get(format!("{addr}/v1/auth/approle/role/{role_name}/role-id"))
+        .header("X-Vault-Token", token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await?;
+    let role_id = role_id_resp
+        .pointer("/data/role_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing role_id in response"))?
+        .to_string();
+
+    let secret_id_resp = http
+        .post(format!("{addr}/v1/auth/approle/role/{role_name}/secret-id"))
+        .header("X-Vault-Token", token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await?;
+    let secret_id = secret_id_resp
+        .pointer("/data/secret_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing secret_id in response"))?
+        .to_string();
+
+    Ok(AppRoleCreds { role_id, secret_id })
+}

--- a/crates/runtime/tests/hashicorp_vault/mod.rs
+++ b/crates/runtime/tests/hashicorp_vault/mod.rs
@@ -1,0 +1,301 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! End-to-end integration tests for the `hashicorp_vault` secret store.
+//!
+//! These spin up a real Vault dev server and a real Postgres container,
+//! write the Postgres password into Vault, then start a Spice runtime
+//! configured with a `hashicorp_vault` secret store and a Postgres
+//! dataset whose `pg_pass` is sourced via `${vault:password}`. We then
+//! query the dataset through `DataFusion` and assert the rows come back.
+//!
+//! That mirrors the same flow the bring-up demo
+//! (`spicepod_test/260429-hashicorp-vault-demo`) walks through manually
+//! and exercises:
+//!   - Secret-store init at runtime build time.
+//!   - Param-string interpolation via `${ <store_name>:<key> }`.
+//!   - The Vault REST round-trip (KV v2 + token auth, KV v2 + `AppRole`
+//!     auth) inside the connector init path.
+//!
+//! Kubernetes and JWT auth are intentionally out of scope here — they
+//! require either an in-cluster service-account token or pre-minted
+//! RSA-signed JWTs and are covered by the live tests under
+//! `crates/runtime-secrets/tests/hashicorp_vault_live.rs`.
+
+use std::sync::Arc;
+
+use app::AppBuilder;
+use arrow::array::{Int32Array, RecordBatch, StringArray};
+use futures::TryStreamExt;
+use runtime::Runtime;
+use serde_json::json;
+use spicepod::component::dataset::Dataset;
+use spicepod::component::secret::Secret;
+use spicepod::param::Params;
+
+use crate::postgres::common as pg_common;
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, test_request_context},
+};
+
+mod common;
+
+/// Path under the default `secret/` mount where the Postgres password
+/// is stored. This matches the `secret/spice/postgres` layout used by
+/// the demo, and the `AppRole` policy granting read on that path.
+const PG_SECRET_PATH: &str = "spice/postgres";
+
+fn make_pg_dataset(port: u16, pg_pass_ref: &str) -> Dataset {
+    let mut dataset = Dataset::new("postgres:public.orders".to_string(), "orders".to_string());
+    dataset.params = Some(Params::from_string_map(
+        [
+            ("pg_host".to_string(), "localhost".to_string()),
+            ("pg_port".to_string(), port.to_string()),
+            ("pg_user".to_string(), "postgres".to_string()),
+            ("pg_db".to_string(), "postgres".to_string()),
+            ("pg_pass".to_string(), pg_pass_ref.to_string()),
+            ("pg_sslmode".to_string(), "disable".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+    dataset
+}
+
+/// Seed three rows into `public.orders` so that the SELECT after
+/// runtime startup has something to return.
+async fn seed_orders(port: u16) -> Result<(), anyhow::Error> {
+    let pool = pg_common::get_postgres_connection_pool(port.into(), None).await?;
+    let conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("connect to postgres: {e}"))?;
+    conn.conn
+        .execute(
+            "CREATE TABLE IF NOT EXISTS orders (
+                 id INT PRIMARY KEY,
+                 customer TEXT NOT NULL
+             );",
+            &[],
+        )
+        .await?;
+    conn.conn.execute("TRUNCATE orders;", &[]).await?;
+    conn.conn
+        .execute(
+            "INSERT INTO orders (id, customer) VALUES \
+             (1, 'Acme Corp'), (2, 'Globex'), (3, 'Initech');",
+            &[],
+        )
+        .await?;
+    Ok(())
+}
+
+async fn assert_orders_query(rt: &Runtime) -> Result<(), anyhow::Error> {
+    let result = rt
+        .datafusion()
+        .query_builder("SELECT id, customer FROM orders ORDER BY id")
+        .build()
+        .run()
+        .await
+        .map_err(|e| anyhow::anyhow!("query failed: {e}"))?;
+
+    let batches: Vec<RecordBatch> = result
+        .data
+        .try_collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("collect failed: {e}"))?;
+    let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(
+        total_rows, 3,
+        "expected 3 rows from orders; got {total_rows}"
+    );
+
+    // Sanity-check the first row's contents so a regression where the
+    // password resolves to an empty string (and we silently get back
+    // some other table or an empty result) trips the assertion.
+    let first = batches.first().expect("at least one batch");
+    let ids = first
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .expect("id column is Int32");
+    let customers = first
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("customer column is Utf8");
+    assert_eq!(ids.value(0), 1);
+    assert_eq!(customers.value(0), "Acme Corp");
+    Ok(())
+}
+
+#[tokio::test]
+async fn vault_token_auth_resolves_pg_password() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,runtime_secrets=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // 1. Spin up Postgres and seed it.
+            let pg_port = pg_common::get_random_port()?;
+            let pg = pg_common::start_postgres_docker_container(pg_port).await?;
+            seed_orders(pg_port.try_into()?).await?;
+
+            // 2. Spin up Vault dev mode and write the Postgres password.
+            let vault_port: u16 = pg_common::get_random_port()?.try_into()?;
+            let vault = common::start_vault_docker_container(vault_port).await?;
+            let mut data = serde_json::Map::new();
+            data.insert(
+                "password".to_string(),
+                json!(pg_common::PG_PASSWORD.to_string()),
+            );
+            common::write_kv_v2_secret(vault_port, common::VAULT_ROOT_TOKEN, PG_SECRET_PATH, data)
+                .await?;
+
+            // 3. Build a Spicepod app: hashicorp_vault store named `vault`
+            //    + Postgres dataset whose pg_pass references it.
+            let secret = Secret {
+                from: format!("hashicorp_vault:{PG_SECRET_PATH}"),
+                name: "vault".to_string(),
+                description: None,
+                params: Some(Params::from_string_map(
+                    [
+                        (
+                            "hashicorp_vault_address".to_string(),
+                            format!("http://127.0.0.1:{vault_port}"),
+                        ),
+                        (
+                            "hashicorp_vault_auth_method".to_string(),
+                            "token".to_string(),
+                        ),
+                        (
+                            "hashicorp_vault_token".to_string(),
+                            common::VAULT_ROOT_TOKEN.to_string(),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )),
+            };
+
+            let pg_port_u16: u16 = pg_port.try_into()?;
+            let app = AppBuilder::new("hashicorp_vault_token_it")
+                .with_secret(secret)
+                .with_dataset(make_pg_dataset(pg_port_u16, "${ vault:password }"))
+                .build();
+
+            // 4. Boot the runtime and run the dataset query.
+            register_test_connectors().await;
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let cloned_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            assert_orders_query(&rt).await?;
+
+            vault.remove().await?;
+            pg.remove().await?;
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn vault_approle_auth_resolves_pg_password() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,runtime_secrets=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let pg_port = pg_common::get_random_port()?;
+            let pg = pg_common::start_postgres_docker_container(pg_port).await?;
+            seed_orders(pg_port.try_into()?).await?;
+
+            let vault_port: u16 = pg_common::get_random_port()?.try_into()?;
+            let vault = common::start_vault_docker_container(vault_port).await?;
+
+            let mut data = serde_json::Map::new();
+            data.insert(
+                "password".to_string(),
+                json!(pg_common::PG_PASSWORD.to_string()),
+            );
+            common::write_kv_v2_secret(vault_port, common::VAULT_ROOT_TOKEN, PG_SECRET_PATH, data)
+                .await?;
+
+            // Configure AppRole + a read-only policy on the demo path,
+            // then mint role_id / secret_id. After this the Spice runtime
+            // never sees the root token.
+            let creds = common::configure_approle(
+                vault_port,
+                common::VAULT_ROOT_TOKEN,
+                "spice-pg",
+                PG_SECRET_PATH,
+            )
+            .await?;
+
+            let secret = Secret {
+                from: format!("hashicorp_vault:{PG_SECRET_PATH}"),
+                name: "vault".to_string(),
+                description: None,
+                params: Some(Params::from_string_map(
+                    [
+                        (
+                            "hashicorp_vault_address".to_string(),
+                            format!("http://127.0.0.1:{vault_port}"),
+                        ),
+                        (
+                            "hashicorp_vault_auth_method".to_string(),
+                            "approle".to_string(),
+                        ),
+                        ("hashicorp_vault_role_id".to_string(), creds.role_id),
+                        ("hashicorp_vault_secret_id".to_string(), creds.secret_id),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )),
+            };
+
+            let pg_port_u16: u16 = pg_port.try_into()?;
+            let app = AppBuilder::new("hashicorp_vault_approle_it")
+                .with_secret(secret)
+                .with_dataset(make_pg_dataset(pg_port_u16, "${ vault:password }"))
+                .build();
+
+            register_test_connectors().await;
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let cloned_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            assert_orders_query(&rt).await?;
+
+            vault.remove().await?;
+            pg.remove().await?;
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -76,6 +76,8 @@ mod git;
 mod github;
 mod glue;
 mod graphql;
+#[cfg(all(feature = "postgres", feature = "hashicorp_vault"))]
+mod hashicorp_vault;
 mod http;
 mod iceberg;
 mod iceberg_api;


### PR DESCRIPTION
## Summary

Adds containerized integration tests for the `hashicorp_vault` secret store landed in #10561. They mirror the manual bring-up flow we used during PR review: real Vault dev container + real Postgres container + a Spice runtime configured to source `pg_pass` from Vault via `${ vault:password }`, then a SELECT to prove the resolved password actually works.

Two tests, one per auth method that doesn't require external infra:

- `hashicorp_vault::vault_token_auth_resolves_pg_password` — root token passed via params.
- `hashicorp_vault::vault_approle_auth_resolves_pg_password` — enables the AppRole backend in the test, installs a read-only policy on the demo path, mints a `role_id` / `secret_id`, and exercises the runtime's login round-trip path (the root token is never seen by the runtime).

Both run in ~33 s combined on my machine (containers + cold runtime build).

## Why not Kubernetes / JWT auth too?

`kubernetes` needs an in-cluster service-account JWT and a Vault role bound to a token reviewer; `jwt` needs a pre-minted RSA-signed JWT. Both add infra weight (kind cluster or openssl key generation) that doesn't pull its weight in CI. They remain covered by the env-gated live tests at `crates/runtime-secrets/tests/hashicorp_vault_live.rs`.

## Files

- `crates/runtime/tests/hashicorp_vault/common.rs` — `start_vault_docker_container`, `write_kv_v2_secret`, `configure_approle` (raw `reqwest`, no Vault SDK).
- `crates/runtime/tests/hashicorp_vault/mod.rs` — the two tests above.
- `crates/runtime/tests/integration.rs` — module wiring, gated `#[cfg(all(feature = "postgres", feature = "hashicorp_vault"))]`.

## Verification

```text
$ cargo test -p runtime --test integration --features "postgres,hashicorp_vault" \
    hashicorp_vault -- --nocapture --test-threads=1
...
INFO runtime::init::dataset: Dataset orders registered (postgres:public.orders), results cache enabled.
INFO sql_query: rows_produced=3
INFO sql_query: captured_output=[{"id":1,"customer":"Acme Corp"},{"id":2,"customer":"Globex"},{"id":3,"customer":"Initech"}]
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 273 filtered out; finished in 33.29s
```

`cargo fmt --all -- --check` clean. `cargo clippy -p runtime --tests --features "postgres,hashicorp_vault" --no-deps` reports nothing in the new files (other warnings are pre-existing dead-code from feature-flag combos).

## Related

- Original feature PR: #10561
- Docs PR: spiceai/docs#1600
