### PR TITLE
ci: guard Install protoc step with relevant_changes check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,6 +105,7 @@ jobs:
         uses: ./.github/actions/setup-cc
 
       - name: Install protoc
+        if: needs.check_changes.outputs.relevant_changes == 'true'
         uses: ./.github/actions/install-protoc
 
       - name: Set up sccache


### PR DESCRIPTION
## Summary

- The `Install protoc` step in the Build Test Binary job (integration.yml) is missing the `if: needs.check_changes.outputs.relevant_changes == 'true'` guard that gates every other step in that job.
- When a PR has no relevant code changes (e.g. only `openapi.json` or `spicepod-schema.json` updates), `actions/checkout` is skipped and the workspace stays empty. The unguarded `Install protoc` step then fails at job setup with `Can't find 'action.yml'... install-protoc`, taking down `Build Test Binary` for every non-Rust PR.
- This regressed in #10566 when the step switched from `arduino/setup-protoc` (a remote action that needs no checkout) to the local `./.github/actions/install-protoc` action.

## Test plan

- [ ] Wait for CI on this PR — Rust changes? No, the PR itself is workflow-only (under `.github/`), which still matches the `relevant_changes` filter, so `Build Test Binary` will run.
- [ ] After merge, re-run CI on a non-Rust PR (e.g. #10501 / #10612) and confirm `Build Test Binary` is skipped cleanly instead of failing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->