### PR TITLE
feat(http): per-user caching for HTTP datasets via sensitive headers and accelerator header keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5394,6 +5394,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "snafu",
  "snowflake-api",
  "spark-connect-rs",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -31,6 +31,7 @@ azure_data_cosmos = { version = "0.30.0", default-features = false, features = [
     "key_auth",
 ], optional = true }
 base64.workspace = true
+sha2.workspace = true
 bb8 = { workspace = true, optional = true }
 bb8-oracle = { version = "0.3", features = ["chrono"], optional = true }
 bigdecimal = { workspace = true, optional = true }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -330,6 +330,15 @@ struct RequestFilterOptions {
     max_body_bytes: usize,
     max_headers_length: usize,
     allowed_headers: HashSet<HeaderName>,
+    /// Header names whose values are treated as sensitive (e.g. bearer tokens).
+    /// Listing a header here permits it in `allowed_headers` even when HTTP
+    /// authentication is configured, causes its value to be redacted in logs and
+    /// error messages, and causes its value to be replaced with a deterministic
+    /// hash before being written into HTTP cache keys or the `request_headers`
+    /// row column persisted by the accelerator. The raw value is still forwarded
+    /// upstream verbatim for authentication.
+    /// See `request_headers_sensitive` dataset parameter.
+    sensitive_headers: HashSet<HeaderName>,
 }
 
 impl Default for RequestFilterOptions {
@@ -340,6 +349,7 @@ impl Default for RequestFilterOptions {
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             max_headers_length: DEFAULT_MAX_HEADERS_LENGTH,
             allowed_headers: HashSet::new(),
+            sensitive_headers: HashSet::new(),
         }
     }
 }
