### PR TITLE
feat: per-principal cache namespacing for SQL/search/caching-accelerator (#10680)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15762,6 +15762,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "pin-project",
+ "sha2",
  "tonic",
  "tower 0.5.3",
  "tracing",

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -86,23 +86,25 @@ impl<'a> From<(&'a str, &'a EmbeddingInput)> for CacheKey<'a> {
 }
 
 impl CacheKey<'_> {
-    #[must_use]
-    pub fn as_raw_key<T: Hasher>(&self, mut hasher: T) -> RawCacheKey {
+    /// Hash this key's payload into `hasher`. Used by both [`Self::as_raw_key`]
+    /// and [`Self::as_raw_key_in_namespace`] so the payload byte stream stays
+    /// identical regardless of whether a namespace prefix was mixed in.
+    fn hash_payload<T: Hasher>(&self, hasher: &mut T) {
         match self {
-            Self::LogicalPlan(logical_plan) => logical_plan.hash(&mut hasher),
-            Self::Search(search_key) => search_key.hash(&mut hasher),
-            Self::EmbeddingRequest(embedding_request) => embedding_request.hash(&mut hasher),
+            Self::LogicalPlan(logical_plan) => logical_plan.hash(hasher),
+            Self::Search(search_key) => search_key.hash(hasher),
+            Self::EmbeddingRequest(embedding_request) => embedding_request.hash(hasher),
             Self::EmbeddingInput(model_name, embedding_input) => {
-                model_name.hash(&mut hasher);
-                embedding_input.hash(&mut hasher);
+                model_name.hash(hasher);
+                embedding_input.hash(hasher);
             }
             Self::Query(sql, param_values) => {
-                sql.hash(&mut hasher);
+                sql.hash(hasher);
                 if let Some(params) = param_values {
                     match params {
                         ParamValues::List(vec) => {
                             for item in vec {
-                                item.value().hash(&mut hasher);
+                                item.value().hash(hasher);
                             }
                         }
                         ParamValues::Map(hash_map) => {
@@ -111,15 +113,52 @@ impl CacheKey<'_> {
                             pairs.sort_by(|a, b| a.0.cmp(b.0)); // Sort by keys
 
                             for (key, value) in pairs {
-                                key.hash(&mut hasher);
-                                value.value().hash(&mut hasher);
+                                key.hash(hasher);
+                                value.value().hash(hasher);
                             }
                         }
                     }
                 }
             }
-            Self::ClientSupplied(user_key) => user_key.hash(&mut hasher),
+            Self::ClientSupplied(user_key) => user_key.hash(hasher),
         }
+    }
+
+    /// Compute the raw cache key with no namespace mixed in. Use this for
+    /// surfaces whose result is a pure function of the inputs and is safe
+    /// to share across all callers — most importantly the embeddings cache,
+    /// where `(model, input) -> embedding` is permission-independent.
+    #[must_use]
+    pub fn as_raw_key<T: Hasher>(&self, mut hasher: T) -> RawCacheKey {
+        self.hash_payload(&mut hasher);
+        RawCacheKey(hasher.finish())
+    }
+
+    /// Compute the raw cache key with a namespace prefix folded into the
+    /// hash. Two requests whose `(namespace_tag, namespace_id)` differ
+    /// hash to distinct keys for otherwise-identical payloads, which is
+    /// what makes cache hits safe under per-user authentication.
+    ///
+    /// `namespace_tag` is the discriminant of the namespace kind
+    /// (`0` = public/shared, `1` = principal, `2` = system) and
+    /// `namespace_id` is the principal's stable opaque id (empty for
+    /// public/system).
+    ///
+    /// The byte stream hashed is:
+    /// `[namespace_tag][namespace_id.len() as u64 LE][namespace_id...][payload...]`
+    /// so that `(tag=1, id="abc")` and `(tag=1, id="a")` followed by a
+    /// payload starting with `"bc"` cannot collide.
+    #[must_use]
+    pub fn as_raw_key_in_namespace<T: Hasher>(
+        &self,
+        mut hasher: T,
+        namespace_tag: u8,
+        namespace_id: &[u8],
+    ) -> RawCacheKey {
+        hasher.write_u8(namespace_tag);
+        hasher.write_u64(namespace_id.len() as u64);
+        hasher.write(namespace_id);
+        self.hash_payload(&mut hasher);
         RawCacheKey(hasher.finish())
     }
 }

--- a/crates/runtime-auth/Cargo.toml
+++ b/crates/runtime-auth/Cargo.toml
@@ -18,3 +18,4 @@ futures.workspace = true
 base64.workspace = true
 pin-project.workspace = true
 http.workspace = true
+sha2.workspace = true

--- a/crates/runtime-auth/src/traits.rs
+++ b/crates/runtime-auth/src/traits.rs
@@ -14,17 +14,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::error::Error;
 use app::spicepod::component::runtime::ApiKey;
 use axum::http;
+use sha2::{Digest, Sha256};
 
 pub type AuthPrincipalRef = Arc<dyn AuthPrincipal + Sync + Send>;
 
 pub trait AuthPrincipal {
     fn username(&self) -> &str; // The username as presented during auth
     fn groups(&self) -> &[&str]; // Group memberships
+
+    /// A stable, opaque identifier for this principal, suitable for use as
+    /// a cache namespace key. Returning `None` means the principal is
+    /// effectively anonymous and should share the public cache scope.
+    ///
+    /// The id MUST be:
+    /// - **stable** across credential rotation for the same identity (so
+    ///   rotating an OIDC token does not invalidate the principal's cache);
+    /// - **opaque** — not the bearer token or API key value itself; and
+    /// - prefixed with the auth scheme (e.g. `apikey:`, `u2m:`) so two
+    ///   schemes that happen to mint the same id never collide.
+    ///
+    /// The default implementation returns `None`, which is the correct
+    /// behavior for anonymous principals. Real principals must override.
+    fn stable_id(&self) -> Option<Cow<'_, str>> {
+        None
+    }
 }
 pub trait AuthRequestContext {
     /// Sets the current authentication principal for the request context.
@@ -59,7 +78,29 @@ impl AuthPrincipal for ApiKey {
             ApiKey::ReadWrite { .. } => &["read_write"],
         }
     }
