### PR TITLE
chore: remove Makefile Targets CI check from endgame template

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -56,7 +56,6 @@ release coordination channel. Secondary DRI should positively acknowledge the ha
 
 1. **E2E Tests**
    - [ ] Verify [E2E Test CI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on `trunk` and the release branch.
-   - [ ] Verify [Makefile Targets](https://github.com/spiceai/spiceai/actions/workflows/makefile_targets.yml) is green on `trunk` and the release branch.
    - [ ] Verify [Test Operator Benchmarks](https://github.com/spiceai/spiceai/actions/workflows/testoperator_run_bench.yml) is green on `trunk` and the release branch.
      - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new benchmark run. Specify `trunk` as the branch source, with the following parameters:
        - Workflow to execute: `bench`


### PR DESCRIPTION
## Summary
- Removes the `Makefile Targets` CI check from the endgame issue template — the `makefile_targets.yml` workflow no longer exists in the repo.