### PR TITLE
feat(spicepod, runtime): add columns[].type / nullable + lenient type parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16060,6 +16060,7 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "linkme",
  "llms",
+ "logos",
  "mediatype",
  "model_components",
  "moka",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -84,6 +84,7 @@ iceberg-datafusion.workspace = true
 iceberg-storage-opendal.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
+logos.workspace = true
 opendal.workspace = true
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 linkme.workspace = true

--- a/crates/runtime/src/component/dataset/declared_type.rs
+++ b/crates/runtime/src/component/dataset/declared_type.rs
@@ -1,0 +1,745 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Lenient parser for `columns[].type` declarations on datasets.
+//!
+//! Accepts three families of type expressions:
+//!
+//!   1. **Arrow display forms** — `Int64`, `Utf8`, `Float64`, `Bool`,
+//!      `Date32`, `Timestamp(Microsecond, UTC)`, `List<Int64>`,
+//!      `Decimal128(p, s)`, etc. Routed through Arrow's
+//!      `DataType::from_str` for primitive lookup.
+//!   2. **Postgres / SQL forms** via `DataFusion`'s `sqlparser` —
+//!      `BIGINT`, `INTEGER`, `INT`, `SMALLINT`, `TEXT`, `VARCHAR(n)`,
+//!      `CHAR(n)`, `BOOLEAN`, `BOOL`, `REAL`, `DOUBLE PRECISION`,
+//!      `NUMERIC(p,s)` / `DECIMAL(p,s)`, `DATE`, `TIME`, `TIMESTAMP`,
+//!      `TIMESTAMP WITH TIME ZONE`, `JSONB` → `Utf8`, `BYTEA` → `Binary`,
+//!      etc.
+//!   3. **Postgres aliases not in `sqlparser`** — `int2`, `int4`, `int8`,
+//!      `float4`, `float8`, `serial`, `bigserial`, `timestamptz`, `uuid`,
+//!      and the `T[]` array suffix.
+//!
+//! In addition, three surface syntaxes for Arrow `Map`:
+//!
+//!   * `Map<K, V>` — friendly Arrow-flavored shorthand
+//!     (e.g. `Map<Utf8, Int64>`).
+//!   * `map<K, V>` — lowercase variant for users coming from Hive,
+//!     Spark, or `ClickHouse`.
+//!   * The full Arrow canonical display form (whatever `DataType::from_str`
+//!     emits) if a user pastes it back from Arrow tooling.
+//!
+//! Map keys default to non-nullable, values to nullable, matching Arrow
+//! conventions and the existing HTTP envelope `response_headers` field
+//! (`Map<Utf8 not null, Utf8>`). The standard `entries` / `keys` /
+//! `values` field naming is used; `keys_sorted` is `false`.
+//!
+//! Postgres has no native `MAP` type. Users who want a map column on a
+//! Postgres source typically model it as `JSONB`, which this parser maps
+//! to `Utf8` (we do not introspect arbitrary JSONB structure).
+//!
+//! ## Implementation
+//!
+//! The parser tokenises the input with `logos` (matching the convention
+//! used by `runtime-secrets::lexer`) and then walks the token stream as a
+//! small recursive-descent parser. The grammar is:
+//!
+//! ```text
+//! type        := primary array_suffix*
+//! array_suffix:= '[' ']'
+//! primary     := map | list | leaf
+//! map         := ('Map'|'map') '<' type ',' type '>'
+//! list        := ('List'|'list') '<' type '>'
+//! leaf        := IDENT IDENT* paren_args?
+//! paren_args  := '(' .* ')'   // matched by paren depth
+//! ```
+//!
+//! Leaf type lookup is delegated, in order, to:
+//!
+//!   1. The Postgres alias table (`parse_pg_alias`).
+//!   2. Arrow's `DataType::from_str`.
+//!   3. `sqlparser::Parser::parse_data_type` mapped to `arrow::DataType`.
+//!
+//! Tokenising before parsing means bracket and comma structure is always
+//! handled at the `logos` layer, keeping the recursive descent free of
+//! ad-hoc string scans and ensuring trailing-junk inputs (e.g.
+//! `Int64<>`) cleanly fail rather than being silently truncated by
+//! `DataType::from_str` or `parse_data_type`.
+
+use std::str::FromStr;
+
+use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+use datafusion::sql::sqlparser::{
+    ast::{DataType as SqlDataType, ExactNumberInfo, TimezoneInfo},
+    dialect::PostgreSqlDialect,
+    parser::Parser,
+    tokenizer::Token,
+};
+use logos::Logos;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu, PartialEq, Eq)]
+pub enum ParseTypeError {
+    #[snafu(display(
+        "Could not parse column type `{input}`. \
+         Accepted forms include Postgres types (e.g. `bigint`, `text`, `numeric(18,4)`, \
+         `timestamptz`, `text[]`), Arrow display forms (e.g. `Int64`, `Utf8`, \
+         `Timestamp(Microsecond, UTC)`, `List<Int64>`, `Decimal128(18, 4)`), and \
+         Map types (`Map<K, V>` / `map<k, v>`)."
+    ))]
+    Unrecognized { input: String },
+
+    #[snafu(display(
+        "Could not parse map type `{input}`: {reason}. \
+         Expected `Map<KeyType, ValueType>` (e.g. `Map<Utf8, Int64>`)."
+    ))]
+    InvalidMap { input: String, reason: String },
+
+    #[snafu(display("Could not parse element type of array `{input}`: {source}"))]
+    InvalidArrayElement {
+        input: String,
+        #[snafu(source(from(ParseTypeError, Box::new)))]
+        source: Box<ParseTypeError>,
+    },
+}
+
+/// Parse a user-supplied type string into an Arrow `DataType`.
+///
+/// See the module-level docs for the full list of accepted forms.
+pub fn parse_declared_type(input: &str) -> Result<DataType, ParseTypeError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(ParseTypeError::Unrecognized {
+            input: input.to_string(),
+        });
+    }
+
+    let tokens = tokenise(input)?;
+    let mut parser = TokenParser {
+        tokens: &tokens,
+        pos: 0,
+        original: input,
+    };
+    let ty = parser.parse_type()?;
+    if parser.pos != tokens.len() {
+        return Err(ParseTypeError::Unrecognized {
+            input: input.to_string(),
+        });
+    }
+    Ok(ty)
+}
+
+#[derive(Logos, Debug, PartialEq, Clone)]
+#[logos(skip r"[ \t\n\r\f]+")]
+enum TypeToken {
+    /// Identifier or keyword (case-insensitive comparisons happen at the
+    /// parser layer). Matches Arrow primitive names (`Int64`, `Utf8`),
+    /// Postgres types (`bigint`, `timestamptz`), keywords inside type
+    /// arguments (`Microsecond`, `UTC`, `with`, `time`, `zone`), etc.
+    #[regex(r"[A-Za-z_][A-Za-z0-9_]*", |lex| lex.slice().to_owned())]
+    Ident(String),
+
+    /// Unsigned decimal literal. Used for type arguments such as
+    /// `Decimal128(18, 4)` and `varchar(255)`.
+    #[regex(r"[0-9]+", |lex| lex.slice().to_owned())]
+    Number(String),
+
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token("<")]
+    LAngle,
+    #[token(">")]
+    RAngle,
+    #[token(",")]
+    Comma,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
+}
+
+struct TokenSpan {
+    token: TypeToken,
+    span: std::ops::Range<usize>,
+}
+
+fn tokenise(input: &str) -> Result<Vec<TokenSpan>, ParseTypeError> {
+    let mut lexer = TypeToken::lexer(input);
+    let mut out = Vec::new();
+    while let Some(result) = lexer.next() {
+        match result {
+            Ok(token) => out.push(TokenSpan {
+                token,
+                span: lexer.span(),
+            }),
+            Err(()) => {
+                return Err(ParseTypeError::Unrecognized {
+                    input: input.to_string(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+struct TokenParser<'a> {
+    tokens: &'a [TokenSpan],
+    pos: usize,
+    original: &'a str,
+}
+
+impl<'a> TokenParser<'a> {
+    fn peek(&self) -> Option<&'a TypeToken> {
+        self.tokens.get(self.pos).map(|t| &t.token)
+    }
+
+    fn peek_at(&self, offset: usize) -> Option<&'a TypeToken> {
+        self.tokens.get(self.pos + offset).map(|t| &t.token)
+    }
+
+    fn advance(&mut self) -> Option<&'a TokenSpan> {
+        let t = self.tokens.get(self.pos)?;
+        self.pos += 1;
+        Some(t)
+    }
+
+    fn expect(&mut self, expected: &TypeToken) -> Result<(), ParseTypeError> {
+        match self.peek() {
+            Some(actual) if std::mem::discriminant(actual) == std::mem::discriminant(expected) => {
+                self.pos += 1;
+                Ok(())
+            }
+            _ => Err(ParseTypeError::Unrecognized {
+                input: self.original.to_string(),
+            }),
+        }
+    }
+
+    fn parse_type(&mut self) -> Result<DataType, ParseTypeError> {
+        let mut ty = self.parse_primary()?;
+        // Trailing array suffixes: T[] → List<T>, applied repeatedly.
+        while matches!(self.peek(), Some(TypeToken::LBracket)) {
+            self.advance();
+            self.expect(&TypeToken::RBracket)?;
+            ty = list_of(ty);
+        }
+        Ok(ty)
+    }
+
+    fn parse_primary(&mut self) -> Result<DataType, ParseTypeError> {
+        // Check for Map<K, V> or List<T> shorthand.
+        if let Some(TypeToken::Ident(name)) = self.peek()
+            && matches!(self.peek_at(1), Some(TypeToken::LAngle))
+        {
+            if name.eq_ignore_ascii_case("map") {
+                self.advance(); // map
+                self.advance(); // <
+                let key = self.parse_type().map_err(|e| ParseTypeError::InvalidMap {
+                    input: self.original.to_string(),
+                    reason: format!("invalid key type: {e}"),
+                })?;
+                self.expect(&TypeToken::Comma)
+                    .map_err(|_| ParseTypeError::InvalidMap {
+                        input: self.original.to_string(),
+                        reason: "expected `,` between key and value types".to_string(),
+                    })?;
+                let value = self.parse_type().map_err(|e| ParseTypeError::InvalidMap {
+                    input: self.original.to_string(),
+                    reason: format!("invalid value type: {e}"),
+                })?;
+                self.expect(&TypeToken::RAngle)
+                    .map_err(|_| ParseTypeError::InvalidMap {
+                        input: self.original.to_string(),
+                        reason: "expected closing `>`".to_string(),
+                    })?;
+                return Ok(map_of(key, value));
+            }
+            if name.eq_ignore_ascii_case("list") {
+                self.advance(); // list
+                self.advance(); // <
+                let element =
+                    self.parse_type()
+                        .map_err(|e| ParseTypeError::InvalidArrayElement {
+                            input: self.original.to_string(),
+                            source: Box::new(e),
+                        })?;
+                self.expect(&TypeToken::RAngle)?;
+                return Ok(list_of(element));
+            }
+        }
+
+        self.parse_leaf()
+    }
+
+    fn parse_leaf(&mut self) -> Result<DataType, ParseTypeError> {
+        let start = self.pos;
+
+        // Consume one or more identifiers (handles multi-word types like
+        // `double precision` and `timestamp with time zone`).
+        let mut consumed_any = false;
+        while matches!(self.peek(), Some(TypeToken::Ident(_))) {
+            self.advance();
+            consumed_any = true;
+        }
+        if !consumed_any {
+            return Err(ParseTypeError::Unrecognized {
+                input: self.original.to_string(),
+            });
+        }
+
+        // Optional parenthesised arguments — consume the matching paren
+        // group as a flat run; the inner sqlparser/Arrow parser
+        // re-interprets it.
+        if matches!(self.peek(), Some(TypeToken::LParen)) {
+            self.advance();
+            let mut depth = 1usize;
+            while depth > 0 {
+                match self.advance() {
+                    Some(t) => match t.token {
+                        TypeToken::LParen => depth += 1,
+                        TypeToken::RParen => depth -= 1,
+                        _ => {}
+                    },
+                    None => {
+                        return Err(ParseTypeError::Unrecognized {
+                            input: self.original.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Reconstruct the leaf substring from token spans (preserving the
+        // user's original capitalization and whitespace), then look up.
+        let span_start = self.tokens[start].span.start;
+        let span_end = self.tokens[self.pos - 1].span.end;
+        let leaf = &self.original[span_start..span_end];
+
+        leaf_lookup(leaf).ok_or_else(|| ParseTypeError::Unrecognized {
+            input: self.original.to_string(),
+        })
+    }
+}
+
+fn list_of(element: DataType) -> DataType {
+    DataType::List(std::sync::Arc::new(Field::new("item", element, true)))
+}
+
+fn map_of(key: DataType, value: DataType) -> DataType {
+    let entries = Field::new(
+        "entries",
+        DataType::Struct(
+            vec![
+                Field::new("keys", key, false),
+                Field::new("values", value, true),
+            ]
+            .into(),
+        ),
+        false,
+    );
+    DataType::Map(std::sync::Arc::new(entries), false)
+}
+
+/// Look up a leaf type expression (one without Map/List shorthand and
+/// without trailing array brackets) by trying, in order:
+///
+///   1. The Postgres / Arrow alias table (`parse_pg_alias`).
+///   2. Arrow's `DataType::from_str`.
+///   3. `sqlparser::Parser::parse_data_type` mapped to `arrow::DataType`.
+fn leaf_lookup(s: &str) -> Option<DataType> {
+    if let Some(dt) = parse_pg_alias(s) {
+        return Some(dt);
+    }
+    if let Ok(dt) = DataType::from_str(s) {
+        return Some(dt);
+    }
+    parse_via_sqlparser(s).ok()
+}
+
+/// Postgres aliases that `sqlparser` either lacks or maps to a different
+/// width than what feels natural, plus lowercase aliases for common Arrow
+/// primitives so users can write `utf8` / `int64` inside shortcuts and
+/// elsewhere.
+///
+/// Note: there is intentionally no lowercase alias for Arrow's `Int8` —
+/// Postgres `int8` is `bigint`/`Int64`. Users wanting Arrow `Int8`
+/// should write `Int8` (capitalized), routed through `DataType::from_str`.
+fn parse_pg_alias(input: &str) -> Option<DataType> {
+    match input.to_ascii_lowercase().as_str() {
+        // Postgres integer aliases
+        "serial" => {
+            tracing::debug!(
+                "Parsed Postgres `serial` as Int32; sequence semantics are not modeled."
+            );
+            Some(DataType::Int32)
+        }
+        "bigserial" => {
+            tracing::debug!(
+                "Parsed Postgres `bigserial` as Int64; sequence semantics are not modeled."
+            );
+            Some(DataType::Int64)
+        }
+        "smallserial" => {
+            tracing::debug!(
+                "Parsed Postgres `smallserial` as Int16; sequence semantics are not modeled."
+            );
+            Some(DataType::Int16)
+        }
+        "timestamptz" => Some(DataType::Timestamp(
+            TimeUnit::Microsecond,
+            Some("UTC".into()),
+        )),
+        // Lowercase aliases for common Arrow primitives.
+        "i8" => Some(DataType::Int8),
+        "int2" | "int16" | "i16" => Some(DataType::Int16),
+        "int4" | "int32" | "i32" => Some(DataType::Int32),
+        "int8" | "int64" | "i64" => Some(DataType::Int64),
+        "uint8" | "u8" => Some(DataType::UInt8),
+        "uint16" | "u16" => Some(DataType::UInt16),
+        "uint32" | "u32" => Some(DataType::UInt32),
+        "uint64" | "u64" => Some(DataType::UInt64),
+        "float4" | "float32" | "f32" => Some(DataType::Float32),
+        "float8" | "float64" | "f64" => Some(DataType::Float64),
+        "uuid" | "utf8" => Some(DataType::Utf8),
+        "largeutf8" | "large_utf8" => Some(DataType::LargeUtf8),
+        "binary" => Some(DataType::Binary),
+        "largebinary" | "large_binary" => Some(DataType::LargeBinary),
+        "boolean" | "bool" => Some(DataType::Boolean),
+        "date32" => Some(DataType::Date32),
+        "date64" => Some(DataType::Date64),
+        _ => None,
+    }
+}
+
+fn parse_via_sqlparser(input: &str) -> Result<DataType, ParseTypeError> {
+    let dialect = PostgreSqlDialect {};
+    let mut parser =
+        Parser::new(&dialect)
+            .try_with_sql(input)
+            .map_err(|_| ParseTypeError::Unrecognized {
+                input: input.to_string(),
+            })?;
+    let sql_dt = parser
+        .parse_data_type()
+        .map_err(|_| ParseTypeError::Unrecognized {
+            input: input.to_string(),
+        })?;
+    // Reject inputs with trailing tokens after a successful parse,
+    // otherwise sqlparser silently accepts e.g. `Int64<>` as `Int64`.
+    if !matches!(parser.peek_token().token, Token::EOF) {
+        return Err(ParseTypeError::Unrecognized {
+            input: input.to_string(),
+        });
+    }
+    sql_to_arrow_type(&sql_dt).ok_or_else(|| ParseTypeError::Unrecognized {
+        input: input.to_string(),
+    })
+}
+
+fn sql_to_arrow_type(sql: &SqlDataType) -> Option<DataType> {
+    Some(match sql {
+        // Integers
+        SqlDataType::TinyInt(_) | SqlDataType::Int8(_) => DataType::Int8,
+        SqlDataType::SmallInt(_) | SqlDataType::Int2(_) => DataType::Int16,
+        SqlDataType::Int(_) | SqlDataType::Integer(_) | SqlDataType::Int4(_) => DataType::Int32,
+        SqlDataType::BigInt(_) | SqlDataType::Int64 => DataType::Int64,
+        SqlDataType::Unsigned | SqlDataType::UInt32 => DataType::UInt32,
+        SqlDataType::UInt8 => DataType::UInt8,
+        SqlDataType::UInt16 => DataType::UInt16,
+        SqlDataType::UInt64 => DataType::UInt64,
+
+        // Booleans
+        SqlDataType::Boolean | SqlDataType::Bool => DataType::Boolean,
+
+        // Floats
+        SqlDataType::Float(_) | SqlDataType::Float4 | SqlDataType::Float32 | SqlDataType::Real => {
+            DataType::Float32
+        }
+        SqlDataType::DoublePrecision
+        | SqlDataType::Float8
+        | SqlDataType::Float64
+        | SqlDataType::Double(_) => DataType::Float64,
+
+        // Decimals / numerics
+        SqlDataType::Decimal(info)
+        | SqlDataType::Numeric(info)
+        | SqlDataType::Dec(info)
+        | SqlDataType::BigDecimal(info)
+        | SqlDataType::BigNumeric(info) => match info {
+            ExactNumberInfo::None => DataType::Decimal128(38, 10),
+            ExactNumberInfo::Precision(p) => DataType::Decimal128(u8::try_from(*p).ok()?, 0),
+            ExactNumberInfo::PrecisionAndScale(p, s) => {
+                DataType::Decimal128(u8::try_from(*p).ok()?, i8::try_from(*s).ok()?)
+            }
+        },
+
+        // Strings
+        SqlDataType::Char(_)
+        | SqlDataType::Character(_)
+        | SqlDataType::CharVarying(_)
+        | SqlDataType::CharacterVarying(_)
+        | SqlDataType::Varchar(_)
+        | SqlDataType::Text
+        | SqlDataType::String(_)
+        | SqlDataType::Nvarchar(_)
+        | SqlDataType::JSON
+        | SqlDataType::JSONB
+        | SqlDataType::Uuid => DataType::Utf8,
+
+        // Binary
+        SqlDataType::Binary(_)
+        | SqlDataType::Varbinary(_)
+        | SqlDataType::Blob(_)
+        | SqlDataType::Bytea
+        | SqlDataType::Bytes(_) => DataType::Binary,
+
+        // Date / time
+        SqlDataType::Date | SqlDataType::Date32 => DataType::Date32,
+        SqlDataType::Time(_, _) => DataType::Time64(TimeUnit::Microsecond),
+        SqlDataType::Datetime(_) => DataType::Timestamp(TimeUnit::Microsecond, None),
+        SqlDataType::Timestamp(_, tz) => match tz {
+            TimezoneInfo::Tz | TimezoneInfo::WithTimeZone => {
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+            }
+            TimezoneInfo::None | TimezoneInfo::WithoutTimeZone => {
+                DataType::Timestamp(TimeUnit::Microsecond, None)
+            }
+        },
+        SqlDataType::Interval { .. } => DataType::Interval(IntervalUnit::MonthDayNano),
+
+        // Arrays via SQL (e.g. `INT ARRAY`, `TEXT ARRAY`).
+        SqlDataType::Array(spec) => {
+            use datafusion::sql::sqlparser::ast::ArrayElemTypeDef;
+            let element = match spec {
+                ArrayElemTypeDef::AngleBracket(inner)
+                | ArrayElemTypeDef::SquareBracket(inner, _)
+                | ArrayElemTypeDef::Parenthesis(inner) => sql_to_arrow_type(inner)?,
+                ArrayElemTypeDef::None => return None,
+            };
+            list_of(element)
+        }
+
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> DataType {
+        parse_declared_type(input)
+            .unwrap_or_else(|e| panic!("expected `{input}` to parse, got error: {e}"))
+    }
+
+    fn fail(input: &str) {
+        match parse_declared_type(input) {
+            Err(_) => {}
+            Ok(dt) => panic!("expected `{input}` to fail to parse, got {dt:?}"),
+        }
+    }
+
+    #[test]
+    fn postgres_integer_aliases() {
+        assert_eq!(parse("int2"), DataType::Int16);
+        assert_eq!(parse("INT2"), DataType::Int16);
+        assert_eq!(parse("int4"), DataType::Int32);
+        assert_eq!(parse("int8"), DataType::Int64);
+        assert_eq!(parse("smallint"), DataType::Int16);
+        assert_eq!(parse("integer"), DataType::Int32);
+        assert_eq!(parse("INT"), DataType::Int32);
+        assert_eq!(parse("bigint"), DataType::Int64);
+        assert_eq!(parse("BIGINT"), DataType::Int64);
+    }
+
+    #[test]
+    fn postgres_float_aliases() {
+        assert_eq!(parse("float4"), DataType::Float32);
+        assert_eq!(parse("float8"), DataType::Float64);
+        assert_eq!(parse("real"), DataType::Float32);
+        assert_eq!(parse("double precision"), DataType::Float64);
+    }
+
+    #[test]
+    fn postgres_serial_logs_and_maps() {
+        assert_eq!(parse("serial"), DataType::Int32);
+        assert_eq!(parse("bigserial"), DataType::Int64);
+        assert_eq!(parse("smallserial"), DataType::Int16);
+    }
+
+    #[test]
+    fn postgres_string_types() {
+        assert_eq!(parse("text"), DataType::Utf8);
+        assert_eq!(parse("TEXT"), DataType::Utf8);
+        assert_eq!(parse("varchar(255)"), DataType::Utf8);
+        assert_eq!(parse("varchar"), DataType::Utf8);
+        assert_eq!(parse("char(10)"), DataType::Utf8);
+        assert_eq!(parse("uuid"), DataType::Utf8);
+        assert_eq!(parse("jsonb"), DataType::Utf8);
+        assert_eq!(parse("json"), DataType::Utf8);
+    }
+
+    #[test]
+    fn postgres_binary_types() {
+        assert_eq!(parse("bytea"), DataType::Binary);
+    }
+
+    #[test]
+    fn postgres_boolean_aliases() {
+        assert_eq!(parse("boolean"), DataType::Boolean);
+        assert_eq!(parse("bool"), DataType::Boolean);
+    }
+
+    #[test]
+    fn postgres_decimals() {
+        assert_eq!(parse("numeric(18,4)"), DataType::Decimal128(18, 4));
+        assert_eq!(parse("numeric(18, 4)"), DataType::Decimal128(18, 4));
+        assert_eq!(parse("decimal(10, 2)"), DataType::Decimal128(10, 2));
+        assert_eq!(parse("decimal(5)"), DataType::Decimal128(5, 0));
+    }
+
+    #[test]
+    fn postgres_timestamps() {
+        assert_eq!(
+            parse("timestamptz"),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            parse("timestamp with time zone"),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            parse("timestamp"),
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(parse("date"), DataType::Date32);
+    }
+
+    #[test]
+    fn postgres_arrays() {
+        let expected = DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Utf8,
+            true,
+        )));
+        assert_eq!(parse("text[]"), expected);
+        assert_eq!(parse("TEXT []"), expected);
+    }
+
+    #[test]
+    fn postgres_nested_arrays() {
+        let inner = DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int64,
+            true,
+        )));
+        let outer = DataType::List(std::sync::Arc::new(Field::new("item", inner, true)));
+        assert_eq!(parse("bigint[][]"), outer);
+    }
+
+    #[test]
+    fn arrow_display_forms() {
+        assert_eq!(parse("Int64"), DataType::Int64);
+        assert_eq!(parse("Utf8"), DataType::Utf8);
+        assert_eq!(parse("Float64"), DataType::Float64);
+        assert_eq!(parse("Boolean"), DataType::Boolean);
+        assert_eq!(parse("Date32"), DataType::Date32);
+        assert_eq!(parse("Binary"), DataType::Binary);
+    }
+
+    #[test]
+    fn arrow_decimal_display() {
+        assert_eq!(parse("Decimal128(18, 4)"), DataType::Decimal128(18, 4));
+    }
+
+    #[test]
+    fn arrow_list_display() {
+        let expected = DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int64,
+            true,
+        )));
+        assert_eq!(parse("List<Int64>"), expected);
+    }
+
+    fn map_of_test(key: DataType, value: DataType) -> DataType {
+        map_of(key, value)
+    }
+
+    #[test]
+    fn map_uppercase() {
+        assert_eq!(
+            parse("Map<Utf8, Int64>"),
+            map_of_test(DataType::Utf8, DataType::Int64)
+        );
+    }
+
+    #[test]
+    fn map_lowercase() {
+        assert_eq!(
+            parse("map<utf8, int64>"),
+            map_of_test(DataType::Utf8, DataType::Int64)
+        );
+    }
+
+    #[test]
+    fn map_postgres_types_inside() {
+        assert_eq!(
+            parse("Map<text, bigint>"),
+            map_of_test(DataType::Utf8, DataType::Int64)
+        );
+    }
+
+    #[test]
+    fn map_nested_value() {
+        let inner_list = DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int64,
+            true,
+        )));
+        assert_eq!(
+            parse("Map<Utf8, List<Int64>>"),
+            map_of_test(DataType::Utf8, inner_list)
+        );
+    }
+
+    #[test]
+    fn whitespace_tolerated() {
+        assert_eq!(parse("  bigint  "), DataType::Int64);
+        assert_eq!(
+            parse("  Map<  Utf8 ,  Int64  >  "),
+            map_of_test(DataType::Utf8, DataType::Int64)
+        );
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        fail("");
+        fail("not_a_type");
+        fail("Map<>");
+        fail("Map<Utf8>");
+        fail("Map<Utf8, Int64");
+        fail("Int64<>");
+        fail("Int64 garbage");
+        fail("@@@");
+    }
+
+    #[test]
+    fn rejects_invalid_array_element() {
+        fail("not_a_type[]");
+    }
+}

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -37,6 +37,7 @@ use std::{collections::HashMap, fmt::Display, str::FromStr, sync::Arc, time::Dur
 
 pub mod acceleration;
 pub mod builder;
+pub mod declared_type;
 pub mod metadata;
 pub mod replication;
 

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -89,6 +89,8 @@ mod nsql {
                         }],
                         description: None,
                         full_text_search: None,
+                        r#type: None,
+                        nullable: None,
                         metadata: HashMap::new(),
                 }];
 

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -83,6 +83,8 @@ mod nsql {
                     }],
                     description: None,
                     full_text_search: None,
