### PR TITLE
fix(iceberg): rebuild storage factory when Hadoop catalog scheme is inferred

### DIFF
--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -41,15 +41,40 @@ pub enum MetadataMode {
     Exact(String),
 }
 
+/// A function that builds a `StorageFactory` for a given URL scheme (e.g. `s3`, `s3a`).
+///
+/// This is used by the `HadoopCatalogBuilder` to allow the storage factory to be
+/// reconstructed when scheme inference detects that the warehouse root scheme does
+/// not match the scheme used in table metadata locations.
+pub type StorageFactoryBuilderFn = Arc<dyn Fn(&str) -> Arc<dyn StorageFactory> + Send + Sync>;
+
 /// Builder for creating a new `HadoopCatalog`
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct HadoopCatalogBuilder {
     warehouse_root: Option<String>,
     file_io: Option<FileIO>,
     metadata_mode: MetadataMode,
     properties: HashMap<String, String>,
     storage_factory: Option<Arc<dyn StorageFactory>>,
+    storage_factory_builder: Option<StorageFactoryBuilderFn>,
     operator: Option<Operator>,
+}
+
+impl std::fmt::Debug for HadoopCatalogBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HadoopCatalogBuilder")
+            .field("warehouse_root", &self.warehouse_root)
+            .field("file_io", &self.file_io)
+            .field("metadata_mode", &self.metadata_mode)
+            .field("properties", &self.properties)
+            .field("storage_factory", &self.storage_factory)
+            .field(
+                "storage_factory_builder",
+                &self.storage_factory_builder.as_ref().map(|_| "<fn>"),
+            )
+            .field("operator", &self.operator)
+            .finish()
+    }
 }
 
 impl HadoopCatalogBuilder {
@@ -72,6 +97,25 @@ impl HadoopCatalogBuilder {
     #[must_use]
     pub fn with_storage_factory(mut self, factory: Arc<dyn StorageFactory>) -> Self {
         self.storage_factory = Some(factory);
+        self
+    }
+
+    /// Sets a builder function that produces a `StorageFactory` for a given URL scheme.
+    ///
+    /// When set, this function is invoked during scheme inference: if the inferred
+    /// scheme differs from the warehouse root scheme, the storage factory is rebuilt
+    /// using the new scheme so that the rebuilt `FileIO` accepts paths with that
+    /// scheme.
+    ///
+    /// If both `with_storage_factory` and `with_storage_factory_builder` are set,
+    /// the builder function takes precedence and is invoked with the warehouse root
+    /// scheme during the initial build.
+    #[must_use]
+    pub fn with_storage_factory_builder<F>(mut self, builder: F) -> Self
+    where
+        F: Fn(&str) -> Arc<dyn StorageFactory> + Send + Sync + 'static,
+    {
+        self.storage_factory_builder = Some(Arc::new(builder));
         self
     }
 
@@ -103,7 +147,7 @@ impl HadoopCatalogBuilder {
         self
     }
 
-    fn inner_build(self, infer_scheme: bool) -> BoxFuture<'static, Result<HadoopCatalog>> {
+    fn inner_build(mut self, infer_scheme: bool) -> BoxFuture<'static, Result<HadoopCatalog>> {
         async move {
             let mut cloned_self = self.clone();
             let mut warehouse_root = self.warehouse_root.ok_or_else(|| {
@@ -112,6 +156,24 @@ impl HadoopCatalogBuilder {
 
             if !warehouse_root.ends_with('/') {
                 warehouse_root.push('/');
+            }
+
+            // If a storage factory builder was provided, materialize the factory
+            // for the current warehouse root scheme. This lets scheme inference
+            // rebuild the factory when re-entering inner_build with a new scheme.
+            if let Some(factory_builder) = &self.storage_factory_builder {
+                if let Some((scheme, _)) = warehouse_root.split_once("://") {
+                    self.storage_factory = Some(factory_builder(scheme));
+                } else if self.file_io.is_none() && self.storage_factory.is_none() {
+                    // The builder needs a scheme to materialize a factory, and we
+                    // have no other source for the FileIO.
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Cannot materialize storage factory: warehouse root '{warehouse_root}' does not contain a URL scheme. Verify the warehouse root is in the format '<scheme>://<path>'.",
+                        ),
+                    ));
+                }
             }
 
             let file_io = if let Some(file_io) = self.file_io {
@@ -123,7 +185,7 @@ impl HadoopCatalogBuilder {
             } else {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
-                    "Either file_io or storage_factory must be provided",
+                    "Either file_io, storage_factory, or storage_factory_builder must be provided",
                 ));
             };
 

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -100,6 +100,60 @@ fn get_s3a_hadoop_catalog() -> HadoopCatalogBuilder {
         .set_property(S3_SECRET_ACCESS_KEY, secret_key)
 }
 
+/// Regression test helper for scheme inference: configures the warehouse root
+/// as `s3://hadoop/` while the underlying table metadata uses `s3a://hadoop/`.
+///
+/// Uses `with_storage_factory_builder` so that when the Hadoop catalog infers the
+/// `s3a` scheme from the metadata locations, the storage factory is rebuilt with
+/// `configured_scheme: "s3a"`. Without this rebuild, the rebuilt `FileIO` would
+/// reject `s3a://...` paths because the original factory was configured for `s3`.
+#[expect(clippy::expect_used)]
+fn get_s3_to_s3a_inferred_hadoop_catalog() -> HadoopCatalogBuilder {
+    #[cfg(not(feature = "test_hadoop_catalog_docker"))]
+    let minio_endpoint = std::env::var("MINIO_ENDPOINT")
+        .expect("Should have MINIO_ENDPOINT environment variable set");
+
+    #[cfg(feature = "test_hadoop_catalog_docker")]
+    let minio_endpoint = {
+        let guard = DOCKER_COMPOSE_ENV
+            .read()
+            .expect("Should acquire read lock on DOCKER_COMPOSE_ENV");
+        let docker_compose = guard.as_ref().expect("Should have DockerCompose instance");
+        let minio_ip = docker_compose.get_container_ip("minio");
+        let minio_socket_addr = SocketAddr::new(minio_ip, MINIO_PORT);
+        format!("http://{minio_socket_addr}")
+    };
+
+    let access_key = std::env::var("MINIO_ACCESS_KEY_ID").unwrap_or("admin".to_string());
+    let secret_key = std::env::var("MINIO_SECRET_ACCESS_KEY").unwrap_or("password".to_string());
+
+    let mut s3_config = opendal::services::S3Config::default();
+    s3_config.bucket = "hadoop".to_string();
+    s3_config.root = Some("/".to_string());
+    s3_config.endpoint = Some(minio_endpoint.clone());
+    s3_config.region = Some("us-east-1".to_string());
+    s3_config.access_key_id = Some(access_key.clone());
+    s3_config.secret_access_key = Some(secret_key.clone());
+
+    let operator = opendal::Operator::new(s3_config.into_builder())
+        .expect("Should build S3 operator")
+        .finish();
+
+    HadoopCatalogBuilder::default()
+        .with_warehouse_root("s3://hadoop/")
+        .with_storage_factory_builder(|scheme| {
+            Arc::new(OpenDalStorageFactory::S3 {
+                configured_scheme: scheme.to_string(),
+                customized_credential_load: None,
+            })
+        })
+        .with_operator(operator)
+        .set_property(S3_REGION, "us-east-1")
+        .set_property(S3_ENDPOINT, minio_endpoint)
+        .set_property(S3_ACCESS_KEY_ID, access_key)
+        .set_property(S3_SECRET_ACCESS_KEY, secret_key)
+}
+
 #[cfg(feature = "test_hadoop_catalog_docker")]
 #[ctor]
 #[expect(clippy::expect_used)]
@@ -146,6 +200,13 @@ async fn build_catalogs() -> Vec<(&'static str, HadoopCatalog)> {
                 .build()
                 .await
                 .expect("Should build S3A catalog"),
+        ),
+        (
+            "s3-to-s3a-inferred",
+            get_s3_to_s3a_inferred_hadoop_catalog()
+                .build()
+                .await
+                .expect("Should build S3-to-S3A inferred catalog (regression test for scheme inference rebuilding the storage factory)"),
         ),
     ]
 }

