### PR TITLE
Add Delta Lake Azure tenant parameter

### DIFF
--- a/crates/data-connectors/connector-delta-lake/src/lib.rs
+++ b/crates/data-connectors/connector-delta-lake/src/lib.rs
@@ -108,6 +108,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("azure_storage_client_secret")
         .description("The service principal client secret for accessing the storage account.")
         .secret(),
+    ParameterSpec::component("azure_storage_tenant_id")
+        .description("The service principal tenant id for accessing the storage account.")
+        .secret(),
     ParameterSpec::component("azure_storage_sas_key")
         .description("The shared access signature key for accessing the storage account.")
         .secret(),
@@ -294,4 +297,49 @@ pub const CONNECTOR_NAME: &str = "delta_lake";
 #[must_use]
 pub fn factory() -> Arc<dyn DataConnectorFactory> {
     DeltaLakeFactory::new_arc()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runtime::secrets::Secrets;
+    use secrecy::SecretString;
+    use tokio::sync::RwLock;
+
+    #[tokio::test]
+    async fn tenant_id_parameter_is_accepted_and_registered() {
+        let parameters = Parameters::try_new(
+            "connector delta_lake",
+            vec![(
+                "delta_lake_azure_storage_tenant_id".to_string(),
+                SecretString::new("tenant-id".to_string().into()),
+            )],
+            "delta_lake",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("tenant id should be accepted for delta_lake");
+
+        assert_eq!(
+            parameters.get("azure_storage_tenant_id").expose().ok(),
+            Some("tenant-id")
+        );
+
+        let delta_table_options = parameters.to_secret_map();
+        assert_eq!(
+            delta_table_options
+                .get("azure_storage_tenant_id")
+                .map(|value| value.expose_secret()),
+            Some("tenant-id")
+        );
+
+        let registry_params = parameters.storage_registry_params();
+        let tenant_id = registry_params
+            .iter()
+            .find(|(key, _)| key == "tenant_id")
+            .map(|(_, value)| value.expose_secret());
+
+        assert_eq!(tenant_id, Some("tenant-id"));
+    }
 }

--- a/crates/data-connectors/connector-delta-lake/src/lib.rs
+++ b/crates/data-connectors/connector-delta-lake/src/lib.rs
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(
             delta_table_options
                 .get("azure_storage_tenant_id")
-                .map(|value| value.expose_secret()),
+                .map(ExposeSecret::expose_secret),
             Some("tenant-id")
         );
 

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -663,6 +663,7 @@ datasets:
       delta_lake_azure_storage_account_key: key
       delta_lake_azure_storage_client_id: client-id
       delta_lake_azure_storage_client_secret: secret
+      delta_lake_azure_storage_tenant_id: tenant-id
       delta_lake_azure_storage_sas_key: sas
       delta_lake_azure_storage_endpoint: endpoint
       # GCP params


### PR DESCRIPTION
Adds `delta_lake_azure_storage_tenant_id` to the Delta Lake connector's accepted Azure storage parameters so local ADLS/Delta configurations using service-principal auth are not rejected during parameter validation.

Summary:
- Add `azure_storage_tenant_id` to the Delta Lake connector parameter spec.
- Extend the regression test to verify the value is preserved for Delta's direct storage options and mapped to `tenant_id` for object-store registry registration.
- Add the parameter to the spicepod schema all-parameters fixture.

Verification:
- `cargo fmt --check -- crates/data-connectors/connector-delta-lake/src/lib.rs`
- `RUSTC_WRAPPER= cargo test -p connector-delta-lake tenant_id_parameter_is_accepted_and_registered`

Note: the focused test compile emits an existing unrelated `runtime` dead-code warning for `set_accelerator`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->