### PR TITLE
Add nolimit HTTP pagination max pages

### DIFF
--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -2039,7 +2039,6 @@ impl ExecutionPlan for HttpExec {
                         // Fetch this page
                         let fetch_result = if state.page == 0 {
                             let path_val = state.path.clone().unwrap_or_default();
-                            let body_val = state.body.as_deref();
                             let merged_query = if let Some(ref template) = config.query_params {
                                 let page_size = config.page_size.unwrap_or(0);
                                 let expanded =
@@ -2062,6 +2061,7 @@ impl ExecutionPlan for HttpExec {
                                 .map_err(DataFusionError::from)?;
                             state.last_page_path = state.path.clone();
                             state.last_page_query = merged_query.clone();
+                            let body_val = state.body.as_deref();
                             provider
                                 .get_response(
                                     &path_val,

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -2001,6 +2001,7 @@ impl ExecutionPlan for HttpExec {
                 done: false,
                 last_page_path: None,
                 last_page_query: None,
+                seen_page_urls: HashSet::new(),
             };
 
             let stream = futures::stream::try_unfold(initial_state, move |mut state| {
@@ -2037,7 +2038,7 @@ impl ExecutionPlan for HttpExec {
 
                         // Fetch this page
                         let fetch_result = if state.page == 0 {
-                            let path_val = state.path.as_deref().unwrap_or("");
+                            let path_val = state.path.clone().unwrap_or_default();
                             let body_val = state.body.as_deref();
                             let merged_query = if let Some(ref template) = config.query_params {
                                 let page_size = config.page_size.unwrap_or(0);
@@ -2054,11 +2055,16 @@ impl ExecutionPlan for HttpExec {
                                     state.query.as_deref(),
                                 )
                             };
+                            let request_url = provider
+                                .build_request_url(&path_val, merged_query.as_deref())
+                                .map_err(DataFusionError::from)?;
+                            record_pagination_request_url(&mut state, &request_url)
+                                .map_err(DataFusionError::from)?;
                             state.last_page_path = state.path.clone();
                             state.last_page_query = merged_query.clone();
                             provider
                                 .get_response(
-                                    path_val,
+                                    &path_val,
                                     merged_query.as_deref(),
                                     body_val,
                                     state.request_headers.as_deref(),
@@ -2076,7 +2082,7 @@ impl ExecutionPlan for HttpExec {
                             // Subsequent pages bypass the HTTP cache intentionally:
                             // each page has unique content that shouldn't be cached
                             // under the same key as the base request.
-                            match &state.next_info {
+                            match state.next_info.clone() {
                                 Some(NextPageInfo::Url(url)) => {
                                     if let Some((globset, patterns)) = &provider.allowed_paths
                                         && !globset.is_match(url.path())
@@ -2095,11 +2101,13 @@ impl ExecutionPlan for HttpExec {
                                             },
                                         )));
                                     }
+                                    record_pagination_request_url(&mut state, &url)
+                                        .map_err(DataFusionError::from)?;
                                     state.last_page_path = Some(url.path().to_string());
                                     state.last_page_query = url.query().map(ToString::to_string);
                                     provider
                                         .perform_request_with_retry(
-                                            url.clone(),
+                                            url,
                                             state.body.as_deref(),
                                             parsed_request_headers.as_ref(),
                                             &format!("page_{}", state.page),
@@ -2116,12 +2124,14 @@ impl ExecutionPlan for HttpExec {
                                         base_query,
                                         state.query.as_deref(),
                                         token_param,
-                                        token,
+                                        &token,
                                     );
                                     state.last_page_path = state.path.clone();
                                     state.last_page_query = Some(merged_query.clone());
                                     let url = provider
                                         .build_request_url(path_val, Some(&merged_query))
+                                        .map_err(DataFusionError::from)?;
+                                    record_pagination_request_url(&mut state, &url)
                                         .map_err(DataFusionError::from)?;
                                     provider
                                         .perform_request_with_retry(
@@ -2138,7 +2148,7 @@ impl ExecutionPlan for HttpExec {
                                     let template = config.query_params.as_deref().unwrap_or("");
                                     let page_size = config.page_size.unwrap_or(0);
                                     let expanded =
-                                        expand_query_params_template(template, *page, page_size)?;
+                                        expand_query_params_template(template, page, page_size)?;
                                     let merged_query =
                                         merge_base_and_partition_queries_with_override(
                                             provider.base_url.query(),
@@ -2149,6 +2159,8 @@ impl ExecutionPlan for HttpExec {
                                     state.last_page_query = Some(merged_query.clone());
                                     let url = provider
                                         .build_request_url(path_val, Some(&merged_query))
+                                        .map_err(DataFusionError::from)?;
+                                    record_pagination_request_url(&mut state, &url)
                                         .map_err(DataFusionError::from)?;
                                     provider
                                         .perform_request_with_retry(
@@ -2306,6 +2318,27 @@ struct PaginationState {
     /// Used to populate accurate `request_path`/`request_query` columns.
     last_page_path: Option<String>,
     last_page_query: Option<String>,
+    seen_page_urls: HashSet<String>,
+}
+
+fn pagination_request_label(url: &Url) -> String {
+    let mut hasher = DefaultHasher::new();
+    url.as_str().hash(&mut hasher);
+    format!("http-pagination-request:{:016x}", hasher.finish())
+}
+
+fn record_pagination_request_url(state: &mut PaginationState, url: &Url) -> Result<()> {
+    let request_url = url.as_str().to_string();
+    ensure!(
+        state.seen_page_urls.insert(request_url),
+        PaginationSnafu {
+            message: format!(
+                "HTTP pagination detected a repeated next page request ({}). The connector stopped before fetching duplicate rows. Check pagination_next_pointer, pagination_link_header, pagination_token_param, or pagination_query_params.",
+                pagination_request_label(url)
+            )
+        }
+    );
+    Ok(())
 }
 
 /// Resolve a next-page URL string (absolute or relative) against the base URL
@@ -5514,6 +5547,40 @@ mod tests {
                 assert!(
                     message.contains("pagination_max_pages"),
                     "error should mention pagination_max_pages: {message}"
+                );
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_pagination_rejects_repeated_request_url() {
+        let mut state = PaginationState {
+            page: 1,
+            next_info: None,
+            rows_fetched: 0,
+            path: None,
+            query: None,
+            body: None,
+            request_headers: None,
+            limit: None,
+            done: false,
+            last_page_path: None,
+            last_page_query: None,
+            seen_page_urls: HashSet::new(),
+        };
+        let url =
+            Url::parse("https://api.example.com/items?page=2").expect("test URL should be valid");
+
+        record_pagination_request_url(&mut state, &url).expect("first request should be accepted");
+        let error = record_pagination_request_url(&mut state, &url)
+            .expect_err("repeated request should fail");
+
+        match error {
+            Error::Pagination { message } => {
+                assert!(
+                    message.contains("repeated next page request"),
+                    "error should mention repeated pagination request: {message}"
                 );
             }
             other => panic!("Unexpected error: {other:?}"),

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -46,7 +46,7 @@ use reqwest::{
 };
 use runtime_rate_control::{Permit, RateController};
 use snafu::prelude::*;
-use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::DefaultHasher};
 use std::{
     any::Any,
     borrow::ToOwned,
@@ -146,6 +146,7 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024; // 16 KiB
 pub const DEFAULT_MAX_HEADERS_LENGTH: usize = 16 * 1024; // 16 KiB
 pub const DEFAULT_PAGINATION_MAX_PAGES: usize = 100;
 const MAX_REQUEST_PATH_LENGTH: usize = 1024;
+const PAGINATION_REPEAT_DETECTION_WINDOW: usize = 1024;
 pub type PartitionSpec = (
     Option<String>,
     Option<String>,
@@ -2001,7 +2002,7 @@ impl ExecutionPlan for HttpExec {
                 done: false,
                 last_page_path: None,
                 last_page_query: None,
-                seen_page_urls: HashSet::new(),
+                recent_page_urls: VecDeque::new(),
             };
 
             let stream = futures::stream::try_unfold(initial_state, move |mut state| {
@@ -2318,7 +2319,7 @@ struct PaginationState {
     /// Used to populate accurate `request_path`/`request_query` columns.
     last_page_path: Option<String>,
     last_page_query: Option<String>,
-    seen_page_urls: HashSet<String>,
+    recent_page_urls: VecDeque<String>,
 }
 
 fn pagination_request_label(url: &Url) -> String {
@@ -2330,7 +2331,7 @@ fn pagination_request_label(url: &Url) -> String {
 fn record_pagination_request_url(state: &mut PaginationState, url: &Url) -> Result<()> {
     let request_url = url.as_str().to_string();
     ensure!(
-        state.seen_page_urls.insert(request_url),
+        !state.recent_page_urls.contains(&request_url),
         PaginationSnafu {
             message: format!(
                 "HTTP pagination detected a repeated next page request ({}). The connector stopped before fetching duplicate rows. Check pagination_next_pointer, pagination_link_header, pagination_token_param, or pagination_query_params.",
@@ -2338,6 +2339,10 @@ fn record_pagination_request_url(state: &mut PaginationState, url: &Url) -> Resu
             )
         }
     );
+    state.recent_page_urls.push_back(request_url);
+    if state.recent_page_urls.len() > PAGINATION_REPEAT_DETECTION_WINDOW {
+        state.recent_page_urls.pop_front();
+    }
     Ok(())
 }
 
@@ -3232,7 +3237,7 @@ mod tests {
     use datafusion::common::Column;
     use datafusion::logical_expr::{BinaryExpr, Expr, Operator, expr::InList};
     use datafusion::scalar::ScalarValue;
-    use std::sync::Arc;
+    use std::sync::{Arc, atomic::AtomicUsize};
     use std::time::Duration;
     use url::Url;
 
@@ -5567,7 +5572,7 @@ mod tests {
             done: false,
             last_page_path: None,
             last_page_query: None,
-            seen_page_urls: HashSet::new(),
+            recent_page_urls: VecDeque::new(),
         };
         let url =
             Url::parse("https://api.example.com/items?page=2").expect("test URL should be valid");
@@ -5585,6 +5590,144 @@ mod tests {
             }
             other => panic!("Unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_pagination_repeated_request_tracking_is_bounded() {
+        let mut state = PaginationState {
+            page: 1,
+            next_info: None,
+            rows_fetched: 0,
+            path: None,
+            query: None,
+            body: None,
+            request_headers: None,
+            limit: None,
+            done: false,
+            last_page_path: None,
+            last_page_query: None,
+            recent_page_urls: VecDeque::new(),
+        };
+
+        for page in 0..=PAGINATION_REPEAT_DETECTION_WINDOW {
+            let url = Url::parse(&format!("https://api.example.com/items?page={page}"))
+                .expect("test URL should be valid");
+            record_pagination_request_url(&mut state, &url)
+                .expect("unique request should be accepted");
+        }
+
+        assert_eq!(
+            state.recent_page_urls.len(),
+            PAGINATION_REPEAT_DETECTION_WINDOW,
+            "recent URL tracking should be capped"
+        );
+
+        let evicted_url =
+            Url::parse("https://api.example.com/items?page=0").expect("test URL should be valid");
+        record_pagination_request_url(&mut state, &evicted_url)
+            .expect("evicted URL should not be retained forever");
+    }
+
+    async fn start_query_param_pagination_server(stop_offset: usize) -> (Url, Arc<AtomicUsize>) {
+        use std::sync::atomic::Ordering;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock server should bind");
+        let address = listener.local_addr().expect("mock server should have addr");
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let request_count_for_server = Arc::clone(&request_count);
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let request_count = Arc::clone(&request_count_for_server);
+
+                tokio::spawn(async move {
+                    let mut buffer = [0_u8; 1024];
+                    let bytes_read = stream.read(&mut buffer).await.unwrap_or(0);
+                    request_count.fetch_add(1, Ordering::SeqCst);
+
+                    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+                    let request_target = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    let request_url = Url::parse(&format!("http://localhost{request_target}"))
+                        .expect("request target should form a valid URL");
+                    let offset = request_url
+                        .query_pairs()
+                        .find_map(|(key, value)| {
+                            (key == "offset")
+                                .then(|| value.parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+
+                    let body = if offset < stop_offset {
+                        format!(r#"{{"docs":[{{"id":{offset}}}]}}"#)
+                    } else {
+                        r#"{"docs":[]}"#.to_string()
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        (
+            Url::parse(&format!("http://{address}/items")).expect("mock URL should be valid"),
+            request_count,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_pagination_without_max_pages_fetches_past_default_limit() {
+        use datafusion::prelude::SessionContext;
+        use std::sync::atomic::Ordering;
+
+        let rows_to_return = DEFAULT_PAGINATION_MAX_PAGES + 5;
+        let (base_url, request_count) = start_query_param_pagination_server(rows_to_return).await;
+        let provider = HttpTableProvider::new(base_url, Client::new(), "json".to_string(), false)
+            .with_pagination(PaginationConfig {
+                query_params: Some("offset={offset}&limit={limit}".to_string()),
+                page_size: Some(1),
+                data_pointer: Some("/docs".to_string()),
+                max_pages: None,
+                use_link_header: false,
+                ..Default::default()
+            })
+            .expect("pagination config should be valid");
+
+        let ctx = SessionContext::new();
+        ctx.register_table("items", Arc::new(provider))
+            .expect("table should register");
+
+        let results = ctx
+            .sql("SELECT content FROM items")
+            .await
+            .expect("query should plan")
+            .collect()
+            .await
+            .expect("query should execute");
+
+        let total_rows: usize = results.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            total_rows, rows_to_return,
+            "unlimited pagination should fetch beyond the default safety limit"
+        );
+        assert!(
+            request_count.load(Ordering::SeqCst) > DEFAULT_PAGINATION_MAX_PAGES,
+            "execution should request pages beyond the old safety limit"
+        );
     }
 
     #[test]

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -183,8 +183,8 @@ pub struct PaginationConfig {
     /// When set, only the array at this path is returned as data rows.
     pub data_pointer: Option<String>,
 
-    /// Maximum number of pages to fetch. Default: 100
-    pub max_pages: usize,
+    /// Maximum number of pages to fetch. Default: 100. `None` disables the limit.
+    pub max_pages: Option<usize>,
 
     /// When `true`, if the data at `data_pointer` (or the top-level response) is a JSON
     /// object/map, extract its values as rows instead of treating it as a single row.
@@ -209,7 +209,7 @@ impl Default for PaginationConfig {
             use_link_header: true,
             token_param: None,
             data_pointer: None,
-            max_pages: DEFAULT_PAGINATION_MAX_PAGES,
+            max_pages: Some(DEFAULT_PAGINATION_MAX_PAGES),
             data_map_to_array: false,
             query_params: None,
             page_size: None,
@@ -770,12 +770,14 @@ impl HttpTableProvider {
                 });
             }
         }
-        ensure!(
-            config.max_pages > 0,
-            ConfigurationSnafu {
-                message: "pagination_max_pages must be greater than 0".to_string()
-            }
-        );
+        if let Some(max_pages) = config.max_pages {
+            ensure!(
+                max_pages > 0,
+                ConfigurationSnafu {
+                    message: "pagination_max_pages must be greater than 0".to_string()
+                }
+            );
+        }
         if let Some(ref pointer) = config.next_pointer {
             ensure!(
                 pointer.starts_with('/'),
@@ -2015,10 +2017,12 @@ impl ExecutionPlan for HttpExec {
                             DataFusionError::Internal("Pagination config missing".to_string())
                         })?;
 
-                        if state.page >= config.max_pages {
+                        if let Some(max_pages) = config.max_pages
+                            && state.page >= max_pages
+                        {
                             tracing::warn!(
                                 "HTTP pagination reached the configured safety limit of {} pages. Increase `pagination_max_pages` to fetch additional pages.",
-                                config.max_pages
+                                max_pages
                             );
                             return Ok(None);
                         }
@@ -5175,7 +5179,7 @@ mod tests {
                 query_params: Some("offset={offset}&limit={limit}".to_string()),
                 page_size: Some(3),
                 data_pointer: Some("/docs".to_string()),
-                max_pages: 2,
+                max_pages: Some(2),
                 use_link_header: false,
                 ..Default::default()
             })
@@ -5480,6 +5484,40 @@ mod tests {
             ..Default::default()
         });
         assert!(result.is_ok(), "should accept link_header pagination");
+    }
+
+    #[test]
+    fn test_pagination_config_valid_with_no_max_pages_limit() {
+        let provider = base_provider();
+        let result = provider.with_pagination(PaginationConfig {
+            next_pointer: Some("/next".to_string()),
+            use_link_header: false,
+            max_pages: None,
+            ..Default::default()
+        });
+        assert!(result.is_ok(), "should accept no max-pages limit");
+    }
+
+    #[test]
+    fn test_pagination_config_rejects_zero_max_pages() {
+        let provider = base_provider();
+        let error = provider
+            .with_pagination(PaginationConfig {
+                next_pointer: Some("/next".to_string()),
+                use_link_header: false,
+                max_pages: Some(0),
+                ..Default::default()
+            })
+            .expect_err("zero max_pages should fail");
+        match error {
+            Error::Configuration { message } => {
+                assert!(
+                    message.contains("pagination_max_pages"),
+                    "error should mention pagination_max_pages: {message}"
+                );
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -58,6 +58,24 @@ use std::time::Duration;
 
 const DEFAULT_CLIENT_TIMEOUT_SECS: u64 = 30;
 
+fn parse_pagination_max_pages(value: &str) -> Option<usize> {
+    let trimmed = value.trim();
+    if trimmed.eq_ignore_ascii_case("nolimit") {
+        return None;
+    }
+
+    match trimmed.parse::<usize>() {
+        Ok(max_pages) => Some(max_pages),
+        Err(_) => {
+            tracing::warn!(
+                "Invalid pagination_max_pages value '{}': expected a positive integer or 'nolimit'. The parameter will be ignored.",
+                value
+            );
+            Some(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Https {
     params: Parameters,
@@ -456,8 +474,10 @@ impl Https {
                 .get("pagination_max_pages")
                 .expose()
                 .ok()
-                .and_then(|v| v.parse::<usize>().ok())
-                .unwrap_or(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES);
+                .map_or(
+                    Some(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES),
+                    parse_pagination_max_pages,
+                );
 
             let data_map_to_array = self
                 .params
@@ -942,6 +962,9 @@ impl Https {
         }
 
         if let Some(pagination_config) = pagination {
+            let max_pages = pagination_config
+                .max_pages
+                .map_or_else(|| "nolimit".to_string(), |max_pages| max_pages.to_string());
             tracing::trace!(
                 "Enabling pagination for {}: next_pointer={:?}, link_header={}, token_param={:?}, data_pointer={:?}, max_pages={}, data_map_to_array={}, query_params={:?}, page_size={:?}",
                 dataset.name,
@@ -949,7 +972,7 @@ impl Https {
                 pagination_config.use_link_header,
                 pagination_config.token_param,
                 pagination_config.data_pointer,
-                pagination_config.max_pages,
+                max_pages,
                 pagination_config.data_map_to_array,
                 pagination_config.query_params,
                 pagination_config.page_size,
@@ -1186,7 +1209,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
         ParameterSpec::runtime("pagination_data_pointer")
             .description("JSON pointer (RFC 6901) to the data array in each page's response (e.g., '/data', '/results', '/items'). When set, only the array at this path is returned as data rows."),
         ParameterSpec::runtime("pagination_max_pages")
-            .description("Maximum number of pages to fetch for pagination. Default: 100."),
+            .description("Maximum number of pages to fetch for pagination. Default: 100. Set to 'nolimit' to disable the limit."),
         ParameterSpec::runtime("pagination_data_map_to_array")
             .description("When 'enabled', if the data at pagination_data_pointer (or the top-level response) is a JSON object/map, extract its values as rows instead of treating it as a single row. Default: 'disabled'.")
             .one_of(&["enabled", "disabled"]),
@@ -1922,6 +1945,48 @@ mod tests {
         );
         assert_eq!(params.request_filters.max_headers_length, 2048);
         assert_eq!(params.max_request_partitions, Some(7000));
+    }
+
+    #[tokio::test]
+    async fn resolve_http_provider_params_parses_finite_pagination_max_pages() {
+        let connector =
+            test_connector_with(&[("pagination", "enabled"), ("pagination_max_pages", "250")])
+                .await;
+        let dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+
+        let params = connector
+            .resolve_http_provider_params(&dataset)
+            .expect("pagination params should be valid");
+
+        assert_eq!(
+            params
+                .pagination
+                .expect("pagination should be configured")
+                .max_pages,
+            Some(250)
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_http_provider_params_parses_nolimit_pagination_max_pages() {
+        let connector = test_connector_with(&[
+            ("pagination", "enabled"),
+            ("pagination_max_pages", "nolimit"),
+        ])
+        .await;
+        let dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+
+        let params = connector
+            .resolve_http_provider_params(&dataset)
+            .expect("pagination params should be valid");
+
+        assert_eq!(
+            params
+                .pagination
+                .expect("pagination should be configured")
+                .max_pages,
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -64,15 +64,14 @@ fn parse_pagination_max_pages(value: &str) -> Option<usize> {
         return None;
     }
 
-    match trimmed.parse::<usize>() {
-        Ok(max_pages) => Some(max_pages),
-        Err(_) => {
-            tracing::warn!(
-                "Invalid pagination_max_pages value '{}': expected a positive integer or 'nolimit'. The parameter will be ignored.",
-                value
-            );
-            Some(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES)
-        }
+    if let Ok(max_pages) = trimmed.parse::<usize>() {
+        Some(max_pages)
+    } else {
+        tracing::warn!(
+            "Invalid pagination_max_pages value '{}': expected a positive integer or 'nolimit'. The parameter will be ignored.",
+            value
+        );
+        Some(data_components::http::provider::DEFAULT_PAGINATION_MAX_PAGES)
     }
 }
 


### PR DESCRIPTION
Adds support for configuring HTTP connector pagination without a maximum page cap by setting `pagination_max_pages` to `nolimit`.

Summary:
- Changes `PaginationConfig::max_pages` to `Option<usize>`, preserving the default limit as `Some(100)`.
- Skips the pagination safety-limit check when `max_pages` is `None`.
- Parses the HTTP connector `pagination_max_pages` value `nolimit` as no limit, while preserving finite numeric limits.
- Updates parameter docs and focused tests for finite, no-limit, and zero-value validation behavior.

Tests:
- `cargo fmt -- crates/data_components/src/http/provider.rs crates/runtime/src/dataconnector/https.rs`
- `git diff --check`
- `RUSTC_WRAPPER= cargo test -p data_components test_pagination_config_`

Note: the focused runtime parser test command was started but cancelled before completion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->