### PR TITLE
ci: authenticate to Docker Hub in workflows that pull images

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -346,6 +346,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so the ubuntu base image
+        # pull uses authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build ARM64 Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -387,6 +396,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so the ubuntu base image
+        # pull uses authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build AMD64 Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -431,6 +449,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits when pulling
+        # registry:2 below.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start local registry
         run: |

--- a/.github/workflows/spice_mysql_bench_docker.yml
+++ b/.github/workflows/spice_mysql_bench_docker.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Pull MySQL Docker image
         run: docker pull mysql:latest
 

--- a/.github/workflows/spice_mysql_tpcds_bench_docker.yml
+++ b/.github/workflows/spice_mysql_tpcds_bench_docker.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Pull MySQL Docker image
         run: docker pull mysql:latest
 

--- a/.github/workflows/spice_postgres_bench_docker.yml
+++ b/.github/workflows/spice_postgres_bench_docker.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Pull Postgres Docker image
         run: docker pull postgres:latest
 

--- a/.github/workflows/spice_postgres_tpcds_bench_docker.yml
+++ b/.github/workflows/spice_postgres_tpcds_bench_docker.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Pull Postgres Docker image
         run: docker pull postgres:latest
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -220,6 +220,15 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: ${{ needs.setup.outputs.run_amd64 == 'true' }}
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so base image pulls (debian, etc.)
+        # use authenticated rate limits instead of anonymous (per-IP) limits.
+        if: ${{ needs.setup.outputs.run_amd64 == 'true' && github.repository == 'spiceai/spiceai' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: default
         run: |
           echo "IMAGE_TAG=default" >> $GITHUB_ENV
@@ -292,6 +301,15 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: ${{ needs.setup.outputs.run_arm64 == 'true' }}
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so base image pulls (debian, etc.)
+        # use authenticated rate limits instead of anonymous (per-IP) limits.
+        if: ${{ needs.setup.outputs.run_arm64 == 'true' && github.repository == 'spiceai/spiceai' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: default
         run: |
           echo "IMAGE_TAG=default" >> $GITHUB_ENV
@@ -344,6 +362,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so base image pulls (nvidia/cuda, etc.)
+        # use authenticated rate limits instead of anonymous (per-IP) limits.
+        if: ${{ needs.setup.outputs.run_cuda == 'true' && github.repository == 'spiceai/spiceai' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Configure CUDA build
         run: |
@@ -412,6 +439,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits when pulling
+        # registry:2 below.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start local registry
         run: |
@@ -518,6 +555,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits when pulling
+        # registry:2 below.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start local registry
         run: |

--- a/.github/workflows/spiced_docker_dev.yml
+++ b/.github/workflows/spiced_docker_dev.yml
@@ -114,6 +114,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so base image pulls (rust, debian, etc.)
+        # use authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set cargo features
         run: |
           variant="${{ inputs.variant }}"
@@ -173,6 +182,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so base image pulls (rust, debian, etc.)
+        # use authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set cargo features
         run: |
           variant="${{ inputs.variant }}"
@@ -224,6 +242,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before pulling so we use the authenticated
+        # rate limits instead of anonymous (per-IP) limits when pulling
+        # registry:2 below.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start local registry
         run: |

--- a/.github/workflows/spidapter_build_and_release.yml
+++ b/.github/workflows/spidapter_build_and_release.yml
@@ -75,6 +75,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so the base image pull
+        # uses the authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/testoperator_build_and_release.yml
+++ b/.github/workflows/testoperator_build_and_release.yml
@@ -75,6 +75,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Login to Docker Hub
+        # Authenticate to Docker Hub before building so the base image pull
+        # uses the authenticated rate limits instead of anonymous (per-IP) limits.
+        if: github.repository == 'spiceai/spiceai'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:


### PR DESCRIPTION
## Summary

Add a `Login to Docker Hub` step (using `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN`) to every workflow that pulls images from Docker Hub, so all pulls use the authenticated rate limits instead of anonymous (per-IP) limits.

Each new step is gated on `github.repository == 'spiceai/spiceai'` so it is a no-op on forks (which don't have access to the secrets).

## Changes

**Direct `docker pull` of Docker Hub images:**
- `spice_postgres_bench_docker.yml` — `postgres:latest`
- `spice_postgres_tpcds_bench_docker.yml` — `postgres:latest`
- `spice_mysql_bench_docker.yml` — `mysql:latest`
- `spice_mysql_tpcds_bench_docker.yml` — `mysql:latest`

**`docker run registry:2` (Docker Hub) before existing GHCR-only logins:**
- `spiced_docker.yml` — both `publish` and `publish-cuda` jobs
- `spiced_docker_dev.yml`
- `build_nightly.yml`

**`docker/build-push-action` jobs whose Dockerfiles `FROM` Docker Hub bases (`debian:trixie-slim`, `rust:...`, `ubuntu:24.04`, `nvidia/cuda:...`):**
- `spiced_docker.yml` — `build-amd64`, `build-arm64`, `build-cuda`
- `spiced_docker_dev.yml` — `build-amd64`, `build-arm64`
- `build_nightly.yml` — `build-docker-amd64`, `build-docker-arm64`
- `spidapter_build_and_release.yml`
- `testoperator_build_and_release.yml`

Workflows pulling only from non-Docker-Hub registries (`mcr.microsoft.com`, `docker.elastic.co`, `quay.io`, `ghcr.io`, `public.ecr.aws`) were left unchanged.

## Validation

All edited YAML files parse successfully via `ruby -ryaml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->