### PR TITLE
Remove git-core PPA from apt sources

### DIFF
--- a/.github/actions/configure-apt/action.yml
+++ b/.github/actions/configure-apt/action.yml
@@ -25,6 +25,21 @@ runs:
         Acquire::ForceIPv4 "true";
         EOF
 
+        # GitHub-hosted Ubuntu runner images can include the git-core PPA.
+        # It is not needed for CI and can make apt update fail when Launchpad
+        # times out.
+        if [ -d /etc/apt/sources.list.d ]; then
+          while IFS= read -r -d '' SOURCE_FILE; do
+            if sudo grep -Eq 'ppa\.launchpadcontent\.net/git-core/ppa|git-core/ppa' "${SOURCE_FILE}"; then
+              echo "Removing git-core PPA apt source: ${SOURCE_FILE}"
+              sudo rm -f "${SOURCE_FILE}"
+            fi
+          done < <(
+            sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \
+              \( -name '*.list' -o -name '*.sources' \) -print0
+          )
+        fi
+
         # Ordered list of Ubuntu archive mirrors close to Pittsburgh, PA
         # (Teraswitch datacenter), with reliable fallbacks. The deb822
         # sources format supports multiple URIs per source, and apt will


### PR DESCRIPTION
## Summary
- remove any runner-provided `git-core/ppa` apt source before apt updates run
- avoid CI failures when `ppa.launchpadcontent.net` times out during apt refresh

## Verification
- `git diff --check -- .github/actions/configure-apt/action.yml`
- VS Code YAML diagnostics for `.github/actions/configure-apt/action.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->