+                    r#type: None,
+                    nullable: None,
                     metadata: HashMap::new(),
             }];
 
@@ -189,6 +191,8 @@ mod search {
                         }],
                         description: None,
                         full_text_search: None,
+                        r#type: None,
+                        nullable: None,
                         metadata: HashMap::new(),
                     }),
                 ))
@@ -248,6 +252,8 @@ mod search {
             }],
             description: None,
             full_text_search: None,
+            r#type: None,
+            nullable: None,
             metadata: HashMap::new(),
         }];
 
@@ -268,6 +274,8 @@ mod search {
             }],
             description: None,
             full_text_search: None,
+            r#type: None,
+            nullable: None,
             metadata: HashMap::new(),
         }];
 
@@ -623,6 +631,8 @@ async fn openai_test_chat_messages() -> Result<(), anyhow::Error> {
                 }],
                 description: None,
                 full_text_search: None,
+                r#type: None,
+                nullable: None,
                 metadata: HashMap::new(),
             }];
 

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -542,6 +542,8 @@ pub(crate) fn item_tpcds_dataset_w_embeddings(
         }],
         description: None,
         full_text_search: None,
+        r#type: None,
+        nullable: None,
         metadata: HashMap::new(),
     }];
 
@@ -585,6 +587,8 @@ pub(crate) fn catalog_page_tpcds_dataset_w_embeddings(
         }],
         description: None,
         full_text_search: None,
