### PR TITLE
Improve Elasticsearch refresh pagination

### DIFF
--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -273,6 +273,19 @@ impl ElasticsearchScanState {
     async fn fetch_next_point_in_time_batch(
         &mut self,
     ) -> Result<Option<RecordBatch>, DataFusionError> {
+        match self.fetch_next_point_in_time_batch_inner().await {
+            Ok(batch) => Ok(batch),
+            Err(err) => {
+                self.close_point_in_time_best_effort().await;
+                self.done = true;
+                Err(err)
+            }
+        }
+    }
+
+    async fn fetch_next_point_in_time_batch_inner(
+        &mut self,
+    ) -> Result<Option<RecordBatch>, DataFusionError> {
         let page_size = self.remaining.map_or(ELASTICSEARCH_PAGE_SIZE, |remaining| {
             remaining.min(ELASTICSEARCH_PAGE_SIZE)
         });
@@ -360,6 +373,10 @@ impl ElasticsearchScanState {
             .close_point_in_time(&pit_id)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))
+    }
+
+    async fn close_point_in_time_best_effort(&mut self) {
+        let _ = self.close_point_in_time().await;
     }
 
     fn hits_to_projected_batch(
@@ -661,9 +678,9 @@ mod tests {
         SearchResponse {
             pit_id: pit_id.map(ToString::to_string),
             hits: HitsEnvelope {
-                total: HitsTotal {
+                total: Some(HitsTotal {
                     value: u64::try_from(hits.len()).expect("hit count should fit in u64"),
-                },
+                }),
                 hits,
             },
         }
@@ -820,6 +837,15 @@ mod tests {
         client: Arc<dyn Elasticsearch>,
         limit: Option<usize>,
     ) -> Vec<RecordBatch> {
+        try_collect_query_table(client, limit)
+            .await
+            .expect("scan should collect successfully")
+    }
+
+    async fn try_collect_query_table(
+        client: Arc<dyn Elasticsearch>,
+        limit: Option<usize>,
+    ) -> datafusion::error::Result<Vec<RecordBatch>> {
         let table = ElasticsearchQueryTable::new(client, "test-index".to_string(), title_schema());
         let ctx = SessionContext::new();
         let plan = table
@@ -827,9 +853,7 @@ mod tests {
             .await
             .expect("scan should create an execution plan");
 
-        collect(plan, ctx.task_ctx())
-            .await
-            .expect("scan should collect successfully")
+        collect(plan, ctx.task_ctx()).await
     }
 
     #[tokio::test]
@@ -886,6 +910,21 @@ mod tests {
             .expect("single search requests mutex should not be poisoned");
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].size, Some(5));
+    }
+
+    #[tokio::test]
+    async fn query_table_scan_closes_point_in_time_on_error() {
+        let mock = Arc::new(MockElasticsearch::with_point_in_time_responses(Vec::new()));
+        let client: Arc<dyn Elasticsearch> = mock.clone();
+
+        let result = try_collect_query_table(client, None).await;
+        assert!(result.is_err(), "scan should fail when PIT search fails");
+
+        let closed = mock
+            .closed_point_in_times
+            .lock()
+            .expect("closed point-in-time mutex should not be poisoned");
+        assert_eq!(closed.as_slice(), ["pit-1"]);
     }
 
     // ── Timestamp ──────────────────────────────────────────────────────────────

--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -866,7 +866,7 @@ mod tests {
             search_response(first_page, Some("pit-2")),
             search_response(second_page, Some("pit-3")),
         ]));
-        let client: Arc<dyn Elasticsearch> = mock.clone();
+        let client: Arc<dyn Elasticsearch> = Arc::<MockElasticsearch>::clone(&mock);
 
         let batches = collect_query_table(client, None).await;
         let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -897,7 +897,7 @@ mod tests {
             (0..5).map(make_sorted_hit).collect(),
             None,
         )));
