### PR TITLE
Use local S3 for CI test binaries

### DIFF
--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -5,15 +5,12 @@ inputs:
   minio_endpoint:
     description: 'MinIO endpoint'
     required: true
-    type: string
   minio_access_key:
     description: 'MinIO access key'
     required: true
-    type: string
   minio_secret_key:
     description: 'MinIO secret key'
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -22,9 +19,22 @@ runs:
       shell: bash
       if: runner.os == 'Linux'
       run: |
-        sudo apt update && sudo apt install wget -y
-        sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-        sudo chmod +x /usr/local/bin/mc
+        set -euo pipefail
+        if command -v mc >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        mc_url="https://dl.min.io/client/mc/release/linux-amd64/mc"
+        tmp_mc="$(mktemp)"
+        if command -v curl >/dev/null 2>&1; then
+          curl --fail --silent --show-error --location --output "$tmp_mc" "$mc_url"
+        elif command -v wget >/dev/null 2>&1; then
+          wget --quiet --output-document="$tmp_mc" "$mc_url"
+        else
+          echo "curl or wget is required to install the MinIO client" >&2
+          exit 1
+        fi
+        sudo install -m 0755 "$tmp_mc" /usr/local/bin/mc
 
     - name: Install MinIO on macOS
       shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,6 +48,13 @@ env:
   CARGO_HTTP_TIMEOUT: 60
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-test-archive/integration.tar.zst
+  INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-retention-oom-test-archive/retention_oom.tar.zst
+  INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-aws-sdk-test-archive/integration_aws_sdk.tar.zst
+  INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-snapshot-refresh-test-archive/integration_snapshot_refresh.tar.zst
+  INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-aws-sdk-credential-bridge-test-archive/integration_aws_sdk_credential_bridge.tar.zst
+  INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-partition-table-test-archive/partition_table_test.tar.zst
+  INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-data-components-test-archive/data_components_hadoop.tar.zst
 
 jobs:
   # `pr` is a required check for pull requests. Therefore we cannot skip the workflow via
@@ -145,76 +152,27 @@ jobs:
           cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
           cargo nextest archive -p data_components --test hadoop_catalog_test --archive-file data_components_hadoop.tar.zst
 
-      # Upload the test archive as an artifact
-      - name: Upload test archive
+      - name: Upload test archives to local MinIO
         if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-test-archive
-          path: ./integration.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload retention OOM test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-retention-oom-test-archive
-          path: ./retention_oom.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload AWS SDK test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-aws-sdk-test-archive
-          path: ./integration_aws_sdk.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload snapshot refresh test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-snapshot-refresh-test-archive
-          path: ./integration_snapshot_refresh.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload AWS SDK credential bridge test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-aws-sdk-credential-bridge-test-archive
-          path: ./integration_aws_sdk_credential_bridge.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload partition table test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-partition-table-test-archive
-          path: ./partition_table_test.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
-
-      - name: Upload data components test archive
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-data-components-test-archive
-          path: ./data_components_hadoop.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to upload integration test archives}"
+          if ! aws --endpoint-url "$MINIO_ENDPOINT" s3api head-bucket --bucket build; then
+            aws --endpoint-url "$MINIO_ENDPOINT" s3 mb s3://build || true
+            aws --endpoint-url "$MINIO_ENDPOINT" s3api head-bucket --bucket build
+          fi
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration.tar.zst "$INTEGRATION_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./retention_oom.tar.zst "$INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_aws_sdk.tar.zst "$INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_snapshot_refresh.tar.zst "$INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_aws_sdk_credential_bridge.tar.zst "$INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./partition_table_test.tar.zst "$INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI"
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./data_components_hadoop.tar.zst "$INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI"
 
   test:
     name: Integration Tests (part ${{ matrix.label }})
@@ -247,20 +205,31 @@ jobs:
         if: needs.check_changes.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-oracle-odpi
 
-      # Download the test archive artifact
-      - name: Download test archive
+      - name: Download test archive from local MinIO
         if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-test-archive
-          path: ./integration_test
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download integration test archive}"
+          mkdir -p ./integration_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
 
-      - name: Download retention OOM test archive
+      - name: Download retention OOM test archive from local MinIO
         if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-retention-oom-test-archive