+
+    /// Stable opaque id derived from the SHA-256 of the API key material,
+    /// truncated to 16 bytes (32 hex chars). The key value itself is
+    /// never exposed; rotating the key produces a new id (which is the
+    /// desired behavior — rotated keys are a different principal).
+    ///
+    /// Format: `apikey:<32-hex-chars>`.
+    fn stable_id(&self) -> Option<Cow<'_, str>> {
+        let key_bytes = match self {
+            ApiKey::ReadOnly { key } | ApiKey::ReadWrite { key } => key.as_bytes(),
+        };
+        let digest = Sha256::digest(key_bytes);
+        let mut id = String::with_capacity("apikey:".len() + 32);
+        id.push_str("apikey:");
+        for byte in &digest[..16] {
+            id.push(HEX[usize::from(byte >> 4)] as char);
+            id.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        Some(Cow::Owned(id))
+    }
 }
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
 
 pub trait HttpAuth {
     /// Receive the entire HTTP request object and return a verdict on whether to allow/deny it

--- a/crates/runtime-request-context/src/cache_namespace.rs
+++ b/crates/runtime-request-context/src/cache_namespace.rs
@@ -1,0 +1,122 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Cache namespace for per-user (and per-system) cache scoping.
+//!
+//! Every cache surface in the runtime — SQL results, search, plan cache,
+//! HTTP-connector caching accelerator — mixes the request's [`CacheNamespace`]
+//! into its hash input. Two requests with different namespaces hash to
+//! different cache keys for otherwise-identical inputs, which is what makes
+//! cached results safe to serve under user-to-machine authentication.
+//!
+//! Scope is automatic and not user-configurable:
+//! - No authenticated principal (or an anonymous principal) → [`CacheNamespace::Public`].
+//! - Internal/system traffic (refresh tasks, cluster RPCs, SWR revalidation,
+//!   health checks) → [`CacheNamespace::System`].
+//! - Authenticated principal → [`CacheNamespace::Principal`] keyed on the
+//!   principal's stable opaque id.
+//!
+//! See `plans/per-user-cache-option-1-namespace.md` and issue #10680 for the
+//! full design.
+
+use std::hash::Hash;
+use std::sync::Arc;
+
+/// The cache scope a request is executing under.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CacheNamespace {
+    /// No authenticated principal; cached entries may be shared across all
+    /// unauthenticated callers. This is the default for unauthenticated
+    /// deployments and matches today's pre-isolation behavior.
+    Public,
+    /// Cached entries are scoped to a single authenticated principal.
+    /// The inner string is a stable opaque identifier produced by the
+    /// principal's `stable_id()`. It is **not** the bearer token or API
+    /// key value; rotating the credential without changing the underlying
+    /// identity must not invalidate the cache.
+    Principal(Arc<str>),
+    /// Internal / system traffic: refresh tasks, cluster RPCs, SWR
+    /// background revalidation, health probes. Entries written under
+    /// `System` are not visible to user requests.
+    System,
+}
+
+impl CacheNamespace {
+    /// A short, low-cardinality string suitable for telemetry dimensions.
+    /// **Must never** include the principal id, which is high-cardinality
+    /// and (depending on auth method) sensitive.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            CacheNamespace::Public => "public",
+            CacheNamespace::Principal(_) => "principal",
+            CacheNamespace::System => "system",
+        }
+    }
+
+    /// A short, lower-case label suitable for the `Results-Cache-Scope` /
+    /// `Search-Results-Cache-Scope` HTTP response headers. Uses HTTP/CDN
+    /// vocabulary (`shared` / `user` / `system`) rather than the internal
+    /// enum names so it matches operator expectations from `Cache-Control:
+    /// private` and similar.
+    #[must_use]
+    pub fn as_header_value(&self) -> &'static str {
+        match self {
+            CacheNamespace::Public => "shared",
+            CacheNamespace::Principal(_) => "user",
+            CacheNamespace::System => "system",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_is_low_cardinality_and_excludes_id() {
+        assert_eq!(CacheNamespace::Public.kind(), "public");
+        assert_eq!(CacheNamespace::System.kind(), "system");
+        let with_id = CacheNamespace::Principal(Arc::from("apikey:0123456789abcdef"));
+        assert_eq!(with_id.kind(), "principal");
+        // The id must not appear anywhere in the dimension value.
+        assert!(!with_id.kind().contains("0123456789abcdef"));
+    }
+
+    #[test]
+    fn header_value_uses_http_vocabulary() {
+        assert_eq!(CacheNamespace::Public.as_header_value(), "shared");
+        assert_eq!(
+            CacheNamespace::Principal(Arc::from("apikey:abc")).as_header_value(),
+            "user"
+        );
+        assert_eq!(CacheNamespace::System.as_header_value(), "system");
+    }
+
+    #[test]
+    fn equal_principal_ids_are_equal_namespaces() {
+        let a = CacheNamespace::Principal(Arc::from("u2m:sub:42"));
+        let b = CacheNamespace::Principal(Arc::from("u2m:sub:42"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_principal_ids_are_distinct() {
+        let a = CacheNamespace::Principal(Arc::from("u2m:sub:42"));
+        let b = CacheNamespace::Principal(Arc::from("u2m:sub:43"));
+        assert_ne!(a, b);
+    }
+}

--- a/crates/runtime-request-context/src/cache_namespace.rs
+++ b/crates/runtime-request-context/src/cache_namespace.rs
@@ -100,6 +100,28 @@ impl CacheNamespace {
             CacheNamespace::System => (2, &[]),
         }
     }
+
+    /// Stable string identifier suitable for storage inside the caching
+    /// accelerator's `__spice_cache_namespace` column. Comparing rows by
+    /// this value is what enforces cross-principal isolation in the
+    /// accelerator.
+    ///
+    /// Format:
+    /// - [`CacheNamespace::Public`] → `"public"`
+    /// - [`CacheNamespace::System`] → `"system"`
+    /// - [`CacheNamespace::Principal`] → the principal's opaque id
+    ///   verbatim (e.g. `"apikey:0123456789abcdef"`)
+    ///
+    /// The values are stable across releases; persisted cache rows must
+    /// continue to compare equal after upgrades.
+    #[must_use]
+    pub fn storage_id(&self) -> &str {
+        match self {
+            CacheNamespace::Public => "public",
+            CacheNamespace::Principal(id) => id.as_ref(),
+            CacheNamespace::System => "system",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -155,5 +177,21 @@ mod tests {
         assert_eq!(p_inputs.1, b"apikey:abc");
         // Tags must be distinct so empty-id Public and System never collide.
         assert_ne!(pub_inputs.0, sys_inputs.0);
+    }
+
+    #[test]
+    fn storage_id_is_stable_per_variant() {
+        assert_eq!(CacheNamespace::Public.storage_id(), "public");
+        assert_eq!(CacheNamespace::System.storage_id(), "system");
+        assert_eq!(
+            CacheNamespace::Principal(Arc::from("apikey:abc")).storage_id(),
+            "apikey:abc",
+        );
+        // public and system are distinct so an unauthenticated user and a
+        // background system task cannot collide on cached rows.
+        assert_ne!(
+            CacheNamespace::Public.storage_id(),
+            CacheNamespace::System.storage_id(),
+        );
     }
 }

--- a/crates/runtime-request-context/src/cache_namespace.rs
+++ b/crates/runtime-request-context/src/cache_namespace.rs
@@ -80,6 +80,26 @@ impl CacheNamespace {
             CacheNamespace::System => "system",
         }
     }
+
+    /// Inputs to be folded into a cache key hash so two distinct namespaces
+    /// produce distinct cache keys for otherwise-identical payloads.
+    ///
+    /// Returns `(tag, id_bytes)` where `tag` is the namespace discriminant
+    /// (kept stable across releases so cached entries survive upgrades):
+    /// - `0` → [`CacheNamespace::Public`] (no id)
+    /// - `1` → [`CacheNamespace::Principal`] (`id_bytes` is the principal's
+    ///   stable opaque id)
+    /// - `2` → [`CacheNamespace::System`] (no id)
+    ///
+    /// Pair with `cache::key::CacheKey::as_raw_key_in_namespace`.
+    #[must_use]
+    pub fn hash_inputs(&self) -> (u8, &[u8]) {
+        match self {
+            CacheNamespace::Public => (0, &[]),
+            CacheNamespace::Principal(id) => (1, id.as_bytes()),
+            CacheNamespace::System => (2, &[]),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -118,5 +138,22 @@ mod tests {
         let a = CacheNamespace::Principal(Arc::from("u2m:sub:42"));
         let b = CacheNamespace::Principal(Arc::from("u2m:sub:43"));
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_inputs_distinct_per_variant() {
+        let pub_ns = CacheNamespace::Public;
+        let sys_ns = CacheNamespace::System;
+        let principal_ns = CacheNamespace::Principal(Arc::from("apikey:abc"));
+        let pub_inputs = pub_ns.hash_inputs();
+        let sys_inputs = sys_ns.hash_inputs();
+        let p_inputs = principal_ns.hash_inputs();
+
+        assert_eq!(pub_inputs, (0, &[][..]));
+        assert_eq!(sys_inputs, (2, &[][..]));
+        assert_eq!(p_inputs.0, 1);
+        assert_eq!(p_inputs.1, b"apikey:abc");
+        // Tags must be distinct so empty-id Public and System never collide.
+        assert_ne!(pub_inputs.0, sys_inputs.0);
     }
 }

--- a/crates/runtime-request-context/src/context.rs
+++ b/crates/runtime-request-context/src/context.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
-use super::{CacheControl, CacheKeyType, Protocol, UserAgent, baggage};
+use super::{CacheControl, CacheKeyType, CacheNamespace, Protocol, UserAgent, baggage};
 use crate::TraceParent;
 use app::App;
 use futures::{Stream, StreamExt};
@@ -49,6 +49,13 @@ pub struct RequestContext {
     protocol: AtomicU8,
     cache_control: CacheControl,
     client_supplied_cache_key: Option<String>,
+    /// Optional explicit override for the cache namespace. When `None`, the
+    /// namespace is derived from `protocol` + `auth_principal` on demand by
+    /// [`Self::cache_namespace`]. Set explicitly by callers that need to
+    /// inherit a namespace from another context (e.g. SWR background
+    /// revalidation must run under the originating user's namespace, not
+    /// `System`).
+    cache_namespace_override: Option<CacheNamespace>,
     dimensions: Vec<KeyValue>,
     auth_principal: OnceLock<AuthPrincipalRef>,
     extensions: RwLock<Extensions>,
@@ -195,6 +202,12 @@ impl RequestContext {
     pub fn to_dimensions(&self) -> Vec<KeyValue> {
         let mut dimensions = vec![KeyValue::new("protocol", self.protocol().as_str())];
         dimensions.extend(self.dimensions.iter().cloned());
+        // Low-cardinality scope dimension: `public` / `principal` / `system`.
+        // Never includes the principal id.
+        dimensions.push(KeyValue::new(
+            "cache_namespace_kind",
+            self.cache_namespace().kind(),
+        ));
         dimensions
     }
 
@@ -229,6 +242,33 @@ impl RequestContext {
     #[must_use]
     pub fn cache_control(&self) -> CacheControl {
         self.cache_control
+    }
+
+    /// The cache namespace this request is executing under.
+    ///
+    /// Computed once per call from `protocol` + `auth_principal`, unless an
+    /// explicit override was set on the builder (used by SWR background
+    /// revalidation and similar flows that must inherit the originating
+    /// request's namespace).
+    ///
+    /// Mapping:
+    /// - `Protocol::Internal` → [`CacheNamespace::System`].
+    /// - Authenticated principal whose `stable_id()` is `Some(id)` →
+    ///   [`CacheNamespace::Principal(id)`].
+    /// - Anything else (no principal, anonymous principal) →
+    ///   [`CacheNamespace::Public`].
+    #[must_use]
+    pub fn cache_namespace(&self) -> CacheNamespace {
+        if let Some(ns) = &self.cache_namespace_override {
+            return ns.clone();
+        }
+        if matches!(self.protocol(), Protocol::Internal) {
+            return CacheNamespace::System;
+        }
+        match self.auth_principal.get().and_then(|p| p.stable_id()) {
+            Some(id) => CacheNamespace::Principal(Arc::from(id.as_ref())),
+            None => CacheNamespace::Public,
+        }
     }
 
     #[must_use]
@@ -319,6 +359,7 @@ pub struct RequestContextBuilder {
     protocol: Protocol,
     cache_control: CacheControl,
     client_supplied_cache_key: Option<String>,
+    cache_namespace_override: Option<CacheNamespace>,
     app: Option<Arc<App>>,
     user_agent: UserAgent,
     baggage: Vec<KeyValue>,
@@ -334,6 +375,7 @@ impl RequestContextBuilder {
             protocol,
             cache_control: CacheControl::Cache(CacheKeyType::Default),
             client_supplied_cache_key: None,
+            cache_namespace_override: None,
             app: None,
             user_agent: UserAgent::Absent,
             baggage: vec![],
@@ -411,6 +453,19 @@ impl RequestContextBuilder {
     #[must_use]
     pub fn with_client_supplied_cache_key(mut self, cache_key: Option<String>) -> Self {
         self.client_supplied_cache_key = cache_key;
+        self
+    }
+
+    /// Override the cache namespace for this request, bypassing the
+    /// `protocol` + `auth_principal` derivation in
+    /// [`RequestContext::cache_namespace`]. Use this only for flows that
+    /// must inherit a namespace from another request — most importantly
+    /// SWR background revalidation, which runs under `Protocol::Internal`
+    /// (would otherwise be `System`) but must store its result under the
+    /// originating user's namespace so the user actually sees the refresh.
+    #[must_use]
+    pub fn with_cache_namespace(mut self, cache_namespace: CacheNamespace) -> Self {
+        self.cache_namespace_override = Some(cache_namespace);
         self
     }
 
@@ -522,6 +577,7 @@ impl RequestContextBuilder {
             protocol: AtomicU8::new(self.protocol as u8),
             cache_control,
             client_supplied_cache_key: user_cache_key,
+            cache_namespace_override: self.cache_namespace_override,
             dimensions,
             auth_principal: OnceLock::new(),
             extensions: RwLock::new(self.extensions),

--- a/crates/runtime-request-context/src/lib.rs
+++ b/crates/runtime-request-context/src/lib.rs
@@ -18,6 +18,8 @@ pub mod baggage;
 pub use baggage::*;
 pub mod cache_control;
 pub use cache_control::*;
+pub mod cache_namespace;
+pub use cache_namespace::*;
 pub mod context;
 pub use context::*;
 pub mod protocol;

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -57,6 +57,56 @@ pub type InFlightRevalidations = Arc<Mutex<HashSet<String>>>;
 
 pub const CACHE_REFRESHED_AT_COLUMN: &str = "fetched_at";
 
+/// Reserved column name added to caching-mode accelerator storage to scope
+/// cached rows by [`runtime_request_context::CacheNamespace`]. The column is
+/// hidden from the user-facing schema and may not be referenced in user
+/// projections, filters, or dataset definitions.
+///
+/// Stored value is the namespace's stable string id (e.g. `"public"`,
+/// `"system"`, or `"apikey:<sha256[..16]>"`). Comparing rows by this column
+/// is what enforces cross-principal isolation inside the caching
+/// accelerator.
+pub const CACHE_NAMESPACE_COLUMN: &str = "__spice_cache_namespace";
+
+/// Returns true if `name` collides with a column reserved by the caching
+/// accelerator. Used by dataset configuration validation so a user-defined
+/// column never silently overwrites internal cache state.
+#[must_use]
+pub fn is_reserved_caching_column(name: &str) -> bool {
+    name.eq_ignore_ascii_case(CACHE_NAMESPACE_COLUMN)
+}
+
+/// Extends a federated/source schema with [`CACHE_NAMESPACE_COLUMN`] so the
+/// caching accelerator can store the per-namespace tag alongside cached
+/// rows. This is only applied to storage; the user-facing
+/// [`crate::accelerated_table::AcceleratedTable`] schema continues to
+/// expose the original column set.
+///
+/// Returns an error if the source schema already defines a column whose
+/// name collides with [`CACHE_NAMESPACE_COLUMN`] — that name is reserved
+/// for the runtime and a collision would silently corrupt cached rows.
+pub fn extend_schema_with_cache_namespace(
+    dataset_name: &str,
+    schema: &arrow::datatypes::Schema,
+) -> DataFusionResult<arrow::datatypes::Schema> {
+    use arrow::datatypes::Field;
+    if schema.column_with_name(CACHE_NAMESPACE_COLUMN).is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "dataset `{dataset_name}` declares a column named `{CACHE_NAMESPACE_COLUMN}`, which is reserved by the caching accelerator for per-user cache scoping. Rename the source column to avoid this name.",
+        )));
+    }
+    let mut fields: Vec<Field> = schema.fields().iter().map(|f| (**f).clone()).collect();
+    fields.push(Field::new(
+        CACHE_NAMESPACE_COLUMN,
+        arrow::datatypes::DataType::Utf8,
+        false,
+    ));
+    Ok(arrow::datatypes::Schema::new_with_metadata(
+        fields,
+        schema.metadata().clone(),
+    ))
+}
+
 /// Maximum number of concurrent refresh requests
 const MAX_CONCURRENT_REFRESHES: usize = 10;
 
@@ -1749,6 +1799,51 @@ impl ExecutionPlan for CachingAccelerationScanExec {
 
         let adapter = RecordBatchStreamAdapter::new(schema, cache_miss_or_stale_stream);
         Ok(Box::pin(adapter))
+    }
+}
+
+#[cfg(test)]
+mod cache_namespace_column_tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn reserved_column_name_is_case_insensitive() {
+        assert!(is_reserved_caching_column(CACHE_NAMESPACE_COLUMN));
+        assert!(is_reserved_caching_column("__SPICE_CACHE_NAMESPACE"));
+        assert!(!is_reserved_caching_column("fetched_at"));
+        assert!(!is_reserved_caching_column("request_path"));
+    }
+
+    #[test]
+    fn extend_schema_appends_namespace_column() {
+        let schema = Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new("content", DataType::Utf8, true),
+        ]);
+        let extended = extend_schema_with_cache_namespace("ds", &schema).expect("ok");
+        assert_eq!(extended.fields().len(), 3);
+        assert_eq!(extended.field(2).name(), CACHE_NAMESPACE_COLUMN);
+        assert_eq!(extended.field(2).data_type(), &DataType::Utf8);
+        assert!(
+            !extended.field(2).is_nullable(),
+            "namespace column is required so missing-on-read indicates a corrupt table"
+        );
+    }
+
+    #[test]
+    fn extend_schema_rejects_collision_with_clear_error() {
+        let schema = Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, true),
+        ]);
+        let err = extend_schema_with_cache_namespace("http_cache", &schema)
+            .expect_err("collision must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("http_cache") && msg.contains(CACHE_NAMESPACE_COLUMN),
+            "error must name the dataset and the reserved column: {msg}"
+        );
     }
 }
 

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -47,6 +47,7 @@ use tokio::task::JoinHandle;
 
 use crate::dataupdate::StreamingDataUpdateExecutionPlan;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
+use runtime_request_context::CacheNamespace;
 use util::expr::combine_exprs_balanced;
 
 /// Type alias for tracking in-flight revalidation requests.
@@ -76,6 +77,44 @@ pub fn is_reserved_caching_column(name: &str) -> bool {
     name.eq_ignore_ascii_case(CACHE_NAMESPACE_COLUMN)
 }
 
+/// Returns a copy of `batch` with [`CACHE_NAMESPACE_COLUMN`] appended,
+/// populated with `namespace_id` for every row. Idempotent: if the column
+/// is already present the batch is returned unchanged.
+///
+/// Called immediately before a [`CacheWriteRequest`] is enqueued so that
+/// every persisted row carries its originating namespace tag, which is
+/// what `__spice_cache_namespace = $current_ns` filtering keys off of on
+/// read.
+pub fn stamp_namespace_column(
+    batch: RecordBatch,
+    namespace_id: &str,
+) -> DataFusionResult<RecordBatch> {
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    let schema = batch.schema();
+    if schema.column_with_name(CACHE_NAMESPACE_COLUMN).is_some() {
+        return Ok(batch);
+    }
+    let n = batch.num_rows();
+    let mut fields: Vec<Field> = schema.fields().iter().map(|f| (**f).clone()).collect();
+    fields.push(Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false));
+    let new_schema = Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()));
+    let ns_array: ArrayRef = Arc::new(StringArray::from(vec![namespace_id; n]));
+    let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
+    cols.push(ns_array);
+    RecordBatch::try_new(new_schema, cols).map_err(|e| {
+        DataFusionError::Execution(format!("failed to stamp {CACHE_NAMESPACE_COLUMN}: {e}"))
+    })
+}
+
+/// Returns a filter expression scoping a scan to a single namespace.
+/// Pushed into the accelerator alongside user filters so cached rows
+/// belonging to other principals are not visible to this request.
+#[must_use]
+pub fn namespace_filter_expr(namespace_id: &str) -> Expr {
+    col(CACHE_NAMESPACE_COLUMN).eq(lit(namespace_id))
+}
+
 /// Extends a federated/source schema with [`CACHE_NAMESPACE_COLUMN`] so the
 /// caching accelerator can store the per-namespace tag alongside cached
 /// rows. This is only applied to storage; the user-facing
