### PR TITLE
fix(benchmarks): redact non-deterministic partition_sizes in explain plan snapshots

### DIFF
--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -69,6 +69,7 @@ pub async fn record_explain_plan(
             (CAYENNE_PATH_FILTER_PATTERN, CAYENNE_PATH_FILTER_REPLACEMENT),
             (VORTEX_RANGE_FILTER_PATTERN, VORTEX_RANGE_FILTER_REPLACEMENT),
             (r"required_guarantees=\[[^\]]*\]", "required_guarantees=[N]"),
+            (r"partition_sizes=\[[^\]]*\]", "partition_sizes=[<redacted>]"),
             (r#"grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\),\s*grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\)"#, "<GROUPING_PAIR>"),
             (r#"grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\),\s*grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\)"#, "<GROUPING_PAIR>")
         ],


### PR DESCRIPTION
## 📝 Summary


PR redacts `partition_sizes=[...]` to `partition_sizes=[<redacted>]` in explain plan snapshot filters. The per-partition row group distribution is non-deterministic for accelerated datasets using `LIMIT` without `ORDER BY`, causing flaky snapshot failures.

Example configuration that produces non-deterministic partitions:

```yaml
acceleration:
  refresh_sql: "SELECT * FROM hits LIMIT 50000000"
  partition_by:
    - bucket(5, "EventDate")
```

`LIMIT` without `ORDER BY` selects a non-deterministic subset of rows each run, causing slightly different row counts per `EventDate` bucket and therefore different `partition_sizes`.

The plan shape, operators, filters, and partition count (`partitions=N`) remain validated — only the per-partition size distribution is redacted.

Example failure: https://github.com/spiceai/spiceai/actions/runs/25251818683/job/74044932596

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->