-          path: ./retention_oom_test
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download retention OOM test archive}"
+          mkdir -p ./retention_oom_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI" ./retention_oom_test/retention_oom.tar.zst
 
       - name: Set up Nextest
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -439,11 +408,17 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Download AWS SDK test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-aws-sdk-test-archive
-          path: ./integration_aws_sdk_test
+      - name: Download AWS SDK test archive from local MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download AWS SDK test archive}"
+          mkdir -p ./integration_aws_sdk_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI" ./integration_aws_sdk_test/integration_aws_sdk.tar.zst
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -480,11 +455,17 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Download AWS SDK credential bridge test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-aws-sdk-credential-bridge-test-archive
-          path: ./integration_aws_sdk_credential_bridge_test
+      - name: Download AWS SDK credential bridge test archive from local MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download AWS SDK credential bridge test archive}"
+          mkdir -p ./integration_aws_sdk_credential_bridge_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI" ./integration_aws_sdk_credential_bridge_test/integration_aws_sdk_credential_bridge.tar.zst
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -524,11 +505,17 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Download snapshot refresh test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-snapshot-refresh-test-archive
-          path: ./integration_snapshot_refresh_test
+      - name: Download snapshot refresh test archive from local MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download snapshot refresh test archive}"
+          mkdir -p ./integration_snapshot_refresh_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI" ./integration_snapshot_refresh_test/integration_snapshot_refresh.tar.zst
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -564,11 +551,17 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Download data components test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-data-components-test-archive
-          path: ./data_components_test
+      - name: Download data components test archive from local MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download data components test archive}"
+          mkdir -p ./data_components_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI" ./data_components_test/data_components_hadoop.tar.zst
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -594,11 +587,17 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Download partition table test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: integration-partition-table-test-archive
-          path: ./partition_table_test
+      - name: Download partition table test archive from local MinIO
+        env:
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download partition table test archive}"
+          mkdir -p ./partition_table_test
+          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI" ./partition_table_test/partition_table_test.tar.zst
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,13 +48,14 @@ env:
   CARGO_HTTP_TIMEOUT: 60
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
-  INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-test-archive/integration.tar.zst
-  INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-retention-oom-test-archive/retention_oom.tar.zst
-  INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-aws-sdk-test-archive/integration_aws_sdk.tar.zst
-  INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-snapshot-refresh-test-archive/integration_snapshot_refresh.tar.zst
-  INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-aws-sdk-credential-bridge-test-archive/integration_aws_sdk_credential_bridge.tar.zst
-  INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-partition-table-test-archive/partition_table_test.tar.zst
-  INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/integration-data-components-test-archive/data_components_hadoop.tar.zst
+  HAS_TEST_MINIO_SECRET: ${{ secrets.TEST_MINIO_ENDPOINT != '' && secrets.TEST_MINIO_ACCESS_KEY != '' && secrets.TEST_MINIO_SECRET_KEY != '' }}
+  INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-test-archive/integration.tar.zst
+  INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-retention-oom-test-archive/retention_oom.tar.zst
+  INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-aws-sdk-test-archive/integration_aws_sdk.tar.zst
+  INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-snapshot-refresh-test-archive/integration_snapshot_refresh.tar.zst
+  INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-aws-sdk-credential-bridge-test-archive/integration_aws_sdk_credential_bridge.tar.zst
+  INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-partition-table-test-archive/partition_table_test.tar.zst
+  INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/integration-data-components-test-archive/data_components_hadoop.tar.zst
 
 jobs:
   # `pr` is a required check for pull requests. Therefore we cannot skip the workflow via
@@ -152,27 +153,92 @@ jobs:
           cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
           cargo nextest archive -p data_components --test hadoop_catalog_test --archive-file data_components_hadoop.tar.zst
 
