### PR TITLE
feat: Allow full version tags in spicepod version

### DIFF
--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -623,10 +623,19 @@ mod version_tests {
         );
     }
 
-    /// Free-form versions like v3, v2.0, v2.0.0, v2.0.0-rc.1 are accepted.
+    /// Partial and full version strings are accepted for supported majors (v1, v2).
     #[test]
     fn test_free_form_versions_accepted() {
-        let cases = ["v3", "v2.0", "v2.0.0", "v2.0.0-rc.1", "v10.20.30-beta-2"];
+        let cases = [
+            "v1",
+            "v2",
+            "v1.0",
+            "v2.0",
+            "v1.0.0",
+            "v2.0.0",
+            "v2.0.0-rc.1",
+            "v1.10.20-beta-2",
+        ];
         for case in cases {
             let parsed: SpicepodVersion =
                 yaml::from_str(case).unwrap_or_else(|e| panic!("Should parse '{case}': {e}"));
@@ -634,6 +643,23 @@ mod version_tests {
                 parsed.to_string(),
                 case,
                 "Parsed version should round-trip to the same string"
+            );
+        }
+    }
+
+    /// Unsupported major versions (anything other than v1 or v2) are rejected
+    /// with an "unsupported spicepod version" error that names the major.
+    #[test]
+    fn test_unsupported_major_rejected() {
+        let cases = ["v0", "v3", "v3.0.0", "v100", "v4.5.6-rc.1"];
+        for case in cases {
+            let result: Result<SpicepodVersion, _> = yaml::from_str(case);
+            let err = result
+                .expect_err(&format!("'{case}' should be rejected as unsupported major"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("unsupported spicepod version") && msg.contains(case),
+                "Error for '{case}' should mention unsupported version, got: {msg}"
             );
         }
     }

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -642,7 +642,19 @@ mod version_tests {
     #[test]
     fn test_malformed_version_error_message() {
         let cases = [
-            "v1beta1", "1.0.0", "vfoo", "v", "v1.", "v1.0.0-", "v1-rc.1", "v1.0.0.0",
+            "v1beta1",
+            "1.0.0",
+            "vfoo",
+            "v",
+            "v1.",
+            "v1.0.0-",
+            "v1-rc.1",
+            "v1.0-rc.1",
+            "v1.0.0.0",
+            "v01",
+            "v2.01",
+            "v2.0.01",
+            "v02.0.0",
         ];
         for case in cases {
             let result: Result<SpicepodVersion, _> = yaml::from_str(case);

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -654,8 +654,8 @@ mod version_tests {
         let cases = ["v0", "v3", "v3.0.0", "v100", "v4.5.6-rc.1"];
         for case in cases {
             let result: Result<SpicepodVersion, _> = yaml::from_str(case);
-            let err = result
-                .expect_err(&format!("'{case}' should be rejected as unsupported major"));
+            let err =
+                result.expect_err(&format!("'{case}' should be rejected as unsupported major"));
             let msg = err.to_string();
             assert!(
                 msg.contains("unsupported spicepod version") && msg.contains(case),

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -714,6 +714,35 @@ mod version_tests {
         assert_eq!(original.to_string(), "v2.0.0-rc.1");
     }
 
+    /// End-to-end: a full `vMAJOR.MINOR.PATCH-PRERELEASE` tag in a complete
+    /// `SpicepodDefinition` YAML deserializes and round-trips through serialization.
+    #[test]
+    fn test_full_version_tag_in_spicepod_definition() {
+        let yaml = r"
+            version: v2.0.0-rc.1
+            kind: Spicepod
+            name: prerelease_pod
+        ";
+        let def: SpicepodDefinition =
+            yaml::from_str(yaml).expect("Should parse SpicepodDefinition with v2.0.0-rc.1");
+        assert_eq!(def.version.to_string(), "v2.0.0-rc.1");
+        assert_eq!(def.version.major(), 2);
+        assert_eq!(def.version.minor(), Some(0));
+        assert_eq!(def.version.patch(), Some(0));
+        assert_eq!(def.version.pre_release(), Some("rc.1"));
+        assert_eq!(def.name, "prerelease_pod");
+
+        // Round-trip through serialize → deserialize preserves the version tag exactly.
+        let serialized = yaml::to_string(&def).expect("Should serialize");
+        assert!(
+            serialized.contains("version: v2.0.0-rc.1"),
+            "Serialized YAML should preserve full version tag, got:\n{serialized}"
+        );
+        let reparsed: SpicepodDefinition =
+            yaml::from_str(&serialized).expect("Should re-parse round-tripped YAML");
+        assert_eq!(reparsed.version, def.version);
+    }
+
     // ========================================================================
     // v1 schema support (backward compat with release/1.11)
     // ========================================================================

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -608,16 +608,72 @@ mod version_tests {
         assert_eq!(def.name, "test_pod");
     }
 
-    /// Unknown version strings produce a deserialization error.
+    /// Malformed version strings produce a deserialization error.
     #[test]
     fn test_invalid_version_rejected() {
         let yaml = r"
-            version: v3
+            version: not-a-version
             kind: Spicepod
             name: invalid
         ";
         let result: Result<SpicepodDefinition, _> = yaml::from_str(yaml);
-        assert!(result.is_err(), "Unknown version 'v3' should be rejected");
+        assert!(
+            result.is_err(),
+            "Malformed version 'not-a-version' should be rejected"
+        );
+    }
+
+    /// Free-form versions like v3, v2.0, v2.0.0, v2.0.0-rc.1 are accepted.
+    #[test]
+    fn test_free_form_versions_accepted() {
+        let cases = ["v3", "v2.0", "v2.0.0", "v2.0.0-rc.1", "v10.20.30-beta-2"];
+        for case in cases {
+            let parsed: SpicepodVersion =
+                yaml::from_str(case).unwrap_or_else(|e| panic!("Should parse '{case}': {e}"));
+            assert_eq!(
+                parsed.to_string(),
+                case,
+                "Parsed version should round-trip to the same string"
+            );
+        }
+    }
+
+    /// Malformed version strings produce errors with a friendly message.
+    #[test]
+    fn test_malformed_version_error_message() {
+        let cases = [
+            "v1beta1", "1.0.0", "vfoo", "v", "v1.", "v1.0.0-", "v1-rc.1", "v1.0.0.0",
+        ];
+        for case in cases {
+            let result: Result<SpicepodVersion, _> = yaml::from_str(case);
+            let err = result.expect_err(&format!("'{case}' should be rejected"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("invalid spicepod version") && msg.contains(case),
+                "Error for '{case}' should be user-friendly, got: {msg}"
+            );
+        }
+    }
+
+    /// Partial and full version strings are structurally distinct.
+    #[test]
+    fn test_partial_versions_are_distinct() {
+        let v2: SpicepodVersion = yaml::from_str("v2").expect("v2");
+        let v2_0: SpicepodVersion = yaml::from_str("v2.0").expect("v2.0");
+        let v2_0_0: SpicepodVersion = yaml::from_str("v2.0.0").expect("v2.0.0");
+        assert_ne!(v2, v2_0);
+        assert_ne!(v2_0, v2_0_0);
+        assert_eq!(v2, SpicepodVersion::V2);
+    }
+
+    /// A full version string with pre-release roundtrips through YAML.
+    #[test]
+    fn test_prerelease_version_roundtrip() {
+        let original: SpicepodVersion = yaml::from_str("v2.0.0-rc.1").expect("Should parse");
+        let yaml_str = yaml::to_string(&original).expect("Should serialize");
+        let roundtripped: SpicepodVersion = yaml::from_str(&yaml_str).expect("Should deserialize");
+        assert_eq!(original, roundtripped);
+        assert_eq!(original.to_string(), "v2.0.0-rc.1");
     }
 
     // ========================================================================

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -169,7 +169,8 @@ const SUPPORTED_MAJORS: &[u64] = &[1, 2];
 /// so external schema validators reject unsupported majors up-front.
 /// Keep in sync with [`SUPPORTED_MAJORS`].
 #[cfg(feature = "schemars")]
-const VERSION_SCHEMA_PATTERN: &str = r"^v(1|2)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
+const VERSION_SCHEMA_PATTERN: &str =
+    r"^v(1|2)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
 
 #[expect(clippy::expect_used)]
 static VERSION_REGEX: LazyLock<Regex> =

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -47,6 +47,9 @@ use crate::extension::Extension;
 /// - `v2.0.0` — major.minor.patch
 /// - `v2.0.0-rc.1` — major.minor.patch with a pre-release identifier
 ///
+/// Currently only `v1` and `v2` majors are supported. Other shapes (`v3`, `v0`, etc.)
+/// fail to parse with an "unsupported major" error.
+///
 /// Equality is structural: `v1` and `v1.0.0` are not equal.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct SpicepodVersion {
@@ -116,29 +119,57 @@ impl Display for SpicepodVersion {
     }
 }
 
-/// Error returned when a spicepod version string is not in the expected format.
+/// Error returned when a spicepod version string cannot be accepted.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpicepodVersionParseError {
     input: String,
+    kind: SpicepodVersionParseErrorKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SpicepodVersionParseErrorKind {
+    /// The input does not match the expected `vMAJOR[.MINOR[.PATCH[-PRERELEASE]]]` format.
+    InvalidFormat,
+    /// The format is valid but the major version is not one of [`SUPPORTED_MAJORS`].
+    UnsupportedMajor(u64),
 }
 
 impl Display for SpicepodVersionParseError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "invalid spicepod version '{}': expected a version string like 'v1', 'v2', 'v2.0', 'v2.0.0', or 'v2.0.0-rc.1'",
-            self.input
-        )
+        match self.kind {
+            SpicepodVersionParseErrorKind::InvalidFormat => write!(
+                f,
+                "invalid spicepod version '{}': expected a version string like 'v1', 'v2', 'v2.0', 'v2.0.0', or 'v2.0.0-rc.1'",
+                self.input
+            ),
+            SpicepodVersionParseErrorKind::UnsupportedMajor(major) => write!(
+                f,
+                "unsupported spicepod version '{}': major version v{major} is not supported (supported majors: v1, v2)",
+                self.input
+            ),
+        }
     }
 }
 
 impl std::error::Error for SpicepodVersionParseError {}
 
-/// Pattern accepted by [`SpicepodVersion::from_str`].
+/// Pattern accepted by [`SpicepodVersion::from_str`] as a well-formed version string.
 ///
 /// Numeric components disallow leading zeros (`v01`, `v2.01.0` are invalid).
 /// A pre-release identifier is only valid alongside a full `major.minor.patch`.
+///
+/// Note that this regex accepts any major version; [`FromStr::from_str`] additionally
+/// validates that the parsed major is in [`SUPPORTED_MAJORS`].
 const VERSION_PATTERN: &str = r"^v(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
+
+/// Currently supported major versions. Keep [`VERSION_SCHEMA_PATTERN`] in sync.
+const SUPPORTED_MAJORS: &[u64] = &[1, 2];
+
+/// JSON Schema pattern — restricted to currently supported major versions
+/// so external schema validators reject unsupported majors up-front.
+/// Keep in sync with [`SUPPORTED_MAJORS`].
+#[cfg(feature = "schemars")]
+const VERSION_SCHEMA_PATTERN: &str = r"^v(1|2)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
 
 #[expect(clippy::expect_used)]
 static VERSION_REGEX: LazyLock<Regex> =
@@ -148,22 +179,30 @@ impl FromStr for SpicepodVersion {
     type Err = SpicepodVersionParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let err = || SpicepodVersionParseError {
+        let invalid_format = || SpicepodVersionParseError {
             input: s.to_string(),
+            kind: SpicepodVersionParseErrorKind::InvalidFormat,
         };
-        let captures = VERSION_REGEX.captures(s).ok_or_else(err)?;
+        let captures = VERSION_REGEX.captures(s).ok_or_else(invalid_format)?;
 
         let parse_num = |idx: usize| -> Result<Option<u64>, SpicepodVersionParseError> {
             captures
                 .get(idx)
-                .map(|m| m.as_str().parse::<u64>().map_err(|_| err()))
+                .map(|m| m.as_str().parse::<u64>().map_err(|_| invalid_format()))
                 .transpose()
         };
 
-        let major = parse_num(1)?.ok_or_else(err)?;
+        let major = parse_num(1)?.ok_or_else(invalid_format)?;
         let minor = parse_num(2)?;
         let patch = parse_num(3)?;
         let pre_release = captures.get(4).map(|m| m.as_str().to_string());
+
+        if !SUPPORTED_MAJORS.contains(&major) {
+            return Err(SpicepodVersionParseError {
+                input: s.to_string(),
+                kind: SpicepodVersionParseErrorKind::UnsupportedMajor(major),
+            });
+        }
 
         Ok(Self {
             major,
@@ -200,8 +239,8 @@ impl JsonSchema for SpicepodVersion {
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": VERSION_PATTERN,
-            "description": "Spicepod schema version. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
+            "pattern": VERSION_SCHEMA_PATTERN,
+            "description": "Spicepod schema version. Supported majors: v1, v2. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
         })
     }
 }

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -144,10 +144,25 @@ impl Display for SpicepodVersionParseError {
             ),
             SpicepodVersionParseErrorKind::UnsupportedMajor(major) => write!(
                 f,
-                "unsupported spicepod version '{}': major version v{major} is not supported (supported majors: v1, v2)",
-                self.input
+                "unsupported spicepod version '{}': major version v{major} is not supported (supported majors: {})",
+                self.input, FormatSupportedMajors,
             ),
         }
+    }
+}
+
+/// Renders [`SUPPORTED_MAJORS`] as a comma-separated list of `vN` tags (e.g. `v1, v2`).
+struct FormatSupportedMajors;
+
+impl Display for FormatSupportedMajors {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        for (i, major) in SUPPORTED_MAJORS.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "v{major}")?;
+        }
+        Ok(())
     }
 }
 
