### PR TITLE
fix: GH connector - explicitly use AWS LC RS crypto provider for jwt, when GH App auth used

### DIFF
--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -18,7 +18,7 @@ limitations under the License.
 use std::{
     fmt,
     hash::DefaultHasher,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -34,6 +34,19 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
+
+// Ensure the aws-lc-rs crypto provider is installed for jsonwebtoken before the first JWT
+// operation. This is required because Cargo feature unification can activate both `aws_lc_rs`
+// and `rust_crypto` features simultaneously (e.g. via a transitive dep like octocrab), causing
+// jsonwebtoken's auto-detection to panic at runtime. Calling install_default() here makes it a
+// compile error if the `aws_lc_rs` feature is ever missing, and a safe no-op if already set.
+static JWT_CRYPTO_INIT: OnceLock<()> = OnceLock::new();
+
+fn ensure_jwt_crypto_provider() {
+    JWT_CRYPTO_INIT.get_or_init(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
 
 #[derive(Debug, Snafu)]
 pub enum GitHubAppError {
@@ -235,6 +248,8 @@ async fn generate_token(
     private_key: Arc<str>,
     installation_id: Arc<str>,
 ) -> Result<GitHubToken, GitHubAppError> {
+    ensure_jwt_crypto_provider();
+
     let iat = usize::try_from(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/runtime/src/token_providers/github_app_token.rs
+++ b/crates/runtime/src/token_providers/github_app_token.rs
@@ -44,6 +44,10 @@ static JWT_CRYPTO_INIT: OnceLock<()> = OnceLock::new();
 
 fn ensure_jwt_crypto_provider() {
     JWT_CRYPTO_INIT.get_or_init(|| {
+        // install_default() returns Err only if a provider is already installed by another caller
+        // (e.g. a test harness). That is not an error — any installed provider is acceptable here.
+        // The only real failure mode (aws_lc_rs feature missing) is a compile error: the symbol
+        // jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER would not exist.
         let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
     });
 }


### PR DESCRIPTION
## Summary

- GitHub connector with GitHub App credentials panics on all CI-built release binaries (rc1, rc2, rc3) since `jsonwebtoken` was upgraded from 9.x to 10.x
- Root cause: `jsonwebtoken` 10.x requires exactly one crypto backend feature (`aws_lc_rs` or `rust_crypto`) to be active. Cargo feature unification activates **both** simultaneously — `aws_lc_rs` from `runtime` and `rust_crypto` from `octocrab` (via `test-framework` dev-dependency) — causing `jsonwebtoken`'s auto-detection to install a panicking provider into its `OnceLock`
- Fix: explicitly call `jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default()` in `generate_token()`, the only site that uses JWT signing. This locks in the correct provider before any JWT operation regardless of how features were unified. Referencing the `aws_lc` submodule directly also makes it a **compile error** if the `aws_lc_rs` feature is ever missing, rather than a runtime panic