@@ -90,9 +129,19 @@ pub fn extend_schema_with_cache_namespace(
     schema: &arrow::datatypes::Schema,
 ) -> DataFusionResult<arrow::datatypes::Schema> {
     use arrow::datatypes::Field;
-    if schema.column_with_name(CACHE_NAMESPACE_COLUMN).is_some() {
+    // Check case-insensitively. Arrow `column_with_name` is case-sensitive,
+    // so a source field named `__SPICE_CACHE_NAMESPACE` would otherwise
+    // slip past this guard, after which we would append our own lowercase
+    // internal column and the schema would end up with two fields whose
+    // names only differ by case — bad regardless of whether downstream
+    // engines treat them as equal or distinct.
+    if schema
+        .fields()
+        .iter()
+        .any(|f| f.name().eq_ignore_ascii_case(CACHE_NAMESPACE_COLUMN))
+    {
         return Err(DataFusionError::Plan(format!(
-            "dataset `{dataset_name}` declares a column named `{CACHE_NAMESPACE_COLUMN}`, which is reserved by the caching accelerator for per-user cache scoping. Rename the source column to avoid this name.",
+            "dataset `{dataset_name}` declares a column named `{CACHE_NAMESPACE_COLUMN}` (case-insensitive match), which is reserved by the caching accelerator for per-user cache scoping. Rename the source column to avoid this name.",
         )));
     }
     let mut fields: Vec<Field> = schema.fields().iter().map(|f| (**f).clone()).collect();
@@ -132,6 +181,13 @@ pub struct CacheWriteRequest {
     pub is_upsert: bool,
     /// Cache key computed from filters, used to track in-flight writes
     pub cache_key: String,
+    /// Stable storage id of the originating namespace (see
+    /// [`runtime_request_context::CacheNamespace::storage_id`]). Stamped into
+    /// `__spice_cache_namespace` on every row at flush time and added to the
+    /// upsert filter set so concurrent writers in different namespaces never
+    /// overwrite each other's rows for the same `(request_path, query, body)`
+    /// key.
+    pub namespace_id: Arc<str>,
 }
 
 /// Sender half of the cache write channel
@@ -248,17 +304,48 @@ async fn flush_cache_writes(
         "Flushing {request_count} cache write requests ({total_rows} total rows) for dataset={dataset_name}"
     );
 
-    // Separate inserts from upserts
+    // Separate inserts from upserts. Stamp the namespace column on every
+    // batch and add a `__spice_cache_namespace = $ns_id` predicate to each
+    // upsert filter set so concurrent writers from different namespaces
+    // never overwrite each other's rows for the same logical key. We do
+    // this here (not at the send-site) so unit-test mocks with a non-
+    // extended schema can opt out by simply not adding the column.
+    let needs_namespace_stamp = accelerator
+        .schema()
+        .column_with_name(CACHE_NAMESPACE_COLUMN)
+        .is_some();
+
     let mut insert_batches: Vec<RecordBatch> = Vec::new();
     let mut upsert_batches: Vec<RecordBatch> = Vec::new();
     let mut upsert_filters: Vec<Vec<Expr>> = Vec::new();
 
     for req in buffer.drain(..) {
+        let mut batches = req.batches;
+        let mut filters = req.filters;
+        if needs_namespace_stamp {
+            let ns_id: &str = &req.namespace_id;
+            batches = match batches
+                .into_iter()
+                .map(|b| stamp_namespace_column(b, ns_id))
+                .collect::<DataFusionResult<Vec<_>>>()
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to stamp {CACHE_NAMESPACE_COLUMN} for dataset={dataset_name}: {e}; dropping write"
+                    );
+                    continue;
+                }
+            };
+            if req.is_upsert {
+                filters.push(namespace_filter_expr(ns_id));
+            }
+        }
         if req.is_upsert {
-            upsert_batches.extend(req.batches);
-            upsert_filters.push(req.filters);
+            upsert_batches.extend(batches);
+            upsert_filters.push(filters);
         } else {
-            insert_batches.extend(req.batches);
+            insert_batches.extend(batches);
         }
     }
 
@@ -451,13 +538,31 @@ fn check_cache_freshness(
     Ok(worst_freshness)
 }
 
-/// Compute a cache key from filter expressions.
-/// The cache key is a string representation of the filter values for `request_path`, `request_query`, and `request_body`.
+/// Compute a cache key from filter expressions only.
+///
+/// Use this only when the resulting key is compared against other keys
+/// computed from the *same* call site (i.e. intra-call deduplication
+/// where the namespace is constant). For any cross-request keying
+/// (in-flight revalidation, batched-write dedup, etc.) use
+/// [`compute_cache_key_from_filters_and_namespace`] so two principals
+/// running the same SQL do not collide.
 fn compute_cache_key_from_filters(filters: &[Expr]) -> String {
-    // Sort and join filter expressions to create a consistent cache key
     let mut parts: Vec<String> = filters.iter().map(ToString::to_string).collect();
     parts.sort();
     parts.join("|")
+}
+
+/// Compute an in-flight / cache-write key from filter expressions plus
+/// the originating cache namespace. The namespace tag is mixed in so that
+/// two principals running the same query do not share an in-flight
+/// revalidation slot or a write-batch dedup slot — if alice and bob both
+/// trigger SWR for the same SQL, both must actually fetch and write
+/// independently into their own namespaces.
+fn compute_cache_key_from_filters_and_namespace(filters: &[Expr], namespace_id: &str) -> String {
+    let mut key = compute_cache_key_from_filters(filters);
+    key.push_str("|__ns=");
+    key.push_str(namespace_id);
+    key
 }
 
 /// Convert a timestamp array to nanosecond precision, returning the original if already nanoseconds.