--- a/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_1.snap
+++ b/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_1.snap
@@ -1,0 +1,10 @@
+---
+source: crates/catalog/hadoop/tests/hadoop_catalog_test.rs
+expression: snapshot_content
+---
++----+------+
+| id | name |
++----+------+
+| 1  | foo  |
+| 2  | bar  |
++----+------+

--- a/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_2.snap
+++ b/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/catalog/hadoop/tests/hadoop_catalog_test.rs
+expression: snapshot_content
+---
++----+------+
+| id | name |
++----+------+
+| 3  | foo  |
+| 4  | bar  |
++----+------+

--- a/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_3.snap
+++ b/crates/data_components/tests/snapshots/hadoop_catalog_test__tests__s3-to-s3a-inferred_my_table_3.snap
@@ -1,0 +1,10 @@
+---
+source: crates/catalog/hadoop/tests/hadoop_catalog_test.rs
+expression: snapshot_content
+---
++----+------+
+| id | name |
++----+------+
+| 5  | foo  |
+| 6  | bar  |
++----+------+

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -37,7 +37,7 @@ use iceberg::{CatalogBuilder, Namespace, NamespaceIdent, io::StorageFactory};
 use iceberg_catalog_rest::{
     REST_CATALOG_PROP_URI, RestCatalog as IcebergRestCatalog, RestCatalogBuilder,
 };