@@ -162,15 +177,25 @@ impl std::error::Error for SpicepodVersionParseError {}
 /// validates that the parsed major is in [`SUPPORTED_MAJORS`].
 const VERSION_PATTERN: &str = r"^v(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
 
-/// Currently supported major versions. Keep [`VERSION_SCHEMA_PATTERN`] in sync.
+/// Currently supported major versions.
+///
+/// To add or remove a supported major, edit this list — the parser error message and the
+/// JSON Schema `pattern` are derived from it, so they stay in sync automatically.
 const SUPPORTED_MAJORS: &[u64] = &[1, 2];
 
-/// JSON Schema pattern — restricted to currently supported major versions
-/// so external schema validators reject unsupported majors up-front.
-/// Keep in sync with [`SUPPORTED_MAJORS`].
+/// JSON Schema pattern — restricted to currently supported major versions so external
+/// schema validators reject unsupported majors up-front. Built once from [`SUPPORTED_MAJORS`].
 #[cfg(feature = "schemars")]
-const VERSION_SCHEMA_PATTERN: &str =
-    r"^v(1|2)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
+static VERSION_SCHEMA_PATTERN: LazyLock<String> = LazyLock::new(|| {
+    let majors = SUPPORTED_MAJORS
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join("|");
+    format!(
+        r"^v({majors})(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$"
+    )
+});
 
 #[expect(clippy::expect_used)]
 static VERSION_REGEX: LazyLock<Regex> =