@@ -602,10 +707,12 @@ impl CacheRefreshHelper {
         federated: Arc<dyn TableProvider>,
         dataset_name: &str,
         filters: &[Expr],
+        namespace: CacheNamespace,
         batch_write_tx: CacheWriteSender,
         in_flight_revalidations: InFlightRevalidations,
     ) -> DataFusionResult<usize> {
-        let cache_key = compute_cache_key_from_filters(filters);
+        let cache_key =
+            compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
         tracing::trace!(
             "Refreshing single cache entry for dataset {dataset_name} with {} filters",
@@ -633,6 +740,9 @@ impl CacheRefreshHelper {
             return Ok(0);
         }
 
+        // Stamping and namespace-scoped upsert filters are applied by the
+        // flush task based on the accelerator's actual schema.
+
         let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
         // Queue write through batched channel
@@ -641,6 +751,7 @@ impl CacheRefreshHelper {
             filters: filters.to_vec(),
             is_upsert: true,
             cache_key: cache_key.clone(),
+            namespace_id: namespace.storage_id().into(),
         };
 
         batch_write_tx
@@ -1092,12 +1203,22 @@ impl CacheRefreshHelper {
 
     /// Propagate cached data to synchronized child accelerators (for localpod caching).
     /// This is called after successfully storing data in the parent accelerator.
+    ///
+    /// Each child accelerator may have its own storage schema. If the
+    /// child's schema includes the `__spice_cache_namespace` column
+    /// (i.e. the child is itself a caching accelerator extended by m4b),
+    /// stamp the batches with the originating namespace before insert so
+    /// the non-null `__spice_cache_namespace` constraint is satisfied and
+    /// the per-principal isolation contract holds end-to-end through the
+    /// localpod chain. Children whose schema does not have the column
+    /// (non-caching accelerators) receive the batches unchanged.
     async fn propagate_to_synchronized_children(
         synchronized_children: &SynchronizedChildren,
         dataset_name: &str,
         filters: &[Expr],
         batches: &[RecordBatch],
         is_expired: bool,
+        namespace_id: &str,
     ) {
         let children = synchronized_children.read().await;
         if children.is_empty() {
@@ -1113,10 +1234,40 @@ impl CacheRefreshHelper {
         );
 
         for (idx, child) in children.iter().enumerate() {
-            let result = if is_expired {
-                Self::upsert_into_accelerator(child, dataset_name, filters, batches.to_vec()).await
+            let stamped: Vec<RecordBatch> = if child
+                .schema()
+                .column_with_name(CACHE_NAMESPACE_COLUMN)
+                .is_some()
+            {
+                let mut out = Vec::with_capacity(batches.len());
+                let mut stamp_err = None;
+                for b in batches {
+                    match stamp_namespace_column(b.clone(), namespace_id) {
+                        Ok(b) => out.push(b),
+                        Err(e) => {
+                            stamp_err = Some(e);
+                            break;
+                        }
+                    }
+                }
+                if let Some(e) = stamp_err {
+                    tracing::warn!(
+                        "Failed to stamp namespace on synchronized child {} for dataset {}: {}",
+                        idx,
+                        dataset_name,
+                        e
+                    );
+                    continue;
+                }
+                out
             } else {
-                Self::insert_into_accelerator(child, dataset_name, batches.to_vec()).await
+                batches.to_vec()
+            };
+
+            let result = if is_expired {
+                Self::upsert_into_accelerator(child, dataset_name, filters, stamped).await
+            } else {
+                Self::insert_into_accelerator(child, dataset_name, stamped).await
             };
 
             if let Err(e) = result {
@@ -1253,6 +1404,7 @@ impl CacheRefreshHelper {
         io_runtime: &Handle,
         synchronized_children: SynchronizedChildren,
         batch_write_tx: CacheWriteSender,
+        namespace: CacheNamespace,
     ) -> SendableRecordBatchStream {
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
             Ok(batches) if !batches.is_empty() => {
@@ -1276,7 +1428,8 @@ impl CacheRefreshHelper {
                 // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
                 let batches_for_propagate = batches_for_cache.clone().unwrap_or_default();
                 let filters_clone: Vec<Expr> = filters.to_vec();
-                let cache_key = compute_cache_key_from_filters(filters);
+                let cache_key =
+                    compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
                 if let Some(batches_for_cache) = batches_for_cache {
                     if batches_for_cache.is_empty() {
@@ -1287,12 +1440,18 @@ impl CacheRefreshHelper {
                         let cache_rows: usize =
                             batches_for_cache.iter().map(RecordBatch::num_rows).sum();
 
-                        // Send write request to batched consumer
+                        // Send write request to batched consumer. The flush
+                        // task is the one that stamps `__spice_cache_namespace`
+                        // and adds the namespace filter to upsert keys, so it
+                        // can do the right thing based on the accelerator's
+                        // actual storage schema (extended in real deployments,
+                        // unextended in unit-test mocks).
                         let write_request = CacheWriteRequest {
                             batches: batches_for_cache,
                             filters: filters.to_vec(),
                             is_upsert: is_expired,
                             cache_key,
+                            namespace_id: namespace.storage_id().into(),
                         };
                         if let Err(e) = batch_write_tx.send(write_request).await {
                             tracing::warn!(
@@ -1307,6 +1466,7 @@ impl CacheRefreshHelper {
                         // Propagate cacheable data to children.
                         let synchronized_children_clone = Arc::clone(&synchronized_children);
                         let dataset_name_clone = dataset_name.to_string();
+                        let namespace_id_clone: Arc<str> = namespace.storage_id().into();
                         io_runtime.spawn(async move {
                             Self::propagate_to_synchronized_children(
                                 &synchronized_children_clone,
@@ -1314,6 +1474,7 @@ impl CacheRefreshHelper {
                                 &filters_clone,
                                 &batches_for_propagate,
                                 is_expired,
+                                &namespace_id_clone,
                             )
                             .await;
                         });
@@ -1393,6 +1554,7 @@ impl CacheRefreshHelper {
         filters: &[Expr],
         in_flight_revalidations: &InFlightRevalidations,
         batch_write_tx: CacheWriteSender,
+        namespace: CacheNamespace,
     ) -> SendableRecordBatchStream {
         let total_cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
 
@@ -1418,7 +1580,10 @@ impl CacheRefreshHelper {
                 }
                 CacheFreshness::Stale => {
                     // Compute cache key to check for in-flight revalidation
-                    let cache_key = compute_cache_key_from_filters(filters);
+                    let cache_key = compute_cache_key_from_filters_and_namespace(
+                        filters,
+                        namespace.storage_id(),
+                    );
 
                     // Try to acquire the revalidation slot for this cache key
                     // Use async lock since we're in an async context
@@ -1454,6 +1619,7 @@ impl CacheRefreshHelper {
                         let filters_for_refresh: Vec<Expr> = filters.to_vec();
                         let batch_write_tx_clone = batch_write_tx.clone();
                         let cache_key_clone = cache_key.clone();
+                        let namespace_clone = namespace.clone();
 
                         io_runtime.spawn(async move {
                             tracing::debug!(
@@ -1463,6 +1629,7 @@ impl CacheRefreshHelper {
                                 federated_clone,
                                 &dataset_name_clone,
                                 &filters_for_refresh,
+                                namespace_clone,
                                 batch_write_tx_clone,
                                 Arc::clone(&in_flight_clone),
                             )
@@ -1658,6 +1825,18 @@ impl ExecutionPlan for CachingAccelerationScanExec {
             self.dataset_name
         );
 
+        // The originating request context is attached to the session as
+        // an extension by `Query::run_internal`. We read it from the
+        // `TaskContext` here and NOT from `RequestContext::current()`,
+        // because DataFusion does not propagate Tokio task-locals through
+        // `execute()`. The task-local lookup would silently fall back to
+        // the global `INTERNAL_REQUEST_CONTEXT` (Protocol::Internal, no
+        // principal), collapsing every caller to `CacheNamespace::System`
+        // and defeating isolation.
+        let request_context = context
+            .session_config()
+            .get_extension::<runtime_request_context::RequestContext>();
+
         // Execute the accelerator scan
         let accelerator_stream = self.input.execute(partition, Arc::clone(&context))?;
 
@@ -1693,6 +1872,14 @@ impl ExecutionPlan for CachingAccelerationScanExec {
 
         // Use stream::once pattern to handle cache miss like FallbackOnZeroResultsScanExec
         let cache_miss_or_stale_stream = futures::stream::once(async move {
+            // Capture the originating request's cache namespace once. Every
+            // subsequent cache lookup, write, and SWR refresh inherits this
+            // value so the entire scan stays inside one principal's scope.
+            let namespace = request_context.as_deref().map_or(
+                runtime_request_context::CacheNamespace::System,
+                runtime_request_context::RequestContext::cache_namespace,
+            );
+
             tracing::debug!(
                 "CacheAccelerationScanExec cache check STARTED for dataset={}",
                 dataset_name
@@ -1755,6 +1942,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             &io_runtime,
                             Arc::clone(&synchronized_children),
                             batch_write_tx.clone(),
+                            namespace,
                         )
                         .await;
                     }
@@ -1772,6 +1960,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     &filters,
                     &in_flight_revalidations,
                     batch_write_tx.clone(),
+                    namespace,
                 )
                 .await
             } else {
@@ -1791,6 +1980,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     &io_runtime,
                     synchronized_children,
                     batch_write_tx,
+                    namespace,
                 )
                 .await
             }
@@ -1844,6 +2034,82 @@ mod cache_namespace_column_tests {
             msg.contains("http_cache") && msg.contains(CACHE_NAMESPACE_COLUMN),
             "error must name the dataset and the reserved column: {msg}"
         );
+    }
+
+    #[test]
+    fn extend_schema_rejects_case_insensitive_collision() {
+        // The reserved-name guard must be case-insensitive: a source
+        // field named `__SPICE_CACHE_NAMESPACE` (or any other casing)
+        // collides with the lowercase internal column we would append,
+        // and must be rejected with the same error.
+        for variant in [
+            "__SPICE_CACHE_NAMESPACE",
+            "__Spice_Cache_Namespace",
+            "__spice_CACHE_namespace",
+        ] {
+            let schema = Schema::new(vec![
+                Field::new("request_path", DataType::Utf8, false),
+                Field::new(variant, DataType::Utf8, true),
+            ]);
+            let err = extend_schema_with_cache_namespace("ds", &schema)
+                .err()
+                .unwrap_or_else(|| panic!("variant `{variant}` should be rejected as a collision"));
+            assert!(
+                err.to_string().contains("reserved"),
+                "variant `{variant}` should produce a clear collision error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn stamp_namespace_column_appends_constant_string_array() {
+        use arrow::array::{Int32Array, StringArray};
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = arrow::array::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
+        )
+        .expect("batch");
+
+        let stamped = stamp_namespace_column(batch, "apikey:abc").expect("ok");
+        assert_eq!(stamped.num_columns(), 2);
+        assert_eq!(stamped.schema().field(1).name(), CACHE_NAMESPACE_COLUMN);
+        let ns_col = stamped
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8");
+        assert_eq!(ns_col.len(), 3);
+        for i in 0..ns_col.len() {
+            assert_eq!(ns_col.value(i), "apikey:abc");
+        }
+    }
+
+    #[test]
+    fn stamp_namespace_column_is_idempotent_when_already_present() {
+        use arrow::array::{Int32Array, StringArray};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false),
+        ]));
+        let batch = arrow::array::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["system"])) as ArrayRef,
+            ],
+        )
+        .expect("batch");
+
+        let stamped = stamp_namespace_column(batch, "public").expect("ok");
+        // Existing column wins; we must not silently rewrite a row's tag
+        // because doing so could mask a bug in upstream stamping.
+        let ns_col = stamped
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8");
+        assert_eq!(ns_col.value(0), "system");
     }
 }
 
@@ -2899,6 +3165,7 @@ mod tests {
             &access_filters,
             &in_flight_revalidations,
             batch_write_tx,
+            CacheNamespace::Public,
         )
         .await;
 
@@ -3012,6 +3279,7 @@ mod tests {
                 filters: vec![],
                 is_upsert: false,
                 cache_key: format!("key_{i}"),
+                namespace_id: "public".into(),
             })
             .await
             .expect("to send write request");
@@ -3066,6 +3334,7 @@ mod tests {
             &tokio::runtime::Handle::current(),
             Arc::new(vec![].into()),
             batch_write_tx.clone(),
+            CacheNamespace::Public,
         )
         .await;
 
@@ -3103,6 +3372,7 @@ mod tests {
             &tokio::runtime::Handle::current(),
             Arc::new(vec![].into()),
             batch_write_tx,
+            CacheNamespace::Public,
         )
         .await;
 
@@ -3172,6 +3442,7 @@ mod tests {
             &tokio::runtime::Handle::current(),
             Arc::new(vec![].into()), // synchronized_children
             batch_write_tx,
+            CacheNamespace::Public,
         )
         .await;
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -269,6 +269,11 @@ pub struct AcceleratedTable {
     /// Sender for batched cache writes. Only used in caching refresh mode.
     batch_write_tx: Option<caching::CacheWriteSender>,
     cluster_role: Option<ClusterRole>,
+    /// Schema exposed to user-facing query planning when it differs from the
+    /// underlying accelerator's storage schema. Currently set only in caching
+    /// mode, where the storage schema is augmented with a hidden
+    /// [`caching::CACHE_NAMESPACE_COLUMN`] for per-principal isolation.
+    user_facing_schema: Option<SchemaRef>,
 }
 
 impl std::fmt::Debug for AcceleratedTable {
@@ -353,6 +358,7 @@ pub struct Builder {
     is_s3_express_acceleration: bool,
     acceleration_layout: Option<runtime_acceleration::snapshot::AccelerationLayout>,
     cluster_role: Option<ClusterRole>,
+    user_facing_schema: Option<SchemaRef>,
     accelerator_write_mutex: Arc<Mutex<()>>,
 }
 
@@ -402,7 +408,16 @@ impl Builder {
             is_s3_express_acceleration: false,
             cluster_role: None,
             accelerator_write_mutex: Arc::new(Mutex::new(())), // can be overridden
+            user_facing_schema: None,
         }
+    }
+
+    /// Override the schema reported by the resulting [`AcceleratedTable`] to
+    /// query planners. Used by caching mode to hide the internal namespace
+    /// storage column from users.
+    pub fn user_facing_schema(&mut self, schema: SchemaRef) -> &mut Self {
+        self.user_facing_schema = Some(schema);
+        self
     }
 
     pub fn cluster_role(&mut self, role: Option<ClusterRole>) -> &mut Self {
@@ -1042,6 +1057,7 @@ impl Builder {
             last_updated_at,
             batch_write_tx,
             cluster_role: self.cluster_role,
+            user_facing_schema: self.user_facing_schema,
         })
     }
 }
@@ -1266,6 +1282,9 @@ impl TableProvider for AcceleratedTable {
     }
 
     fn schema(&self) -> SchemaRef {
+        if let Some(s) = self.user_facing_schema.as_ref() {
+            return Arc::clone(s);
+        }
         self.accelerator.schema()
     }
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1368,10 +1368,24 @@ impl TableProvider for AcceleratedTable {
             }
         }
 
-        // For caching mode with filters, extend projection to include fetched_at for freshness checking if needed.
-        // Added columns will be automatically stripped by `SchemaCastScanExec`, similar to
-        // fallback-to-source on cache miss where results return all columns.
-        let extended_projection = if is_caching_mode && !filters.is_empty() {
+        // For caching mode, extend the accelerator scan projection to
+        // include the storage-only columns the caching pipeline needs:
+        // `fetched_at` (freshness check inside
+        // `CachingAccelerationScanExec`) and `__spice_cache_namespace`
+        // (per-principal isolation `FilterExec` applied below). The added
+        // columns are stripped from the user-facing output by
+        // `SchemaCastScanExec` on top of the plan, so they never leak
+        // into query results.
+        //
+        // Done unconditionally for caching mode (not gated on having
+        // user filters) because the namespace `FilterExec` is always
+        // applied and must always be able to resolve the namespace
+        // column. Without this, a caching-mode scan with a non-empty
+        // user projection but no user filters (e.g. `SELECT content FROM
+        // ds`) would push only the user's columns to the accelerator
+        // and the FilterExec on top would fail with `No field named
+        // __spice_cache_namespace`.
+        let extended_projection = if is_caching_mode {
             extend_projection_for_caching(projection, &self.accelerator.schema())
         } else {
             None
@@ -1379,6 +1393,50 @@ impl TableProvider for AcceleratedTable {
         let scan_projection = extended_projection.as_ref().or(projection);
         // For UseSource mode, the scan is handled inside the match arm below (with filter
         // splitting). For all other modes, perform the accelerator scan upfront.
+        // For caching mode, scope the accelerator scan to the current
+        // request's namespace by appending a `__spice_cache_namespace = $ns_id`
+        // predicate. The federated source still receives only the user's
+        // original filters via `CachingAccelerationScanExec`, since the
+        // namespace column does not exist on the source side. Skipped when
+        // the storage schema does not have the column (e.g. unit-test mocks).
+        //
+        // The originating request context is attached to the session as an
+        // extension by `Query::run_internal`. We must read it from there
+        // and NOT from `RequestContext::current()`, because DataFusion does
+        // not propagate Tokio task-locals across the `TableProvider::scan`
+        // await point. The task-local lookup would silently fall back to
+        // the global `INTERNAL_REQUEST_CONTEXT` (Protocol::Internal, no
+        // principal), collapsing every caller to `CacheNamespace::System`
+        // and defeating isolation.
+        let namespace_filter: Option<Expr> = if is_caching_mode
+            && self
+                .accelerator
+                .schema()
+                .column_with_name(caching::CACHE_NAMESPACE_COLUMN)
+                .is_some()
+        {
+            let ns = state
+                .config()
+                .get_extension::<runtime_request_context::RequestContext>()
+                .map_or(runtime_request_context::CacheNamespace::System, |ctx| {
+                    ctx.cache_namespace()
+                });
+            Some(caching::namespace_filter_expr(ns.storage_id()))
+        } else {
+            None
+        };
+        let storage_filters: Vec<Expr> = if let Some(ref nf) = namespace_filter {
+            let mut sf = filters.to_vec();
+            sf.push(nf.clone());
+            sf
+        } else {
+            filters.to_vec()
+        };
+        let scan_filters: &[Expr] = if is_caching_mode {
+            &storage_filters
+        } else {
+            filters
+        };
         let input = if matches!(
             (is_caching_mode, &self.zero_results_action),
             (false, ZeroResultsAction::UseSource)
@@ -1387,7 +1445,7 @@ impl TableProvider for AcceleratedTable {
         } else {
             Some(
                 self.accelerator
-                    .scan(state, scan_projection, filters, limit)
+                    .scan(state, scan_projection, scan_filters, limit)
                     .await?,
             )
         };
@@ -1406,9 +1464,45 @@ impl TableProvider for AcceleratedTable {
                     )
                 })?;
 
-                // Check which filters the accelerator doesn't fully support and need to be re-applied.
-                // This ensures correct results when the accelerator returns Inexact or Unsupported for some filters.
-                let filters_to_reapply = self.get_filters_to_reapply(filters)?;
+                // Check which user filters the accelerator doesn't fully
+                // support and need to be re-applied. This ensures correct
+                // results when the accelerator returns Inexact or
+                // Unsupported for some filters.
+                let mut filters_to_reapply = self.get_filters_to_reapply(filters)?;
+                // Re-apply the cache-namespace predicate as a hard
+                // FilterExec only if the accelerator does NOT report exact
+                // pushdown for it.
+                //
+                // The DataFusion contract for `supports_filters_pushdown`
+                // is: `Exact` means the provider guarantees the predicate
+                // will be applied (the caller does not have to re-apply);
+                // `Inexact` / `Unsupported` mean the caller MUST re-apply
+                // or rows that should be filtered may slip through. Cache
+                // isolation is a correctness invariant, so we re-apply
+                // whenever the accelerator does not give an exact
+                // guarantee.
+                //
+                // We deliberately do NOT wrap on `Exact`: the wrap is not
+                // just redundant, it is harmful. `FilterExec` coalesces
+                // its output through `BatchCoalescer`, which strictly
+                // compares `Field` metadata across consecutive batches.
+                // Some accelerator <-> source schema combinations (notably
+                // `Map` field naming round-tripped through DuckDB, which
+                // canonicalizes `keys`/`values` to `key`/`value`) trigger
+                // a false-positive panic in `BatchCoalescer` even though
+                // the data itself is well-formed. This bites the localpod
+                // chained-accelerator path in particular.
+                if let Some(nf) = namespace_filter {
+                    let nf_pushdown = self
+                        .accelerator
+                        .supports_filters_pushdown(&[&nf])?
+                        .into_iter()
+                        .next()
+                        .unwrap_or(TableProviderFilterPushDown::Unsupported);
+                    if !matches!(nf_pushdown, TableProviderFilterPushDown::Exact) {
+                        filters_to_reapply.push(nf);
+                    }
+                }
                 let input = if filters_to_reapply.is_empty() {
                     input
                 } else {
@@ -1650,22 +1744,36 @@ impl TableProvider for AcceleratedTable {
     }
 }
 
-/// Extends projection to include `fetched_at` column for cache freshness checking.
-/// Returns `Some(extended_projection)` if extension was needed,
-/// or `None` if no extension needed (projection already includes it or is None).
+/// Extends projection to include columns required by the caching pipeline
+/// for accelerator scans: `fetched_at` (freshness check) and
+/// `__spice_cache_namespace` (per-principal isolation filter applied as a
+/// hard `FilterExec` on top of the scan).
+///
+/// Returns `Some(extended_projection)` if any extension was needed, or
+/// `None` if both columns are already present (or `projection` is `None`,
+/// meaning the caller already wants the full schema).
 fn extend_projection_for_caching(
     projection: Option<&Vec<usize>>,
     schema: &SchemaRef,
 ) -> Option<Vec<usize>> {
     let proj = projection?;
-    let idx = schema.index_of(caching::CACHE_REFRESHED_AT_COLUMN).ok()?;
-    if proj.contains(&idx) {
-        return None;
+    let mut extended: Option<Vec<usize>> = None;
+    for col in [
+        caching::CACHE_REFRESHED_AT_COLUMN,
+        caching::CACHE_NAMESPACE_COLUMN,
+    ] {
+        let Ok(idx) = schema.index_of(col) else {
+            continue;
+        };
+        if proj.contains(&idx) {
+            continue;
+        }
+        let target = extended.get_or_insert_with(|| proj.clone());
+        if !target.contains(&idx) {
+            target.push(idx);
+        }
     }
-    // User projection doesn't include fetched_at - add it as last column
-    let mut extended = proj.clone();
-    extended.push(idx);
-    Some(extended)
+    extended
 }
 
 fn filters_for_accelerator_scan(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2010,11 +2010,35 @@ impl DataFusion {
             &dataset.name.to_string(),
         )?;
 
+        // For caching mode, the underlying accelerator storage is augmented
+        // with a hidden `__spice_cache_namespace` column so cached rows can be
+        // scoped per-principal. The user-facing schema (and therefore query
+        // planning, projection indices, and federation) continues to see only
+        // the original columns. This is a breaking change: existing caching
+        // accelerator storage from earlier Spice versions does not have the
+        // column and must be deleted (e.g. remove the duckdb_file or drop the
+        // SQLite/Postgres/Cayenne backing table) before upgrading.
+        let storage_schema = if matches!(refresh_mode, RefreshMode::Caching) {
+            Arc::new(
+                crate::accelerated_table::caching::extend_schema_with_cache_namespace(
+                    &dataset.name.to_string(),
+                    &refresh_schema,
+                )
+                .map_err(|source| Error::UnableToCreateDataAccelerator {
+                    source: crate::dataaccelerator::Error::InvalidConfiguration {
+                        msg: source.to_string(),
+                    },
+                })?,
+            )
+        } else {
+            Arc::clone(&refresh_schema)
+        };
+
         let accelerated_table_provider = self
             .accelerator_engine_registry
             .create_accelerator_table(
                 dataset.name.clone(),
-                Arc::clone(&refresh_schema),
+                Arc::clone(&storage_schema),
                 constraints.as_ref(),
                 &acceleration_settings,
                 Arc::clone(&secrets),
@@ -2158,6 +2182,11 @@ impl DataFusion {
         accelerated_table_builder.cpu_runtime(self.refresh_runtime().cloned());
         accelerated_table_builder.cluster_role(self.cluster_config.effective_role());
         accelerated_table_builder.accelerator_write_mutex(Arc::clone(&accelerator_write_mutex));
+        if matches!(refresh_mode, RefreshMode::Caching) {
+            // Hide the storage-only namespace column from query planning. Users
+            // see the same columns they would have seen pre-isolation.
+            accelerated_table_builder.user_facing_schema(Arc::clone(&refresh_schema));
+        }
 
         let retention_delete_expr = match dataset.retention_sql() {
             Some(retention_sql) => {

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -326,10 +326,11 @@ impl Query {
                 pre_parsed_plan,
                 ..
             } => {
-                // Use the existing get_plan_or_cached which handles all cache control,
-                // stale-while-revalidate, and query tracking. `read_only` is
-                // threaded through so cached results cannot bypass
-                // `validate_sql_query_read_only` below.
+                // Use the existing get_plan_or_cached which handles all cache
+                // control, stale-while-revalidate, and query tracking. The
+                // cache itself is namespaced per principal and refuses to
+                // store write-capable plans, so a read-only caller cannot
+                // observe a cached entry produced by a write-capable plan.
                 match Query::get_plan_or_cached(
                     &self.df,
                     &session,
@@ -337,7 +338,6 @@ impl Query {
                     sql,
                     parameters.clone(),
                     tracker,
-                    self.read_only,
                     pre_parsed_plan.clone(),
                 )
                 .await?
@@ -622,7 +622,6 @@ impl Query {
                             sql,
                             parameters.clone(),
                             tracker,
-                            ctx.read_only,
                             pre_parsed_plan.clone(),
                         )
                         .await?

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -31,7 +31,7 @@ use datafusion::{
     sql::TableReference,
 };
 use futures::TryStreamExt;
-use runtime_request_context::{CacheControl, CacheKeyType, Protocol, RequestContext};
+use runtime_request_context::{CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext};
 use snafu::ResultExt;
 use std::sync::OnceLock;
 use std::{collections::HashSet, hash::Hasher, sync::Arc};
@@ -395,7 +395,13 @@ impl Query {
                     CacheKey::LogicalPlan(p) => Some(*p),
                     _ => None,
                 };
-                Self::trigger_background_query_revalidation(Arc::clone(df), sql, plan, raw_key);
+                Self::trigger_background_query_revalidation(
+                    Arc::clone(df),
+                    sql,
+                    plan,
+                    raw_key,
+                    request_context.cache_namespace(),
+                );
             }
         }
 
@@ -462,16 +468,21 @@ impl Query {
     /// - The `DataFusion` context is dropped (runtime shutdown)
     /// - The query execution is interrupted via the session context
     ///
-    /// Creates a background request context for cache revalidation.
+    /// Build the request context that drives a background SWR revalidation
+    /// query. We must inherit the originating request's cache namespace so
+    /// the refreshed entry lands in the same scope (otherwise a per-user
+    /// triggered refresh would write into the System scope and the user
+    /// would never see the new data on their next request).
     ///
-    /// Uses `NoCache` to prevent the background query from going through the normal
-    /// cache lookup/store path. This avoids false cache misses and duplicate storage.
-    /// The `cache_revalidation_result` function handles storing results under the correct
-    /// original cache key that triggered the stale-while-revalidate.
-    fn create_background_context() -> Arc<RequestContext> {
+    /// `NoCache` is intentional: the revalidation flow stores the result
+    /// directly under the original cache key via `cache_revalidation_result`,
+    /// so going through the normal cache lookup/store path would be
+    /// redundant and would also confuse hit/miss accounting.
+    fn create_background_context(namespace: CacheNamespace) -> Arc<RequestContext> {
         Arc::new(
             RequestContext::builder(Protocol::Internal)
                 .with_cache_control(CacheControl::NoCache)
+                .with_cache_namespace(namespace)
                 .build(),
         )
     }
@@ -571,6 +582,7 @@ impl Query {
         sql: &str,
         plan: Option<&LogicalPlan>,
         cache_key: RawCacheKey,
+        namespace: CacheNamespace,
     ) {
         // Static Moka cache to track ongoing revalidation tasks by cache key.
         // This provides built-in single-in-flight semantics - if multiple requests
@@ -587,7 +599,7 @@ impl Query {
         let cache_key_u64 = cache_key.as_u64();
 
         // Create a background request context with NoCache to bypass cache lookup
-        let background_context = Self::create_background_context();
+        let background_context = Self::create_background_context(namespace);
 
         // Clone sql and plan for the async block
         let sql_owned = sql.to_string();
@@ -803,6 +815,90 @@ mod tests {
 
         let manager = RequestCacheManager::new(cache_status, raw_cache_key);
         assert!(manager.should_cache_results());
+    }
+
+    /// SWR background revalidation must run under the originating user's
+    /// namespace, not `System`. Without this, any sub-cache lookups in the
+    /// background task (planner cache, accelerator cache) would land in the
+    /// wrong scope and either leak across users or never serve the user
+    /// who triggered the refresh.
+    ///
+    /// We verify the contract end-to-end: Alice triggers SWR, the background
+    /// refresh runs, and a second principal (Bob) still sees a MISS for the
+    /// same SQL. If the background context fell back to `System`, Bob would
+    /// either see a cross-user HIT (security regression) or Alice's refresh
+    /// would land in `System` and leave her STALE.
+    #[tokio::test]
+    async fn test_swr_revalidation_inherits_originating_namespace() {
+        let df = prepare_runtime(Some(SQLResultsCacheConfig {
+            item_ttl: Some("1s".to_string()),
+            cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            stale_while_revalidate_ttl: Some("5s".to_string()),
+            ..Default::default()
+        }))
+        .await;
+
+        let alice = create_test_request_context_in_namespace(
+            CacheControl::MaxStale(CacheKeyType::Raw, Some(Duration::from_secs(5))),
+            CacheNamespace::Principal("apikey:alice".into()),
+        );
+        let bob = create_test_request_context_in_namespace(
+            CacheControl::Cache(CacheKeyType::Raw),
+            CacheNamespace::Principal("apikey:bob".into()),
+        );
+
+        // Alice populates her namespace.
+        let q = QueryBuilder::new("SELECT 42", Arc::clone(&df)).build();
+        Arc::clone(&alice)
+            .scope(async move {
+                let r = q.run().await.expect("ok");
+                assert_eq!(r.cache_status, CacheStatus::CacheMiss);
+                let _ = r.data.try_collect::<Vec<_>>().await.expect("drain");
+            })
+            .await;
+
+        // Wait past TTL but within stale-while-revalidate window.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // Alice's stale request triggers background revalidation.
+        let q = QueryBuilder::new("SELECT 42", Arc::clone(&df)).build();
+        Arc::clone(&alice)
+            .scope(async move {
+                let r = q.run().await.expect("ok");
+                assert_eq!(r.cache_status, CacheStatus::CacheStaleWhileRevalidate);
+                let _ = r.data.try_collect::<Vec<_>>().await.expect("drain");
+            })
+            .await;
+
+        // Allow the background task to finish.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if let Some(cp) = df.results_cache_provider() {
+            cp.run_pending_tasks().await;
+        }
+
+        // Alice now sees a fresh HIT — proving SWR wrote back into her
+        // namespace, not into System.
+        let q = QueryBuilder::new("SELECT 42", Arc::clone(&df)).build();
+        Arc::clone(&alice)
+            .scope(async move {
+                let r = q.run().await.expect("ok");
+                assert_eq!(r.cache_status, CacheStatus::CacheHit);
+            })
+            .await;
+
+        // Bob still sees MISS for the same SQL — SWR did not bleed Alice's
+        // entry into a cross-user scope.
+        let q = QueryBuilder::new("SELECT 42", Arc::clone(&df)).build();
+        Arc::clone(&bob)
+            .scope(async move {
+                let r = q.run().await.expect("ok");
+                assert_eq!(
+                    r.cache_status,
+                    CacheStatus::CacheMiss,
+                    "SWR refresh must not leak into bob's scope"
+                );
+            })
+            .await;
     }
 
     /// Two distinct principals running the same SQL must each see a cache

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -121,6 +121,8 @@ impl Query {
         pre_parsed_plan: Option<Box<LogicalPlan>>,
     ) -> super::Result<PlanOrCached> {
         let cache_control = request_context.cache_control();
+        let cache_namespace = request_context.cache_namespace();
+        let (ns_tag, ns_id) = cache_namespace.hash_inputs();
         let sql_cache_key = CacheKey::Query(sql, parameters.as_ref());
         let scoped_user_cache_key =
             if cache_control.cache_key_type() == Some(CacheKeyType::ClientSupplied) {
@@ -161,7 +163,8 @@ impl Query {
             }
         };
 
-        let sql_raw_cache_key = sql_cache_key.as_raw_key(Self::plan_hasher(df));
+        let sql_raw_cache_key =
+            sql_cache_key.as_raw_key_in_namespace(Self::plan_hasher(df), ns_tag, ns_id);
         let plan: Box<LogicalPlan> = if let Some(plan) = pre_parsed_plan {
             // Reuse the pre-parsed plan to avoid re-parsing. Parameters are
             // already bound from `check_read_only_sql`.
@@ -331,7 +334,11 @@ impl Query {
             }
         }
 
-        let raw_key = key.as_raw_key(cache_provider.hasher());
+        let raw_key = {
+            let ns = request_context.cache_namespace();
+            let (ns_tag, ns_id) = ns.hash_inputs();
+            key.as_raw_key_in_namespace(cache_provider.hasher(), ns_tag, ns_id)
+        };
 
         let cached_result = match cache_provider.get_raw_key(&raw_key).await {
             Ok(Some(result)) => result,
@@ -723,7 +730,7 @@ mod tests {
         datafusion::{DataFusion, query::QueryBuilder},
         status,
     };
-    use runtime_request_context::{CacheControl, CacheKeyType, Protocol, RequestContext};
+    use runtime_request_context::{CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext};
 
     // Helper function to create a test RequestContext
     fn create_test_request_context(
@@ -734,6 +741,21 @@ mod tests {
             RequestContext::builder(Protocol::Internal)
                 .with_cache_control(cache_control)
                 .with_client_supplied_cache_key(user_cache_key)
+                .build(),
+        )
+    }
+
+    /// Build a `RequestContext` with an explicit cache namespace. Used to
+    /// drive cross-principal isolation tests in this module without going
+    /// through real auth middleware.
+    fn create_test_request_context_in_namespace(
+        cache_control: CacheControl,
+        namespace: CacheNamespace,
+    ) -> Arc<RequestContext> {
+        Arc::new(
+            RequestContext::builder(Protocol::Internal)
+                .with_cache_control(cache_control)
+                .with_cache_namespace(namespace)
                 .build(),
         )
     }
@@ -781,6 +803,94 @@ mod tests {
 
         let manager = RequestCacheManager::new(cache_status, raw_cache_key);
         assert!(manager.should_cache_results());
+    }
+
+    /// Two distinct principals running the same SQL must each see a cache
+    /// MISS for the other's first request, and a HIT only on their own
+    /// repeat. Cross-principal HITs would be a security regression — the
+    /// whole point of `CacheNamespace`.
+    #[tokio::test]
+    async fn test_results_cache_isolated_per_principal() {
+        let df = prepare_runtime(Some(SQLResultsCacheConfig {
+            item_ttl: Some("10m".to_string()),
+            cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            ..Default::default()
+        }))
+        .await;
+
+        let alice = create_test_request_context_in_namespace(
+            CacheControl::Cache(CacheKeyType::Raw),
+            CacheNamespace::Principal("apikey:alice".into()),
+        );
+        let bob = create_test_request_context_in_namespace(
+            CacheControl::Cache(CacheKeyType::Raw),
+            CacheNamespace::Principal("apikey:bob".into()),
+        );
+
+        // Alice runs SELECT 1, populates the cache under her namespace.
+        let q = QueryBuilder::new("SELECT 1", Arc::clone(&df)).build();
+        Arc::clone(&alice)
+            .scope(async move {
+                let result = q.run().await.expect("query should succeed");
+                assert_eq!(result.cache_status, CacheStatus::CacheMiss);
+                let _ = result
+                    .data
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .expect("should drain");
+            })
+            .await;
+
+        // Alice repeats: HIT (own namespace).
+        let q = QueryBuilder::new("SELECT 1", Arc::clone(&df)).build();
+        Arc::clone(&alice)
+            .scope(async move {
+                let result = q.run().await.expect("query should succeed");
+                assert_eq!(result.cache_status, CacheStatus::CacheHit);
+            })
+            .await;
+
+        // Bob runs the same SQL: MUST be a MISS, otherwise we leaked
+        // Alice's cached result across principals.
+        let q = QueryBuilder::new("SELECT 1", Arc::clone(&df)).build();
+        Arc::clone(&bob)
+            .scope(async move {
+                let result = q.run().await.expect("query should succeed");
+                assert_eq!(
+                    result.cache_status,
+                    CacheStatus::CacheMiss,
+                    "bob must not see alice's cached entry"
+                );
+                let _ = result
+                    .data
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .expect("should drain");
+            })
+            .await;
+
+        // Bob repeats: HIT in his own namespace.
+        let q = QueryBuilder::new("SELECT 1", Arc::clone(&df)).build();
+        Arc::clone(&bob)
+            .scope(async move {
+                let result = q.run().await.expect("query should succeed");
+                assert_eq!(result.cache_status, CacheStatus::CacheHit);
+            })
+            .await;
+
+        // And an unauthenticated (Public) caller must also miss — it
+        // shares no namespace with either Alice or Bob.
+        let public = create_test_request_context_in_namespace(
+            CacheControl::Cache(CacheKeyType::Raw),
+            CacheNamespace::Public,
+        );
+        let q = QueryBuilder::new("SELECT 1", Arc::clone(&df)).build();
+        Arc::clone(&public)
+            .scope(async move {
+                let result = q.run().await.expect("query should succeed");
+                assert_eq!(result.cache_status, CacheStatus::CacheMiss);
+            })
+            .await;
     }
 
     #[tokio::test]

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -31,7 +31,9 @@ use datafusion::{
     sql::TableReference,
 };
 use futures::TryStreamExt;
-use runtime_request_context::{CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext};
+use runtime_request_context::{
+    CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext,
+};
 use snafu::ResultExt;
 use std::sync::OnceLock;
 use std::{collections::HashSet, hash::Hasher, sync::Arc};
@@ -97,19 +99,20 @@ enum CacheResult {
 impl Query {
     /// Returns a `LogicalPlan` if the result is not cached and needs to be executed, otherwise returns a cached `QueryResult`.
     ///
-    /// When `read_only` is true, both the SQL-keyed and plan-keyed results-cache
-    /// lookups are skipped, and the returned [`RequestCacheManager`] is forced to
-    /// [`CacheStatus::CacheDisabled`]. This is required because the read-only
-    /// contract (enforced by [`super::validate_sql_query_read_only`]) runs on the
-    /// [`LogicalPlan`] *after* `get_plan_or_cached` returns — a cache hit would
-    /// otherwise short-circuit validation and let write-capable plans served from
-    /// a prior cache-store bypass the read-only guarantee on `/v1/tools/sql` and
-    /// `/v1/nsql`. The existing cache-eligibility check
-    /// ([`cache::QueryResultsCacheProvider::cache_is_enabled_for_plan`]) only
-    /// filters the classic DDL/DML/Copy/Statement plan variants and does not
-    /// cover Spice's write-capable [`LogicalPlan::Extension`] nodes (e.g.
-    /// `DmlExtension`, `DistributedCayenneInsert`).
-    #[expect(clippy::too_many_arguments)]
+    /// Cache lookups and population are *not* gated on read-only mode. The two
+    /// hazards that would have justified gating are handled elsewhere:
+    ///
+    /// 1. **Cross-principal leakage.** Cache keys are mixed with the originating
+    ///    [`runtime_request_context::CacheNamespace`], so a read-only caller
+    ///    can only ever observe entries it (or another caller in the same
+    ///    namespace) populated.
+    /// 2. **Write-capable plans served from cache.**
+    ///    [`cache::QueryResultsCacheProvider::cache_is_enabled_for_plan`]
+    ///    refuses to cache DDL/DML/Copy/Statement and every
+    ///    [`LogicalPlan::Extension`] whose name appears in
+    ///    [`cache::WRITE_CAPABLE_EXTENSION_NAMES`] (currently `DdlExtension`
+    ///    and `DmlExtension`). New write-capable extension nodes must be
+    ///    added there to keep this property.
     pub(super) async fn get_plan_or_cached(
         df: &Arc<DataFusion>,
         session: &SessionState,
@@ -117,7 +120,6 @@ impl Query {
         sql: &str,
         parameters: Option<ParamValues>,
         tracker: Option<QueryTracker>,
-        read_only: bool,
         pre_parsed_plan: Option<Box<LogicalPlan>>,
     ) -> super::Result<PlanOrCached> {
         let cache_control = request_context.cache_control();
@@ -135,32 +137,25 @@ impl Query {
             _ => sql_cache_key,
         };
 
-        // Try to get cached results from SQL or client key. When `read_only` is
-        // true, skip the cache lookup entirely so read-only validation always
-        // gets a chance to run on the freshly-planned query.
+        // Try to get cached results from SQL or client key.
         let CacheResponse {
             tracker,
             raw_key: sql_or_client_raw_key,
             ..
-        } = if read_only {
-            CacheResponse::from(CacheResult::MissOrSkipped, CacheStatus::CacheDisabled)
-                .with_query_tracker(tracker)
-        } else {
-            match Self::try_get_cached_result(
-                df,
-                &request_context,
-                tracker,
-                &sql_or_user_cache_key,
-                sql,
-            )
-            .await?
-            {
-                CacheResponse {
-                    result: CacheResult::Hit(result),
-                    ..
-                } => return Ok(PlanOrCached::Cached(result)),
-                response => response,
-            }
+        } = match Self::try_get_cached_result(
+            df,
+            &request_context,
+            tracker,
+            &sql_or_user_cache_key,
+            sql,
+        )
+        .await?
+        {
+            CacheResponse {
+                result: CacheResult::Hit(result),
+                ..
+            } => return Ok(PlanOrCached::Cached(result)),
+            response => response,
         };
 
         let sql_raw_cache_key =
@@ -186,32 +181,26 @@ impl Query {
             }
         };
 
-        // Try to get cached results from plan (skipped for read-only, same
-        // reasoning as the SQL-keyed lookup above).
+        // Try to get cached results from plan.
         let CacheResponse {
             mut tracker,
             raw_key: plan_raw_cache_key,
             status,
             ..
-        } = if read_only {
-            CacheResponse::from(CacheResult::MissOrSkipped, CacheStatus::CacheDisabled)
-                .with_query_tracker(tracker)
-        } else {
-            match Self::try_get_cached_result(
-                df,
-                &request_context,
-                tracker,
-                &CacheKey::LogicalPlan(&plan),
-                sql,
-            )
-            .await?
-            {
-                CacheResponse {
-                    result: CacheResult::Hit(result),
-                    ..
-                } => return Ok(PlanOrCached::Cached(result)),
-                response => response,
-            }
+        } = match Self::try_get_cached_result(
+            df,
+            &request_context,
+            tracker,
+            &CacheKey::LogicalPlan(&plan),
+            sql,
+        )
+        .await?
+        {
+            CacheResponse {
+                result: CacheResult::Hit(result),
+                ..
+            } => return Ok(PlanOrCached::Cached(result)),
+            response => response,
         };
 
         let request_raw_cache_key = match request_context.cache_control() {
@@ -223,15 +212,7 @@ impl Query {
         }
         .unwrap_or(sql_raw_cache_key);
 
-        // Read-only requests must also not populate the results cache — the
-        // plan has not yet been validated at this point, and we don't want a
-        // writable surface's cached output to leak back through a read-only
-        // caller on a later identical query.
-        let cache_status = if read_only {
-            CacheStatus::CacheDisabled
-        } else {
-            Self::should_cache_results(df, &plan, status)
-        };
+        let cache_status = Self::should_cache_results(df, &plan, status);
         tracker = tracker.map(|t| t.results_cache_hit(false));
 
         Ok(PlanOrCached::Plan(
@@ -742,7 +723,9 @@ mod tests {
         datafusion::{DataFusion, query::QueryBuilder},
         status,
     };
-    use runtime_request_context::{CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext};
+    use runtime_request_context::{
+        CacheControl, CacheKeyType, CacheNamespace, Protocol, RequestContext,
+    };
 
     // Helper function to create a test RequestContext
     fn create_test_request_context(

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -67,7 +67,7 @@ use snafu::ResultExt;
 use futures::TryStreamExt;
 
 use runtime_auth::AuthPrincipalRef;
-use runtime_request_context::{AsyncMarker, RequestContext};
+use runtime_request_context::{AsyncMarker, CacheNamespace, RequestContext};
 
 use crate::datafusion::request_context_extension::DataFusionContextExtension;
 #[cfg(feature = "openapi")]
@@ -349,9 +349,32 @@ fn attach_cache_headers(
         headers.insert("Results-Cache-Status", val);
     }
 
+    // Surface the cache scope so callers can tell whether a MISS came
+    // from per-user isolation (a coworker's cached entry is not visible)
+    // versus a true cold cache.
+    let cache_namespace = request_context.cache_namespace();
+    headers.insert(
+        "Results-Cache-Scope",
+        HeaderValue::from_static(cache_namespace.as_header_value()),
+    );
+
     // Tell CDN entry is unique per user cache key
     if user_key_specified {
-        headers.insert("Vary", HeaderValue::from_static("Spice-Cache-Key"));
+        append_vary(headers, "Spice-Cache-Key");
+    }
+
+    // For per-user scope, additionally vary on every header that can
+    // identify a principal so an HTTP cache between Spice and the client
+    // never collapses entries belonging to different principals.
+    // - `Authorization` covers Bearer / Basic / future U2M flows.
+    // - `X-API-Key` is the header used by the API-key auth flow today;
+    //   without it shared proxies/CDNs would happily reuse Alice's
+    //   response for Bob.
+    // - `Cookie` covers any future session-cookie based auth.
+    if matches!(cache_namespace, CacheNamespace::Principal(_)) {
+        append_vary(headers, "Authorization");
+        append_vary(headers, "X-API-Key");
+        append_vary(headers, "Cookie");
     }
 
     // Add Cache-Control response header with stale-while-revalidate if configured
@@ -380,6 +403,29 @@ fn attach_cache_headers(
             }
         }
     }
+}
+
+/// Append `field` to the `Vary` response header, preserving any prior
+/// value(s). RFC 7231 §7.1.4 allows comma-separated field lists.
+pub(super) fn append_vary(headers: &mut HeaderMap, field: &'static str) {
+    use http::header::VARY;
+    if let Some(existing) = headers.get(VARY)
+        && let Ok(existing_str) = existing.to_str()
+    {
+        // Skip if already present.
+        if existing_str
+            .split(',')
+            .any(|f| f.trim().eq_ignore_ascii_case(field))
+        {
+            return;
+        }
+        let combined = format!("{existing_str}, {field}");
+        if let Ok(v) = HeaderValue::from_str(&combined) {
+            headers.insert(VARY, v);
+        }
+        return;
+    }
+    headers.insert(VARY, HeaderValue::from_static(field));
 }
 
 /// This is the legacy cache header, preserved for backwards compatibility.

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -25,7 +25,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use http::{HeaderMap, HeaderValue};
-use runtime_request_context::{AsyncMarker, RequestContext};
+use runtime_request_context::{AsyncMarker, CacheNamespace, RequestContext};
 use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Instant};
 use tracing::Instrument;
@@ -167,9 +167,29 @@ pub(crate) async fn post(
                     headers.insert("Search-Results-Cache-Status", val);
                 }
 
+                // Surface the cache scope so callers can tell whether a MISS
+                // came from per-user isolation versus a true cold cache.
+                let cache_namespace = request_context.cache_namespace();
+                headers.insert(
+                    "Search-Results-Cache-Scope",
+                    HeaderValue::from_static(cache_namespace.as_header_value()),
+                );
+
                 // Tell CDN entry is unique per user cache key
                 if request_context.client_supplied_cache_key().is_some() {
-                    headers.insert("Vary", HeaderValue::from_static("Spice-Cache-Key"));
+                    super::append_vary(&mut headers, "Spice-Cache-Key");
+                }
+
+                // For per-user scope, additionally vary on every header
+                // that can identify a principal so an HTTP cache between
+                // Spice and the client never collapses entries belonging
+                // to different principals. See the matching block in
+                // `http/v1/mod.rs::add_cache_response_headers` for the
+                // rationale on each header.
+                if matches!(cache_namespace, CacheNamespace::Principal(_)) {
+                    super::append_vary(&mut headers, "Authorization");
+                    super::append_vary(&mut headers, "X-API-Key");
+                    super::append_vary(&mut headers, "Cookie");
                 }
 
                 (

--- a/crates/runtime/src/search/search_engine.rs
+++ b/crates/runtime/src/search/search_engine.rs
@@ -248,7 +248,11 @@ impl SearchEngine {
                 _ => CacheKey::Search(&search_key),
             };
 
-            let raw_cache_key = cache_key.as_raw_key(cache_provider.hasher());
+            let raw_cache_key = {
+                let ns = request_context.cache_namespace();
+                let (ns_tag, ns_id) = ns.hash_inputs();
+                cache_key.as_raw_key_in_namespace(cache_provider.hasher(), ns_tag, ns_id)
+            };
 
             match (
                 cache_control,

--- a/crates/runtime/tests/acceleration/caching_mode_per_principal.rs
+++ b/crates/runtime/tests/acceleration/caching_mode_per_principal.rs
@@ -1,0 +1,495 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+
+//! End-to-end regression coverage for per-principal isolation in the
+//! caching acceleration mode.
+//!
+//! These tests deliberately exercise the *full* pipeline (auth principal ->
+//! `RequestContext` -> `Query::run_internal` -> `TableProvider::scan` ->
+//! `CachingAccelerationScanExec::execute` -> `DuckDB`) because the unit tests
+//! in `accelerated_table::caching` cannot reach the two failure modes that
+//! were caught only by manual end-to-end testing:
+//!
+//! 1. **Filters passed to `TableProvider::scan` are an optimization hint,
+//!    not a contract.** An accelerator that returns `Inexact` /
+//!    `Unsupported` (or that simply fails to push down a predicate) would
+//!    let rows from another principal's namespace leak through to the
+//!    caller. The fix is a strict `FilterExec` re-application on top of
+//!    the accelerator scan; without it, `DuckDB` silently serves another
+//!    principal's cached row.
+//!
+//! 2. **`DataFusion` does not propagate Tokio task-locals across
+//!    `TableProvider::scan` and `ExecutionPlan::execute`.** Reading the
+//!    cache namespace via `RequestContext::current()` in those code paths
+//!    silently falls back to the global `INTERNAL_REQUEST_CONTEXT`
+//!    (`Protocol::Internal`, no principal), collapsing every caller to
+//!    `CacheNamespace::System`. The fix is to pull the request context
+//!    out of the `SessionConfig` / `TaskContext` extension where
+//!    `Query::run_internal` attaches it.
+//!
+//! Both regressions would silently turn the cross-principal test below
+//! into a data-leak (alice's repeat upstream count would stay at 1, bob's
+//! body would equal alice's), so this file is the canonical regression
+//! gate for cache-namespace isolation.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use app::AppBuilder;
+use app::spicepod::component::runtime::ApiKey;
+use arrow::array::{Array, RecordBatch, StringArray};
+use axum::{Router, routing::get};
+use futures::TryStreamExt;
+use runtime::Runtime;
+use runtime_auth::{AuthPrincipalRef, AuthRequestContext};
+use runtime_request_context::{Protocol, RequestContext, UserAgent};
+use spicepod::{
+    acceleration::{Acceleration, Mode, RefreshMode},
+    component::dataset::Dataset,
+    param::Params,
+};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+use crate::acceleration::get_params;
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, runtime_ready_check},
+};
+
+/// Spawn a tiny HTTP server that returns a JSON array containing a
+/// monotonically-increasing counter. The counter is bumped once per
+/// successful request, so test code can read `counter.load(...)` to
+/// determine how many upstream fetches actually occurred.
+async fn start_per_principal_mock() -> (oneshot::Sender<()>, SocketAddr, Arc<AtomicUsize>) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_clone = Arc::clone(&counter);
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let app = Router::new().route(
+        "/api/data",
+        get(move || {
+            let c = Arc::clone(&counter_clone);
+            async move {
+                let n = c.fetch_add(1, Ordering::SeqCst) + 1;
+                let body = format!("[{{\"served_at\":{n}}}]");
+                ([("content-type", "application/json")], body)
+            }
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock listener");
+    let addr = listener.local_addr().expect("local_addr");
+
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                rx.await.ok();
+            })
+            .await
+            .unwrap_or_default();
+    });
+
+    (tx, addr, counter)
+}
+
+/// Build a `RequestContext` whose only principal is an API key.
+///
+/// The cache namespace is derived deterministically from the key bytes
+/// (`apikey:<sha256[..16]>`), so two distinct key strings produce two
+/// distinct namespaces and therefore two disjoint cache scopes.
+fn principal_request_context(api_key: &str) -> Arc<RequestContext> {
+    let ctx = Arc::new(
+        RequestContext::builder(Protocol::Http)
+            .with_user_agent(UserAgent::from_ua_str("spiceci/per-principal-test"))
+            .build(),
+    );
+    let principal: AuthPrincipalRef = Arc::new(ApiKey::ReadOnly {
+        key: api_key.to_string(),
+    });
+    ctx.set_auth_principal(principal)
+        .expect("set_auth_principal");
+    ctx
+}
+
+fn make_caching_dataset(base_url: &str, duckdb_file: &str) -> Dataset {
+    let mut dataset = Dataset::new(base_url, "http_data");
+    dataset.params = Some(Params::from_string_map(
+        vec![
+            ("file_format".to_string(), "json".to_string()),
+            ("allowed_request_paths".to_string(), "/api/data".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("duckdb".to_string()),
+        mode: Mode::File,
+        refresh_mode: Some(RefreshMode::Caching),
+        params: get_params(&Mode::File, Some(duckdb_file.to_string()), "duckdb"),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+/// Run a `SELECT content FROM http_data WHERE request_path = '/api/data'`
+/// inside the given principal's request scope and return the parsed
+/// `served_at` integer from the response body.
+///
+/// Goes through `Query::run_internal` (via `query_builder`) so the
+/// principal's `RequestContext` is attached to the `SessionConfig` as
+/// an extension; the accelerator scan path under test reads the cache
+/// namespace from there. Bypassing this and going through the raw
+/// `DataFrame` API would silently fall back to `INTERNAL_REQUEST_CONTEXT`
+/// (`Protocol::Internal`, no principal) and collapse every caller to
+/// `CacheNamespace::System`, defeating the test.
+///
+/// Sleeps briefly after collecting results so that the asynchronous
+/// cache flush (writes flow through a channel to a background task)
+/// has a chance to land before the next scan looks for the cached row.
+///
+/// Returning the integer (rather than asserting on it inline) lets the
+/// caller compare the values from successive scans / different principals
+/// and produce assertion messages with both sides visible.
+async fn collect_served_at(rt: &Runtime, ctx: &Arc<RequestContext>) -> usize {
+    let rt_clone = rt.clone();
+    let ctx_clone = Arc::clone(ctx);
+    let value = ctx_clone
+        .scope(async move {
+            let result = rt_clone
+                .datafusion()
+                .query_builder("SELECT content FROM http_data WHERE request_path = '/api/data'")
+                .build()
+                .run()
+                .await
+                .expect("query run");
+            let batches: Vec<RecordBatch> = result
+                .data
+                .try_collect()
+                .await
+                .expect("collect scan results");
+            assert!(!batches.is_empty(), "scan returned no batches");
+            assert_eq!(
+                batches[0].num_rows(),
+                1,
+                "scan returned wrong row count: {}",
+                batches[0].num_rows()
+            );
+
+            let arr = batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("content column should be Utf8");
+            let body = arr.value(0);
+            let v: serde_json::Value =
+                serde_json::from_str(body).expect("response body is valid JSON");
+            let obj = match &v {
+                serde_json::Value::Object(_) => &v,
+                serde_json::Value::Array(a) => a
+                    .first()
+                    .unwrap_or_else(|| panic!("empty JSON array in body: {body}")),
+                _ => panic!("unexpected JSON shape in body: {body}"),
+            };
+            let value = obj
+                .get("served_at")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_else(|| panic!("missing served_at in body: {body}"));
+            usize::try_from(value).expect("served_at fits in usize")
+        })
+        .await;
+    // Cache writes flow through an async channel to a background flush
+    // task with a 500ms flush interval (`CACHE_WRITE_FLUSH_INTERVAL_MS`
+    // in `accelerated_table::caching`). Wait long enough that the write
+    // is guaranteed to have landed in the accelerator before the next
+    // scan looks for the row.
+    tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
+    value
+}
+
+/// End-to-end isolation test for caching-mode acceleration with two
+/// distinct API-key principals against an HTTP source backed by `DuckDB`
+/// (file mode).
+///
+/// Walks the canonical four-step interleaving:
+///
+/// | Step | Caller | Upstream count delta | Body must equal |
+/// |------|--------|----------------------|-----------------|
+/// |  1   | alice  |        +1            | (records `alice1`) |
+/// |  2   | alice  |         0            | `alice1` (cache hit) |
+/// |  3   | bob    |        +1            | NOT `alice1` (separate ns) |
+/// |  4   | bob    |         0            | bob's step-3 body  |
+/// |  5   | alice  |         0            | `alice1` (untouched by bob) |
+///
+/// Either of the two regression vectors documented at the top of this
+/// file would manifest as step 3 reusing alice's cached row (delta 0,
+/// body equal to `alice1`) or step 5 returning bob's body (alice's
+/// entry overwritten or filter not re-applied).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn caching_accelerator_isolates_per_principal_e2e() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,runtime::accelerated_table::caching=debug",
+    ));
+    register_test_connectors().await;
+
+    let (server_tx, addr, counter) = start_per_principal_mock().await;
+    let base_url = format!("http://{addr}");
+
+    let temp_dir = tempfile::tempdir()?;
+    let duckdb_path = temp_dir
+        .path()
+        .join("per_principal_cache.duckdb")
+        .to_string_lossy()
+        .into_owned();
+
+    // Setup runs under an admin (`Protocol::Internal`, no principal)
+    // context; only the actual queries scope into alice / bob. This
+    // mirrors the real runtime, where dataset registration, refresh, and
+    // checkpoint code all run as `System` while incoming HTTP / Flight
+    // requests carry their own per-call contexts.
+    let admin_ctx = Arc::new(
+        RequestContext::builder(Protocol::Internal)
+            .with_user_agent(UserAgent::from_ua_str("spiceci/per-principal-test-admin"))
+            .build(),
+    );
+
+    let result: Result<(), anyhow::Error> = admin_ctx
+        .scope(async {
+            let dataset = make_caching_dataset(&base_url, &duckdb_path);
+            let mut app = AppBuilder::new("test_caching_per_principal")
+                .with_dataset(dataset)
+                .build();
+
+            // Disable the SQL results cache so this test measures *only*
+            // the acceleration-layer cache; otherwise a duplicate query
+            // could be served from the SQL results cache without ever
+            // reaching the accelerator scan.
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let load_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg(
+                        "Timed out waiting for caching dataset to load",
+                    ));
+                }
+                () = load_rt.load_components() => {}
+            }
+            runtime_ready_check(&rt).await;
+
+            let alice = principal_request_context("alice-key-aaaaaaaaaaaaaaaaaaaa");
+            let bob = principal_request_context("bob-key-bbbbbbbbbbbbbbbbbbbbbb");
+
+            let upstream = || counter.load(Ordering::SeqCst);
+            let baseline = upstream();
+
+            // 1. Alice cold scan: must trigger exactly one upstream fetch.
+            let alice1 = collect_served_at(&rt, &alice).await;
+            assert_eq!(
+                upstream() - baseline,
+                1,
+                "alice cold scan should fetch upstream exactly once \
+                 (saw {} fetches)",
+                upstream() - baseline,
+            );
+
+            // 2. Alice repeat: must serve from her own cached row,
+            //    no upstream fetch.
+            let alice2 = collect_served_at(&rt, &alice).await;
+            assert_eq!(
+                upstream() - baseline,
+                1,
+                "alice repeat must NOT fetch upstream \
+                 (saw {} fetches; expected 1)",
+                upstream() - baseline,
+            );
+            assert_eq!(
+                alice1, alice2,
+                "alice repeat must return alice's own cached body \
+                 (alice1={alice1}, alice2={alice2})",
+            );
+
+            // 3. Bob cold scan, same SQL: must NOT inherit alice's
+            //    cached row -> must trigger a new upstream fetch.
+            //
+            //    This is the cross-principal isolation gate. Either
+            //    regression vector documented at the top of this file
+            //    would let alice's row be served here, with the upstream
+            //    counter staying at 1.
+            let bob1 = collect_served_at(&rt, &bob).await;
+            assert_eq!(
+                upstream() - baseline,
+                2,
+                "bob cold scan must fetch upstream \
+                 (cross-principal cache leak? saw {} fetches; expected 2)",
+                upstream() - baseline,
+            );
+            assert_ne!(
+                alice1, bob1,
+                "bob must not see alice's cached body \
+                 (alice1={alice1}, bob1={bob1})",
+            );
+
+            // 4. Bob repeat: must serve from bob's own cached row.
+            let bob2 = collect_served_at(&rt, &bob).await;
+            assert_eq!(
+                upstream() - baseline,
+                2,
+                "bob repeat must NOT fetch upstream \
+                 (saw {} fetches; expected 2)",
+                upstream() - baseline,
+            );
+            assert_eq!(
+                bob1, bob2,
+                "bob repeat must return bob's own cached body \
+                 (bob1={bob1}, bob2={bob2})",
+            );
+
+            // 5. Alice again, after bob: alice's cached row must still
+            //    be intact (bob's writes went to a different namespace).
+            let alice3 = collect_served_at(&rt, &alice).await;
+            assert_eq!(
+                upstream() - baseline,
+                2,
+                "alice repeat after bob must NOT fetch upstream \
+                 (saw {} fetches; expected 2)",
+                upstream() - baseline,
+            );
+            assert_eq!(
+                alice1, alice3,
+                "alice's cached body must survive bob's writes intact \
+                 (alice1={alice1}, alice3={alice3})",
+            );
+
+            Ok(())
+        })
+        .await;
+
+    let _ = server_tx.send(());
+    result
+}
+
+/// User-facing schema must NOT expose the internal
+/// `__spice_cache_namespace` storage column, even though it lives in
+/// the underlying accelerator table for caching mode. This protects
+/// users from accidentally depending on an internal column whose
+/// presence and meaning are an implementation detail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn caching_accelerator_hides_namespace_column_from_user_schema() -> Result<(), anyhow::Error>
+{
+    let _tracing = init_tracing(Some("integration=debug,runtime=debug"));
+    register_test_connectors().await;
+
+    let (server_tx, addr, _counter) = start_per_principal_mock().await;
+    let base_url = format!("http://{addr}");
+
+    let temp_dir = tempfile::tempdir()?;
+    let duckdb_path = temp_dir
+        .path()
+        .join("hidden_column.duckdb")
+        .to_string_lossy()
+        .into_owned();
+
+    let admin_ctx = Arc::new(
+        RequestContext::builder(Protocol::Internal)
+            .with_user_agent(UserAgent::from_ua_str("spiceci/hidden-column-test"))
+            .build(),
+    );
+
+    let result: Result<(), anyhow::Error> = admin_ctx
+        .scope(async {
+            let dataset = make_caching_dataset(&base_url, &duckdb_path);
+            let mut app = AppBuilder::new("test_caching_hidden_column")
+                .with_dataset(dataset)
+                .build();
+            if app.runtime.caching.sql_results.is_none() {
+                app.runtime.caching.sql_results =
+                    Some(spicepod::component::caching::SQLResultsCacheConfig::default());
+            }
+            if let Some(ref mut sql_cache) = app.runtime.caching.sql_results {
+                sql_cache.enabled = false;
+            }
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let load_rt = Arc::new(rt.clone());
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg(
+                        "Timed out waiting for caching dataset to load",
+                    ));
+                }
+                () = load_rt.load_components() => {}
+            }
+            runtime_ready_check(&rt).await;
+
+            let table = rt
+                .datafusion()
+                .ctx
+                .table("http_data")
+                .await
+                .expect("table http_data");
+            let schema = table.schema();
+            let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+            assert!(
+                !names.contains(&"__spice_cache_namespace"),
+                "user-facing schema must NOT expose the internal \
+                 __spice_cache_namespace column; got: {names:?}",
+            );
+
+            // Referencing the column in SQL must produce a normal
+            // schema error (the reserved name behaves like any other
+            // missing field; it is not silently resolved against the
+            // hidden storage column).
+            let err = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT __spice_cache_namespace FROM http_data \
+                     WHERE request_path = '/api/data'",
+                )
+                .build()
+                .run()
+                .await
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_default();
+            assert!(
+                err.contains("__spice_cache_namespace")
+                    && (err.contains("No field") || err.contains("Schema error")),
+                "expected a schema error for the reserved column; got: {err}",
+            );
+
+            Ok(())
+        })
+        .await;
+
+    let _ = server_tx.send(());
+    result
+}

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -22,6 +22,8 @@ use spicepod::{acceleration::Mode, param::Params};
 
 mod caching_mode;
 #[cfg(feature = "duckdb")]
+mod caching_mode_per_principal;
+#[cfg(feature = "duckdb")]
 mod checkpoint_duckdb;
 #[cfg(feature = "postgres-accel")]
 mod checkpoint_postgres;


### PR DESCRIPTION
Implements per-principal caching scope (issue #10680). When a user authenticates, every cache layer (SQL results, search results, caching-mode acceleration storage) becomes per-principal so that one caller's cached output cannot be served back to a different caller. When auth is disabled, behavior is unchanged: every caller shares the public namespace.

Issue: https://github.com/spiceai/spiceai/issues/10680

## Why

Today the SQL results cache, search cache, and caching-mode accelerator are global. Two principals running the same query against the same dataset can serve each other's data. This is fine while the runtime is single-tenant, but it is a blocker for the upcoming U2M auth work and for any deployment with multiple API keys.

This PR makes the cache *namespace* a function of the request principal:

- Anonymous (auth disabled or auth not present): `public` namespace - everyone shares.
- Background / refresh / system internals: `system` namespace.
- Authenticated principal: opaque per-principal id (e.g. `apikey:<sha256[..16]>`).

There are no user-facing knobs to turn isolation off. Scope follows auth presence by construction, so the runtime cannot drift into a state where two principals share a cache scope by accident.

## What changed

The work is split into 7 commits, oldest first:

1. `feat(runtime-request-context): add CacheNamespace + AuthPrincipal::stable_id` - foundation: `CacheNamespace` enum (`Public` / `System` / `Principal`), `AuthPrincipal::stable_id()` trait method, `ApiKey::stable_id()` impl using SHA-256 of the key bytes (key value never exposed).
2. `feat: scope SQL results + search caches by CacheNamespace; add Results-Cache-Scope header` - SQL/plan/search cache key hashing now mixes in the namespace tag + id; new `Results-Cache-Scope` / `Search-Results-Cache-Scope` response headers; `Vary: Authorization` when scope is `user`.
3. `feat(runtime): SWR background revalidation inherits originating cache namespace` - stale-while-revalidate refresh runs in the originating principal's namespace, not the background `system` namespace, so a stale alice entry is refreshed *for alice*.
4. `feat(runtime): reserve __spice_cache_namespace column for caching accelerator (m4 foundation)` - `CACHE_NAMESPACE_COLUMN` constant + `extend_schema_with_cache_namespace` helper that errors with a clear, dataset-aware message if the source schema already has the column.
5. `feat(runtime): extend caching accelerator storage schema with namespace column; hide from user-facing schema (m4b)` - storage schema gains the column; `SchemaCastScanExec` strips it (along with `fetched_at`) by name from user-facing output.
6. `feat(runtime): namespace-scope caching accelerator + drop redundant read-only cache bypass (m4cd)` - the safety-meaningful change. Stamps every cache write with the originating namespace id (at flush time, gated on the accelerator schema actually having the column so test mocks stay simple); appends `__spice_cache_namespace = $current_ns` to every accelerator scan; strictly re-applies that predicate as a `FilterExec` on top so an accelerator that does not push down can never leak rows from another principal. SWR refresh inherits the namespace via a single capture at the top of `CachingAccelerationScanExec::execute`. **Also drops the read-only short-circuit in `get_plan_or_cached`** because per-namespace cache + the existing `WRITE_CAPABLE_EXTENSION_NAMES` filter make it both unnecessary and actively harmful (it forced read-only API keys to skip a cache they could safely use).
7. `test(runtime): integration coverage for per-principal caching-accelerator isolation` - end-to-end regression gate for the m4cd work; see "Testing" below.

## The subtle bit (worth highlighting in review)

DataFusion does **not** propagate Tokio task-locals across the `TableProvider::scan` await point or into `ExecutionPlan::execute` on worker threads. This means `RequestContext::current()` in those code paths silently falls back to the global `INTERNAL_REQUEST_CONTEXT` (`Protocol::Internal`, no principal), which collapses every caller to `CacheNamespace::System` and defeats isolation.

Both `AcceleratedTable::scan` and `CachingAccelerationScanExec::execute` now read the request context from the `SessionConfig` / `TaskContext` extension where `Query::run_internal` attaches it. This matches the existing pattern used by `BytesProcessedExec`. End-to-end testing caught this; unit tests cannot.

## Compatibility

This is a **breaking change for the caching accelerator on upgrade**: the storage schema gains an internal `__spice_cache_namespace` column. Existing accelerator storage from earlier versions does not have the column and must be deleted (e.g. remove the `duckdb_file`, drop the SQLite/Postgres/Cayenne backing table) before upgrading. The runtime errors with a clear, dataset-aware message at startup if it sees a non-extended schema.

The SQL results cache and search cache are not persistent so no migration is needed.

`Results-Cache-Scope` / `Search-Results-Cache-Scope` are new response headers, not breaking.

## Testing

**Unit:** all 185 `accelerated_table` lib tests pass (36 of which are the caching subset); all 32 `datafusion::query` lib tests pass.

**Integration:** 2 new tokio integration tests in `crates/runtime/tests/acceleration/caching_mode_per_principal.rs` (gated on `feature = "duckdb"`):

- `caching_accelerator_isolates_per_principal_e2e` walks the canonical alice -> alice -> bob -> bob -> alice interleaving against an axum mock with a request counter and a DuckDB file accelerator, asserting upstream fetch counts at every step plus body inequality across principals. The test goes through `query_builder().build().run()` so `Query::run_internal` attaches the per-call `RequestContext` to `SessionConfig` (the raw DataFrame path bypasses this and would silently fall back to `System`).
- `caching_accelerator_hides_namespace_column_from_user_schema` confirms the user-facing schema does not expose `__spice_cache_namespace` and that referencing it in SQL fails with a normal "no field" error.

Verified the regression test actually catches the bug it's meant to: temporarily restoring `RequestContext::current()` in `CachingAccelerationScanExec::execute` makes the test fail with *"alice repeat must NOT fetch upstream (saw 2 fetches; expected 1)"*. 5/5 consecutive runs pass at ~6.6s each.

**Manual:** verified all of T1-T5 + T7 against a local `spiced` with two API keys (read-write and read-only), confirming the read-side `Results-Cache-Scope` headers, cross-key isolation, same-key cache hits, public-namespace fallback when auth is disabled, `Cache-Control: no-cache` BYPASS, `Spice-Cache-Key` per-principal scoping, and SWR background refresh staying inside the originating namespace.

## Deferred to follow-up PRs

- M5: Pingora result-cache shard (currently `RESULT_SHARDS_BY_REGION_BY_NAMESPACE` wraps the existing global by namespace; the upstream Pingora shard remains shared until horizontal-scaling work picks this up).
- M6: per-namespace eviction metrics and dashboards.
- Spicepod-level reservation check that catches a user declaring a column named `__spice_cache_namespace` at parse time. Today only the runtime check at schema-extension time exists, and the only way to trigger it is to pair caching mode with a connector whose schema can be user-influenced. Caching mode is HTTP-only today and the HTTP connector has a fixed base schema, so the runtime check is unreachable through any current public surface. Adding the spicepod-level check is belt-and-suspenders for a column with the `__spice_` prefix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->