@@ -352,6 +362,79 @@ impl RequestFilterOptions {
     fn is_enabled(&self, kind: RequestFilterKind) -> bool {
         self.enabled_filters.contains(&kind)
     }
+
+    /// True when at least one header is marked sensitive.
+    fn has_sensitive_headers(&self) -> bool {
+        !self.sensitive_headers.is_empty()
+    }
+
+    /// Returns a JSON object string equivalent to `raw` but with the values of
+    /// any sensitive headers replaced by a deterministic hash (prefixed with
+    /// [`SENSITIVE_HASH_PREFIX`]). Returns `raw` unchanged when no sensitive
+    /// headers are configured, when `raw` is not a JSON object, or when no
+    /// sensitive header is present in the object.
+    ///
+    /// Determinism (same input value -> same hash) is required so that two
+    /// requests from the same end client (same bearer token) produce the same
+    /// cache key and therefore share a cached response. The hash is one-way,
+    /// so a redacted value cannot be replayed against the upstream API.
+    fn redact_sensitive_request_headers(&self, raw: &str) -> String {
+        if !self.has_sensitive_headers() {
+            return raw.to_string();
+        }
+        let Ok(serde_json::Value::Object(mut obj)) = serde_json::from_str::<serde_json::Value>(raw)
+        else {
+            // Not a JSON object: leave alone. Validation elsewhere rejects
+            // these inputs before they reach a cache key, so the only way to
+            // hit this branch is via direct test usage.
+            return raw.to_string();
+        };
+        let mut changed = false;
+        for (name, value) in obj.iter_mut() {
+            let Ok(header_name) = HeaderName::try_from(name.as_str()) else {
+                continue;
+            };
+            if !self.sensitive_headers.contains(&header_name) {
+                continue;
+            }
+            if let Some(s) = value.as_str() {
+                *value = serde_json::Value::String(hash_sensitive_value(s));
+                changed = true;
+            }
+        }
+        if !changed {
+            return raw.to_string();
+        }
+        serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_else(|_| raw.to_string())
+    }
+}
+
+/// Prefix used to mark a hashed sensitive header value in cache keys and the
+/// persisted `request_headers` row column. The accelerator uses this prefix to
+/// detect rows that cannot be background-refreshed (the upstream call would
+/// require the original token, which is not recoverable from the hash).
+pub const SENSITIVE_HASH_PREFIX: &str = "spice-redacted-sha256:";
+
+/// Compute a deterministic, one-way hash of a sensitive header value, prefixed
+/// so consumers can recognize it as a redacted token rather than a real value.
+#[must_use]
+pub fn hash_sensitive_value(value: &str) -> String {
+    use base64::Engine;
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(value.as_bytes());
+    format!(
+        "{SENSITIVE_HASH_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+    )
+}
+
+/// True if `headers_json` contains any value that has been redacted via
+/// [`hash_sensitive_value`]. Used by the caching accelerator to skip
+/// background refresh of rows whose original token is not recoverable.
+#[must_use]
+pub fn request_headers_contain_redacted_value(headers_json: &str) -> bool {
+    // Cheap substring check is sufficient because the prefix is namespaced.
+    headers_json.contains(SENSITIVE_HASH_PREFIX)
 }
 
 struct HttpFetchResult {
@@ -559,6 +642,34 @@ impl HttpTableProvider {
         self
     }
 
+    /// Mark the supplied header names as sensitive. Sensitive headers may
+    /// appear in `request_header_allowlist` even when HTTP authentication is
+    /// configured (the conflict guard in `enable_header_filters` and
+    /// `parse_request_headers` is lifted for them). Their values are also
+    /// redacted in logs and error messages.
+    ///
+    /// Note: this should be called *before* `enable_header_filters` so the
+    /// allowlist validation can honor the sensitive set.
+    pub fn with_sensitive_headers<I, S>(mut self, header_names: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut sensitive = HashSet::new();
+        for header_name in header_names {
+            let raw = header_name.as_ref().trim();
+            if raw.is_empty() {
+                continue;
+            }
+            let parsed = HeaderName::try_from(raw).map_err(|e| Error::Configuration {
+                message: format!("Invalid request_headers_sensitive entry '{raw}': {e}"),
+            })?;
+            sensitive.insert(parsed);
+        }
+        self.request_filter_options.sensitive_headers = sensitive;
+        Ok(self)
+    }
+
     pub fn enable_header_filters<I, S>(mut self, max_length: usize, header_names: I) -> Result<Self>
     where
         I: IntoIterator<Item = S>,
@@ -576,10 +687,18 @@ impl HttpTableProvider {
             let parsed = HeaderName::try_from(raw).map_err(|e| Error::Configuration {
                 message: format!("Invalid request_header_allowlist entry '{raw}': {e}"),
             })?;
+            // Allow `authorization` in the allowlist when HTTP authentication
+            // is configured, but only if the header is also marked sensitive.
+            // This supports per-user caching where the bearer token comes from
+            // the client request rather than the dataset's static auth.
+            let is_sensitive = self
+                .request_filter_options
+                .sensitive_headers
+                .contains(&parsed);
             ensure!(
-                !(self.auth.is_some() && parsed == AUTHORIZATION),
+                !(self.auth.is_some() && parsed == AUTHORIZATION && !is_sensitive),
                 ConfigurationSnafu {
-                    message: "request_header_allowlist cannot include 'authorization' when HTTP authentication is configured. Remove 'authorization' from request_header_allowlist or disable HTTP authentication.".to_string()
+                    message: "request_header_allowlist cannot include 'authorization' when HTTP authentication is configured. Either remove 'authorization' from request_header_allowlist, disable HTTP authentication, or add 'authorization' to request_headers_sensitive to acknowledge that per-request bearer tokens override the dataset-level auth.".to_string()
                 }
             );
             allowed_headers.insert(parsed);
@@ -814,6 +933,7 @@ impl HttpTableProvider {
     }
 
     /// Extract path and query from filters
+    #[cfg_attr(not(test), allow(dead_code))]
     fn get_cache_key(
         path: &str,
         query: Option<&str>,
@@ -821,6 +941,30 @@ impl HttpTableProvider {
         request_headers: Option<&str>,
     ) -> CacheKey {
         CacheKey::new(path, query, body, request_headers)
+    }
+
+    /// Like [`Self::get_cache_key`] but redacts the values of any headers
+    /// marked sensitive (`request_headers_sensitive`) before they are folded
+    /// into the cache key. The raw value is never stored in the cache.
+    fn get_cache_key_with_redacted_headers(
+        &self,
+        path: &str,
+        query: Option<&str>,
+        body: Option<&str>,
+        request_headers: Option<&str>,
+    ) -> CacheKey {
+        let redacted = self.redact_request_headers_for_storage(request_headers);
+        CacheKey::new(path, query, body, redacted.as_deref())
+    }
+
+    /// Returns a copy of `request_headers` with the values of any sensitive
+    /// headers replaced by a one-way hash. Used for everything that persists or
+    /// keys on the headers JSON (HTTP cache key, the `request_headers` row
+    /// column written to the accelerator). The raw JSON is still required for
+    /// the live upstream request and must be obtained separately.
+    fn redact_request_headers_for_storage(&self, raw: Option<&str>) -> Option<String> {
+        let raw = raw?;
+        Some(self.request_filter_options.redact_sensitive_request_headers(raw))
     }
 
     /// Validates the HTTP endpoint by attempting a request to a custom health probe path if configured,
@@ -1017,7 +1161,7 @@ impl HttpTableProvider {
         request_headers: Option<&str>,
         result: &HttpFetchResult,
     ) {
-        let cache_key = Self::get_cache_key(path, query, body, request_headers);
+        let cache_key = self.get_cache_key_with_redacted_headers(path, query, body, request_headers);
         let cached_response = CachedResponse {
             content: Arc::new(result.content.clone()),
             cached_at: SystemTime::now(),
@@ -1280,7 +1424,7 @@ impl HttpTableProvider {
                 .await;
         }
 
-        let cache_key = Self::get_cache_key(path, query, body, request_headers);
+        let cache_key = self.get_cache_key_with_redacted_headers(path, query, body, request_headers);
 
         // Try to get from cache
         let cached = {
@@ -1632,7 +1776,12 @@ impl HttpExec {
         let path_for_batch = path.unwrap_or("");
         let query_for_batch = query.unwrap_or("");
         let body_for_batch = body.unwrap_or("");
-        let headers_for_batch = request_headers.unwrap_or("");
+        let headers_for_batch_owned = self
+            .provider
+            .redact_request_headers_for_storage(request_headers);
+        let headers_for_batch = headers_for_batch_owned
+            .as_deref()
+            .unwrap_or("");
 
         tracing::debug!(
             "Creating batch with request_path={:?}, content_len={}, num_rows={}",
@@ -3065,9 +3214,17 @@ impl HttpTableProvider {
                 });
             }
 
-            if self.auth.is_some() && header_name == AUTHORIZATION {
+            // The same authorization conflict guard as `enable_header_filters`:
+            // permit `authorization` to flow through when the dataset has opted
+            // in via `request_headers_sensitive`, signalling that per-request
+            // bearer tokens are intended to override the dataset-level auth.
+            let is_sensitive = self
+                .request_filter_options
+                .sensitive_headers
+                .contains(&header_name);
+            if self.auth.is_some() && header_name == AUTHORIZATION && !is_sensitive {
                 return Err(Error::FilterRejected {
-                    message: "The 'request_headers' object cannot set 'authorization' when HTTP authentication is configured. Remove 'authorization' from request_headers or disable HTTP authentication.".to_string(),
+                    message: "The 'request_headers' object cannot set 'authorization' when HTTP authentication is configured. Either remove 'authorization' from request_headers, disable HTTP authentication, or add 'authorization' to request_headers_sensitive on the dataset.".to_string(),
                 });
             }
 
@@ -3737,6 +3894,142 @@ mod tests {
             }
             other => panic!("Unexpected error: {other:?}"),
         }
+    }
+
+    /// When `authorization` is in `request_headers_sensitive`, it should be allowed
+    /// in `request_header_allowlist` even when HTTP authentication is configured.
+    /// This is the per-user caching scenario where the bearer token comes from the
+    /// client request rather than the dataset-level auth.
+    #[test]
+    fn test_sensitive_authorization_allowlist_with_auth() {
+        base_provider()
+            .with_sensitive_headers(vec!["authorization"])
+            .expect("sensitive headers should accept authorization")
+            .with_auth(Arc::new(TestAuthenticator))
+            .enable_header_filters(DEFAULT_MAX_HEADERS_LENGTH, vec!["authorization"])
+            .expect(
+                "authorization should be allowlistable when also marked sensitive and auth is set",
+            );
+    }
+
+    /// When `authorization` is in `request_headers_sensitive`, dynamic
+    /// `request_headers` filters carrying an `authorization` value should be
+    /// accepted even when HTTP authentication is configured.
+    #[test]
+    fn test_sensitive_authorization_filter_with_auth() {
+        let provider = base_provider()
+            .with_sensitive_headers(vec!["authorization"])
+            .expect("sensitive headers should accept authorization")
+            .with_auth(Arc::new(TestAuthenticator))
+            .enable_header_filters(DEFAULT_MAX_HEADERS_LENGTH, vec!["authorization"])
+            .expect("sensitive authorization is allowlisted under HTTP auth");
+        let filters = vec![Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(Expr::Column(Column::from_name("request_headers"))),
+            op: Operator::Eq,
+            right: Box::new(Expr::Literal(
+                ScalarValue::Utf8(Some(r#"{"authorization":"Bearer abc"}"#.to_string())),
+                None,
+            )),
+        })];
+
+        let partitions = provider
+            .extract_partitions(&filters)
+            .expect("sensitive authorization filter should be accepted");
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(
+            partitions[0],
+            (
+                None,
+                None,
+                None,
+                Some(r#"{"authorization":"Bearer abc"}"#.to_string())
+            )
+        );
+    }
+
+    /// `with_sensitive_headers` should reject malformed header names early.
+    #[test]
+    fn test_sensitive_headers_rejects_invalid_name() {
+        let err = base_provider()
+            .with_sensitive_headers(vec!["not a valid header"])
+            .expect_err("invalid header name should be rejected");
+        let message = format!("{err}");
+        assert!(message.contains("request_headers_sensitive"));
+    }
+
+    /// The hash is deterministic, prefixed with the documented sentinel, and
+    /// distinguishes different inputs. Determinism is required so the same
+    /// bearer token produces the same cache key on every request.
+    #[test]
+    fn test_hash_sensitive_value_is_deterministic_and_distinct() {
+        let h1 = hash_sensitive_value("Bearer abc");
+        let h2 = hash_sensitive_value("Bearer abc");
+        let h3 = hash_sensitive_value("Bearer xyz");
+        assert_eq!(h1, h2, "hash must be deterministic");
+        assert_ne!(h1, h3, "different inputs must hash to different values");
+        assert!(
+            h1.starts_with(SENSITIVE_HASH_PREFIX),
+            "hash must carry the sentinel prefix; got {h1}"
+        );
+        assert!(
+            !h1.contains("abc"),
+            "raw token must not appear in hashed value: {h1}"
+        );
+        assert!(request_headers_contain_redacted_value(
+            &format!(r#"{{"authorization":"{h1}"}}"#)
+        ));
+        assert!(!request_headers_contain_redacted_value(
+            r#"{"authorization":"Bearer abc"}"#
+        ));
+    }
+
+    /// When a header is marked sensitive, redaction replaces only that
+    /// header's value with the hashed sentinel; non-sensitive header values are
+    /// passed through verbatim.
+    #[test]
+    fn test_redact_sensitive_request_headers_replaces_only_listed_headers() {
+        let provider = base_provider()
+            .with_sensitive_headers(vec!["authorization"])
+            .expect("sensitive headers configured")
+            .enable_header_filters(
+                DEFAULT_MAX_HEADERS_LENGTH,
+                vec!["authorization", "x-region"],
+            )
+            .expect("allowlist configured");
+
+        let raw = r#"{"authorization":"Bearer abc","x-region":"us-west"}"#;
+        let redacted = provider
+            .request_filter_options
+            .redact_sensitive_request_headers(raw);
+
+        assert!(
+            !redacted.contains("Bearer abc"),
+            "raw token must not appear in redacted output: {redacted}"
+        );
+        assert!(
+            redacted.contains("us-west"),
+            "non-sensitive header value must be preserved: {redacted}"
+        );
+        assert!(
+            redacted.contains(SENSITIVE_HASH_PREFIX),
+            "redacted output must include the sentinel prefix: {redacted}"
+        );
+        // Determinism check via the public helper.
+        let again = provider
+            .request_filter_options
+            .redact_sensitive_request_headers(raw);
+        assert_eq!(redacted, again);
+    }
+
+    /// Without any sensitive headers configured, redaction is a no-op.
+    #[test]
+    fn test_redact_sensitive_request_headers_noop_when_unconfigured() {
+        let provider = base_provider();
+        let raw = r#"{"authorization":"Bearer abc"}"#;
+        let out = provider
+            .request_filter_options
+            .redact_sensitive_request_headers(raw);
+        assert_eq!(out, raw);
     }
 
     #[test]

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -438,6 +438,7 @@ impl CacheRefreshHelper {
         dataset_name: &str,
         ttl: Duration,
         accelerator_write_mutex: Arc<Mutex<()>>,
+        allowed_request_headers: &[String],
     ) -> DataFusionResult<usize> {
         let ctx = SessionContext::new();
         let state = ctx.state();
@@ -470,7 +471,8 @@ impl CacheRefreshHelper {
         let stale_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
 
         // Extract unique filter sets from stale rows
-        let filter_sets = Self::extract_unique_filter_sets(&stale_batches)?;
+        let filter_sets =
+            Self::extract_unique_filter_sets(&stale_batches, allowed_request_headers)?;
 
         let total_stale_rows: usize = stale_batches.iter().map(RecordBatch::num_rows).sum();
         tracing::debug!(
@@ -603,15 +605,27 @@ impl CacheRefreshHelper {
         Ok(refreshed_rows)
     }
 
-    /// Extract filter expressions from a row containing `request_path`, `request_query`, `request_body`
+    /// Extract filter expressions from a row containing `request_path`, `request_query`, `request_body`,
+    /// and (when `allowed_request_headers` is non-empty) `request_headers`.
+    ///
+    /// Returns `Ok(None)` when the row carries a redacted sensitive header
+    /// value (see [`data_components::http::provider::SENSITIVE_HASH_PREFIX`])
+    /// in `request_headers`. Such rows cannot be replayed against the upstream
+    /// API because the original token has been one-way hashed; they will
+    /// instead expire via TTL and be re-populated on the next live request.
     fn extract_filters_from_row(
         batch: &RecordBatch,
         row_idx: usize,
-    ) -> DataFusionResult<Vec<Expr>> {
+        allowed_request_headers: &[String],
+    ) -> DataFusionResult<Option<Vec<Expr>>> {
         let schema = batch.schema();
         let mut filters = Vec::new();
 
-        let filter_columns = ["request_path", "request_query", "request_body"];
+        let mut filter_columns: Vec<&str> =
+            vec!["request_path", "request_query", "request_body"];
+        if !allowed_request_headers.is_empty() {
+            filter_columns.push("request_headers");
+        }
 
         for column_name in filter_columns {
             if let Some((idx, _)) = schema.column_with_name(column_name) {
@@ -629,6 +643,17 @@ impl CacheRefreshHelper {
                     let value = array.value(row_idx).to_string();
                     // Only add filter if value is non-empty (empty string means no filter)
                     if !value.is_empty() {
+                        if column_name == "request_headers"
+                            && data_components::http::provider::request_headers_contain_redacted_value(
+                                &value,
+                            )
+                        {
+                            tracing::debug!(
+                                "Skipping background refresh of row with redacted sensitive header value; \
+                                 row will be re-populated lazily on next live request."
+                            );
+                            return Ok(None);
+                        }
                         tracing::debug!("Extracted {column_name} filter: {value}");
                         filters.push(col(column_name).eq(lit(value)));
                     }
@@ -640,22 +665,31 @@ impl CacheRefreshHelper {
             "Extracted {} total filters from row (including empty values)",
             filters.len()
         );
-        Ok(filters)
+        Ok(Some(filters))
     }
 
     /// Extract unique filter sets from batches, deduplicating rows with identical
-    /// `(request_path, request_query, request_body)` values.
+    /// `(request_path, request_query, request_body[, request_headers])` values.
     ///
     /// This is needed because HTTP connector JSON array responses are stored as multiple rows
     /// with identical request parameters. Without deduplication, refreshing N rows from the
     /// same JSON array would trigger N identical HTTP requests.
-    fn extract_unique_filter_sets(batches: &[RecordBatch]) -> DataFusionResult<Vec<Vec<Expr>>> {
+    fn extract_unique_filter_sets(
+        batches: &[RecordBatch],
+        allowed_request_headers: &[String],
+    ) -> DataFusionResult<Vec<Vec<Expr>>> {
         let mut seen_filter_keys = std::collections::HashSet::new();
         let mut filter_sets: Vec<Vec<Expr>> = Vec::new();
 
         for batch in batches {
             for row_idx in 0..batch.num_rows() {
-                let row_filters = Self::extract_filters_from_row(batch, row_idx)?;
+                let Some(row_filters) =
+                    Self::extract_filters_from_row(batch, row_idx, allowed_request_headers)?
+                else {
+                    // Row carries a redacted sensitive header value and cannot
+                    // be background-refreshed.
+                    continue;
+                };
                 let cache_key = compute_cache_key_from_filters(&row_filters);
                 if seen_filter_keys.insert(cache_key) {
                     filter_sets.push(row_filters);
@@ -2054,6 +2088,146 @@ mod tests {
         ]))
     }
 
+    /// A row whose `request_headers` value contains a redacted sensitive header
+    /// (sentinel-prefixed hash) cannot be replayed against upstream and must be
+    /// skipped during background refresh — the row will instead be re-populated
+    /// lazily on the next live request from a user with the matching token.
+    #[test]
+    fn test_extract_filters_from_row_skips_redacted_request_headers() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("request_path", DataType::Utf8, true),
+            Field::new("request_query", DataType::Utf8, true),
+            Field::new("request_body", DataType::Utf8, true),
+            Field::new("request_headers", DataType::Utf8, true),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
+            Field::new(
+                CACHE_REFRESHED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        ]));
+
+        let hashed =
+            data_components::http::provider::hash_sensitive_value("Bearer abc");
+        let redacted_headers_json = format!(r#"{{"authorization":"{hashed}"}}"#);
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec![Some("/api/users"), Some("/api/users")])),
+                Arc::new(StringArray::from(vec![Some("page=1"), Some("page=1")])),
+                Arc::new(StringArray::from(vec![None::<&str>, None])),
+                Arc::new(StringArray::from(vec![
+                    Some(redacted_headers_json.as_str()),
+                    Some(r#"{"x-region":"us-west"}"#),
+                ])),
+                Arc::new(UInt16Array::from(vec![200, 200])),
+                Arc::new(TimestampNanosecondArray::from(vec![Some(now), Some(now)])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        let allowed = vec!["authorization".to_string(), "x-region".to_string()];
+
+        // Row 0: redacted token → skipped.
+        let result = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &allowed)
+            .expect("Should not error");
+        assert!(
+            result.is_none(),
+            "row carrying a redacted sensitive header value must not be refreshable"
+        );
+
+        // Row 1: non-sensitive header value → still refreshable.
+        let result = CacheRefreshHelper::extract_filters_from_row(&batch, 1, &allowed)
+            .expect("Should not error")
+            .expect("row should still be refreshable");
+        assert!(!result.is_empty());
+
+        // Sanity: extract_unique_filter_sets should also skip the redacted row.
+        let sets = CacheRefreshHelper::extract_unique_filter_sets(&[batch], &allowed)
+            .expect("Should not error");
+        assert_eq!(
+            sets.len(),
+            1,
+            "only the non-redacted row should produce a refresh filter set"
+        );
+    }
+
+    /// When `request_headers` is in the allowed list, it should be included as
+    /// an additional filter alongside path/query/body. This enables per-user
+    /// caching with `refresh_mode: caching` where the bearer token (carried in
+    /// `request_headers`) participates in the row-level cache key.
+    #[test]
+    fn test_extract_filters_from_row_includes_request_headers_when_allowed() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("request_path", DataType::Utf8, true),
+            Field::new("request_query", DataType::Utf8, true),
+            Field::new("request_body", DataType::Utf8, true),
+            Field::new("request_headers", DataType::Utf8, true),
+            Field::new(RESPONSE_STATUS_COLUMN, DataType::UInt16, false),
+            Field::new(
+                CACHE_REFRESHED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        ]));
+
+        #[expect(clippy::cast_possible_truncation)]
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_nanos() as i64;
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(StringArray::from(vec![Some("/api/users")])),
+                Arc::new(StringArray::from(vec![Some("page=1")])),
+                Arc::new(StringArray::from(vec![Some("{\"id\":1}")])),
+                Arc::new(StringArray::from(vec![Some(
+                    r#"{"authorization":"Bearer abc"}"#,
+                )])),
+                Arc::new(UInt16Array::from(vec![200])),
+                Arc::new(TimestampNanosecondArray::from(vec![Some(now)])),
+            ],
+        )
+        .expect("Failed to create batch");
+
+        // Without allowlist: only path/query/body extracted (3 filters).
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &[])
+            .map(Option::unwrap_or_default)
+            .expect("Should extract filters");
+        assert_eq!(filters.len(), 3);
+
+        // With allowlist set: request_headers also extracted (4 filters).
+        let allowed = vec!["authorization".to_string()];
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &allowed)
+            .expect("Should extract filters with request_headers")
+            .expect("row should be refreshable");
+        assert_eq!(filters.len(), 4);
+        let filter_strs: Vec<String> = filters.iter().map(ToString::to_string).collect();
+        assert!(
+            filter_strs.iter().any(|s| s.contains("request_headers")),
+            "expected request_headers filter; got: {filter_strs:?}"
+        );
+        assert!(
+            filter_strs
+                .iter()
+                .any(|s| s.contains("Bearer abc") || s.contains("authorization")),
+            "expected request_headers value in filter; got: {filter_strs:?}"
+        );
+    }
+
     #[test]
     fn test_extract_filters_from_row_all_columns_present() {
         let schema = create_test_schema_with_request_params();
@@ -2084,7 +2258,8 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0)
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &[])
+            .map(Option::unwrap_or_default)
             .expect("Should extract filters");
         assert_eq!(filters.len(), 3, "Should extract 3 filters");
     }
@@ -2119,7 +2294,8 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0)
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &[])
+            .map(Option::unwrap_or_default)
             .expect("Should extract filters");
         // Only path and body should be extracted (query is null)
         assert_eq!(filters.len(), 2, "Should only extract non-null filters");
@@ -2155,7 +2331,8 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0)
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &[])
+            .map(Option::unwrap_or_default)
             .expect("Should extract filters");
         // Only query should be extracted (path and body are empty strings)
         assert_eq!(
@@ -2192,7 +2369,8 @@ mod tests {
         )
         .expect("Failed to create batch");
 
-        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0)
+        let filters = CacheRefreshHelper::extract_filters_from_row(&batch, 0, &[])
+            .map(Option::unwrap_or_default)
             .expect("Should extract filters");
         assert_eq!(
             filters.len(),
@@ -2603,7 +2781,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 6, "Should have 6 rows total");
 
         // Extract unique filter sets
