### PR TITLE
Support Responses API across model providers

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -6985,9 +6985,13 @@
           ]
         },
         "responses_api": {
-          "description": "Whether to enable use of this model via the Responses API. `disabled` by default.",
+          "description": "Whether to use the Responses API backend when serving `/v1/chat/completions` for this model. `disabled` proxies to backend `/v1/chat/completions`; `enabled` proxies to backend `/v1/responses`.",
           "type": "string",
-          "default": "disabled"
+          "default": "disabled",
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
         },
         "openai_responses_tools": {
           "description": "The OpenAI Responses tools to use when calling the model from the Responses API",
@@ -7211,9 +7215,13 @@
           "default": ""
         },
         "responses_api": {
-          "description": "Whether to enable use of this model via the Responses API. `disabled` by default.",
+          "description": "Whether to use the Responses API backend when serving `/v1/chat/completions` for this model. `disabled` proxies to backend `/v1/chat/completions`; `enabled` proxies to backend `/v1/responses`.",
           "type": "string",
-          "default": "disabled"
+          "default": "disabled",
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
         },
         "tools": {
           "description": "Which tools should be made available to the model. Set to 'auto' to use all available tools.",

--- a/crates/llms/src/openai/chat.rs
+++ b/crates/llms/src/openai/chat.rs
@@ -29,7 +29,7 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use tracing_futures::Instrument;
 
-use super::Openai;
+use super::{ChatBackend, Openai, responses_adapter};
 
 #[async_trait]
 impl<C: Config + Send + Sync + Clone> Chat for Openai<C> {
@@ -46,6 +46,10 @@ impl<C: Config + Send + Sync + Clone> Chat for Openai<C> {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        if self.chat_backend == ChatBackend::Responses {
+            return self.chat_completions_stream_using_responses_api(req).await;
+        }
+
         let outer_model = req.model.clone();
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
@@ -109,6 +113,10 @@ impl<C: Config + Send + Sync + Clone> Chat for Openai<C> {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
+        if self.chat_backend == ChatBackend::Responses {
+            return self.chat_completions_request_using_responses_api(req).await;
+        }
+
         let outer_model = req.model.clone();
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
@@ -125,5 +133,49 @@ impl<C: Config + Send + Sync + Clone> Chat for Openai<C> {
 
         resp.model = outer_model;
         Ok(resp)
+    }
+}
+
+impl<C: Config + Send + Sync + Clone> Openai<C> {
+    async fn chat_completions_stream_using_responses_api(
+        &self,
+        req: CreateChatCompletionRequest,
+    ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let outer_model = req.model.clone();
+        let inner_req =
+            responses_adapter::responses_request_from_chat_completion_request(req, &self.model)?;
+
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
+        let stream = self.client.responses().create_stream(inner_req).await?;
+
+        drop(permit);
+
+        Ok(responses_adapter::chat_completion_stream_from_response_stream(stream, outer_model))
+    }
+
+    async fn chat_completions_request_using_responses_api(
+        &self,
+        req: CreateChatCompletionRequest,
+    ) -> Result<CreateChatCompletionResponse, OpenAIError> {
+        let outer_model = req.model.clone();
+        let inner_req =
+            responses_adapter::responses_request_from_chat_completion_request(req, &self.model)?;
+
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
+        let response = self.client.responses().create(inner_req).await?;
+
+        drop(permit);
+
+        responses_adapter::chat_completion_response_from_response(response, outer_model)
     }
 }

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -28,6 +28,7 @@ pub mod chat;
 pub mod embed;
 pub mod list_models;
 pub mod responses;
+mod responses_adapter;
 
 pub use list_models::OpenAiModelLister;
 
@@ -38,6 +39,13 @@ pub(crate) const TEXT_EMBED_3_SMALL: &str = "text-embedding-3-small";
 
 pub const DEFAULT_LLM_MODEL: &str = GPT_4O_MINI;
 pub const DEFAULT_EMBEDDING_MODEL: &str = TEXT_EMBED_3_SMALL;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ChatBackend {
+    #[default]
+    ChatCompletions,
+    Responses,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UsageTier {
@@ -101,6 +109,7 @@ pub struct Openai<C: Config + Clone> {
     model: String,
 
     rate_controller: Arc<RateController>,
+    chat_backend: ChatBackend,
 }
 
 pub(crate) fn default_rate_controller() -> Arc<RateController> {
@@ -124,6 +133,27 @@ pub fn new_azure_client(
     entra_token: Option<&str>,
     api_key: Option<&str>,
 ) -> Openai<AzureConfig> {
+    new_azure_client_with_chat_backend(
+        model,
+        api_base,
+        api_version,
+        deployment_name,
+        entra_token,
+        api_key,
+        ChatBackend::ChatCompletions,
+    )
+}
+
+#[must_use]
+pub fn new_azure_client_with_chat_backend(
+    model: String,
+    api_base: Option<&str>,
+    api_version: Option<&str>,
+    deployment_name: Option<&str>,
+    entra_token: Option<&str>,
+    api_key: Option<&str>,
+    chat_backend: ChatBackend,
+) -> Openai<AzureConfig> {
     let mut cfg = AzureConfig::new().with_deployment_id(deployment_name.unwrap_or(model.as_str()));
 
     if let Some(api_base) = api_base {
@@ -146,6 +176,7 @@ pub fn new_azure_client(
         client: Client::with_config(cfg),
         model,
         rate_controller: default_rate_controller(),
+        chat_backend,
     }
 }
 
@@ -157,6 +188,27 @@ pub fn new_openai_client(
     org_id: Option<&str>,
     project_id: Option<&str>,
     usage_tier: Option<UsageTier>,
+) -> Openai<OpenAIConfig> {
+    new_openai_client_with_chat_backend(
+        model,
+        api_base,
+        api_key,
+        org_id,
+        project_id,
+        usage_tier,
+        ChatBackend::ChatCompletions,
+    )
+}
+
+#[must_use]
+pub fn new_openai_client_with_chat_backend(
+    model: String,
+    api_base: Option<&str>,
+    api_key: Option<&str>,
+    org_id: Option<&str>,
+    project_id: Option<&str>,
+    usage_tier: Option<UsageTier>,
+    chat_backend: ChatBackend,
 ) -> Openai<OpenAIConfig> {
     // Default to empty API key to avoid picking up ENV variable in downstream library.
     let mut cfg = OpenAIConfig::new().with_api_key("");
@@ -180,6 +232,7 @@ pub fn new_openai_client(
         client: Client::with_config(cfg),
         model,
         rate_controller: usage_tier.map_or_else(default_rate_controller, Into::into),
+        chat_backend,
     }
 }
 
@@ -192,6 +245,7 @@ pub fn new_openai_client_with_config<C: async_openai::config::Config + Clone>(
         client: Client::with_config(cfg),
         model,
         rate_controller: default_rate_controller(),
+        chat_backend: ChatBackend::ChatCompletions,
     }
 }
 

--- a/crates/llms/src/openai/responses_adapter.rs
+++ b/crates/llms/src/openai/responses_adapter.rs
@@ -78,7 +78,12 @@ pub(super) fn responses_request_from_chat_completion_request(
                 effort: Some(effort),
                 summary: None,
             }),
-        metadata: req.metadata.take().map(metadata_to_hash_map).transpose()?,
+        metadata: req
+            .metadata
+            .take()
+            .as_ref()
+            .map(metadata_to_hash_map)
+            .transpose()?,
         parallel_tool_calls: req.parallel_tool_calls,
         prompt_cache_key: req.prompt_cache_key.take().or(req.user.take()),
         safety_identifier: req.safety_identifier.take(),
@@ -142,7 +147,10 @@ pub(super) fn chat_completion_response_from_response(
             .transpose()?,
         system_fingerprint: None,
         object: "chat.completion".to_string(),
-        usage: response.usage.map(completion_usage_from_response_usage),
+        usage: response
+            .usage
+            .as_ref()
+            .map(completion_usage_from_response_usage),
     })
 }
 
@@ -259,16 +267,16 @@ fn input_item_from_chat_tool_call(
         }
         ChatCompletionMessageToolCalls::Custom(custom_call) => {
             Ok(InputItem::Item(Item::CustomToolCall(custom_tool_call(
-                custom_call.id.clone(),
-                custom_call.custom_tool.input,
-                custom_call.custom_tool.name,
-                custom_call.id,
+                &custom_call.id,
+                &custom_call.custom_tool.input,
+                &custom_call.custom_tool.name,
+                &custom_call.id,
             )?)))
         }
     }
 }
 
-fn metadata_to_hash_map(metadata: Metadata) -> Result<HashMap<String, String>, OpenAIError> {
+fn metadata_to_hash_map(metadata: &Metadata) -> Result<HashMap<String, String>, OpenAIError> {
     let Some(object) = metadata.as_value().as_object() else {
         return Err(OpenAIError::InvalidArgument(
             "Chat Completions metadata must be a JSON object when proxying to the Responses API"
@@ -283,18 +291,17 @@ fn metadata_to_hash_map(metadata: Metadata) -> Result<HashMap<String, String>, O
                 key.clone(),
                 value
                     .as_str()
-                    .map(ToString::to_string)
-                    .unwrap_or_else(|| value.to_string()),
+                    .map_or_else(|| value.to_string(), ToString::to_string),
             )
         })
         .collect())
 }
 
 fn custom_tool_call(
-    call_id: String,
-    input: String,
-    name: String,
-    id: String,
+    call_id: &str,
+    input: &str,
+    name: &str,
+    id: &str,
 ) -> Result<CustomToolCall, OpenAIError> {
     serde_json::from_value(serde_json::json!({
         "type": "custom_tool_call",
@@ -487,7 +494,7 @@ fn response_tool_choice_from_chat_tool_choice(
                         .map(move |tool| (allowed.mode.clone(), tool))
                 })
                 .map(|(mode, tool)| {
-                    let chat_tool = serde_json::from_value::<ChatCompletionTools>(tool.clone())
+                    let chat_tool = serde_json::from_value::<ChatCompletionTools>(tool)
                         .map_err(|e| invalid_conversion("allowed tool", e))?;
                     let response_tool = response_tool_from_chat_tool(chat_tool)?;
                     let tool_value = serde_json::to_value(response_tool)
@@ -498,8 +505,7 @@ fn response_tool_choice_from_chat_tool_choice(
 
             let mode = tools
                 .first()
-                .map(|(mode, _)| mode.clone())
-                .unwrap_or(ChatToolChoiceAllowedMode::Auto);
+                .map_or(ChatToolChoiceAllowedMode::Auto, |(mode, _)| mode.clone());
 
             Ok(ResponsesToolChoiceParam::AllowedTools(
                 ResponsesToolChoiceAllowed {
@@ -718,7 +724,10 @@ fn chat_completion_stream_event_from_response_event(
                     response.id,
                     model,
                     vec![],
-                    response.usage.map(completion_usage_from_response_usage),
+                    response
+                        .usage
+                        .as_ref()
+                        .map(completion_usage_from_response_usage),
                     state,
                 ))
             } else {
@@ -733,7 +742,10 @@ fn chat_completion_stream_event_from_response_event(
                         None,
                         Some(FinishReason::Stop),
                     )],
-                    response.usage.map(completion_usage_from_response_usage),
+                    response
+                        .usage
+                        .as_ref()
+                        .map(completion_usage_from_response_usage),
                     state,
                 ))
             }
@@ -755,7 +767,10 @@ fn chat_completion_stream_event_from_response_event(
                     None,
                     Some(FinishReason::Length),
                 )],
-                response.usage.map(completion_usage_from_response_usage),
+                response
+                    .usage
+                    .as_ref()
+                    .map(completion_usage_from_response_usage),
                 state,
             ))
         }
@@ -845,7 +860,7 @@ fn chat_custom_tool_call_chunk_from_response_custom_call(
     }
 }
 
