### PR TITLE
Fix spiceio model archive uploads

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -131,18 +131,32 @@ jobs:
 
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration.tar.zst
 
+      - name: Preserve sccache spiceio log
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: cp "${{ runner.temp }}/spiceio.log" "${{ runner.temp }}/spiceio-sccache.log" || true
+
+      - name: Stop sccache spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Set up spiceio for build archive
+        if: env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio-build
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
       - name: Upload test archive to spiceio
         if: env.HAS_SPICEIO_SECRET == 'true'
         env:
-          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio-build.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the AI integration test archive}"
-          bucket_status=$(curl --silent --show-error --output /tmp/spiceio-create-build-bucket --write-out "%{http_code}" --request PUT "${SPICEIO_ENDPOINT%/}/build")
-          if [[ "$bucket_status" != "200" && "$bucket_status" != "204" && "$bucket_status" != "409" ]]; then
-            cat /tmp/spiceio-create-build-bucket
-            exit 1
-          fi
           archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_TEST_ARCHIVE_S3_URI#s3://}"
           curl --fail --silent --show-error --upload-file ./integration.tar.zst "$archive_url"
 
@@ -155,16 +169,16 @@ jobs:
           retention-days: 3
           compression-level: 1
 
-      - name: Kill spiceio
-        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
-        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+      - name: Kill build archive spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio-build.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio-build.outputs.pid }} || true
 
       - name: Upload spiceio logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: spiceio-models-build-logs
-          path: ${{ runner.temp }}/spiceio.log
+          path: ${{ runner.temp }}/spiceio*.log
           if-no-files-found: ignore
 
   test-models:
@@ -552,18 +566,32 @@ jobs:
 
           cargo nextest archive -p runtime --test integration_models --features ${FEATURES} --archive-file integration-extended.tar.zst
 
+      - name: Preserve sccache spiceio log
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: cp "${{ runner.temp }}/spiceio.log" "${{ runner.temp }}/spiceio-sccache.log" || true
+
+      - name: Stop sccache spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Set up spiceio for build archive
+        if: env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio-build
+        uses: spiceai/spiceio/.github/actions/setup@18e298c86831c6969a0ff16ee827fe2fd816df7d # v0.5.1
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: build
+          region: us-west-1
+
       - name: Upload test archive to spiceio
         if: env.HAS_SPICEIO_SECRET == 'true'
         env:
-          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio.outputs.endpoint }}
+          SPICEIO_ENDPOINT: ${{ steps.setup-spiceio-build.outputs.endpoint }}
         run: |
           set -euo pipefail
           : "${SPICEIO_ENDPOINT:?spiceio endpoint is required to upload the extended AI integration test archive}"
-          bucket_status=$(curl --silent --show-error --output /tmp/spiceio-create-build-bucket --write-out "%{http_code}" --request PUT "${SPICEIO_ENDPOINT%/}/build")
-          if [[ "$bucket_status" != "200" && "$bucket_status" != "204" && "$bucket_status" != "409" ]]; then
-            cat /tmp/spiceio-create-build-bucket
-            exit 1
-          fi
           archive_url="${SPICEIO_ENDPOINT%/}/${AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI#s3://}"
           curl --fail --silent --show-error --upload-file ./integration-extended.tar.zst "$archive_url"
 
@@ -576,14 +604,14 @@ jobs:
           retention-days: 3
           compression-level: 1
 
-      - name: Kill spiceio
-        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
-        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+      - name: Kill build archive spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio-build.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio-build.outputs.pid }} || true
 
       - name: Upload spiceio logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: spiceio-models-build-extended-logs
-          path: ${{ runner.temp }}/spiceio.log
+          path: ${{ runner.temp }}/spiceio*.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- stop using the `sccache` spiceio endpoint for model integration archive uploads
- restart spiceio with the `build` bucket before uploading regular and extended model archives
- preserve both spiceio logs for failed build debugging

## Testing
- `python3` PyYAML parse of `.github/workflows/integration_models.yml`
- `git diff --check -- .github/workflows/integration_models.yml`
- VS Code diagnostics for `.github/workflows/integration_models.yml`

`actionlint` was not installed locally, so that check was not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->