### PR TITLE
fix: Upgrade Docker versions for library links

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -243,6 +243,12 @@ jobs:
             GITHUB_REPOSITORY=${{ github.repository }}
         if: ${{ needs.setup.outputs.run_amd64 == 'true' }}
 
+      - name: Validate AMD64 image
+        run: |
+          docker load -i /tmp/image-amd64-${{ env.IMAGE_TAG }}.tar
+          docker run --rm localhost:5000/spiceai:${{ env.IMAGE_TAG }}-amd64 --version
+        if: ${{ needs.setup.outputs.run_amd64 == 'true' }}
+
       - name: Upload AMD64 artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -309,6 +315,12 @@ jobs:
             GITHUB_REPOSITORY=${{ github.repository }}
         if: ${{ needs.setup.outputs.run_arm64 == 'true' }}
 
+      - name: Validate ARM64 image
+        run: |
+          docker load -i /tmp/image-arm64-${{ env.IMAGE_TAG }}.tar
+          docker run --rm localhost:5000/spiceai:${{ env.IMAGE_TAG }}-arm64 --version
+        if: ${{ needs.setup.outputs.run_arm64 == 'true' }}
+
       - name: Upload ARM64 artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -354,6 +366,12 @@ jobs:
             CARGO_FEATURES=${{ env.CARGO_FEATURES }}
             CUDA_COMPUTE_CAP=${{ env.CUDA_COMPUTE_CAP }}
             GITHUB_REPOSITORY=${{ github.repository }}
+        if: ${{ needs.setup.outputs.run_cuda == 'true' }}
+
+      - name: Validate CUDA image
+        run: |
+          docker load -i /tmp/images-amd64-cuda.tar
+          docker run --rm localhost:5000/spiceai:${{ env.IMAGE_TAG }}-amd64 --version
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
 
       - name: Upload CUDA artifacts

--- a/.github/workflows/spiced_docker_dev.yml
+++ b/.github/workflows/spiced_docker_dev.yml
@@ -136,6 +136,11 @@ jobs:
             CARGO_FEATURES=${{ env.CARGO_FEATURES }}
             RUST_PROFILE=${{ env.RUST_PROFILE }}
 
+      - name: Validate ARM64 image
+        run: |
+          docker load -i /tmp/image-arm64.tar
+          docker run --rm localhost:5000/spiceai:dev-arm64 --version
+
       - name: Upload ARM64 artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -189,6 +194,11 @@ jobs:
           build-args: |
             CARGO_FEATURES=${{ env.CARGO_FEATURES }}
             RUST_PROFILE=${{ env.RUST_PROFILE }}
+
+      - name: Validate AMD64 image
+        run: |
+          docker load -i /tmp/image-amd64.tar
+          docker run --rm localhost:5000/spiceai:dev-amd64 --version
 
       - name: Upload AMD64 artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.2
 ARG RUST_VERSION=1.94.1
-FROM rust:${RUST_VERSION}-slim-bookworm as build
+FROM rust:${RUST_VERSION}-slim-trixie as build
 
 # cache mounts below may already exist and owned by root
 USER root
@@ -40,7 +40,7 @@ RUN \
     fi && \
     cp /build/target/${RUST_PROFILE}/spiced /root/spiced
 
-FROM debian:bookworm-slim as sandbox-setup
+FROM debian:trixie-slim as sandbox-setup
 
 ARG CARGO_FEATURES
 

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -45,7 +45,7 @@ RUN \
     cargo build --release --features ${CARGO_FEATURES:-default} && \
     cp /build/target/release/spiced /root/spiced
 
-FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu24.04 AS runtime
+FROM nvidia/cuda:12.6.0-cudnn-runtime-ubuntu24.04 AS runtime
 ENV CUDA_NVCC_FLAGS=-fPIE
 ARG CARGO_FEATURES
 

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -53,7 +53,7 @@ ARG CARGO_FEATURES
 RUN mkdir /.duckdb/ && chmod 777 /.duckdb/
 
 RUN apt update \
-    && apt install --yes ca-certificates libssl3 tzdata --no-install-recommends \
+    && apt install --yes ca-certificates libssl3 tzdata cuda-compat-12-6 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 RUN if echo "$CARGO_FEATURES" | grep -q "odbc"; then \
@@ -63,6 +63,8 @@ RUN if echo "$CARGO_FEATURES" | grep -q "odbc"; then \
     fi
 
 COPY --from=build /root/spiced /usr/local/bin/spiced
+
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.6/compat:${LD_LIBRARY_PATH}
 
 WORKDIR /app
 

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1.2
 ARG RUST_VERSION=1.94.1
 
-FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS build
+FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu24.04 AS build
 
 # cache mounts below may already exist and owned by root
 USER root
@@ -45,7 +45,7 @@ RUN \
     cargo build --release --features ${CARGO_FEATURES:-default} && \
     cp /build/target/release/spiced /root/spiced
 
-FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04 AS runtime
+FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu24.04 AS runtime
 ENV CUDA_NVCC_FLAGS=-fPIE
 ARG CARGO_FEATURES
 

--- a/Dockerfile-cuda-release
+++ b/Dockerfile-cuda-release
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.7
 
-ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.6.0-cudnn-runtime-ubuntu24.04
 
 FROM ${CUDA_RUNTIME_IMAGE} AS binary
 

--- a/Dockerfile-cuda-release
+++ b/Dockerfile-cuda-release
@@ -36,7 +36,7 @@ ARG CUDA_COMPUTE_CAP=80
 RUN mkdir /.duckdb/ && chmod 777 /.duckdb/
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends ca-certificates libssl3 tzdata \
+    && apt-get install --yes --no-install-recommends ca-certificates libssl3 tzdata cuda-compat-12-6 \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 RUN if echo "$CARGO_FEATURES" | grep -q "odbc"; then \
@@ -48,6 +48,7 @@ RUN if echo "$CARGO_FEATURES" | grep -q "odbc"; then \
 COPY --from=binary /root/spiced /usr/local/bin/spiced
 
 ENV CUDA_COMPUTE_CAP=${CUDA_COMPUTE_CAP}
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.6/compat:${LD_LIBRARY_PATH}
 
 WORKDIR /app
 

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.7
 
-ARG BASE_IMAGE=debian:bookworm-slim
+ARG BASE_IMAGE=debian:trixie-slim
 
 FROM ${BASE_IMAGE} AS binary
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Upgrades docker images to Ubuntu 24.04 as the runners that build binaries recently updated from 22.04 to 24.04 - causing library linker errors as 22.04 only has GLIBC 26, not the 28/29 as required by 24.04 (Debian Trixie equivalent)
* Adds post-build validation to make sure the image at least runs with `spiced --version` before publishing
* Successful build run: https://github.com/spiceai/spiceai/actions/runs/25198864300/job/73885455442