### PR TITLE
feat(datasets): add on-demand dataset loading

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -615,6 +615,7 @@ pub async fn run(args: Args) -> Result<()> {
     });
 
     let rt = Arc::new(rt);
+    rt.install_on_demand_loader();
 
     if needs_metrics {
         rt.init_cache_metrics();

--- a/crates/runtime-api-types/src/v1/status.rs
+++ b/crates/runtime-api-types/src/v1/status.rs
@@ -206,6 +206,9 @@ pub enum ComponentStatus {
 
     /// The component is in the process of shutting down
     ShuttingDown,
+
+    /// The component is configured but not loaded yet
+    NotLoaded,
 }
 
 impl ComponentStatus {
@@ -220,6 +223,7 @@ impl ComponentStatus {
             ComponentStatus::Error(_) => 3,
             ComponentStatus::Refreshing => 4,
             ComponentStatus::ShuttingDown => 5,
+            ComponentStatus::NotLoaded => 6,
         }
     }
 
@@ -270,6 +274,7 @@ impl Display for ComponentStatus {
             ComponentStatus::Error(_) => write!(f, "Error"),
             ComponentStatus::Refreshing => write!(f, "Refreshing"),
             ComponentStatus::ShuttingDown => write!(f, "ShuttingDown"),
+            ComponentStatus::NotLoaded => write!(f, "NotLoaded"),
         }
     }
 }
@@ -300,6 +305,7 @@ impl<'de> Deserialize<'de> for ComponentStatus {
             "Error" => Ok(ComponentStatus::Error(None)),
             "Refreshing" => Ok(ComponentStatus::Refreshing),
             "ShuttingDown" => Ok(ComponentStatus::ShuttingDown),
+            "NotLoaded" => Ok(ComponentStatus::NotLoaded),
             other => Err(serde::de::Error::unknown_variant(
                 other,
                 &[
@@ -309,6 +315,7 @@ impl<'de> Deserialize<'de> for ComponentStatus {
                     "Error",
                     "Refreshing",
                     "ShuttingDown",
+                    "NotLoaded",
                 ],
             )),
         }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -431,6 +431,11 @@ impl RuntimeBuilder {
             distributed,
             resource_monitor,
             config: Arc::clone(&self.runtime_config),
+            on_demand_datasets: Arc::new(RwLock::new(HashMap::new())),
+            on_demand_load_locks: Arc::new(Mutex::new(HashMap::new())),
+            dataset_load_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                dataset_parallelism.unwrap_or(tokio::sync::Semaphore::MAX_PERMITS),
+            )),
             telemetry_config: self.telemetry_config,
         };
 

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    CheckAvailability, Dataset, Error, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
+    CheckAvailability, Dataset, Error, Load, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
     acceleration, replication, validate_identifier,
 };
 use crate::Runtime;
@@ -63,6 +63,7 @@ pub struct DatasetBuilder {
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    pub load: Load,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -151,6 +152,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             runtime: None,
             vectors: dataset.vectors,
             check_availability: CheckAvailability::from(dataset.check_availability),
+            load: Load::from(dataset.load),
         })
     }
 }
@@ -182,6 +184,7 @@ impl DatasetBuilder {
             runtime: None,
             vectors: None,
             check_availability: CheckAvailability::default(),
+            load: Load::default(),
         })
     }
 
@@ -279,6 +282,7 @@ impl DatasetBuilder {
             runtime,
             vectors: self.vectors,
             check_availability: self.check_availability,
+            load: self.load,
         };
 
         Ok(dataset)

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -248,6 +248,34 @@ impl Display for CheckAvailability {
     }
 }
 
