### PR TITLE
Increase ready_wait timeout for iceberg-duckdb[file] bench/throughput tests

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
@@ -4,10 +4,12 @@ tests:
     query_set: tpch
     runner_type: spiceai-dev-runners
     validate_results: true
+    ready_wait: 180
   throughput:
     spicepod_path: accelerated/iceberg-duckdb[file].yaml
     query_set: tpch
     runner_type: spiceai-dev-runners
+    ready_wait: 180
   load:
     spicepod_path: accelerated/iceberg-duckdb[file].yaml
     query_set: tpch


### PR DESCRIPTION
## 📝 Summary

Adds `ready_wait: 180` to the bench and throughput test configurations for `iceberg-duckdb[file]`. These tests were using the default 30s timeout, which is insufficient for loading TPCH SF1 datasets from Iceberg REST with DuckDB file acceleration, causing intermittent CI failures on slower runners.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
