### PR TITLE
fix: make Helm chart probes configurable

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -38,7 +38,7 @@ helm install spiceai deploy/chart \
 | `volumeMounts`                  | Additional volume mounts                                                     | `[]`                              |
 | `spicepod`                      | Spicepod configuration (inlined into a ConfigMap)                            | see `values.yaml`                 |
 
-Probe values use the standard Kubernetes probe configuration shape. They can be omitted entirely to use the built-in defaults, or partially overridden while omitted fields keep the defaults from `values.yaml`.
+Probe values use the standard Kubernetes probe configuration shape. They can be omitted entirely to use the built-in defaults, or partially overridden while omitted fields keep the defaults from `values.yaml`. If `exec`, `tcpSocket`, or `grpc` is configured, the chart omits the default `httpGet` handler from the rendered probe.
 
 ### ServiceAccount Annotations for Cloud IAM
 

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -38,6 +38,8 @@ helm install spiceai deploy/chart \
 | `volumeMounts`                  | Additional volume mounts                                                     | `[]`                              |
 | `spicepod`                      | Spicepod configuration (inlined into a ConfigMap)                            | see `values.yaml`                 |
 
+Probe values use the standard Kubernetes probe configuration shape. They can be omitted entirely to use the defaults, or partially overridden while omitted fields keep the defaults from `values.yaml`.
+
 ### ServiceAccount Annotations for Cloud IAM
 
 Use `serviceAccount.annotations` to bind cloud IAM roles to Spice.ai pods, granting access to cloud resources (S3, DynamoDB, GCS, etc.) without static credentials. This works with any Kubernetes distribution that supports annotation-based identity federation.

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -23,6 +23,9 @@ helm install spiceai deploy/chart \
 | `serviceAccount.annotations`    | Annotations for the ServiceAccount                                           | `{}`                              |
 | `service.type`                  | Kubernetes Service type (`ClusterIP`, `NodePort`, `LoadBalancer`, or `null`) | `null`                            |
 | `service.additionalAnnotations` | Additional annotations on the Service                                        | `{}`                              |
+| `livenessProbe`                 | Kubernetes liveness probe configuration                                      | see `values.yaml`                 |
+| `readinessProbe`                | Kubernetes readiness probe configuration                                     | see `values.yaml`                 |
+| `startupProbe`                  | Kubernetes startup probe configuration                                       | see `values.yaml`                 |
 | `stateful.enabled`              | Use a StatefulSet with PVC                                                   | `false`                           |
 | `stateful.storageClass`         | StorageClass for StatefulSet PVC                                             | `standard`                        |
 | `stateful.size`                 | PVC size                                                                     | `1Gi`                             |

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -38,7 +38,7 @@ helm install spiceai deploy/chart \
 | `volumeMounts`                  | Additional volume mounts                                                     | `[]`                              |
 | `spicepod`                      | Spicepod configuration (inlined into a ConfigMap)                            | see `values.yaml`                 |
 
-Probe values use the standard Kubernetes probe configuration shape. They can be omitted entirely to use the defaults, or partially overridden while omitted fields keep the defaults from `values.yaml`.
+Probe values use the standard Kubernetes probe configuration shape. They can be omitted entirely to use the built-in defaults, or partially overridden while omitted fields keep the defaults from `values.yaml`.
 
 ### ServiceAccount Annotations for Cloud IAM
 

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -79,3 +79,24 @@ app.kubernetes.io/name: {{ include "spiceai.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render a Kubernetes probe with built-in HTTP defaults.
+*/}}
+{{- define "spiceai.probe" -}}
+{{- $probe := .probe -}}
+{{- if $probe -}}
+{{- if or $probe.exec $probe.tcpSocket $probe.grpc -}}
+{{- omit $probe "httpGet" | toYaml -}}
+{{- else -}}
+{{- toYaml $probe -}}
+{{- end -}}
+{{- else -}}
+httpGet:
+  path: {{ .path }}
+  port: {{ .port }}
+timeoutSeconds: 1
+periodSeconds: 10
+failureThreshold: 3
+{{- end -}}
+{{- end -}}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -82,18 +82,18 @@ spec:
               name: metrics
             - containerPort: 50051
               name: flight
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: 8090
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /v1/ready
-              port: 8090
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
           startupProbe:
