### PR TITLE
fix: preserve field and schema metadata in Vortex type transformation

### DIFF
--- a/crates/cayenne/src/schema.rs
+++ b/crates/cayenne/src/schema.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! Arrow schema transformations for Vortex compatibility.
 
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion_table_providers::UnsupportedTypeAction;
 
@@ -55,11 +55,9 @@ pub fn transform_schema_for_vortex(
                 "Converting Float16 field '{}' to Float32 for Vortex compatibility",
                 field.name()
             );
-            transformed_fields.push(std::sync::Arc::new(Field::new(
-                field.name(),
-                DataType::Float32,
-                field.is_nullable(),
-            )));
+            transformed_fields.push(std::sync::Arc::new(
+                field.as_ref().clone().with_data_type(DataType::Float32),
+            ));
             continue;
         }
 
@@ -71,11 +69,12 @@ pub fn transform_schema_for_vortex(
                 field.name(),
                 unit
             );
-            transformed_fields.push(std::sync::Arc::new(Field::new(
-                field.name(),
-                DataType::Timestamp(TimeUnit::Microsecond, tz.clone()),
-                field.is_nullable(),
-            )));
+            transformed_fields.push(std::sync::Arc::new(
+                field
+                    .as_ref()
+                    .clone()
+                    .with_data_type(DataType::Timestamp(TimeUnit::Microsecond, tz.clone())),
+            ));
             continue;
         }
 
@@ -89,11 +88,9 @@ pub fn transform_schema_for_vortex(
                         data_type,
                         field.name()
                     );
-                    transformed_fields.push(std::sync::Arc::new(Field::new(
-                        field.name(),
-                        DataType::Utf8,
-                        field.is_nullable(),
-                    )));
+                    transformed_fields.push(std::sync::Arc::new(
+                        field.as_ref().clone().with_data_type(DataType::Utf8),
+                    ));
                 }
                 UnsupportedTypeAction::Error => {
                     unsupported_fields.push(format!("'{}' (type: {:?})", field.name(), data_type));
@@ -126,11 +123,16 @@ pub fn transform_schema_for_vortex(
         )));
     }
 
-    Ok(Schema::new(transformed_fields))
+    Ok(Schema::new_with_metadata(
+        transformed_fields,
+        schema.metadata().clone(),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion_table_providers::UnsupportedTypeAction;
 
@@ -168,5 +170,57 @@ mod tests {
         )]);
         transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
             .expect_err("Duration should be unsupported");
+    }
+
+    #[test]
+    fn field_metadata_preserved_on_type_conversion() {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("logicalType".to_string(), "FIXED".to_string());
+        field_metadata.insert("scale".to_string(), "2".to_string());
+
+        let field = Field::new("x", DataType::Float16, false).with_metadata(field_metadata.clone());
+        let mut schema_metadata = HashMap::new();
+        schema_metadata.insert("source".to_string(), "snowflake".to_string());
+
+        let schema = Schema::new_with_metadata(vec![field], schema_metadata.clone());
+        let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect("should succeed");
+
+        assert_eq!(out.field(0).data_type(), &DataType::Float32);
+        assert_eq!(out.field(0).metadata(), &field_metadata);
+        assert_eq!(out.metadata(), &schema_metadata);
+    }
+
+    #[test]
+    fn field_metadata_preserved_on_timestamp_conversion() {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("logicalType".to_string(), "TIMESTAMP_NTZ".to_string());
+
+        let field = Field::new("ts", DataType::Timestamp(TimeUnit::Nanosecond, None), false)
+            .with_metadata(field_metadata.clone());
+        let schema = Schema::new(vec![field]);
+        let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect("should succeed");
+
+        assert_eq!(
+            out.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(out.field(0).metadata(), &field_metadata);
+    }
+
+    #[test]
+    fn field_metadata_preserved_on_unsupported_to_string() {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("originalType".to_string(), "interval".to_string());
+
+        let field = Field::new("d", DataType::Duration(TimeUnit::Second), false)
+            .with_metadata(field_metadata.clone());
+        let schema = Schema::new(vec![field]);
+        let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::String)
+            .expect("should succeed");
+
+        assert_eq!(out.field(0).data_type(), &DataType::Utf8);
+        assert_eq!(out.field(0).metadata(), &field_metadata);
     }
 }


### PR DESCRIPTION
## Summary

`transform_schema_for_vortex` used `Field::new(name, type, nullable)` when converting field types for Vortex compatibility (Float16→Float32, non-microsecond Timestamp→Microsecond, unsupported→Utf8). `Field::new` drops all field-level metadata (`dict_id`, `dict_is_ordered`, custom key-value pairs like Snowflake `logicalType` or Parquet extension annotations). Similarly, `Schema::new(fields)` dropped schema-level metadata.

This caused silent metadata loss when accelerating datasets through the Vortex engine — connectors that annotate fields with source-specific metadata (e.g., Snowflake logical types, Parquet extension metadata) would lose those annotations after the type transformation.

## Fix

- Replace `Field::new(name, new_type, nullable)` with `field.as_ref().clone().with_data_type(new_type)` to preserve all field metadata through type conversions
- Replace `Schema::new(fields)` with `Schema::new_with_metadata(fields, schema.metadata().clone())` to preserve schema-level metadata

## Test plan

- Added `field_metadata_preserved_on_type_conversion` — verifies Float16→Float32 preserves field metadata and schema metadata
- Added `field_metadata_preserved_on_timestamp_conversion` — verifies Nanosecond→Microsecond preserves field metadata
- Added `field_metadata_preserved_on_unsupported_to_string` — verifies Duration→Utf8 preserves field metadata
- `cargo clippy -p cayenne -- -D warnings` passes
- `cargo test -p cayenne` passes (12/12)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->