@@ -238,10 +263,14 @@ impl JsonSchema for SpicepodVersion {
     }
 
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        let pattern: &str = &VERSION_SCHEMA_PATTERN;
+        let description = format!(
+            "Spicepod schema version. Supported majors: {FormatSupportedMajors}. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
+        );
         json_schema!({
             "type": "string",
-            "pattern": VERSION_SCHEMA_PATTERN,
-            "description": "Spicepod schema version. Supported majors: v1, v2. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
+            "pattern": pattern,
+            "description": description,
         })
     }
 }

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use std::{collections::HashMap, fmt::Debug};
 
 use crate::component::catalog::Catalog;
@@ -134,51 +134,35 @@ impl Display for SpicepodVersionParseError {
 
 impl std::error::Error for SpicepodVersionParseError {}
 
-fn version_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"^v(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$")
-            .expect("spicepod version regex must compile")
-    })
-}
+/// Pattern accepted by [`SpicepodVersion::from_str`].
+///
+/// Numeric components disallow leading zeros (`v01`, `v2.01.0` are invalid).
+/// A pre-release identifier is only valid alongside a full `major.minor.patch`.
+const VERSION_PATTERN: &str = r"^v(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
+
+static VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(VERSION_PATTERN).expect("spicepod version regex must compile"));
 
 impl FromStr for SpicepodVersion {
     type Err = SpicepodVersionParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let captures = version_regex()
-            .captures(s)
-            .ok_or_else(|| SpicepodVersionParseError {
-                input: s.to_string(),
-            })?;
+        let err = || SpicepodVersionParseError {
+            input: s.to_string(),
+        };
+        let captures = VERSION_REGEX.captures(s).ok_or_else(err)?;
 
         let parse_num = |idx: usize| -> Result<Option<u64>, SpicepodVersionParseError> {
             captures
                 .get(idx)
-                .map(|m| {
-                    m.as_str()
-                        .parse::<u64>()
-                        .map_err(|_| SpicepodVersionParseError {
-                            input: s.to_string(),
-                        })
-                })
+                .map(|m| m.as_str().parse::<u64>().map_err(|_| err()))
                 .transpose()
         };
 
-        let major = parse_num(1)?.ok_or_else(|| SpicepodVersionParseError {
-            input: s.to_string(),
-        })?;
+        let major = parse_num(1)?.ok_or_else(err)?;
         let minor = parse_num(2)?;
         let patch = parse_num(3)?;
         let pre_release = captures.get(4).map(|m| m.as_str().to_string());
-
-        // Pre-release requires a full major.minor.patch — otherwise the regex
-        // would have matched the pre-release as part of the minor/patch slots.
-        if pre_release.is_some() && (minor.is_none() || patch.is_none()) {
-            return Err(SpicepodVersionParseError {
-                input: s.to_string(),
-            });
-        }
 
         Ok(Self {
             major,
@@ -215,7 +199,7 @@ impl JsonSchema for SpicepodVersion {
     fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": r"^v\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$",
+            "pattern": VERSION_PATTERN,
             "description": "Spicepod schema version. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
         })
     }

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -140,6 +140,7 @@ impl std::error::Error for SpicepodVersionParseError {}
 /// A pre-release identifier is only valid alongside a full `major.minor.patch`.
 const VERSION_PATTERN: &str = r"^v(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?$";
 
+#[expect(clippy::expect_used)]
 static VERSION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(VERSION_PATTERN).expect("spicepod version regex must compile"));
 

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use regex::Regex;
 #[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+use std::sync::OnceLock;
 use std::{collections::HashMap, fmt::Debug};
 
 use crate::component::catalog::Catalog;