-        let client: Arc<dyn Elasticsearch> = mock.clone();
+        let client: Arc<dyn Elasticsearch> = Arc::<MockElasticsearch>::clone(&mock);
 
         let batches = collect_query_table(client, Some(5)).await;
         let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -915,7 +915,7 @@ mod tests {
     #[tokio::test]
     async fn query_table_scan_closes_point_in_time_on_error() {
         let mock = Arc::new(MockElasticsearch::with_point_in_time_responses(Vec::new()));
-        let client: Arc<dyn Elasticsearch> = mock.clone();
+        let client: Arc<dyn Elasticsearch> = Arc::<MockElasticsearch>::clone(&mock);
 
         let result = try_collect_query_table(client, None).await;
         assert!(result.is_err(), "scan should fail when PIT search fails");

--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -46,6 +46,9 @@ use datafusion::physical_plan::{
 use datafusion::prelude::Expr;
 use elasticsearch::{Elasticsearch, SearchRequest};
 
+const ELASTICSEARCH_PAGE_SIZE: usize = 10_000;
+const ELASTICSEARCH_PIT_KEEP_ALIVE: &str = "1m";
+
 /// A [`TableProvider`] backed by an Elasticsearch index.
 ///
 /// Each scan issues a `_search` request and streams the results as Arrow batches.
@@ -100,6 +103,12 @@ impl TableProvider for ElasticsearchQueryTable {
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         let projected_schema = project_schema(&self.schema, projection)?;
+        if limit == Some(0) {
+            return Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                projected_schema,
+            )));
+        }
+
         Ok(Arc::new(ElasticsearchQueryExec {
             client: Arc::clone(&self.client),
             index: self.index.clone(),
@@ -174,32 +183,195 @@ impl ExecutionPlan for ElasticsearchQueryExec {
         let projection = self.projection.clone();
         let limit = self.limit;
 
-        let stream = futures::stream::once(async move {
-            let size = limit.unwrap_or(10_000).min(10_000);
-            let req = SearchRequest {
-                query: Some(elasticsearch::match_all_query()),
-                size: Some(size),
-                ..Default::default()
-            };
-
-            let response = client
-                .search(&index, &req)
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-            let batch = hits_to_record_batch(&response.hits.hits, &full_schema)?;
-
-            if let Some(proj) = &projection {
-                Ok(batch.project(proj)?)
-            } else {
-                Ok(batch)
-            }
-        });
+        let stream = futures::stream::try_unfold(
+            ElasticsearchScanState::new(client, index, full_schema, projection, limit),
+            |mut state| async move {
+                state
+                    .next_batch()
+                    .await
+                    .map(|batch| batch.map(|batch| (batch, state)))
+            },
+        );
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             projected_schema,
             stream,
         )))
+    }
+}
+
+struct ElasticsearchScanState {
+    client: Arc<dyn Elasticsearch>,
+    index: String,
+    full_schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    remaining: Option<usize>,
+    pit_id: Option<String>,
+    search_after: Option<Vec<serde_json::Value>>,
+    use_point_in_time: bool,
+    done: bool,
+}
+
+impl ElasticsearchScanState {
+    fn new(
+        client: Arc<dyn Elasticsearch>,
+        index: String,
+        full_schema: SchemaRef,
+        projection: Option<Vec<usize>>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            client,
+            index,
+            full_schema,
+            projection,
+            remaining: limit,
+            pit_id: None,
+            search_after: None,
+            use_point_in_time: limit.is_none_or(|limit| limit > ELASTICSEARCH_PAGE_SIZE),
+            done: false,
+        }
+    }
+
+    async fn next_batch(&mut self) -> Result<Option<RecordBatch>, DataFusionError> {
+        if self.done {
+            return Ok(None);
+        }
+
+        if self.remaining == Some(0) {
+            self.close_point_in_time().await?;
+            self.done = true;
+            return Ok(None);
+        }
+
+        if self.use_point_in_time {
+            self.fetch_next_point_in_time_batch().await
+        } else {
+            self.fetch_single_batch().await
+        }
+    }
+
+    async fn fetch_single_batch(&mut self) -> Result<Option<RecordBatch>, DataFusionError> {
+        let size = self.remaining.unwrap_or(ELASTICSEARCH_PAGE_SIZE);
+        let req = SearchRequest {
+            query: Some(elasticsearch::match_all_query()),
+            size: Some(size),
+            ..Default::default()
+        };
+
+        let response = self
+            .client
+            .search(&self.index, &req)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        self.remaining = Some(0);
+        self.done = true;
+
+        self.hits_to_projected_batch(&response.hits.hits).map(Some)
+    }
+
+    async fn fetch_next_point_in_time_batch(
+        &mut self,
+    ) -> Result<Option<RecordBatch>, DataFusionError> {
+        let page_size = self.remaining.map_or(ELASTICSEARCH_PAGE_SIZE, |remaining| {
+            remaining.min(ELASTICSEARCH_PAGE_SIZE)
+        });
+
+        let pit_id = self.open_point_in_time().await?;
+        let mut req = serde_json::json!({
+            "query": elasticsearch::match_all_query(),
+            "pit": {
+                "id": pit_id,
+                "keep_alive": ELASTICSEARCH_PIT_KEEP_ALIVE,
+            },
+            "size": page_size,
+            "sort": [{ "_shard_doc": "asc" }],
+            "track_total_hits": false,
+        });
+
+        if let Some(search_after) = &self.search_after {
+            req["search_after"] = serde_json::Value::Array(search_after.clone());
+        }
+
+        let response = self
+            .client
+            .search_point_in_time(&req)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        if let Some(pit_id) = response.pit_id.as_ref() {
+            self.pit_id = Some(pit_id.clone());
+        }
+
+        let hits = response.hits.hits;
+        if hits.is_empty() {
+            self.close_point_in_time().await?;
+            self.done = true;
+            return Ok(None);
+        }
+
+        let hits_len = hits.len();
+        let batch = self.hits_to_projected_batch(&hits)?;
+
+        if let Some(remaining) = self.remaining.as_mut() {
+            *remaining = remaining.saturating_sub(hits_len);
+        }
+
+        let exhausted = hits_len < page_size || self.remaining == Some(0);
+        if exhausted {
+            self.close_point_in_time().await?;
+            self.done = true;
+        } else {
+            let sort = hits
+                .last()
+                .and_then(|hit| hit.sort.as_ref())
+                .cloned()
+                .ok_or_else(|| {
+                    DataFusionError::Execution(String::from(
+                        "Elasticsearch point-in-time scan did not return hit sort values for search_after pagination",
+                    ))
+                })?;
+            self.search_after = Some(sort);
+        }
+
+        Ok(Some(batch))
+    }
+
+    async fn open_point_in_time(&mut self) -> Result<String, DataFusionError> {
+        if let Some(pit_id) = &self.pit_id {
+            return Ok(pit_id.clone());
+        }
+
+        let pit_id = self
+            .client
+            .open_point_in_time(&self.index, ELASTICSEARCH_PIT_KEEP_ALIVE)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        self.pit_id = Some(pit_id.clone());
+        Ok(pit_id)
+    }
+
+    async fn close_point_in_time(&mut self) -> Result<(), DataFusionError> {
+        let Some(pit_id) = self.pit_id.take() else {
+            return Ok(());
+        };
+
+        self.client
+            .close_point_in_time(&pit_id)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))
+    }
+
+    fn hits_to_projected_batch(
+        &self,
+        hits: &[elasticsearch::Hit],
+    ) -> Result<RecordBatch, DataFusionError> {
+        let batch = hits_to_record_batch(hits, &self.full_schema)?;
+        if let Some(proj) = &self.projection {
+            Ok(batch.project(proj)?)
+        } else {
+            Ok(batch)
+        }
     }
 }
 
