### PR TITLE
feat(http): pass through HTTP metadata columns with JSON schema decomposition

### DIFF
--- a/crates/data_components/src/http/json_nest.rs
+++ b/crates/data_components/src/http/json_nest.rs
@@ -37,6 +37,15 @@ limitations under the License.
 //! declared static field is projected as a top-level `Utf8` column, and
 //! all remaining keys are serialized into a JSON object string stored in
 //! the catch-all column.
+//!
+//! In addition, declared columns whose names match one of the HTTP
+//! connector's built-in metadata fields (`request_path`,
+//! `request_query`, `request_body`, `request_headers`, `content`,
+//! `response_status`, `response_headers`, `fetched_at`) are *passed
+//! through* from the HTTP request/response rather than being decomposed
+//! from the JSON body. This lets queries reference both decomposed
+//! columns and the original HTTP metadata (e.g. for direct fetches via
+//! filter pushdown on `request_path`).
 
 use snafu::{ResultExt, Snafu};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -65,26 +74,41 @@ pub struct HttpJsonNesting {
     /// position.
     pub column_order: Vec<String>,
     /// Set of declared static field names (i.e. `column_order` minus
-    /// `json_field_name`).
+    /// `json_field_name` and `metadata_fields`). These are extracted as
+    /// top-level keys from each JSON response row.
     pub static_fields: HashSet<String>,
+    /// Set of declared columns sourced from HTTP request/response
+    /// metadata rather than from the JSON body. Names must match
+    /// fields in [`HttpTableProvider::base_table_schema`].
+    ///
+    /// [`HttpTableProvider::base_table_schema`]: super::provider::HttpTableProvider::base_table_schema
+    pub metadata_fields: HashSet<String>,
     /// Name of the catch-all JSON column.
     pub json_field_name: String,
 }
 
 impl HttpJsonNesting {
-    /// Build a new nesting configuration from the declared column order
-    /// and the name of the catch-all column. The catch-all column name
-    /// must appear in `column_order`.
+    /// Build a new nesting configuration from the declared column order,
+    /// the name of the catch-all column, and the set of declared columns
+    /// that should be sourced from HTTP metadata rather than the JSON
+    /// body. The catch-all column name must appear in `column_order`.
     #[must_use]
-    pub fn new(column_order: Vec<String>, json_field_name: String) -> Self {
+    pub fn new(
+        column_order: Vec<String>,
+        json_field_name: String,
+        metadata_fields: HashSet<String>,
+    ) -> Self {
         let static_fields: HashSet<String> = column_order
             .iter()
-            .filter(|c| c.as_str() != json_field_name.as_str())
+            .filter(|c| {
+                c.as_str() != json_field_name.as_str() && !metadata_fields.contains(c.as_str())
+            })
             .cloned()
             .collect();
         Self {
             column_order,
             static_fields,
+            metadata_fields,
             json_field_name,
         }
     }
@@ -114,6 +138,14 @@ pub fn decompose_json_row(json_row: &str, nesting: &HttpJsonNesting) -> Result<D
             let mut catchall: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
             for (k, v) in map {
+                if nesting.metadata_fields.contains(&k) {
+                    // Body keys colliding with HTTP metadata names are
+                    // ignored here; the metadata column is populated
+                    // from the actual HTTP request/response, not from
+                    // the body. Drop the body key from both the static
+                    // and catch-all outputs.
+                    continue;
+                }
                 if nesting.static_fields.contains(&k) {
                     out.insert(k, json_value_to_string(v));
                 } else {
@@ -172,6 +204,15 @@ mod tests {
         HttpJsonNesting::new(
             cols.iter().map(|s| (*s).to_string()).collect(),
             json_field.to_string(),
+            HashSet::new(),
+        )
+    }
+
+    fn nesting_with_meta(cols: &[&str], json_field: &str, meta: &[&str]) -> HttpJsonNesting {
+        HttpJsonNesting::new(
+            cols.iter().map(|s| (*s).to_string()).collect(),
+            json_field.to_string(),
+            meta.iter().map(|s| (*s).to_string()).collect(),
         )
     }
 
@@ -246,5 +287,33 @@ mod tests {
         let row = json!({"id": null, "extra": 1}).to_string();
         let d = decompose_json_row(&row, &n).expect("decompose");
         assert!(d.get("id").expect("id").is_none());
+    }
+
+    #[test]
+    fn metadata_field_is_not_extracted_from_body() {
+        // `request_path` is declared as a metadata column. Even if the
+        // body contains a `request_path` key, it must not appear in the
+        // decomposed output (the metadata column is filled separately
+        // by the batch builder) and must not leak into the catch-all.
+        let n = nesting_with_meta(&["request_path", "id", "data"], "data", &["request_path"]);
+        let row = json!({
+            "request_path": "/should-be-ignored",
+            "id": "abc",
+            "extra": 1
+        })
+        .to_string();
+        let d = decompose_json_row(&row, &n).expect("decompose");
+        assert!(
+            !d.contains_key("request_path"),
+            "metadata field must not be populated from body"
+        );
+        assert_eq!(d.get("id").expect("id").as_deref(), Some("abc"));
+        let catchall = d.get("data").expect("data").as_deref().expect("val");
+        let parsed: serde_json::Value = serde_json::from_str(catchall).expect("parse");
+        assert!(
+            parsed.get("request_path").is_none(),
+            "metadata field must not leak into catch-all"
+        );
+        assert_eq!(parsed["extra"], 1);
     }
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -503,15 +503,36 @@ impl HttpTableProvider {
     }
 
     /// Configure JSON schema decomposition. Replaces the provider's
-    /// schema with one built from the user-declared columns (all
-    /// `Utf8`, nullable). Each scanned JSON response row is decomposed
-    /// at query time via [`decompose_json_row`].
+    /// schema with one built from the user-declared columns. Body-derived
+    /// columns are typed as `Utf8` (nullable); columns declared with
+    /// names matching [`Self::base_table_schema`] fields are passed
+    /// through with their original type so queries can reference HTTP
+    /// metadata (e.g. filter on `request_path` for direct fetches).
+    /// Each scanned JSON response row is decomposed at query time via
+    /// [`decompose_json_row`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `nesting.metadata_fields` contains a name that is not
+    /// a column in [`Self::base_table_schema`]. Callers (notably
+    /// `parse_http_json_nesting` in the HTTPS data connector) are
+    /// responsible for validating this invariant.
     #[must_use]
     pub fn with_json_nesting(mut self, nesting: HttpJsonNesting) -> Self {
+        let base = Self::base_table_schema();
         let fields: Vec<Field> = nesting
             .column_order
             .iter()
-            .map(|name| Field::new(name, DataType::Utf8, true))
+            .map(|name| {
+                if nesting.metadata_fields.contains(name) {
+                    match base.field_with_name(name) {
+                        Ok(f) => f.clone(),
+                        Err(_) => Field::new(name, DataType::Utf8, true),
+                    }
+                } else {
+                    Field::new(name, DataType::Utf8, true)
+                }
+            })
             .collect();
         self.schema = Arc::new(Schema::new(fields));
         self.json_nesting = Some(nesting);
@@ -1690,7 +1711,15 @@ impl HttpExec {
         }
 
         if let Some(nesting) = &self.provider.json_nesting {
-            return self.create_batch_from_rows_nested(content_rows, nesting);
+            return self.create_batch_from_rows_nested(
+                path,
+                query,
+                body,
+                request_headers,
+                content_rows,
+                fetch_result,
+                nesting,
+            );
         }
 
         // Store the actual values from the partition for the primary key
@@ -1707,80 +1736,24 @@ impl HttpExec {
         );
 
         // Use response Date header if available, otherwise use current time
-        let timestamp_nanos = if let Some(date) = fetch_result.response_date {
-            i64::try_from(
-                date.duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|e| DataFusionError::Execution(format!("Invalid response date: {e}")))?
-                    .as_nanos(),
-            )
-            .map_err(|e| DataFusionError::Execution(format!("Timestamp overflow: {e}")))?
-        } else {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to get current time: {e}"))
-                })?;
-            i64::try_from(now.as_nanos())
-                .map_err(|e| DataFusionError::Execution(format!("Timestamp overflow: {e}")))?
-        };
+        let timestamp_nanos = Self::compute_fetched_at_nanos(fetch_result)?;
 
         let columns = self
             .projected_schema
             .fields()
             .iter()
-            .map(|field| match field.name().as_str() {
-                "request_path" => {
-                    Ok(Arc::new(StringArray::from(vec![path_for_batch; num_rows])) as ArrayRef)
-                }
-                "request_query" => {
-                    Ok(Arc::new(StringArray::from(vec![query_for_batch; num_rows])) as ArrayRef)
-                }
-                "request_body" => {
-                    Ok(Arc::new(StringArray::from(vec![body_for_batch; num_rows])) as ArrayRef)
-                }
-                "request_headers" => {
-                    Ok(Arc::new(StringArray::from(vec![headers_for_batch; num_rows])) as ArrayRef)
-                }
-                "content" => Ok(Arc::new(StringArray::from_iter_values(
-                    content_rows.iter().map(String::as_str),
-                )) as ArrayRef),
-                "response_status" => Ok(Arc::new(UInt16Array::from(vec![
-                    fetch_result
-                        .response_status;
-                    num_rows
-                ])) as ArrayRef),
-                "response_headers" => {
-                    let mut builder = MapBuilder::new(
-                        Some(MapFieldNames {
-                            entry: "entries".to_string(),
-                            key: "keys".to_string(),
-                            value: "values".to_string(),
-                        }),
-                        StringBuilder::new(),
-                        StringBuilder::new(),
-                    );
-                    for _ in 0..num_rows {
-                        for (k, v) in &fetch_result.response_headers {
-                            builder.keys().append_value(k);
-                            builder.values().append_value(v);
-                        }
-                        builder
-                            .append(true)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                    }
-                    Ok(Arc::new(builder.finish()) as ArrayRef)
-                }
-                "fetched_at" => {
-                    use arrow::array::TimestampNanosecondArray;
-                    Ok(Arc::new(TimestampNanosecondArray::from(vec![
-                        timestamp_nanos;
-                        num_rows
-                    ])) as ArrayRef)
-                }
-                _ => Err(DataFusionError::Execution(format!(
-                    "Unsupported field name: {}",
-                    field.name()
-                ))),
+            .map(|field| {
+                Self::build_metadata_array(
+                    field.name().as_str(),
+                    path_for_batch,
+                    query_for_batch,
+                    body_for_batch,
+                    headers_for_batch,
+                    content_rows,
+                    fetch_result,
+                    timestamp_nanos,
+                    num_rows,
+                )
             })
             .collect::<DataFusionResult<Vec<ArrayRef>>>()?;
 
@@ -1789,26 +1762,146 @@ impl HttpExec {
         Ok(batch)
     }
 
+    /// Build a single Arrow array for one of the HTTP connector's
+    /// built-in metadata columns. Used by both the default scan path
+    /// and the JSON-decomposition path so that metadata columns behave
+    /// identically in both modes.
+    #[expect(clippy::too_many_arguments)]
+    fn build_metadata_array(
+        name: &str,
+        path_for_batch: &str,
+        query_for_batch: &str,
+        body_for_batch: &str,
+        headers_for_batch: &str,
+        content_rows: &[String],
+        fetch_result: &HttpFetchResult,
+        timestamp_nanos: i64,
+        num_rows: usize,
+    ) -> DataFusionResult<ArrayRef> {
+        match name {
+            "request_path" => {
+                Ok(Arc::new(StringArray::from(vec![path_for_batch; num_rows])) as ArrayRef)
+            }
+            "request_query" => {
+                Ok(Arc::new(StringArray::from(vec![query_for_batch; num_rows])) as ArrayRef)
+            }
+            "request_body" => {
+                Ok(Arc::new(StringArray::from(vec![body_for_batch; num_rows])) as ArrayRef)
+            }
+            "request_headers" => {
+                Ok(Arc::new(StringArray::from(vec![headers_for_batch; num_rows])) as ArrayRef)
+            }
+            "content" => Ok(Arc::new(StringArray::from_iter_values(
+                content_rows.iter().map(String::as_str),
+            )) as ArrayRef),
+            "response_status" => Ok(Arc::new(UInt16Array::from(vec![
+                fetch_result.response_status;
+                num_rows
+            ])) as ArrayRef),
+            "response_headers" => {
+                let mut builder = MapBuilder::new(
+                    Some(MapFieldNames {
+                        entry: "entries".to_string(),
+                        key: "keys".to_string(),
+                        value: "values".to_string(),
+                    }),
+                    StringBuilder::new(),
+                    StringBuilder::new(),
+                );
+                for _ in 0..num_rows {
+                    for (k, v) in &fetch_result.response_headers {
+                        builder.keys().append_value(k);
+                        builder.values().append_value(v);
+                    }
+                    builder
+                        .append(true)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                }
+                Ok(Arc::new(builder.finish()) as ArrayRef)
+            }
+            "fetched_at" => {
+                use arrow::array::TimestampNanosecondArray;
+                Ok(Arc::new(TimestampNanosecondArray::from(vec![
+                    timestamp_nanos;
+                    num_rows
+                ])) as ArrayRef)
+            }
+            other => Err(DataFusionError::Execution(format!(
+                "Unsupported field name: {other}"
+            ))),
+        }
+    }
+
+    /// Compute the per-batch `fetched_at` timestamp in nanoseconds since
+    /// the Unix epoch, preferring the response `Date` header and falling
+    /// back to the current system time.
+    fn compute_fetched_at_nanos(fetch_result: &HttpFetchResult) -> DataFusionResult<i64> {
+        if let Some(date) = fetch_result.response_date {
+            i64::try_from(
+                date.duration_since(std::time::UNIX_EPOCH)
+                    .map_err(|e| DataFusionError::Execution(format!("Invalid response date: {e}")))?
+                    .as_nanos(),
+            )
+            .map_err(|e| DataFusionError::Execution(format!("Timestamp overflow: {e}")))
+        } else {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| {
+                    DataFusionError::Execution(format!("Failed to get current time: {e}"))
+                })?;
+            i64::try_from(now.as_nanos())
+                .map_err(|e| DataFusionError::Execution(format!("Timestamp overflow: {e}")))
+        }
+    }
+
     /// Create a `RecordBatch` for the user-declared columns by
     /// decomposing each JSON response row according to the nesting
-    /// configuration. All output columns are `Utf8`.
+    /// configuration. Body-derived columns are produced as `Utf8` from
+    /// the decomposed JSON; columns whose names match HTTP metadata
+    /// fields (see [`HttpJsonNesting::metadata_fields`]) are populated
+    /// from the request/response metadata via [`Self::build_metadata_array`]
+    /// with their original types.
     ///
     /// Fast path: when the catch-all column is not in the projected
     /// schema we skip building the catch-all `BTreeMap` and re-
     /// serializing it, which is the dominant cost for wide JSON rows.
     /// Non-object rows still fall through to `decompose_json_row` so
     /// static columns become NULL and no data is dropped.
+    #[expect(clippy::too_many_arguments)]
     fn create_batch_from_rows_nested(
         &self,
+        path: Option<&str>,
+        query: Option<&str>,
+        body: Option<&str>,
+        request_headers: Option<&str>,
         content_rows: &[String],
+        fetch_result: &HttpFetchResult,
         nesting: &HttpJsonNesting,
     ) -> DataFusionResult<RecordBatch> {
         let fields = self.projected_schema.fields();
-        let field_names: Vec<&str> = fields.iter().map(|f| f.name().as_str()).collect();
-        let catchall_projected = field_names.contains(&nesting.json_field_name.as_str());
+        let num_rows = content_rows.len();
 
-        let mut builders: Vec<StringBuilder> = std::iter::repeat_with(StringBuilder::new)
-            .take(fields.len())
+        // Per-batch values for metadata columns. Computed lazily-ish:
+        // cheap enough to always derive, and only used when at least
+        // one metadata column is projected.
+        let path_for_batch = path.unwrap_or("");
+        let query_for_batch = query.unwrap_or("");
+        let body_for_batch = body.unwrap_or("");
+        let headers_for_batch = request_headers.unwrap_or("");
+        let timestamp_nanos = Self::compute_fetched_at_nanos(fetch_result)?;
+
+        // Identify which projected fields are body-derived vs metadata.
+        let body_field_names: Vec<&str> = fields
+            .iter()
+            .filter(|f| !nesting.metadata_fields.contains(f.name()))
+            .map(|f| f.name().as_str())
+            .collect();
+        let catchall_projected = body_field_names.contains(&nesting.json_field_name.as_str());
+
+        // Build body-derived columns via string builders, in projected
+        // (not full-schema) order, restricted to non-metadata fields.
+        let mut body_builders: Vec<StringBuilder> = std::iter::repeat_with(StringBuilder::new)
+            .take(body_field_names.len())
             .collect();
 
         for row in content_rows {
@@ -1816,7 +1909,7 @@ impl HttpExec {
                 && let Ok(serde_json::Value::Object(obj)) =
                     serde_json::from_str::<serde_json::Value>(row)
             {
-                for (builder, name) in builders.iter_mut().zip(field_names.iter()) {
+                for (builder, name) in body_builders.iter_mut().zip(body_field_names.iter()) {
                     match obj.get(*name) {
                         None | Some(serde_json::Value::Null) => builder.append_null(),
                         Some(serde_json::Value::String(s)) => builder.append_value(s),
@@ -1829,7 +1922,7 @@ impl HttpExec {
             let decomposed = decompose_json_row(row, nesting).map_err(|source| {
                 DataFusionError::External(Box::new(Error::JsonNesting { source }))
             })?;
-            for (builder, name) in builders.iter_mut().zip(field_names.iter()) {
+            for (builder, name) in body_builders.iter_mut().zip(body_field_names.iter()) {
                 match decomposed.get(*name).and_then(|v| v.as_deref()) {
                     Some(v) => builder.append_value(v),
                     None => builder.append_null(),
@@ -1837,10 +1930,37 @@ impl HttpExec {
             }
         }
 
-        let columns: Vec<ArrayRef> = builders
+        let mut body_arrays: std::collections::VecDeque<ArrayRef> = body_builders
             .into_iter()
             .map(|mut b| Arc::new(b.finish()) as ArrayRef)
             .collect();
+
+        // Stitch together the final column list in projected-schema
+        // order, slotting metadata-built arrays where appropriate.
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(fields.len());
+        for field in fields {
+            if nesting.metadata_fields.contains(field.name()) {
+                columns.push(Self::build_metadata_array(
+                    field.name().as_str(),
+                    path_for_batch,
+                    query_for_batch,
+                    body_for_batch,
+                    headers_for_batch,
+                    content_rows,
+                    fetch_result,
+                    timestamp_nanos,
+                    num_rows,
+                )?);
+            } else {
+                let array = body_arrays.pop_front().ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "json-nested batch: body array count does not match non-metadata projected fields"
+                            .to_string(),
+                    )
+                })?;
+                columns.push(array);
+            }
+        }
 
         RecordBatch::try_new(Arc::clone(&self.projected_schema), columns)
             .map_err(DataFusionError::from)
@@ -6210,11 +6330,23 @@ mod tests {
         let nesting = HttpJsonNesting::new(
             column_order.iter().map(|s| (*s).to_string()).collect(),
             json_field.to_string(),
+            std::collections::HashSet::new(),
         );
         let provider = Arc::new(base_provider().with_json_nesting(nesting.clone()));
         let schema = provider.schema();
         let exec = HttpExec::new(schema, provider, vec![(None, None, None, None)], None);
         (exec, nesting)
+    }
+
+    fn empty_fetch_result() -> HttpFetchResult {
+        HttpFetchResult {
+            content: String::new(),
+            max_age: std::time::Duration::from_secs(0),
+            detected_format: "application/json".to_string(),
+            response_date: None,
+            response_status: 200,
+            response_headers: Vec::new(),
+        }
     }
 
     fn string_col(batch: &RecordBatch, name: &str) -> Vec<Option<String>> {
@@ -6246,7 +6378,15 @@ mod tests {
             r#"{"id":"2","name":"beta","k":42}"#.to_string(),
         ];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
@@ -6268,7 +6408,15 @@ mod tests {
         let (exec, nesting) = nested_exec(&["id", "name", "details"], "details");
         let rows = vec![r#"{"id":"1"}"#.to_string()];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(string_col(&batch, "id"), vec![Some("1".to_string())]);
         assert_eq!(string_col(&batch, "name"), vec![None]);
@@ -6283,7 +6431,15 @@ mod tests {
             r#"{"name":"beta"}"#.to_string(),
         ];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 2);
 
@@ -6306,7 +6462,15 @@ mod tests {
             "42".to_string(),
         ];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 3);
         for v in string_col(&batch, "id") {
@@ -6326,7 +6490,15 @@ mod tests {
         let (exec, nesting) = nested_exec(&["id", "name", "details"], "details");
         let rows = vec![r#"{"id":"1","name":"alpha"}"#.to_string()];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(string_col(&batch, "id")[0].as_deref(), Some("1"));
@@ -6344,6 +6516,7 @@ mod tests {
         let nesting = HttpJsonNesting::new(
             vec!["id".to_string(), "name".to_string(), "details".to_string()],
             "details".to_string(),
+            std::collections::HashSet::new(),
         );
         let provider = Arc::new(base_provider().with_json_nesting(nesting.clone()));
         // Project only static columns, not "details".
@@ -6359,7 +6532,15 @@ mod tests {
         let exec = HttpExec::new(projected, provider, vec![(None, None, None, None)], None);
         let rows = vec![r#"{"id":"42","name":"fast","extra":"ignored"}"#.to_string()];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("fast-path batch should be created");
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 2);
@@ -6375,6 +6556,7 @@ mod tests {
         let nesting = HttpJsonNesting::new(
             vec!["id".to_string(), "details".to_string()],
             "details".to_string(),
+            std::collections::HashSet::new(),
         );
         let provider = Arc::new(base_provider().with_json_nesting(nesting.clone()));
         let full_schema = provider.schema();
@@ -6384,7 +6566,15 @@ mod tests {
         let exec = HttpExec::new(projected, provider, vec![(None, None, None, None)], None);
         let rows = vec!["[1,2,3]".to_string(), r#"{"id":"x"}"#.to_string()];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 1);
@@ -6398,6 +6588,7 @@ mod tests {
         let nesting = HttpJsonNesting::new(
             vec!["id".to_string(), "details".to_string()],
             "details".to_string(),
+            std::collections::HashSet::new(),
         );
         let provider = Arc::new(base_provider().with_json_nesting(nesting.clone()));
         let full_schema = provider.schema();
@@ -6414,10 +6605,127 @@ mod tests {
             r#"{"id":"2"}"#.to_string(),
         ];
         let batch = exec
-            .create_batch_from_rows_nested(&rows, &nesting)
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
             .expect("batch should be created");
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 1);
+    }
+
+    #[test]
+    fn create_batch_from_rows_nested_passes_through_metadata_columns() {
+        // Mix decomposed body columns with HTTP metadata columns. The
+        // metadata columns should keep their base-schema types and be
+        // populated from the per-batch HTTP request/response values,
+        // not from the JSON body.
+        let nesting = HttpJsonNesting::new(
+            vec![
+                "request_path".to_string(),
+                "response_status".to_string(),
+                "id".to_string(),
+                "details".to_string(),
+            ],
+            "details".to_string(),
+            ["request_path".to_string(), "response_status".to_string()]
+                .into_iter()
+                .collect(),
+        );
+        let provider = Arc::new(base_provider().with_json_nesting(nesting.clone()));
+        let schema = provider.schema();
+
+        // Schema should keep base-table types for metadata columns.
+        assert_eq!(
+            schema
+                .field_with_name("request_path")
+                .expect("request_path field")
+                .data_type(),
+            &arrow::datatypes::DataType::Utf8
+        );
+        assert_eq!(
+            schema
+                .field_with_name("response_status")
+                .expect("response_status field")
+                .data_type(),
+            &arrow::datatypes::DataType::UInt16
+        );
+
+        let exec = HttpExec::new(
+            Arc::clone(&schema),
+            provider,
+            vec![(Some("/shows/1".to_string()), None, None, None)],
+            None,
+        );
+        let fetch_result = HttpFetchResult {
+            content: String::new(),
+            max_age: Duration::from_secs(0),
+            detected_format: "json".to_string(),
+            response_date: None,
+            response_status: 201,
+            response_headers: Vec::new(),
+        };
+        // Body has a key colliding with a metadata name; it must be
+        // ignored in favor of the actual HTTP value.
+        let rows = vec![
+            r#"{"id":"1","request_path":"/from-body","extra":"x"}"#.to_string(),
+            r#"{"id":"2"}"#.to_string(),
+        ];
+        let batch = exec
+            .create_batch_from_rows_nested(
+                Some("/shows/1"),
+                None,
+                None,
+                None,
+                &rows,
+                &fetch_result,
+                &nesting,
+            )
+            .expect("batch should be created");
+
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 4);
+
+        // request_path: from HTTP metadata, repeated per row.
+        assert_eq!(
+            string_col(&batch, "request_path"),
+            vec![Some("/shows/1".to_string()), Some("/shows/1".to_string())]
+        );
+
+        // response_status: typed UInt16 from fetch_result.
+        let status = batch
+            .column(
+                batch
+                    .schema()
+                    .index_of("response_status")
+                    .expect("response_status column index"),
+            )
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("response_status should be UInt16");
+        assert_eq!(status.value(0), 201);
+        assert_eq!(status.value(1), 201);
+
+        // id: decomposed from body.
+        assert_eq!(
+            string_col(&batch, "id"),
+            vec![Some("1".to_string()), Some("2".to_string())]
+        );
+
+        // catch-all: must NOT contain `request_path` (it was a metadata
+        // collision), but must contain `extra` for row 0.
+        let details = string_col(&batch, "details");
+        let parsed: serde_json::Value =
+            serde_json::from_str(details[0].as_deref().expect("row 0 details"))
+                .expect("row 0 details parses as JSON");
+        assert!(parsed.get("request_path").is_none());
+        assert_eq!(parsed["extra"], "x");
+        assert!(details[1].is_none());
     }
 
     #[test]

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1039,11 +1039,49 @@ fn parse_http_json_nesting(dataset: &Dataset) -> DataConnectorResult<Option<Http
 
     let column_order: Vec<String> = dataset.columns.iter().map(|col| col.name.clone()).collect();
 
+    // Reject the catch-all column itself being named after a reserved
+    // HTTP metadata field — it would be ambiguous whether the column
+    // should hold the JSON catch-all or the metadata value.
+    if HTTP_METADATA_FIELDS.contains(&json_column.name.as_str()) {
+        return Err(DataConnectorError::InvalidConfigurationNoSource {
+            dataconnector: "https".to_string(),
+            connector_component: ConnectorComponent::from(dataset),
+            message: format!(
+                "Column '{}' is marked as the JSON catch-all (json_object: \"*\") but its name is reserved for HTTP metadata. Rename the column.",
+                json_column.name
+            ),
+        });
+    }
+
+    let metadata_fields: std::collections::HashSet<String> = column_order
+        .iter()
+        .filter(|name| HTTP_METADATA_FIELDS.contains(&name.as_str()))
+        .cloned()
+        .collect();
+
     Ok(Some(HttpJsonNesting::new(
         column_order,
         json_column.name.clone(),
+        metadata_fields,
     )))
 }
+
+/// Names of columns in [`HttpTableProvider::base_table_schema`].
+/// When schema decomposition is enabled, declared columns whose names
+/// match one of these are sourced from HTTP request/response metadata
+/// instead of being decomposed from the JSON body.
+///
+/// [`HttpTableProvider::base_table_schema`]: data_components::http::provider::HttpTableProvider::base_table_schema
+const HTTP_METADATA_FIELDS: &[&str] = &[
+    "request_path",
+    "request_query",
+    "request_body",
+    "request_headers",
+    "content",
+    "response_status",
+    "response_headers",
+    "fetched_at",
+];
 
 #[async_trait]
 impl DataConnector for Https {
@@ -2120,6 +2158,56 @@ mod tests {
                 assert!(
                     message.contains("invalid 'json_object' value"),
                     "expected invalid-value error, got: {message}"
+                );
+            }
+            other => panic!("expected InvalidConfigurationNoSource, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_http_json_nesting_classifies_metadata_columns() {
+        let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+        dataset.columns = vec![
+            Column::new("request_path"),
+            Column::new("response_status"),
+            Column::new("id"),
+            column_with_marker("data", Value::String("*".to_string())),
+        ];
+        let nesting = parse_http_json_nesting(&dataset)
+            .expect("parse should succeed")
+            .expect("expected Some(nesting) when marker is present");
+        assert_eq!(nesting.json_field_name, "data");
+        assert_eq!(
+            nesting.column_order,
+            vec!["request_path", "response_status", "id", "data"]
+        );
+        assert!(nesting.metadata_fields.contains("request_path"));
+        assert!(nesting.metadata_fields.contains("response_status"));
+        assert!(
+            !nesting.metadata_fields.contains("id"),
+            "non-reserved column must not be classified as metadata"
+        );
+        // Reserved-name columns must not also be treated as static body
+        // fields, otherwise the body would shadow the HTTP metadata.
+        assert!(!nesting.static_fields.contains("request_path"));
+        assert!(!nesting.static_fields.contains("response_status"));
+        assert!(nesting.static_fields.contains("id"));
+    }
+
+    #[tokio::test]
+    async fn parse_http_json_nesting_rejects_catchall_named_after_metadata() {
+        let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+        dataset.columns = vec![
+            Column::new("id"),
+            column_with_marker("response_status", Value::String("*".to_string())),
+        ];
+        let error = parse_http_json_nesting(&dataset)
+            .expect_err("reserved-name catch-all should be rejected");
+        match error {
+            DataConnectorError::InvalidConfigurationNoSource { message, .. } => {
+                assert!(
+                    message.contains("reserved for HTTP metadata"),
+                    "expected reserved-name error, got: {message}"
                 );
             }
             other => panic!("expected InvalidConfigurationNoSource, got: {other}"),


### PR DESCRIPTION
## Summary

When a dataset uses JSON schema decomposition (`metadata.json_object: "*"`), declared columns whose names match the HTTP connector's built-in metadata fields are now populated from the HTTP request/response (with their original Arrow types) instead of being decomposed from the JSON body.

Reserved metadata names: `request_path`, `request_query`, `request_body`, `request_headers`, `content`, `response_status`, `response_headers`, `fetched_at`.

This lets a single dataset expose both decomposed body columns and HTTP metadata, so queries can filter on a typed `response_status = 200` or push a path filter via `request_path` on the same table that decomposes the JSON body.

## Example

```yaml
datasets:
  - from: https://api.tvmaze.com/shows
    name: tvmaze_shows
    columns:
      - name: request_path        # Utf8, from HTTP request
      - name: response_status     # UInt16, from HTTP response
      - name: fetched_at          # Timestamp(ns), from response Date
      - name: id                  # decomposed from JSON body
      - name: name                # decomposed from JSON body
      - name: premiered           # decomposed from JSON body
      - name: details             # catch-all
        metadata:
          json_object: "*"
```

```sql
SELECT id, name, response_status, fetched_at
FROM tvmaze_shows
WHERE request_path = '/shows/1' AND response_status = 200;
```

## Rules

- A body key colliding with a reserved metadata name is dropped — it does not shadow the real HTTP value and does not leak into the catch-all column.
- Declaring the catch-all column itself (`json_object: "*"`) with a reserved name is rejected at registration time as ambiguous.
- Datasets that don't use decomposition are unaffected; datasets that use decomposition without any reserved-name columns behave exactly as before.

## Implementation

- `HttpJsonNesting` gains a `metadata_fields: HashSet<String>` set; `static_fields` excludes both the catch-all and any metadata field. `decompose_json_row` skips body keys that match a metadata field (defensive — collisions are validated as out-of-scope but the decomposer enforces it regardless).
- `HttpTableProvider::with_json_nesting` builds the schema by looking up each declared metadata column in `base_table_schema()`, preserving its real Arrow type (`UInt16` for `response_status`, `Timestamp(ns)` for `fetched_at`, `Map<Utf8, Utf8>` for `response_headers`, etc.). Body-derived columns remain `Utf8`/nullable.
- The metadata-column array construction was extracted from `create_batch_from_rows` into a shared `HttpExec::build_metadata_array` helper; both the default scan path and the JSON-decomposition path call it. The fast path that skips catch-all serialization when not projected is preserved and now correctly accounts for metadata columns.
- `parse_http_json_nesting` in `crates/runtime/src/dataconnector/https.rs` classifies declared columns whose names match a single `HTTP_METADATA_FIELDS` constant, and rejects the catch-all-named-after-reserved case.

## Tests

- `crates/data_components/src/http/json_nest.rs`: new `metadata_field_is_not_extracted_from_body` test.
- `crates/data_components/src/http/provider.rs`: new `create_batch_from_rows_nested_passes_through_metadata_columns` test verifying typed `UInt16` `response_status`, per-row repeated `request_path`, and that body keys colliding with a metadata name are dropped.
- `crates/runtime/src/dataconnector/https.rs`: new `parse_http_json_nesting_classifies_metadata_columns` and `parse_http_json_nesting_rejects_catchall_named_after_metadata` tests.

All 158 existing `data_components::http::*` tests continue to pass.

## Manual verification

Tested against `https://api.tvmaze.com/shows` with both a decomposition-only dataset (regression, behavior unchanged) and a mixed dataset with `request_path`/`response_status`/`fetched_at` plus decomposed `id`/`name`/`premiered`/`details` catch-all:

```
+--------------+-----------------+---------------+-------------+
| column_name  |    data_type    |              | is_nullable |
+--------------+-----------------+---------------+-------------+
| request_path    | Utf8          |              | NO          |
| response_status | UInt16        |              | NO          |
| fetched_at      | Timestamp(ns) |              | YES         |
| id              | Utf8          |              | YES         |
| name            | Utf8          |              | YES         |
| premiered       | Utf8          |              | YES         |
| details         | Utf8          |              | YES         |
+--------------+-----------------+---------------+-------------+
```

`SELECT count(*) WHERE response_status = 200` returns 240 (typed UInt16 predicate). The bad-config validation fires at registration time with a clear error.

## Checklist

- [x] `make lint-rust` passes
- [x] All affected unit tests pass
- [x] Manually tested end-to-end against a live HTTP API
- [x] Backward compatible (datasets without reserved-name columns are unchanged)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->