### PR TITLE
Fix DuckLake catalog `include` filter being ignored

### DIFF
--- a/crates/data_components/src/ducklake/provider.rs
+++ b/crates/data_components/src/ducklake/provider.rs
@@ -30,6 +30,7 @@ use datafusion::sql::TableReference;
 use datafusion_table_providers::duckdb::DuckDBTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
+use globset::GlobSet;
 use snafu::prelude::*;
 
 use crate::RefreshableCatalogProvider;
@@ -76,6 +77,8 @@ pub struct DuckLakeCatalogProvider {
     writable: bool,
     /// Whether DDL operations are allowed
     ddl_enabled: bool,
+    /// Optional glob filter for table inclusion (`schema.table` format)
+    include: Option<Arc<GlobSet>>,
 }
 
 impl std::fmt::Debug for DuckLakeCatalogProvider {
@@ -96,12 +99,14 @@ impl DuckLakeCatalogProvider {
     /// * `catalog_name` - The catalog name as attached in `DuckDB`
     /// * `writable` - Whether write operations (INSERT, UPDATE, DELETE) are allowed
     /// * `ddl_enabled` - Whether DDL operations (CREATE TABLE, DROP TABLE) are allowed
+    /// * `include` - Optional glob filter for table inclusion (`schema.table` format)
     #[must_use]
     pub fn new(
         pool: Arc<DuckDbConnectionPool>,
         catalog_name: String,
         writable: bool,
         ddl_enabled: bool,
+        include: Option<GlobSet>,
     ) -> Self {
         // Create a table factory that uses the same pool (with ducklake already attached)
         let duckdb_factory = Arc::new(DuckDBTableFactory::new(Arc::clone(&pool)));
@@ -112,6 +117,7 @@ impl DuckLakeCatalogProvider {
             schemas: RwLock::new(HashMap::new()),
             writable,
             ddl_enabled,
+            include: include.map(Arc::new),
         }
     }
 
@@ -180,6 +186,7 @@ impl DuckLakeCatalogProvider {
                 schema_name.clone(),
                 self.writable,
                 self.ddl_enabled,
+                self.include.clone(),
             );
             schema_provider.refresh().await?;
             schemas.insert(schema_name, Arc::new(schema_provider));
@@ -271,6 +278,7 @@ impl CatalogProvider for DuckLakeCatalogProvider {
                 schema_name,
                 ducklake_schema.writable,
                 ducklake_schema.ddl_enabled,
+                ducklake_schema.include.clone(),
             ))
         } else {
             Arc::new(DuckLakeSchemaProvider::new(
@@ -280,6 +288,7 @@ impl CatalogProvider for DuckLakeCatalogProvider {
                 schema_name,
                 self.writable,
                 self.ddl_enabled,
+                self.include.clone(),
             ))
         };
 
@@ -392,6 +401,8 @@ pub struct DuckLakeSchemaProvider {
     writable: bool,
     /// Whether DDL operations are allowed
     ddl_enabled: bool,
+    /// Optional glob filter for table inclusion (`schema.table` format)
+    include: Option<Arc<GlobSet>>,
 }
 
 impl std::fmt::Debug for DuckLakeSchemaProvider {
@@ -415,6 +426,7 @@ impl DuckLakeSchemaProvider {
     /// * `schema_name` - The schema name
     /// * `writable` - Whether write operations (INSERT, UPDATE, DELETE) are allowed
     /// * `ddl_enabled` - Whether DDL operations (CREATE TABLE, DROP TABLE) are allowed
+    /// * `include` - Optional glob filter for table inclusion (`schema.table` format)
     #[must_use]
     pub fn new(
         pool: Arc<DuckDbConnectionPool>,
@@ -423,6 +435,7 @@ impl DuckLakeSchemaProvider {
         schema_name: String,
         writable: bool,
         ddl_enabled: bool,
+        include: Option<Arc<GlobSet>>,
     ) -> Self {
         Self {
             pool,
@@ -432,6 +445,7 @@ impl DuckLakeSchemaProvider {
             tables: RwLock::new(HashMap::new()),
             writable,
             ddl_enabled,
+            include,
         }
     }
 
@@ -481,6 +495,14 @@ impl DuckLakeSchemaProvider {
 
         let mut tables = HashMap::new();
         for table_name in table_names {
+            let schema_with_table = format!("{}.{}", self.schema_name, table_name);
+            if let Some(include) = &self.include
+                && !include.is_match(&schema_with_table)
+            {
+                tracing::debug!("Table {schema_with_table} is not included, skipping");
+                continue;
+            }
+
             // Create a fully qualified table reference for the DuckLake table
             let table_ref = TableReference::full(
                 self.catalog_name.clone(),

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -293,6 +293,7 @@ impl CatalogConnector for DuckLakeCatalog {
             catalog_name,
             writable,
             ddl_enabled,
+            catalog.include.clone(),
         ));
 
         // Initial refresh to populate schemas and tables

--- a/crates/runtime/tests/ducklake/mod.rs
+++ b/crates/runtime/tests/ducklake/mod.rs
@@ -1,0 +1,416 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::utils::{register_test_connectors, runtime_ready_check, test_request_context};
+use crate::{configure_test_datafusion, init_tracing};
+use app::AppBuilder;
+use arrow::array::RecordBatch;
+use datafusion::assert_batches_eq;
+use futures::TryStreamExt;
+use runtime::Runtime;
+use spicepod::component::catalog::Catalog;
+use spicepod::component::dataset::Dataset;
+use spicepod::param::Params;
+use tempfile::TempDir;
+
+/// Bootstrap a `DuckLake` catalog at the given metadata path with test tables.
+///
+/// Creates tables: `orders`, `customers`, `products` under the `main` schema.
+fn bootstrap_ducklake(metadata_path: &str, data_path: &str) {
+    let db = duckdb::Connection::open_in_memory().expect("open in-memory DuckDB");
+    db.execute("INSTALL ducklake", [])
+        .expect("install ducklake");
+    db.execute("LOAD ducklake", []).expect("load ducklake");
+
+    let escaped_metadata = metadata_path.replace('\'', "''");
+    let escaped_data = data_path.replace('\'', "''");
+    let attach_sql =
+        format!("ATTACH 'ducklake:{escaped_metadata}' AS test_lake (DATA_PATH '{escaped_data}')");
+    db.execute(&attach_sql, []).expect("attach ducklake");
+
+    db.execute(
+        "CREATE TABLE test_lake.main.orders (id INTEGER, customer_id INTEGER, total DOUBLE)",
+        [],
+    )
+    .expect("create orders");
+    db.execute(
+        "INSERT INTO test_lake.main.orders VALUES (1, 10, 99.99), (2, 20, 149.50), (3, 10, 25.00)",
+        [],
+    )
+    .expect("insert orders");
+
+    db.execute(
+        "CREATE TABLE test_lake.main.customers (id INTEGER, name VARCHAR)",
+        [],
+    )
+    .expect("create customers");
+    db.execute(
+        "INSERT INTO test_lake.main.customers VALUES (10, 'Alice'), (20, 'Bob')",
+        [],
+    )
+    .expect("insert customers");
+
+    db.execute(
+        "CREATE TABLE test_lake.main.products (id INTEGER, name VARCHAR, price DOUBLE)",
+        [],
+    )
+    .expect("create products");
+    db.execute(
+        "INSERT INTO test_lake.main.products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 19.99)",
+        [],
+    )
+    .expect("insert products");
+}
+
+fn make_ducklake_catalog_params(metadata_path: &str) -> Params {
+    Params::from_string_map(HashMap::from([(
+        "ducklake_connection_string".to_string(),
+        metadata_path.to_string(),
+    )]))
+}
+
+/// Tests that the `include` filter on a `DuckLake` catalog correctly limits
+/// which tables are registered. Without the fix, all tables would appear.
+#[tokio::test]
+async fn ducklake_catalog_include_filter() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir.path().join("test.ducklake").display().to_string();
+    let data_path = tmp_dir.path().join("data").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            // Register catalog with include filter: only main.orders and main.customers
+            let mut catalog = Catalog::new("ducklake".to_string(), "test_lake".to_string());
+            catalog.params = Some(make_ducklake_catalog_params(&metadata_path));
+            catalog.include = vec!["main.orders".to_string(), "main.customers".to_string()];
+
+            let app = AppBuilder::new("ducklake_include_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Query information_schema to verify only included tables are registered
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_catalog, table_schema, table_name, table_type \
+                     FROM information_schema.tables \
+                     WHERE table_catalog = 'test_lake' \
+                       AND table_schema != 'information_schema' \
+                     ORDER BY table_name",
+                )
+                .build()
+                .run()
+                .await?;
+
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+
+            // Only orders and customers should appear, NOT products
+            assert_batches_eq!(
+                &[
+                    "+---------------+--------------+------------+------------+",
+                    "| table_catalog | table_schema | table_name | table_type |",
+                    "+---------------+--------------+------------+------------+",
+                    "| test_lake     | main         | customers  | BASE TABLE |",
+                    "| test_lake     | main         | orders     | BASE TABLE |",
+                    "+---------------+--------------+------------+------------+",
+                ],
+                &results
+            );
+
+            // Verify included tables are queryable
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT id, name FROM test_lake.main.customers ORDER BY id")
+                .build()
+                .run()
+                .await?;
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+",
+                    "| id | name  |",
+                    "+----+-------+",
+                    "| 10 | Alice |",
+                    "| 20 | Bob   |",
+                    "+----+-------+",
+                ],
+                &results
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Tests that a `DuckLake` catalog without an `include` filter registers all tables.
+#[tokio::test]
+async fn ducklake_catalog_no_filter() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir
+        .path()
+        .join("test_all.ducklake")
+        .display()
+        .to_string();
+    let data_path = tmp_dir.path().join("data_all").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            // Register catalog WITHOUT include filter — all tables should appear
+            let mut catalog = Catalog::new("ducklake".to_string(), "all_tables".to_string());
+            catalog.params = Some(make_ducklake_catalog_params(&metadata_path));
+
+            let app = AppBuilder::new("ducklake_all_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // Query information_schema to verify ALL tables are registered
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_catalog, table_schema, table_name, table_type \
+                     FROM information_schema.tables \
+                     WHERE table_catalog = 'all_tables' \
+                       AND table_schema != 'information_schema' \
+                     ORDER BY table_name",
+                )
+                .build()
+                .run()
+                .await?;
+
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+
+            assert_batches_eq!(
+                &[
+                    "+---------------+--------------+------------+------------+",
+                    "| table_catalog | table_schema | table_name | table_type |",
+                    "+---------------+--------------+------------+------------+",
+                    "| all_tables    | main         | customers  | BASE TABLE |",
+                    "| all_tables    | main         | orders     | BASE TABLE |",
+                    "| all_tables    | main         | products   | BASE TABLE |",
+                    "+---------------+--------------+------------+------------+",
+                ],
+                &results
+            );
+
+            // Verify a catalog table is queryable
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT id, total FROM all_tables.main.orders ORDER BY id")
+                .build()
+                .run()
+                .await?;
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------+",
+                    "| id | total |",
+                    "+----+-------+",
+                    "| 1  | 99.99 |",
+                    "| 2  | 149.5 |",
+                    "| 3  | 25.0  |",
+                    "+----+-------+",
+                ],
+                &results
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Tests that the `include` filter works with glob patterns.
+#[tokio::test]
+async fn ducklake_catalog_include_glob_pattern() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir
+        .path()
+        .join("test_glob.ducklake")
+        .display()
+        .to_string();
+    let data_path = tmp_dir.path().join("data_glob").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            // Use glob pattern: main.o* should match only 'orders'
+            let mut catalog = Catalog::new("ducklake".to_string(), "glob_lake".to_string());
+            catalog.params = Some(make_ducklake_catalog_params(&metadata_path));
+            catalog.include = vec!["main.o*".to_string()];
+
+            let app = AppBuilder::new("ducklake_glob_test")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT table_catalog, table_schema, table_name, table_type \
+                     FROM information_schema.tables \
+                     WHERE table_catalog = 'glob_lake' \
+                       AND table_schema != 'information_schema' \
+                     ORDER BY table_name",
+                )
+                .build()
+                .run()
+                .await?;
+
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+
+            assert_batches_eq!(
+                &[
+                    "+---------------+--------------+------------+------------+",
+                    "| table_catalog | table_schema | table_name | table_type |",
+                    "+---------------+--------------+------------+------------+",
+                    "| glob_lake     | main         | orders     | BASE TABLE |",
+                    "+---------------+--------------+------------+------------+",
+                ],
+                &results
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Tests that a standalone `DuckLake` dataset (registered individually, not via catalog)
+/// is queryable.
+#[tokio::test]
+async fn ducklake_standalone_dataset() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir
+        .path()
+        .join("test_standalone.ducklake")
+        .display()
+        .to_string();
+    let data_path = tmp_dir.path().join("data_standalone").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            // Register a standalone dataset using the ducklake data connector
+            let mut dataset = Dataset::new(
+                "ducklake:main.products".to_string(),
+                "my_products".to_string(),
+            );
+            dataset.params = Some(Params::from_string_map(HashMap::from([(
+                "ducklake_connection_string".to_string(),
+                metadata_path.clone(),
+            )])));
+
+            let app = AppBuilder::new("ducklake_standalone_test")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let result = rt
+                .datafusion()
+                .query_builder("SELECT id, name, price FROM my_products ORDER BY id")
+                .build()
+                .run()
+                .await?;
+            let results: Vec<RecordBatch> = result.data.try_collect().await?;
+            assert_batches_eq!(
+                &[
+                    "+----+--------+-------+",
+                    "| id | name   | price |",
+                    "+----+--------+-------+",
+                    "| 1  | Widget | 9.99  |",
+                    "| 2  | Gadget | 19.99 |",
+                    "+----+--------+-------+",
+                ],
+                &results
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -66,6 +66,8 @@ mod delta_lake;
 mod docker;
 #[cfg(feature = "duckdb")]
 mod duckdb;
+#[cfg(feature = "duckdb")]
+mod ducklake;
 #[cfg(feature = "dynamodb")]
 pub mod dynamodb;
 mod endpoint_auth;


### PR DESCRIPTION
## 📝 Summary

Fixes #10737

The DuckLake catalog connector was not passing the `include` glob filter to `DuckLakeCatalogProvider`, causing all tables to be registered regardless of the filter configuration.

**Changes:**
- `DuckLakeCatalogProvider` and `DuckLakeSchemaProvider` now accept an `include: Option<GlobSet>` parameter
- `DuckLakeSchemaProvider::refresh()` filters tables by matching `schema_name.table_name` against the glob set, consistent with the PostgreSQL catalog connector
- `DuckLakeCatalog::refreshable_catalog_provider()` passes `catalog.include` to the provider
- Added integration tests for include filtering with exact names, glob patterns, and no-filter behavior

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->