### PR TITLE
fix: use checked arithmetic in timestamp-to-nanosecond conversions

### DIFF
--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -1244,10 +1244,18 @@ fn to_delta_kernel_scalar(scalar: ScalarValue) -> Option<Scalar> {
                 None
             }
         }
-        ScalarValue::TimestampSecond(Some(v), Some(_)) => Some(Scalar::Timestamp(v * 1_000_000)), // Convert to microseconds
-        ScalarValue::TimestampSecond(Some(v), None) => Some(Scalar::TimestampNtz(v * 1_000_000)), // Convert to microseconds
-        ScalarValue::TimestampMillisecond(Some(v), Some(_)) => Some(Scalar::Timestamp(v * 1000)), // Convert to microseconds
-        ScalarValue::TimestampMillisecond(Some(v), None) => Some(Scalar::TimestampNtz(v * 1000)), // Convert to microseconds
+        ScalarValue::TimestampSecond(Some(v), Some(_)) => {
+            v.checked_mul(1_000_000).map(Scalar::Timestamp)
+        }
+        ScalarValue::TimestampSecond(Some(v), None) => {
+            v.checked_mul(1_000_000).map(Scalar::TimestampNtz)
+        }
+        ScalarValue::TimestampMillisecond(Some(v), Some(_)) => {
+            v.checked_mul(1000).map(Scalar::Timestamp)
+        }
+        ScalarValue::TimestampMillisecond(Some(v), None) => {
+            v.checked_mul(1000).map(Scalar::TimestampNtz)
+        }
         ScalarValue::TimestampMicrosecond(Some(v), Some(_)) => Some(Scalar::Timestamp(v)),
         ScalarValue::TimestampMicrosecond(Some(v), None) => Some(Scalar::TimestampNtz(v)),
         ScalarValue::TimestampNanosecond(Some(v), Some(_)) => Some(Scalar::Timestamp(v / 1000)), // Convert to microseconds

--- a/crates/data_components/src/turso.rs
+++ b/crates/data_components/src/turso.rs
@@ -1881,11 +1881,21 @@ fn convert_timestamp_to_turso(
             // Convert to RFC3339 string format
             use chrono::{DateTime, Utc};
 
-            // Convert value to nanoseconds
+            // Convert value to nanoseconds (checked to prevent overflow for dates beyond ~year 2262)
             let nanos = match unit {
-                TimeUnit::Second => value * timestamp_conversion::NANOS_PER_SECOND,
-                TimeUnit::Millisecond => value * timestamp_conversion::NANOS_PER_MILLI,
-                TimeUnit::Microsecond => value * 1_000,
+                TimeUnit::Second => value
+                    .checked_mul(timestamp_conversion::NANOS_PER_SECOND)
+                    .ok_or_else(|| {
+                        format!("Timestamp value {value}s overflows nanosecond conversion")
+                    })?,
+                TimeUnit::Millisecond => value
+                    .checked_mul(timestamp_conversion::NANOS_PER_MILLI)
+                    .ok_or_else(|| {
+                    format!("Timestamp value {value}ms overflows nanosecond conversion")
+                })?,
+                TimeUnit::Microsecond => value.checked_mul(1_000).ok_or_else(|| {
+                    format!("Timestamp value {value}us overflows nanosecond conversion")
+                })?,
                 TimeUnit::Nanosecond => value,
             };
 
@@ -2439,6 +2449,27 @@ mod tests {
         assert!(
             arr.is_null(0),
             "Nanosecond-precision timestamp should be NULL for year 2300 (overflow)"
+        );
+    }
+
+    #[test]
+    fn test_convert_timestamp_to_turso_rfc3339_overflow_returns_error() {
+        let result =
+            convert_timestamp_to_turso(i64::MAX, TimeUnit::Second, None, TimestampFormat::Rfc3339);
+        assert!(
+            result.is_err(),
+            "TimestampSecond i64::MAX should overflow when converting to nanoseconds"
+        );
+
+        let result = convert_timestamp_to_turso(
+            i64::MAX,
+            TimeUnit::Millisecond,
+            None,
+            TimestampFormat::Rfc3339,
+        );
+        assert!(
+            result.is_err(),
+            "TimestampMillisecond i64::MAX should overflow when converting to nanoseconds"
         );
     }
 }

--- a/crates/runtime-table-partition/src/provider/pruning.rs
+++ b/crates/runtime-table-partition/src/provider/pruning.rs
@@ -812,13 +812,16 @@ fn evaluate_date_trunc_inequality(
         return Ok(false); // Conservative: don't prune if granularity not a string
     };
 
