### PR TITLE
fix: add snapshot mode guards to delete_from/update and delegate DML in SwappableTableProvider

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1542,6 +1542,13 @@ impl TableProvider for AcceleratedTable {
         state: &dyn Session,
         filters: Vec<Expr>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if self.refresh_mode == RefreshMode::Snapshot {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "deletes on accelerated table {} are not permitted when refresh_mode is 'snapshot'; the accelerator is driven exclusively from the snapshot store",
+                self.dataset_name
+            )));
+        }
+
         self.update_last_updated_at();
 
         match &self.write_mode {
@@ -1580,6 +1587,13 @@ impl TableProvider for AcceleratedTable {
         assignments: Vec<(String, Expr)>,
         filters: Vec<Expr>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if self.refresh_mode == RefreshMode::Snapshot {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "updates on accelerated table {} are not permitted when refresh_mode is 'snapshot'; the accelerator is driven exclusively from the snapshot store",
+                self.dataset_name
+            )));
+        }
+
         self.update_last_updated_at();
 
         match &self.write_mode {

--- a/crates/runtime/src/dataaccelerator/swappable.rs
+++ b/crates/runtime/src/dataaccelerator/swappable.rs
@@ -197,6 +197,23 @@ impl TableProvider for SwappableTableProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         self.current().insert_into(state, input, insert_op).await
     }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.current().delete_from(state, filters).await
+    }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.current().update(state, assignments, filters).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `AcceleratedTable::insert_into` correctly rejects writes when `refresh_mode` is `snapshot`, but `delete_from` and `update` were missing the same guard
- `SwappableTableProvider` only delegated `insert_into` to the inner provider — `delete_from` and `update` fell through to DataFusion's default `NotImplemented` error
- A `DELETE FROM` or `UPDATE` against a snapshot-accelerated table would either hit a confusing error or succeed but have changes silently overwritten on the next snapshot reload

## Fix
- Add snapshot mode rejection to `delete_from` and `update` in `AcceleratedTable`, matching the existing `insert_into` guard
- Add `delete_from` and `update` delegations to `SwappableTableProvider`

## Test plan
- `cargo fmt --all -- --check` passes
- `cargo clippy -p runtime` passes
- Performance impact: none (early-return guard before any work)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->