### PR TITLE
Pipeline CDC ingestion: overlap source reads with batch apply

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -109,12 +109,32 @@ impl RefreshTask {
         let reader_dataset = dataset_name.clone();
         let reader_handle = tokio::spawn(async move {
             let mut stream = changes_stream;
-            while let Some(item) = stream.next().await {
-                if tx.send(item).await.is_err() {
-                    tracing::debug!(
-                        "CDC consumer for {reader_dataset} dropped; reader exiting"
-                    );
-                    return;
+            // `select!` on `tx.closed()` lets the reader exit promptly even
+            // when it is parked in `stream.next()`. This matters at shutdown:
+            // when the parent task is aborted, its locals (including `rx`)
+            // are dropped, which closes `tx`. Without this select, a reader
+            // blocked on the source (e.g., a Postgres replication recv) would
+            // remain alive holding the source connection until the next item
+            // happens to arrive. With it, the reader notices the consumer is
+            // gone and tears down its source connection immediately.
+            loop {
+                tokio::select! {
+                    biased;
+                    () = tx.closed() => {
+                        tracing::debug!(
+                            "CDC consumer for {reader_dataset} dropped; reader exiting"
+                        );
+                        return;
+                    }
+                    item = stream.next() => {
+                        let Some(item) = item else { return; };
+                        if tx.send(item).await.is_err() {
+                            tracing::debug!(
+                                "CDC consumer for {reader_dataset} dropped; reader exiting"
+                            );
+                            return;
+                        }
+                    }
                 }
             }
         });
@@ -1011,5 +1031,564 @@ mod tests {
         assert_eq!(result[1].1.len(), 2);
         assert_eq!(result[2].0, ChangeOperationType::Upsert);
         assert_eq!(result[2].1.len(), 2);
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests for `start_changes_stream` (the CDC source-stream → apply
+    // pipeline). These exercise correctness of the prefetch-channel design:
+    // ordering, commit-after-write, error continuation, clean termination,
+    // dataset-ready signaling, actual pipelining behavior under a slow
+    // accelerator, and prompt reader cancellation when the consumer goes
+    // away. Together they nail down the invariants the broader CDC stack
+    // relies on (PG WAL, Kafka/Debezium, DynamoDB Streams).
+    // ---------------------------------------------------------------------
+
+    use async_trait::async_trait;
+    use data_components::cdc::{
+        ChangeEnvelope, CommitChange, CommitError, StreamError as CdcStreamError,
+    };
+    use datafusion::catalog::Session;
+    use datafusion::error::Result as DataFusionResult;
+    use datafusion::logical_expr::dml::InsertOp;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::prelude::Expr;
+    use futures::stream::{self as fstream, BoxStream, StreamExt};
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use tokio::sync::Mutex as TokioMutex;
+    use tokio::sync::Notify;
+
+    /// Records when each envelope is committed and in what order.
+    /// Used to assert the apply→commit ordering invariant.
+    #[derive(Default)]
+    struct CommitLog {
+        // (envelope_id, commit_outcome)
+        events: TokioMutex<Vec<(i32, Result<(), String>)>>,
+    }
+
+    impl CommitLog {
+        fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        async fn ids(&self) -> Vec<i32> {
+            self.events
+                .lock()
+                .await
+                .iter()
+                .map(|(id, _)| *id)
+                .collect()
+        }
+    }
+
+    struct TrackingCommitter {
+        id: i32,
+        log: Arc<CommitLog>,
+        outcome: Result<(), String>,
+    }
+
+    #[async_trait]
+    impl CommitChange for TrackingCommitter {
+        async fn commit(&self) -> Result<(), CommitError> {
+            self.log
+                .events
+                .lock()
+                .await
+                .push((self.id, self.outcome.clone()));
+            match &self.outcome {
+                Ok(()) => Ok(()),
+                Err(msg) => Err(CommitError::UnableToCommitChange {
+                    source: msg.clone().into(),
+                }),
+            }
+        }
+    }
+
+    fn make_tracked_envelope(
+        id: i32,
+        log: Arc<CommitLog>,
+        is_ready: bool,
+    ) -> ChangeEnvelope {
+        let batch =
+            create_test_change_batch(vec!["c"], &[vec!["id"]], vec![id], vec![Some("row")]);
+        ChangeEnvelope::new(
+            Box::new(TrackingCommitter {
+                id,
+                log,
+                outcome: Ok(()),
+            }),
+            batch,
+            is_ready,
+        )
+    }
+
+    /// Stream wrapper that signals on Drop. Used to verify the reader task
+    /// is torn down when the consumer goes away.
+    struct DropSignalStream<S> {
+        inner: S,
+        notify_on_drop: Arc<Notify>,
+    }
+
+    impl<S> Drop for DropSignalStream<S> {
+        fn drop(&mut self) {
+            self.notify_on_drop.notify_waiters();
+        }
+    }
+
+    impl<S: futures::Stream + Unpin> futures::Stream for DropSignalStream<S> {
+        type Item = S::Item;
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            Pin::new(&mut self.inner).poll_next(cx)
+        }
+    }
+
+    /// Builds a `ChangesStream` from a vector of pre-built items. Items are
+    /// yielded in order; the stream then ends.
+    fn make_changes_stream(
+        items: Vec<Result<ChangeEnvelope, CdcStreamError>>,
+    ) -> ChangesStream {
+        fstream::iter(items).boxed()
+    }
+
+    /// Counts every poll on the inner stream, and lets us pull on demand via
+    /// an inner channel. This makes pipeline overlap directly observable.
+    async fn run_changes_stream(
+        task: &RefreshTask,
+        stream: ChangesStream,
+        ready_sender: Option<Arc<Notify>>,
+        initial_load_completed: Arc<AtomicBool>,
+    ) -> crate::accelerated_table::Result<()> {
+        let refresh = Arc::new(RwLock::new(crate::accelerated_table::refresh::Refresh::default()));
+        task.start_changes_stream(refresh, stream, None, ready_sender, initial_load_completed)
+            .await
+    }
+
+    // -- Correctness: ordering ------------------------------------------------
+
+    #[tokio::test]
+    async fn test_start_changes_stream_processes_envelopes_in_order() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+        let stream = make_changes_stream(vec![
+            Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
+            Ok(make_tracked_envelope(2, Arc::clone(&log), false)),
+            Ok(make_tracked_envelope(3, Arc::clone(&log), false)),
+            Ok(make_tracked_envelope(4, Arc::clone(&log), false)),
+        ]);
+
+        run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false)))
+            .await
+            .expect("start_changes_stream should succeed");
+
+        assert_eq!(
+            log.ids().await,
+            vec![1, 2, 3, 4],
+            "envelopes must be committed in arrival order"
+        );
+    }
+
+    // -- Correctness: commit-after-write ordering -----------------------------
+
+    /// Wraps a TableProvider and records each `insert_into` call.
+    /// Together with `CommitLog`, this lets us assert that for every
+    /// envelope `id`, the write event happens strictly before the commit.
+    #[derive(Debug)]
+    struct WriteOrderRecordingProvider {
+        inner: Arc<dyn TableProvider>,
+        write_log: Arc<TokioMutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl TableProvider for WriteOrderRecordingProvider {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn schema(&self) -> arrow::datatypes::SchemaRef {
+            self.inner.schema()
+        }
+        fn table_type(&self) -> datafusion::datasource::TableType {
+            self.inner.table_type()
+        }
+        async fn scan(
+            &self,
+            state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            filters: &[Expr],
+            limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            self.inner.scan(state, projection, filters, limit).await
+        }
+        async fn insert_into(
+            &self,
+            state: &dyn Session,
+            input: Arc<dyn ExecutionPlan>,
+            insert_op: InsertOp,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            self.write_log.lock().await.push("write");
+            self.inner.insert_into(state, input, insert_op).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_changes_stream_commits_after_write() {
+        let write_log: Arc<TokioMutex<Vec<&'static str>>> =
+            Arc::new(TokioMutex::new(Vec::new()));
+        let provider = Arc::new(WriteOrderRecordingProvider {
+            inner: make_mem_table() as Arc<dyn TableProvider>,
+            write_log: Arc::clone(&write_log),
+        });
+        let task = make_refresh_task(provider as Arc<dyn TableProvider>);
+
+        // Use a single CommitLog and append "commit" markers to the same
+        // shared write log on commit, so we can read off the interleaved
+        // sequence of write/commit events.
+        let combined: Arc<TokioMutex<Vec<&'static str>>> = Arc::clone(&write_log);
+
+        struct SequencedCommitter {
+            log: Arc<TokioMutex<Vec<&'static str>>>,
+        }
+        #[async_trait]
+        impl CommitChange for SequencedCommitter {
+            async fn commit(&self) -> Result<(), CommitError> {
+                self.log.lock().await.push("commit");
+                Ok(())
+            }
+        }
+
+        let mk = |id: i32| -> ChangeEnvelope {
+            let batch = create_test_change_batch(
+                vec!["c"],
+                &[vec!["id"]],
+                vec![id],
+                vec![Some("row")],
+            );
+            ChangeEnvelope::new(
+                Box::new(SequencedCommitter {
+                    log: Arc::clone(&combined),
+                }),
+                batch,
+                false,
+            )
+        };
+
+        let stream = make_changes_stream(vec![Ok(mk(1)), Ok(mk(2)), Ok(mk(3))]);
+        run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false)))
+            .await
+            .expect("start_changes_stream should succeed");
+
+        let observed = combined.lock().await.clone();
+        // For each envelope: write must precede the next commit. With three
+        // envelopes the strict expected sequence is W,C,W,C,W,C.
+        assert_eq!(
+            observed,
+            vec!["write", "commit", "write", "commit", "write", "commit"],
+            "each envelope must be written, then committed, in order"
+        );
+    }
+
+    // -- Correctness: error path continues the loop ---------------------------
+
+    #[tokio::test]
+    async fn test_start_changes_stream_continues_after_stream_error() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+
+        // Sandwich a fatal stream error between two healthy envelopes; both
+        // valid envelopes must still be committed (the loop logs the error
+        // and continues — it does not abort).
+        let stream = make_changes_stream(vec![
+            Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
+            Err(CdcStreamError::Arrow("synthetic test failure".into())),
+            Ok(make_tracked_envelope(2, Arc::clone(&log), false)),
+        ]);
+
+        run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false)))
+            .await
+            .expect("start_changes_stream should not propagate stream errors");
+
+        assert_eq!(
+            log.ids().await,
+            vec![1, 2],
+            "both pre- and post-error envelopes must be committed"
+        );
+    }
+
+    // -- Correctness: clean termination on stream end -------------------------
+
+    #[tokio::test]
+    async fn test_start_changes_stream_terminates_on_stream_end() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+
+        // Empty stream: returns None immediately. start_changes_stream must
+        // exit cleanly (does not hang).
+        let stream = make_changes_stream(vec![]);
+
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false))),
+        )
+        .await
+        .expect("must not hang on empty stream");
+        res.expect("must return Ok on empty stream");
+        assert!(log.ids().await.is_empty());
+    }
+
+    // -- Correctness: dataset-ready signaling ---------------------------------
+
+    #[tokio::test]
+    async fn test_start_changes_stream_signals_dataset_ready() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+        let initial_load = Arc::new(AtomicBool::new(false));
+        let notify = Arc::new(Notify::new());
+
+        // Subscribe BEFORE running so we don't miss the notify_waiters signal.
+        let notified = {
+            let n = Arc::clone(&notify);
+            tokio::spawn(async move {
+                let waiter = n.notified();
+                tokio::pin!(waiter);
+                tokio::time::timeout(Duration::from_secs(5), &mut waiter)
+                    .await
+                    .is_ok()
+            })
+        };
+        // Yield so the subscriber registers before we proceed.
+        tokio::task::yield_now().await;
+
+        let stream = make_changes_stream(vec![
+            Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
+            Ok(make_tracked_envelope(2, Arc::clone(&log), true)), // ready=true
+            Ok(make_tracked_envelope(3, Arc::clone(&log), false)),
+        ]);
+        run_changes_stream(&task, stream, Some(Arc::clone(&notify)), Arc::clone(&initial_load))
+            .await
+            .expect("start_changes_stream should succeed");
+
+        assert!(
+            initial_load.load(Ordering::Relaxed),
+            "initial_load_completed must flip to true once a ready envelope is processed"
+        );
+        assert!(
+            notified.await.expect("ready notifier task must finish"),
+            "ready_sender.notify_waiters() must fire when a ready envelope is processed"
+        );
+    }
+
+    // -- Pipelining: verify reader prefetches under a slow apply --------------
+
+    /// TableProvider that delays each `insert_into` to simulate a slow
+    /// accelerator. Used to expose pipeline overlap: while the apply task
+    /// is sleeping inside `insert_into`, the reader task should be free to
+    /// drain ahead and fill the prefetch channel.
+    #[derive(Debug)]
+    struct SlowProvider {
+        inner: Arc<dyn TableProvider>,
+        delay: Duration,
+        writes_started: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl TableProvider for SlowProvider {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn schema(&self) -> arrow::datatypes::SchemaRef {
+            self.inner.schema()
+        }
+        fn table_type(&self) -> datafusion::datasource::TableType {
+            self.inner.table_type()
+        }
+        async fn scan(
+            &self,
+            state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            filters: &[Expr],
+            limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            self.inner.scan(state, projection, filters, limit).await
+        }
+        async fn insert_into(
+            &self,
+            state: &dyn Session,
+            input: Arc<dyn ExecutionPlan>,
+            insert_op: InsertOp,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            self.writes_started.fetch_add(1, AtomicOrdering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            self.inner.insert_into(state, input, insert_op).await
+        }
+    }
+
+    /// A stream wrapper that increments a counter every time `poll_next`
+    /// produces a new item. This makes "items pulled from source" directly
+    /// observable.
+    struct CountingStream<S> {
+        inner: S,
+        pulled: Arc<AtomicUsize>,
+    }
+
+    impl<S: futures::Stream + Unpin> futures::Stream for CountingStream<S> {
+        type Item = S::Item;
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(item)) => {
+                    self.pulled.fetch_add(1, AtomicOrdering::SeqCst);
+                    Poll::Ready(Some(item))
+                }
+                other => other,
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_start_changes_stream_pipelines_reads_with_writes() {
+        // 6 envelopes, accelerator delays 80ms per write. With pipelining,
+        // the reader should pull all 6 items into the prefetch channel
+        // within the first apply window, well before the writes complete.
+        // Without pipelining (serial), pulls and writes would alternate and
+        // we'd see at most ~1 pull worth of headroom.
+        let writes_started = Arc::new(AtomicUsize::new(0));
+        let pulled = Arc::new(AtomicUsize::new(0));
+
+        let slow = Arc::new(SlowProvider {
+            inner: make_mem_table() as Arc<dyn TableProvider>,
+            delay: Duration::from_millis(80),
+            writes_started: Arc::clone(&writes_started),
+        });
+        let task = make_refresh_task(slow as Arc<dyn TableProvider>);
+
+        let log = CommitLog::new();
+        let envelopes: Vec<Result<ChangeEnvelope, CdcStreamError>> = (1..=6)
+            .map(|id| Ok(make_tracked_envelope(id, Arc::clone(&log), false)))
+            .collect();
+
+        let inner = fstream::iter(envelopes);
+        let counting = CountingStream {
+            inner: Box::pin(inner),
+            pulled: Arc::clone(&pulled),
+        };
+        let stream: ChangesStream = counting.boxed();
+
+        let task_handle = tokio::spawn(async move {
+            run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false))).await
+        });
+
+        // Wait until the first write has started — that means the apply task
+        // has consumed one envelope from the channel and is now in the slow
+        // insert. Give it a generous window so this isn't flaky on loaded
+        // CI; the assertion below still requires real pipelining.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while writes_started.load(AtomicOrdering::SeqCst) == 0 {
+            if std::time::Instant::now() > deadline {
+                panic!("apply task never started writing");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        // Give the reader a moment to fill the prefetch channel while the
+        // apply is sleeping inside its 80ms insert.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        let pulled_now = pulled.load(AtomicOrdering::SeqCst);
+        let writes_now = writes_started.load(AtomicOrdering::SeqCst);
+        // Reader is ahead of applier: at least 2 more items pulled than
+        // writes started. (Channel buffer is 4, so headroom can be up to 5.)
+        assert!(
+            pulled_now >= writes_now + 2,
+            "expected reader to prefetch ahead of applier; pulled={pulled_now}, writes_started={writes_now}",
+        );
+
+        task_handle
+            .await
+            .expect("task join")
+            .expect("changes stream should succeed");
+        // Final invariant: every envelope was committed exactly once, in order.
+        assert_eq!(log.ids().await, vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    // -- Reliability: reader exits when consumer is dropped -------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_start_changes_stream_reader_exits_on_consumer_drop() {
+        // Build a stream that yields one item, then PARKS forever (returns
+        // Pending and never wakes). If the reader were not racing on
+        // tx.closed(), aborting the parent task would leave the reader
+        // stuck in stream.next() and the source would never be dropped.
+        struct ParkingForeverStream {
+            yielded: bool,
+            log: Arc<CommitLog>,
+        }
+        impl futures::Stream for ParkingForeverStream {
+            type Item = Result<ChangeEnvelope, CdcStreamError>;
+            fn poll_next(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Option<Self::Item>> {
+                if !self.yielded {
+                    self.yielded = true;
+                    let env = make_tracked_envelope(1, Arc::clone(&self.log), false);
+                    Poll::Ready(Some(Ok(env)))
+                } else {
+                    // Pending forever — never registers a waker.
+                    Poll::Pending
+                }
+            }
+        }
+
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+        let drop_signal = Arc::new(Notify::new());
+
+        let parking = ParkingForeverStream {
+            yielded: false,
+            log: Arc::clone(&log),
+        };
+        let drop_signaling = DropSignalStream {
+            inner: Box::pin(parking),
+            notify_on_drop: Arc::clone(&drop_signal),
+        };
+        let stream: ChangesStream = drop_signaling.boxed();
+
+        let join = tokio::spawn(async move {
+            run_changes_stream(&task, stream, None, Arc::new(AtomicBool::new(false))).await
+        });
+
+        // Wait for the first envelope to commit so we know the apply loop is
+        // active and the reader is now parked in stream.next().
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if !log.ids().await.is_empty() {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("first envelope never committed");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // Abort the parent task. This drops `rx`, which closes `tx`, which
+        // must wake the reader's `tokio::select!` and cause it to exit —
+        // dropping the source stream as it goes. Without the select-on-
+        // tx.closed() guard, the reader would remain alive forever holding
+        // the source.
+        join.abort();
+
+        let dropped = tokio::time::timeout(Duration::from_secs(2), drop_signal.notified())
+            .await
+            .is_ok();
+        assert!(
+            dropped,
+            "reader task did not drop its source stream within 2s after parent abort — \
+             this regression would leak source connections at shutdown"
+        );
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -205,16 +205,38 @@ impl RefreshTask {
             }
         }
 
-        // rx returned None: the reader dropped its sender (stream ended or
-        // panicked). Join to surface panics; this should be immediate.
-        if let Err(e) = reader_handle.await
-            && !self.runtime_status.is_shutdown()
-        {
-            tracing::warn!("CDC reader task for {dataset_name} did not exit cleanly: {e}");
-        }
-
-        if !self.runtime_status.is_shutdown() {
-            tracing::warn!("Changes stream ended for dataset {dataset_name}");
+        // rx returned None: the reader dropped its sender. Three causes:
+        //   1) source stream returned None (clean end-of-stream),
+        //   2) reader saw `tx.closed()` and exited (consumer was dropped),
+        //   3) reader panicked.
+        // (1) and (2) join Ok; (3) joins Err with `is_panic()` true. We must
+        // surface (3) loudly — silently swallowing it would leave the dataset
+        // appearing healthy/ready while CDC ingestion has stopped. Cancelled
+        // joins are expected during shutdown and do not need to escalate.
+        match reader_handle.await {
+            Ok(()) => {
+                if !self.runtime_status.is_shutdown() {
+                    tracing::warn!("Changes stream ended for dataset {dataset_name}");
+                }
+            }
+            Err(e) if e.is_cancelled() => {
+                tracing::debug!(
+                    "CDC reader task for {dataset_name} was cancelled (likely shutdown)"
+                );
+            }
+            Err(e) if !self.runtime_status.is_shutdown() => {
+                let err_msg = format!("CDC reader task ended unexpectedly: {e}");
+                tracing::error!("{err_msg} (dataset={dataset_name})");
+                self.set_refresh_status(
+                    refresh.read().await.display_sql().as_deref(),
+                    status::ComponentStatus::error_with_message(err_msg),
+                )
+                .await;
+            }
+            Err(_) => {
+                // Shutdown in progress and reader did not exit cleanly —
+                // expected during teardown; nothing to escalate.
+            }
         }
 
         Ok(())
@@ -1051,7 +1073,7 @@ mod tests {
     use datafusion::logical_expr::dml::InsertOp;
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion::prelude::Expr;
-    use futures::stream::{self as fstream, BoxStream, StreamExt};
+    use futures::stream::{self as fstream};
     use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::task::{Context, Poll};
@@ -1472,23 +1494,31 @@ mod tests {
         // CI; the assertion below still requires real pipelining.
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while writes_started.load(AtomicOrdering::SeqCst) == 0 {
-            if std::time::Instant::now() > deadline {
-                panic!("apply task never started writing");
-            }
+            assert!(
+                std::time::Instant::now() <= deadline,
+                "apply task never started writing",
+            );
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
-        // Give the reader a moment to fill the prefetch channel while the
-        // apply is sleeping inside its 80ms insert.
-        tokio::time::sleep(Duration::from_millis(40)).await;
-
-        let pulled_now = pulled.load(AtomicOrdering::SeqCst);
-        let writes_now = writes_started.load(AtomicOrdering::SeqCst);
-        // Reader is ahead of applier: at least 2 more items pulled than
-        // writes started. (Channel buffer is 4, so headroom can be up to 5.)
-        assert!(
-            pulled_now >= writes_now + 2,
-            "expected reader to prefetch ahead of applier; pulled={pulled_now}, writes_started={writes_now}",
-        );
+        // Poll until the reader has prefetched at least 2 items ahead of the
+        // applier, or time out. The invariant we care about — reader ahead of
+        // applier under a slow accelerator — must hold during the 80ms apply
+        // window; we just don't want to depend on hitting any specific
+        // moment in that window. Polling avoids fixed-sleep flakiness under
+        // CI scheduling variance.
+        let prefetch_deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let p = pulled.load(AtomicOrdering::SeqCst);
+            let w = writes_started.load(AtomicOrdering::SeqCst);
+            if p >= w + 2 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() <= prefetch_deadline,
+                "expected reader to prefetch ahead of applier; pulled={p}, writes_started={w}",
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
 
         task_handle
             .await
@@ -1516,13 +1546,13 @@ mod tests {
                 mut self: Pin<&mut Self>,
                 _cx: &mut Context<'_>,
             ) -> Poll<Option<Self::Item>> {
-                if !self.yielded {
+                if self.yielded {
+                    // Pending forever — never registers a waker.
+                    Poll::Pending
+                } else {
                     self.yielded = true;
                     let env = make_tracked_envelope(1, Arc::clone(&self.log), false);
                     Poll::Ready(Some(Ok(env)))
-                } else {
-                    // Pending forever — never registers a waker.
-                    Poll::Pending
                 }
             }
         }
@@ -1552,9 +1582,10 @@ mod tests {
             if !log.ids().await.is_empty() {
                 break;
             }
-            if std::time::Instant::now() > deadline {
-                panic!("first envelope never committed");
-            }
+            assert!(
+                std::time::Instant::now() <= deadline,
+                "first envelope never committed",
+            );
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
 

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1202,7 +1202,7 @@ mod tests {
 
     // -- Correctness: commit-after-write ordering -----------------------------
 
-    /// Wraps a TableProvider and records each `insert_into` call.
+    /// Wraps a `TableProvider` and records each `insert_into` call.
     /// Together with `CommitLog`, this lets us assert that for every
     /// envelope `id`, the write event happens strictly before the commit.
     #[derive(Debug)]
@@ -1242,6 +1242,20 @@ mod tests {
         }
     }
 
+    /// Records "commit" into a shared log when its `commit()` runs, so we
+    /// can assert the interleaved write/commit sequence in
+    /// `test_start_changes_stream_commits_after_write`.
+    struct SequencedCommitter {
+        log: Arc<TokioMutex<Vec<&'static str>>>,
+    }
+    #[async_trait]
+    impl CommitChange for SequencedCommitter {
+        async fn commit(&self) -> Result<(), CommitError> {
+            self.log.lock().await.push("commit");
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_start_changes_stream_commits_after_write() {
         let write_log: Arc<TokioMutex<Vec<&'static str>>> = Arc::new(TokioMutex::new(Vec::new()));
@@ -1251,21 +1265,9 @@ mod tests {
         });
         let task = make_refresh_task(provider as Arc<dyn TableProvider>);
 
-        // Use a single CommitLog and append "commit" markers to the same
-        // shared write log on commit, so we can read off the interleaved
-        // sequence of write/commit events.
+        // Use a single shared log; both `insert_into` and `commit()` push
+        // markers, so we can read off the interleaved write/commit sequence.
         let combined: Arc<TokioMutex<Vec<&'static str>>> = Arc::clone(&write_log);
-
-        struct SequencedCommitter {
-            log: Arc<TokioMutex<Vec<&'static str>>>,
-        }
-        #[async_trait]
-        impl CommitChange for SequencedCommitter {
-            async fn commit(&self) -> Result<(), CommitError> {
-                self.log.lock().await.push("commit");
-                Ok(())
-            }
-        }
 
         let mk = |id: i32| -> ChangeEnvelope {
             let batch =
@@ -1391,7 +1393,7 @@ mod tests {
 
     // -- Pipelining: verify reader prefetches under a slow apply --------------
 
-    /// TableProvider that delays each `insert_into` to simulate a slow
+    /// `TableProvider` that delays each `insert_into` to simulate a slow
     /// accelerator. Used to expose pipeline overlap: while the apply task
     /// is sleeping inside `insert_into`, the reader task should be free to
     /// drain ahead and fill the prefetch channel.

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -101,10 +101,9 @@ impl RefreshTask {
         // The bounded channel provides natural backpressure: when the apply
         // loop is the bottleneck, the reader parks on `send` and stops
         // pulling, so we never accumulate unbounded memory.
-        let (tx, mut rx) =
-            tokio::sync::mpsc::channel::<Result<cdc::ChangeEnvelope, cdc::StreamError>>(
-                CDC_PREFETCH_BUFFER,
-            );
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<
+            Result<cdc::ChangeEnvelope, cdc::StreamError>,
+        >(CDC_PREFETCH_BUFFER);
 
         let reader_dataset = dataset_name.clone();
         let reader_handle = tokio::spawn(async move {
@@ -1074,12 +1073,7 @@ mod tests {
         }
 
         async fn ids(&self) -> Vec<i32> {
-            self.events
-                .lock()
-                .await
-                .iter()
-                .map(|(id, _)| *id)
-                .collect()
+            self.events.lock().await.iter().map(|(id, _)| *id).collect()
         }
     }
 
@@ -1106,13 +1100,8 @@ mod tests {
         }
     }
 
-    fn make_tracked_envelope(
-        id: i32,
-        log: Arc<CommitLog>,
-        is_ready: bool,
-    ) -> ChangeEnvelope {
-        let batch =
-            create_test_change_batch(vec!["c"], &[vec!["id"]], vec![id], vec![Some("row")]);
+    fn make_tracked_envelope(id: i32, log: Arc<CommitLog>, is_ready: bool) -> ChangeEnvelope {
+        let batch = create_test_change_batch(vec!["c"], &[vec!["id"]], vec![id], vec![Some("row")]);
         ChangeEnvelope::new(
             Box::new(TrackingCommitter {
                 id,
@@ -1139,19 +1128,14 @@ mod tests {
 
     impl<S: futures::Stream + Unpin> futures::Stream for DropSignalStream<S> {
         type Item = S::Item;
-        fn poll_next(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Option<Self::Item>> {
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             Pin::new(&mut self.inner).poll_next(cx)
         }
     }
 
     /// Builds a `ChangesStream` from a vector of pre-built items. Items are
     /// yielded in order; the stream then ends.
-    fn make_changes_stream(
-        items: Vec<Result<ChangeEnvelope, CdcStreamError>>,
-    ) -> ChangesStream {
+    fn make_changes_stream(items: Vec<Result<ChangeEnvelope, CdcStreamError>>) -> ChangesStream {
         fstream::iter(items).boxed()
     }
 
@@ -1163,7 +1147,9 @@ mod tests {
         ready_sender: Option<Arc<Notify>>,
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated_table::Result<()> {
-        let refresh = Arc::new(RwLock::new(crate::accelerated_table::refresh::Refresh::default()));
+        let refresh = Arc::new(RwLock::new(
+            crate::accelerated_table::refresh::Refresh::default(),
+        ));
         task.start_changes_stream(refresh, stream, None, ready_sender, initial_load_completed)
             .await
     }
@@ -1236,8 +1222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_changes_stream_commits_after_write() {
-        let write_log: Arc<TokioMutex<Vec<&'static str>>> =
-            Arc::new(TokioMutex::new(Vec::new()));
+        let write_log: Arc<TokioMutex<Vec<&'static str>>> = Arc::new(TokioMutex::new(Vec::new()));
         let provider = Arc::new(WriteOrderRecordingProvider {
             inner: make_mem_table() as Arc<dyn TableProvider>,
             write_log: Arc::clone(&write_log),
@@ -1261,12 +1246,8 @@ mod tests {
         }
 
         let mk = |id: i32| -> ChangeEnvelope {
-            let batch = create_test_change_batch(
-                vec!["c"],
-                &[vec!["id"]],
-                vec![id],
-                vec![Some("row")],
-            );
+            let batch =
+                create_test_change_batch(vec!["c"], &[vec!["id"]], vec![id], vec![Some("row")]);
             ChangeEnvelope::new(
                 Box::new(SequencedCommitter {
                     log: Arc::clone(&combined),
@@ -1367,9 +1348,14 @@ mod tests {
             Ok(make_tracked_envelope(2, Arc::clone(&log), true)), // ready=true
             Ok(make_tracked_envelope(3, Arc::clone(&log), false)),
         ]);
-        run_changes_stream(&task, stream, Some(Arc::clone(&notify)), Arc::clone(&initial_load))
-            .await
-            .expect("start_changes_stream should succeed");
+        run_changes_stream(
+            &task,
+            stream,
+            Some(Arc::clone(&notify)),
+            Arc::clone(&initial_load),
+        )
+        .await
+        .expect("start_changes_stream should succeed");
 
         assert!(
             initial_load.load(Ordering::Relaxed),
@@ -1436,10 +1422,7 @@ mod tests {
 
     impl<S: futures::Stream + Unpin> futures::Stream for CountingStream<S> {
         type Item = S::Item;
-        fn poll_next(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Option<Self::Item>> {
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             match Pin::new(&mut self.inner).poll_next(cx) {
                 Poll::Ready(Some(item)) => {
                     self.pulled.fetch_add(1, AtomicOrdering::SeqCst);

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -71,11 +71,18 @@ macro_rules! extract_primary_key {
     }};
 }
 
+/// Channel depth between the CDC source-stream reader and the apply loop.
+/// Each slot can hold one decoded `ChangeEnvelope`, so peak prefetch memory
+/// is `CDC_PREFETCH_BUFFER * max_batch_bytes`. Tuned small to keep memory
+/// bounded for sources that emit large per-transaction batches (e.g.,
+/// Postgres logical replication during bulk inserts).
+const CDC_PREFETCH_BUFFER: usize = 4;
+
 impl RefreshTask {
     pub async fn start_changes_stream(
         &self,
         refresh: Arc<RwLock<Refresh>>,
-        mut changes_stream: ChangesStream,
+        changes_stream: ChangesStream,
         caching: Option<Weak<Caching>>,
         ready_sender: Option<Arc<Notify>>,
         initial_load_completed: Arc<AtomicBool>,
@@ -86,7 +93,33 @@ impl RefreshTask {
         self.set_refresh_status(sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 
-        while let Some(update) = changes_stream.next().await {
+        // Pipeline source-stream reads with apply+commit by running the source
+        // in its own task on the refresh runtime and feeding a bounded channel.
+        // While the apply loop writes batch N to the accelerator and commits
+        // its source-side offset, the reader task can already be pulling and
+        // decoding batch N+1 (network/CPU work that would otherwise be idle).
+        // The bounded channel provides natural backpressure: when the apply
+        // loop is the bottleneck, the reader parks on `send` and stops
+        // pulling, so we never accumulate unbounded memory.
+        let (tx, mut rx) =
+            tokio::sync::mpsc::channel::<Result<cdc::ChangeEnvelope, cdc::StreamError>>(
+                CDC_PREFETCH_BUFFER,
+            );
+
+        let reader_dataset = dataset_name.clone();
+        let reader_handle = tokio::spawn(async move {
+            let mut stream = changes_stream;
+            while let Some(item) = stream.next().await {
+                if tx.send(item).await.is_err() {
+                    tracing::debug!(
+                        "CDC consumer for {reader_dataset} dropped; reader exiting"
+                    );
+                    return;
+                }
+            }
+        });
+
+        while let Some(update) = rx.recv().await {
             match update {
                 Ok(change_envelope) => {
                     match self
@@ -151,6 +184,14 @@ impl RefreshTask {
                     .await;
                 }
             }
+        }
+
+        // rx returned None: the reader dropped its sender (stream ended or
+        // panicked). Join to surface panics; this should be immediate.
+        if let Err(e) = reader_handle.await
+            && !self.runtime_status.is_shutdown()
+        {
+            tracing::warn!("CDC reader task for {dataset_name} did not exit cleanly: {e}");
         }
 
         if !self.runtime_status.is_shutdown() {

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1591,6 +1591,15 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
 
+        // Register the drop notifier BEFORE aborting. `Notify::notify_waiters`
+        // does not buffer — if we created the `notified()` future after
+        // `abort()` returned, the reader could already have torn down the
+        // stream and called `notify_waiters` with no waiters registered,
+        // which would lose the signal and make this test wait the full
+        // timeout for nothing.
+        let dropped_fut = drop_signal.notified();
+        tokio::pin!(dropped_fut);
+
         // Abort the parent task. This drops `rx`, which closes `tx`, which
         // must wake the reader's `tokio::select!` and cause it to exit —
         // dropping the source stream as it goes. Without the select-on-
@@ -1598,7 +1607,7 @@ mod tests {
         // the source.
         join.abort();
 
-        let dropped = tokio::time::timeout(Duration::from_secs(2), drop_signal.notified())
+        let dropped = tokio::time::timeout(Duration::from_secs(2), &mut dropped_fut)
             .await
             .is_ok();
         assert!(


### PR DESCRIPTION
## Summary
- All three CDC mechanisms (Postgres logical replication, Kafka/Debezium, DynamoDB Streams) share `start_changes_stream` in `refresh_task/changes.rs` as the unified consumer. Today the loop is strictly serial: pull envelope → apply to accelerator → commit source-side offset → repeat. A single high-throughput dataset uses just one worker thread of the refresh runtime at a time.
- Decouple the source-stream reader from the apply loop. A spawned reader task drains the source into a bounded mpsc channel (`CDC_PREFETCH_BUFFER = 4`); the apply loop receives from the channel. The reader and applier run on separate refresh-runtime worker threads, so source-side I/O (WAL decode, JSON deserialization, batch build) overlaps with destination-side work (accelerator insert, source-side ack).
- Per-batch ordering and exactly-once-write semantics are preserved exactly. Backpressure is automatic: when the apply loop is the bottleneck the reader parks on `send`, so memory stays bounded. Single-site change at the unified consumer means uniform improvement across all three CDC sources.

## Test plan
- [ ] `cargo test -p runtime --lib --features postgres,kafka,debezium,dynamodb -- accelerated_table::refresh_task::changes` (15 tests) pass
- [ ] Postgres replication integration tests (`crates/runtime/tests/postgres/replication.rs`, `replication_tpch.rs`) pass
- [ ] Kafka and Debezium CDC integration tests pass
- [ ] DynamoDB Streams integration tests pass
- [ ] Manual: run a high-throughput PG bulk insert and confirm WAL ingestion throughput improves; verify LSN advances monotonically
- [ ] Manual: confirm clean shutdown and no goroutine/task leak when the source stream errors or ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->