+      - name: Set up MinIO client
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Upload test archives to local MinIO
-        if: needs.check_changes.outputs.relevant_changes == 'true'
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to upload integration test archives}"
-          if ! aws --endpoint-url "$MINIO_ENDPOINT" s3api head-bucket --bucket build; then
-            aws --endpoint-url "$MINIO_ENDPOINT" s3 mb s3://build || true
-            aws --endpoint-url "$MINIO_ENDPOINT" s3api head-bucket --bucket build
-          fi
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration.tar.zst "$INTEGRATION_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./retention_oom.tar.zst "$INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_aws_sdk.tar.zst "$INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_snapshot_refresh.tar.zst "$INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./integration_aws_sdk_credential_bridge.tar.zst "$INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./partition_table_test.tar.zst "$INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI"
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp ./data_components_hadoop.tar.zst "$INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI"
+          mc mb --ignore-existing spice-minio/build
+          mc cp ./integration.tar.zst "spice-minio/${INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./retention_oom.tar.zst "spice-minio/${INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./integration_aws_sdk.tar.zst "spice-minio/${INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./integration_snapshot_refresh.tar.zst "spice-minio/${INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./integration_aws_sdk_credential_bridge.tar.zst "spice-minio/${INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./partition_table_test.tar.zst "spice-minio/${INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI#s3://}"
+          mc cp ./data_components_hadoop.tar.zst "spice-minio/${INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI#s3://}"
+
+      - name: Upload test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-test-archive
+          path: ./integration.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload retention OOM test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-retention-oom-test-archive
+          path: ./retention_oom.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload AWS SDK test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-aws-sdk-test-archive
+          path: ./integration_aws_sdk.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload snapshot refresh test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-snapshot-refresh-test-archive
+          path: ./integration_snapshot_refresh.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload AWS SDK credential bridge test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-aws-sdk-credential-bridge-test-archive
+          path: ./integration_aws_sdk_credential_bridge.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload partition table test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-partition-table-test-archive
+          path: ./partition_table_test.tar.zst
+          retention-days: 3
+          compression-level: 1
+
+      - name: Upload data components test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-data-components-test-archive
+          path: ./data_components_hadoop.tar.zst
+          retention-days: 3
+          compression-level: 1
 
   test:
     name: Integration Tests (part ${{ matrix.label }})
@@ -205,31 +271,47 @@ jobs:
         if: needs.check_changes.outputs.relevant_changes == 'true'
         uses: ./.github/actions/setup-oracle-odpi
 
+      - name: Set up MinIO client
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download test archive from local MinIO
-        if: needs.check_changes.outputs.relevant_changes == 'true'
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download integration test archive}"
           mkdir -p ./integration_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
+          mc cp "spice-minio/${INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}" ./integration_test/integration.tar.zst
+
+      - name: Download test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-test-archive
+          path: ./integration_test
 
       - name: Download retention OOM test archive from local MinIO
-        if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3'
+        if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3' && env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download retention OOM test archive}"
           mkdir -p ./retention_oom_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI" ./retention_oom_test/retention_oom.tar.zst
+          mc cp "spice-minio/${INTEGRATION_RETENTION_OOM_TEST_ARCHIVE_S3_URI#s3://}" ./retention_oom_test/retention_oom.tar.zst
+
+      - name: Download retention OOM test archive
+        if: needs.check_changes.outputs.relevant_changes == 'true' && matrix.partition == 'count:1/3' && env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-retention-oom-test-archive
+          path: ./retention_oom_test
 
       - name: Set up Nextest
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -408,17 +490,30 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up MinIO client
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download AWS SDK test archive from local MinIO
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download AWS SDK test archive}"
           mkdir -p ./integration_aws_sdk_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI" ./integration_aws_sdk_test/integration_aws_sdk.tar.zst
+          mc cp "spice-minio/${INTEGRATION_AWS_SDK_TEST_ARCHIVE_S3_URI#s3://}" ./integration_aws_sdk_test/integration_aws_sdk.tar.zst
+
+      - name: Download AWS SDK test archive
+        if: env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-aws-sdk-test-archive
+          path: ./integration_aws_sdk_test
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -455,17 +550,30 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up MinIO client
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download AWS SDK credential bridge test archive from local MinIO
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download AWS SDK credential bridge test archive}"
           mkdir -p ./integration_aws_sdk_credential_bridge_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI" ./integration_aws_sdk_credential_bridge_test/integration_aws_sdk_credential_bridge.tar.zst
+          mc cp "spice-minio/${INTEGRATION_AWS_SDK_CREDENTIAL_BRIDGE_TEST_ARCHIVE_S3_URI#s3://}" ./integration_aws_sdk_credential_bridge_test/integration_aws_sdk_credential_bridge.tar.zst
+
+      - name: Download AWS SDK credential bridge test archive
+        if: env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-aws-sdk-credential-bridge-test-archive
+          path: ./integration_aws_sdk_credential_bridge_test
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -505,17 +613,30 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up MinIO client
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download snapshot refresh test archive from local MinIO
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download snapshot refresh test archive}"
           mkdir -p ./integration_snapshot_refresh_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI" ./integration_snapshot_refresh_test/integration_snapshot_refresh.tar.zst
