### PR TITLE
refactor(runtime): introduce DatasetInitialization value type

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -23,6 +23,7 @@ use crate::dataaccelerator::BootstrapStatus;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::caching_engine::CachingEngineSys;
 use crate::datafusion::OnDemandTableLoader;
+use crate::init::dataset_initialization::DatasetInitialization;
 use crate::{
     AcceleratedTableInvalidChangesSnafu, AcceleratorEngineNotAvailableSnafu,
     AcceleratorInitializationFailedSnafu, Error, FullTextSearchRequiresAccelerationSnafu,
@@ -598,9 +599,16 @@ impl Runtime {
         }
 
         let runtime = ds.runtime();
-        runtime
-            .register_loaded_dataset(ds, connector, None, bootstrap_status, load_semaphore)
-            .await
+        DatasetInitialization::plan_eager(
+            ds,
+            runtime,
+            connector,
+            bootstrap_status,
+            load_semaphore,
+            None,
+        )
+        .initialize()
+        .await
     }
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
@@ -654,7 +662,7 @@ impl Runtime {
         }
     }
 
-    async fn register_loaded_dataset(
+    pub(crate) async fn register_loaded_dataset(
         self: Arc<Self>,
         ds: Arc<Dataset>,
         data_connector: Arc<dyn DataConnector>,
@@ -910,15 +918,16 @@ impl Runtime {
                     .remove_dataset(ds.name.clone(), ds.acceleration.as_ref())
                     .await;
 
-                if let Err(e) = Arc::clone(&self)
-                    .register_loaded_dataset(
-                        Arc::clone(&ds),
-                        Arc::clone(&connector),
-                        None,
-                        BootstrapStatus::None,
-                        None,
-                    )
-                    .await
+                if let Err(e) = DatasetInitialization::plan_eager(
+                    Arc::clone(&ds),
+                    Arc::clone(&self),
+                    Arc::clone(&connector),
+                    BootstrapStatus::None,
+                    None,
+                    None,
+                )
+                .initialize()
+                .await
                 {
                     self.status.update_dataset(
                         &ds.name,
@@ -1026,13 +1035,15 @@ impl Runtime {
         tracing::debug!("Accelerated table for dataset {} is ready", ds.name);
 
         // Hot reload doesn't bootstrap from snapshot
-        self.register_loaded_dataset(
+        DatasetInitialization::plan_eager(
             ds,
+            Arc::clone(&self),
             Arc::clone(&connector),
-            Some(accelerated_table),
             BootstrapStatus::None,
             None,
+            Some(accelerated_table),
         )
+        .initialize()
         .await?;
 
         Ok(())

--- a/crates/runtime/src/init/dataset_initialization.rs
+++ b/crates/runtime/src/init/dataset_initialization.rs
@@ -1,0 +1,153 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Dataset initialization value type.
+//!
+//! `DatasetInitialization` is a pure-data planning value that captures
+//! everything needed to materialize one dataset, with no I/O at
+//! construction. Calling [`DatasetInitialization::initialize`] runs the
+//! full bring-up: building the connector (if needed), resolving the
+//! schema, registering the dataset with `DataFusion`, registering with
+//! the health monitor, and starting any accelerated table refresh.
+//!
+//! Today only the eager flow is supported:
+//!
+//!   * [`ConnectorSource::Eager`] — connector is already built before
+//!     `DatasetInitialization::plan_eager` is called. This matches the
+//!     existing dataset bring-up path one-to-one.
+//!   * [`SchemaSource::FromProvider`] — `initialize` will call
+//!     `DataConnector::read_provider` to obtain the schema.
+//!   * `should_initialize_at_startup` always returns `true`.
+//!
+//! `initialize` currently delegates to `Runtime::register_loaded_dataset`
+//! so behavior matches the prior call sites exactly.
+
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use crate::component::dataset::Dataset;
+use crate::dataaccelerator::BootstrapStatus;
+use crate::dataconnector::DataConnector;
+use crate::{Result, Runtime, accelerated_table::AcceleratedTable};
+
+/// Where the `DataConnector` for this dataset comes from.
+pub(crate) enum ConnectorSource {
+    /// Connector is already constructed. This matches today's bring-up
+    /// path (`Runtime::load_dataset_connector` runs first, then
+    /// `register_loaded_dataset` is called with the resolved connector)
+    /// and the hot-reload path (which also has the connector in hand by
+    /// the time `register_loaded_dataset` runs).
+    Eager(Arc<dyn DataConnector>),
+}
+
+/// How the dataset's schema is resolved.
+pub(crate) enum SchemaSource {
+    /// Schema is unknown at planning time; `initialize` will call
+    /// `DataConnector::read_provider` and use the provider's schema.
+    FromProvider,
+}
+
+/// Pure-data plan for materializing one dataset.
+///
+/// Construction is I/O-free. All side effects (connector construction,
+/// `read_provider`, catalog registration, refresh-task spawning, health
+/// monitor registration) happen inside [`DatasetInitialization::initialize`].
+pub(crate) struct DatasetInitialization {
+    dataset: Arc<Dataset>,
+    runtime: Arc<Runtime>,
+    connector_source: ConnectorSource,
+    schema_source: SchemaSource,
+    bootstrap_status: BootstrapStatus,
+    load_semaphore: Option<Arc<Semaphore>>,
+    /// Set on the hot-reload path where an `AcceleratedTable` instance
+    /// has already been constructed and should be reused instead of
+    /// being rebuilt by `register_loaded_dataset`.
+    preloaded_accelerated_table: Option<Arc<AcceleratedTable>>,
+}
+
+impl DatasetInitialization {
+    /// Build an eager initialization plan for a dataset whose connector
+    /// has already been constructed.
+    ///
+    /// I/O-free.
+    pub(crate) fn plan_eager(
+        dataset: Arc<Dataset>,
+        runtime: Arc<Runtime>,
+        connector: Arc<dyn DataConnector>,
+        bootstrap_status: BootstrapStatus,
+        load_semaphore: Option<Arc<Semaphore>>,
+        preloaded_accelerated_table: Option<Arc<AcceleratedTable>>,
+    ) -> Self {
+        Self {
+            dataset,
+            runtime,
+            connector_source: ConnectorSource::Eager(connector),
+            schema_source: SchemaSource::FromProvider,
+            bootstrap_status,
+            load_semaphore,
+            preloaded_accelerated_table,
+        }
+    }
+
+    /// Synchronous accessor: the dataset this plan will initialize.
+    #[expect(dead_code)] // Reserved for upcoming deferred-initialization callers.
+    pub(crate) fn dataset(&self) -> &Dataset {
+        &self.dataset
+    }
+
+    /// True iff this plan must run at startup. False iff it can be
+    /// deferred to first reference.
+    ///
+    /// Currently always `true`; will return `false` for deferred
+    /// initialization once additional `ConnectorSource` / `SchemaSource`
+    /// variants are introduced.
+    #[expect(dead_code)] // Reserved for upcoming deferred-initialization callers.
+    pub(crate) fn should_initialize_at_startup(&self) -> bool {
+        match (&self.connector_source, &self.schema_source) {
+            (ConnectorSource::Eager(_), SchemaSource::FromProvider) => true,
+        }
+    }
+
+    /// Consume the plan and run the dataset bring-up to completion.
+    ///
+    /// Currently delegates to `Runtime::register_loaded_dataset` so
+    /// behavior matches the prior bring-up path exactly.
+    pub(crate) async fn initialize(self) -> Result<()> {
+        let Self {
+            dataset,
+            runtime,
+            connector_source,
+            schema_source,
+            bootstrap_status,
+            load_semaphore,
+            preloaded_accelerated_table,
+        } = self;
+
+        let ConnectorSource::Eager(connector) = connector_source;
+        let SchemaSource::FromProvider = schema_source;
+
+        runtime
+            .register_loaded_dataset(
+                dataset,
+                connector,
+                preloaded_accelerated_table,
+                bootstrap_status,
+                load_semaphore,
+            )
+            .await
+    }
+}

--- a/crates/runtime/src/init/mod.rs
+++ b/crates/runtime/src/init/mod.rs
@@ -19,6 +19,7 @@ limitations under the License.
 pub(crate) mod caching;
 pub(crate) mod catalog;
 pub(crate) mod dataset;
+pub(crate) mod dataset_initialization;
 pub(crate) mod embedding;
 pub(crate) mod extension;
 pub(crate) mod llm;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
+#![recursion_limit = "256"]
 
 use ::tools::SpiceModelTool;
 use ::tools::rename::with_name;


### PR DESCRIPTION
Phase 3 of [Enhancement #10660: Declared-schema deferred datasets (and removal of `load:`)](https://github.com/spiceai/spiceai/issues/10660).

## What

Adds a new pure-data planning value type, `DatasetInitialization`, that captures everything needed to bring up one dataset, and exposes a single `initialize().await` entry point that performs the full bring-up.

```rust
pub(crate) enum ConnectorSource {
    Eager(Arc<dyn DataConnector>),
    // Lazy added in Phase 5
}

pub(crate) enum SchemaSource {
    FromProvider,
    // Known added in Phase 5
}

pub(crate) struct DatasetInitialization {
    dataset: Arc<Dataset>,
    runtime: Arc<Runtime>,
    connector_source: ConnectorSource,
    schema_source: SchemaSource,
    bootstrap_status: BootstrapStatus,
    load_semaphore: Option<Arc<Semaphore>>,
    preloaded_accelerated_table: Option<Arc<AcceleratedTable>>,
}

impl DatasetInitialization {
    pub(crate) fn plan_eager(...) -> Self;
    pub(crate) fn dataset(&self) -> &Dataset;
    pub(crate) fn should_initialize_at_startup(&self) -> bool;  // always true in Phase 3
    pub(crate) async fn initialize(self) -> Result<()>;
}
```

In Phase 3 only the eager flow exists. The body of `initialize` delegates to the existing `Runtime::register_loaded_dataset`, so on-disk behavior is byte-for-byte identical. The three pre-existing call sites of `register_loaded_dataset` are rewired to construct a `DatasetInitialization` and call `.initialize().await`:

1. Startup load (`try_load_dataset_once`).
2. Retry-after-failure (inside `apply_dataset_diff`).
3. Hot reload (`reload_accelerated_dataset`).

`register_loaded_dataset` itself is unchanged in body; visibility is widened from private to `pub(crate)` so the new module can call it.

## Why

This is the **behavior-preserving** scaffolding step for the declared-schema deferred datasets work. By landing the value type and call-site plumbing first — with no semantic change — the next two PRs become much smaller and easier to review:

* **Phase 4** — `DatasetTableProvider` placeholder always registered at t=0; `replace_table` swap inside `ensure_ready`. Still eager-only; validates the swap path under existing tests before introducing deferral.
* **Phase 5** — `ConnectorSource::Lazy` for deferred connector construction; `SchemaSource::Known` for declared / static schemas; `should_initialize_at_startup` returns `false` when the trigger condition holds; `DatasetInitializationResolver` query-planning hook with AtomicBool fast path.

See `plans/declared-schema-deferred-datasets.md` §A1 for the long-term shape of this type.

## Notes for reviewers

Bumps `runtime`'s `#![recursion_limit]` from the default 128 to 256:

```text
error: queries overflow the depth limit!
  = note: query depth increased by 130 when computing layout of
          `{async block@crates/runtime/src/init/dataset.rs:75:5: 75:10}`
```

Threading dataset bring-up through one extra `await` level pushed the existing async state machine for `load_on_demand_tables` over the default query depth limit. The compiler explicitly prompts for this. The new limit is well within typical Rust crate ranges.

The Phase 3 `initialize` body intentionally takes the simplest possible form (delegate to the pre-existing path) so that this PR can land independently and the diff is a true refactor. Phase 4 will inline the `register_loaded_dataset` body into `initialize` so the eager and lazy paths can begin to diverge.

## Tests

No new tests in this PR — existing dataset bring-up coverage exercises every code path that now runs through `DatasetInitialization`. `cargo build -p runtime` and `cargo check -p runtime --tests` both succeed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->