-            httpGet:
-              path: /health
-              port: 8090
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
             {{- .Values.volumeMounts | toYaml | nindent 12 }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -82,17 +82,41 @@ spec:
               name: metrics
             - containerPort: 50051
               name: flight
-          {{- with .Values.livenessProbe }}
+          {{- if .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- else }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
           {{- end }}
-          {{- with .Values.readinessProbe }}
+          {{- if .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- else }}
+          readinessProbe:
+            httpGet:
+              path: /v1/ready
+              port: 8090
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
           {{- end }}
-          {{- with .Values.startupProbe }}
+          {{- if .Values.startupProbe }}
           startupProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- else }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
           {{- end }}
           volumeMounts:
             {{- if .Values.volumeMounts }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -82,42 +82,12 @@ spec:
               name: metrics
             - containerPort: 50051
               name: flight
-          {{- if .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
-          {{- else }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8090
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
-          {{- end }}
-          {{- if .Values.readinessProbe }}
+            {{- include "spiceai.probe" (dict "probe" .Values.livenessProbe "path" "/health" "port" 8090) | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- else }}
-          readinessProbe:
-            httpGet:
-              path: /v1/ready
-              port: 8090
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
-          {{- end }}
-          {{- if .Values.startupProbe }}
+            {{- include "spiceai.probe" (dict "probe" .Values.readinessProbe "path" "/v1/ready" "port" 8090) | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
-          {{- else }}
-          startupProbe:
-            httpGet:
-              path: /health
-              port: 8090
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
-          {{- end }}
+            {{- include "spiceai.probe" (dict "probe" .Values.startupProbe "path" "/health" "port" 8090) | nindent 12 }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
             {{- .Values.volumeMounts | toYaml | nindent 12 }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -49,6 +49,31 @@ serviceAccount:
 #   - --flight
 #   - 0.0.0.0:50051
 
+# Configure Kubernetes probes for the Spice.ai runtime container
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8090
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /v1/ready
+    port: 8090
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8090
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
 # Additional environment variables
 # additionalEnv:
 #   - name: ENV_VAR_NAME

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -49,7 +49,8 @@ serviceAccount:
 #   - --flight
 #   - 0.0.0.0:50051
 
-# Configure Kubernetes probes for the Spice.ai runtime container
+# Configure Kubernetes probes for the Spice.ai runtime container.
+# Omitted probe fields keep these defaults, so overrides can be partial.
 livenessProbe:
   httpGet:
     path: /health

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -52,6 +52,7 @@ serviceAccount:
 # Configure Kubernetes probes for the Spice.ai runtime container.
 # Omitted probe fields keep these defaults, so overrides can be partial.
 # If a probe value is omitted entirely, the template renders these defaults.
+# If exec, tcpSocket, or grpc is configured, the template omits the default httpGet handler.
 livenessProbe:
   httpGet:
     path: /health

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -51,6 +51,7 @@ serviceAccount:
 
 # Configure Kubernetes probes for the Spice.ai runtime container.
 # Omitted probe fields keep these defaults, so overrides can be partial.
+# If a probe value is omitted entirely, the template renders these defaults.
 livenessProbe:
   httpGet:
     path: /health


### PR DESCRIPTION
## Summary
- Add configurable `livenessProbe`, `readinessProbe`, and `startupProbe` values with current default paths/ports and explicit timing defaults.
- Render probe definitions from chart values so users can override paths, ports, and probe timing parameters.
- Document the new chart values in the Helm chart README.

Fixes #10691

## Testing
- `helm template spiceai deploy/chart`
- `helm lint deploy/chart`
- `helm template spiceai deploy/chart --set livenessProbe.httpGet.path=/live --set livenessProbe.httpGet.port=8181 --set readinessProbe.timeoutSeconds=5 --set startupProbe.failureThreshold=30 | awk '/livenessProbe:/,/volumeMounts:/'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->