+          mc cp "spice-minio/${INTEGRATION_SNAPSHOT_REFRESH_TEST_ARCHIVE_S3_URI#s3://}" ./integration_snapshot_refresh_test/integration_snapshot_refresh.tar.zst
+
+      - name: Download snapshot refresh test archive
+        if: env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-snapshot-refresh-test-archive
+          path: ./integration_snapshot_refresh_test
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -551,17 +672,30 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up MinIO client
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download data components test archive from local MinIO
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download data components test archive}"
           mkdir -p ./data_components_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI" ./data_components_test/data_components_hadoop.tar.zst
+          mc cp "spice-minio/${INTEGRATION_DATA_COMPONENTS_TEST_ARCHIVE_S3_URI#s3://}" ./data_components_test/data_components_hadoop.tar.zst
+
+      - name: Download data components test archive
+        if: env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-data-components-test-archive
+          path: ./data_components_test
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
@@ -587,17 +721,30 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up MinIO client
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
       - name: Download partition table test archive from local MinIO
+        if: env.HAS_TEST_MINIO_SECRET == 'true'
         env:
           MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
           : "${MINIO_ENDPOINT:?TEST_MINIO_ENDPOINT is required to download partition table test archive}"
           mkdir -p ./partition_table_test
-          aws --endpoint-url "$MINIO_ENDPOINT" s3 cp "$INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI" ./partition_table_test/partition_table_test.tar.zst
+          mc cp "spice-minio/${INTEGRATION_PARTITION_TABLE_TEST_ARCHIVE_S3_URI#s3://}" ./partition_table_test/partition_table_test.tar.zst
+
+      - name: Download partition table test archive
+        if: env.HAS_TEST_MINIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: integration-partition-table-test-archive
+          path: ./partition_table_test
 
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -94,6 +94,9 @@ jobs:
   build:
     name: Build Test Binary
     runs-on: spiceai-macos
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
+      TEST_BINARY_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/llms_integration_test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -112,18 +115,35 @@ jobs:
           TEST_BINARY_PATH=$(cargo test -p llms --test integration --features metal --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
           cp $TEST_BINARY_PATH ./llms_integration_test
 
-      - name: Upload test binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
         with:
-          name: llms-integration-test-binary
-          path: ./llms_integration_test
-          retention-days: 3
-          # Test binary is already a compact native binary; use minimal artifact zip compression.
-          compression-level: 1
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
+      - name: Upload test binary to spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the LLM integration test binary}"
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./llms_integration_test "$TEST_BINARY_S3_URI"
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
 
   test:
     runs-on: ${{ matrix.target.runner }}
     needs: [build, setup-matrix]
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
+      TEST_BINARY_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/llms_integration_test
     strategy:
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -133,11 +153,26 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Download test binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
         with:
-          name: llms-integration-test-binary
-          path: ./integration_test
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
+      - name: Download test binary from spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the LLM integration test binary}"
+          mkdir -p ./integration_test
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$TEST_BINARY_S3_URI" ./integration_test/llms_integration_test
 
       - name: Mark test binary as executable
         run: chmod +x ./integration_test/llms_integration_test
@@ -176,3 +211,7 @@ jobs:
           fi
           # `--test-threads` to reduce possible rate limiting/ connection issues for hosted models.
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture -- llms::tests --test-threads=2
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: spiceai-macos
     env:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
-      TEST_BINARY_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/llms_integration_test
+      TEST_BINARY_OBJECT_KEY: test_binaries/${{ github.run_id }}/llms_integration_test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -127,12 +127,23 @@ jobs:
           region: us-west-1
 
       - name: Upload test binary to spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the LLM integration test binary}"
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./llms_integration_test "$TEST_BINARY_S3_URI"
+          test_binary_url="${SPICEIO_ENDPOINT%/}/build/${TEST_BINARY_OBJECT_KEY}"
+          curl --fail --silent --show-error --upload-file ./llms_integration_test "$test_binary_url"
+
+      - name: Upload test binary
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: llms-integration-test-binary
+          path: ./llms_integration_test
+          retention-days: 3
+          compression-level: 1
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
@@ -143,7 +154,7 @@ jobs:
     needs: [build, setup-matrix]
     env:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
