### PR TITLE
Reuse existing snapshot update PRs

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -1,5 +1,5 @@
-name: 'Add benchmark snapshots to PR'
-description: 'Commits and pushes any updated benchmark snapshots to the current branch.'
+name: 'Add snapshots to PR'
+description: 'Commits and pushes updated snapshots to an automation PR.'
 inputs:
   token:
     description: 'GitHub token with permissions to push to the repository'
@@ -21,8 +21,8 @@ runs:
         if ! command -v gh &> /dev/null; then
           (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
             && sudo mkdir -p -m 755 /etc/apt/keyrings \
-            && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-            && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+            && out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            && cat "$out" | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
             && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
             && sudo mkdir -p -m 755 /etc/apt/sources.list.d \
             && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
@@ -31,37 +31,70 @@ runs:
         else
           echo "GH CLI is already installed"
         fi
-    - name: Upload benchmark snapshots to branch
+    - name: Upload snapshots to branch
       shell: bash
       run: |
-        BRANCH_ID=${{ github.run_id }}
-        BRANCH_NAME="snapshot-update/${BRANCH_ID}"
+        set -euo pipefail
+
+        EXISTING_PR_JSON="$(mktemp)"
+        gh pr list --state open --base trunk --limit 100 --json number,title,headRefName,author,body > "${EXISTING_PR_JSON}"
+        EXISTING_PR_NUMBER="$(jq -r --arg title "${PR_TITLE}" '
+          [.[]
+            | select(.title == $title)
+            | select(
+                .author.login == "github-actions[bot]"
+                or .author.login == "spiceaibot"
+                or ((.body // "") | contains("Automated snapshot update from workflow run"))
+                or ((.body // "") | contains("<!-- spice-snapshot-update -->"))
+              )]
+          | sort_by(.number)
+          | last
+          | .number // empty
+        ' "${EXISTING_PR_JSON}")"
+        EXISTING_PR_BRANCH="$(jq -r --argjson number "${EXISTING_PR_NUMBER:-0}" '
+          .[] | select(.number == $number) | .headRefName
+        ' "${EXISTING_PR_JSON}")"
+
+        if [[ -n "${EXISTING_PR_BRANCH}" ]]; then
+          BRANCH_NAME="${EXISTING_PR_BRANCH}"
+          echo "Found existing snapshot update PR #${EXISTING_PR_NUMBER}; updating ${BRANCH_NAME}"
+        else
+          RAW_BRANCH_NAME="${GITHUB_WORKFLOW:-snapshot-update}-${GITHUB_JOB:-job}-${PR_TITLE}"
+          BRANCH_SLUG="$(printf '%s' "${RAW_BRANCH_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' | cut -c1-80)"
+          BRANCH_NAME="snapshot-update/${BRANCH_SLUG:-${GITHUB_RUN_ID}}"
+        fi
 
         git config --global user.name 'Spice Snapshot Update Bot'
         git config --global user.email 'spiceaibot@spice.ai'
-        git checkout -b ${BRANCH_NAME}
+        git checkout -b "${BRANCH_NAME}"
         git add '*.snap'
         if git diff --cached --quiet; then
           echo "No changes to commit"
         else
-          git commit -m "${{ inputs.title }}"
-          if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
-            git pull --rebase origin ${BRANCH_NAME}
+          git commit -m "${PR_TITLE}"
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}"; then
+            if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+              git fetch --unshallow origin
+            fi
+            git fetch origin "${BRANCH_NAME}"
+            git rebase -X theirs "origin/${BRANCH_NAME}"
           fi
-          git push origin ${BRANCH_NAME}
+          git push origin "HEAD:${BRANCH_NAME}"
 
-          PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
-          if [[ -n "${PR_URL}" ]]; then
-            echo "PR already exists -> ${PR_URL}"
+          if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
+            PR_URL="$(gh pr view "${EXISTING_PR_NUMBER}" --json url --jq .url)"
+            echo "Updated existing PR -> ${PR_URL}"
             exit 0
           else
-            BODY="${{ inputs.description }}"
+            BODY="${PR_DESCRIPTION}"
             if [[ -z "${BODY}" ]]; then
-              BODY="Automated snapshot update from workflow run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+              BODY="$(printf 'Automated snapshot update from workflow run [#%s](%s/%s/actions/runs/%s).\n\n<!-- spice-snapshot-update -->' "${GITHUB_RUN_ID}" "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}")"
             fi
-            gh pr create --title "${{ inputs.title }}" --body "${BODY}" --base trunk --head ${BRANCH_NAME} --label kind/bug
-            gh pr merge --squash --auto ${BRANCH_NAME} || echo "Auto-merge not available for this branch; PR created and requires manual merge."
+            gh pr create --title "${PR_TITLE}" --body "${BODY}" --base trunk --head "${BRANCH_NAME}" --label kind/bug
+            gh pr merge --squash --auto "${BRANCH_NAME}" || echo "Auto-merge not available for this branch; PR created and requires manual merge."
           fi
         fi
       env:
         GH_TOKEN: ${{ inputs.token }}
+        PR_TITLE: ${{ inputs.title }}
+        PR_DESCRIPTION: ${{ inputs.description }}


### PR DESCRIPTION
Updates the shared snapshot-update action so scheduled integration snapshot runs reuse an existing open automation PR instead of creating a new PR on every run.

Summary:
- Detects matching open snapshot PRs by title and automation markers.
- Pushes new snapshot commits to the existing PR branch when one is found.
- Uses stable branch names for newly created snapshot PRs so future runs converge.
- Keeps action metadata aligned with its broader integration snapshot usage.

Validation:
- `ruby -ryaml -e 'YAML.load_file(".github/actions/push-snap-changes/action.yml")'`
- Embedded Bash parsed with `bash -n`
- `shellcheck -s bash /tmp/push-snap-step-*.sh`
- `git diff --check HEAD~1..HEAD -- .github/actions/push-snap-changes/action.yml`

Note: `actionlint` was not installed locally, so it was not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->