+/// Controls when a dataset is loaded by the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Load {
+    /// Load the dataset during runtime startup.
+    #[default]
+    OnStartup,
+    /// Load the dataset when it is first queried or explicitly refreshed.
+    OnDemand,
+}
+
+impl From<spicepod_dataset::Load> for Load {
+    fn from(load: spicepod_dataset::Load) -> Self {
+        match load {
+            spicepod_dataset::Load::OnStartup => Load::OnStartup,
+            spicepod_dataset::Load::OnDemand => Load::OnDemand,
+        }
+    }
+}
+
+impl Display for Load {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Load::OnStartup => write!(f, "on_startup"),
+            Load::OnDemand => write!(f, "on_demand"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Dataset {
     pub from: String,
@@ -271,6 +299,7 @@ pub struct Dataset {
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
     pub check_availability: CheckAvailability,
+    pub load: Load,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -296,6 +325,7 @@ impl std::fmt::Debug for Dataset {
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
             .field("check_availability", &self.check_availability)
+            .field("load", &self.load)
             .finish_non_exhaustive()
     }
 }
@@ -321,6 +351,7 @@ impl PartialEq for Dataset {
             && self.metrics == other.metrics
             && self.vectors == other.vectors
             && self.check_availability == other.check_availability
+            && self.load == other.load
     }
 }
 

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -527,6 +527,7 @@ impl DataFusionBuilder {
             pending_sink_tables: TokioRwLock::new(Vec::new()),
             deferred_tables: TokioRwLock::new(HashMap::new()),
             deferred_catalogs: TokioRwLock::new(HashMap::new()),
+            on_demand_table_loader: RwLock::new(None),
             accelerated_tables: TokioRwLock::new(HashSet::new()),
             accelerator_engine_registry: self.accelerator_engine_registry,
             acceleration_refresh_semaphore: self.accelerated_refresh_semaphore,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock, RwLock, Weak};
 use std::time::Duration;
 
 use crate::accelerated_table::refresh::{self, RefreshOverrides};
@@ -58,6 +58,7 @@ use crate::cluster::partition::service::PartitionService;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::error::ArrowError;
 use arrow_tools::schema::verify_schema;
+use async_trait::async_trait;
 use builder::DataFusionBuilder;
 use cache::TabledCacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
@@ -74,7 +75,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::physical_plan::collect;
-use datafusion::sql::parser::DFParser;
+use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{ResolvedTableReference, TableReference};
 use datafusion_expr::Expr;
@@ -540,6 +541,15 @@ struct DeferredTableRegistration {
     connector: Arc<dyn DataConnector>,
 }
 
+#[async_trait]
+pub trait OnDemandTableLoader: Send + Sync {
+    async fn has_on_demand_tables(&self) -> bool;
+    async fn load_on_demand_tables(
+        &self,
+        table_references: Vec<TableReference>,
+    ) -> std::result::Result<(), DataFusionError>;
+}
+
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     pub(crate) runtime_status: Arc<status::RuntimeStatus>,
@@ -557,6 +567,7 @@ pub struct DataFusion {
     pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
     deferred_tables: TokioRwLock<HashMap<String, DeferredTableRegistration>>,
     deferred_catalogs: TokioRwLock<HashMap<String, Arc<DeferredCatalogProvider>>>,
+    on_demand_table_loader: RwLock<Option<Weak<dyn OnDemandTableLoader>>>,
 
     pub(crate) accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     // Controls the parallelism of accelerated table refreshes
@@ -626,6 +637,19 @@ impl DataFusion {
 
     pub fn accelerator_engine_registry(&self) -> Arc<AcceleratorEngineRegistry> {
         Arc::clone(&self.accelerator_engine_registry)
+    }
+
+    pub fn set_on_demand_table_loader(&self, loader: Weak<dyn OnDemandTableLoader>) {
+        if let Ok(mut on_demand_table_loader) = self.on_demand_table_loader.write() {
+            *on_demand_table_loader = Some(loader);
+        }
+    }
+
+    fn on_demand_table_loader(&self) -> Option<Arc<dyn OnDemandTableLoader>> {
+        self.on_demand_table_loader
+            .read()
+            .ok()
+            .and_then(|loader| loader.as_ref().and_then(Weak::upgrade))
     }
 
     pub async fn get_table(
@@ -1121,6 +1145,33 @@ impl DataFusion {
             })?;
 
         Ok(table_provider)
+    }
+
+    async fn load_on_demand_tables_for_statement(
+        &self,
+        session: &SessionState,
+        statement: &Statement,
+    ) -> Result<(), DataFusionError> {
+        let Some(loader) = self.on_demand_table_loader() else {
+            return Ok(());
+        };
+        if !loader.has_on_demand_tables().await {
+            return Ok(());
+        }
+        let table_refs = session.resolve_table_references(statement)?;
+        loader.load_on_demand_tables(table_refs).await
+    }
+
+    pub async fn load_on_demand_dataset(
+        &self,
+        table_reference: TableReference,
+    ) -> Result<(), DataFusionError> {
+        let Some(loader) = self.on_demand_table_loader() else {
+            return Err(DataFusionError::Execution(format!(
+                "Cannot load on-demand dataset {table_reference}: on-demand loader is not initialized yet"
+            )));
+        };
+        loader.load_on_demand_tables(vec![table_reference]).await
     }
 
     pub async fn load_deferred_dataset(&self, table_reference: TableReference) -> Result<()> {
@@ -2801,6 +2852,11 @@ impl DataFusion {
         session: &SessionState,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
+        let dialect = session.config().options().sql_parser.dialect;
+        let statement = session.sql_to_statement(sql, &dialect)?;
+        self.load_on_demand_tables_for_statement(session, &statement)
+            .await?;
+
         let ctx = planner::PlannerContext {
             catalog_mode: if self.has_cayenne_catalog() {
                 planner::CatalogMode::Cayenne
@@ -2814,7 +2870,7 @@ impl DataFusion {
             io_runtime: self.io_runtime.clone(),
         };
 
-        planner::create_logical_plan(sql, session, &ctx).await
+        planner::create_logical_plan_from_statement(sql, statement, session, &ctx).await
     }
 
     /// On Windows the `planner` module is not available, so delegate
@@ -2825,7 +2881,11 @@ impl DataFusion {
         session: &SessionState,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
-        session.create_logical_plan(sql).await
+        let dialect = session.config().options().sql_parser.dialect;
+        let statement = session.sql_to_statement(sql, &dialect)?;
+        self.load_on_demand_tables_for_statement(session, &statement)
+            .await?;
+        session.statement_to_plan(statement).await
     }
 
     pub(crate) async fn clear_cached_plans(&self) {
@@ -3383,6 +3443,7 @@ mod tests {
                 runtime: Arc::new(runtime),
                 vectors: None,
                 check_availability: crate::component::dataset::CheckAvailability::Disabled,
+                load: crate::component::dataset::Load::OnStartup,
             }
         }
 

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -139,7 +139,15 @@ pub async fn create_logical_plan(
 ) -> DFResult<LogicalPlan> {
     let dialect = session.config().options().sql_parser.dialect;
     let statement = session.sql_to_statement(sql, &dialect)?;
+    create_logical_plan_from_statement(sql, statement, session, ctx).await
+}
 
+pub async fn create_logical_plan_from_statement(
+    sql: &str,
+    statement: Statement,
+    session: &SessionState,
+    ctx: &PlannerContext,
+) -> DFResult<LogicalPlan> {
     if let Statement::Statement(ref sql_stmt) = statement {
         match sql_stmt.as_ref() {
             SQLStatement::CreateTable(ct) if ct.like.is_some() => {

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -32,6 +32,7 @@ use datafusion::sql::TableReference;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use spicepod::component::dataset::Load;
 use tokio::sync::RwLock;
 
 use super::{Format, convert_entry_to_csv, dataset_status, require_write_access};
@@ -224,10 +225,15 @@ pub struct AccelerationRequest {
 
 /// Refresh Dataset
 ///
-/// Trigger an on-demand refresh for an accelerated dataset.
+/// Trigger an on-demand refresh for an accelerated dataset, or trigger the
+/// initial load of an on-demand (non-accelerated) dataset.
 ///
-/// This endpoint triggers an on-demand refresh for an accelerated dataset.
-/// The refresh only applies to `full` and `append` refresh modes (not `changes` mode).
+/// For accelerated datasets this triggers an on-demand refresh. The refresh
+/// only applies to `full` and `append` refresh modes (not `changes` mode).
+///
+/// For datasets configured with `load: on_demand` that are *not* accelerated,
+/// this endpoint triggers dataset initialization. Subsequent calls are
+/// idempotent (no-op) once the dataset has been loaded.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/datasets/{name}/acceleration/refresh",
@@ -248,7 +254,7 @@ pub struct AccelerationRequest {
         ))
     ),
     responses(
-        (status = 201, description = "Dataset refresh triggered successfully", content((
+        (status = 201, description = "Dataset refresh triggered (accelerated) or dataset loaded (on-demand) successfully", content((
             MessageResponse = "application/json",
             example = json!({
                 "message": "Dataset refresh triggered for taxi_trips."
@@ -260,7 +266,7 @@ pub struct AccelerationRequest {
                 "message": "Dataset taxi_trips not found"
             })
         ))),
-        (status = 400, description = "Acceleration not enabled for the dataset", content((
+        (status = 400, description = "Dataset is neither accelerated nor configured with load: on_demand; nothing to refresh or load", content((
             MessageResponse = "application/json",
             example = json!({
                 "message": "Dataset taxi_trips does not have acceleration enabled"
@@ -317,8 +323,9 @@ pub(crate) async fn refresh(
     };
 
     let acceleration_enabled = dataset.acceleration.as_ref().is_some_and(|f| f.enabled);
+    let is_on_demand = dataset.load == Load::OnDemand;
 
-    if !acceleration_enabled {
+    if !acceleration_enabled && !is_on_demand {
         return (
             status::StatusCode::BAD_REQUEST,
             Json(MessageResponse {
@@ -328,11 +335,32 @@ pub(crate) async fn refresh(
             .into_response();
     }
 
+    let table_ref = TableReference::parse_str(dataset.name.as_str());
+
+    if is_on_demand {
+        if let Err(err) = df.load_on_demand_dataset(table_ref.clone()).await {
+            return (
+                status::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(MessageResponse {
+                    message: format!("{err}"),
+                }),
+            )
+                .into_response();
+        }
+
+        if !acceleration_enabled {
+            return (
+                status::StatusCode::CREATED,
+                Json(MessageResponse {
+                    message: format!("Dataset {dataset_name} loaded."),
+                }),
+            )
+                .into_response();
+        }
+    }
+
     match df
-        .refresh_table(
-            &TableReference::parse_str(dataset.name.as_str()),
-            overrides_opt.map(|Json(overrides)| overrides),
-        )
+        .refresh_table(&table_ref, overrides_opt.map(|Json(overrides)| overrides))
         .await
     {
         Ok(_) => (

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -17,10 +17,12 @@ limitations under the License.
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Instant};
 
 use crate::cluster::partition::get_partition_filter_exprs;
+use crate::component::dataset::Load;
 use crate::component::dataset::acceleration::Mode;
 use crate::dataaccelerator::BootstrapStatus;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::caching_engine::CachingEngineSys;
+use crate::datafusion::OnDemandTableLoader;
 use crate::{
     AcceleratedTableInvalidChangesSnafu, AcceleratorEngineNotAvailableSnafu,
     AcceleratorInitializationFailedSnafu, Error, FullTextSearchRequiresAccelerationSnafu,
@@ -53,14 +55,34 @@ use crate::{
     warn_spaced,
 };
 use app::App;
-use datafusion::sql::TableReference;
+use async_trait::async_trait;
+use datafusion::{error::DataFusionError, sql::TableReference};
 #[cfg(any(feature = "duckdb", feature = "sqlite"))]
 use futures::StreamExt;
 use futures::future::join_all;
 use opentelemetry::KeyValue;
 use snafu::prelude::*;
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex, Semaphore};
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
+
+#[async_trait]
+impl OnDemandTableLoader for Runtime {
+    async fn has_on_demand_tables(&self) -> bool {
+        self.has_on_demand_datasets().await
+    }
+
+    async fn load_on_demand_tables(
+        &self,
+        table_references: Vec<TableReference>,
+    ) -> std::result::Result<(), DataFusionError> {
+        for table_reference in table_references {
+            self.load_on_demand_dataset(&table_reference)
+                .await
+                .map_err(|err| DataFusionError::External(Box::new(err)))?;
+        }
+        Ok(())
+    }
+}
 
 impl Runtime {
     pub(crate) async fn load_datasets(self: Arc<Self>) {
@@ -68,12 +90,9 @@ impl Runtime {
             return;
         };
 
-        // Control the number of parallel dataset loads
-        let semaphore = if let Some(parallel_num) = app.runtime.dataset_load_parallelism {
-            Arc::new(Semaphore::new(parallel_num))
-        } else {
-            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
-        };
+        // Use the shared semaphore so that startup and on-demand loads share
+        // the same `runtime.dataset_load_parallelism` budget.
+        let semaphore = Arc::clone(&self.dataset_load_semaphore);
 
         // Before loading datasets, we must initialize views accelerators (if any).
         // This is required for acceleration federation for some engines (e.g. `DuckDB`).
@@ -81,21 +100,34 @@ impl Runtime {
         self.initialize_views_accelerators(&valid_views).await;
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(&app, LogErrors(true));
+        let mut startup_datasets = Vec::new();
+        let mut on_demand_datasets = Vec::new();
+        for ds in valid_datasets {
+            if ds.load == Load::OnDemand {
+                on_demand_datasets.push(ds);
+            } else {
+                startup_datasets.push(ds);
+            }
+        }
+
+        self.register_on_demand_datasets(&on_demand_datasets).await;
 
         // Validate Cayenne snapshot consistency before initializing accelerators.
         // All Cayenne datasets sharing the same metadata directory must have the same
         // snapshot configuration (either all enabled or all disabled).
         let acceleration_sources: Vec<Arc<dyn AccelerationSource>> =
-            valid_datasets.iter().map(|ds| ds.clone_arc()).collect();
+            startup_datasets.iter().map(|ds| ds.clone_arc()).collect();
         if let Err(err) = validate_cayenne_snapshot_consistency(&acceleration_sources) {
             tracing::error!("{err}");
             return;
         }
 
-        let init_results = self.initialize_datasets_accelerators(&valid_datasets).await;
+        let init_results = self
+            .initialize_datasets_accelerators(&startup_datasets)
+            .await;
 
         // Validate that no datasets with snapshots share acceleration files
-        let initialized_sources: Vec<Arc<dyn AccelerationSource>> = valid_datasets
+        let initialized_sources: Vec<Arc<dyn AccelerationSource>> = startup_datasets
             .iter()
             .filter(|ds| init_results.get(&ds.name).is_some_and(Result::is_ok))
             .map(|ds| ds.clone_arc())
@@ -110,7 +142,7 @@ impl Runtime {
         let mut localpod_datasets = Vec::new();
 
         // First create futures for non-localpod datasets
-        for ds in &valid_datasets {
+        for ds in &startup_datasets {
             let bootstrap_status = match init_results.get(&ds.name) {
                 Some(Ok(status)) => status.clone(),
                 Some(Err(_)) => {
@@ -203,7 +235,7 @@ impl Runtime {
         // sentinel for real failures.
         let dispatched = spawned_tasks.len();
         let init_skipped = init_results.values().filter(|r| r.is_err()).count();
-        let total = valid_datasets.len();
+        let total = startup_datasets.len();
         if total > 0 {
             tracing::info!(
                 "Loading datasets: {dispatched} tasks dispatched, {init_skipped} skipped at accelerator init (of {total} total; localpod datasets may be chained)."
@@ -310,6 +342,152 @@ impl Runtime {
             })
     }
 
+    async fn register_on_demand_datasets(&self, datasets: &[Arc<Dataset>]) {
+        if datasets.is_empty() {
+            return;
+        }
+
+        let mut on_demand_datasets = self.on_demand_datasets.write().await;
+        for ds in datasets {
+            self.status
+                .update_dataset(&ds.name, status::ComponentStatus::NotLoaded);
+            on_demand_datasets.insert(ds.name.clone(), Arc::clone(ds));
+        }
+        tracing::info!(
+            "Configured {} datasets with load: on_demand; they will be loaded on first query or refresh.",
+            datasets.len()
+        );
+    }
+
+    async fn matching_on_demand_dataset(
+        &self,
+        table_reference: &TableReference,
+    ) -> Option<TableReference> {
+        let on_demand_datasets = self.on_demand_datasets.read().await;
+        let candidate = table_reference.to_string().to_ascii_lowercase();
+        let bare = table_reference.table().to_ascii_lowercase();
+        let candidate_is_bare = candidate == bare;
+
+        let mut bare_match: Option<TableReference> = None;
+
+        for key in on_demand_datasets.keys() {
+            let key_string = key.to_string();
+            let key_lower = key_string.to_ascii_lowercase();
+
+            if key_lower == candidate {
+                return Some(key.clone());
+            }
+
+            if !candidate_is_bare {
+                continue;
+            }
+
+            let matches_bare = key_lower == bare
+                || key_lower
+                    .rsplit('.')
+                    .next()
+                    .is_some_and(|part| part == bare);
+
+            if matches_bare {
+                if bare_match.is_some() {
+                    tracing::debug!(
+                        "Skipping on-demand load for ambiguous unqualified table reference {}",
+                        table_reference
+                    );
+                    return None;
+                }
+                bare_match = Some(key.clone());
+            }
+        }
+
+        bare_match
+    }
+
+    pub(crate) async fn has_on_demand_datasets(&self) -> bool {
+        !self.on_demand_datasets.read().await.is_empty()
+    }
+
+    pub(crate) async fn load_on_demand_dataset(
+        &self,
+        table_reference: &TableReference,
+    ) -> Result<()> {
+        let Some(dataset_key) = self.matching_on_demand_dataset(table_reference).await else {
+            return Ok(());
+        };
+
+        let load_lock = {
+            let mut locks = self.on_demand_load_locks.lock().await;
+            Arc::clone(
+                locks
+                    .entry(dataset_key.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(()))),
+            )
+        };
+        let _guard = load_lock.lock().await;
+
+        let Some(ds) = self
+            .on_demand_datasets
+            .read()
+            .await
+            .get(&dataset_key)
+            .cloned()
+        else {
+            return Ok(());
+        };
+
+        self.status
+            .update_dataset(&ds.name, status::ComponentStatus::Initializing);
+
+        let init_results = self
+            .initialize_datasets_accelerators(&[Arc::clone(&ds)])
+            .await;
+        let bootstrap_status = match init_results.get(&ds.name) {
+            Some(Ok(status)) => status.clone(),
+            Some(Err(err)) => {
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(err.to_string()),
+                );
+                return Err(Error::UnableToLoadDatasetConnector {
+                    dataset: ds.name.clone(),
+                });
+            }
+            None => {
+                let err = Error::UnableToLoadDatasetConnector {
+                    dataset: ds.name.clone(),
+                };
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(err.to_string()),
+                );
+                return Err(err);
+            }
+        };
+
+        let load_result = self
+            .try_load_dataset_once(
+                Arc::clone(&ds),
+                bootstrap_status,
+                Some(Arc::clone(&self.dataset_load_semaphore)),
+            )
+            .await;
+
+        match load_result {
+            Ok(()) => {
+                self.on_demand_datasets.write().await.remove(&dataset_key);
+                self.on_demand_load_locks.lock().await.remove(&dataset_key);
+                Ok(())
+            }
+            Err(err) => {
+                self.status.update_dataset(
+                    &ds.name,
+                    status::ComponentStatus::error_with_message(err.to_string()),
+                );
+                Err(err)
+            }
+        }
+    }
+
     async fn load_dataset_connector(&self, ds: Arc<Dataset>) -> Result<Arc<dyn DataConnector>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
         let source = ds.source();
@@ -373,6 +551,58 @@ impl Runtime {
         Ok(data_connector)
     }
 
+    async fn try_load_dataset_once(
+        &self,
+        ds: Arc<Dataset>,
+        bootstrap_status: BootstrapStatus,
+        load_semaphore: Option<Arc<Semaphore>>,
+    ) -> Result<()> {
+        let spaced_tracer = Arc::clone(&self.spaced_tracer);
+
+        if let Err(err) = validate_dataset(&ds) {
+            let ds_name = &ds.name;
+            metrics::datasets::LOAD_ERROR.add(1, &[]);
+            error_spaced!(spaced_tracer, "{}{err}", "");
+            self.status.update_dataset(
+                ds_name,
+                status::ComponentStatus::error_with_message(err.to_string()),
+            );
+            return Err(err);
+        }
+
+        let connector_start = Instant::now();
+        let connector = match self.load_dataset_connector(Arc::clone(&ds)).await {
+            Ok(connector) => {
+                tracing::debug!(dataset = %ds.name, duration_ms = connector_start.elapsed().as_millis(), "Dataset connector created");
+                connector
+            }
+            Err(err) => {
+                if !self.status.is_shutdown() {
+                    let ds_name = &ds.name;
+                    self.status.update_dataset(
+                        ds_name,
+                        status::ComponentStatus::error_with_message(err.to_string()),
+                    );
+                    metrics::datasets::LOAD_ERROR.add(1, &[]);
+                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
+                }
+                return Err(err);
+            }
+        };
+
+        // Check shutdown between connector load and registration.
+        if self.status.is_shutdown() {
+            return Err(crate::Error::UnableToInitializeDataConnector {
+                source: "Runtime is shutting down".into(),
+            });
+        }
+
+        let runtime = ds.runtime();
+        runtime
+            .register_loaded_dataset(ds, connector, None, bootstrap_status, load_semaphore)
+            .await
+    }
+
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
     ///
     /// The `load_semaphore` limits concurrent schema inference via
@@ -385,19 +615,6 @@ impl Runtime {
         bootstrap_status: BootstrapStatus,
         load_semaphore: Arc<Semaphore>,
     ) {
-        let spaced_tracer = Arc::clone(&self.spaced_tracer);
-
-        if let Err(err) = validate_dataset(&ds) {
-            let ds_name = &ds.name;
-            metrics::datasets::LOAD_ERROR.add(1, &[]);
-            error_spaced!(spaced_tracer, "{}{err}", "");
-            self.status.update_dataset(
-                ds_name,
-                status::ComponentStatus::error_with_message(err.to_string()),
-            );
-            return;
-        }
-
         let retry_strategy = FibonacciBackoffBuilder::new().max_retries(None).build();
 
         let runtime = Arc::clone(&self);
@@ -412,61 +629,21 @@ impl Runtime {
                 ));
             }
 
-            let connector_start = Instant::now();
-            let connector = match Arc::clone(&runtime)
-                .load_dataset_connector(Arc::clone(&ds))
-                .await
-            {
-                Ok(connector) => {
-                    tracing::debug!(dataset = %ds.name, duration_ms = connector_start.elapsed().as_millis(), "Dataset connector created");
-                    connector
-                }
-                Err(err) => {
-                    if runtime.status.is_shutdown() {
-                        // should not retry or trace error if runtime is shutting down
-                        return Err(RetryError::permanent(err));
-                    }
-
-                    let ds_name = &ds.name;
-                    runtime.status.update_dataset(
-                        ds_name,
-                        status::ComponentStatus::error_with_message(err.to_string()),
-                    );
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
-                    return Err(RetryError::transient(err));
-                }
-            };
-
-            // Check shutdown between connector load and registration.
-            if runtime.status.is_shutdown() {
-                return Err(RetryError::permanent(
-                    crate::Error::UnableToInitializeDataConnector {
-                        source: "Runtime is shutting down".into(),
-                    },
-                ));
-            }
-
-            if let Err(err) = Arc::clone(&runtime)
-                .register_loaded_dataset(
+            match runtime
+                .try_load_dataset_once(
                     Arc::clone(&ds),
-                    connector,
-                    None,
                     bootstrap_status.clone(),
                     Some(Arc::clone(&load_semaphore)),
                 )
                 .await
             {
-                if runtime.status.is_shutdown() {
-                    return Err(RetryError::permanent(err));
+                Ok(()) => Ok(()),
+                Err(err) if runtime.status.is_shutdown() => Err(RetryError::permanent(err)),
+                Err(err) if matches!(err, Error::PermanentDatasetFailure { .. }) => {
+                    Err(RetryError::permanent(err))
                 }
-                if matches!(err, Error::PermanentDatasetFailure { .. }) {
-                    return Err(RetryError::permanent(err));
-                }
-                return Err(RetryError::transient(err));
+                Err(err) => Err(RetryError::transient(err)),
             }
-
-            Ok(())
         });
 
         // Use tokio::select! so that backoff sleeps inside `retry` are immediately
@@ -1061,7 +1238,7 @@ impl Runtime {
 
         if let Some(notifier) = notifier {
             // spawn a background task to wait for the accelerated table to be ready before creating schedules
-            let runtime = Arc::clone(&self);
+            let runtime = ds.runtime();
             let ds = Arc::clone(&ds);
             let dataset_name = ds.name.to_string();
             tokio::task::spawn(async move {
@@ -1081,19 +1258,31 @@ impl Runtime {
         new_app: &Arc<App>,
     ) {
         let valid_datasets = Arc::clone(&self).get_valid_datasets(new_app, LogErrors(true));
+        let mut startup_datasets = Vec::new();
+        let mut on_demand_datasets = Vec::new();
+        for ds in valid_datasets {
+            if ds.load == Load::OnDemand {
+                on_demand_datasets.push(ds);
+            } else {
+                startup_datasets.push(ds);
+            }
+        }
+        self.register_on_demand_datasets(&on_demand_datasets).await;
 
         // Validate Cayenne snapshot consistency before initializing accelerators.
         let acceleration_sources: Vec<Arc<dyn AccelerationSource>> =
-            valid_datasets.iter().map(|ds| ds.clone_arc()).collect();
+            startup_datasets.iter().map(|ds| ds.clone_arc()).collect();
         if let Err(err) = validate_cayenne_snapshot_consistency(&acceleration_sources) {
             tracing::error!("{err}");
             return;
         }
 
-        let init_results = self.initialize_datasets_accelerators(&valid_datasets).await;
+        let init_results = self
+            .initialize_datasets_accelerators(&startup_datasets)
+            .await;
         let existing_datasets = Arc::clone(&self).get_valid_datasets(current_app, LogErrors(false));
 
-        for ds in &valid_datasets {
+        for ds in &startup_datasets {
             let bootstrap_status = match init_results.get(&ds.name) {
                 Some(Ok(status)) => status.clone(),
                 Some(Err(_)) => {
@@ -1151,6 +1340,8 @@ impl Runtime {
                     }
                 };
 
+                self.on_demand_datasets.write().await.remove(&ds_name);
+                self.on_demand_load_locks.lock().await.remove(&ds_name);
                 self.status
                     .update_dataset(&ds_name, status::ComponentStatus::Disabled);
                 Arc::clone(&self)
@@ -1328,5 +1519,105 @@ async fn update_cached_dataset_timestamps(dataset: &Dataset) {
                 dataset.name
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataconnector::{
+        ConnectorParams, DataConnectorFactory, DataConnectorResult, NewDataConnectorResult,
+        register_connector_factory,
+    };
+    use crate::parameters::ParameterSpec;
+    use async_trait::async_trait;
+    use datafusion::datasource::TableProvider;
+    use std::any::Any;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingConnectorFactory {
+        creates: Arc<AtomicUsize>,
+    }
+
+    impl DataConnectorFactory for CountingConnectorFactory {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn create(
+            &self,
+            _params: ConnectorParams,
+        ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+            let creates = Arc::clone(&self.creates);
+            Box::pin(async move {
+                creates.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::new(CountingConnector) as Arc<dyn DataConnector>)
+            })
+        }
+
+        fn prefix(&self) -> &'static str {
+            "counting_on_demand"
+        }
+
+        fn parameters(&self) -> &'static [ParameterSpec] {
+            &[]
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingConnector;
+
+    #[async_trait]
+    impl DataConnector for CountingConnector {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn read_provider(
+            &self,
+            _dataset: &Dataset,
+        ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+            unimplemented!("on-demand startup should not create or read from this connector")
+        }
+    }
+
+    #[tokio::test]
+    async fn load_on_demand_dataset_does_not_create_connector_at_startup() {
+        let creates = Arc::new(AtomicUsize::new(0));
+        register_connector_factory(
+            "counting_on_demand",
+            Arc::new(CountingConnectorFactory {
+                creates: Arc::clone(&creates),
+            }),
+        )
+        .await;
+
+        let mut dataset =
+            spicepod::component::dataset::Dataset::new("counting_on_demand:any", "lazy_dataset");
+        dataset.load = spicepod::component::dataset::Load::OnDemand;
+
+        let app = app::AppBuilder::new("on_demand_test")
+            .with_dataset(dataset)
+            .build();
+        let runtime = Arc::new(crate::Runtime::builder().with_app(app).build().await);
+
+        Arc::clone(&runtime).set_components_initializing().await;
+        Arc::clone(&runtime).load_datasets().await;
+
+        assert_eq!(creates.load(Ordering::SeqCst), 0);
+        let dataset_ref = TableReference::parse_str("lazy_dataset");
+        assert_eq!(
+            runtime.status().get_dataset_statuses().get(&dataset_ref),
+            Some(&status::ComponentStatus::NotLoaded)
+        );
+        assert!(
+            runtime
+                .on_demand_datasets()
+                .read()
+                .await
+                .contains_key(&dataset_ref)
+        );
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -36,9 +36,10 @@ use tools::factory::{ToolFactory, default_catalog_names};
 use util::force_shutdown_signal;
 use worker::WorkerRegistry;
 
+use crate::component::dataset::Load;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
-use crate::datafusion::DataFusion;
 use crate::datafusion::error::format_datafusion_error;
+use crate::datafusion::{DataFusion, OnDemandTableLoader};
 use crate::model::LLMResponsesModelStore;
 use crate::{auth::EndpointAuth, dataconnector::DataConnector};
 
@@ -538,6 +539,16 @@ pub struct Runtime {
 
     config: Arc<Config>,
 
+    /// Datasets configured with `load: on_demand` that have not been loaded yet.
+    on_demand_datasets: Arc<RwLock<HashMap<TableReference, Arc<component::dataset::Dataset>>>>,
+    /// Per-dataset locks to ensure concurrent triggers only load a dataset once.
+    on_demand_load_locks: Arc<Mutex<HashMap<TableReference, Arc<Mutex<()>>>>>,
+
+    /// Shared semaphore that bounds concurrent dataset schema inference
+    /// (`read_provider`) calls so that startup loads and on-demand loads both
+    /// honor `runtime.dataset_load_parallelism`.
+    dataset_load_semaphore: Arc<tokio::sync::Semaphore>,
+
     /// Handle for resolving the spicepod `TelemetryConfig` for anonymous
     /// telemetry. For executors this is set after the app definition is
     /// fetched from the scheduler; for all other modes it is set before
@@ -566,6 +577,13 @@ impl Runtime {
     #[must_use]
     pub fn datafusion(&self) -> Arc<DataFusion> {
         Arc::clone(&self.df)
+    }
+
+    #[must_use]
+    pub fn on_demand_datasets(
+        &self,
+    ) -> Arc<RwLock<HashMap<TableReference, Arc<component::dataset::Dataset>>>> {
+        Arc::clone(&self.on_demand_datasets)
     }
 
     #[must_use]
@@ -1228,8 +1246,12 @@ impl Runtime {
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(&app, LogErrors(false));
         for ds in &valid_datasets {
-            self.status
-                .update_dataset(&ds.name, ComponentStatus::Initializing);
+            let status = if ds.load == Load::OnDemand {
+                ComponentStatus::NotLoaded
+            } else {
+                ComponentStatus::Initializing
+            };
+            self.status.update_dataset(&ds.name, status);
         }
 
         if cfg!(feature = "models") {
@@ -1277,11 +1299,25 @@ impl Runtime {
         }
     }
 
+    /// Install the on-demand table loader on the embedded `DataFusion` so that
+    /// query planning and the refresh endpoint can trigger loads of
+    /// `load: on_demand` datasets. Should be called immediately after the
+    /// `Runtime` is wrapped in an `Arc`, before any servers start accepting
+    /// requests.
+    pub fn install_on_demand_loader(self: &Arc<Self>) {
+        let loader: Arc<dyn OnDemandTableLoader> = Arc::<Runtime>::clone(self);
+        self.df.set_on_demand_table_loader(Arc::downgrade(&loader));
+    }
+
     /// Will load all of the components of the Runtime, including `secret_stores`, `catalogs`, `datasets`, `models`, and `embeddings`.
     ///
     /// The future returned by this function will not resolve until all components have been loaded and marked as ready.
     /// This includes waiting for the first refresh of any accelerated tables to complete.
     pub async fn load_components(self: Arc<Self>) {
+        // Idempotent: ensures the loader is installed even when callers (tests,
+        // embedders) skip the `install_on_demand_loader` step.
+        self.install_on_demand_loader();
+
         Arc::clone(&self).set_components_initializing().await;
 
         Arc::clone(&self).start_extensions().await;

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -200,7 +200,7 @@ impl RuntimeStatus {
         // Record cluster node status metric
         // Map ComponentStatus to cluster status values: 0=Unknown, 1=Healthy, 2=Unhealthy, 3=Draining
         let status_value = match &status {
-            ComponentStatus::Initializing => 0,
+            ComponentStatus::Initializing | ComponentStatus::NotLoaded => 0,
             ComponentStatus::Ready | ComponentStatus::Refreshing => 1, // Refreshing is still healthy
             ComponentStatus::Disabled | ComponentStatus::Error(_) => 2,
             ComponentStatus::ShuttingDown => 3, // Draining

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -117,6 +117,18 @@ pub enum CheckAvailability {
     Disabled,
 }
 
+/// Controls when a dataset is loaded by the runtime.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Load {
+    /// Load the dataset during runtime startup.
+    #[default]
+    OnStartup,
+    /// Load the dataset when it is first queried or explicitly refreshed.
+    OnDemand,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
@@ -186,6 +198,13 @@ pub struct Dataset {
     /// and report metrics. Dataset availability is only checked if the dataset is not accelerated.
     #[serde(default, skip_serializing_if = "is_default")]
     pub check_availability: CheckAvailability,
+
+    /// Controls when this dataset is loaded by the runtime. Defaults to
+    /// `on_startup`. When set to `on_demand`, the dataset is not initialized at
+    /// runtime startup. The first query against the dataset (or an explicit
+    /// refresh) will trigger initialization.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub load: Load,
 }
 
 impl Nameable for Dataset {
@@ -219,6 +238,7 @@ impl Dataset {
             metrics: None,
             vectors: None,
             check_availability: CheckAvailability::default(),
+            load: Load::default(),
         }
     }
 
@@ -307,6 +327,7 @@ impl WithDependsOn<Dataset> for Dataset {
             metrics: self.metrics.clone(),
             vectors: self.vectors.clone(),
             check_availability: self.check_availability,
+            load: self.load,
         }
     }
 }
@@ -384,6 +405,8 @@ struct DatasetDeserializer {
     vectors: Option<VectorStore>,
     #[serde(default, skip_serializing_if = "is_default")]
     check_availability: CheckAvailability,
+    #[serde(default, skip_serializing_if = "is_default")]
+    load: Load,
 }
 
 #[expect(deprecated)]
@@ -435,7 +458,35 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             metrics: deserializer.metrics,
             vectors: deserializer.vectors,
             check_availability: deserializer.check_availability,
+            load: deserializer.load,
         })
+    }
+}
+
+#[cfg(test)]
+mod load_tests {
+    use super::*;
+    use yaml;
+
+    #[test]
+    fn test_load_default_is_on_startup() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.load, Load::OnStartup);
+    }
+
+    #[test]
+    fn test_load_on_demand_via_config() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+            load: on_demand
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.load, Load::OnDemand);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds dataset-level on-demand loading via `load: on_demand` (`load: on_startup` remains the default).

```yaml
datasets:
  - from: postgres:public.large_table
    name: large_table
    load: on_demand
```

Until triggered, the runtime does not create connector params, instantiate the connector, infer schema, initialize acceleration, register object stores, start refresh tasks, or register a placeholder table.

## Behavior

- Startup parses the dataset config and registers the dataset status as `NotLoaded`.
- Runtime stores unloaded dataset definitions in a lightweight on-demand registry.
- First query parses SQL once, extracts table references, asks the runtime loader to materialize matching on-demand datasets, then plans using the same parsed statement.
- `POST /v1/datasets/{name}/acceleration/refresh` also triggers loading. For non-accelerated on-demand datasets, it returns after loading; for accelerated datasets, it loads first and then triggers refresh.
- Concurrent triggers for the same dataset are coordinated with a per-dataset lock so the dataset is only initialized once.
- Failed loads remain registered for retry.

## Notes

- View deferral for views that depend on on-demand datasets is intentionally left for a follow-up commit.

## Tests

- `cargo check -p runtime -p spicepod`
- `cargo test -p spicepod`
- `cargo test -p runtime --lib init::dataset::tests::load_on_demand_dataset_does_not_create_connector_at_startup`
- `cargo test -p runtime --lib datafusion::tests::test_get_or_create_logical_plan`
- `make lint-rust`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->