### PR TITLE
fix(benchmarks): Sanitize explain plan RecordBatch values before formatting to eliminate padding diffs

### DIFF
--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{panic, sync::Arc};
 
-use crate::{flight::query_to_batches, queries::Query};
+use crate::{flight::query_to_batches, queries::Query, utils::sanitize_record_batches};
 use spiceai::Client as SpiceClient;
 
 pub const CAYENNE_PATH_FILTER_PATTERN: &str =
@@ -27,6 +27,30 @@ const VORTEX_RANGE_FILTER_REPLACEMENT: &str = "$1:<RANGE>";
 
 fn make_tmpdir_regex_pattern(tempdir: &str) -> String {
     format!(r"(?:{tempdir}|private/{tempdir})/[^/]*/(\.spice/)?data")
+}
+
+/// Build the list of regex filters for normalizing explain plan output.
+fn build_explain_filters(temp_dir: &std::path::Path) -> Vec<(String, &'static str)> {
+    let temp_dir_str = temp_dir.to_str().unwrap_or_default();
+    let temp_dir_clean = temp_dir_str.trim_end_matches('/').trim_start_matches('/');
+    let temp_dir_pattern = regex::escape(temp_dir_clean);
+    let path_filter_pattern = make_tmpdir_regex_pattern(temp_dir_pattern.as_str());
+
+    vec![
+        (path_filter_pattern, "/data"),
+        (CAYENNE_PATH_FILTER_PATTERN.to_string(), CAYENNE_PATH_FILTER_REPLACEMENT),
+        (VORTEX_RANGE_FILTER_PATTERN.to_string(), VORTEX_RANGE_FILTER_REPLACEMENT),
+        (r"required_guarantees=\[[^\]]*\]".to_string(), "required_guarantees=[N]"),
+        (r"partition_sizes=\[[^\]]*\]".to_string(), "partition_sizes=[<redacted>]"),
+        (
+            r#"grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\),\s*grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\)"#.to_string(),
+            "<GROUPING_PAIR>",
+        ),
+        (
+            r#"grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\),\s*grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\)"#.to_string(),
+            "<GROUPING_PAIR>",
+        ),
+    ]
 }
 
 pub async fn record_explain_plan(
@@ -43,36 +67,23 @@ pub async fn record_explain_plan(
         .await
         .map_err(|e| anyhow::anyhow!("query `{query_name}` to plan: {e}"))?;
 
-    let explain_plan_raw = arrow::util::pretty::pretty_format_batches(&plan_results)?;
+    // Apply filters to raw RecordBatch values before formatting so that
+    // pretty_format_batches computes column widths from normalized values,
+    // eliminating non-deterministic padding diffs.
+    let filters = build_explain_filters(&std::env::temp_dir());
+    let sanitized = sanitize_record_batches(&plan_results, &filters)?;
+
+    let explain_plan_raw = arrow::util::pretty::pretty_format_batches(&sanitized)?;
 
     // Sort PartitionedUnionExec children for deterministic snapshot comparison
     let explain_plan = sort_partitioned_union_children(&explain_plan_raw.to_string());
 
     let mut assertion_err: Option<String> = None;
 
-    let temp_dir = std::env::temp_dir();
-    let temp_dir_str = temp_dir.to_str().unwrap_or_default();
-    let temp_dir_clean = temp_dir_str.trim_end_matches('/').trim_start_matches('/');
-    let temp_dir_pattern = regex::escape(temp_dir_clean);
-
-    // Create two patterns:
-    // 1. Exact match starting with the temp_dir: {temp_dir}/some_dir/data
-    // 2. Match with "private" prefix: private{temp_dir}/some_dir/data
-    let path_filter_pattern = make_tmpdir_regex_pattern(temp_dir_pattern.as_str());
-
     insta::with_settings!({
         description => format!("Query: {query_name}"),
         omit_expression => true,
         snapshot_path => "snapshots/explain",
-        filters => vec![
-            (path_filter_pattern.as_str(), "/data"),
-            (CAYENNE_PATH_FILTER_PATTERN, CAYENNE_PATH_FILTER_REPLACEMENT),
-            (VORTEX_RANGE_FILTER_PATTERN, VORTEX_RANGE_FILTER_REPLACEMENT),
-            (r"required_guarantees=\[[^\]]*\]", "required_guarantees=[N]"),
-            (r"partition_sizes=\[[^\]]*\]", "partition_sizes=[<redacted>]"),
-            (r#"grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\),\s*grouping\((?:item|"item")\.(?:i_category|i_class|"i_category"|"i_class")\)"#, "<GROUPING_PAIR>"),
-            (r#"grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\),\s*grouping\((?:store|"store")\.(?:s_state|s_county|"s_state"|"s_county")\)"#, "<GROUPING_PAIR>")
-        ],
     }, {
         let snapshot_name = if (scale_factor - 1.0).abs() < f64::EPSILON {
             format!("{name}_{query_name}_explain")

--- a/crates/test-framework/src/utils/mod.rs
+++ b/crates/test-framework/src/utils/mod.rs
@@ -244,10 +244,13 @@ mod tests {
             schema,
             vec![
                 Arc::new(StringArray::from(
-                    plan_types.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                    plan_types
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
                 )),
                 Arc::new(StringArray::from(
-                    plans.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                    plans.iter().map(ToString::to_string).collect::<Vec<_>>(),
                 )),
             ],
         )
@@ -257,8 +260,8 @@ mod tests {
     #[test]
     fn test_sanitize_no_filters() {
         let batch = make_batch(&["logical_plan"], &["Scan /tmp/abc/data"]);
-        let result =
-            sanitize_record_batches(&[batch.clone()], &[] as &[(&str, &str)]).expect("to sanitize");
+        let result = sanitize_record_batches(std::slice::from_ref(&batch), &[] as &[(&str, &str)])
+            .expect("to sanitize");
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].column(1).as_string::<i32>().value(0),

--- a/crates/test-framework/src/utils/mod.rs
+++ b/crates/test-framework/src/utils/mod.rs
@@ -20,10 +20,14 @@ use std::{
     future::Future,
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 use tokio_util::sync::CancellationToken;
+
+use arrow::array::{AsArray, LargeStringArray, RecordBatch, StringArray};
+use arrow::datatypes::DataType;
+use arrow::error::ArrowError;
 
 use crate::process::{MemoryReading, MemoryReadingsHandle};
 
@@ -49,6 +53,80 @@ pub fn hash<T: Hash>(value: &T) -> u64 {
     let mut hasher = DefaultHasher::new();
     value.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Apply regex filters to all string columns in a list of `RecordBatch`es.
+///
+/// Filters use the same `(pattern, replacement)` tuple format as insta snapshot
+/// filters. Each cell value in every `Utf8` column is run through the filters
+/// in order. This should be applied **before** `pretty_format_batches` so that
+/// table column widths are computed from the normalized (deterministic) values.
+///
+/// # Errors
+///
+/// Returns an error if a filter pattern is not a valid regex or if rebuilding
+/// a `RecordBatch` fails.
+pub fn sanitize_record_batches<P: AsRef<str>, R: AsRef<str>>(
+    batches: &[RecordBatch],
+    filters: &[(P, R)],
+) -> anyhow::Result<Vec<RecordBatch>> {
+    let compiled: Vec<(Regex, &str)> = filters
+        .iter()
+        .map(|(pattern, replacement)| {
+            let pattern = pattern.as_ref();
+            let regex = Regex::new(pattern)?;
+            Ok((regex, replacement.as_ref()))
+        })
+        .collect::<Result<Vec<_>, regex::Error>>()?;
+    batches
+        .iter()
+        .map(|batch| sanitize_batch(batch, &compiled).map_err(Into::into))
+        .collect()
+}
+
+fn sanitize_batch(
+    batch: &RecordBatch,
+    filters: &[(Regex, &str)],
+) -> Result<RecordBatch, ArrowError> {
+    let schema = batch.schema();
+    let new_columns: Vec<Arc<dyn arrow::array::Array>> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let col = batch.column(i);
+            match field.data_type() {
+                DataType::Utf8 => {
+                    let str_array = col.as_string::<i32>();
+                    let sanitized: StringArray = str_array
+                        .iter()
+                        .map(|opt| opt.map(|v| apply_filters(v, filters)))
+                        .collect();
+                    Arc::new(sanitized) as Arc<dyn arrow::array::Array>
+                }
+                DataType::LargeUtf8 => {
+                    let str_array = col.as_string::<i64>();
+                    let sanitized: LargeStringArray = str_array
+                        .iter()
+                        .map(|opt| opt.map(|v| apply_filters(v, filters)))
+                        .collect();
+                    Arc::new(sanitized) as Arc<dyn arrow::array::Array>
+                }
+                _ => Arc::clone(col),
+            }
+        })
+        .collect();
+
+    RecordBatch::try_new(Arc::clone(&schema), new_columns)
+}
+
+/// Apply a list of regex filters to a string, returning the result.
+fn apply_filters(value: &str, filters: &[(Regex, &str)]) -> String {
+    let mut result = value.to_string();
+    for (regex, replacement) in filters {
+        result = regex.replace_all(&result, *replacement).into_owned();
+    }
+    result
 }
 
 // replace insta headers with an empty string
@@ -149,4 +227,144 @@ pub fn recursively_get_dir_size(dir: &PathBuf) -> anyhow::Result<usize> {
         }
     }
     Ok(total_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int32Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    fn make_batch(plan_types: &[&str], plans: &[&str]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("plan_type", DataType::Utf8, false),
+            Field::new("plan", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(
+                    plan_types.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    plans.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .expect("failed to create test batch")
+    }
+
+    #[test]
+    fn test_sanitize_no_filters() {
+        let batch = make_batch(&["logical_plan"], &["Scan /tmp/abc/data"]);
+        let result =
+            sanitize_record_batches(&[batch.clone()], &[] as &[(&str, &str)]).expect("to sanitize");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].column(1).as_string::<i32>().value(0),
+            "Scan /tmp/abc/data"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_single_filter() {
+        let batch = make_batch(
+            &["physical_plan"],
+            &["Scan /tmp/sess123/.spice/data/table.parquet"],
+        );
+        let filters = vec![(r"/tmp/[^/]+/\.spice/data", "<DATA>")];
+        let result = sanitize_record_batches(&[batch], &filters).expect("to sanitize");
+        assert_eq!(
+            result[0].column(1).as_string::<i32>().value(0),
+            "Scan <DATA>/table.parquet"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_multiple_filters_applied_in_order() {
+        let batch = make_batch(
+            &["physical_plan"],
+            &["file.vortex:100..200 required_guarantees=[a, b]"],
+        );
+        let filters = vec![
+            (r"(\.vortex):\d+\.\.\d+", "$1:<RANGE>"),
+            (r"required_guarantees=\[[^\]]*\]", "required_guarantees=[N]"),
+        ];
+        let result = sanitize_record_batches(&[batch], &filters).expect("to sanitize");
+        assert_eq!(
+            result[0].column(1).as_string::<i32>().value(0),
+            "file.vortex:<RANGE> required_guarantees=[N]"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_preserves_non_string_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["abc123", "def456"])),
+            ],
+        )
+        .expect("failed to create test batch");
+
+        let filters: Vec<(&str, &str)> = vec![(r"\d+", "N")];
+        let result = sanitize_record_batches(&[batch], &filters).expect("to sanitize");
+
+        // Int column untouched
+        let int_col = result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("int col");
+        assert_eq!(int_col.value(0), 1);
+        assert_eq!(int_col.value(1), 2);
+
+        // String column filtered
+        let str_col = result[0].column(1).as_string::<i32>();
+        assert_eq!(str_col.value(0), "abcN");
+        assert_eq!(str_col.value(1), "defN");
+    }
+
+    #[test]
+    fn test_sanitize_preserves_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new("plan", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![
+                Some("hello123"),
+                None,
+                Some("world456"),
+            ]))],
+        )
+        .expect("failed to create test batch");
+
+        let filters: Vec<(&str, &str)> = vec![(r"\d+", "N")];
+        let result = sanitize_record_batches(&[batch], &filters).expect("to sanitize");
+        let col = result[0].column(0).as_string::<i32>();
+        assert_eq!(col.value(0), "helloN");
+        assert!(col.is_null(1));
+        assert_eq!(col.value(2), "worldN");
+    }
+
+    #[test]
+    fn test_sanitize_multiple_batches() {
+        let b1 = make_batch(&["logical_plan"], &["path /tmp/a/data"]);
+        let b2 = make_batch(&["physical_plan"], &["path /tmp/b/data"]);
+        let filters = vec![(r"/tmp/[a-z]/data", "<DIR>")];
+        let result = sanitize_record_batches(&[b1, b2], &filters).expect("to sanitize");
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0].column(1).as_string::<i32>().value(0),
+            "path <DIR>"
+        );
+        assert_eq!(
+            result[1].column(1).as_string::<i32>().value(0),
+            "path <DIR>"
+        );
+    }
 }


### PR DESCRIPTION
## 📝 Summary

`pretty_format_batches` pads all rows to the width of the longest cell value. When insta filters run post-formatting and shorten cell values (e.g. replacing temp dir paths), the padding from the original longer values remains, causing non-deterministic snapshot diffs across environments.

This PR moves regex filter application from post-formatting (insta filters) to pre-formatting (directly on `RecordBatch` string column values), so `pretty_format_batches` computes column widths from already-normalized values.

Example run: https://github.com/spiceai/spiceai/actions/runs/25491066679. Diff: https://github.com/spiceai/spiceai/pull/10733/changes

This also leads to more compact explain snapshots.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->