### PR TITLE
feat(runtime): optional task_history persistence via data connector

### DIFF
--- a/crates/runtime/src/init/task_history.rs
+++ b/crates/runtime/src/init/task_history.rs
@@ -222,9 +222,10 @@ impl Runtime {
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 
-        let connector = match dataconnector::create_new_connector(&source, params).await {
-            Some(result) => result.context(UnableToInitializeDataConnectorSnafu)?,
-            None => {
+        let connector =
+            if let Some(result) = dataconnector::create_new_connector(&source, params).await {
+                result.context(UnableToInitializeDataConnectorSnafu)?
+            } else {
                 let suggestion = suggest_connector(&source).await;
                 let available = registered_connector_names().await;
                 return Err(UnknownDataConnectorSnafu {
@@ -233,8 +234,7 @@ impl Runtime {
                     available,
                 }
                 .build());
-            }
-        };
+            };
 
         let provider = connector
             .read_write_provider(&dataset)

--- a/crates/runtime/src/init/task_history.rs
+++ b/crates/runtime/src/init/task_history.rs
@@ -179,11 +179,22 @@ impl Runtime {
     /// Resolves the configured `task_history.persistence` block into a
     /// writable `TableProvider` that the accelerated table will write back to.
     /// The connector name is the prefix of `from:` (e.g. `postgres` in
-    /// `postgres:public.task_history`), and must support DDL/DML.
+    /// `postgres:public.task_history`), and must expose a writable provider
+    /// (DML — INSERT, plus DELETE for retention).
     async fn build_task_history_persistence_source(
         self: &Arc<Self>,
         persistence: TaskHistoryPersistence,
     ) -> Result<Arc<dyn TableProvider>> {
+        if persistence.from.trim().is_empty() {
+            return Err(Error::UnableToTrackTaskHistory {
+                source: task_history::Error::InvalidConfiguration {
+                    source: "task_history.persistence.from must be a non-empty \
+                             `<connector>:<path>` reference (e.g. \
+                             `postgres:public.task_history`)"
+                        .into(),
+                },
+            });
+        }
         let app = self.app();
         let app_guard = app.read().await;
         let app_ref =

--- a/crates/runtime/src/init/task_history.rs
+++ b/crates/runtime/src/init/task_history.rs
@@ -15,13 +15,20 @@ limitations under the License.
 */
 
 use crate::cluster::DistributedNode;
+use crate::component::access::AccessMode;
+use crate::component::dataset::builder::DatasetBuilder;
+use crate::dataconnector::{
+    self, parameters::ConnectorParamsBuilder, registered_connector_names, suggest_connector,
+};
 use crate::{
-    Error, Result, Runtime, UnableToCreateBackendSnafu, datafusion::SPICE_RUNTIME_SCHEMA,
-    task_history,
+    Error, Result, Runtime, UnableToCreateBackendSnafu,
+    UnableToInitializeDataConnectorSnafu, UnknownDataConnectorSnafu,
+    datafusion::SPICE_RUNTIME_SCHEMA, task_history,
 };
 use datafusion::catalog::TableProvider;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
+use spicepod::component::runtime::TaskHistoryPersistence;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -89,10 +96,16 @@ impl Runtime {
         let effective_role = self.df.cluster_config.effective_role();
         let is_cluster_mode = effective_role.is_some();
 
+        let persistence_source = match app.runtime.task_history.persistence.clone() {
+            Some(persistence) => Some(self.build_task_history_persistence_source(persistence).await?),
+            None => None,
+        };
+
         let local_table = task_history::TaskSpan::instantiate_table(
             self.status(),
             retention_period_secs,
             retention_check_interval_secs,
+            persistence_source,
             Arc::clone(&self),
             is_cluster_mode,
         )
@@ -158,5 +171,80 @@ impl Runtime {
                 table_to_register,
             )
             .context(UnableToCreateBackendSnafu)
+    }
+
+    /// Resolves the configured `task_history.persistence` block into a
+    /// writable `TableProvider` that the accelerated table will write back to.
+    /// The connector name is the prefix of `from:` (e.g. `postgres` in
+    /// `postgres:public.task_history`), and must support DDL/DML.
+    async fn build_task_history_persistence_source(
+        self: &Arc<Self>,
+        persistence: TaskHistoryPersistence,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let app = self.app();
+        let app_guard = app.read().await;
+        let app_ref =
+            app_guard
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| Error::UnableToTrackTaskHistory {
+                    source: task_history::Error::InvalidConfiguration {
+                        source: "task_history.persistence requires a loaded spicepod App".into(),
+                    },
+                })?;
+        drop(app_guard);
+
+        let table_name = format!(
+            "{SPICE_RUNTIME_SCHEMA}.{}",
+            task_history::DEFAULT_TASK_HISTORY_TABLE
+        );
+        let mut dataset = DatasetBuilder::try_new(persistence.from.clone(), &table_name)?
+            .with_app(app_ref)
+            .with_runtime(Arc::clone(self))
+            .build()
+            .map_err(|source| Error::InvalidSpicepodDataset { source })?;
+        dataset.access = AccessMode::ReadWrite;
+        dataset.params = persistence.params;
+
+        let source = dataset.source().to_string();
+        let dataset = Arc::new(dataset);
+
+        let connector_name: Arc<str> = Arc::from(source.as_str());
+        let params = ConnectorParamsBuilder::new(connector_name, (&dataset).into())
+            .build(self.secrets(), self.tokio_io_runtime())
+            .await
+            .context(UnableToInitializeDataConnectorSnafu)?;
+
+        let connector = match dataconnector::create_new_connector(&source, params).await {
+            Some(result) => result.context(UnableToInitializeDataConnectorSnafu)?,
+            None => {
+                let suggestion = suggest_connector(&source).await;
+                let available = registered_connector_names().await;
+                return Err(UnknownDataConnectorSnafu {
+                    data_connector: source,
+                    suggestion,
+                    available,
+                }
+                .build());
+            }
+        };
+
+        let provider = connector
+            .read_write_provider(&dataset)
+            .await
+            .ok_or_else(|| Error::UnableToTrackTaskHistory {
+                source: task_history::Error::InvalidConfiguration {
+                    source: format!(
+                        "data connector `{source}` does not support DDL/DML and cannot back \
+                         `runtime.task_history.persistence`"
+                    )
+                    .into(),
+                },
+            })?
+            .map_err(|e| Error::UnableToInitializeDataConnector {
+                source: Box::new(e),
+            })?;
+
+        Ok(provider)
     }
 }

--- a/crates/runtime/src/init/task_history.rs
+++ b/crates/runtime/src/init/task_history.rs
@@ -21,14 +21,14 @@ use crate::dataconnector::{
     self, parameters::ConnectorParamsBuilder, registered_connector_names, suggest_connector,
 };
 use crate::{
-    Error, Result, Runtime, UnableToCreateBackendSnafu,
-    UnableToInitializeDataConnectorSnafu, UnknownDataConnectorSnafu,
-    datafusion::SPICE_RUNTIME_SCHEMA, task_history,
+    Error, Result, Runtime, UnableToCreateBackendSnafu, UnableToInitializeDataConnectorSnafu,
+    UnknownDataConnectorSnafu, datafusion::SPICE_RUNTIME_SCHEMA, task_history,
 };
 use datafusion::catalog::TableProvider;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
 use spicepod::component::runtime::TaskHistoryPersistence;
+use spicepod::param::Params;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -97,7 +97,10 @@ impl Runtime {
         let is_cluster_mode = effective_role.is_some();
 
         let persistence_source = match app.runtime.task_history.persistence.clone() {
-            Some(persistence) => Some(self.build_task_history_persistence_source(persistence).await?),
+            Some(persistence) => Some(
+                self.build_task_history_persistence_source(persistence)
+                    .await?,
+            ),
             None => None,
         };
 
@@ -204,7 +207,11 @@ impl Runtime {
             .build()
             .map_err(|source| Error::InvalidSpicepodDataset { source })?;
         dataset.access = AccessMode::ReadWrite;
-        dataset.params = persistence.params;
+        dataset.params = persistence
+            .params
+            .as_ref()
+            .map(Params::as_string_map)
+            .unwrap_or_default();
 
         let source = dataset.source().to_string();
         let dataset = Arc::new(dataset);
@@ -235,8 +242,8 @@ impl Runtime {
             .ok_or_else(|| Error::UnableToTrackTaskHistory {
                 source: task_history::Error::InvalidConfiguration {
                     source: format!(
-                        "data connector `{source}` does not support DDL/DML and cannot back \
-                         `runtime.task_history.persistence`"
+                        "data connector `{source}` does not expose a writable provider \
+                         (INSERT/DELETE) and cannot back `runtime.task_history.persistence`"
                     )
                     .into(),
                 },

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -145,8 +145,8 @@ pub async fn create_internal_accelerated_table(
 /// Like [`create_internal_accelerated_table`], but persists writes to a
 /// caller-provided federated source via the accelerated table's write-back
 /// mode. The local accelerator continues to serve as the synchronous buffer;
-/// the source provider must support `insert_into` (i.e. expose a
-/// `read_write_provider`).
+/// the source provider must expose a `read_write_provider` and support DML
+/// (INSERT, plus DELETE if the caller configures retention).
 #[expect(clippy::too_many_arguments)]
 pub async fn create_internal_accelerated_table_with_persistence(
     runtime_status: Arc<status::RuntimeStatus>,

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -127,8 +127,75 @@ pub async fn create_internal_accelerated_table(
     secrets: Arc<RwLock<Secrets>>,
     runtime: Arc<Runtime>,
 ) -> Result<Arc<AcceleratedTable>, Error> {
-    let source_table_provider =
-        get_local_table_provider(&name, &schema, primary_key.clone(), Arc::clone(&runtime)).await?;
+    create_internal_accelerated_table_inner(
+        runtime_status,
+        name,
+        schema,
+        primary_key,
+        acceleration,
+        refresh,
+        retention,
+        secrets,
+        runtime,
+        None,
+    )
+    .await
+}
+
+/// Like [`create_internal_accelerated_table`], but persists writes to a
+/// caller-provided federated source via the accelerated table's write-back
+/// mode. The local accelerator continues to serve as the synchronous buffer;
+/// the source provider must support `insert_into` (i.e. expose a
+/// `read_write_provider`).
+#[expect(clippy::too_many_arguments)]
+pub async fn create_internal_accelerated_table_with_persistence(
+    runtime_status: Arc<status::RuntimeStatus>,
+    name: TableReference,
+    schema: Arc<Schema>,
+    primary_key: Option<Vec<String>>,
+    acceleration: Acceleration,
+    refresh: Refresh,
+    retention: Option<Retention>,
+    secrets: Arc<RwLock<Secrets>>,
+    runtime: Arc<Runtime>,
+    persistence_source: Arc<dyn TableProvider>,
+) -> Result<Arc<AcceleratedTable>, Error> {
+    create_internal_accelerated_table_inner(
+        runtime_status,
+        name,
+        schema,
+        primary_key,
+        acceleration,
+        refresh,
+        retention,
+        secrets,
+        runtime,
+        Some(persistence_source),
+    )
+    .await
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn create_internal_accelerated_table_inner(
+    runtime_status: Arc<status::RuntimeStatus>,
+    name: TableReference,
+    schema: Arc<Schema>,
+    primary_key: Option<Vec<String>>,
+    acceleration: Acceleration,
+    refresh: Refresh,
+    retention: Option<Retention>,
+    secrets: Arc<RwLock<Secrets>>,
+    runtime: Arc<Runtime>,
+    persistence_source: Option<Arc<dyn TableProvider>>,
+) -> Result<Arc<AcceleratedTable>, Error> {
+    let local_source = persistence_source.is_none();
+    let source_table_provider = match persistence_source {
+        Some(provider) => provider,
+        None => {
+            get_local_table_provider(&name, &schema, primary_key.clone(), Arc::clone(&runtime))
+                .await?
+        }
+    };
     let federated_table = Arc::new(FederatedTable::new_unchecked(Arc::clone(
         &source_table_provider,
     )));
@@ -156,7 +223,11 @@ pub async fn create_internal_accelerated_table(
         runtime.tokio_io_runtime(),
     );
     builder.cpu_runtime(runtime.datafusion().refresh_runtime().cloned());
-    builder.write_to_accelerator_only();
+    if local_source {
+        builder.write_to_accelerator_only();
+    } else {
+        builder.write_back();
+    }
 
     builder.retention(retention);
 

--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -18,7 +18,9 @@ use crate::accelerated_table::refresh::Refresh;
 use crate::component::dataset::acceleration::OnConflictBehavior;
 use crate::datafusion::DataFusion;
 use crate::dataupdate::{DataUpdate, UpdateType};
-use crate::internal_table::create_internal_accelerated_table;
+use crate::internal_table::{
+    create_internal_accelerated_table, create_internal_accelerated_table_with_persistence,
+};
 use crate::{Runtime, status};
 use crate::{component::dataset::TimeFormat, secrets::Secrets};
 use crate::{component::dataset::acceleration::Acceleration, datafusion::SPICE_RUNTIME_SCHEMA};
@@ -26,6 +28,7 @@ use arrow::array::{ArrayBuilder, MapBuilder, RecordBatch, StringArray, StringBui
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow_schema::ArrowError;
 use data_components::arrow::struct_builder::StructBuilder;
+use datafusion::catalog::TableProvider;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::util::column_reference::ColumnReference;
 use datafusion_table_providers::util::constraints::UpsertOptions;
@@ -92,6 +95,7 @@ impl TaskSpan {
         status: Arc<status::RuntimeStatus>,
         retention_period_secs: u64,
         retention_check_interval_secs: u64,
+        persistence_source: Option<Arc<dyn TableProvider>>,
         runtime: Arc<Runtime>,
         is_cluster_mode: bool,
     ) -> Result<Arc<AcceleratedTable>, Error> {
@@ -122,20 +126,41 @@ impl TaskSpan {
             .into(),
         );
 
-        create_internal_accelerated_table(
-            status,
-            tbl_reference,
-            Arc::new(TaskSpan::table_schema(is_cluster_mode)),
-            Some(vec!["span_id".to_string()]),
-            acceleration_settings,
-            Refresh::default(),
-            retention,
-            Arc::new(RwLock::new(Secrets::default())),
-            runtime,
-        )
-        .await
-        .boxed()
-        .context(UnableToRegisterTableSnafu)
+        let schema = Arc::new(TaskSpan::table_schema(is_cluster_mode));
+        let primary_key = Some(vec!["span_id".to_string()]);
+        let secrets = Arc::new(RwLock::new(Secrets::default()));
+
+        match persistence_source {
+            Some(source) => create_internal_accelerated_table_with_persistence(
+                status,
+                tbl_reference,
+                schema,
+                primary_key,
+                acceleration_settings,
+                Refresh::default(),
+                retention,
+                secrets,
+                runtime,
+                source,
+            )
+            .await
+            .boxed()
+            .context(UnableToRegisterTableSnafu),
+            None => create_internal_accelerated_table(
+                status,
+                tbl_reference,
+                schema,
+                primary_key,
+                acceleration_settings,
+                Refresh::default(),
+                retention,
+                secrets,
+                runtime,
+            )
+            .await
+            .boxed()
+            .context(UnableToRegisterTableSnafu),
+        }
     }
 
     fn table_schema(is_cluster_mode: bool) -> Schema {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -464,7 +464,11 @@ pub struct TaskHistory {
     /// Optional persistent backing store for the `runtime.task_history` table.
     /// When set, writes are buffered to the local in-memory table and
     /// asynchronously flushed to the configured data connector. The connector
-    /// must support DDL/DML (e.g. `postgres`, `mysql`, `sqlite`, `duckdb`).
+    /// must support writes via `read_write_provider` (INSERT, plus DELETE for
+    /// retention) — e.g. `postgres`, `mysql`, `sqlite`, `duckdb`. The target
+    /// table is not auto-created; for SQL connectors it must already exist
+    /// with a schema compatible with the columns described in the
+    /// `runtime.task_history` schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persistence: Option<TaskHistoryPersistence>,
 }
@@ -478,10 +482,11 @@ pub struct TaskHistoryPersistence {
     /// `postgres:public.task_history`, `sqlite:/var/lib/spice/task_history.db`).
     pub from: String,
 
-    /// Connector-specific parameters (the same keys you'd put under a
-    /// dataset's `params:` field).
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub params: HashMap<String, String>,
+    /// Connector-specific parameters (the same shape as a dataset's
+    /// `params:` field — non-string YAML scalars like ports or booleans
+    /// don't need to be quoted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Params>,
 }
 
 fn default_none() -> Arc<str> {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -460,6 +460,28 @@ pub struct TaskHistory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub min_plan_duration: Option<Arc<str>>,
+
+    /// Optional persistent backing store for the `runtime.task_history` table.
+    /// When set, writes are buffered to the local in-memory table and
+    /// asynchronously flushed to the configured data connector. The connector
+    /// must support DDL/DML (e.g. `postgres`, `mysql`, `sqlite`, `duckdb`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persistence: Option<TaskHistoryPersistence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct TaskHistoryPersistence {
+    /// The data connector source for the persistent table, in the same
+    /// `<connector>:<path>` form used by datasets (e.g.
+    /// `postgres:public.task_history`, `sqlite:/var/lib/spice/task_history.db`).
+    pub from: String,
+
+    /// Connector-specific parameters (the same keys you'd put under a
+    /// dataset's `params:` field).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub params: HashMap<String, String>,
 }
 
 fn default_none() -> Arc<str> {
@@ -489,6 +511,7 @@ impl Default for TaskHistory {
             min_sql_duration: None,
             captured_plan: None,
             min_plan_duration: None,
+            persistence: None,
         }
     }
 }
@@ -1285,6 +1308,7 @@ mod tests {
                 min_sql_duration: Some(duration_str.into()),
                 captured_plan: None,
                 min_plan_duration: None,
+                persistence: None,
             };
 
             let result = task_history
@@ -1307,6 +1331,7 @@ mod tests {
             min_sql_duration: Some("invalid".into()),
             captured_plan: None,
             min_plan_duration: None,
+            persistence: None,
         };
         assert!(
             task_history.min_sql_duration_as_millis().is_err(),
@@ -1402,6 +1427,7 @@ mod tests {
             min_sql_duration: None,
             captured_plan: Some("none".into()),
             min_plan_duration: None,
+            persistence: None,
         };
         assert_eq!(
             task_history.get_captured_plan().expect("should parse"),
@@ -1418,6 +1444,7 @@ mod tests {
             min_sql_duration: None,
             captured_plan: Some("explain".into()),
             min_plan_duration: None,
+            persistence: None,
         };
         assert_eq!(
             task_history.get_captured_plan().expect("should parse"),
@@ -1434,6 +1461,7 @@ mod tests {
             min_sql_duration: None,
             captured_plan: Some("explain analyze".into()),
             min_plan_duration: None,
+            persistence: None,
         };
         assert_eq!(
             task_history.get_captured_plan().expect("should parse"),
@@ -1450,6 +1478,7 @@ mod tests {
             min_sql_duration: None,
             captured_plan: Some("invalid".into()),
             min_plan_duration: None,
+            persistence: None,
         };
         assert!(
             task_history.get_captured_plan().is_err(),
@@ -1488,6 +1517,7 @@ mod tests {
                 min_sql_duration: None,
                 captured_plan: Some("explain".into()),
                 min_plan_duration: Some(duration_str.into()),
+                persistence: None,
             };
 
             let result = task_history
@@ -1510,6 +1540,7 @@ mod tests {
             min_sql_duration: None,
             captured_plan: Some("explain".into()),
             min_plan_duration: Some("invalid".into()),
+            persistence: None,
         };
         assert!(
             task_history.min_plan_duration_as_millis().is_err(),

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -114,13 +114,15 @@ runtime:
     min_sql_duration: 100ms
     captured_plan: logical # none, logical, physical
     min_plan_duration: 500ms
-    # Optional: persist task history to a connector that supports DDL/DML.
-    # Writes are buffered locally and asynchronously flushed to this target.
+    # Optional: persist task history to a writable connector. Writes are
+    # buffered locally and asynchronously flushed to this target. The target
+    # table is not auto-created — for SQL connectors (postgres, mysql, …)
+    # it must already exist with a schema compatible with `runtime.task_history`.
     persistence:
       from: postgres:public.task_history
       params:
         pg_host: localhost
-        pg_port: '5432'
+        pg_port: 5432
         pg_db: spice
         pg_user: ${secrets:PG_USER}
         pg_pass: ${secrets:PG_PASS}

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -114,6 +114,16 @@ runtime:
     min_sql_duration: 100ms
     captured_plan: logical # none, logical, physical
     min_plan_duration: 500ms
+    # Optional: persist task history to a connector that supports DDL/DML.
+    # Writes are buffered locally and asynchronously flushed to this target.
+    persistence:
+      from: postgres:public.task_history
+      params:
+        pg_host: localhost
+        pg_port: '5432'
+        pg_db: spice
+        pg_user: ${secrets:PG_USER}
+        pg_pass: ${secrets:PG_PASS}
 
   # Authentication configuration
   auth:

--- a/tools/spicepodschema/tests/spicepod.runtime.yaml
+++ b/tools/spicepodschema/tests/spicepod.runtime.yaml
@@ -24,3 +24,7 @@ runtime:
   task_history:
     enabled: true
     captured_context: redacted
+    persistence:
+      from: sqlite:task_history
+      params:
+        sqlite_file: /var/lib/spice/task_history.db


### PR DESCRIPTION
## Summary
- Adds `runtime.task_history.persistence` (optional `from:` + `params:`) so users can persist the `runtime.task_history` table to any data connector that supports DDL/DML (postgres, mysql, sqlite, duckdb, …).
- Local in-memory Arrow accelerated table still buffers writes; the configured connector becomes the federated source and receives writes (and retention deletes) asynchronously via the existing `write_back` mode. Default behavior — Arrow-only, in-memory — is unchanged.
- New `create_internal_accelerated_table_with_persistence` helper in `internal_table.rs` so other internal tables can opt into the same pattern later.

## Example
```yaml
runtime:
  task_history:
    enabled: true
    persistence:
      from: postgres:public.task_history
      params:
        pg_host: localhost
        pg_user: ${secrets:PG_USER}
```
or for a local file:
```yaml
runtime:
  task_history:
    persistence:
      from: sqlite:task_history
      params:
        sqlite_file: /var/lib/spice/task_history.db
```

If the named connector isn't registered, the user gets the same "did you mean…" error UX as with regular datasets. If the connector exists but doesn't expose a `read_write_provider`, init fails with a clear message that DDL/DML support is required.

## Known limitation
Write-back forwards every input batch to the federated source, but the accelerator's `span_id` upsert dedup is local-only. If a span is rewritten (e.g. `override_trace_id`) the persistence target sees both rows. Users should size their target table accordingly (no `PRIMARY KEY (span_id)` constraint, or dedupe downstream).

## Test plan
- [x] `cargo check -p spicepod` and `cargo check -p runtime`
- [x] `cargo clippy -p spicepod -p runtime`
- [x] `cargo test -p spicepod --lib` (134 passing, includes existing `TaskHistory` tests with new `persistence: None`)
- [ ] Manual: configure a sqlite persistence target locally, run a few queries, verify rows appear in the sqlite file
- [ ] Manual: configure a postgres persistence target, verify writes flow through and survive restart
- [ ] Manual: misconfigure to a read-only connector (e.g. `s3:`) and verify the error message names DDL/DML as the missing capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->