-      TEST_BINARY_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/llms_integration_test
+      TEST_BINARY_OBJECT_KEY: test_binaries/${{ github.run_id }}/llms_integration_test
     strategy:
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -166,13 +177,22 @@ jobs:
           region: us-west-1
 
       - name: Download test binary from spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the LLM integration test binary}"
           mkdir -p ./integration_test
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$TEST_BINARY_S3_URI" ./integration_test/llms_integration_test
+          test_binary_url="${SPICEIO_ENDPOINT%/}/build/${TEST_BINARY_OBJECT_KEY}"
+          curl --fail --silent --show-error --output ./integration_test/llms_integration_test "$test_binary_url"
+
+      - name: Download test binary
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: llms-integration-test-binary
+          path: ./integration_test
 
       - name: Mark test binary as executable
         run: chmod +x ./integration_test/llms_integration_test

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -71,6 +71,8 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CARGO_NET_RETRY: 10
   CARGO_HTTP_TIMEOUT: 60
+  AI_INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/ai-integration-test-archive/integration.tar.zst
+  AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/ai-integration-test-archive-extended/integration-extended.tar.zst
 
 jobs:
   build:
@@ -129,15 +131,17 @@ jobs:
 
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration.tar.zst
 
-      # Upload the test archive as an artifact
-      - name: Upload test archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ai-integration-test-archive
-          path: ./integration.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
+      - name: Upload test archive to spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the AI integration test archive}"
+          if ! aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build; then
+            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 mb s3://build || true
+            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build
+          fi
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./integration.tar.zst "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI"
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
@@ -155,6 +159,8 @@ jobs:
     name: Test Models, AI & Search
     needs: build
     runs-on: spiceai-macos
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -166,11 +172,25 @@ jobs:
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
 
-      - name: Download test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
         with:
-          name: ai-integration-test-archive
-          path: ./integration_test
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
+      - name: Download test archive from spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
+          mkdir -p ./integration_test
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
 
       - name: Set up API Keys
         run: |
@@ -310,11 +330,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
   test-hf:
     name: Test Hugging Face Models
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' || github.event_name == 'schedule' }}
     runs-on: spiceai-macos
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -326,11 +352,25 @@ jobs:
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
 
-      - name: Download test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
         with:
-          name: ai-integration-test-archive
-          path: ./integration_test
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
+      - name: Download test archive from spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
+          mkdir -p ./integration_test
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
 
       - name: Run integration test
         env:
@@ -360,11 +400,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
   test-bedrock:
     name: Test Bedrock Models
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' || github.event_name == 'schedule' }}
     runs-on: spiceai-macos
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -376,11 +422,25 @@ jobs:
       - name: Set up Nextest
         uses: ./.github/actions/setup-nextest
 
-      - name: Download test archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
         with:
-          name: ai-integration-test-archive
-          path: ./integration_test
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
+      - name: Download test archive from spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
+          mkdir -p ./integration_test
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
 
       - name: Run Beta functionality embedding tests
         env:
@@ -395,6 +455,10 @@ jobs:
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
 
   build-extended:
     name: Build Test Binary (Extended)
@@ -449,15 +513,17 @@ jobs:
 
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration-extended.tar.zst
 
-      # Upload the test archive as an artifact
-      - name: Upload test archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ai-integration-test-archive-extended
-          path: ./integration-extended.tar.zst
-          retention-days: 3
-          # Archive is already zstd-compressed; use minimal artifact zip compression.
-          compression-level: 1
+      - name: Upload test archive to spiceio
+        env:
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+        run: |
+          set -euo pipefail
+          : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the extended AI integration test archive}"
+          if ! aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build; then
+            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 mb s3://build || true
+            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build
+          fi
+          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./integration-extended.tar.zst "$AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI"
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -71,8 +71,8 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CARGO_NET_RETRY: 10
   CARGO_HTTP_TIMEOUT: 60
-  AI_INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/ai-integration-test-archive/integration.tar.zst
-  AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/${{ github.run_attempt }}/ai-integration-test-archive-extended/integration-extended.tar.zst
+  AI_INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/ai-integration-test-archive/integration.tar.zst
+  AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/ai-integration-test-archive-extended/integration-extended.tar.zst
 
 jobs:
   build:
@@ -132,16 +132,28 @@ jobs:
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration.tar.zst
 
       - name: Upload test archive to spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the AI integration test archive}"