-use iceberg_storage_opendal::OpenDalStorageFactory;
+use iceberg_storage_opendal::{CustomAwsCredentialLoader, OpenDalStorageFactory};
 use ns_lookup::verify_ns_lookup_and_tcp_connect;
 use opendal::Operator;
 use secrecy::ExposeSecret;
@@ -112,24 +112,10 @@ impl IcebergCatalog {
 
     async fn load_hadoop_catalog(
         props: HashMap<String, String>,
-        storage_factory: Option<Arc<dyn StorageFactory>>,
+        s3_credential_loader: Option<CustomAwsCredentialLoader>,
         catalog: &Catalog,
         catalog_id: &str,
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
-        // Determine storage factory from scheme if not explicitly provided
-        let factory = storage_factory.unwrap_or_else(|| {
-            if catalog_id.starts_with("gs://") || catalog_id.starts_with("gcs://") {
-                Arc::new(OpenDalStorageFactory::Gcs)
-            } else if catalog_id.starts_with("s3://") || catalog_id.starts_with("s3a://") {
-                Arc::new(OpenDalStorageFactory::S3 {
-                    configured_scheme: s3_scheme_from_url(catalog_id),
-                    customized_credential_load: None,
-                })
-            } else {
-                Arc::new(iceberg::io::LocalFsStorageFactory) as Arc<dyn StorageFactory>
-            }
-        });
-
         let operator = build_opendal_operator(catalog_id, &props).map_err(|e| {
             super::Error::InvalidConfiguration {
                 connector: "iceberg".into(),
@@ -140,12 +126,31 @@ impl IcebergCatalog {
         })?;
 
         // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
-        let catalog_builder = HadoopCatalogBuilder::default()
+        let mut catalog_builder = HadoopCatalogBuilder::default()
             .with_warehouse_root(catalog_id)
             .with_metadata_mode(MetadataMode::Infer)
-            .with_storage_factory(factory)
             .with_operator(operator)
             .with_properties(props);
+
+        // Use a builder closure for the storage factory so that scheme inference
+        // (e.g. inferring `s3a://` from table metadata when the warehouse root is
+        // configured as `s3://`) can rebuild the factory with the new scheme. The
+        // S3 `OpenDalStorageFactory` validates that paths match the configured
+        // scheme, so the factory must be reconstructed when the scheme changes.
+        if catalog_id.starts_with("gs://") || catalog_id.starts_with("gcs://") {
+            catalog_builder =
+                catalog_builder.with_storage_factory(Arc::new(OpenDalStorageFactory::Gcs));
+        } else if catalog_id.starts_with("s3://") || catalog_id.starts_with("s3a://") {
+            catalog_builder = catalog_builder.with_storage_factory_builder(move |scheme| {
+                Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: scheme.to_string(),
+                    customized_credential_load: s3_credential_loader.clone(),
+                })
+            });
+        } else {
+            catalog_builder =
+                catalog_builder.with_storage_factory(Arc::new(iceberg::io::LocalFsStorageFactory));
+        }
 
         let hadoop_catalog =
             catalog_builder
@@ -337,7 +342,7 @@ impl CatalogConnector for IcebergCatalog {
             }
         }
 
-        let storage_factory: Option<Arc<dyn StorageFactory>> =
+        let s3_credential_loader: Option<CustomAwsCredentialLoader> =
             if let Some(endpoint) = props.get("s3.endpoint") {
                 verify_s3_endpoint(endpoint).await.map_err(|e| {
                     super::Error::InvalidConfiguration {
@@ -376,12 +381,7 @@ impl CatalogConnector for IcebergCatalog {
                     })?
                     .into_custom_loader();
 
-                let configured_scheme = s3_scheme_from_url(&catalog_id);
-
-                Some(Arc::new(OpenDalStorageFactory::S3 {
-                    configured_scheme,
-                    customized_credential_load: Some(custom_loader),
-                }) as Arc<dyn StorageFactory>)
+                Some(custom_loader)
             } else {
                 None
             };
@@ -394,12 +394,30 @@ impl CatalogConnector for IcebergCatalog {
         {
             return IcebergCatalog::load_hadoop_catalog(
                 props,
-                storage_factory,
+                s3_credential_loader,
                 catalog,
                 &catalog_id,
             )
             .await;
         }
+
+        // For the REST catalog path, materialize the storage factory now so it can
+        // be passed to `get_rest_catalog`. The configured scheme is derived from the
+        // catalog's `warehouse` property (if present) since `catalog_id` is an HTTP
+        // URL for REST catalogs and would otherwise always resolve to plain `s3`.
+        // Falling back to `catalog_id` preserves prior behavior for callers that
+        // do not set a `warehouse` property.
+        let configured_s3_scheme = props.get("warehouse").map_or_else(
+            || s3_scheme_from_url(&catalog_id),
+            |w| s3_scheme_from_url(w),
+        );
+        let storage_factory: Option<Arc<dyn StorageFactory>> =
+            s3_credential_loader.map(|custom_loader| {
+                Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: configured_s3_scheme,
+                    customized_credential_load: Some(custom_loader),
+                }) as Arc<dyn StorageFactory>
+            });
 
         let (base_uri, new_props, namespace) = match parse_catalog_url(catalog_id.as_str()) {
             Ok(result) => result,


### PR DESCRIPTION
## Description

When a Hadoop catalog's warehouse root scheme (e.g. `s3://`) does not match the scheme used in the table metadata locations (e.g. `s3a://`), the existing scheme inference logic in `HadoopCatalogBuilder::inner_build` rebuilds the catalog with the inferred warehouse root. However, since the iceberg-rust v0.9 upgrade (#9917), the `OpenDalStorageFactory::S3` variant validates that paths match its `configured_scheme`. If the factory was constructed with `configured_scheme: "s3"` but the rebuilt catalog tries to operate on `s3a://...` paths, it errors with:

```
DataInvalid => Invalid s3 url: s3a://hadoop/, should start with s3://hadoop/
```

This caused the [`catalogs/iceberg-hadoop` cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/iceberg-hadoop) to fail to register its catalog (the recipe writes table metadata via Spark using `s3a://`).

Reproduction (before this fix), with the cookbook's `iceberg-hadoop` recipe:

```
ERROR runtime::init::catalog: Failed to initialize catalog connector: Cannot setup the catalog hadoop (iceberg) with an invalid configuration. Failed to create Hadoop Catalog for Iceberg with base URI: s3://hadoop/
```

(The actual underlying error was previously hidden because `Error::InvalidConfiguration`'s `Display` impl only shows the `message` field, not the `source`. The full chain is `DataInvalid => Invalid s3 url: s3a://hadoop/, should start with s3://hadoop/`.)

## Fix

- Add `HadoopCatalogBuilder::with_storage_factory_builder(Fn(&str) -> Arc<...>)`, a closure that produces a `StorageFactory` for a given URL scheme. When set, the factory is materialized in `inner_build` from the current warehouse root scheme, which allows scheme inference to rebuild the factory with the inferred scheme on the recursive `inner_build(false)` call.
- Update the iceberg catalog connector (`crates/runtime/src/catalogconnector/iceberg.rs`) to use the new builder closure for the S3 case, so the `CustomAwsCredentialLoader` is captured and the factory is rebuilt with the correct scheme when inferred.
- Add a regression test `get_s3_to_s3a_inferred_hadoop_catalog` that configures the warehouse root as `s3://hadoop/` (while the underlying metadata uses `s3a://hadoop/`) and verifies the catalog builds successfully via scheme inference + factory rebuild.

## Validation

End-to-end with the `catalogs/iceberg-hadoop` cookbook recipe:

```
INFO runtime::init::catalog: Registering catalog 'hadoop' for iceberg
INFO runtime::init::catalog: Registered catalog 'hadoop' with 1 schema and 8 tables
```

TPC-H Q1 against the catalog returns expected results:

```sql
SELECT l_returnflag, l_linestatus, SUM(l_quantity) AS sum_qty
FROM hadoop.tpch.lineitem WHERE l_shipdate <= DATE '1998-09-02'
GROUP BY l_returnflag, l_linestatus
ORDER BY l_returnflag, l_linestatus;
```

| l_returnflag | l_linestatus | sum_qty    |
|--------------|--------------|------------|
| A            | F            | 37734107.0 |
| N            | F            | 991417.0   |
| N            | O            | 74476040.0 |
| R            | F            | 37719753.0 |

`make lint-rust` passes locally.

## Linked Issues

Found while testing for #10547 (v2.0.0-rc.4 endgame).
