### PR TITLE
Fix NSQL sampling failure when column names are SQL reserved keywords

### DIFF
--- a/crates/runtime/src/tools/builtin/sample/distinct.rs
+++ b/crates/runtime/src/tools/builtin/sample/distinct.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow_schema::DataType;
-use datafusion::{common::utils::quote_identifier, sql::TableReference};
+use datafusion::sql::TableReference;
 use itertools::Itertools;
 use std::{
     fmt::{Display, Formatter},
@@ -23,7 +23,7 @@ use std::{
 };
 use tracing::Span;
 use tracing_futures::Instrument;
-use util::security::quote_table_reference;
+use util::security::{quote_column_identifier, quote_table_reference};
 
 use crate::datafusion::DataFusion;
 use arrow::compute::concat;
@@ -73,7 +73,7 @@ impl DistinctColumnsParams {
         // Ensure that we still get `n` rows when `len(distinct(col)) < n`, whilst
         // stilling getting all possible distinct values.
         let tbl_quoted = quote_table_reference(tbl);
-        let col = quote_identifier(column);
+        let col = quote_column_identifier(column);
         Self::_sample_col(
             Arc::clone(&df),
             &format!(
@@ -98,6 +98,7 @@ impl DistinctColumnsParams {
         n: usize,
     ) -> Result<ArrayRef, Box<dyn std::error::Error + Send + Sync>> {
         let tbl_quoted = quote_table_reference(tbl);
+        let col = quote_column_identifier(col);
         Self::_sample_col(
             Arc::clone(&df),
             &format!("SELECT {col} FROM {tbl_quoted} LIMIT {n}"),

--- a/crates/util/src/security.rs
+++ b/crates/util/src/security.rs
@@ -200,6 +200,21 @@ pub fn quote_table_reference(tbl: &TableReference) -> String {
     }
 }
 
+/// Unconditionally wraps a column name in double quotes, escaping any embedded
+/// double quotes per the SQL standard (by doubling them).
+///
+/// Unlike [`datafusion::common::utils::quote_identifier`], which quotes based on
+/// character-composition and valid-identifier checks (first character, allowed
+/// character set), this function **always** quotes. DataFusion's
+/// `quote_identifier` does not account for SQL reserved keywords (`INTERVAL`,
+/// `DATE`, `ORDER`, `GROUP`, `SELECT`, `TABLE`, `USER`, `TYPE`, `KEY`, `VALUE`,
+/// etc.). A column named `interval` passes its validity check unquoted, causing
+/// `sqlparser` to misparse it as the `INTERVAL` keyword.
+#[must_use = "quoted identifier must be used in SQL queries to prevent injection"]
+pub fn quote_column_identifier(column: &str) -> String {
+    format!("\"{}\"", column.replace('"', "\"\""))
+}
+
 /// Calculates the maximum nesting depth of a JSON value.
 ///
 /// This function is critical for preventing stack overflow attacks from maliciously


### PR DESCRIPTION
## 📝 Summary

Fixes HTTP 500 errors from `/v1/nsql` when a dataset contains columns named with SQL reserved keywords (e.g., `interval`, `date`, `order`, `type`, `value`).

Root cause: The distinct column sampling code in `sample_distinct_from_column` and `sample_from_column` used DataFusion's `quote_identifier()` to quote column names in internally-generated SQL. However, `quote_identifier()` only checks character composition (lowercase + digits + underscores) — it does not check for SQL reserved keywords. A column named `interval` passes its check unquoted, causing `sqlparser` to misparse it as the `INTERVAL` keyword:

```
ParserError("Expected: ), found: interval at Line: 2, Column: 24")
```

Fix: Add `quote_column_identifier()` to `util::security` that unconditionally double-quotes column identifiers (matching the approach already used by `quote_table_reference`). Update both `sample_distinct_from_column` and `sample_from_column` to use it.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->