### PR TITLE
feat(dataconnector): add DataConnectorFactory::static_schema (default None)

### DIFF
--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -555,6 +555,30 @@ pub trait DataConnectorFactory: Send + Sync {
     fn reserved_keywords(&self) -> &'static [&'static str] {
         &[]
     }
+
+    /// Returns a static schema for the given dataset if this connector's
+    /// schema is fully determined by configuration and does not require
+    /// any source-facing I/O or connector construction.
+    ///
+    /// Called during dataset registration **before** the connector itself
+    /// is built (no `create` call is required first). Implementations may
+    /// consult `params` (e.g. a configured file format) and `dataset`
+    /// (e.g. declared content type, JSON column decomposition) but must
+    /// not perform any I/O.
+    ///
+    /// When `Some(schema)` is returned, the runtime is allowed to register
+    /// the dataset using that schema and defer building the connector and
+    /// calling [`DataConnector::read_provider`] until the dataset is
+    /// actually referenced. The connector is still expected to return a
+    /// `TableProvider` whose schema matches on the first `read_provider`
+    /// call; mismatches surface at first scan as a hard error rather than
+    /// being silently retried (the static schema is configuration, not
+    /// source state).
+    ///
+    /// Default: `None`. Most connectors infer schema from the source.
+    fn static_schema(&self, _params: &ConnectorParams, _dataset: &Dataset) -> Option<SchemaRef> {
+        None
+    }
 }
 
 /// A `DataConnector` knows how to retrieve and optionally write or stream data.
@@ -887,6 +911,55 @@ mod tests {
         .build(secrets, Handle::current())
         .await
         .expect("failed to build connector params")
+    }
+
+    #[tokio::test]
+    async fn test_static_schema_default_returns_none() {
+        // Any factory that doesn't override `static_schema` should return
+        // None. This is the contract relied on by the deferred-dataset
+        // path: a None return falls back to the eager source-contact
+        // registration flow.
+        struct DefaultFactory;
+        impl DataConnectorFactory for DefaultFactory {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+            fn create(
+                &self,
+                _params: ConnectorParams,
+            ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+                unimplemented!("static_schema must not require create()")
+            }
+            fn prefix(&self) -> &'static str {
+                "default_factory"
+            }
+            fn parameters(&self) -> &'static [ParameterSpec] {
+                &[]
+            }
+        }
+
+        register_connector_factory("default_factory", Arc::new(DefaultFactory)).await;
+
+        let app = Arc::new(app::AppBuilder::new("test_app").build());
+        let rt = Arc::new(crate::Runtime::builder().build().await);
+        let secrets = Arc::new(RwLock::new(Secrets::default()));
+        let dataset = DatasetBuilder::try_new("default_factory:tbl".to_string(), "tbl")
+            .expect("Failed to create builder")
+            .with_app(Arc::clone(&app))
+            .with_runtime(Arc::clone(&rt))
+            .build()
+            .expect("Failed to build dataset");
+
+        let params = ConnectorParamsBuilder::new(
+            "default_factory".into(),
+            ConnectorComponent::Dataset(Arc::new(dataset.clone())),
+        )
+        .build(secrets, Handle::current())
+        .await
+        .expect("failed to build connector params");
+
+        let factory = DefaultFactory;
+        assert!(factory.static_schema(&params, &dataset).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Phase 2a of [Enhancement #10660: Declared-schema deferred datasets (and removal of `load:`)](https://github.com/spiceai/spiceai/issues/10660).

## What

Adds a new optional method to the `DataConnectorFactory` trait:

```rust
fn static_schema(
    &self,
    _params: &ConnectorParams,
    _dataset: &Dataset,
) -> Option<SchemaRef> {
    None
}
```

The default implementation returns `None`, so all existing connectors continue to work unchanged.

## Why

Phase 2a of supporting very large numbers of datasets (target: 10k) without contacting their sources at startup. Some connector kinds — notably `https:` with a configured file format and connectors that route purely through user-declared `columns[]` — can determine their schema entirely from configuration without any source-facing I/O.

The contract:

- Called during dataset registration **before** the connector itself is built (no `create()` call is required first). The default impl is on the factory rather than on `DataConnector` precisely so deferred datasets can return a known schema without paying the cost of constructing the connector.
- Implementations may consult `params` (e.g. configured file format) and `dataset` (e.g. declared content type, declared columns) but must not perform any I/O.
- When `Some(schema)` is returned, the runtime is allowed to register the dataset using that schema and defer building the connector and calling `DataConnector::read_provider` until the dataset is actually referenced. The connector is still expected to return a `TableProvider` whose schema matches on the first `read_provider` call; mismatches surface at first scan as a hard error rather than being silently retried (the static schema is configuration, not source state).
- Default `None` means "I need to talk to the source to know my schema" — current behavior for every connector today.

This phase is **purely additive** with a default implementation, so it is mergeable on its own and a no-op at runtime. Later phases override it on connectors that can support it (Phase 2b: `declared_schema` / `deferred_schema_for` plumbing on top of this hook; Phase 6: `https:` static_schema for structured formats; future connectors as appropriate).

## Tests

One new unit test in `crates/runtime/src/dataconnector/mod.rs` (`test_static_schema_default_returns_none`) verifying that a factory which doesn't override `static_schema` returns `None`. The test factory's `create()` panics, asserting that the default `static_schema` does not require constructing the connector.

`cargo test -p runtime --lib dataconnector::tests::test_static_schema_default_returns_none` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->