### PR TITLE
fix(test-framework): deserialize search response `_score` field

### DIFF
--- a/crates/test-framework/src/spicetest/search/worker.rs
+++ b/crates/test-framework/src/spicetest/search/worker.rs
@@ -150,6 +150,9 @@ pub struct SearchResponseResult {
     // `matches` is left as a generic JSON value (`serde_json::Value`) instead of a strongly typed struct.
     // The search API can return different sets of fields here depending on dataset or configuration
     pub matches: serde_json::Value,
+    // The runtime serializes this field as `_score` (see `crates/runtime/src/search/types.rs`).
+    // Accept the legacy `score` name as an alias to stay compatible with older runtimes.
+    #[serde(rename = "_score", alias = "score")]
     pub score: f64,
     pub dataset: String,
     /// Primary key can be different types depending on the dataset. Default to empty map, if not present.


### PR DESCRIPTION
All scheduled `benchmarks_search.yml` runs have been failing for weeks (every job in every run) with:

```
Error: error decoding response body

Caused by:
    missing field `score` at line 1 column 158
```

## Root cause

The v2.0 breaking-changes PR (#9233) renamed the `Match.score` field to `_score` on the wire (`crates/runtime/src/search/types.rs`):

```rust
#[serde(rename = "_score")]
score: f64,
```

The Spice CLI client (`bin/spice/src/commands/search.rs`) was updated at the same time:

```rust
#[serde(rename = "_score", alias = "score")]
```

But the `test-framework` client used by `testoperator` for the search benchmarks was not updated, so it still tries to deserialize a bare `score` field. The very first response from `/v1/search` fails to decode and the worker bubbles the error up — which is why all 10 matrix configurations (full_text / hybrid / vector × arrow / duckdb / cayenne / s3_vectors) fail identically in every scheduled run.

Example failing run: https://github.com/spiceai/spiceai/actions/runs/25205623036

## Fix

Mirror the CLI: rename to `_score` with `score` as a serde alias so we stay compatible with older runtimes.

```rust
#[serde(rename = "_score", alias = "score")]
pub score: f64,
```

## Verification

- `cargo build -p test-framework` ✅
- `cargo build -p testoperator` ✅
- Next scheduled `benchmarks_search.yml` run (Sun 2026-05-04 06:30 UTC) should go green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->