-        let filter_sets = CacheRefreshHelper::extract_unique_filter_sets(&[batch])
+        let filter_sets = CacheRefreshHelper::extract_unique_filter_sets(&[batch], &[])
             .expect("Should extract filter sets");
 
         // Should only have 2 unique filter sets (5 duplicates + 1 unique)

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -344,6 +344,7 @@ pub struct Builder {
     caching_ttl: Option<Duration>,
     caching_stale_while_revalidate_ttl: Option<Duration>,
     caching_stale_if_error: bool,
+    caching_allowed_request_headers: Vec<String>,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     bootstrap_status: BootstrapStatus,
     /// Whether the acceleration uses S3 Express One Zone storage.
@@ -392,6 +393,7 @@ impl Builder {
             caching_ttl: None,
             caching_stale_while_revalidate_ttl: None,
             caching_stale_if_error: false,
+            caching_allowed_request_headers: Vec::new(),
             resource_monitor: None,
             bootstrap_status: BootstrapStatus::none(),
             acceleration_layout: None,
@@ -586,6 +588,19 @@ impl Builder {
     /// Set whether to serve expired data on upstream error in cache mode
     pub fn caching_stale_if_error(&mut self, enabled: bool) -> &mut Self {
         self.caching_stale_if_error = enabled;
+        self
+    }
+
+    /// Headers (lowercased names) that participate in the caching
+    /// accelerator's row-level cache key when the dataset uses
+    /// `refresh_mode: caching`. When non-empty, the `request_headers` column
+    /// is included alongside `request_path`/`request_query`/`request_body`
+    /// when extracting filters from cached rows for background refresh.
+    pub fn caching_allowed_request_headers(
+        &mut self,
+        headers: Vec<String>,
+    ) -> &mut Self {
+        self.caching_allowed_request_headers = headers;
         self
     }
 
@@ -788,6 +803,10 @@ impl Builder {
         }
 
         refresher.with_s3_express_acceleration(self.is_s3_express_acceleration);
+
+        refresher.with_caching_allowed_request_headers(Arc::new(
+            self.caching_allowed_request_headers,
+        ));
 
         let (refresh_handle, refresh_trigger) =
             if matches!(self.cluster_role, Some(ClusterRole::Scheduler)) {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -648,6 +648,9 @@ pub struct Refresher {
     last_updated_at: Arc<AtomicI64>,
     /// Whether the acceleration uses S3 Express One Zone storage.
     is_s3_express_acceleration: bool,
+    /// Lowercased header names that participate in the caching accelerator's
+    /// cache key (caching mode only).
+    caching_allowed_request_headers: Arc<Vec<String>>,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -701,6 +704,7 @@ impl Refresher {
             bootstrap_status: BootstrapStatus::none(),
             last_updated_at: Arc::new(AtomicI64::from(0)),
             is_s3_express_acceleration: false,
+            caching_allowed_request_headers: Arc::new(Vec::new()),
         }
     }
 
@@ -794,6 +798,16 @@ impl Refresher {
     /// Set whether the acceleration uses S3 Express One Zone storage.
     pub fn with_s3_express_acceleration(&mut self, is_s3_express: bool) -> &mut Self {
         self.is_s3_express_acceleration = is_s3_express;
+        self
+    }
+
+    /// Set the lowercased header names that participate in the caching
+    /// accelerator's cache key (caching mode only).
+    pub fn with_caching_allowed_request_headers(
+        &mut self,
+        headers: Arc<Vec<String>>,
+    ) -> &mut Self {
+        self.caching_allowed_request_headers = headers;
         self
     }
 
@@ -937,6 +951,10 @@ impl Refresher {
 
         refresh_task_runner =
             refresh_task_runner.with_s3_express_acceleration(self.is_s3_express_acceleration);
+
+        refresh_task_runner = refresh_task_runner.with_caching_allowed_request_headers(
+            Arc::clone(&self.caching_allowed_request_headers),
+        );
 
         let mut refresh_task_runner = refresh_task_runner.build();
 
@@ -1178,6 +1196,7 @@ impl Refresher {
             .with_on_stream_batch_process_callback(on_batch_process_callback)
             .with_last_updated_at(Arc::clone(&self.last_updated_at))
             .with_s3_express_acceleration(self.is_s3_express_acceleration)
+            .with_caching_allowed_request_headers(Arc::clone(&self.caching_allowed_request_headers))
             .build(),
         );
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -129,6 +129,10 @@ pub struct RefreshTaskBuilder {
     last_updated_at: Arc<AtomicI64>,
     /// Whether the acceleration uses S3 Express One Zone storage.
     is_s3_express_acceleration: bool,
+    /// Header names (lowercased) that participate in the caching accelerator's
+    /// cache key. When non-empty, `request_headers` is added to the columns
+    /// extracted as filters when scanning stale rows for refresh.
+    caching_allowed_request_headers: Arc<Vec<String>>,
 }
 
 impl RefreshTaskBuilder {
@@ -158,6 +162,7 @@ impl RefreshTaskBuilder {
             on_stream_batch_process_callback: None,
             last_updated_at: Arc::new(AtomicI64::new(0)),
             is_s3_express_acceleration: false,
+            caching_allowed_request_headers: Arc::new(Vec::new()),
         }
     }
 
@@ -217,6 +222,17 @@ impl RefreshTaskBuilder {
         self
     }
 
+    /// Set the lowercased header names that participate in the caching
+    /// accelerator's cache key (caching mode only).
+    #[must_use]
+    pub fn with_caching_allowed_request_headers(
+        mut self,
+        headers: Arc<Vec<String>>,
+    ) -> RefreshTaskBuilder {
+        self.caching_allowed_request_headers = headers;
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> RefreshTask {
         let semaphore = self
@@ -267,6 +283,7 @@ impl RefreshTaskBuilder {
             on_stream_batch_process_callback: self.on_stream_batch_process_callback,
             last_updated_at: self.last_updated_at,
             is_s3_express_acceleration: self.is_s3_express_acceleration,
+            caching_allowed_request_headers: self.caching_allowed_request_headers,
         }
     }
 }
@@ -291,6 +308,10 @@ pub struct RefreshTask {
     last_updated_at: Arc<AtomicI64>,
     /// Whether the acceleration uses S3 Express One Zone storage.
     is_s3_express_acceleration: bool,
+    /// Header names (lowercased) that participate in the caching accelerator's
+    /// cache key when extracting filters from stale rows during background
+    /// refresh.
+    caching_allowed_request_headers: Arc<Vec<String>>,
 }
 
 impl std::fmt::Debug for RefreshTask {
@@ -891,6 +912,7 @@ impl RefreshTask {
             self.dataset_name.to_string().as_str(),
             ttl,
             Arc::clone(&self.accelerator_write_mutex),
+            self.caching_allowed_request_headers.as_slice(),
         )
         .await
         .map_err(|e| RetryError::permanent(super::Error::FailedToRefreshDataset { source: e }))?;

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -59,6 +59,9 @@ pub struct RefreshTaskRunnerBuilder {
     last_updated_at: Arc<AtomicI64>,
     /// Whether the acceleration uses S3 Express One Zone storage.
     is_s3_express_acceleration: bool,
+    /// Lowercased header names that participate in the caching accelerator's
+    /// cache key (caching mode only).
+    caching_allowed_request_headers: Arc<Vec<String>>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -90,6 +93,7 @@ impl RefreshTaskRunnerBuilder {
             accelerator_write_mutex,
             last_updated_at: Arc::new(AtomicI64::new(0)),
             is_s3_express_acceleration: false,
+            caching_allowed_request_headers: Arc::new(Vec::new()),
         }
     }
 
@@ -140,6 +144,17 @@ impl RefreshTaskRunnerBuilder {
         self
     }
 
+    /// Set the lowercased header names that participate in the caching
+    /// accelerator's cache key (caching mode only).
+    #[must_use]
+    pub fn with_caching_allowed_request_headers(
+        mut self,
+        headers: Arc<Vec<String>>,
+    ) -> Self {
+        self.caching_allowed_request_headers = headers;
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> RefreshTaskRunner {
         let mut refresh_task_builder = RefreshTask::builder(
@@ -167,6 +182,9 @@ impl RefreshTaskRunnerBuilder {
 
         refresh_task_builder =
             refresh_task_builder.with_s3_express_acceleration(self.is_s3_express_acceleration);
+
+        refresh_task_builder = refresh_task_builder
+            .with_caching_allowed_request_headers(self.caching_allowed_request_headers);
 
         let refresh_task = Arc::new(refresh_task_builder.build());
 

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -273,6 +273,14 @@ pub struct Acceleration {
 
     pub caching_stale_if_error: StaleIfError,
 
+    /// Headers (by lowercase name) that are allowed to participate in the
+    /// caching accelerator's cache key for `refresh_mode: caching` datasets.
+    /// When non-empty, `request_headers` filters are included in the row-level
+    /// cache key alongside `request_path`, `request_query`, and `request_body`.
+    /// Intended for per-user caching of HTTP datasets where authentication
+    /// headers vary per request (e.g. bearer tokens).
+    pub caching_allowed_request_headers: Vec<String>,
+
     pub refresh_cron: Option<Arc<str>>,
 
     pub refresh_sql: Option<String>,
@@ -472,6 +480,8 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
         let caching_stale_while_revalidate_ttl =
             parse_caching_stale_while_revalidate_ttl(&mut params)?;
         let caching_stale_if_error = parse_caching_stale_if_error(&mut params)?;
+        let caching_allowed_request_headers =
+            parse_caching_allowed_request_headers(&mut params)?;
 
         let refresh_check_interval = try_parse_duration(
             "refresh_check_interval",
@@ -500,6 +510,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             caching_ttl,
             caching_stale_while_revalidate_ttl,
             caching_stale_if_error,
+            caching_allowed_request_headers,
             refresh_cron,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
@@ -550,6 +561,7 @@ impl Default for Acceleration {
             caching_ttl: None,
             caching_stale_while_revalidate_ttl: None,
             caching_stale_if_error: StaleIfError::default(),
+            caching_allowed_request_headers: Vec::new(),
             refresh_cron: None,
             refresh_sql: None,
             refresh_data_window: None,
@@ -613,6 +625,35 @@ fn parse_caching_stale_while_revalidate_ttl(
     params: &mut Option<Params>,
 ) -> Result<Option<Duration>, crate::Error> {
     parse_duration_param(params, "caching_stale_while_revalidate_ttl")
+}
+
+/// Parse `caching_allowed_request_headers` (comma-separated header names) from
+/// params for caching mode. Returns the lowercased header names with empty
+/// entries dropped. When unset, returns an empty vector (no headers participate
+/// in the cache key, which preserves pre-existing behavior).
+#[expect(clippy::result_large_err)]
+fn parse_caching_allowed_request_headers(
+    params: &mut Option<Params>,
+) -> Result<Vec<String>, crate::Error> {
+    let Some(params) = params else {
+        return Ok(Vec::new());
+    };
+    let Some(value) = params.data.remove("caching_allowed_request_headers") else {
+        return Ok(Vec::new());
+    };
+    match value {
+        spicepod::param::ParamValue::String(s) => Ok(s
+            .split(',')
+            .map(|name| name.trim().to_ascii_lowercase())
+            .filter(|name| !name.is_empty())
+            .collect()),
+        _ => Err(crate::Error::InvalidAccelerationConfiguration {
+            source: format!(
+                "Invalid 'caching_allowed_request_headers' param value: {value:?}. Expected a comma-separated string of header names."
+            )
+            .into(),
+        }),
+    }
 }
 
 /// Parse `caching_stale_if_error` from params for caching mode.
@@ -740,5 +781,43 @@ mod tests {
         // Test missing parameter (default)
         let result = parse_caching_stale_if_error(&mut None).expect("to parse");
         assert_eq!(result, StaleIfError::Disabled);
+    }
+
+    #[test]
+    fn test_parse_caching_allowed_request_headers() {
+        // Comma-separated, normalized to lowercase, whitespace trimmed,
+        // empty entries dropped.
+        let mut params = Some(Params::from_string_map(HashMap::from([(
+            "caching_allowed_request_headers".to_string(),
+            " Authorization , X-Api-Key ,, x-region".to_string(),
+        )])));
+        let result =
+            parse_caching_allowed_request_headers(&mut params).expect("to parse");
+        assert_eq!(
+            result,
+            vec![
+                "authorization".to_string(),
+                "x-api-key".to_string(),
+                "x-region".to_string()
+            ]
+        );
+        // The param should be consumed from the map.
+        assert!(
+            params
+                .as_ref()
+                .map(|p| p.data.is_empty())
+                .unwrap_or(true),
+            "caching_allowed_request_headers should be removed from params after parsing"
+        );
+
+        // Missing param yields empty vector (no headers participate, preserving
+        // pre-existing behavior).
+        let result = parse_caching_allowed_request_headers(&mut None).expect("to parse");
+        assert!(result.is_empty());
+
+        let mut empty_params = Some(Params::from_string_map(HashMap::new()));
+        let result =
+            parse_caching_allowed_request_headers(&mut empty_params).expect("to parse");
+        assert!(result.is_empty());
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -190,6 +190,7 @@ struct RequestFilterParams {
     allow_header_filters: bool,
     max_headers_length: usize,
     request_header_allowlist: Vec<String>,
+    request_headers_sensitive: Vec<String>,
 }
 
 struct HttpProviderParams {
@@ -311,6 +312,20 @@ impl Https {
         let request_header_allowlist = self
             .params
             .get("request_header_allowlist")
+            .expose()
+            .ok()
+            .map(|value| {
+                value
+                    .split(',')
+                    .map(|header_name| header_name.trim().to_string())
+                    .filter(|header_name| !header_name.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let request_headers_sensitive = self
+            .params
+            .get("request_headers_sensitive")
             .expose()
             .ok()
             .map(|value| {
@@ -466,6 +481,7 @@ impl Https {
                 allow_header_filters,
                 max_headers_length,
                 request_header_allowlist,
+                request_headers_sensitive,
             },
             max_request_partitions,
             health_probe,
@@ -771,6 +787,7 @@ impl Https {
             allow_header_filters,
             max_headers_length,
             request_header_allowlist,
+            request_headers_sensitive,
         } = request_filters;
 
         let mut provider = data_components::http::provider::HttpTableProvider::new(
@@ -845,6 +862,22 @@ impl Https {
         if allow_body_filters {
             tracing::trace!("Enabling body filters with max_bytes={}", max_body_bytes);
             provider = provider.enable_body_filters(max_body_bytes);
+        }
+
+        if !request_headers_sensitive.is_empty() {
+            tracing::trace!(
+                "Marking {} sensitive header(s) for {}",
+                request_headers_sensitive.len(),
+                dataset.name
+            );
+            provider = provider
+                .with_sensitive_headers(&request_headers_sensitive)
+                .map_err(|e| DataConnectorError::InvalidConfiguration {
+                    dataconnector: "https".to_string(),
+                    message: format!("Invalid request_headers_sensitive configuration: {e}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: e.into(),
+                })?;
         }
 
         if allow_header_filters {
@@ -1056,6 +1089,8 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             .one_of(&["enabled", "disabled"]),
         ParameterSpec::runtime("request_header_allowlist")
             .description("Comma-separated list of HTTP request header names that request_headers filters may set. Required when request_header_filters is enabled."),
+        ParameterSpec::runtime("request_headers_sensitive")
+            .description("Comma-separated list of HTTP request header names whose values are treated as sensitive (e.g. bearer tokens). Listed headers may appear in request_header_allowlist even when HTTP authentication is configured, signalling that per-request bearer tokens override the dataset-level auth. Intended for per-user caching of HTTP datasets."),
         ParameterSpec::runtime("max_request_headers_length")
             .description("Maximum size (in bytes) for request_headers filter values. Default: 16384 (16KiB)."),
         ParameterSpec::runtime("max_request_partitions")

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1820,6 +1820,9 @@ impl DataFusion {
             );
             accelerated_table_builder
                 .caching_stale_if_error(acceleration_settings.caching_stale_if_error.is_enabled());
+            accelerated_table_builder.caching_allowed_request_headers(
+                acceleration_settings.caching_allowed_request_headers.clone(),
+            );
         }
 
         // Get the acceleration layout (used for snapshots and size metrics)


### PR DESCRIPTION
## Summary

Adds two opt-in parameters that together enable per-user (per-bearer-token) caching of HTTP-backed datasets without leaking one user's data to another, with sensitive header values redacted before they ever land in any cache key or persisted column.

1. **`datasets[].params.request_headers_sensitive`** (comma-separated header names) — on the `https` connector. Two effects:
   - Lifts the existing *"`authorization` cannot be in `request_header_allowlist` when HTTP authentication is configured"* guard for headers explicitly marked sensitive. This allows per-request bearer tokens (carried in `request_headers` filters / the `request_headers` schema column) to coexist with dataset-level HTTP authentication.
   - **Replaces those header values with a deterministic one-way hash** (sentinel-prefixed: `spice-redacted-sha256:<base64url>`) before they are written into the HTTP provider's in-memory cache key or the `request_headers` row column persisted by the accelerator. The raw value is still forwarded upstream verbatim for authentication; **only the redacted form is ever stored**. Determinism of the hash is required: two requests from the same end client (same bearer token) must produce the same cache key and therefore share a cached response.

2. **`datasets[].acceleration.params.caching_allowed_request_headers`** (comma-separated header names) — on the acceleration block. When non-empty, the caching accelerator's row-level cache key extraction (`extract_filters_from_row`) includes the `request_headers` column alongside `request_path` / `request_query` / `request_body`. **Rows whose `request_headers` value carries the redacted sentinel are skipped during background stale-row refresh by design** — the upstream call would require the original token, which is one-way hashed and not recoverable. Those rows are re-populated lazily on the next live request with the matching token.

Both parameters default to empty / off, so this change is fully backward compatible.

## Behavior

- With neither param set: identical behavior to today. `authorization` is still blocked from `request_header_allowlist` when HTTP auth is configured, and the caching accelerator continues to key only on path/query/body.
- With only `request_headers_sensitive` set (and `authorization` listed in both `request_header_allowlist` and `request_headers_sensitive`): the dataset can accept per-request `authorization` headers in `request_headers` filters even when dataset-level HTTP auth is configured. The HTTP provider's in-memory cache keys on the redacted hash, so per-user caching works end-to-end without persisting raw tokens.
- With `caching_allowed_request_headers` additionally set on the accelerator: the caching accelerator's stale-row refresh path also keys on the (redacted) request headers, so per-user entries refresh correctly when re-requested. Rows whose stored `request_headers` value contains the redaction sentinel are skipped from background refresh and refresh lazily on the next live request.

## Example

```yaml
datasets:
  - from: https://api.example.com
    name: per_user_endpoint
    params:
      http_auth: bearer
      http_bearer_token: ${ env:SERVICE_TOKEN }
      request_header_filters: enabled
      request_header_allowlist: authorization
      request_headers_sensitive: authorization
    acceleration:
      enabled: true
      refresh_mode: caching
      params:
        caching_allowed_request_headers: authorization
```

## Code touchpoints

- `crates/data_components/src/http/provider.rs`
  - `RequestFilterOptions::sensitive_headers` and `with_sensitive_headers(...)` builder.
  - `enable_header_filters` and `parse_request_headers` lift the AUTHORIZATION-with-auth guard for sensitive headers only.
  - New `hash_sensitive_value(&str) -> String` and `SENSITIVE_HASH_PREFIX` constant — deterministic SHA-256 + URL-safe base64, sentinel-prefixed.
  - New `request_headers_contain_redacted_value(&str) -> bool` — used by the accelerator to detect non-refreshable rows.
  - `RequestFilterOptions::redact_sensitive_request_headers(&str) -> String` — replaces only listed-sensitive header values with the hash; preserves non-sensitive values.
  - `HttpTableProvider::get_cache_key_with_redacted_headers(...)` and `redact_request_headers_for_storage(...)` — used by `cache_response`, `get_response`, and `create_batch_from_rows` so the in-memory cache key and the persisted `request_headers` row column always carry the redacted form.
- `crates/runtime/src/dataconnector/https.rs`
  - Parses the new `request_headers_sensitive` dataset param and threads it into the provider before `enable_header_filters` is called.
- `crates/runtime/src/component/dataset/acceleration.rs`
  - `Acceleration.caching_allowed_request_headers` plus `parse_caching_allowed_request_headers` (lowercases, trims, drops empties).
- `crates/runtime/src/accelerated_table/{mod.rs,refresh.rs,refresh_task.rs,refresh_task_runner.rs,caching.rs}`
  - Plumbs `caching_allowed_request_headers` from `Acceleration` → `AcceleratedTable::Builder` → `Refresher` → `RefreshTaskRunner` → `RefreshTask`.
  - `CacheRefreshHelper::extract_filters_from_row` now returns `Option<Vec<Expr>>`; `None` signals a row that cannot be background-refreshed (its `request_headers` carries the redaction sentinel). `extract_unique_filter_sets` skips such rows.
- `crates/runtime/src/datafusion/mod.rs`
  - Wires `acceleration_settings.caching_allowed_request_headers` into the `AcceleratedTable` builder alongside the other `caching_*` params.

## Tests

New unit tests:
- `data_components::http::provider::tests`
  - `test_sensitive_authorization_allowlist_with_auth` — `authorization` is allowlistable with HTTP auth when also marked sensitive.
  - `test_sensitive_authorization_filter_with_auth` — `request_headers` filters carrying `authorization` are accepted under HTTP auth when sensitive.
  - `test_sensitive_headers_rejects_invalid_name` — malformed names rejected early.
  - `test_hash_sensitive_value_is_deterministic_and_distinct` — same input → same hash, different inputs → different hashes, raw value never appears in output, sentinel prefix present, `request_headers_contain_redacted_value` correctly distinguishes redacted vs raw.
  - `test_redact_sensitive_request_headers_replaces_only_listed_headers` — only sensitive header values are hashed; non-sensitive values pass through; redaction is deterministic.
  - `test_redact_sensitive_request_headers_noop_when_unconfigured` — no sensitive headers → no-op.
- `runtime::accelerated_table::caching::tests`
  - `test_extract_filters_from_row_includes_request_headers_when_allowed` — `request_headers` is included in extracted filters only when in the allowlist.
  - `test_extract_filters_from_row_skips_redacted_request_headers` — rows with redacted sensitive header values return `Ok(None)` from `extract_filters_from_row` and are skipped by `extract_unique_filter_sets`; non-redacted rows still refresh.
- `runtime::component::dataset::acceleration::tests::test_parse_caching_allowed_request_headers` — comma-split, lowercased, trimmed, consumed from the params map.

All existing tests pass:
- `cargo test -p data_components --lib http::provider::tests` → 139 passed.
- `cargo test -p runtime --lib accelerated_table::caching::tests` → 33 passed.
- `cargo test -p runtime --lib dataconnector::https` → 16 passed.
- `cargo test -p runtime --lib component::dataset::acceleration` → 3 passed.
- `cargo clippy -p data_components -p runtime --tests` → no new warnings.

## Compatibility

Fully backward compatible. Both parameters default to empty; without them the existing AUTHORIZATION guard and the existing path/query/body-only accelerator cache key behavior are preserved exactly.

## Out of scope / follow-ups

- User-facing docs updates (the `docs/examples/http_refresh_sql_example.md` example is unchanged; new params are additive).
