### PR TITLE
Fix repeated spiceio setup in model archive builds

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -139,6 +139,10 @@ jobs:
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
         run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
 
+      - name: Clean spiceio install directory
+        if: env.HAS_SPICEIO_SECRET == 'true'
+        run: rm -rf "${{ runner.temp }}/spiceio-bin"
+
       - name: Set up spiceio for build archive
         if: env.HAS_SPICEIO_SECRET == 'true'
         id: setup-spiceio-build
@@ -573,6 +577,10 @@ jobs:
       - name: Stop sccache spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
         run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Clean spiceio install directory
+        if: env.HAS_SPICEIO_SECRET == 'true'
+        run: rm -rf "${{ runner.temp }}/spiceio-bin"
 
       - name: Set up spiceio for build archive
         if: env.HAS_SPICEIO_SECRET == 'true'


### PR DESCRIPTION
Fixes the model integration archive build when the job starts `spiceio` twice.

Summary:
- Clean `${{ runner.temp }}/spiceio-bin` before the second `spiceio` setup in the model archive build job.
- Apply the same cleanup to the extended model archive build path.
- Prevent `gh release download` from failing on an existing `spiceio-*.tar.gz.sha256` file left by the earlier sccache `spiceio` setup.

Validation:
- `git diff --check -- .github/workflows/integration_models.yml`
- VS Code workflow diagnostics reported no errors.
- `actionlint` was not installed locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->