@@ -36,18 +39,185 @@ use crate::component::{
 };
 use crate::extension::Extension;
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum SpicepodVersion {
-    V1,
-    #[default]
-    V2,
+/// The version of a Spicepod definition.
+///
+/// Accepts free-form version strings of the form:
+/// - `v1`, `v2` — major only
+/// - `v2.0` — major.minor
+/// - `v2.0.0` — major.minor.patch
+/// - `v2.0.0-rc.1` — major.minor.patch with a pre-release identifier
+///
+/// Equality is structural: `v1` and `v1.0.0` are not equal.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub struct SpicepodVersion {
+    major: u64,
+    minor: Option<u64>,
+    patch: Option<u64>,
+    pre_release: Option<String>,
+}
+
+impl SpicepodVersion {
+    /// `v1` — equivalent to parsing the string `"v1"`.
+    pub const V1: Self = Self {
+        major: 1,
+        minor: None,
+        patch: None,
+        pre_release: None,
+    };
+
+    /// `v2` — equivalent to parsing the string `"v2"`.
+    pub const V2: Self = Self {
+        major: 2,
+        minor: None,
+        patch: None,
+        pre_release: None,
+    };
+
+    #[must_use]
+    pub fn major(&self) -> u64 {
+        self.major
+    }
+
+    #[must_use]
+    pub fn minor(&self) -> Option<u64> {
+        self.minor
+    }
+
+    #[must_use]
+    pub fn patch(&self) -> Option<u64> {
+        self.patch
+    }
+
+    #[must_use]
+    pub fn pre_release(&self) -> Option<&str> {
+        self.pre_release.as_deref()
+    }
+}
+
+impl Default for SpicepodVersion {
+    fn default() -> Self {
+        Self::V2
+    }
 }
 
 impl Display for SpicepodVersion {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "v{}", self.major)?;