+        r#type: None,
+        nullable: None,
         metadata: HashMap::new(),
     }];
     ds_tpcds_cp
@@ -1965,6 +1969,8 @@ async fn test_multi_column_w_existing_embedding() -> Result<(), anyhow::Error> {
             embeddings: vec![
                 ColumnLevelEmbeddingConfig::model("hf_minilm").with_row_id("cp_catalog_page_sk"),
             ],
+            r#type: None,
+            nullable: None,
             metadata: HashMap::new(),
         },
         Column {
@@ -1974,6 +1980,8 @@ async fn test_multi_column_w_existing_embedding() -> Result<(), anyhow::Error> {
             embeddings: vec![
                 ColumnLevelEmbeddingConfig::model("hf_minilm").with_row_id("cp_catalog_page_sk"),
             ],
+            r#type: None,
+            nullable: None,
             metadata: HashMap::new(),
         },
     ];

--- a/crates/spicepod/src/semantic.rs
+++ b/crates/spicepod/src/semantic.rs
@@ -33,6 +33,20 @@ pub struct Column {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Optional column data type. Accepts Postgres-style names (e.g.
+    /// `bigint`, `timestamptz`, `text[]`, `numeric(18,4)`) and Arrow display
+    /// forms (e.g. `Int64`, `Utf8`, `Map<Utf8, Int64>`).
+    ///
+    /// Stored as a raw string at the spicepod layer; parsed into an Arrow
+    /// `DataType` by the runtime via `parse_declared_type`.
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "data_type")]
+    pub r#type: Option<String>,
+
+    /// Optional nullability for the column. When omitted, the runtime
+    /// defaults to nullable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub embeddings: Vec<ColumnLevelEmbeddingConfig>,
 