-          if ! aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build; then
-            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 mb s3://build || true
-            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build
+          bucket_status=$(curl --silent --show-error --output /tmp/spiceio-create-build-bucket --write-out "%{http_code}" --request PUT "${SPICEIO_ENDPOINT%/}/build")
+          if [[ "$bucket_status" != "200" && "$bucket_status" != "204" && "$bucket_status" != "409" ]]; then
+            cat /tmp/spiceio-create-build-bucket
+            exit 1
           fi
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./integration.tar.zst "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI"
+          archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
+          curl --fail --silent --show-error --upload-file ./integration.tar.zst "$archive_url"
+
+      - name: Upload test archive
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ai-integration-test-archive
+          path: ./integration.tar.zst
+          retention-days: 3
+          compression-level: 1
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
@@ -184,13 +196,22 @@ jobs:
           region: us-west-1
 
       - name: Download test archive from spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
           mkdir -p ./integration_test
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
+          archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
+          curl --fail --silent --show-error --output ./integration_test/integration.tar.zst "$archive_url"
+
+      - name: Download test archive
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ai-integration-test-archive
+          path: ./integration_test
 
       - name: Set up API Keys
         run: |
@@ -364,13 +385,22 @@ jobs:
           region: us-west-1
 
       - name: Download test archive from spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
           mkdir -p ./integration_test
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
+          archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
+          curl --fail --silent --show-error --output ./integration_test/integration.tar.zst "$archive_url"
+
+      - name: Download test archive
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ai-integration-test-archive
+          path: ./integration_test
 
       - name: Run integration test
         env:
@@ -434,13 +464,22 @@ jobs:
           region: us-west-1
 
       - name: Download test archive from spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to download the AI integration test archive}"
           mkdir -p ./integration_test
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp "$AI_INTEGRATION_TEST_ARCHIVE_S3_URI" ./integration_test/integration.tar.zst
+          archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
+          curl --fail --silent --show-error --output ./integration_test/integration.tar.zst "$archive_url"
+
+      - name: Download test archive
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ai-integration-test-archive
+          path: ./integration_test
 
       - name: Run Beta functionality embedding tests
         env:
@@ -514,16 +553,28 @@ jobs:
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration-extended.tar.zst
 
       - name: Upload test archive to spiceio
+        if: env.HAS_SPICEIO_SECRET == 'true'
         env:
           SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the extended AI integration test archive}"
-          if ! aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build; then
-            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 mb s3://build || true
-            aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3api head-bucket --bucket build
+          bucket_status=$(curl --silent --show-error --output /tmp/spiceio-create-build-bucket --write-out "%{http_code}" --request PUT "${SPICEIO_ENDPOINT%/}/build")
+          if [[ "$bucket_status" != "200" && "$bucket_status" != "204" && "$bucket_status" != "409" ]]; then
+            cat /tmp/spiceio-create-build-bucket
+            exit 1
           fi
-          aws --endpoint-url "$SPICEIO_ENDPOINT" --no-sign-request s3 cp ./integration-extended.tar.zst "$AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI"
+          archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI#s3://}"
+          curl --fail --silent --show-error --upload-file ./integration-extended.tar.zst "$archive_url"
+
+      - name: Upload test archive
+        if: env.HAS_SPICEIO_SECRET != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ai-integration-test-archive-extended
+          path: ./integration-extended.tar.zst
+          retention-days: 3
+          compression-level: 1
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''


### PR DESCRIPTION
## Summary
- upload `spiceai-dev-runners` integration nextest archives to local MinIO under `s3://build/test_binaries/` using the repo-local `mc` setup action, avoiding any AWS CLI dependency
- make the shared MinIO setup action install `mc` without `apt`, using an existing `mc`, `curl`, or `wget` on Linux runners
- upload macOS LLM/model test binaries and nextest archives to the local spiceio S3 endpoint with `curl`
- use `github.run_id`-stable object keys and keep GitHub artifact fallback paths for fork/no-secret contexts
- keep unrelated GitHub artifacts, such as logs and snapshot update artifacts, on GitHub artifacts

## Verification
- `git diff --check -- .github/workflows/integration.yml .github/workflows/integration_llms.yml .github/workflows/integration_models.yml`
- Ruby YAML parse for `.github/workflows/integration.yml`, `.github/workflows/integration_llms.yml`, and `.github/workflows/integration_models.yml`
- `RUSTC_WRAPPER= make lint`
- `git diff --check -- .github/actions/setup-minio/action.yml`
- Ruby YAML parse for `.github/actions/setup-minio/action.yml`
- VS Code workflow/action diagnostics checked; the remaining `app-id` deprecation warning in `.github/workflows/integration.yml` was already present before these PR-review fixes
- `actionlint` was not installed locally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->