@@ -459,15 +631,261 @@ mod tests {
         Array, LargeStringArray, ListArray, StringArray, TimestampMicrosecondArray,
     };
     use arrow::datatypes::{Field, Schema, TimeUnit};
-    use elasticsearch::Hit;
+    use datafusion::physical_plan::collect;
+    use datafusion::prelude::SessionContext;
+    use elasticsearch::{Hit, HitsEnvelope, HitsTotal, MappingResponse, SearchResponse};
     use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn make_hit(source: serde_json::Value) -> Hit {
         Hit {
             id: "id".to_string(),
             score: Some(1.0),
+            sort: None,
             source,
         }
+    }
+
+    fn make_sorted_hit(id: usize) -> Hit {
+        Hit {
+            id: id.to_string(),
+            score: Some(1.0),
+            sort: Some(vec![json!(id)]),
+            source: json!({ "title": format!("title-{id}") }),
+        }
+    }
+
+    fn search_response(hits: Vec<Hit>, pit_id: Option<&str>) -> SearchResponse {
+        SearchResponse {
+            pit_id: pit_id.map(ToString::to_string),
+            hits: HitsEnvelope {
+                total: HitsTotal {
+                    value: u64::try_from(hits.len()).expect("hit count should fit in u64"),
+                },
+                hits,
+            },
+        }
+    }
+
+    fn title_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("title", DataType::Utf8, true)]))
+    }
+
+    fn unexpected_call_error(method: &str) -> elasticsearch::Error {
+        elasticsearch::Error::ElasticsearchError {
+            status: 500,
+            message: format!("unexpected call to {method}"),
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockElasticsearch {
+        single_search_response: Mutex<Option<SearchResponse>>,
+        single_search_requests: Mutex<Vec<SearchRequest>>,
+        point_in_time_responses: Mutex<VecDeque<SearchResponse>>,
+        point_in_time_requests: Mutex<Vec<serde_json::Value>>,
+        opened_point_in_times: AtomicUsize,
+        closed_point_in_times: Mutex<Vec<String>>,
+    }
+
+    impl MockElasticsearch {
+        fn with_single_response(response: SearchResponse) -> Self {
+            Self {
+                single_search_response: Mutex::new(Some(response)),
+                single_search_requests: Mutex::new(Vec::new()),
+                point_in_time_responses: Mutex::new(VecDeque::new()),
+                point_in_time_requests: Mutex::new(Vec::new()),
+                opened_point_in_times: AtomicUsize::new(0),
+                closed_point_in_times: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_point_in_time_responses(responses: Vec<SearchResponse>) -> Self {
+            Self {
+                single_search_response: Mutex::new(None),
+                single_search_requests: Mutex::new(Vec::new()),
+                point_in_time_responses: Mutex::new(VecDeque::from(responses)),
+                point_in_time_requests: Mutex::new(Vec::new()),
+                opened_point_in_times: AtomicUsize::new(0),
+                closed_point_in_times: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Elasticsearch for MockElasticsearch {
+        async fn get_mapping(&self, _index: &str) -> elasticsearch::Result<MappingResponse> {
+            Err(unexpected_call_error("get_mapping"))
+        }
+
+        async fn search(
+            &self,
+            _index: &str,
+            body: &SearchRequest,
+        ) -> elasticsearch::Result<SearchResponse> {
+            self.single_search_requests
+                .lock()
+                .expect("single search requests mutex should not be poisoned")
+                .push(body.clone());
+
+            self.single_search_response
+                .lock()
+                .expect("single search response mutex should not be poisoned")
+                .take()
+                .ok_or_else(|| unexpected_call_error("search"))
+        }
+
+        async fn search_raw(
+            &self,
+            _index: &str,
+            _body: &serde_json::Value,
+        ) -> elasticsearch::Result<SearchResponse> {
+            Err(unexpected_call_error("search_raw"))
+        }
+
+        async fn open_point_in_time(
+            &self,
+            _index: &str,
+            _keep_alive: &str,
+        ) -> elasticsearch::Result<String> {
+            let next_id = self.opened_point_in_times.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(format!("pit-{next_id}"))
+        }
+
+        async fn search_point_in_time(
+            &self,
+            body: &serde_json::Value,
+        ) -> elasticsearch::Result<SearchResponse> {
+            self.point_in_time_requests
+                .lock()
+                .expect("point-in-time requests mutex should not be poisoned")
+                .push(body.clone());
+
+            self.point_in_time_responses
+                .lock()
+                .expect("point-in-time responses mutex should not be poisoned")
+                .pop_front()
+                .ok_or_else(|| unexpected_call_error("search_point_in_time"))
+        }
+
+        async fn close_point_in_time(&self, pit_id: &str) -> elasticsearch::Result<()> {
+            self.closed_point_in_times
+                .lock()
+                .expect("closed point-in-time mutex should not be poisoned")
+                .push(pit_id.to_string());
+            Ok(())
+        }
+
+        async fn index_exists(&self, _index: &str) -> elasticsearch::Result<bool> {
+            Err(unexpected_call_error("index_exists"))
+        }
+
+        async fn create_index(
+            &self,
+            _index: &str,
+            _body: &serde_json::Value,
+        ) -> elasticsearch::Result<serde_json::Value> {
+            Err(unexpected_call_error("create_index"))
+        }
+
+        async fn put_mapping(
+            &self,
+            _index: &str,
+            _body: &serde_json::Value,
+        ) -> elasticsearch::Result<serde_json::Value> {
+            Err(unexpected_call_error("put_mapping"))
+        }
+
+        async fn index_document(
+            &self,
+            _index: &str,
+            _id: &str,
+            _doc: &serde_json::Value,
+        ) -> elasticsearch::Result<serde_json::Value> {
+            Err(unexpected_call_error("index_document"))
+        }
+
+        async fn bulk_index(
+            &self,
+            _index: &str,
+            _docs: &[(Option<String>, serde_json::Value)],
+        ) -> elasticsearch::Result<serde_json::Value> {
+            Err(unexpected_call_error("bulk_index"))
+        }
+    }
+
+    async fn collect_query_table(
+        client: Arc<dyn Elasticsearch>,
+        limit: Option<usize>,
+    ) -> Vec<RecordBatch> {
+        let table = ElasticsearchQueryTable::new(client, "test-index".to_string(), title_schema());
+        let ctx = SessionContext::new();
+        let plan = table
+            .scan(&ctx.state(), None, &[], limit)
+            .await
+            .expect("scan should create an execution plan");
+
+        collect(plan, ctx.task_ctx())
+            .await
+            .expect("scan should collect successfully")
+    }
+
+    #[tokio::test]
+    async fn query_table_scan_paginates_with_point_in_time() {
+        let first_page = (0..ELASTICSEARCH_PAGE_SIZE)
+            .map(make_sorted_hit)
+            .collect::<Vec<_>>();
+        let second_page = vec![make_sorted_hit(ELASTICSEARCH_PAGE_SIZE)];
+        let mock = Arc::new(MockElasticsearch::with_point_in_time_responses(vec![
+            search_response(first_page, Some("pit-2")),
+            search_response(second_page, Some("pit-3")),
+        ]));
+        let client: Arc<dyn Elasticsearch> = mock.clone();
+
+        let batches = collect_query_table(client, None).await;
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, ELASTICSEARCH_PAGE_SIZE + 1);
+
+        let requests = mock
+            .point_in_time_requests
+            .lock()
+            .expect("point-in-time requests mutex should not be poisoned");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["pit"]["id"], "pit-1");
+        assert_eq!(requests[1]["pit"]["id"], "pit-2");
+        assert_eq!(
+            requests[1]["search_after"],
+            json!([ELASTICSEARCH_PAGE_SIZE - 1])
+        );
+
+        let closed = mock
+            .closed_point_in_times
+            .lock()
+            .expect("closed point-in-time mutex should not be poisoned");
+        assert_eq!(closed.as_slice(), ["pit-3"]);
+    }
+
+    #[tokio::test]
+    async fn query_table_scan_respects_limit_without_point_in_time() {
+        let mock = Arc::new(MockElasticsearch::with_single_response(search_response(
+            (0..5).map(make_sorted_hit).collect(),
+            None,
+        )));
+        let client: Arc<dyn Elasticsearch> = mock.clone();
+
+        let batches = collect_query_table(client, Some(5)).await;
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, 5);
+
+        assert_eq!(mock.opened_point_in_times.load(Ordering::SeqCst), 0);
+        let requests = mock
+            .single_search_requests
+            .lock()
+            .expect("single search requests mutex should not be poisoned");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].size, Some(5));
     }
 
     // ── Timestamp ──────────────────────────────────────────────────────────────

--- a/crates/elasticsearch/src/lib.rs
+++ b/crates/elasticsearch/src/lib.rs
@@ -123,17 +123,21 @@ pub struct KnnQuery {
 /// Top-level search response.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SearchResponse {
+    #[serde(default)]
+    pub pit_id: Option<String>,
     pub hits: HitsEnvelope,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct HitsEnvelope {
+    #[serde(default)]
     pub total: HitsTotal,
     pub hits: Vec<Hit>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct HitsTotal {
+    #[serde(default)]
     pub value: u64,
 }
 
@@ -143,8 +147,15 @@ pub struct Hit {
     pub id: String,
     #[serde(default, rename = "_score")]
     pub score: Option<f64>,
+    #[serde(default)]
+    pub sort: Option<Vec<serde_json::Value>>,
     #[serde(default, rename = "_source")]
     pub source: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenPointInTimeResponse {
+    id: String,
 }
 
 // ── Client ─────────────────────────────────────────────────────────────────
@@ -322,6 +333,46 @@ impl Client {
         resp.json().await.context(JsonParseSnafu)
     }
 
+    /// Open an Elasticsearch point-in-time reader for `index`.
+    pub async fn open_point_in_time(&self, index: &str, keep_alive: &str) -> Result<String> {
+        let url = format!("{}/{index}/_pit", self.base_url);
+        let resp = self
+            .auth(self.http.post(&url))
+            .query(&[("keep_alive", keep_alive)])
+            .send()
+            .await
+            .context(HttpRequestSnafu)?;
+        let resp = check_status(resp).await?;
+        let body: OpenPointInTimeResponse = resp.json().await.context(JsonParseSnafu)?;
+        Ok(body.id)
+    }
+
+    /// Execute a raw JSON search using a point-in-time reader.
+    pub async fn search_point_in_time(&self, body: &serde_json::Value) -> Result<SearchResponse> {
+        let url = format!("{}/_search", self.base_url);
+        let resp = self
+            .auth(self.http.post(&url))
+            .json(body)
+            .send()
+            .await
+            .context(HttpRequestSnafu)?;
+        let resp = check_status(resp).await?;
+        resp.json().await.context(JsonParseSnafu)
+    }
+
+    /// Close an Elasticsearch point-in-time reader.
+    pub async fn close_point_in_time(&self, pit_id: &str) -> Result<()> {
+        let url = format!("{}/_pit", self.base_url);
+        let resp = self
+            .auth(self.http.delete(&url))
+            .json(&serde_json::json!({ "id": pit_id }))
+            .send()
+            .await
+            .context(HttpRequestSnafu)?;
+        check_status(resp).await?;
+        Ok(())
+    }
+
     // ── Index Management ───────────────────────────────────────────────
 
     /// Check whether an index exists via `HEAD /<index>`.
@@ -497,6 +548,9 @@ pub trait Elasticsearch: std::fmt::Debug + Send + Sync {
     async fn get_mapping(&self, index: &str) -> Result<MappingResponse>;
     async fn search(&self, index: &str, body: &SearchRequest) -> Result<SearchResponse>;
     async fn search_raw(&self, index: &str, body: &serde_json::Value) -> Result<SearchResponse>;
+    async fn open_point_in_time(&self, index: &str, keep_alive: &str) -> Result<String>;
+    async fn search_point_in_time(&self, body: &serde_json::Value) -> Result<SearchResponse>;
+    async fn close_point_in_time(&self, pit_id: &str) -> Result<()>;
     async fn index_exists(&self, index: &str) -> Result<bool>;
     async fn create_index(
         &self,
@@ -530,6 +584,18 @@ impl Elasticsearch for Client {
 
     async fn search_raw(&self, index: &str, body: &serde_json::Value) -> Result<SearchResponse> {
         self.search_raw(index, body).await
+    }
+
+    async fn open_point_in_time(&self, index: &str, keep_alive: &str) -> Result<String> {
+        self.open_point_in_time(index, keep_alive).await
+    }
+
+    async fn search_point_in_time(&self, body: &serde_json::Value) -> Result<SearchResponse> {
+        self.search_point_in_time(body).await
+    }
+
+    async fn close_point_in_time(&self, pit_id: &str) -> Result<()> {
+        self.close_point_in_time(pit_id).await
     }
 
     async fn index_exists(&self, index: &str) -> Result<bool> {

--- a/crates/elasticsearch/src/lib.rs
+++ b/crates/elasticsearch/src/lib.rs
@@ -131,13 +131,12 @@ pub struct SearchResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct HitsEnvelope {
     #[serde(default)]
-    pub total: HitsTotal,
+    pub total: Option<HitsTotal>,
     pub hits: Vec<Hit>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct HitsTotal {
-    #[serde(default)]
     pub value: u64,
 }
 
@@ -587,15 +586,15 @@ impl Elasticsearch for Client {
     }
 
     async fn open_point_in_time(&self, index: &str, keep_alive: &str) -> Result<String> {
-        self.open_point_in_time(index, keep_alive).await
+        Client::open_point_in_time(self, index, keep_alive).await
     }
 
     async fn search_point_in_time(&self, body: &serde_json::Value) -> Result<SearchResponse> {
-        self.search_point_in_time(body).await
+        Client::search_point_in_time(self, body).await
     }
 
     async fn close_point_in_time(&self, pit_id: &str) -> Result<()> {
-        self.close_point_in_time(pit_id).await
+        Client::close_point_in_time(self, pit_id).await
     }
 
     async fn index_exists(&self, index: &str) -> Result<bool> {

--- a/crates/elasticsearch/tests/integration_test.rs
+++ b/crates/elasticsearch/tests/integration_test.rs
@@ -178,7 +178,14 @@ async fn test_search_match_all() {
         ..Default::default()
     };
     let resp = client.search(index, &req).await.expect("search");
-    assert_eq!(resp.hits.total.value, 3);
+    assert_eq!(
+        resp.hits
+            .total
+            .as_ref()
+            .expect("search response should include total hits")
+            .value,
+        3
+    );
     assert_eq!(resp.hits.hits.len(), 3);
 }
 
@@ -266,7 +273,14 @@ async fn test_index_document_and_retrieve() {
         ..Default::default()
     };
     let resp = client.search(index, &req).await.expect("search");
-    assert_eq!(resp.hits.total.value, 1);
+    assert_eq!(
+        resp.hits
+            .total
+            .as_ref()
+            .expect("search response should include total hits")
+            .value,
+        1
+    );
     assert_eq!(resp.hits.hits[0].id, "test_1");
 }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -571,11 +571,7 @@ impl DataAccelerator for DuckDBAccelerator {
                 }
             }
 
-            if config.is_empty() {
-                None
-            } else {
-                Some(make_on_refresh_write_handler(dataset_name, config))
-            }
+            Some(make_on_refresh_write_handler(dataset_name, config))
         });
 
         Ok(create_table_provider(&self.duckdb_factory, &cmd, write_completion_handler).await?)
@@ -792,10 +788,6 @@ impl OnRefreshConfig {
         self.sort_columns = columns;
         self
     }
-
-    fn is_empty(&self) -> bool {
-        self.retention_delete.is_none() && self.sort_columns.is_empty()
-    }
 }
 
 fn make_on_refresh_write_handler(
@@ -894,6 +886,12 @@ fn make_on_refresh_write_handler(
                 "On-refresh sort applied before commit"
             );
         }
+
+        table_manager.create_indexes(tx).map_err(|err| {
+            DataFusionError::Execution(format!(
+                "Failed to create DuckDB indexes for dataset {dataset_name} (table {internal_table_name}) before refresh commit: {err}"
+            ))
+        })?;
 
         Ok(())
     })
@@ -1015,6 +1013,107 @@ mod tests {
         }
 
         assert_eq!(values, vec![5, 7]);
+    }
+
+    #[tokio::test]
+    async fn overwrite_index_failure_keeps_previous_duckdb_view() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+        let df_schema = ToDFSchema::to_dfschema_ref(Arc::clone(&schema))
+            .expect("to convert Arrow schema to DataFusion schema");
+
+        let mut options = HashMap::new();
+        options.insert("indexes".to_string(), "value:unique".to_string());
+
+        let external_table = CreateExternalTable {
+            schema: df_schema,
+            name: TableReference::bare("indexed_overwrite_table"),
+            location: String::new(),
+            file_type: String::new(),
+            table_partition_cols: vec![],
+            if_not_exists: true,
+            or_replace: false,
+            definition: None,
+            order_exprs: vec![],
+            unbounded: false,
+            options,
+            constraints: Constraints::new_unverified(vec![]),
+            column_defaults: HashMap::default(),
+            temporary: false,
+        };
+
+        let duckdb_accelerator = DuckDBAccelerator::new();
+        let handler = super::make_on_refresh_write_handler(
+            "indexed_overwrite_dataset".to_string(),
+            super::OnRefreshConfig::empty(),
+        );
+
+        let table = super::create_table_provider(
+            &duckdb_accelerator.duckdb_factory,
+            &external_table,
+            Some(handler),
+        )
+        .await
+        .expect("table should be created");
+
+        let write_ctx = SessionContext::new();
+        let initial_input = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1, 2]))],
+        )
+        .expect("to create initial RecordBatch");
+        let initial_exec = Arc::new(MockExec::new(vec![Ok(initial_input)], Arc::clone(&schema)));
+        let initial_insert = table
+            .insert_into(&write_ctx.state(), initial_exec, InsertOp::Overwrite)
+            .await
+            .expect("to create initial insert plan");
+        collect(initial_insert, write_ctx.task_ctx())
+            .await
+            .expect("initial overwrite should succeed");
+
+        let duplicate_input = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![3, 3]))],
+        )
+        .expect("to create duplicate RecordBatch");
+        let duplicate_exec = Arc::new(MockExec::new(
+            vec![Ok(duplicate_input)],
+            Arc::clone(&schema),
+        ));
+        let duplicate_insert = table
+            .insert_into(&write_ctx.state(), duplicate_exec, InsertOp::Overwrite)
+            .await
+            .expect("to create duplicate insert plan");
+        let duplicate_result = collect(duplicate_insert, write_ctx.task_ctx()).await;
+        assert!(
+            duplicate_result.is_err(),
+            "duplicate unique-index overwrite should fail"
+        );
+
+        let read_ctx = SessionContext::new();
+        let scan_plan = table
+            .scan(&read_ctx.state(), None, &[], None)
+            .await
+            .expect("to create scan plan");
+        let batches = collect(scan_plan, read_ctx.task_ctx())
+            .await
+            .expect("to execute scan");
+
+        let mut values = Vec::new();
+        for batch in &batches {
+            let column = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("to downcast column to Int64Array");
+            values.extend((0..column.len()).map(|idx| column.value(idx)));
+        }
+        values.sort_unstable();
+
+        assert_eq!(values, vec![1, 2]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add Elasticsearch point-in-time + search_after pagination for query-table scans that need more than 10k rows.
- Preserve the single-search path for small limited scans and handle PIT response details such as rotated PIT IDs and omitted total hits.
- Create configured DuckDB indexes inside the refresh write transaction before commit so failed index creation keeps the previous view visible.

## Tests
- `cargo fmt --manifest-path /Users/lukim/dev/spiceai/Cargo.toml --all --check`
- `git -C /Users/lukim/dev/spiceai diff --check`
- `env -u RUSTC_WRAPPER cargo test --manifest-path /Users/lukim/dev/spiceai/Cargo.toml -p elasticsearch --lib`
- `env -u RUSTC_WRAPPER cargo test --manifest-path /Users/lukim/dev/spiceai/Cargo.toml -p data_components --features elasticsearch --lib query_table_scan`
- `env -u RUSTC_WRAPPER cargo test -p runtime --features duckdb --lib overwrite_index_failure_keeps_previous_duckdb_view`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->