+        if let Some(minor) = self.minor {
+            write!(f, ".{minor}")?;
+        }
+        if let Some(patch) = self.patch {
+            write!(f, ".{patch}")?;
+        }
+        if let Some(pre) = &self.pre_release {
+            write!(f, "-{pre}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Error returned when a spicepod version string is not in the expected format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpicepodVersionParseError {
+    input: String,
+}
+
+impl Display for SpicepodVersionParseError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "invalid spicepod version '{}': expected a version string like 'v1', 'v2', 'v2.0', 'v2.0.0', or 'v2.0.0-rc.1'",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for SpicepodVersionParseError {}
+
+fn version_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^v(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$")
+            .expect("spicepod version regex must compile")
+    })
+}
+
+impl FromStr for SpicepodVersion {
+    type Err = SpicepodVersionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let captures = version_regex()
+            .captures(s)
+            .ok_or_else(|| SpicepodVersionParseError {
+                input: s.to_string(),
+            })?;
+
+        let parse_num = |idx: usize| -> Result<Option<u64>, SpicepodVersionParseError> {
+            captures
+                .get(idx)
+                .map(|m| {
+                    m.as_str()
+                        .parse::<u64>()
+                        .map_err(|_| SpicepodVersionParseError {
+                            input: s.to_string(),
+                        })
+                })
+                .transpose()
+        };
+
+        let major = parse_num(1)?.ok_or_else(|| SpicepodVersionParseError {
+            input: s.to_string(),
+        })?;
+        let minor = parse_num(2)?;
+        let patch = parse_num(3)?;
+        let pre_release = captures.get(4).map(|m| m.as_str().to_string());
+
+        // Pre-release requires a full major.minor.patch — otherwise the regex
+        // would have matched the pre-release as part of the minor/patch slots.
+        if pre_release.is_some() && (minor.is_none() || patch.is_none()) {
+            return Err(SpicepodVersionParseError {
+                input: s.to_string(),
+            });
+        }
+
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            pre_release,
+        })
+    }
+}
+
+impl Serialize for SpicepodVersion {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for SpicepodVersion {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Self::from_str(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl JsonSchema for SpicepodVersion {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SpicepodVersion".into()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        concat!(module_path!(), "::SpicepodVersion").into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^v\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$",
+            "description": "Spicepod schema version. Examples: 'v1', 'v2', 'v2.0', 'v2.0.0', 'v2.0.0-rc.1'."
+        })
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Allows specifying a full or partial version in the Spicepod `.version` property, like `v2.0.0-rc.2`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->