-    // Extract timestamp from partition_value
-    let partition_ts = match partition_value {
-        ScalarValue::TimestampNanosecond(Some(ts), _) => *ts,
-        ScalarValue::TimestampMicrosecond(Some(ts), _) => ts * 1_000,
-        ScalarValue::TimestampMillisecond(Some(ts), _) => ts * 1_000_000,
-        ScalarValue::TimestampSecond(Some(ts), _) => ts * NANOS_PER_SECOND,
+    // Extract timestamp from partition_value, converting to nanoseconds.
+    // Use checked arithmetic to avoid overflow for timestamps beyond ~year 2262.
+    let Some(partition_ts) = (match partition_value {
+        ScalarValue::TimestampNanosecond(Some(ts), _) => Some(*ts),
+        ScalarValue::TimestampMicrosecond(Some(ts), _) => ts.checked_mul(1_000),
+        ScalarValue::TimestampMillisecond(Some(ts), _) => ts.checked_mul(1_000_000),
+        ScalarValue::TimestampSecond(Some(ts), _) => ts.checked_mul(NANOS_PER_SECOND),
         _ => return Ok(false), // Conservative: not a timestamp
+    }) else {
+        return Ok(false); // Overflow: don't prune
     };
 
     // Compute the upper bound based on granularity
@@ -833,7 +836,9 @@ fn evaluate_date_trunc_inequality(
         _ => return Ok(false), // Unknown granularity, be conservative
     };
 
-    let partition_upper_ts = partition_ts + nanos_in_granularity;
+    let Some(partition_upper_ts) = partition_ts.checked_add(nanos_in_granularity) else {
+        return Ok(false); // Overflow: don't prune
+    };
 
     // Create upper bound ScalarValue matching the partition_value type
     let partition_upper = match partition_value {
@@ -2567,6 +2572,33 @@ mod tests {
                 "Partition {partition_value} should not be pruned for user_id != 42 (bucket partitioning)",
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_prune_partition_date_trunc_timestamp_overflow_does_not_prune()
+    -> Result<(), DataFusionError> {
+        let schema = Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Second, None),
+            false,
+        )]);
+        let partition_by = date_trunc(lit("year"), col("ts"));
+
+        // i64::MAX seconds (~year 292 billion) overflows when converted to nanoseconds.
+        // The partition should NOT be pruned (conservative behavior), not panic or wrap.
+        let overflow_ts = i64::MAX;
+        let partition_value = ScalarValue::TimestampSecond(Some(overflow_ts), None);
+
+        let filter_value = ScalarValue::TimestampSecond(Some(1_000_000_000), None);
+        let filters = &[col("ts").gt(lit(filter_value))];
+
+        let pruned = prune_partition(&filters[..], &partition_by, &partition_value, &schema)?;
+        assert!(
+            !pruned,
+            "Partition with overflowing timestamp should not be pruned (conservative)"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
Unchecked `i64` multiplication when converting timestamps to nanoseconds silently wraps in release builds for dates beyond ~year 2262, causing wrong results in three places:

- **Partition pruning** (`pruning.rs`): overflow produces an incorrect nanosecond value that causes wrong partition inclusion/exclusion — queries silently return incorrect results
- **Turso RFC3339 conversion** (`turso.rs`): overflow corrupts the formatted timestamp string written to Turso
- **Delta Lake scalar conversion** (`delta_lake.rs`): overflow corrupts the microsecond value sent to the Delta kernel for predicate pushdown

## Fix
Replace unchecked `*` / `+` with `checked_mul` / `checked_add`:
- Partition pruning: returns `Ok(false)` (conservative: don't prune) on overflow
- Turso: returns an error on overflow instead of writing a corrupted value
- Delta Lake: returns `None` (NULL) on overflow instead of a wrapped value

## Test plan
- Added regression test `test_prune_partition_date_trunc_timestamp_overflow_does_not_prune` — verifies `i64::MAX` seconds doesn't panic or produce wrong pruning
- Added regression test `test_convert_timestamp_to_turso_rfc3339_overflow_returns_error` — verifies `i64::MAX` seconds/millis returns an error
- `cargo clippy -p runtime-table-partition --all-targets -- -D warnings` passes
- `cargo clippy -p data_components --features turso -- -D warnings` passes
- `cargo clippy -p data_components --features delta_lake -- -D warnings` passes
- All existing pruning and turso tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->