### PR TITLE
fix(snapshot): keep refresh_mode snapshot read-only

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3741,6 +3741,14 @@ async fn build_snapshot_creation_config(
         Arc<dyn runtime_acceleration::snapshot::engine::SnapshotEngine>,
     >,
 ) -> Result<Option<SnapshotCreationConfig>> {
+    // `refresh_mode: snapshot` is a read-only snapshot consumer. Even when the
+    // dataset uses `acceleration.snapshots: enabled` (which normally enables
+    // both bootstrap and creation), snapshot refresh mode must not publish new
+    // snapshots or run the refresh-complete snapshot creation path.
+    if matches!(refresh_mode, RefreshMode::Snapshot) {
+        return Ok(None);
+    }
+
     let is_streaming_refresh = matches!(refresh_mode, RefreshMode::Changes)
         || (matches!(refresh_mode, RefreshMode::Append) && dataset.time_column.is_none());
     let snapshot_trigger = &acceleration_settings.snapshots_trigger;
@@ -4241,6 +4249,64 @@ mod tests {
             .await;
 
             assert!(result.expect("config should exist").is_none());
+        }
+
+        #[tokio::test]
+        async fn test_snapshot_refresh_mode_is_reader_only() {
+            let dataset = create_test_dataset(None).await;
+            let acceleration = create_acceleration_with_trigger(
+                Some("file:///tmp".to_string()),
+                Engine::DuckDB,
+                Some(SnapshotsTrigger::RefreshComplete),
+                None,
+                &dataset.runtime().secrets(),
+            );
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let snapshot_path = temp_dir.path().join("snapshot.db");
+
+            let result = build_snapshot_creation_config(
+                &dataset,
+                &acceleration,
+                RefreshMode::Snapshot,
+                AccelerationLayout::file(snapshot_path),
+                None,
+            )
+            .await;
+
+            assert!(
+                result.expect("snapshot reader should not error").is_none(),
+                "refresh_mode: snapshot must not create a snapshot creation config"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_snapshot_refresh_mode_ignores_create_trigger_validation() {
+            let dataset = create_test_dataset(None).await;
+            let acceleration = create_acceleration_with_trigger(
+                Some("file:///tmp".to_string()),
+                Engine::DuckDB,
+                Some(SnapshotsTrigger::StreamBatches),
+                Some("not-a-valid-batch-count".to_string()),
+                &dataset.runtime().secrets(),
+            );
+            let temp_dir = TempDir::new().expect("Failed to create temp dir");
+            let snapshot_path = temp_dir.path().join("snapshot.db");
+
+            let result = build_snapshot_creation_config(
+                &dataset,
+                &acceleration,
+                RefreshMode::Snapshot,
+                AccelerationLayout::file(snapshot_path),
+                None,
+            )
+            .await;
+
+            assert!(
+                result
+                    .expect("snapshot reader should ignore creation trigger config")
+                    .is_none(),
+                "refresh_mode: snapshot should ignore snapshot creation trigger settings"
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
- Treat `refresh_mode: snapshot` datasets as read-only snapshot consumers for snapshot creation config
- Prevent `acceleration.snapshots: enabled` from wiring refresh-complete snapshot creation for snapshot-mode readers
- Add unit coverage for reader-only behavior and ignored writer trigger validation

## Testing
- `cargo test -p runtime --lib build_snapshot_creation_config_tests --features duckdb,snapshots`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->