-fn completion_usage_from_response_usage(usage: ResponseUsage) -> CompletionUsage {
+fn completion_usage_from_response_usage(usage: &ResponseUsage) -> CompletionUsage {
     CompletionUsage {
         prompt_tokens: usage.input_tokens,
         completion_tokens: usage.output_tokens,
@@ -955,7 +970,7 @@ mod tests {
     #[test]
     fn maps_response_to_chat_completion_response() {
         let response: Response = serde_json::from_value(json!({
-            "created_at": 1755639134,
+            "created_at": 1_755_639_134,
             "id": "resp_123",
             "model": "backend-model",
             "object": "response",
@@ -1106,7 +1121,7 @@ mod tests {
 
     fn minimal_response_json(id: &str, status: &str) -> serde_json::Value {
         json!({
-            "created_at": 1755639134,
+            "created_at": 1_755_639_134,
             "id": id,
             "model": "backend-model",
             "object": "response",

--- a/crates/llms/src/openai/responses_adapter.rs
+++ b/crates/llms/src/openai/responses_adapter.rs
@@ -1,0 +1,1117 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{collections::HashMap, time::SystemTime};
+
+use async_openai::{
+    error::{ApiError, OpenAIError},
+    types::{
+        Metadata,
+        chat::{
+            ChatChoice, ChatChoiceStream, ChatCompletionMessageCustomToolCall,
+            ChatCompletionMessageToolCall, ChatCompletionMessageToolCallChunk,
+            ChatCompletionMessageToolCalls, ChatCompletionRequestAssistantMessage,
+            ChatCompletionRequestAssistantMessageContent,
+            ChatCompletionRequestAssistantMessageContentPart,
+            ChatCompletionRequestDeveloperMessageContent,
+            ChatCompletionRequestDeveloperMessageContentPart, ChatCompletionRequestMessage,
+            ChatCompletionRequestSystemMessageContent,
+            ChatCompletionRequestSystemMessageContentPart, ChatCompletionRequestToolMessageContent,
+            ChatCompletionRequestToolMessageContentPart, ChatCompletionRequestUserMessageContent,
+            ChatCompletionRequestUserMessageContentPart, ChatCompletionResponseMessage,
+            ChatCompletionResponseStream, ChatCompletionStreamResponseDelta,
+            ChatCompletionToolChoiceOption, ChatCompletionTools, CompletionTokensDetails,
+            CompletionUsage, CreateChatCompletionRequest, CreateChatCompletionResponse,
+            CreateChatCompletionStreamResponse, CustomTool, FinishReason, FunctionCall,
+            FunctionCallStream, FunctionType, PromptTokensDetails, ResponseFormat,
+            Role as ChatRole, ToolChoiceAllowedMode as ChatToolChoiceAllowedMode,
+            ToolChoiceOptions as ChatToolChoiceOptions,
+        },
+        responses::{
+            CreateResponse, CustomToolCall, CustomToolParam, EasyInputContent, EasyInputMessage,
+            FunctionCallOutput, FunctionCallOutputItemParam, FunctionTool, FunctionToolCall,
+            InputContent, InputImageContent, InputItem, InputParam, InputTextContent, Item,
+            MessageType, OutputItem, OutputMessage, OutputMessageContent, OutputStatus, Reasoning,
+            Response, ResponseStream, ResponseStreamEvent, ResponseTextParam, ResponseUsage,
+            Role as ResponsesRole, Status, TextResponseFormatConfiguration, Tool as ResponsesTool,
+            ToolChoiceAllowed as ResponsesToolChoiceAllowed,
+            ToolChoiceAllowedMode as ResponsesToolChoiceAllowedMode,
+            ToolChoiceCustom as ResponsesToolChoiceCustom,
+            ToolChoiceFunction as ResponsesToolChoiceFunction,
+            ToolChoiceOptions as ResponsesToolChoiceOptions,
+            ToolChoiceParam as ResponsesToolChoiceParam,
+        },
+    },
+};
+use futures::{StreamExt, future};
+use serde::{Serialize, de::DeserializeOwned};
+
+#[expect(deprecated)]
+pub(super) fn responses_request_from_chat_completion_request(
+    mut req: CreateChatCompletionRequest,
+    backend_model: &str,
+) -> Result<CreateResponse, OpenAIError> {
+    let max_output_tokens = req.max_completion_tokens.take().or(req.max_tokens.take());
+
+    Ok(CreateResponse {
+        input: chat_messages_to_response_input(std::mem::take(&mut req.messages))?,
+        model: Some(backend_model.to_string()),
+        max_output_tokens,
+        reasoning: req
+            .reasoning_effort
+            .map(|effort| convert_json(effort, "reasoning_effort"))
+            .transpose()?
+            .map(|effort| Reasoning {
+                effort: Some(effort),
+                summary: None,
+            }),
+        metadata: req.metadata.take().map(metadata_to_hash_map).transpose()?,
+        parallel_tool_calls: req.parallel_tool_calls,
+        prompt_cache_key: req.prompt_cache_key.take().or(req.user.take()),
+        safety_identifier: req.safety_identifier.take(),
+        service_tier: req
+            .service_tier
+            .map(|service_tier| convert_json(service_tier, "service_tier"))
+            .transpose()?,
+        store: req.store,
+        stream: req.stream,
+        stream_options: req.stream_options.map(|opts| {
+            async_openai::types::responses::ResponseStreamOptions {
+                include_obfuscation: opts.include_obfuscation,
+            }
+        }),
+        temperature: req.temperature,
+        text: response_text_param(req.response_format.take(), req.verbosity.take())?,
+        tool_choice: req
+            .tool_choice
+            .map(response_tool_choice_from_chat_tool_choice)
+            .transpose()?,
+        tools: req.tools.map(response_tools_from_chat_tools).transpose()?,
+        top_logprobs: req.top_logprobs,
+        top_p: req.top_p,
+        ..Default::default()
+    })
+}
+
+#[expect(deprecated)]
+pub(super) fn chat_completion_response_from_response(
+    response: Response,
+    model: String,
+) -> Result<CreateChatCompletionResponse, OpenAIError> {
+    if response.status == Status::Failed {
+        return Err(response_failed_error(&response));
+    }
+
+    let created = created_at_to_u32(response.created_at)?;
+    let has_tool_calls = response_has_tool_calls(&response);
+    let message = chat_message_from_response_output(response.output);
+    let finish_reason = if has_tool_calls {
+        Some(FinishReason::ToolCalls)
+    } else if response.status == Status::Incomplete {
+        Some(FinishReason::Length)
+    } else {
+        Some(FinishReason::Stop)
+    };
+
+    Ok(CreateChatCompletionResponse {
+        id: response.id,
+        choices: vec![ChatChoice {
+            index: 0,
+            message,
+            finish_reason,
+            logprobs: None,
+        }],
+        created,
+        model,
+        service_tier: response
+            .service_tier
+            .map(|service_tier| convert_json(service_tier, "service_tier"))
+            .transpose()?,
+        system_fingerprint: None,
+        object: "chat.completion".to_string(),
+        usage: response.usage.map(completion_usage_from_response_usage),
+    })
+}
+
+pub(super) fn chat_completion_stream_from_response_stream(
+    stream: ResponseStream,
+    model: String,
+) -> ChatCompletionResponseStream {
+    Box::pin(
+        stream
+            .scan(ChatCompletionStreamState::default(), move |state, event| {
+                future::ready(Some(chat_completion_stream_event_from_response_event(
+                    event, &model, state,
+                )))
+            })
+            .filter_map(future::ready),
+    )
+}
+
+fn chat_messages_to_response_input(
+    messages: Vec<ChatCompletionRequestMessage>,
+) -> Result<InputParam, OpenAIError> {
+    let mut items = Vec::with_capacity(messages.len());
+    for message in messages {
+        items.extend(input_items_from_chat_message(message)?);
+    }
+    Ok(InputParam::Items(items))
+}
+
+fn input_items_from_chat_message(
+    message: ChatCompletionRequestMessage,
+) -> Result<Vec<InputItem>, OpenAIError> {
+    match message {
+        ChatCompletionRequestMessage::Developer(msg) => Ok(vec![easy_message(
+            ResponsesRole::Developer,
+            EasyInputContent::Text(developer_content_to_text(msg.content)),
+        )]),
+        ChatCompletionRequestMessage::System(msg) => Ok(vec![easy_message(
+            ResponsesRole::System,
+            EasyInputContent::Text(system_content_to_text(msg.content)),
+        )]),
+        ChatCompletionRequestMessage::User(msg) => Ok(vec![easy_message(
+            ResponsesRole::User,
+            user_content_to_easy_input_content(msg.content)?,
+        )]),
+        ChatCompletionRequestMessage::Assistant(msg) => input_items_from_assistant_message(msg),
+        ChatCompletionRequestMessage::Tool(msg) => Ok(vec![InputItem::Item(
+            Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                call_id: msg.tool_call_id,
+                output: FunctionCallOutput::Text(tool_content_to_text(msg.content)),
+                id: None,
+                status: Some(OutputStatus::Completed),
+            }),
+        )]),
+        ChatCompletionRequestMessage::Function(msg) => Ok(vec![InputItem::Item(
+            Item::FunctionCallOutput(FunctionCallOutputItemParam {
+                call_id: msg.name,
+                output: FunctionCallOutput::Text(msg.content.unwrap_or_default()),
+                id: None,
+                status: Some(OutputStatus::Completed),
+            }),
+        )]),
+    }
+}
+
+#[expect(deprecated)]
+fn input_items_from_assistant_message(
+    mut msg: ChatCompletionRequestAssistantMessage,
+) -> Result<Vec<InputItem>, OpenAIError> {
+    let mut items = Vec::new();
+
+    if let Some(content) = msg.content.take() {
+        items.push(easy_message(
+            ResponsesRole::Assistant,
+            EasyInputContent::Text(assistant_content_to_text(content)),
+        ));
+    } else if let Some(refusal) = msg.refusal.take() {
+        items.push(easy_message(
+            ResponsesRole::Assistant,
+            EasyInputContent::Text(refusal),
+        ));
+    }
+
+    if let Some(tool_calls) = msg.tool_calls.take() {
+        for tool_call in tool_calls {
+            items.push(input_item_from_chat_tool_call(tool_call)?);
+        }
+    }
+
+    if let Some(function_call) = msg.function_call.take() {
+        items.push(InputItem::Item(Item::FunctionCall(FunctionToolCall {
+            call_id: function_call.name.clone(),
+            name: function_call.name,
+            arguments: function_call.arguments,
+            id: None,
+            status: Some(OutputStatus::Completed),
+        })));
+    }
+
+    Ok(items)
+}
+
+fn input_item_from_chat_tool_call(
+    tool_call: ChatCompletionMessageToolCalls,
+) -> Result<InputItem, OpenAIError> {
+    match tool_call {
+        ChatCompletionMessageToolCalls::Function(function_call) => {
+            Ok(InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                call_id: function_call.id.clone(),
+                name: function_call.function.name,
+                arguments: function_call.function.arguments,
+                id: Some(function_call.id),
+                status: Some(OutputStatus::Completed),
+            })))
+        }
+        ChatCompletionMessageToolCalls::Custom(custom_call) => {
+            Ok(InputItem::Item(Item::CustomToolCall(custom_tool_call(
+                custom_call.id.clone(),
+                custom_call.custom_tool.input,
+                custom_call.custom_tool.name,
+                custom_call.id,
+            )?)))
+        }
+    }
+}
+
+fn metadata_to_hash_map(metadata: Metadata) -> Result<HashMap<String, String>, OpenAIError> {
+    let Some(object) = metadata.as_value().as_object() else {
+        return Err(OpenAIError::InvalidArgument(
+            "Chat Completions metadata must be a JSON object when proxying to the Responses API"
+                .to_string(),
+        ));
+    };
+
+    Ok(object
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.clone(),
+                value
+                    .as_str()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| value.to_string()),
+            )
+        })
+        .collect())
+}
+
+fn custom_tool_call(
+    call_id: String,
+    input: String,
+    name: String,
+    id: String,
+) -> Result<CustomToolCall, OpenAIError> {
+    serde_json::from_value(serde_json::json!({
+        "type": "custom_tool_call",
+        "call_id": call_id,
+        "input": input,
+        "name": name,
+        "id": id,
+    }))
+    .map_err(|e| invalid_conversion("custom tool call", e))
+}
+
+fn easy_message(role: ResponsesRole, content: EasyInputContent) -> InputItem {
+    InputItem::EasyMessage(EasyInputMessage {
+        r#type: MessageType::Message,
+        role,
+        content,
+    })
+}
+
+fn developer_content_to_text(content: ChatCompletionRequestDeveloperMessageContent) -> String {
+    match content {
+        ChatCompletionRequestDeveloperMessageContent::Text(text) => text,
+        ChatCompletionRequestDeveloperMessageContent::Array(parts) => parts
+            .into_iter()
+            .map(|part| match part {
+                ChatCompletionRequestDeveloperMessageContentPart::Text(text) => text.text,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+fn system_content_to_text(content: ChatCompletionRequestSystemMessageContent) -> String {
+    match content {
+        ChatCompletionRequestSystemMessageContent::Text(text) => text,
+        ChatCompletionRequestSystemMessageContent::Array(parts) => parts
+            .into_iter()
+            .map(|part| match part {
+                ChatCompletionRequestSystemMessageContentPart::Text(text) => text.text,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+fn user_content_to_easy_input_content(
+    content: ChatCompletionRequestUserMessageContent,
+) -> Result<EasyInputContent, OpenAIError> {
+    match content {
+        ChatCompletionRequestUserMessageContent::Text(text) => Ok(EasyInputContent::Text(text)),
+        ChatCompletionRequestUserMessageContent::Array(parts) => parts
+            .into_iter()
+            .map(input_content_from_user_content_part)
+            .collect::<Result<Vec<_>, _>>()
+            .map(EasyInputContent::ContentList),
+    }
+}
+
+fn input_content_from_user_content_part(
+    part: ChatCompletionRequestUserMessageContentPart,
+) -> Result<InputContent, OpenAIError> {
+    match part {
+        ChatCompletionRequestUserMessageContentPart::Text(text) => {
+            Ok(InputContent::InputText(InputTextContent {
+                text: text.text,
+            }))
+        }
+        ChatCompletionRequestUserMessageContentPart::ImageUrl(image) => {
+            Ok(InputContent::InputImage(InputImageContent {
+                detail: image.image_url.detail.unwrap_or_default(),
+                file_id: None,
+                image_url: Some(image.image_url.url),
+            }))
+        }
+        ChatCompletionRequestUserMessageContentPart::File(file) => {
+            Ok(InputContent::InputFile(convert_json(file.file, "file")?))
+        }
+        ChatCompletionRequestUserMessageContentPart::InputAudio(_) => {
+            Err(OpenAIError::InvalidArgument(
+                "Audio chat input cannot be proxied to the Responses API".to_string(),
+            ))
+        }
+    }
+}
+
+fn assistant_content_to_text(content: ChatCompletionRequestAssistantMessageContent) -> String {
+    match content {
+        ChatCompletionRequestAssistantMessageContent::Text(text) => text,
+        ChatCompletionRequestAssistantMessageContent::Array(parts) => parts
+            .into_iter()
+            .map(|part| match part {
+                ChatCompletionRequestAssistantMessageContentPart::Text(text) => text.text,
+                ChatCompletionRequestAssistantMessageContentPart::Refusal(refusal) => {
+                    refusal.refusal
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+fn tool_content_to_text(content: ChatCompletionRequestToolMessageContent) -> String {
+    match content {
+        ChatCompletionRequestToolMessageContent::Text(text) => text,
+        ChatCompletionRequestToolMessageContent::Array(parts) => parts
+            .into_iter()
+            .map(|part| match part {
+                ChatCompletionRequestToolMessageContentPart::Text(text) => text.text,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+fn response_text_param(
+    format: Option<ResponseFormat>,
+    verbosity: Option<async_openai::types::chat::Verbosity>,
+) -> Result<Option<ResponseTextParam>, OpenAIError> {
+    match (format, verbosity) {
+        (None, None) => Ok(None),
+        (format, verbosity) => Ok(Some(ResponseTextParam {
+            format: match format.unwrap_or(ResponseFormat::Text) {
+                ResponseFormat::Text => TextResponseFormatConfiguration::Text,
+                ResponseFormat::JsonObject => TextResponseFormatConfiguration::JsonObject,
+                ResponseFormat::JsonSchema { json_schema } => {
+                    TextResponseFormatConfiguration::JsonSchema(json_schema)
+                }
+            },
+            verbosity: verbosity
+                .map(|value| convert_json(value, "verbosity"))
+                .transpose()?,
+        })),
+    }
+}
+
+fn response_tools_from_chat_tools(
+    tools: Vec<ChatCompletionTools>,
+) -> Result<Vec<ResponsesTool>, OpenAIError> {
+    tools
+        .into_iter()
+        .map(response_tool_from_chat_tool)
+        .collect()
+}
+
+fn response_tool_from_chat_tool(tool: ChatCompletionTools) -> Result<ResponsesTool, OpenAIError> {
+    match tool {
+        ChatCompletionTools::Function(function_tool) => Ok(ResponsesTool::Function(FunctionTool {
+            name: function_tool.function.name,
+            parameters: function_tool.function.parameters,
+            strict: function_tool.function.strict,
+            description: function_tool.function.description,
+        })),
+        ChatCompletionTools::Custom(custom_tool) => Ok(ResponsesTool::Custom(CustomToolParam {
+            name: custom_tool.custom.name,
+            description: custom_tool.custom.description,
+            format: convert_json(custom_tool.custom.format, "custom tool format")?,
+        })),
+    }
+}
+
+fn response_tool_choice_from_chat_tool_choice(
+    tool_choice: ChatCompletionToolChoiceOption,
+) -> Result<ResponsesToolChoiceParam, OpenAIError> {
+    match tool_choice {
+        ChatCompletionToolChoiceOption::Mode(mode) => {
+            Ok(ResponsesToolChoiceParam::Mode(match mode {
+                ChatToolChoiceOptions::None => ResponsesToolChoiceOptions::None,
+                ChatToolChoiceOptions::Auto => ResponsesToolChoiceOptions::Auto,
+                ChatToolChoiceOptions::Required => ResponsesToolChoiceOptions::Required,
+            }))
+        }
+        ChatCompletionToolChoiceOption::Function(function) => Ok(
+            ResponsesToolChoiceParam::Function(ResponsesToolChoiceFunction {
+                name: function.function.name,
+            }),
+        ),
+        ChatCompletionToolChoiceOption::Custom(custom) => Ok(ResponsesToolChoiceParam::Custom(
+            ResponsesToolChoiceCustom {
+                name: custom.custom.name,
+            },
+        )),
+        ChatCompletionToolChoiceOption::AllowedTools(allowed_tools) => {
+            let tools = allowed_tools
+                .allowed_tools
+                .into_iter()
+                .flat_map(|allowed| {
+                    allowed
+                        .tools
+                        .into_iter()
+                        .map(move |tool| (allowed.mode.clone(), tool))
+                })
+                .map(|(mode, tool)| {
+                    let chat_tool = serde_json::from_value::<ChatCompletionTools>(tool.clone())
+                        .map_err(|e| invalid_conversion("allowed tool", e))?;
+                    let response_tool = response_tool_from_chat_tool(chat_tool)?;
+                    let tool_value = serde_json::to_value(response_tool)
+                        .map_err(|e| invalid_conversion("allowed tool", e))?;
+                    Ok((mode, tool_value))
+                })
+                .collect::<Result<Vec<_>, OpenAIError>>()?;
+
+            let mode = tools
+                .first()
+                .map(|(mode, _)| mode.clone())
+                .unwrap_or(ChatToolChoiceAllowedMode::Auto);
+
+            Ok(ResponsesToolChoiceParam::AllowedTools(
+                ResponsesToolChoiceAllowed {
+                    mode: match mode {
+                        ChatToolChoiceAllowedMode::Auto => ResponsesToolChoiceAllowedMode::Auto,
+                        ChatToolChoiceAllowedMode::Required => {
+                            ResponsesToolChoiceAllowedMode::Required
+                        }
+                    },
+                    tools: tools.into_iter().map(|(_, tool)| tool).collect(),
+                },
+            ))
+        }
+    }
+}
+
+#[expect(deprecated)]
+fn chat_message_from_response_output(output: Vec<OutputItem>) -> ChatCompletionResponseMessage {
+    let mut text_parts = Vec::new();
+    let mut refusal_parts = Vec::new();
+    let mut tool_calls = Vec::new();
+
+    for item in output {
+        match item {
+            OutputItem::Message(message) => {
+                collect_output_message_content(message, &mut text_parts, &mut refusal_parts);
+            }
+            OutputItem::FunctionCall(function_call) => {
+                tool_calls.push(ChatCompletionMessageToolCalls::Function(
+                    chat_tool_call_from_response_function_call(function_call),
+                ));
+            }
+            OutputItem::CustomToolCall(custom_call) => {
+                tool_calls.push(ChatCompletionMessageToolCalls::Custom(
+                    chat_custom_tool_call_from_response_custom_call(custom_call),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    ChatCompletionResponseMessage {
+        content: (!text_parts.is_empty()).then(|| text_parts.join("\n")),
+        refusal: (!refusal_parts.is_empty()).then(|| refusal_parts.join("\n")),
+        tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),
+        annotations: None,
+        role: ChatRole::Assistant,
+        function_call: None,
+        audio: None,
+    }
+}
+
+fn collect_output_message_content(
+    message: OutputMessage,
+    text_parts: &mut Vec<String>,
+    refusal_parts: &mut Vec<String>,
+) {
+    for content in message.content {
+        match content {
+            OutputMessageContent::OutputText(text) => text_parts.push(text.text),
+            OutputMessageContent::Refusal(refusal) => refusal_parts.push(refusal.refusal),
+        }
+    }
+}
+
+fn response_has_tool_calls(response: &Response) -> bool {
+    response.output.iter().any(|item| {
+        matches!(
+            item,
+            OutputItem::FunctionCall(_) | OutputItem::CustomToolCall(_)
+        )
+    })
+}
+
+fn chat_tool_call_from_response_function_call(
+    function_call: FunctionToolCall,
+) -> ChatCompletionMessageToolCall {
+    ChatCompletionMessageToolCall {
+        id: function_call.id.unwrap_or(function_call.call_id),
+        function: FunctionCall {
+            name: function_call.name,
+            arguments: function_call.arguments,
+        },
+    }
+}
+
+fn chat_custom_tool_call_from_response_custom_call(
+    custom_call: CustomToolCall,
+) -> ChatCompletionMessageCustomToolCall {
+    ChatCompletionMessageCustomToolCall {
+        id: custom_call.id,
+        custom_tool: CustomTool {
+            name: custom_call.name,
+            input: custom_call.input,
+        },
+    }
+}
+
+#[derive(Default)]
+struct ChatCompletionStreamState {
+    response_id: Option<String>,
+    created: Option<u32>,
+}
+
+impl ChatCompletionStreamState {
+    fn update_response(&mut self, response: &Response) -> Result<(), OpenAIError> {
+        self.response_id = Some(response.id.clone());
+        self.created = Some(created_at_to_u32(response.created_at)?);
+        Ok(())
+    }
+
+    fn chunk_id(&self, fallback: String) -> String {
+        self.response_id.clone().unwrap_or(fallback)
+    }
+
+    fn created(&self) -> Result<u32, OpenAIError> {
+        self.created.map_or_else(current_unix_timestamp, Ok)
+    }
+}
+
+fn chat_completion_stream_event_from_response_event(
+    event: Result<ResponseStreamEvent, OpenAIError>,
+    model: &str,
+    state: &mut ChatCompletionStreamState,
+) -> Option<Result<CreateChatCompletionStreamResponse, OpenAIError>> {
+    let event = match event {
+        Ok(event) => event,
+        Err(e) => return Some(Err(e)),
+    };
+
+    match event {
+        ResponseStreamEvent::ResponseCreated(created) => {
+            state.update_response(&created.response).err().map(Err)
+        }
+        ResponseStreamEvent::ResponseInProgress(in_progress) => {
+            state.update_response(&in_progress.response).err().map(Err)
+        }
+        ResponseStreamEvent::ResponseOutputTextDelta(delta) => Some(chat_stream_chunk(
+            state.chunk_id(delta.item_id),
+            model,
+            vec![chat_stream_choice(
+                delta.output_index,
+                Some(delta.delta),
+                None,
+                None,
+                Some(ChatRole::Assistant),
+                None,
+            )],
+            None,
+            state,
+        )),
+        ResponseStreamEvent::ResponseRefusalDelta(delta) => Some(chat_stream_chunk(
+            state.chunk_id(delta.item_id),
+            model,
+            vec![chat_stream_choice(
+                delta.output_index,
+                None,
+                Some(delta.delta),
+                None,
+                Some(ChatRole::Assistant),
+                None,
+            )],
+            None,
+            state,
+        )),
+        ResponseStreamEvent::ResponseOutputItemDone(done) => match done.item {
+            OutputItem::FunctionCall(function_call) => Some(chat_stream_chunk(
+                state.chunk_id(
+                    function_call
+                        .id
+                        .clone()
+                        .unwrap_or_else(|| function_call.call_id.clone()),
+                ),
+                model,
+                vec![chat_stream_choice(
+                    done.output_index,
+                    None,
+                    None,
+                    Some(vec![chat_tool_call_chunk_from_response_function_call(
+                        function_call,
+                        done.output_index,
+                    )]),
+                    Some(ChatRole::Assistant),
+                    Some(FinishReason::ToolCalls),
+                )],
+                None,
+                state,
+            )),
+            OutputItem::CustomToolCall(custom_call) => Some(chat_stream_chunk(
+                state.chunk_id(custom_call.id.clone()),
+                model,
+                vec![chat_stream_choice(
+                    done.output_index,
+                    None,
+                    None,
+                    Some(vec![chat_custom_tool_call_chunk_from_response_custom_call(
+                        custom_call,
+                        done.output_index,
+                    )]),
+                    Some(ChatRole::Assistant),
+                    Some(FinishReason::ToolCalls),
+                )],
+                None,
+                state,
+            )),
+            _ => None,
+        },
+        ResponseStreamEvent::ResponseCompleted(completed) => {
+            let response = completed.response;
+            if let Err(e) = state.update_response(&response) {
+                return Some(Err(e));
+            }
+
+            if response_has_tool_calls(&response) {
+                Some(chat_stream_chunk(
+                    response.id,
+                    model,
+                    vec![],
+                    response.usage.map(completion_usage_from_response_usage),
+                    state,
+                ))
+            } else {
+                Some(chat_stream_chunk(
+                    response.id,
+                    model,
+                    vec![chat_stream_choice(
+                        0,
+                        None,
+                        None,
+                        None,
+                        None,
+                        Some(FinishReason::Stop),
+                    )],
+                    response.usage.map(completion_usage_from_response_usage),
+                    state,
+                ))
+            }
+        }
+        ResponseStreamEvent::ResponseIncomplete(incomplete) => {
+            let response = incomplete.response;
+            if let Err(e) = state.update_response(&response) {
+                return Some(Err(e));
+            }
+
+            Some(chat_stream_chunk(
+                response.id,
+                model,
+                vec![chat_stream_choice(
+                    0,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(FinishReason::Length),
+                )],
+                response.usage.map(completion_usage_from_response_usage),
+                state,
+            ))
+        }
+        ResponseStreamEvent::ResponseFailed(failed) => {
+            Some(Err(response_failed_error(&failed.response)))
+        }
+        ResponseStreamEvent::ResponseError(error) => Some(Err(OpenAIError::ApiError(ApiError {
+            message: error.message,
+            r#type: Some("responses_api_error".to_string()),
+            param: error.param,
+            code: error.code,
+        }))),
+        _ => None,
+    }
+}
+
+#[expect(deprecated)]
+fn chat_stream_chunk(
+    id: String,
+    model: &str,
+    choices: Vec<ChatChoiceStream>,
+    usage: Option<CompletionUsage>,
+    state: &ChatCompletionStreamState,
+) -> Result<CreateChatCompletionStreamResponse, OpenAIError> {
+    Ok(CreateChatCompletionStreamResponse {
+        id,
+        choices,
+        created: state.created()?,
+        model: model.to_string(),
+        service_tier: None,
+        system_fingerprint: None,
+        object: "chat.completion.chunk".to_string(),
+        usage,
+    })
+}
+
+#[expect(deprecated)]
+fn chat_stream_choice(
+    index: u32,
+    content: Option<String>,
+    refusal: Option<String>,
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    role: Option<ChatRole>,
+    finish_reason: Option<FinishReason>,
+) -> ChatChoiceStream {
+    ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            content,
+            function_call: None,
+            tool_calls,
+            role,
+            refusal,
+        },
+        finish_reason,
+        logprobs: None,
+    }
+}
+
+fn chat_tool_call_chunk_from_response_function_call(
+    function_call: FunctionToolCall,
+    index: u32,
+) -> ChatCompletionMessageToolCallChunk {
+    ChatCompletionMessageToolCallChunk {
+        index,
+        id: Some(function_call.id.unwrap_or(function_call.call_id)),
+        r#type: Some(FunctionType::Function),
+        function: Some(FunctionCallStream {
+            name: Some(function_call.name),
+            arguments: Some(function_call.arguments),
+        }),
+    }
+}
+
+fn chat_custom_tool_call_chunk_from_response_custom_call(
+    custom_call: CustomToolCall,
+    index: u32,
+) -> ChatCompletionMessageToolCallChunk {
+    ChatCompletionMessageToolCallChunk {
+        index,
+        id: Some(custom_call.id),
+        r#type: None,
+        function: Some(FunctionCallStream {
+            name: Some(custom_call.name),
+            arguments: Some(custom_call.input),
+        }),
+    }
+}
+
+fn completion_usage_from_response_usage(usage: ResponseUsage) -> CompletionUsage {
+    CompletionUsage {
+        prompt_tokens: usage.input_tokens,
+        completion_tokens: usage.output_tokens,
+        total_tokens: usage.total_tokens,
+        prompt_tokens_details: Some(PromptTokensDetails {
+            audio_tokens: None,
+            cached_tokens: Some(usage.input_tokens_details.cached_tokens),
+        }),
+        completion_tokens_details: Some(CompletionTokensDetails {
+            accepted_prediction_tokens: None,
+            audio_tokens: None,
+            reasoning_tokens: Some(usage.output_tokens_details.reasoning_tokens),
+            rejected_prediction_tokens: None,
+        }),
+    }
+}
+
+fn created_at_to_u32(created_at: u64) -> Result<u32, OpenAIError> {
+    u32::try_from(created_at).map_err(|e| OpenAIError::InvalidArgument(e.to_string()))
+}
+
+fn current_unix_timestamp() -> Result<u32, OpenAIError> {
+    let seconds = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?
+        .as_secs();
+    created_at_to_u32(seconds)
+}
+
+fn response_failed_error(response: &Response) -> OpenAIError {
+    let (message, code) = response.error.as_ref().map_or_else(
+        || ("Responses API request failed".to_string(), None),
+        |error| (error.message.clone(), Some(error.code.clone())),
+    );
+
+    OpenAIError::ApiError(ApiError {
+        message,
+        r#type: Some("responses_api_error".to_string()),
+        param: None,
+        code,
+    })
+}
+
+fn convert_json<T, U>(value: T, context: &str) -> Result<U, OpenAIError>
+where
+    T: Serialize,
+    U: DeserializeOwned,
+{
+    let value = serde_json::to_value(value).map_err(|e| invalid_conversion(context, e))?;
+    serde_json::from_value(value).map_err(|e| invalid_conversion(context, e))
+}
+
+fn invalid_conversion(context: &str, err: impl std::fmt::Display) -> OpenAIError {
+    OpenAIError::InvalidArgument(format!(
+        "Failed to convert Chat Completions {context} to Responses API format: {err}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_openai::types::chat::{
+        ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
+        ChatCompletionRequestUserMessageContent,
+    };
+    use futures::stream;
+    use serde_json::json;
+
+    #[test]
+    fn maps_chat_request_to_responses_request() {
+        let req: CreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "public-model",
+            "messages": [
+                {"role": "system", "content": "Be terse."},
+                {"role": "user", "content": "Hello"}
+            ],
+            "max_completion_tokens": 42,
+            "temperature": 0.2,
+            "tool_choice": "auto",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Look something up",
+                    "parameters": {"type": "object"},
+                    "strict": true
+                }
+            }]
+        }))
+        .expect("chat request should deserialize");
+
+        let response_req = responses_request_from_chat_completion_request(req, "backend-model")
+            .expect("request should map to Responses API");
+
+        assert_eq!(response_req.model.as_deref(), Some("backend-model"));
+        assert_eq!(response_req.max_output_tokens, Some(42));
+        assert_eq!(response_req.temperature, Some(0.2));
+        assert_eq!(response_req.tools.as_ref().map(Vec::len), Some(1));
+        assert!(matches!(
+            response_req.tool_choice,
+            Some(ResponsesToolChoiceParam::Mode(
+                ResponsesToolChoiceOptions::Auto
+            ))
+        ));
+    }
+
+    #[test]
+    fn maps_response_to_chat_completion_response() {
+        let response: Response = serde_json::from_value(json!({
+            "created_at": 1755639134,
+            "id": "resp_123",
+            "model": "backend-model",
+            "object": "response",
+            "output": [{
+                "type": "message",
+                "id": "msg_123",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "logprobs": null,
+                    "text": "hello"
+                }]
+            }],
+            "status": "completed",
+            "usage": {
+                "input_tokens": 3,
+                "input_tokens_details": {"cached_tokens": 1},
+                "output_tokens": 2,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": 5
+            }
+        }))
+        .expect("response should deserialize");
+
+        let chat_response =
+            chat_completion_response_from_response(response, "public-model".to_string())
+                .expect("response should map to chat completion");
+
+        assert_eq!(chat_response.id, "resp_123");
+        assert_eq!(chat_response.model, "public-model");
+        assert_eq!(
+            chat_response.choices[0].message.content.as_deref(),
+            Some("hello")
+        );
+        assert_eq!(
+            chat_response.usage.as_ref().map(|usage| usage.total_tokens),
+            Some(5)
+        );
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn maps_chat_tool_messages_to_responses_function_items() {
+        let req = CreateChatCompletionRequest {
+            model: "public-model".to_string(),
+            messages: vec![
+                ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
+                    content: None,
+                    refusal: None,
+                    name: None,
+                    audio: None,
+                    tool_calls: Some(vec![ChatCompletionMessageToolCalls::Function(
+                        ChatCompletionMessageToolCall {
+                            id: "call_123".to_string(),
+                            function: FunctionCall {
+                                name: "lookup".to_string(),
+                                arguments: "{\"q\":\"spice\"}".to_string(),
+                            },
+                        },
+                    )]),
+                    function_call: None,
+                }),
+                ChatCompletionRequestMessage::Tool(
+                    async_openai::types::chat::ChatCompletionRequestToolMessage {
+                        content: ChatCompletionRequestToolMessageContent::Text(
+                            "result".to_string(),
+                        ),
+                        tool_call_id: "call_123".to_string(),
+                    },
+                ),
+                ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
+                    content: ChatCompletionRequestUserMessageContent::Text("continue".to_string()),
+                    name: None,
+                }),
+            ],
+            ..Default::default()
+        };
+
+        let response_req = responses_request_from_chat_completion_request(req, "backend-model")
+            .expect("request should map to Responses API");
+        let InputParam::Items(items) = response_req.input else {
+            panic!("chat messages should map to response input items");
+        };
+
+        assert!(matches!(items[0], InputItem::Item(Item::FunctionCall(_))));
+        assert!(matches!(
+            items[1],
+            InputItem::Item(Item::FunctionCallOutput(_))
+        ));
+        assert!(matches!(items[2], InputItem::EasyMessage(_)));
+    }
+
+    #[tokio::test]
+    async fn maps_response_stream_deltas_to_response_id() {
+        let created: ResponseStreamEvent = serde_json::from_value(json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": minimal_response_json("resp_123", "in_progress")
+        }))
+        .expect("created stream event should deserialize");
+        let delta: ResponseStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "sequence_number": 1,
+            "item_id": "msg_123",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hel"
+        }))
+        .expect("text delta stream event should deserialize");
+        let completed: ResponseStreamEvent = serde_json::from_value(json!({
+            "type": "response.completed",
+            "sequence_number": 2,
+            "response": minimal_response_json("resp_123", "completed")
+        }))
+        .expect("completed stream event should deserialize");
+
+        let response_stream: ResponseStream =
+            Box::pin(stream::iter(vec![Ok(created), Ok(delta), Ok(completed)]));
+        let mut chat_stream = chat_completion_stream_from_response_stream(
+            response_stream,
+            "public-model".to_string(),
+        );
+
+        let delta_chunk = chat_stream
+            .next()
+            .await
+            .expect("stream should include delta chunk")
+            .expect("delta chunk should be valid");
+        assert_eq!(delta_chunk.id, "resp_123");
+        assert_eq!(delta_chunk.created, 1_755_639_134);
+        assert_eq!(delta_chunk.model, "public-model");
+        assert_eq!(delta_chunk.choices[0].delta.content.as_deref(), Some("hel"));
+
+        let completed_chunk = chat_stream
+            .next()
+            .await
+            .expect("stream should include completion chunk")
+            .expect("completion chunk should be valid");
+        assert_eq!(completed_chunk.id, "resp_123");
+        assert_eq!(completed_chunk.created, 1_755_639_134);
+        assert_eq!(
+            completed_chunk.choices[0].finish_reason,
+            Some(FinishReason::Stop)
+        );
+    }
+
+    fn minimal_response_json(id: &str, status: &str) -> serde_json::Value {
+        json!({
+            "created_at": 1755639134,
+            "id": id,
+            "model": "backend-model",
+            "object": "response",
+            "output": [],
+            "status": status
+        })
+    }
+}

--- a/crates/runtime/src/http/v1/responses.rs
+++ b/crates/runtime/src/http/v1/responses.rs
@@ -111,6 +111,7 @@ fn extract_text(resp: &OpenAIResponse) -> String {
                 }
             })
         ))),
+        (status = 400, description = "The specified model provider does not support the Responses API or the request is invalid"),
         (status = 404, description = "The specified model was not found"),
         (status = 500, description = "An internal server error occurred while processing the response", content((
             serde_json::Value = "application/json",

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -27,21 +27,7 @@ use llms::{
 };
 use secrecy::SecretString;
 use snafu::ResultExt;
-use spicepod::component::model::{Model as SpicepodModel, ModelSource};
-
-fn supports_responses_api(m: &SpicepodModel, params: &HashMap<String, SecretString>) -> bool {
-    // xAI always uses Responses API (chat/completions is legacy)
-    if m.get_source() == Some(ModelSource::Xai) {
-        return true;
-    }
-
-    params
-        .get("responses_api")
-        .map(secrecy::ExposeSecret::expose_secret)
-        .unwrap_or_default()
-        .trim()
-        .eq_ignore_ascii_case("enabled")
-}
+use spicepod::component::model::Model as SpicepodModel;
 
 impl Runtime {
     /// Loads a specific LLM from the spicepod. If an error occurs, no retry attempt is made.
@@ -63,13 +49,9 @@ impl Runtime {
             .map_err(try_map_boxed_error_to_box)
             .context(UnableToInitializeLlmSnafu)?;
 
-        let mut responses_model = if supports_responses_api(&m, &params) {
-            try_to_responses_model(&m, &params, Arc::new(self.clone()))
-                .await
-                .ok()
-        } else {
-            None
-        };
+        let mut responses_model = try_to_responses_model(&m, &params, Arc::new(self.clone()))
+            .await
+            .ok();
 
         if let Some(model) = &responses_model
             && let Err(e) = model.health().await

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -49,9 +49,18 @@ impl Runtime {
             .map_err(try_map_boxed_error_to_box)
             .context(UnableToInitializeLlmSnafu)?;
 
-        let mut responses_model = try_to_responses_model(&m, &params, Arc::new(self.clone()))
+        let mut responses_model = match try_to_responses_model(&m, &params, Arc::new(self.clone()))
             .await
-            .ok();
+        {
+            Ok(model) => Some(model),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to construct Responses API endpoint for model '{}': {e}. The model will not be available via /v1/responses.",
+                    m.name
+                );
+                None
+            }
+        };
 
         if let Some(model) = &responses_model
             && let Err(e) = model.health().await

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -444,7 +444,7 @@ fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>
             param: "openai_usage_tier".to_string(),
             message: "Must be 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'".to_string(),
         })?;
-    let chat_backend = chat_backend(params, "openai_responses_api")?;
+    let chat_backend = chat_backend(params)?;
 
     if let Some(temperature_str) = params.get("temperature").expose().ok() {
         match temperature_str.parse::<f64>() {
@@ -493,7 +493,7 @@ fn azure(
     let deployment_name = params.get("deployment_name").expose().ok();
     let api_key = params.get("api_key").expose().ok();
     let entra_token = params.get("entra_token").expose().ok();
-    let chat_backend = chat_backend(params, "azure_responses_api")?;
+    let chat_backend = chat_backend(params)?;
 
     if api_base.is_none() {
         return Err(LlmError::FailedToLoadModel {
@@ -532,7 +532,7 @@ fn azure(
     )) as Arc<dyn Chat>)
 }
 
-fn chat_backend(params: &Parameters, param_name: &'static str) -> Result<ChatBackend, LlmError> {
+fn chat_backend(params: &Parameters) -> Result<ChatBackend, LlmError> {
     let value = params
         .get("responses_api")
         .expose()
@@ -546,7 +546,7 @@ fn chat_backend(params: &Parameters, param_name: &'static str) -> Result<ChatBac
         Ok(ChatBackend::Responses)
     } else {
         Err(LlmError::InvalidParamValueError {
-            param: param_name.to_string(),
+            param: "responses_api".to_string(),
             message: "Must be 'enabled' or 'disabled'".to_string(),
         })
     }
@@ -622,8 +622,7 @@ mod test {
     fn responses_api_defaults_to_chat_completions() {
         let params = parameters_with_responses_api(None);
 
-        let api = chat_backend(&params, "openai_responses_api")
-            .expect("default responses_api should be valid");
+        let api = chat_backend(&params).expect("default responses_api should be valid");
 
         assert_eq!(api, ChatBackend::ChatCompletions);
     }
@@ -632,8 +631,7 @@ mod test {
     fn responses_api_enabled_uses_responses() {
         let params = parameters_with_responses_api(Some("enabled"));
 
-        let api = chat_backend(&params, "openai_responses_api")
-            .expect("enabled responses_api should be valid");
+        let api = chat_backend(&params).expect("enabled responses_api should be valid");
 
         assert_eq!(api, ChatBackend::Responses);
     }
@@ -642,13 +640,12 @@ mod test {
     fn responses_api_rejects_unknown_value() {
         let params = parameters_with_responses_api(Some("legacy"));
 
-        let err = chat_backend(&params, "openai_responses_api")
-            .expect_err("unknown responses_api should be invalid");
+        let err = chat_backend(&params).expect_err("unknown responses_api should be invalid");
 
         assert!(matches!(
             err,
             LlmError::InvalidParamValueError { ref param, .. }
-                if param == "openai_responses_api"
+                if param == "responses_api"
         ));
     }
 

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -20,7 +20,7 @@ use llms::{
     bedrock::chat::{BedrockConverse, guardrail::GuardRail},
     chat::{Chat, Error as LlmError},
     google::Google,
-    openai::UsageTier,
+    openai::{ChatBackend, UsageTier},
     xai::Xai,
 };
 use llms::{config::GenericAuthMechanism, openai::DEFAULT_LLM_MODEL};
@@ -444,6 +444,7 @@ fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>
             param: "openai_usage_tier".to_string(),
             message: "Must be 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'".to_string(),
         })?;
+    let chat_backend = chat_backend(params, "openai_responses_api")?;
 
     if let Some(temperature_str) = params.get("temperature").expose().ok() {
         match temperature_str.parse::<f64>() {
@@ -464,13 +465,14 @@ fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>
         }
     }
 
-    Ok(Arc::new(llms::openai::new_openai_client(
+    Ok(Arc::new(llms::openai::new_openai_client_with_chat_backend(
         model_id.unwrap_or(DEFAULT_LLM_MODEL.to_string()),
         api_base,
         api_key,
         org_id,
         project_id,
         usage_tier,
+        chat_backend,
     )) as Arc<dyn Chat>)
 }
 
@@ -491,6 +493,7 @@ fn azure(
     let deployment_name = params.get("deployment_name").expose().ok();
     let api_key = params.get("api_key").expose().ok();
     let entra_token = params.get("entra_token").expose().ok();
+    let chat_backend = chat_backend(params, "azure_responses_api")?;
 
     if api_base.is_none() {
         return Err(LlmError::FailedToLoadModel {
@@ -518,14 +521,35 @@ fn azure(
         });
     }
 
-    Ok(Arc::new(llms::openai::new_azure_client(
+    Ok(Arc::new(llms::openai::new_azure_client_with_chat_backend(
         model_name,
         api_base,
         api_version,
         deployment_name,
         entra_token,
         api_key,
+        chat_backend,
     )) as Arc<dyn Chat>)
+}
+
+fn chat_backend(params: &Parameters, param_name: &'static str) -> Result<ChatBackend, LlmError> {
+    let value = params
+        .get("responses_api")
+        .expose()
+        .ok()
+        .unwrap_or("disabled")
+        .trim();
+
+    if value.eq_ignore_ascii_case("disabled") {
+        Ok(ChatBackend::ChatCompletions)
+    } else if value.eq_ignore_ascii_case("enabled") {
+        Ok(ChatBackend::Responses)
+    } else {
+        Err(LlmError::InvalidParamValueError {
+            param: param_name.to_string(),
+            message: "Must be 'enabled' or 'disabled'".to_string(),
+        })
+    }
 }
 
 #[cfg(feature = "models")]
@@ -580,6 +604,53 @@ mod test {
     use super::*;
     use serde_json::Number;
     use spicepod::component::model::Model;
+
+    fn parameters_with_responses_api(value: Option<&str>) -> Parameters {
+        Parameters::new(
+            value.map_or_else(Vec::new, |value| {
+                vec![(
+                    "responses_api".to_string(),
+                    SecretString::from(value.to_string()),
+                )]
+            }),
+            "openai",
+            crate::model::params::openai::PARAMETERS,
+        )
+    }
+
+    #[test]
+    fn responses_api_defaults_to_chat_completions() {
+        let params = parameters_with_responses_api(None);
+
+        let api = chat_backend(&params, "openai_responses_api")
+            .expect("default responses_api should be valid");
+
+        assert_eq!(api, ChatBackend::ChatCompletions);
+    }
+
+    #[test]
+    fn responses_api_enabled_uses_responses() {
+        let params = parameters_with_responses_api(Some("enabled"));
+
+        let api = chat_backend(&params, "openai_responses_api")
+            .expect("enabled responses_api should be valid");
+
+        assert_eq!(api, ChatBackend::Responses);
+    }
+
+    #[test]
+    fn responses_api_rejects_unknown_value() {
+        let params = parameters_with_responses_api(Some("legacy"));
+
+        let err = chat_backend(&params, "openai_responses_api")
+            .expect_err("unknown responses_api should be invalid");
+
+        assert!(matches!(
+            err,
+            LlmError::InvalidParamValueError { ref param, .. }
+                if param == "openai_responses_api"
+        ));
+    }
 
     #[test]
     fn test_get_openai_request_overrides_with_deprecated() {

--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -46,8 +46,7 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         )
         .default(""),
     ParameterSpec::runtime("responses_api")
-        .description(
-            "Whether to enable use of this model via the Responses API. `disabled` by default.",
-        )
+        .description("Whether to use the Responses API backend when serving `/v1/chat/completions` for this model. `disabled` proxies to backend `/v1/chat/completions`; `enabled` proxies to backend `/v1/responses`.")
+        .one_of(&["enabled", "disabled"])
         .default("disabled"),
 ];

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -43,7 +43,8 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
         .one_of(&["free", "tier1", "tier2", "tier3", "tier4", "tier5"])
         .default("tier1"),
     ParameterSpec::runtime("responses_api")
-        .description("Whether to enable use of this model via the Responses API. `disabled` by default.")
+        .description("Whether to use the Responses API backend when serving `/v1/chat/completions` for this model. `disabled` proxies to backend `/v1/chat/completions`; `enabled` proxies to backend `/v1/responses`.")
+        .one_of(&["enabled", "disabled"])
         .default("disabled"),
     ParameterSpec::component("responses_tools")
         .description("The OpenAI Responses tools to use when calling the model from the Responses API")

--- a/crates/runtime/src/model/responses.rs
+++ b/crates/runtime/src/model/responses.rs
@@ -23,6 +23,8 @@ use crate::parameters::Parameters;
 use crate::tools::options::SpiceToolsOptions;
 use crate::tools::registry::{TOOL_EMBEDDING_MODEL_PARAM, prepare_model_tools};
 use crate::tools::utils::{create_table_allowlist, get_tools_with_allowlist};
+use async_openai::error::{ApiError, OpenAIError};
+use async_trait::async_trait;
 use llms::chat::Error as LlmError;
 use llms::openai::{DEFAULT_LLM_MODEL, UsageTier};
 use llms::responses::Responses;
@@ -58,6 +60,16 @@ pub async fn try_to_responses_model(
     let source = component.get_source().ok_or(LlmError::UnknownModelSource {
         from: component.from.clone(),
     })?;
+
+    if !matches!(
+        source,
+        ModelSource::OpenAi | ModelSource::Azure | ModelSource::Xai
+    ) {
+        return Ok(Arc::new(UnsupportedResponsesModel::new(
+            component.name.clone(),
+            source.short_name(),
+        )));
+    }
 
     let param_spec = get_params_spec(&source).ok_or(LlmError::UnsupportedTaskForModel {
         from: component.from.clone(),
@@ -191,6 +203,53 @@ pub fn get_openai_responses_request_overrides(model: &Model, prefix: &str) -> Ve
     request_overrides.into_iter().collect()
 }
 
+struct UnsupportedResponsesModel {
+    model_name: String,
+    provider: &'static str,
+}
+
+impl UnsupportedResponsesModel {
+    fn new(model_name: String, provider: &'static str) -> Self {
+        Self {
+            model_name,
+            provider,
+        }
+    }
+
+    fn error(&self) -> OpenAIError {
+        OpenAIError::ApiError(ApiError {
+            message: format!(
+                "Model '{}' uses provider '{}' which does not support the OpenAI Responses API. Use /v1/chat/completions for this model or configure a model provider that supports Responses.",
+                self.model_name, self.provider
+            ),
+            r#type: Some("invalid_request_error".to_string()),
+            param: Some("model".to_string()),
+            code: Some("invalid_request_error".to_string()),
+        })
+    }
+}
+
+#[async_trait]
+impl Responses for UnsupportedResponsesModel {
+    async fn health(&self) -> llms::responses::Result<()> {
+        Ok(())
+    }
+
+    async fn responses_stream(
+        &self,
+        _req: async_openai::types::responses::CreateResponse,
+    ) -> Result<async_openai::types::responses::ResponseStream, OpenAIError> {
+        Err(self.error())
+    }
+
+    async fn responses_request(
+        &self,
+        _req: async_openai::types::responses::CreateResponse,
+    ) -> Result<async_openai::types::responses::Response, OpenAIError> {
+        Err(self.error())
+    }
+}
+
 fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Responses>, LlmError> {
     let api_base = params.get("endpoint").expose().ok();
     let api_key = params.get("api_key").expose().ok();
@@ -302,6 +361,7 @@ fn xai(model_id: Option<&str>, params: &Parameters) -> Result<Arc<dyn Responses>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_openai::types::responses::CreateResponseArgs;
     use spicepod::component::model::Model;
 
     #[test]
@@ -330,6 +390,34 @@ mod tests {
                 .iter()
                 .any(|(key, value)| key == "prompt_cache_retention"
                     && value == &Value::String("24h".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_responses_model_returns_invalid_request_error() {
+        let model = UnsupportedResponsesModel::new("anthropic_model".to_string(), "anthropic");
+        let req = CreateResponseArgs::default()
+            .model("anthropic_model")
+            .input("hello")
+            .build()
+            .expect("response request should build");
+
+        let err = model
+            .responses_request(req)
+            .await
+            .expect_err("unsupported provider should return an error");
+
+        let OpenAIError::ApiError(api_error) = err else {
+            panic!("unsupported provider should return an OpenAI API error");
+        };
+
+        assert_eq!(api_error.r#type.as_deref(), Some("invalid_request_error"));
+        assert_eq!(api_error.param.as_deref(), Some("model"));
+        assert_eq!(api_error.code.as_deref(), Some("invalid_request_error"));
+        assert!(
+            api_error
+                .message
+                .contains("does not support the OpenAI Responses API")
         );
     }
 }

--- a/crates/runtime/tests/models/models_http_endpoint.rs
+++ b/crates/runtime/tests/models/models_http_endpoint.rs
@@ -5,7 +5,6 @@ use reqwest::Client;
 use runtime::{Runtime, auth::EndpointAuth, status::ComponentStatus};
 use runtime_api_types::v1::ComponentError;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::sync::Arc;
 
 use crate::{
@@ -59,17 +58,8 @@ async fn test_models_http_endpoint() -> Result<(), Error> {
                 .await
                 .map_err(anyhow::Error::msg)?;
 
-            let mut responses_model = get_openai_model("gpt-4o-mini", "responses_model");
-            responses_model.params.insert(
-                "responses_api".to_string(),
-                Value::String("enabled".to_string()),
-            );
-
-            let mut chat_model = get_openai_model("gpt-4o-mini", "chat_model");
-            chat_model.params.insert(
-                "responses_api".to_string(),
-                Value::String("disabled".to_string()),
-            );
+            let responses_model = get_openai_model("gpt-4o-mini", "responses_model");
+            let chat_model = get_openai_model("gpt-4o-mini", "chat_model");
 
             let app = AppBuilder::new("model_endpoint")
                 .with_model(responses_model)
@@ -172,7 +162,12 @@ async fn test_models_http_endpoint() -> Result<(), Error> {
             let models_response: OpenAIModelResponse =
                 response.json().await.map_err(anyhow::Error::from)?;
 
-            assert_json_snapshot!("models_response_with_metadata", &models_response);
+            assert!(models_response.data.iter().all(|model| {
+                model
+                    .metadata
+                    .as_ref()
+                    .is_some_and(|metadata| metadata.supports_responses_api)
+            }));
 
             Ok(())
         })

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -695,12 +695,7 @@ async fn openai_responses_api_non_streaming() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(anyhow::Error::msg)?;
 
-            let mut model = get_openai_model("gpt-4o-mini", "openai_model");
-
-            model.params.insert(
-                "responses_api".to_string(),
-                Value::String("enabled".to_string()),
-            );
+            let model = get_openai_model("gpt-4o-mini", "openai_model");
 
             let app = AppBuilder::new("responses_api").with_model(model).build();
 
@@ -750,11 +745,7 @@ async fn openai_responses_api_streaming() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(anyhow::Error::msg)?;
 
-            let mut model = get_openai_model("gpt-4o-mini", "openai_model");
-            model.params.insert(
-                "responses_api".to_string(),
-                Value::String("enabled".to_string()),
-            );
+            let model = get_openai_model("gpt-4o-mini", "openai_model");
 
             let app = AppBuilder::new("responses_api").with_model(model).build();
 
@@ -845,11 +836,6 @@ async fn openai_responses_api_with_tools_streaming() -> Result<(), anyhow::Error
                 .params
                 .insert("tools".to_string(), Value::String("auto".to_string()));
 
-            model.params.insert(
-                "responses_api".to_string(),
-                Value::String("enabled".to_string()),
-            );
-
             let app = AppBuilder::new("responses_api")
                 .with_model(model)
                 .with_dataset(get_taxi_trips_dataset())
@@ -939,11 +925,6 @@ async fn openai_responses_api_with_tools_non_streaming() -> Result<(), anyhow::E
 
             let mut model = get_openai_model("gpt-4o-mini", "openai_model");
 
-            model.params.insert(
-                "responses_api".to_string(),
-                Value::String("enabled".to_string()),
-            );
-
             model
                 .params
                 .insert("tools".to_string(), Value::String("auto".to_string()));
@@ -1002,10 +983,6 @@ fn get_responses_model_with_tools(
     model
         .params
         .insert("tools".into(), serde_json::Value::String("auto".into()));
-    model.params.insert(
-        "responses_api".into(),
-        serde_json::Value::String("enabled".into()),
-    );
     model
 }
 

--- a/tools/spicepodschema/tests/spicepod.models.yaml
+++ b/tools/spicepodschema/tests/spicepod.models.yaml
@@ -17,6 +17,7 @@ models:
     from: openai:gpt-4
     params:
       openai_api_key: sk-test
+      responses_api: enabled
       tools: auto
       system_prompt: You are a helpful assistant.
 


### PR DESCRIPTION
## Summary
- Register a `/v1/responses` model entry for every configured model by default.
- Return an OpenAI-style `invalid_request_error` for providers that do not support the Responses API instead of omitting the model.
- Keep `responses_api: enabled|disabled` for OpenAI/Azure Chat Completions backend selection, where `enabled` proxies `/v1/chat/completions` to backend `/v1/responses`.
- Add Chat Completions-to-Responses request/response/stream adaptation for OpenAI-compatible providers and update schema/docs/tests accordingly.

## Tests
- `cargo fmt --check && git diff --check`
- `cargo test -p llms openai::responses_adapter --lib`
- `cargo test -p runtime responses_api --lib --features models`
- `cargo test -p runtime unsupported_responses_model --lib --features models`

Note: the focused runtime test builds emit an existing unrelated warning in `crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs` about an irrefutable `if let` pattern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->