### PR TITLE
Fix clickhouse installation

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1007,13 +1007,11 @@ jobs:
       - name: Install Clickhouse
         if: matrix.target.target_os == 'linux'
         run: |
-          CLICKHOUSE_VERSION="26.3.9.8-lts"
-          CLICKHOUSE_VER_NUM="${CLICKHOUSE_VERSION%-lts}"
-          BASE_URL="https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}"
-          curl -fsSL "${BASE_URL}/clickhouse-common-static_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-common-static.deb
-          curl -fsSL "${BASE_URL}/clickhouse-server_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-server.deb
-          curl -fsSL "${BASE_URL}/clickhouse-client_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-client.deb
-          sudo DEBIAN_FRONTEND=noninteractive dpkg -i clickhouse-common-static.deb clickhouse-server.deb clickhouse-client.deb
+          CLICKHOUSE_VERSION="26.3.9.8"
+          curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | sudo gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/sources.list.d/clickhouse.list
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server=${CLICKHOUSE_VERSION} clickhouse-client=${CLICKHOUSE_VERSION}
           sudo -u clickhouse /usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --daemon  -- --tcp_port=9001
           sleep 5
           clickhouse client --port 9001 -udefault --query="CREATE USER test_user IDENTIFIED BY 'password';"

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1008,12 +1008,12 @@ jobs:
         if: matrix.target.target_os == 'linux'
         run: |
           CLICKHOUSE_VERSION="26.3.9.8-lts"
-          curl -fsSL "https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}/clickhouse-linux-amd64" -o clickhouse-linux-amd64
-          curl -fsSL "https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}/clickhouse-linux-amd64.sha512" -o clickhouse-linux-amd64.sha512
-          sha512sum -c clickhouse-linux-amd64.sha512
-          mv clickhouse-linux-amd64 clickhouse
-          chmod +x clickhouse
-          sudo ./clickhouse install
+          CLICKHOUSE_VER_NUM="${CLICKHOUSE_VERSION%-lts}"
+          BASE_URL="https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}"
+          curl -fsSL "${BASE_URL}/clickhouse-common-static_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-common-static.deb
+          curl -fsSL "${BASE_URL}/clickhouse-server_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-server.deb
+          curl -fsSL "${BASE_URL}/clickhouse-client_${CLICKHOUSE_VER_NUM}_amd64.deb" -o clickhouse-client.deb
+          sudo DEBIAN_FRONTEND=noninteractive dpkg -i clickhouse-common-static.deb clickhouse-server.deb clickhouse-client.deb
           sudo -u clickhouse /usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --daemon  -- --tcp_port=9001
           sleep 5
           clickhouse client --port 9001 -udefault --query="CREATE USER test_user IDENTIFIED BY 'password';"
@@ -1024,12 +1024,13 @@ jobs:
         if: matrix.target.target_os == 'darwin'
         run: |
           CLICKHOUSE_VERSION="26.3.9.8-lts"
-          curl -fsSL "https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}/clickhouse-macos-aarch64" -o clickhouse-macos-aarch64
-          curl -fsSL "https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}/clickhouse-macos-aarch64.sha512" -o clickhouse-macos-aarch64.sha512
-          shasum -a 512 -c clickhouse-macos-aarch64.sha512
-          mv clickhouse-macos-aarch64 clickhouse
-          chmod +x clickhouse
-          sudo ./clickhouse install
+          CLICKHOUSE_VER_NUM="${CLICKHOUSE_VERSION%-lts}"
+          BASE_URL="https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}"
+          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz" -o clickhouse-common-static.tgz
+          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512" -o clickhouse-common-static.tgz.sha512
+          shasum -a 512 -c clickhouse-common-static.tgz.sha512
+          tar xzf clickhouse-common-static.tgz
+          sudo ./usr/bin/clickhouse install
           sudo clickhouse server --config=/etc/clickhouse-server/config.xml --daemon  -- --tcp_port=9001
           sleep 5
           clickhouse client --port 9001 -udefault --query="CREATE USER test_user IDENTIFIED BY 'password';"

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1022,13 +1022,11 @@ jobs:
         if: matrix.target.target_os == 'darwin'
         run: |
           CLICKHOUSE_VERSION="26.3.9.8-lts"
-          CLICKHOUSE_VER_NUM="${CLICKHOUSE_VERSION%-lts}"
           BASE_URL="https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}"
-          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz" -o "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz"
-          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512" -o "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512"
-          shasum -a 512 -c "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512"
-          tar xzf "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz"
-          sudo ./usr/bin/clickhouse install
+          curl -fsSL "${BASE_URL}/clickhouse-macos-aarch64" -o clickhouse-macos-aarch64
+          mv clickhouse-macos-aarch64 clickhouse
+          chmod +x clickhouse
+          sudo ./clickhouse install --noninteractive
           sudo clickhouse server --config=/etc/clickhouse-server/config.xml --daemon  -- --tcp_port=9001
           sleep 5
           clickhouse client --port 9001 -udefault --query="CREATE USER test_user IDENTIFIED BY 'password';"

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1026,10 +1026,10 @@ jobs:
           CLICKHOUSE_VERSION="26.3.9.8-lts"
           CLICKHOUSE_VER_NUM="${CLICKHOUSE_VERSION%-lts}"
           BASE_URL="https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}"
-          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz" -o clickhouse-common-static.tgz
-          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512" -o clickhouse-common-static.tgz.sha512
-          shasum -a 512 -c clickhouse-common-static.tgz.sha512
-          tar xzf clickhouse-common-static.tgz
+          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz" -o "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz"
+          curl -fsSL "${BASE_URL}/clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512" -o "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512"
+          shasum -a 512 -c "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz.sha512"
+          tar xzf "clickhouse-common-static-${CLICKHOUSE_VER_NUM}-arm64.tgz"
           sudo ./usr/bin/clickhouse install
           sudo clickhouse server --config=/etc/clickhouse-server/config.xml --daemon  -- --tcp_port=9001
           sleep 5


### PR DESCRIPTION
## 📝 Summary

ClickHouse 26.x dropped the unified single-binary release artifacts (`clickhouse-linux-amd64`, `clickhouse-macos-aarch64`) that the workflow relied on. Updated the Linux install to use .deb packages and the macOS install to use the arm64.tgz archive instead.

https://github.com/spiceai/spiceai/actions/runs/25198495957

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->