### PR TITLE
fix(benchmarks): Replace wget with curl in setup-odbc action

### DIFF
--- a/.github/actions/setup-odbc/action.yml
+++ b/.github/actions/setup-odbc/action.yml
@@ -14,7 +14,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
-        wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
+        curl -fsSL -o SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
         unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
         sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
         ls -lh /opt/simba/spark/lib/64/
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install alien -y
-        wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
+        curl -fsSL -o AmazonAthenaODBC-2.0.3.0.rpm https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
         sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
         ls -lh /opt/athena/odbc/lib/
         cat <<EOF > /tmp/odbcinst.ini


### PR DESCRIPTION
## 📝 Summary

The setup-odbc action fails on self-hosted ARC runners (ghcr.io/actions/actions-runner:latest) because wget is not included in the minimal runner image. Replace wget with curl -fsSL -o which is always available.

Example run: https://github.com/spiceai/spiceai/actions/runs/25484163549

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->