### PR TITLE
fix: use InsertOp::Overwrite in DynamoDB re-bootstrap

### DIFF
--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -1063,7 +1063,7 @@ async fn scan_and_overwrite_accelerator(
     let table_sink = TableSink::new(accelerated_table_provider);
     let _guard = accelerator_write_mutex.lock().await;
     if let Err(e) = table_sink
-        .insert_into(instrumented_stream, InsertOp::Append)
+        .insert_into(instrumented_stream, InsertOp::Overwrite)
         .await
     {
         tracing::error!(


### PR DESCRIPTION
## Summary
`scan_and_overwrite_accelerator` used `InsertOp::Append` instead of `InsertOp::Overwrite`. When DynamoDB Streams shards expire and the runtime triggers a re-bootstrap, the full DynamoDB table scan is **appended** on top of existing rows instead of replacing them, causing data duplication in the accelerated table.

The function is named `scan_and_overwrite_accelerator` but was using `Append` due to a refactoring oversight when PR #10616 extracted the shared helper from `do_rebootstrap`.

## Fix
Change `InsertOp::Append` to `InsertOp::Overwrite` at `dynamodb.rs:1066`.

## Test plan
- `cargo clippy -p runtime --features dynamodb -- -D warnings` passes
- The initial bootstrap path (empty table) produces the same result with both Append and Overwrite
- The re-bootstrap path now correctly replaces all existing data instead of duplicating it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->