@@ -49,6 +63,8 @@ impl Column {
         Self {
             name: name.to_string(),
             description: None,
+            r#type: None,
+            nullable: None,
             embeddings: Vec::new(),
             full_text_search: None,
             metadata: HashMap::new(),
@@ -58,6 +74,18 @@ impl Column {
     #[must_use]
     pub fn with_metadata(mut self, metadata: HashMap<String, Value>) -> Self {
         self.metadata = metadata;
+        self
+    }
+
+    #[must_use]
+    pub fn with_type(mut self, ty: impl Into<String>) -> Self {
+        self.r#type = Some(ty.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = Some(nullable);
         self
     }
 


### PR DESCRIPTION
Phase 1 of [Enhancement #10660: Declared-schema deferred datasets (and removal of `load:`)](https://github.com/spiceai/spiceai/issues/10660).

## What

Adds two new optional fields to dataset `columns[]` in spicepods, plus a lenient type parser that future phases will consume to register datasets with a known schema and defer their source connection.

### `type:` and `nullable:` on columns

`columns[]` entries now accept `type` (string) and `nullable` (bool). Both are optional and have no runtime effect in this PR — they are forwarded through the spicepod model for later phases.

`type` accepts a wide range of forms: Postgres-style names, Arrow display forms, Postgres aliases not in sqlparser, and `Map` / `List` shorthand. Users write whatever they're comfortable with.

#### Postgres-style

```yaml
datasets:
  - from: postgres:public.events
    name: events
    columns:
      - name: id
        type: bigint
        nullable: false
      - name: ts
        type: timestamptz
      - name: tags
        type: text[]
      - name: amount
        type: numeric(18,4)
      - name: payload
        type: jsonb
      - name: blob
        type: bytea
```

#### Arrow display forms

```yaml
columns:
  - { name: id,      type: Int64, nullable: false }
  - { name: name,    type: Utf8 }
  - { name: created, type: Timestamp(Microsecond, UTC) }
  - { name: amount,  type: Decimal128(18, 4) }
  - { name: bools,   type: List<Boolean> }
```

#### Mixed styles in a single dataset

```yaml
columns:
  - { name: id,         type: bigint }              # Postgres
  - { name: name,       type: Utf8 }                # Arrow
  - { name: created_at, type: timestamp with time zone }
  - { name: tags,       type: text[] }              # Postgres array
  - { name: scores,     type: List<Float64> }       # Arrow shorthand
```

#### `Map` types (three syntaxes)

```yaml
columns:
  - { name: headers, type: 'Map<Utf8, Utf8>' }      # Arrow-style shorthand
  - { name: counts,  type: 'map<utf8, int64>' }     # lowercase (Hive/Spark/ClickHouse)
  - { name: nested,  type: 'Map<Utf8, List<Int64>>' }  # nested values
```

Map keys default to non-nullable, values nullable; the standard Arrow `entries` / `keys` / `values` field naming is used.

### `parse_declared_type` parser

New module `crates/runtime/src/component/dataset/declared_type.rs`. Tokenises with `logos` (matching the convention used by `runtime-secrets::lexer`) and walks the token stream as a small recursive-descent parser. Grammar:

```text
type        := primary array_suffix*
array_suffix:= '[' ']'
primary     := map | list | leaf
map         := ('Map'|'map') '<' type ',' type '>'
list        := ('List'|'list') '<' type '>'
leaf        := IDENT IDENT* paren_args?
paren_args  := '(' .* ')'   // matched by paren depth
```

Leaf types are resolved in order against:

1. The Postgres / Arrow alias table (`int2`/`int4`/`int8`, `float4`/`float8`, `serial`/`bigserial`, `timestamptz`, `uuid`, `utf8`/`int64`/lowercase Arrow primitives, etc.).
2. Arrow's `DataType::from_str`.
3. `sqlparser::Parser::parse_data_type` mapped into Arrow types (`BIGINT`, `VARCHAR(n)`, `NUMERIC(p,s)`, `TIMESTAMP WITH TIME ZONE`, `JSONB` → `Utf8`, `BYTEA` → `Binary`, etc.).

Tokenising before parsing means bracket / comma structure is always handled at the `logos` layer, so trailing-junk inputs like `Int64<>` cleanly fail rather than being silently truncated by `DataType::from_str` or `parse_data_type`.

## Why

Phase 1 of supporting very large numbers of datasets (target: 10k) without contacting their sources at startup. Later phases consume `columns[].type` and `nullable` to register datasets with a known schema and only contact the source on first reference.

This phase is **purely additive**. No runtime behavior change — the new fields are not yet consumed by registration. Mergeable on its own.

## Tests

20 new unit tests in `crates/runtime/src/component/dataset/declared_type.rs`:

- All Postgres alias families (integers, floats, decimals, strings, binary, booleans, timestamps, dates).
- Postgres array suffix (`text[]`, nested `bigint[][]`).
- Arrow display forms (`Int64`, `Utf8`, `Decimal128(p,s)`, `List<Int64>`).
- Map shorthand uppercase / lowercase / nested values / Postgres types inside.
- Multi-word leaf types (`double precision`, `timestamp with time zone`).
- Whitespace tolerance.
- Garbage-input rejection (`Int64<>`, `Map<>`, `Map<Utf8>`, unterminated, trailing junk, etc.).

`cargo test -p spicepod` and `cargo test -p runtime --lib component::dataset::declared_type` pass.