### PR TITLE
Strip high-cardinality datasets dim from anonymous telemetry; sort dataset names

### DIFF
--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -80,16 +80,17 @@ impl QueryTracker {
             tags.push("error");
         }
 
+        let mut dataset_names: Vec<String> =
+            self.datasets.iter().map(ToString::to_string).collect();
+        // Sort so that the same set of datasets always produces the same
+        // joined string. Without this, HashSet iteration order would cause
+        // identical workloads to land on multiple distinct telemetry series
+        // (e.g. "a,b" vs "b,a").
+        dataset_names.sort();
+
         let mut labels = vec![
             KeyValue::new("tags", tags.join(",")),
-            KeyValue::new(
-                "datasets",
-                self.datasets
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<String>>()
-                    .join(","),
-            ),
+            KeyValue::new("datasets", dataset_names.join(",")),
         ];
 
         labels.extend(request_context.to_dimensions());

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -106,7 +106,7 @@ static QUERY_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
 });
 
 pub fn track_query_duration(duration: Duration, dimensions: &[KeyValue]) {
-    telemetry::track_query_duration(duration, dimensions);
+    telemetry::track_query_duration(duration, &without_anonymous_excluded(dimensions));
     QUERY_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
 }
 
@@ -122,8 +122,26 @@ static QUERY_EXECUTION_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| 
 });
 
 pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue]) {
-    telemetry::track_query_execution_duration(duration, dimensions);
+    telemetry::track_query_execution_duration(duration, &without_anonymous_excluded(dimensions));
     QUERY_EXECUTION_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
+}
+
+/// Attribute keys that must never be exported via the spice.ai anonymous
+/// telemetry pipeline. They are kept on the runtime's own meter (so users
+/// who connect their own OTel/Prometheus stack still see them) but are
+/// stripped before forwarding to the anonymous exporter.
+///
+/// `datasets` is a comma-joined list of dataset names referenced by a
+/// query and is not needed for the aggregate latency shape that anonymous
+/// telemetry tracks.
+const ANONYMOUS_TELEMETRY_EXCLUDED_KEYS: &[&str] = &["datasets"];
+
+fn without_anonymous_excluded(dimensions: &[KeyValue]) -> Vec<KeyValue> {
+    dimensions
+        .iter()
+        .filter(|kv| !ANONYMOUS_TELEMETRY_EXCLUDED_KEYS.contains(&kv.key.as_str()))
+        .cloned()
+        .collect()
 }
 
 static AI_INFERENCES_WITH_SPICE_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary

Two small fixes to the `datasets` attribute on the `query_duration_ms` and `query_execution_duration_ms` metrics.

### 1. Sort dataset names before joining

`QueryTracker` builds a `datasets` label by iterating an `Arc<HashSet<TableReference>>` and joining the names with a comma. HashSet iteration order is non-deterministic, so the same set of datasets could produce `"a,b"` on one query and `"b,a"` on the next, which any downstream metrics backend treats as two distinct series.

Sorting the names before joining makes the label deterministic for a given set, so identical workloads land on the same series — which matters for anyone running their own OTel/Prometheus stack against the runtime.

### 2. Drop `datasets` from the anonymous telemetry path

The runtime currently records both metrics into two meters: the runtime's own meter (exported by user-configured exporters) and the spice.ai anonymous telemetry meter. The `datasets` dimension isn't useful for the aggregate latency shape that anonymous telemetry tracks, and it's per-deployment unbounded.

Strip `datasets` from the dimensions passed to `telemetry::track_query_duration` / `track_query_execution_duration`, while keeping the full set of dimensions on the runtime's own meter. The exclusion list is a small `const` so adding more keys later is a one-line change.

## Files changed

- `crates/runtime/src/datafusion/query/tracker.rs` — sort dataset names before joining.
- `crates/runtime/src/metrics/telemetry/mod.rs` — filter `datasets` out of the anonymous telemetry call for the two affected metrics.

## Verification

- `cargo build -p runtime` ✅
- `make lint-rust` ✅

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->