### PR TITLE
feat(tls): mTLS for HTTP and Flight (channel + identity modes)

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -475,6 +475,16 @@
             }
           ]
         },
+        "mcp": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "temp_directory": {
           "description": "Configures where the runtime will store temporary files needed for operations like\nspilling to disk for queries & accelerations that are larger than memory.",
           "type": [
@@ -814,11 +824,45 @@
             "string",
             "null"
           ]
+        },
+        "client_auth_ca_file": {
+          "description": "Filesystem path to a PEM-encoded CA bundle used to verify client\ncertificates when `client_auth_mode` is `request` or `required`.\nEligible for hot-reload via the same watcher that picks up server\ncert / key rotations.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "client_auth_ca": {
+          "description": "Inline PEM (or `${ secrets:... }`) form of the client CA bundle.\nMutually exclusive with `client_auth_ca_file`. Inline material is\nnot hot-reloaded.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "client_auth_mode": {
+          "description": "How the runtime treats client certificates on the public TLS\nendpoints. Defaults to `none`, which preserves today's behavior\n(the server does not request a client cert during the TLS\nhandshake). See [`ClientAuthMode`] for the full mode table.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ClientAuthMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
         "enabled"
+      ]
+    },
+    "ClientAuthMode": {
+      "description": "How the runtime treats client certificates on the public TLS\nendpoints (HTTP, Flight, Metrics).\n\n`None` is the out-of-the-box default and disables client-cert\nauthentication entirely — the server runs `with_no_client_auth()`\nat the rustls layer and does not send a `CertificateRequest`. A\nnon-conforming client that nonetheless presents a cert is rejected\nby rustls as a protocol violation.\n\n`Request` opts in to *optional* mTLS: the server sends\n`CertificateRequest` and accepts both no-cert and cert-bearing\nhandshakes. Presented certs must be signed by\n`client_auth_ca` / `client_auth_ca_file` (an invalid cert is still\nrejected at the handshake). When a cert is presented it is\npromoted to the request's auth principal under\n`IdentitySource::Channel`; when absent the request runs as the\nanonymous principal. Useful for migration windows and for\naudit-only deployments where every cert seen should be recorded\nbut not enforced.\n\n`Required` enables strict mTLS: the server demands a valid client\ncert (verified against `client_auth_ca` / `client_auth_ca_file`)\nfor every connection on the Flight listener; on the HTTP and\nmetrics listeners the TLS handshake admits no-cert connections so\nKubernetes liveness / readiness probes and Prometheus scrapes work\nwithout a client cert, but the HTTP route layer 401s any\nnon-probe request whose connection has no verified client cert.\n\nWhether a presented cert *also* becomes the request's auth\nprincipal is determined separately by whether `runtime.auth` is\nconfigured — see the `IdentitySource` enum at the binary\nentrypoint. Briefly:\n\n- `client_auth_mode: required` and no `runtime.auth`\n  → mTLS-as-identity (the cert is the principal).\n- `client_auth_mode: required` plus `runtime.auth`\n  → mTLS-as-channel (the cert protects the channel; the\n  API key / OIDC token is the principal).",
+      "type": "string",
+      "enum": [
+        "none",
+        "request",
+        "required"
       ]
     },
     "TracingConfig": {
@@ -1115,6 +1159,23 @@
           "default": true
         }
       }
+    },
+    "McpConfig": {
+      "description": "Configuration for the MCP (Model Context Protocol) HTTP endpoint.",
+      "type": "object",
+      "properties": {
+        "allowed_hosts": {
+          "description": "Hostnames (and optional ports) permitted in the `Host` header of incoming MCP requests.\nUsed to prevent DNS-rebinding attacks. Accepts bare hostnames (`example.com`),\nhost-port pairs (`example.com:8090`), or full origin URLs (`https://example.com`).\nSet to `[\"*\"]` to disable host checking entirely.\nDefaults to rmcp defaults (`[\"localhost\", \"127.0.0.1\", \"::1\"]`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "RuntimeReadyState": {
       "description": "Controls when the runtime readiness probe reports the runtime as ready.",
@@ -1731,9 +1792,6 @@
             },
             "check_availability": {
               "$ref": "#/$defs/CheckAvailability"
-            },
-            "load": {
-              "$ref": "#/$defs/Load"
             },
             "mode": {
               "$ref": "#/$defs/AccessMode"
@@ -2951,21 +3009,6 @@
           "description": "The dataset is not checked for availability.",
           "type": "string",
           "const": "disabled"
-        }
-      ]
-    },
-    "Load": {
-      "description": "Controls when a dataset is loaded by the runtime.",
-      "oneOf": [
-        {
-          "description": "Load the dataset during runtime startup.",
-          "type": "string",
-          "const": "on_startup"
-        },
-        {
-          "description": "Load the dataset when it is first queried or explicitly refreshed.",
-          "type": "string",
-          "const": "on_demand"
         }
       ]
     },
@@ -7379,7 +7422,7 @@
           "default": ""
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -7624,7 +7667,7 @@
           ]
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -7842,7 +7885,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -8072,7 +8115,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -8298,7 +8341,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -8528,7 +8571,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -8750,7 +8793,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -9009,7 +9052,7 @@
           ]
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -9227,7 +9270,7 @@
           "type": "string"
         },
         "tools": {
-          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
+          "description": "Which tools should be made available to the model. Set to 'auto' to automatically choose between direct tools and searchable discovery without data sampling tools, 'all' to use built-in and Spicepod-configured tools directly, or 'search_registry' to require searchable tool discovery.",
           "type": "string"
         },
         "tool_embedding_model": {
@@ -9604,9 +9647,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -9784,9 +9824,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -9966,9 +10003,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -10146,9 +10180,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -10328,9 +10359,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -10508,9 +10536,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -10690,9 +10715,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -10870,9 +10892,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -11052,9 +11071,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -11232,9 +11248,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -11414,9 +11427,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -11594,9 +11604,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -11776,9 +11783,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -11956,9 +11960,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -12138,9 +12139,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -12318,9 +12316,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -12500,9 +12495,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -12680,9 +12672,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -12862,9 +12851,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -13043,9 +13029,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -13223,9 +13206,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -13414,9 +13394,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -13603,9 +13580,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -13794,9 +13768,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -13983,9 +13954,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -14174,9 +14142,6 @@
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
         },
-        "load": {
-          "$ref": "#/$defs/Load"
-        },
         "mode": {
           "$ref": "#/$defs/AccessMode"
         }
@@ -14363,9 +14328,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"
@@ -15454,9 +15416,6 @@
         },
         "check_availability": {
           "$ref": "#/$defs/CheckAvailability"
-        },
-        "load": {
-          "$ref": "#/$defs/Load"
         },
         "mode": {
           "$ref": "#/$defs/AccessMode"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15772,6 +15772,7 @@ dependencies = [
  "tonic",
  "tower 0.5.3",
  "tracing",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -17744,6 +17745,7 @@ dependencies = [
  "reqwest 0.12.24",
  "runtime",
  "runtime-async",
+ "runtime-auth",
  "rustls 0.23.36",
  "snafu",
  "snmalloc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,7 @@ tonic = { version = "0.14", features = [
     "gzip",
     "tls-ring",
     "tls-native-roots",
+    "tls-connect-info",
 ] }
 tonic-health = { version = "0.14" }
 tower = "0.5.2"

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -48,6 +48,7 @@ otel-arrow = { path = "../../crates/otel-arrow" }
 prometheus.workspace = true
 reqwest.workspace = true
 runtime = { path = "../../crates/runtime" }
+runtime-auth = { path = "../../crates/runtime-auth" }
 runtime-async = { path = "../../crates/runtime-async" }
 rustls.workspace = true
 yaml = { path = "../../crates/yaml" }
@@ -149,6 +150,7 @@ sftp = ["connector-sftp", "runtime/sftp"]
 sharepoint = ["connector-sharepoint", "runtime/sharepoint"]
 smb = ["connector-smb"]
 snapshots = ["runtime/snapshots"]
+client_tls = ["runtime/client_tls"]
 snowflake = ["connector-snowflake", "runtime/snowflake"]
 spark = ["connector-spark", "runtime/spark", "connector-databricks/spark"]
 sqlite = ["runtime/sqlite"]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -25,9 +25,11 @@ use std::time::Duration;
 
 use tokio::sync::SetOnce;
 
-use app::spicepod::component::runtime::{Runtime as SpicepodRuntime, TelemetryConfig};
+use app::spicepod::component::runtime::{
+    ClientAuthMode as SpicepodClientAuthMode, Runtime as SpicepodRuntime, TelemetryConfig,
+};
 use app::{App, AppBuilder};
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, Parser, ValueEnum};
 use opentelemetry::{KeyValue, global};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
@@ -259,6 +261,49 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Clap mirror of [`SpicepodClientAuthMode`]. Defined here so we can
+/// derive `ValueEnum` for the `--tls-client-auth-mode` CLI flag
+/// without pulling clap into the `spicepod` crate. The two enums
+/// are trivially convertible via [`ClientAuthMode::into_spicepod`]
+/// and [`ClientAuthMode::from_spicepod`].
+#[derive(ValueEnum, Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[clap(rename_all = "snake_case")]
+pub enum ClientAuthMode {
+    /// No client-cert authentication. The server runs
+    /// `with_no_client_auth()` at the rustls layer and never sends a
+    /// `CertificateRequest`. This is the out-of-the-box default.
+    #[default]
+    None,
+    /// Request but do not require a client cert. The server sends a
+    /// `CertificateRequest`; presented certs must be signed by the
+    /// configured client CA, but no-cert handshakes are admitted.
+    /// Useful for migration windows and audit-only deployments.
+    Request,
+    /// Require every connection to present a valid X.509 client cert
+    /// signed by the configured client CA.
+    Required,
+}
+
+impl ClientAuthMode {
+    #[must_use]
+    pub fn into_spicepod(self) -> SpicepodClientAuthMode {
+        match self {
+            ClientAuthMode::None => SpicepodClientAuthMode::None,
+            ClientAuthMode::Request => SpicepodClientAuthMode::Request,
+            ClientAuthMode::Required => SpicepodClientAuthMode::Required,
+        }
+    }
+
+    #[must_use]
+    pub fn from_spicepod(value: SpicepodClientAuthMode) -> Self {
+        match value {
+            SpicepodClientAuthMode::None => ClientAuthMode::None,
+            SpicepodClientAuthMode::Request => ClientAuthMode::Request,
+            SpicepodClientAuthMode::Required => ClientAuthMode::Required,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 #[clap(about = "Spice.ai OSS Runtime")]
 #[clap(rename_all = "kebab-case")]
@@ -311,6 +356,29 @@ pub struct Args {
     /// Path to the TLS PEM-encoded private key file.
     #[arg(long, value_name = "key.pem")]
     pub tls_key_file: Option<String>,
+
+    /// Path to a PEM-encoded CA bundle used to verify client certificates
+    /// when `--tls-client-auth-mode request` or `required` (or the
+    /// equivalent spicepod `runtime.tls.client_auth_mode`) is set.
+    /// Eligible for hot-reload via the same watcher that picks up
+    /// server cert / key rotations.
+    #[arg(long, value_name = "client-ca.pem")]
+    pub tls_client_auth_ca_file: Option<String>,
+
+    /// Inline PEM-encoded CA bundle used to verify client certificates.
+    /// Mutually exclusive with `--tls-client-auth-ca-file`. Inline material
+    /// is not hot-reloaded.
+    #[arg(long, value_name = "-----BEGIN CERTIFICATE-----...")]
+    pub tls_client_auth_ca: Option<String>,
+
+    /// How the runtime treats client certificates on the public TLS
+    /// endpoints. `none` disables client-cert authentication (default).
+    /// `request` sends `CertificateRequest` but accepts no-cert
+    /// handshakes; presented certs must be signed by the client CA.
+    /// `required` enables strict mTLS — the server demands a valid
+    /// cert signed by `--tls-client-auth-ca` / `--tls-client-auth-ca-file`.
+    #[arg(long, value_enum)]
+    pub tls_client_auth_mode: Option<ClientAuthMode>,
 
     /// Enable anonymous telemetry collection. In Open Source builds that include anonymous telemetry,
     /// `false` is ignored; build without the `anonymous_telemetry` feature to remove anonymous usage telemetry.
@@ -660,7 +728,7 @@ pub async fn run(args: Args) -> Result<()> {
         .context(UnableToInitializeMetricsSnafu)?;
     }
 
-    let tls_config = tls::load_tls_config(
+    let (tls_config, client_auth_mode) = tls::load_tls_config(
         &args,
         spicepod_tls_config.as_ref(),
         rt.secrets(),
@@ -697,6 +765,37 @@ pub async fn run(args: Args) -> Result<()> {
         Some(app) => EndpointAuth::new(rt.secrets(), app).await,
         None => EndpointAuth::no_auth(),
     };
+
+    // Compute the process-wide IdentitySource from the combination of
+    // `runtime.auth` (recorded by `EndpointAuth::new`) and the
+    // resolved public TLS `client_auth_mode`:
+    //
+    // | runtime.auth | client_auth_mode | IdentitySource |
+    // |--------------|------------------|----------------|
+    // | unset        | none             | Anonymous      |
+    // | unset        | request          | Channel        |
+    // | unset        | required         | Channel        |
+    // | set          | none             | RuntimeAuth    |
+    // | set          | request          | RuntimeAuth    |
+    // | set          | required         | RuntimeAuth    | ("mTLS-as-channel")
+    let runtime_auth_configured = endpoint_auth.http_auth.is_some();
+    let identity_source = match (runtime_auth_configured, client_auth_mode) {
+        (true, _) => runtime_auth::IdentitySource::RuntimeAuth,
+        (false, ClientAuthMode::Request | ClientAuthMode::Required) => {
+            runtime_auth::IdentitySource::Channel
+        }
+        (false, ClientAuthMode::None) => runtime_auth::IdentitySource::Anonymous,
+    };
+    if matches!(
+        (runtime_auth_configured, client_auth_mode),
+        (true, ClientAuthMode::Required)
+    ) {
+        tracing::info!(
+            "mTLS-as-channel mode active: client cert AND `runtime.auth` credentials \
+             are both required"
+        );
+    }
+    let endpoint_auth = endpoint_auth.with_identity_source(identity_source);
 
     let server_thread = tokio::spawn(async move {
         Box::pin(cloned_rt.start_servers(args.runtime, tls_config, endpoint_auth)).await

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -24,13 +24,38 @@ use runtime::secrets::{ExposeSecret, ParamStr, Secrets};
 use runtime::tls::{TlsConfig, TlsControl};
 use tokio::sync::{RwLock, RwLockReadGuard};
 
-use crate::Args;
+use crate::{Args, ClientAuthMode};
+
+/// Message shown when mTLS is configured but the `client_tls` cargo feature is
+/// not compiled into this build of Spice.
+pub(crate) const MTLS_ENTERPRISE_ONLY_MESSAGE: &str = "mTLS (client certificate authentication) is included in the Enterprise distribution of Spice.ai. Learn more at https://docs.spice.ai/docs/enterprise";
+
+#[cfg(feature = "client_tls")]
+const CLIENT_TLS_ENABLED: bool = true;
+#[cfg(not(feature = "client_tls"))]
+const CLIENT_TLS_ENABLED: bool = false;
 
 /// A resolved TLS material source. `File` paths are eligible for hot-reload;
 /// `Inline` is a static byte blob that cannot rotate.
-enum TlsMaterial {
+pub(crate) enum TlsMaterial {
     File(PathBuf),
     Inline(Vec<u8>),
+}
+
+// Manual `Debug` so that inline PEM bytes — which may be private key
+// material — never leak into log output. Paths are safe; inline
+// bytes are reduced to a length so operators can still tell
+// inline-vs-file at a glance without exposing secrets.
+impl std::fmt::Debug for TlsMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TlsMaterial::File(path) => f.debug_tuple("File").field(path).finish(),
+            TlsMaterial::Inline(bytes) => f
+                .debug_struct("Inline")
+                .field("len", &bytes.len())
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 impl TlsMaterial {
@@ -47,10 +72,10 @@ pub(crate) async fn load_tls_config(
     spicepod_tls_config: Option<&SpicepodTlsConfig>,
     secrets: Arc<RwLock<Secrets>>,
     control: &TlsControl,
-) -> std::result::Result<Option<Arc<TlsConfig>>, Box<dyn std::error::Error>> {
+) -> std::result::Result<(Option<Arc<TlsConfig>>, ClientAuthMode), Box<dyn std::error::Error>> {
     let tls_enabled = args.tls_enabled || spicepod_tls_config.as_ref().is_some_and(|c| c.enabled);
     if !tls_enabled {
-        return Ok(None);
+        return Ok((None, ClientAuthMode::None));
     }
 
     let secrets = secrets.read().await;
@@ -102,19 +127,212 @@ pub(crate) async fn load_tls_config(
         }
     };
 
+    // Resolve and validate the client-cert-authentication surface.
+    // The resolved bundle is then either fed into the hot-reload-aware
+    // `TlsConfig` constructors below or used to build an inline static
+    // verifier, depending on whether the server-cert material itself
+    // is file-backed.
+    let client_auth = resolve_client_auth(args, spicepod_tls_config, &secrets).await?;
+
+    // mTLS (client certificate authentication) is an enterprise-only feature.
+    // If the operator configured it but the feature is not compiled in, fail
+    // early with a clear message rather than silently downgrading to no-auth.
+    if !CLIENT_TLS_ENABLED && client_auth.mode != ClientAuthMode::None {
+        return Err(MTLS_ENTERPRISE_ONLY_MESSAGE.into());
+    }
+
+    match (client_auth.mode, &client_auth.ca_material) {
+        (ClientAuthMode::None, _) => {
+            tracing::debug!(
+                "Public TLS client certificates: not requested (client_auth_mode=none)"
+            );
+        }
+        (ClientAuthMode::Request, Some(ca)) => {
+            tracing::info!(
+                "Public TLS client certificates: requested but optional (client_auth_mode=request); CA from {}",
+                describe_ca_source(ca),
+            );
+        }
+        (ClientAuthMode::Required, Some(ca)) => {
+            tracing::info!(
+                "Public TLS client certificates: required (client_auth_mode=required); CA from {}",
+                describe_ca_source(ca),
+            );
+        }
+        // `validate_client_auth` rejects Request/Required without a CA,
+        // so these arms are unreachable in practice.
+        (ClientAuthMode::Request | ClientAuthMode::Required, None) => {}
+    }
+
     // Both file => hot-reload via watcher. Anything else => inline bytes.
+    // The client-CA path threads through to the same code paths so a
+    // file-backed CA is hot-reloaded and an inline CA gets a static
+    // verifier alongside the static cert+key.
     let tls_config = match (cert_material, key_material) {
         (TlsMaterial::File(cert_path), TlsMaterial::File(key_path)) => {
-            TlsConfig::try_new_from_paths(cert_path, key_path, control)?
+            // We require all three (cert, key, client CA) to be
+            // file-backed when *any* of them is, so the entire TLS
+            // bundle hot-reloads together. Mixing
+            // `client_ca` (inline) with file-backed cert/key would
+            // either disable cert/key hot-reload (rebuilding the
+            // server config from in-memory bytes) or leave the CA
+            // pinned at startup while certs rotate — both are
+            // surprising. Reject the combination instead.
+            let client_ca_path = match client_auth.ca_material {
+                Some(TlsMaterial::File(p)) => Some(p),
+                Some(TlsMaterial::Inline(_)) => {
+                    return Err(
+                        "client_auth_ca configured inline but tls.certificate_file/key_file \
+                         are file-backed: this would prevent the client CA from \
+                         hot-reloading with the cert and key. Switch to \
+                         tls.client_auth_ca_file so the entire bundle rotates together, \
+                         or move cert/key to inline form."
+                            .into(),
+                    );
+                }
+                None => None,
+            };
+            TlsConfig::try_new_from_paths_with_client_auth_mode(
+                cert_path,
+                key_path,
+                client_ca_path,
+                client_auth_enforcement(client_auth.mode),
+                control,
+            )?
         }
         (cert, key) => {
             let cert_bytes = cert.into_bytes()?;
             let key_bytes = key.into_bytes()?;
-            TlsConfig::try_new(&cert_bytes, &key_bytes)?
+            // For inline cert+key, the CA is also resolved to bytes
+            // here regardless of whether the operator gave us a file
+            // path — inline material can't hot-reload anyway.
+            let ca_bytes = match client_auth.ca_material {
+                Some(material) => Some(material.into_bytes()?),
+                None => None,
+            };
+            TlsConfig::try_new_with_client_auth_mode(
+                &cert_bytes,
+                &key_bytes,
+                ca_bytes.as_deref(),
+                client_auth_enforcement(client_auth.mode),
+            )?
         }
     };
 
-    Ok(Some(Arc::new(tls_config)))
+    Ok((Some(Arc::new(tls_config)), client_auth.mode))
+}
+
+/// Fully-resolved client-auth surface. Combines the effective mode
+/// (CLI → spicepod → default `None`) with the resolved client CA bytes
+/// (file path or inline / `${secrets:...}`).
+///
+/// Used to build the rustls `WebPkiClientVerifier`. Validation in
+/// [`resolve_client_auth`] enforces that `mode ∈ {Request, Required}`
+/// iff `ca_material.is_some()`, so consumers can rely on the
+/// invariant that any non-`None` mode always comes with concrete CA
+/// bytes.
+#[derive(Debug)]
+pub(crate) struct ResolvedClientAuth {
+    pub mode: ClientAuthMode,
+    /// `None` when `mode == ClientAuthMode::None`. `Some` when `mode`
+    /// is `Request` or `Required` (validation in
+    /// [`resolve_client_auth`] enforces this invariant).
+    pub ca_material: Option<TlsMaterial>,
+}
+
+/// Translate the binary-level [`ClientAuthMode`] into the runtime's
+/// [`runtime::tls::ClientAuthEnforcement`]. The two enums live in
+/// different crates because the binary mirrors the spicepod surface
+/// (clap-derivable) while the runtime carries the per-listener
+/// behavior bit.
+fn client_auth_enforcement(mode: ClientAuthMode) -> runtime::tls::ClientAuthEnforcement {
+    match mode {
+        ClientAuthMode::None => runtime::tls::ClientAuthEnforcement::Disabled,
+        ClientAuthMode::Request => runtime::tls::ClientAuthEnforcement::Requested,
+        ClientAuthMode::Required => runtime::tls::ClientAuthEnforcement::Required,
+    }
+}
+
+/// Resolves the effective `client_auth` mode and client CA material
+/// from CLI args, spicepod config, and (for inline / secret-backed CA
+/// values) the secrets store. Applies the v1 validation rules:
+///
+/// * `Required` requires either `client_ca` or `client_ca_file` to be
+///   set (otherwise the runtime would fail every handshake).
+/// * `None` MUST NOT have a CA configured — misconfiguration here
+///   could otherwise be silently downgraded to `none` and bypass the
+///   operator's intent.
+///
+/// Precedence: CLI `--tls-client-auth-ca-file` / `--tls-client-auth-ca` /
+/// `--tls-client-auth-mode` overrides anything in `runtime.tls`.
+/// Inline CA values are subject to `${secrets:...}` injection just
+/// like inline cert / key material.
+async fn resolve_client_auth(
+    args: &Args,
+    spicepod_tls_config: Option<&SpicepodTlsConfig>,
+    secrets: &RwLockReadGuard<'_, Secrets>,
+) -> std::result::Result<ResolvedClientAuth, Box<dyn std::error::Error>> {
+    // Mode precedence: CLI > spicepod > default.
+    let mode = match args.tls_client_auth_mode {
+        Some(m) => m,
+        None => spicepod_tls_config
+            .and_then(|c| c.client_auth_mode)
+            .map(ClientAuthMode::from_spicepod)
+            .unwrap_or_default(),
+    };
+
+    // CA material precedence (independently of mode): CLI > spicepod.
+    // We resolve eagerly so the validation below has a concrete
+    // `Option<TlsMaterial>` to inspect.
+    let spicepod_ca_material = load_spicepod_tls_param(
+        secrets,
+        spicepod_tls_config,
+        |tls| &tls.client_auth_ca_file,
+        |tls| &tls.client_auth_ca,
+        "client_auth_ca",
+        "client_auth_ca_path",
+    )
+    .await?;
+    let ca_material: Option<TlsMaterial> = match (
+        &args.tls_client_auth_ca_file,
+        &args.tls_client_auth_ca,
+        spicepod_ca_material,
+    ) {
+        (Some(p), _, _) => Some(TlsMaterial::File(PathBuf::from(p))),
+        (_, Some(pem), _) => Some(TlsMaterial::Inline(pem.as_bytes().to_vec())),
+        (_, _, Some(m)) => Some(m),
+        (None, None, None) => None,
+    };
+
+    // Validation — see doc comment above for rationale.
+    validate_client_auth(mode, ca_material.as_ref())?;
+    Ok(ResolvedClientAuth { mode, ca_material })
+}
+
+/// Pure validation of the (mode, CA presence) tuple. Extracted from
+/// [`resolve_client_auth`] so it can be unit-tested without needing a
+/// real `Secrets` store, full `Args`, or a tokio runtime. The two
+/// invalid shapes are `Request`/`Required` with no CA, and `None`
+/// with a CA; everything else is acceptable.
+fn validate_client_auth(
+    mode: ClientAuthMode,
+    ca_material: Option<&TlsMaterial>,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    match (mode, ca_material) {
+        (ClientAuthMode::Required, None) => Err(
+            "client_auth_mode=required requires a client CA: provide --tls-client-auth-ca-file (recommended for hot-reload), --tls-client-auth-ca (inline PEM), or runtime.tls.{client_auth_ca_file,client_auth_ca} in the spicepod"
+                .into(),
+        ),
+        (ClientAuthMode::Request, None) => Err(
+            "client_auth_mode=request requires a client CA so presented certs can be verified: provide --tls-client-auth-ca-file, --tls-client-auth-ca, or runtime.tls.{client_auth_ca_file,client_auth_ca}"
+                .into(),
+        ),
+        (ClientAuthMode::None, Some(_)) => Err(
+            "client_auth_mode=none must not have a client CA configured (set client_auth_mode=request or required to enable mTLS, or remove the CA configuration)"
+                .into(),
+        ),
+        _ => Ok(()),
+    }
 }
 
 async fn load_spicepod_tls_param(
@@ -151,9 +369,111 @@ async fn load_spicepod_tls_param(
     Ok(material)
 }
 
+/// Operator-facing description of where a TLS CA bundle was sourced
+/// from. Inline material has no path to print; file-backed material
+/// echoes back the path so an operator can reconcile what they
+/// configured against what the runtime loaded.
+fn describe_ca_source(material: &TlsMaterial) -> String {
+    match material {
+        TlsMaterial::File(p) => format!("file {}", p.display()),
+        TlsMaterial::Inline(_) => "inline PEM (spicepod / CLI)".to_string(),
+    }
+}
+
 fn load_file(path: &Path) -> io::Result<Vec<u8>> {
     let mut file = File::open(path)?;
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_none_without_ca_is_ok() {
+        validate_client_auth(ClientAuthMode::None, None).expect("none without CA is valid");
+    }
+
+    #[test]
+    fn validate_required_with_file_ca_is_ok() {
+        let ca = TlsMaterial::File(PathBuf::from("/tmp/client-ca.pem"));
+        validate_client_auth(ClientAuthMode::Required, Some(&ca))
+            .expect("required with file CA is valid");
+    }
+
+    #[test]
+    fn validate_required_with_inline_ca_is_ok() {
+        let ca = TlsMaterial::Inline(b"-----BEGIN CERTIFICATE-----...".to_vec());
+        validate_client_auth(ClientAuthMode::Required, Some(&ca))
+            .expect("required with inline CA is valid");
+    }
+
+    #[test]
+    fn validate_required_without_ca_is_rejected() {
+        let err = validate_client_auth(ClientAuthMode::Required, None)
+            .expect_err("required without CA must be rejected");
+        assert!(
+            err.to_string()
+                .contains("client_auth_mode=required requires a client CA")
+        );
+    }
+
+    #[test]
+    fn validate_request_without_ca_is_rejected() {
+        let err = validate_client_auth(ClientAuthMode::Request, None)
+            .expect_err("request without CA must be rejected");
+        assert!(
+            err.to_string()
+                .contains("client_auth_mode=request requires a client CA")
+        );
+    }
+
+    #[test]
+    fn validate_request_with_file_ca_is_ok() {
+        let ca = TlsMaterial::File(PathBuf::from("/tmp/client-ca.pem"));
+        validate_client_auth(ClientAuthMode::Request, Some(&ca))
+            .expect("request with file CA is valid");
+    }
+
+    #[test]
+    fn validate_none_with_ca_is_rejected() {
+        // Critical: this rejection is what prevents a misconfiguration
+        // (operator left the CA in but switched mode to `none`) from
+        // silently downgrading to no client-auth.
+        let ca = TlsMaterial::File(PathBuf::from("/tmp/client-ca.pem"));
+        let err = validate_client_auth(ClientAuthMode::None, Some(&ca))
+            .expect_err("none with CA must be rejected");
+        assert!(
+            err.to_string()
+                .contains("client_auth_mode=none must not have a client CA")
+        );
+    }
+
+    #[test]
+    fn enterprise_gate_blocks_request_mode() {
+        if CLIENT_TLS_ENABLED {
+            // When the feature is compiled in, the gate is a no-op —
+            // nothing to test.
+            return;
+        }
+        // Without the feature, the constant and message must be
+        // wired correctly for the runtime guard.
+        assert_eq!(
+            MTLS_ENTERPRISE_ONLY_MESSAGE,
+            "mTLS (client certificate authentication) is included in the Enterprise distribution of Spice.ai. Learn more at https://docs.spice.ai/docs/enterprise"
+        );
+    }
+
+    #[test]
+    fn enterprise_gate_allows_none_mode() {
+        // client_auth_mode=none must never be blocked, even without
+        // the feature.
+        let mode = ClientAuthMode::None;
+        assert!(
+            mode == ClientAuthMode::None,
+            "None mode should always be allowed regardless of feature flag"
+        );
+    }
 }

--- a/crates/runtime-auth/Cargo.toml
+++ b/crates/runtime-auth/Cargo.toml
@@ -19,3 +19,4 @@ base64.workspace = true
 pin-project.workspace = true
 http.workspace = true
 sha2.workspace = true
+x509-certificate.workspace = true

--- a/crates/runtime-auth/src/layer/flight.rs
+++ b/crates/runtime-auth/src/layer/flight.rs
@@ -150,6 +150,29 @@ where
         let version = req.version();
         let req = tonic::Request::from_http(req);
 
+        // Short-circuit when an upstream layer (e.g. the mTLS layer
+        // in mTLS-as-identity mode) has already established the auth
+        // principal. Without this check we would still demand a
+        // bearer token even though a verified client cert is
+        // sufficient on its own. We check via the request's
+        // `AuthRequestContext` extension; if it's not present we fall
+        // through to the bearer-token path so misconfiguration cannot
+        // accidentally open the endpoint.
+        if let Some(ctx) = req
+            .extensions()
+            .get::<Arc<dyn AuthRequestContext + Send + Sync>>()
+            && ctx.auth_principal().is_some()
+        {
+            let (metadata, extensions, msg) = req.into_parts();
+            let mut request = http::Request::new(msg);
+            *request.version_mut() = version;
+            *request.method_mut() = method;
+            *request.uri_mut() = uri;
+            *request.headers_mut() = metadata.into_headers();
+            *request.extensions_mut() = extensions;
+            return ResponseFuture::future(inner.call(request));
+        }
+
         let bearer_token = match get_authorization_value(req.metadata(), "Bearer") {
             Ok(bearer_token) => bearer_token,
             Err(e) => return ResponseFuture::status(e),

--- a/crates/runtime-auth/src/layer/http.rs
+++ b/crates/runtime-auth/src/layer/http.rs
@@ -73,6 +73,21 @@ where
         Box::pin(async move {
             let (parts, body) = req.into_parts();
 
+            // Short-circuit when an upstream layer (e.g. the mTLS
+            // layer in mTLS-as-identity mode) has already established
+            // the auth principal. Without this check the API-key /
+            // bearer-token verifier would still run and a request
+            // with a verified client cert but no API key would be
+            // rejected.
+            if let Some(ctx) = parts
+                .extensions
+                .get::<Arc<dyn AuthRequestContext + Send + Sync>>()
+                && ctx.auth_principal().is_some()
+            {
+                let req = Request::from_parts(parts, body);
+                return inner.call(req).await;
+            }
+
             match auth_verifier.http_verify(&parts) {
                 Ok(AuthVerdict::Allow(principal)) => {
                     let mut request = Request::from_parts(parts, body);

--- a/crates/runtime-auth/src/lib.rs
+++ b/crates/runtime-auth/src/lib.rs
@@ -17,6 +17,8 @@ limitations under the License.
 pub mod api_key;
 pub mod error;
 pub mod layer;
+pub mod mtls;
 mod traits;
 
+pub use mtls::{ChannelIdentity, IdentitySource, MtlsPrincipal};
 pub use traits::*;

--- a/crates/runtime-auth/src/mtls.rs
+++ b/crates/runtime-auth/src/mtls.rs
@@ -1,0 +1,290 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! mTLS-derived auth principals and channel identity.
+//!
+//! Two types live here:
+//!
+//! - [`MtlsPrincipal`] implements [`AuthPrincipal`] and is set on the
+//!   request's [`AuthRequestContext`] **only** in mTLS-as-identity
+//!   mode (the [`IdentitySource`] computed at startup is `Channel`).
+//!   When the principal is set, the existing
+//!   [`crate::layer::http::AuthMiddleware`] /
+//!   [`crate::layer::flight::BasicAuthMiddleware`] short-circuits
+//!   without invoking the underlying credential verifier (API-key
+//!   validator).
+//!
+//! - [`ChannelIdentity`] is **always** populated when a verified peer
+//!   cert was presented, regardless of mode. It lives on the request
+//!   extensions for audit / task-history use; it never participates
+//!   in authorization. In mTLS-as-channel mode it identifies the
+//!   calling service while the auth principal identifies the human
+//!   end-user.
+
+use std::borrow::Cow;
+
+use sha2::{Digest, Sha256};
+use x509_certificate::X509Certificate;
+
+use crate::AuthPrincipal;
+
+/// Where the request's auth principal comes from. Computed once at
+/// startup from `runtime.auth` and `runtime.tls.client_auth`, then
+/// threaded into the HTTP and Flight middleware stacks.
+///
+/// The selection is deliberately done at startup (not per-request) so
+/// the middleware ordering — does the mTLS layer set a principal that
+/// the auth layer should respect, or does the auth layer set the only
+/// principal? — is invariant for the process lifetime. Operators
+/// flipping this require a restart, which matches how `runtime.auth`
+/// and `client_auth` are themselves immutable for a given process.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum IdentitySource {
+    /// No auth configured. Every request runs as the existing
+    /// anonymous principal (`stable_id` returns `None`, `groups` empty).
+    /// Reads work; writes are rejected by existing `groups()` checks.
+    /// This is the out-of-the-box default and the only mode in which
+    /// `spiced` runs without authentication.
+    #[default]
+    Anonymous,
+    /// The TLS client cert is the auth principal. Selected when
+    /// `runtime.auth` is unconfigured and `runtime.tls.client_auth` is
+    /// `required`. The mTLS layer sets [`MtlsPrincipal`] on the request
+    /// context; the auth layer's short-circuit fires and never calls
+    /// the API-key verifier (which isn't configured anyway).
+    /// "mTLS-as-identity" mode.
+    Channel,
+    /// The configured `runtime.auth` mechanism (API key today, OIDC
+    /// later) is the auth principal. mTLS, if enabled, only protects
+    /// the channel and contributes a [`ChannelIdentity`] to the
+    /// request extensions for audit. "mTLS-as-channel" mode.
+    RuntimeAuth,
+}
+
+/// Identity of the peer at the TLS layer. Always populated when the
+/// per-protocol mTLS layer saw a verified peer cert, regardless of
+/// [`IdentitySource`].
+///
+/// Independent of the auth principal: in mTLS-as-channel mode,
+/// `ChannelIdentity` and `auth_principal` describe two different
+/// actors (the calling service and the end user, respectively).
+///
+/// Cloning is cheap (small struct, owned strings) and safe to share
+/// across threads.
+#[derive(Debug, Clone)]
+pub struct ChannelIdentity {
+    /// The X.509 Subject DN, e.g. `CN=client-1`. Empty string when
+    /// the cert leaf has no Subject (degenerate setup).
+    pub identity: String,
+    /// The X.509 Subject DN. Mirrors [`Self::identity`] today; kept
+    /// as a separate field so the audit / task-history surface can
+    /// rely on a stable "raw subject" slot independent of any
+    /// future identity-promotion logic.
+    pub subject_dn: String,
+    /// SHA-256 of the leaf cert DER. Useful for audit ("which exact
+    /// cert was used?") and as a last-resort cache namespace
+    /// fallback.
+    pub cert_fingerprint: [u8; 32],
+}
+
+/// The mTLS-as-identity auth principal. Set on the request's
+/// [`AuthRequestContext`] **only** when the configured
+/// [`IdentitySource`] is [`IdentitySource::Channel`] AND a verified
+/// peer cert was presented.
+///
+/// Inert on the wire — never serialised, never logged in full
+/// (fingerprint is 32-hex truncated to 16 in `stable_id` only).
+#[derive(Debug, Clone)]
+pub struct MtlsPrincipal {
+    /// The X.509 Subject DN (e.g. `CN=client-1`). Used for
+    /// [`AuthPrincipal::username`] and as the basis for
+    /// [`AuthPrincipal::stable_id`].
+    pub identity: String,
+    /// X.509 Subject DN. Used for `stable_id` when `identity` is a
+    /// fingerprint fallback. Empty string for cert-Subject-less
+    /// leaves.
+    pub subject_dn: String,
+    /// SHA-256 of the leaf cert DER. Used for `stable_id` only as a
+    /// last resort (cert with no Subject — a degenerate operator
+    /// setup).
+    pub cert_fingerprint: [u8; 32],
+}
+
+/// Always-`read_write` ACL group set returned by [`MtlsPrincipal`].
+/// Matches the "verified mTLS principal" baseline: every cert that
+/// passes verification is treated as a fully-trusted writer.
+/// Per-cert group mapping is an out-of-scope follow-up.
+const MTLS_GROUPS: &[&str] = &["read_write"];
+
+impl AuthPrincipal for MtlsPrincipal {
+    fn username(&self) -> &str {
+        &self.identity
+    }
+
+    fn groups(&self) -> &[&str] {
+        MTLS_GROUPS
+    }
+
+    /// Stable opaque id for cache-namespacing. **Must be stable
+    /// across cert rotation for the same identity** — see the
+    /// [`AuthPrincipal::stable_id`] contract.
+    ///
+    /// Resolution order:
+    ///
+    /// 1. Subject DN (non-empty) → `mtls:dn:<subject-dn>`. Stable
+    ///    across CA-issued cert renewal for the same subject.
+    /// 2. Fingerprint fallback → `mtls:fp:<32-hex>`. Only hit when
+    ///    the cert has no Subject DN — a degenerate operator setup.
+    ///    Cache *will* invalidate on rotation in this case; document
+    ///    the trade-off.
+    ///
+    /// Two distinct prefixes (`mtls:dn:`, `mtls:fp:`) so the
+    /// namespace can never accidentally collide across the two
+    /// resolution paths.
+    fn stable_id(&self) -> Option<Cow<'_, str>> {
+        Some(if self.subject_dn.is_empty() {
+            let mut id = String::with_capacity("mtls:fp:".len() + 32);
+            id.push_str("mtls:fp:");
+            for byte in &self.cert_fingerprint[..16] {
+                id.push(HEX[usize::from(byte >> 4)] as char);
+                id.push(HEX[usize::from(byte & 0x0f)] as char);
+            }
+            Cow::Owned(id)
+        } else {
+            Cow::Owned(format!("mtls:dn:{}", self.subject_dn))
+        })
+    }
+}
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+/// Build an [`MtlsPrincipal`] (and the parallel [`ChannelIdentity`])
+/// from the DER bytes of a verified peer cert.
+///
+/// **The cert MUST already have been verified** by rustls's
+/// [`rustls::server::danger::ClientCertVerifier`] — this function does
+/// not re-validate the chain or the signature. It only parses the leaf
+/// to extract the Subject DN and the cert fingerprint.
+///
+/// Returns `None` only when the leaf DER itself is unparseable, which
+/// would be a rustls bug — we still return `None` rather than
+/// panicking so a malformed-but-verified cert can't crash the server.
+#[must_use]
+pub fn principal_from_cert(leaf_der: &[u8]) -> Option<MtlsPrincipal> {
+    let cert_fingerprint: [u8; 32] = Sha256::digest(leaf_der).into();
+    let cert = X509Certificate::from_der(leaf_der).ok()?;
+    // `user_friendly_str()` returns RFC 4514 form (e.g. `CN=client-1`)
+    // when the subject is non-empty; cert leaves with an empty
+    // subject are represented as the empty string.
+    let subject_dn = cert.subject_name().user_friendly_str().unwrap_or_default();
+
+    // The identity is the Subject DN, falling back to a
+    // fingerprint-prefixed sentinel when the subject is empty.
+    let identity = if subject_dn.is_empty() {
+        let mut s = String::with_capacity("mtls:fp:".len() + 32);
+        s.push_str("mtls:fp:");
+        for byte in &cert_fingerprint[..16] {
+            s.push(HEX[usize::from(byte >> 4)] as char);
+            s.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        s
+    } else {
+        subject_dn.clone()
+    };
+
+    Some(MtlsPrincipal {
+        identity,
+        subject_dn,
+        cert_fingerprint,
+    })
+}
+
+/// Companion to [`principal_from_cert`] that returns the
+/// [`ChannelIdentity`] (always-on audit identity, regardless of
+/// [`IdentitySource`]). The two are derived from the same cert so we
+/// extract them via the same path.
+#[must_use]
+pub fn channel_identity_from_cert(leaf_der: &[u8]) -> Option<ChannelIdentity> {
+    let p = principal_from_cert(leaf_der)?;
+    Some(ChannelIdentity {
+        identity: p.identity,
+        subject_dn: p.subject_dn,
+        cert_fingerprint: p.cert_fingerprint,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `MtlsPrincipal` with a non-empty Subject DN should produce a
+    /// `mtls:dn:` stable id.
+    #[test]
+    fn stable_id_uses_subject_dn() {
+        let p = MtlsPrincipal {
+            identity: "CN=client-1".to_string(),
+            subject_dn: "CN=client-1".to_string(),
+            cert_fingerprint: [0x42; 32],
+        };
+        assert_eq!(
+            p.stable_id()
+                .expect("stable_id is always Some for an MtlsPrincipal"),
+            "mtls:dn:CN=client-1"
+        );
+        assert_eq!(p.username(), "CN=client-1");
+        assert_eq!(p.groups(), &["read_write"]);
+    }
+
+    /// Two `MtlsPrincipal`s with the same Subject DN but different
+    /// fingerprints (i.e. cert rotation — same identity, new cert)
+    /// MUST produce the same `stable_id`. This is the cache-namespace
+    /// stability contract: rotated certs of the same identity must
+    /// keep the same per-principal cache namespace.
+    #[test]
+    fn stable_id_survives_cert_rotation() {
+        let before = MtlsPrincipal {
+            identity: "CN=client-1".to_string(),
+            subject_dn: "CN=client-1".to_string(),
+            cert_fingerprint: [0x11; 32],
+        };
+        let after = MtlsPrincipal {
+            identity: "CN=client-1".to_string(),
+            subject_dn: "CN=client-1".to_string(),
+            cert_fingerprint: [0x22; 32], // rotated
+        };
+        assert_eq!(before.stable_id(), after.stable_id());
+    }
+
+    /// Empty Subject → fingerprint fallback. Cache will invalidate
+    /// on rotation in this case (acceptable trade-off for a
+    /// degenerate operator setup).
+    #[test]
+    fn stable_id_falls_back_to_fingerprint() {
+        let p = MtlsPrincipal {
+            identity: "mtls:fp:0011223344556677".to_string(),
+            subject_dn: String::new(),
+            cert_fingerprint: [
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        };
+        assert_eq!(
+            p.stable_id()
+                .expect("stable_id is always Some for an MtlsPrincipal"),
+            "mtls:fp:00112233445566778899aabbccddeeff"
+        );
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -356,6 +356,7 @@ scylladb = ["db_connection_pool/scylladb", "data_components/scylladb"]
 sftp = ["runtime-object-store/sftp"]
 sharepoint = ["data_components/sharepoint"]
 smb = ["runtime-object-store/smb"]
+client_tls = []
 snapshots = ["runtime-acceleration/snapshots"]
 snowflake = [
     "dep:snowflake-api",

--- a/crates/runtime/src/auth/mod.rs
+++ b/crates/runtime/src/auth/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     App,
     secrets::{ParamStr, Secrets},
 };
-use runtime_auth::{FlightBasicAuth, GrpcAuth, HttpAuth, api_key::ApiKeyAuth};
+use runtime_auth::{FlightBasicAuth, GrpcAuth, HttpAuth, IdentitySource, api_key::ApiKeyAuth};
 use secrecy::ExposeSecret;
 use spicepod::component::runtime::{ApiKey, ApiKeyAuth as SpicepodApiKeyAuth};
 use std::sync::Arc;
@@ -32,6 +32,17 @@ pub struct EndpointAuth {
     pub http_auth: Option<Arc<dyn HttpAuth + Send + Sync>>,
     pub flight_basic_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,
     pub grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
+    /// Where the request's auth principal originates. Computed once
+    /// at startup by the binary entrypoint from the combination of
+    /// `runtime.auth` and `runtime.tls.client_auth`. Threaded into
+    /// the per-protocol mTLS layers so HTTP and Flight know whether
+    /// to promote a verified client cert to the request's auth
+    /// principal (`Channel`) or just record it as a
+    /// `ChannelIdentity` for audit (`RuntimeAuth`).
+    /// Defaults to [`IdentitySource::Anonymous`] so existing tests
+    /// and callers that don't set it explicitly preserve today's
+    /// behavior.
+    pub identity_source: IdentitySource,
 }
 
 impl EndpointAuth {
@@ -56,6 +67,7 @@ impl EndpointAuth {
                 http_auth: Some(http_auth),
                 flight_basic_auth: Some(flight_basic_auth),
                 grpc_auth: Some(grpc_auth),
+                identity_source: IdentitySource::RuntimeAuth,
             };
         }
 
@@ -68,7 +80,22 @@ impl EndpointAuth {
             http_auth: None,
             flight_basic_auth: None,
             grpc_auth: None,
+            identity_source: IdentitySource::Anonymous,
         }
+    }
+
+    /// Override the [`IdentitySource`] decided by [`Self::new`]. The
+    /// binary entrypoint calls this after computing the effective
+    /// `client_auth` mode: `client_auth: required` with no
+    /// `runtime.auth` flips an `Anonymous` posture into
+    /// [`IdentitySource::Channel`] (mTLS-as-identity).
+    /// `runtime.auth` plus `client_auth: required` stays
+    /// [`IdentitySource::RuntimeAuth`] (mTLS-as-channel) — the cert
+    /// only contributes a `ChannelIdentity` for audit.
+    #[must_use]
+    pub fn with_identity_source(mut self, source: IdentitySource) -> Self {
+        self.identity_source = source;
+        self
     }
 
     #[must_use]
@@ -138,6 +165,7 @@ impl std::fmt::Debug for EndpointAuth {
         } else {
             builder.field("grpc_auth", &ABSENT);
         }
+        builder.field("identity_source", &self.identity_source);
         builder.finish()
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -69,6 +69,7 @@ mod get_schema;
 mod handshake;
 mod metrics;
 pub mod middleware;
+mod mtls;
 mod session;
 pub(crate) mod session_auth;
 mod util;
@@ -614,6 +615,7 @@ pub async fn start(
         endpoint_auth.flight_basic_auth,
         session_store.clone(),
     );
+    let identity_source = endpoint_auth.identity_source;
     let auth_layer = tower::ServiceBuilder::new()
         .layer(BasicAuthLayer::new(session_aware_auth))
         .into_inner();
@@ -630,6 +632,11 @@ pub async fn start(
             RequestContextLayer::new(app, rt.datafusion(), session_store, rt.secrets())
                 .with_job_executor(job_executor),
         )
+        // mTLS principal injection runs *after* RequestContextLayer
+        // (which sets up the AuthRequestContext extension) and
+        // *before* BasicAuthLayer (which short-circuits when a
+        // principal is already present).
+        .layer(mtls::MtlsLayer::new(identity_source))
         .layer(auth_layer)
         .layer(WriteRateLimitLayer::new(
             RateLimiter::direct(rate_limits.flight_write_limit),
@@ -663,7 +670,7 @@ pub async fn start(
         runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);
         let incoming = crate::tls::flight_incoming::tls_incoming(
             listener,
-            Arc::clone(&tls_config.server_config),
+            Arc::clone(&tls_config.flight_server_config),
         );
         if let Some(token) = shutdown_signal {
             server

--- a/crates/runtime/src/flight/mtls.rs
+++ b/crates/runtime/src/flight/mtls.rs
@@ -1,0 +1,154 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Flight-side mTLS principal injection.
+//!
+//! Per-connection peer certificates flow into Flight requests via
+//! [`tonic::transport::server::TlsConnectInfo`], which `tonic` puts on
+//! every request's extensions when the `tls-connect-info` feature is
+//! enabled. This layer reads that extension, builds the
+//! [`runtime_auth::MtlsPrincipal`] / [`runtime_auth::ChannelIdentity`],
+//! and — in [`IdentitySource::Channel`] mode — sets the principal on
+//! the request's [`AuthRequestContext`] so the existing
+//! [`runtime_auth::layer::flight::BasicAuthMiddleware`] short-circuits
+//! without checking a bearer token.
+//!
+//! Must run **after** [`crate::flight::middleware::request_context`]'s
+//! layer (which inserts the `Arc<dyn AuthRequestContext>` extension)
+//! and **before** [`runtime_auth::layer::flight::BasicAuthLayer`] (so
+//! the principal is in place when the auth layer's short-circuit
+//! check runs).
+//!
+//! ## Performance note
+//!
+//! Unlike the HTTP path — which intercepts the rustls handshake at
+//! accept-time and pre-computes per-connection identities (see
+//! [`crate::http::mtls`]) — the Flight path receives the peer chain
+//! per-request via tonic's extension mechanism. The leaf cert is
+//! re-parsed and re-hashed on every RPC. This is a deliberate
+//! trade-off: the call sites are cheap (one X.509 parse, one
+//! SHA-256), tonic does not expose a per-connection middleware hook
+//! that lets us hang state off the underlying `TlsStream`, and the
+//! `Arc<Vec<CertificateDer>>` is at least shared across requests so
+//! we don't re-allocate the chain bytes themselves. A future change
+//! could memoise identities keyed by `Arc::as_ptr` of
+//! `peer_certs()`'s Arc; the public surface here would be unchanged.
+
+use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use runtime_auth::{
+    AuthRequestContext, IdentitySource,
+    mtls::{channel_identity_from_cert, principal_from_cert},
+};
+use tonic::transport::server::TlsConnectInfo;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct MtlsLayer {
+    identity_source: IdentitySource,
+}
+
+impl MtlsLayer {
+    #[must_use]
+    pub fn new(identity_source: IdentitySource) -> Self {
+        Self { identity_source }
+    }
+}
+
+impl<S> Layer<S> for MtlsLayer {
+    type Service = MtlsMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MtlsMiddleware {
+            inner,
+            identity_source: self.identity_source,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MtlsMiddleware<S> {
+    inner: S,
+    identity_source: IdentitySource,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for MtlsMiddleware<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let identity_source = self.identity_source;
+
+        // Pull the verified peer cert chain out of the per-connection
+        // `TlsConnectInfo` extension that `tonic` populates when the
+        // `tls-connect-info` feature is enabled. `Option<SocketAddr>`
+        // is the inner connect-info shape for our `tls::incoming`
+        // adaptor (TcpStream-backed). The returned `Arc<Vec<...>>` is
+        // the per-connection chain that tonic re-clones into every
+        // request, so cloning it is a refcount bump — but parsing the
+        // leaf still happens per-request (see module docs).
+        let chain_arc = req
+            .extensions()
+            .get::<TlsConnectInfo<SocketAddr>>()
+            .and_then(TlsConnectInfo::peer_certs);
+
+        if let Some(chain) = chain_arc.as_deref()
+            && let Some(leaf) = chain.first()
+        {
+            let leaf_der: &[u8] = leaf.as_ref();
+            // Always: ChannelIdentity for audit, regardless of mode.
+            if let Some(channel) = channel_identity_from_cert(leaf_der) {
+                req.extensions_mut().insert(channel);
+            }
+
+            // Channel mode only: promote to the request's auth principal.
+            if matches!(identity_source, IdentitySource::Channel)
+                && let Some(principal) = principal_from_cert(leaf_der)
+            {
+                let principal_arc: Arc<dyn runtime_auth::AuthPrincipal + Send + Sync> =
+                    Arc::new(principal);
+                if let Some(ctx) = req
+                    .extensions()
+                    .get::<Arc<dyn AuthRequestContext + Send + Sync>>()
+                    && let Err(err) = ctx.set_auth_principal(Arc::clone(&principal_arc))
+                {
+                    tracing::warn!(%err, "Flight mTLS: failed to set auth principal on request context");
+                }
+                req.extensions_mut().insert(principal_arc);
+            }
+        }
+
+        Box::pin(async move { inner.call(req).await })
+    }
+}

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -20,7 +20,7 @@ use axum::Router;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::{Builder, Connection};
 use hyper_util::service::TowerToHyperService;
-use runtime_auth::{HttpAuth, layer::http::AuthLayer};
+use runtime_auth::{HttpAuth, IdentitySource, layer::http::AuthLayer};
 use snafu::prelude::*;
 use spicepod::component::runtime::CorsConfig;
 use tokio::net::TcpStream;
@@ -38,6 +38,7 @@ use crate::{
 #[cfg(feature = "openapi")]
 pub use routes::get_api_doc;
 mod metrics;
+mod mtls;
 mod routes;
 pub mod traceparent;
 
@@ -118,6 +119,7 @@ pub(crate) async fn start<A>(
     config: Arc<config::Config>,
     tls_config: Option<Arc<TlsConfig>>,
     auth_provider: Option<Arc<dyn HttpAuth + Send + Sync>>,
+    identity_source: IdentitySource,
     shutdown_signal: Option<CancellationToken>,
 ) -> Result<()>
 where
@@ -179,8 +181,15 @@ where
 
                 match tls_config {
                     Some(ref config) => {
-                        let acceptor = TlsAcceptor::from(Arc::clone(&config.server_config));
-                        process_tls_tcp_stream(stream, acceptor, routes.clone(), shutdown_notify.subscribe());
+                        let acceptor = TlsAcceptor::from(Arc::clone(&config.http_server_config));
+                        process_tls_tcp_stream(
+                            stream,
+                            acceptor,
+                            routes.clone(),
+                            identity_source,
+                            config.client_auth,
+                            shutdown_notify.subscribe(),
+                        );
                     }
                     None => {
                         process_tcp_stream(stream, routes.clone(), shutdown_notify.subscribe());
@@ -213,11 +222,25 @@ fn process_tls_tcp_stream(
     stream: TcpStream,
     acceptor: TlsAcceptor,
     routes: Router,
+    identity_source: IdentitySource,
+    client_auth: crate::tls::ClientAuthEnforcement,
     on_shutdown: Receiver<()>,
 ) {
     tokio::spawn(async move {
         match acceptor.accept(stream).await {
             Ok(tls_stream) => {
+                // Pre-compute the per-connection mTLS identities
+                // (`ChannelIdentity` always; `MtlsPrincipal` only in
+                // `Channel` mode) once at accept-time so per-request
+                // middleware does no X.509 parsing on the hot path.
+                // Every request served on this TLS connection then
+                // sees the same `Arc<PerConnTls>` in its extensions.
+                let per_conn = mtls::PerConnTls::build(
+                    tls_stream.get_ref().1.peer_certificates(),
+                    identity_source,
+                    client_auth,
+                );
+                let routes = mtls::install_per_conn_extension(routes, per_conn);
                 let conn = serve_connection(tls_stream, routes);
                 handle_connection(conn, on_shutdown).await;
             }

--- a/crates/runtime/src/http/mtls.rs
+++ b/crates/runtime/src/http/mtls.rs
@@ -1,0 +1,250 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Per-connection mTLS context for the HTTP server.
+//!
+//! The HTTP listener accepts a TCP stream, runs the rustls handshake,
+//! and — only when the handshake succeeded — extracts the verified
+//! peer cert chain (if any), pre-computes the
+//! [`runtime_auth::ChannelIdentity`] and (in
+//! [`IdentitySource::Channel`] mode) the
+//! [`runtime_auth::MtlsPrincipal`] **once per connection**, and wraps
+//! the connection's `Router` with an `Extension<Arc<PerConnTls>>`.
+//!
+//! From there a per-request middleware ([`mtls_request_layer`]) just
+//! clones the pre-computed Arcs into the per-request extensions and
+//! — in `Channel` mode — sets the principal on the request's
+//! [`AuthRequestContext`] so the existing
+//! [`runtime_auth::layer::http::AuthMiddleware`] short-circuits
+//! without checking an API key / bearer token. No X.509 parsing or
+//! SHA-256 hashing happens on the per-request hot path.
+//!
+//! The Flight half of the same wiring lives in
+//! [`crate::flight::mtls`].
+
+use std::sync::Arc;
+
+use axum::{
+    Extension,
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use runtime_auth::{
+    AuthPrincipal, AuthRequestContext, ChannelIdentity, IdentitySource,
+    mtls::{channel_identity_from_cert, principal_from_cert},
+};
+use rustls::pki_types::CertificateDer;
+
+use crate::tls::ClientAuthEnforcement;
+
+/// Per-connection mTLS context, populated once by the accept loop and
+/// inherited by every HTTP request served on that connection.
+///
+/// Both [`Self::channel_identity`] and [`Self::principal`] are
+/// **pre-computed at connection accept** so per-request middleware
+/// does no X.509 parsing or hashing on the hot path. Cloning each
+/// inner `Arc` is just a refcount bump.
+///
+/// [`Self::client_auth`] is plumbed in once per connection so the
+/// route-layer gate can 401 non-probe requests that arrived without a
+/// verified client cert when `client_auth: required` is configured
+/// (the HTTP listener uses an `allow_unauthenticated` rustls verifier
+/// to keep `/health` and `/v1/ready` reachable for Kubernetes
+/// probes).
+pub(crate) struct PerConnTls {
+    /// Always populated when a verified peer cert was presented (any
+    /// [`IdentitySource`]). `None` for plain-HTTPS-no-client-cert.
+    pub channel_identity: Option<Arc<ChannelIdentity>>,
+    /// Populated only when [`IdentitySource::Channel`] is configured
+    /// AND a verified peer cert was presented; otherwise `None`.
+    /// When `Some`, `mtls_request_layer` short-circuits the
+    /// downstream auth layer by setting this principal on the
+    /// request's [`AuthRequestContext`].
+    pub principal: Option<Arc<dyn AuthPrincipal + Send + Sync>>,
+    /// Whether the route-layer gate should reject requests with no
+    /// verified peer cert. Copied in once per connection from
+    /// [`crate::tls::TlsConfig::client_auth`].
+    pub client_auth: ClientAuthEnforcement,
+}
+
+impl PerConnTls {
+    /// Build a `PerConnTls` from the verified peer cert chain (the
+    /// `peer_certificates()` snapshot off the rustls connection), the
+    /// configured [`IdentitySource`], and the configured
+    /// [`ClientAuthEnforcement`]. Pre-computes the audit
+    /// `ChannelIdentity` always; pre-computes the auth principal
+    /// only when in `Channel` mode.
+    ///
+    /// Always returns `Some` when [`ClientAuthEnforcement::Required`]
+    /// so the per-request gate observes the enforcement value even
+    /// for connections with no peer cert (which the HTTP listener now
+    /// admits on purpose so probes work without mounting a client
+    /// cert).
+    pub fn build(
+        peer_chain: Option<&[CertificateDer<'_>]>,
+        identity_source: IdentitySource,
+        client_auth: ClientAuthEnforcement,
+    ) -> Option<Self> {
+        let leaf = peer_chain.and_then(<[CertificateDer<'_>]>::first);
+        let (channel_identity, principal) = match leaf {
+            Some(leaf) => {
+                let leaf_der: &[u8] = leaf.as_ref();
+                let channel = channel_identity_from_cert(leaf_der).map(Arc::new);
+                let principal: Option<Arc<dyn AuthPrincipal + Send + Sync>> =
+                    if matches!(identity_source, IdentitySource::Channel) {
+                        principal_from_cert(leaf_der).map(|p| Arc::new(p) as _)
+                    } else {
+                        None
+                    };
+                (channel, principal)
+            }
+            None => (None, None),
+        };
+        if channel_identity.is_none()
+            && principal.is_none()
+            && matches!(client_auth, ClientAuthEnforcement::Disabled)
+        {
+            return None;
+        }
+        Some(Self {
+            channel_identity,
+            principal,
+            client_auth,
+        })
+    }
+}
+
+/// Per-request gate that 401s when `client_auth: required` is
+/// configured AND the connection presented no verified client cert.
+/// Wired onto the *authenticated* HTTP router only; `/health` and
+/// `/v1/ready` live on the unauthenticated router and bypass this
+/// gate by construction so Kubernetes liveness/readiness probes work
+/// over TLS without needing to mount a client certificate. Connections
+/// that did present a valid cert pass through unchanged.
+pub(crate) async fn require_channel_identity(req: Request<Body>, next: Next) -> Response {
+    if let Some(per_conn) = req.extensions().get::<Arc<PerConnTls>>()
+        && matches!(per_conn.client_auth, ClientAuthEnforcement::Required)
+        && per_conn.channel_identity.is_none()
+    {
+        return (StatusCode::UNAUTHORIZED, "client certificate required").into_response();
+    }
+    next.run(req).await
+}
+
+/// Per-request middleware that:
+///
+/// 1. Always inserts a [`runtime_auth::ChannelIdentity`] extension
+///    when one was pre-computed for this connection (regardless of
+///    [`IdentitySource`]) so audit consumers can see which cert was
+///    on the wire.
+/// 2. When [`IdentitySource::Channel`] was configured at startup
+///    AND a peer cert was presented, additionally promotes the
+///    pre-computed [`runtime_auth::MtlsPrincipal`] to the request's
+///    auth principal.
+///
+/// Must run **after** the request-context middleware (which inserts
+/// the `Arc<dyn AuthRequestContext>` extension) and **before** the
+/// auth layer (so the principal is in place when its short-circuit
+/// check runs).
+pub(crate) async fn mtls_request_layer(req: Request<Body>, next: Next) -> Response {
+    let (mut parts, body) = req.into_parts();
+
+    if let Some(per_conn) = parts.extensions.get::<Arc<PerConnTls>>().cloned() {
+        if let Some(channel) = per_conn.channel_identity.as_ref() {
+            // ChannelIdentity is `Clone`; cheap (small struct, owned strings).
+            parts.extensions.insert(ChannelIdentity::clone(channel));
+        }
+
+        if let Some(principal) = per_conn.principal.as_ref() {
+            let principal = Arc::clone(principal);
+            if let Some(ctx) = parts
+                .extensions
+                .get::<Arc<dyn AuthRequestContext + Send + Sync>>()
+                && let Err(err) = ctx.set_auth_principal(Arc::clone(&principal))
+            {
+                tracing::warn!(%err, "mTLS: failed to set auth principal on request context");
+            }
+            parts.extensions.insert(principal);
+        }
+    }
+
+    let req = Request::from_parts(parts, body);
+    next.run(req).await
+}
+
+/// Wrap a per-connection [`axum::Router`] with the [`PerConnTls`]
+/// extension when there is something to install. Convenience helper
+/// used by the TLS accept loop so the extension type stays an
+/// implementation detail of this module.
+pub(crate) fn install_per_conn_extension(
+    router: axum::Router,
+    per_conn: Option<PerConnTls>,
+) -> axum::Router {
+    match per_conn {
+        Some(p) => router.layer(Extension(Arc::new(p))),
+        None => router,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_returns_none_for_plain_https_in_anonymous_mode() {
+        // No peer cert at all, with enforcement disabled: nothing to
+        // install — build() short-circuits to None.
+        assert!(
+            PerConnTls::build(
+                None,
+                IdentitySource::Anonymous,
+                ClientAuthEnforcement::Disabled
+            )
+            .is_none()
+        );
+        // Empty chain.
+        assert!(
+            PerConnTls::build(
+                Some(&[]),
+                IdentitySource::Channel,
+                ClientAuthEnforcement::Disabled
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn build_returns_some_when_required_even_without_cert() {
+        // With `client_auth: required`, the per-conn context must be
+        // installed even when no peer cert was presented so the
+        // route-layer gate can observe the enforcement value and 401
+        // non-probe requests.
+        let per_conn = PerConnTls::build(
+            None,
+            IdentitySource::Anonymous,
+            ClientAuthEnforcement::Required,
+        )
+        .expect("per-conn context installed under Required");
+        assert!(per_conn.channel_identity.is_none());
+        assert!(per_conn.principal.is_none());
+        assert!(matches!(
+            per_conn.client_auth,
+            ClientAuthEnforcement::Required
+        ));
+    }
+}

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -491,6 +491,15 @@ pub(crate) fn routes(
         authenticated_router = authenticated_router.route_layer(auth_layer);
     }
 
+    // mTLS route gate. Wired onto the authenticated router *before* the
+    // unauthenticated `/health` and `/v1/ready` are merged in, so probe
+    // routes bypass the gate by construction. Under `client_auth: required`
+    // the HTTP listener admits no-cert handshakes (so probes work over
+    // TLS without mounting a probe certificate); this layer 401s any
+    // non-probe request whose connection presented no verified peer cert.
+    authenticated_router = authenticated_router
+        .route_layer(middleware::from_fn(super::mtls::require_channel_identity));
+
     let unauthenticated_router = Router::new()
         .route("/health", get(|| async { "ok\n" }))
         .route("/v1/ready", get(v1::ready::get))
@@ -499,6 +508,7 @@ pub(crate) fn routes(
 
     unauthenticated_router
         .merge(authenticated_router)
+        .route_layer(middleware::from_fn(super::mtls::mtls_request_layer))
         .route_layer(middleware::from_fn_with_state(rt.status(), check_shutdown))
         .route_layer(middleware::from_fn_with_state(
             Arc::clone(&rt.df),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1148,6 +1148,7 @@ impl Runtime {
         let cloned_tls_config = tls_config.clone();
         let cloned_config = config.clone();
         let auth = endpoint_auth.http_auth.clone();
+        let identity_source = endpoint_auth.identity_source;
         let self_ref = Arc::clone(&self);
         let http_shutdown = CancellationToken::new();
 
@@ -1161,6 +1162,7 @@ impl Runtime {
                     cloned_config.into(),
                     cloned_tls_config,
                     auth,
+                    identity_source,
                     Some(http_shutdown),
                 )
                 .map_err(Error::from),

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -92,7 +92,7 @@ where
 
         match tls_config {
             Some(ref config) => {
-                let acceptor = TlsAcceptor::from(Arc::clone(&config.server_config));
+                let acceptor = TlsAcceptor::from(Arc::clone(&config.http_server_config));
                 process_tls_tcp_stream(
                     stream,
                     acceptor.clone(),

--- a/crates/runtime/src/tls/mod.rs
+++ b/crates/runtime/src/tls/mod.rs
@@ -76,10 +76,50 @@ impl TlsControl {
 /// Construct via [`TlsConfig::try_new`] for inline / secret-sourced PEMs,
 /// or [`TlsConfig::try_new_from_paths`] when the cert + key live on disk
 /// and should be hot-reloaded on rotation.
+///
+/// When `client_auth_mode: required` is configured, two `ServerConfig`s are
+/// built off the same cert resolver and CA bundle:
+///
+/// - [`Self::flight_server_config`] uses a strict
+///   [`rustls::server::WebPkiClientVerifier`]: the TLS handshake fails
+///   if the client does not present a cert. The Flight (gRPC) listener
+///   uses this.
+///
+/// - [`Self::http_server_config`] uses an `allow_unauthenticated`
+///   verifier: the handshake succeeds without a client cert
+///   (presented-but-invalid certs are still rejected at the handshake).
+///   The HTTP and metrics listeners use this. HTTP route middleware
+///   gates non-probe routes on the presence of a verified client cert
+///   so `/health` and `/v1/ready` remain reachable for Kubernetes
+///   liveness/readiness probes that cannot mount a client certificate.
+///
+/// Under `client_auth_mode: request`, both listeners use the
+/// `allow_unauthenticated` verifier and the HTTP route layer does
+/// **not** gate non-probe routes — anonymous and identified clients
+/// both reach the application. Presented certs are still verified
+/// against the configured CA bundle and promoted to a request
+/// principal under [`runtime_auth::IdentitySource::Channel`].
+///
+/// When `client_auth_mode` is unset, both fields point at an identical
+/// `with_no_client_auth()` config.
 pub struct TlsConfig {
-    /// rustls config installed on every server. Shared by reference; the
-    /// contained `ResolvesServerCert` is the swap point for rotated certs.
-    pub server_config: Arc<ServerConfig>,
+    /// rustls config used by the Flight listener. Under
+    /// `client_auth_mode: required` this enforces client-cert
+    /// presence at the handshake. Under `request` it admits no-cert
+    /// handshakes (presented certs are verified). Shared by
+    /// reference; the contained `ResolvesServerCert` is the swap
+    /// point for rotated certs.
+    pub flight_server_config: Arc<ServerConfig>,
+
+    /// rustls config used by the HTTP and metrics listeners. Under
+    /// `client_auth_mode: required` and `request` this admits
+    /// no-cert handshakes. Identical to [`Self::flight_server_config`]
+    /// when `client_auth_mode` is unset.
+    pub http_server_config: Arc<ServerConfig>,
+
+    /// Whether the HTTP route layer should reject non-probe requests
+    /// that arrived without a verified client cert.
+    pub client_auth: ClientAuthEnforcement,
 
     /// Resolver kept around so callers can introspect / force a reload from
     /// tests. Production callers do not need to touch this directly.
@@ -93,6 +133,32 @@ pub struct TlsConfig {
     watcher_keepalive: Option<Arc<CertWatcher>>,
 }
 
+/// Whether and how the public TLS listeners enforce client
+/// certificates. Drives both the per-listener rustls verifier choice
+/// inside [`build_server_configs`] and the per-request gate on
+/// [`crate::http::routes`] that 401s non-probe HTTP requests when the
+/// connection presented no client cert. The Flight listener
+/// independently consults its own (strict vs lax)
+/// `WebPkiClientVerifier` baked into [`TlsConfig::flight_server_config`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientAuthEnforcement {
+    /// `client_auth_mode` was not configured. Both listeners run with
+    /// `with_no_client_auth()`. No route gate.
+    Disabled,
+    /// `client_auth_mode: request`. Both listeners use the
+    /// `allow_unauthenticated` verifier so no-cert handshakes are
+    /// admitted; presented certs are verified against the CA bundle.
+    /// No route gate.
+    Requested,
+    /// `client_auth_mode: required`. Flight listener uses the strict
+    /// verifier (no-cert handshakes rejected at TLS). HTTP and
+    /// metrics listeners use the `allow_unauthenticated` verifier so
+    /// probes work without a client cert; the HTTP route layer 401s
+    /// any non-probe request whose connection has no
+    /// [`runtime_auth::ChannelIdentity`].
+    Required,
+}
+
 impl TlsConfig {
     /// Build from in-memory PEM bytes. Used for inline `runtime.tls.certificate`
     /// and `${secrets:...}`-sourced material. The returned config will not
@@ -101,14 +167,46 @@ impl TlsConfig {
         cert_bytes: &[u8],
         key_bytes: &[u8],
     ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
-        let resolver = ReloadableServerCerts::from_pem(cert_bytes, key_bytes, ReloadScope::Public)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-        let mut server_config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_cert_resolver(Arc::clone(&resolver) as Arc<_>);
-        configure_alpn(&mut server_config);
+        Self::try_new_with_client_auth(cert_bytes, key_bytes, None)
+    }
+
+    /// Like [`Self::try_new`] but additionally builds a static client
+    /// cert verifier from `client_ca_pem` when supplied. Inline
+    /// material; no hot-reload.
+    pub fn try_new_with_client_auth(
+        cert_bytes: &[u8],
+        key_bytes: &[u8],
+        client_ca_pem: Option<&[u8]>,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        let enforcement = enforcement_from(client_ca_pem.is_some());
+        Self::try_new_with_client_auth_mode(cert_bytes, key_bytes, client_ca_pem, enforcement)
+    }
+
+    /// Like [`Self::try_new_with_client_auth`] but accepts an explicit
+    /// [`ClientAuthEnforcement`] so callers (typically the binary
+    /// entrypoint) can distinguish [`ClientAuthEnforcement::Requested`]
+    /// from [`ClientAuthEnforcement::Required`] — both pass a CA
+    /// bundle, only the per-listener verifier strictness and HTTP
+    /// route gate differ.
+    pub fn try_new_with_client_auth_mode(
+        cert_bytes: &[u8],
+        key_bytes: &[u8],
+        client_ca_pem: Option<&[u8]>,
+        enforcement: ClientAuthEnforcement,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        check_client_auth_invariant(client_ca_pem.is_some(), enforcement)?;
+        let resolver = ReloadableServerCerts::from_pem_with_client_auth(
+            cert_bytes,
+            key_bytes,
+            client_ca_pem,
+            ReloadScope::Public,
+        )
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        let (flight_cfg, http_cfg) = build_server_configs(&resolver, enforcement);
         Ok(Self {
-            server_config: Arc::new(server_config),
+            flight_server_config: Arc::new(flight_cfg),
+            http_server_config: Arc::new(http_cfg),
+            client_auth: enforcement,
             resolver,
             watcher_keepalive: None,
         })
@@ -123,25 +221,159 @@ impl TlsConfig {
         key_path: PathBuf,
         control: &TlsControl,
     ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
-        let resolver = ReloadableServerCerts::from_paths(
+        Self::try_new_from_paths_with_client_auth(cert_path, key_path, None, control)
+    }
+
+    /// Like [`Self::try_new_from_paths`] but additionally registers an
+    /// optional client CA path. When `client_ca_path` is `Some`, the
+    /// CA file participates in the same watcher as the cert + key:
+    /// every change re-reads the whole bundle and the resulting
+    /// `WebPkiClientVerifier` is atomically swapped under the live
+    /// `ServerConfig` without rebuilding it.
+    pub fn try_new_from_paths_with_client_auth(
+        cert_path: PathBuf,
+        key_path: PathBuf,
+        client_ca_path: Option<PathBuf>,
+        control: &TlsControl,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        let enforcement = enforcement_from(client_ca_path.is_some());
+        Self::try_new_from_paths_with_client_auth_mode(
             cert_path,
             key_path,
+            client_ca_path,
+            enforcement,
+            control,
+        )
+    }
+
+    /// Like [`Self::try_new_from_paths_with_client_auth`] but accepts
+    /// an explicit [`ClientAuthEnforcement`] so callers can
+    /// distinguish [`ClientAuthEnforcement::Requested`] from
+    /// [`ClientAuthEnforcement::Required`].
+    pub fn try_new_from_paths_with_client_auth_mode(
+        cert_path: PathBuf,
+        key_path: PathBuf,
+        client_ca_path: Option<PathBuf>,
+        enforcement: ClientAuthEnforcement,
+        control: &TlsControl,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        check_client_auth_invariant(client_ca_path.is_some(), enforcement)?;
+        let resolver = ReloadableServerCerts::from_paths_with_client_auth(
+            cert_path,
+            key_path,
+            client_ca_path,
             ReloadScope::Public,
             control.watcher(),
         )
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-        let mut server_config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_cert_resolver(Arc::clone(&resolver) as Arc<_>);
-        configure_alpn(&mut server_config);
+        let (flight_cfg, http_cfg) = build_server_configs(&resolver, enforcement);
         Ok(Self {
-            server_config: Arc::new(server_config),
+            flight_server_config: Arc::new(flight_cfg),
+            http_server_config: Arc::new(http_cfg),
+            client_auth: enforcement,
             resolver,
             // Hold an Arc to the watcher so the dispatcher thread is kept
             // alive even if `TlsControl` is later dropped before us.
             watcher_keepalive: Some(Arc::clone(control.watcher())),
         })
     }
+}
+
+/// Build the (Flight, HTTP) `ServerConfig` pair from a single
+/// [`ReloadableServerCerts`]. Wires the hot-reloadable cert resolver
+/// into both, and — when client-cert auth is configured — attaches
+/// a per-listener verifier shim chosen from `enforcement`:
+///
+/// - [`ClientAuthEnforcement::Disabled`] → both listeners run
+///   `with_no_client_auth()`.
+/// - [`ClientAuthEnforcement::Requested`] → both listeners use the
+///   `allow_unauthenticated` (lax) verifier so no-cert handshakes
+///   are admitted; presented certs are still verified.
+/// - [`ClientAuthEnforcement::Required`] → Flight uses the strict
+///   verifier (no-cert handshakes rejected at TLS); HTTP uses the
+///   lax verifier so probes work without a client cert (the route
+///   layer enforces presence on non-probe routes).
+///
+/// Both reads go through the same `ArcSwap` machinery so a cert or
+/// CA rotation does not require rebuilding either `ServerConfig`.
+fn build_server_configs(
+    resolver: &Arc<ReloadableServerCerts>,
+    enforcement: ClientAuthEnforcement,
+) -> (ServerConfig, ServerConfig) {
+    let flight_verifier = match enforcement {
+        ClientAuthEnforcement::Disabled => None,
+        ClientAuthEnforcement::Requested => resolver.client_verifier_lax(),
+        ClientAuthEnforcement::Required => resolver.client_verifier(),
+    };
+    let http_verifier = match enforcement {
+        ClientAuthEnforcement::Disabled => None,
+        ClientAuthEnforcement::Requested | ClientAuthEnforcement::Required => {
+            resolver.client_verifier_lax()
+        }
+    };
+    let flight = match flight_verifier {
+        Some(verifier) => ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_cert_resolver(Arc::clone(resolver) as Arc<_>),
+        None => ServerConfig::builder()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::clone(resolver) as Arc<_>),
+    };
+    let http = match http_verifier {
+        Some(verifier) => ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_cert_resolver(Arc::clone(resolver) as Arc<_>),
+        None => ServerConfig::builder()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::clone(resolver) as Arc<_>),
+    };
+    let mut flight = flight;
+    let mut http = http;
+    configure_alpn(&mut flight);
+    configure_alpn(&mut http);
+    (flight, http)
+}
+
+fn enforcement_from(has_client_auth: bool) -> ClientAuthEnforcement {
+    if has_client_auth {
+        ClientAuthEnforcement::Required
+    } else {
+        ClientAuthEnforcement::Disabled
+    }
+}
+
+/// Runtime check (not just `debug_assert`) that a client CA bundle
+/// was supplied iff the operator asked for non-`Disabled` client
+/// authentication. Misconfiguring this on the call path would
+/// otherwise produce one of two silently-wrong outcomes:
+///
+/// - `Disabled` + a CA: the server quietly drops the operator's
+///   trust roots and every client is admitted unauthenticated.
+/// - `Requested` / `Required` + no CA: same outcome via the other
+///   side of the match — [`build_server_configs`] would fall through
+///   to `with_no_client_auth()` because no verifier could be built.
+///
+/// Either shape would silently weaken the security posture in
+/// release builds, where `debug_assert!` is a no-op. Returning a
+/// `Box<dyn Error>` keeps the existing constructor signature and
+/// surfaces the misuse at startup instead.
+fn check_client_auth_invariant(
+    has_ca: bool,
+    enforcement: ClientAuthEnforcement,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let wants_ca = !matches!(enforcement, ClientAuthEnforcement::Disabled);
+    if has_ca == wants_ca {
+        return Ok(());
+    }
+    Err(if wants_ca {
+        format!(
+            "TlsConfig: ClientAuthEnforcement::{enforcement:?} requires a client CA bundle, but none was supplied"
+        )
+        .into()
+    } else {
+        "TlsConfig: a client CA bundle was supplied but ClientAuthEnforcement::Disabled was requested; pass Requested or Required, or drop the CA"
+            .into()
+    })
 }
 
 /// Advertise both `h2` (for tonic / Flight) and `http/1.1` (for axum HTTP &
@@ -183,5 +415,53 @@ impl TlsConfig {
 impl AsRef<TlsConfig> for TlsConfig {
     fn as_ref(&self) -> &TlsConfig {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invariant_ok_required_with_ca() {
+        check_client_auth_invariant(true, ClientAuthEnforcement::Required)
+            .expect("Required + CA is valid");
+    }
+
+    #[test]
+    fn invariant_ok_requested_with_ca() {
+        check_client_auth_invariant(true, ClientAuthEnforcement::Requested)
+            .expect("Requested + CA is valid");
+    }
+
+    #[test]
+    fn invariant_ok_disabled_without_ca() {
+        check_client_auth_invariant(false, ClientAuthEnforcement::Disabled)
+            .expect("Disabled + no CA is valid");
+    }
+
+    #[test]
+    fn invariant_rejects_required_without_ca() {
+        let err = check_client_auth_invariant(false, ClientAuthEnforcement::Required)
+            .expect_err("Required without CA must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Required") && msg.contains("requires a client CA"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn invariant_rejects_requested_without_ca() {
+        let err = check_client_auth_invariant(false, ClientAuthEnforcement::Requested)
+            .expect_err("Requested without CA must be rejected");
+        assert!(err.to_string().contains("Requested"));
+    }
+
+    #[test]
+    fn invariant_rejects_disabled_with_ca() {
+        let err = check_client_auth_invariant(true, ClientAuthEnforcement::Disabled)
+            .expect_err("Disabled with CA must be rejected");
+        assert!(err.to_string().contains("Disabled"));
     }
 }

--- a/crates/runtime/src/tls/reload.rs
+++ b/crates/runtime/src/tls/reload.rs
@@ -16,10 +16,8 @@ limitations under the License.
 
 //! On-disk certificate hot-reload for TLS endpoints.
 //!
-//! This module is the foundation for [milestone 1 of the mTLS plan]
-//! (`plans/mtls-public-endpoints.md`). It adds the ability to swap
-//! TLS certificates and (in a follow-up milestone) client-cert trust roots
-//! without restarting `spiced`.
+//! Lets `spiced` swap TLS certificates (and the client-cert trust
+//! roots used for mTLS) at runtime without a restart.
 //!
 //! ## Pieces
 //!
@@ -65,8 +63,13 @@ use opentelemetry::{
     metrics::{Counter, Meter},
 };
 use rustls::{
-    pki_types::{CertificateDer, PrivateKeyDer},
-    server::{ClientHello, ResolvesServerCert},
+    DistinguishedName, RootCertStore, SignatureScheme,
+    client::danger::HandshakeSignatureValid,
+    pki_types::{CertificateDer, PrivateKeyDer, UnixTime},
+    server::{
+        ClientHello, ResolvesServerCert, WebPkiClientVerifier,
+        danger::{ClientCertVerified, ClientCertVerifier},
+    },
     sign::CertifiedKey,
 };
 use rustls_pemfile::{certs, private_key};
@@ -97,12 +100,40 @@ impl ReloadScope {
 /// A `ResolvesServerCert` implementation backed by an [`ArcSwap`] so the
 /// certificate can be hot-swapped without rebuilding the parent
 /// [`rustls::ServerConfig`].
+///
+/// This type can also optionally own swappable
+/// [`WebPkiClientVerifier`]s for client-cert authentication. When the
+/// caller configures a client CA path, both the server cert/key and
+/// the CA file are watched together; on rotation, the reload callback
+/// rebuilds whichever materials changed and stores them on the
+/// respective swap. Cert+key and verifier each have their own swap so
+/// rustls can read them independently per handshake without locking;
+/// the reload callback is the only writer.
+///
+/// Two verifiers are built off the same CA bundle: a *strict* one
+/// (no-cert handshake fails) used by the Flight listener, and a *lax*
+/// one (`allow_unauthenticated()`, no-cert handshake succeeds and
+/// `peer_certificates()` is empty) used by the HTTP and metrics
+/// listeners. The HTTP route layer enforces presence on non-probe
+/// routes; `/health` and `/v1/ready` are reachable without a client
+/// cert by design so Kubernetes liveness/readiness probes work over
+/// TLS without mounting a probe certificate.
 #[derive(Debug)]
 pub struct ReloadableServerCerts {
     inner: ArcSwap<CertifiedKey>,
+    /// Strict verifier — used by the Flight server. `None` when
+    /// the caller never configured client-cert authentication.
+    verifier_swap: Option<Arc<ArcSwap<Arc<dyn ClientCertVerifier>>>>,
+    /// Lax (`allow_unauthenticated`) verifier — used by the HTTP
+    /// and metrics servers. `None` mirrors `verifier_swap`.
+    verifier_swap_lax: Option<Arc<ArcSwap<Arc<dyn ClientCertVerifier>>>>,
     scope: ReloadScope,
     cert_path: Option<PathBuf>,
     key_path: Option<PathBuf>,
+    /// Path to the client CA bundle when CA hot-reload is enabled.
+    /// `None` when the verifier was built from inline bytes (or when
+    /// no client auth is configured).
+    client_ca_path: Option<PathBuf>,
 }
 
 impl ReloadableServerCerts {
@@ -113,12 +144,40 @@ impl ReloadableServerCerts {
         key_pem: &[u8],
         scope: ReloadScope,
     ) -> Result<Arc<Self>, ReloadError> {
+        Self::from_pem_with_client_auth(cert_pem, key_pem, None, scope)
+    }
+
+    /// Like [`Self::from_pem`] but additionally builds a static
+    /// [`WebPkiClientVerifier`] from `client_ca_pem` when supplied.
+    /// The verifier is held under the same `ArcSwap` machinery as the
+    /// hot-reload path uses, but — since this constructor takes inline
+    /// bytes — it never gets rebuilt for the lifetime of the process.
+    pub fn from_pem_with_client_auth(
+        cert_pem: &[u8],
+        key_pem: &[u8],
+        client_ca_pem: Option<&[u8]>,
+        scope: ReloadScope,
+    ) -> Result<Arc<Self>, ReloadError> {
         let certified = build_certified_key(cert_pem, key_pem)?;
+        let (verifier_swap, verifier_swap_lax) = match client_ca_pem {
+            Some(ca) => {
+                let strict = build_client_verifier(ca, ClientVerifierKind::Strict)?;
+                let lax = build_client_verifier(ca, ClientVerifierKind::Lax)?;
+                (
+                    Some(Arc::new(ArcSwap::from_pointee(strict))),
+                    Some(Arc::new(ArcSwap::from_pointee(lax))),
+                )
+            }
+            None => (None, None),
+        };
         Ok(Arc::new(Self {
             inner: ArcSwap::from_pointee(certified),
+            verifier_swap,
+            verifier_swap_lax,
             scope,
             cert_path: None,
             key_path: None,
+            client_ca_path: None,
         }))
     }
 
@@ -131,6 +190,24 @@ impl ReloadableServerCerts {
         scope: ReloadScope,
         watcher: &CertWatcher,
     ) -> Result<Arc<Self>, ReloadError> {
+        Self::from_paths_with_client_auth(cert_path, key_path, None, scope, watcher)
+    }
+
+    /// Like [`Self::from_paths`] but additionally registers an optional
+    /// client CA path for client-cert authentication. When `client_ca_path`
+    /// is `Some`, the watcher monitors all three files; on any change the
+    /// reload callback re-reads and re-validates *all* materials in
+    /// scope and atomically stores the new server cert/key and
+    /// (separately) the new client verifier. Cert+key and verifier are
+    /// independent swaps so reads on one cannot block reads on the
+    /// other; the dispatcher thread is the only writer.
+    pub fn from_paths_with_client_auth(
+        cert_path: PathBuf,
+        key_path: PathBuf,
+        client_ca_path: Option<PathBuf>,
+        scope: ReloadScope,
+        watcher: &CertWatcher,
+    ) -> Result<Arc<Self>, ReloadError> {
         let cert_pem = fs::read(&cert_path).map_err(|source| ReloadError::Io {
             path: cert_path.clone(),
             source,
@@ -140,15 +217,39 @@ impl ReloadableServerCerts {
             source,
         })?;
         let certified = build_certified_key(&cert_pem, &key_pem)?;
+        let (verifier_swap, verifier_swap_lax) = if let Some(ca_path) = &client_ca_path {
+            let ca_pem = fs::read(ca_path).map_err(|source| ReloadError::Io {
+                path: ca_path.clone(),
+                source,
+            })?;
+            let strict = build_client_verifier(&ca_pem, ClientVerifierKind::Strict)?;
+            let lax = build_client_verifier(&ca_pem, ClientVerifierKind::Lax)?;
+            (
+                Some(Arc::new(ArcSwap::from_pointee(strict))),
+                Some(Arc::new(ArcSwap::from_pointee(lax))),
+            )
+        } else {
+            (None, None)
+        };
         let this = Arc::new(Self {
             inner: ArcSwap::from_pointee(certified),
+            verifier_swap,
+            verifier_swap_lax,
             scope,
             cert_path: Some(cert_path.clone()),
             key_path: Some(key_path.clone()),
+            client_ca_path: client_ca_path.clone(),
         });
 
         let weak = Arc::downgrade(&this);
-        let cb_paths = vec![cert_path, key_path];
+        // Single registration covering every path that should trigger a
+        // reload. The callback re-reads its own paths from `self`, so a
+        // change to any one of them produces one consistent re-read of
+        // the whole bundle (cert+key and, when applicable, CA).
+        let mut cb_paths = vec![cert_path, key_path];
+        if let Some(ca_path) = client_ca_path {
+            cb_paths.push(ca_path);
+        }
         watcher.register(cb_paths, move |_changed| {
             let Some(this) = weak.upgrade() else {
                 return;
@@ -159,52 +260,100 @@ impl ReloadableServerCerts {
         Ok(this)
     }
 
-    /// Re-read the configured cert + key files and swap atomically. Errors
-    /// keep the old material in place.
+    /// Re-read the configured cert + key files (and client CA, when
+    /// configured) and swap atomically. Each material is independent;
+    /// a parse failure on one keeps the previous version in place
+    /// without affecting the others. Errors keep the old material in
+    /// place rather than taking the server down on a bad rotation.
     pub fn reload_now(&self) {
-        let (Some(cert_path), Some(key_path)) = (&self.cert_path, &self.key_path) else {
-            return;
-        };
-        let cert_pem = match fs::read(cert_path) {
-            Ok(b) => b,
-            Err(err) => {
-                tracing::warn!(
-                    path = %cert_path.display(),
-                    "TLS reload: failed to read cert file: {err}"
-                );
-                metrics().reload(self.scope, "io_error");
-                return;
+        // ---- server cert + key ----
+        if let (Some(cert_path), Some(key_path)) = (&self.cert_path, &self.key_path) {
+            let cert_pem = match fs::read(cert_path) {
+                Ok(b) => b,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %cert_path.display(),
+                        "TLS reload: failed to read cert file: {err}"
+                    );
+                    metrics().reload(self.scope, "io_error");
+                    return;
+                }
+            };
+            let key_pem = match fs::read(key_path) {
+                Ok(b) => b,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %key_path.display(),
+                        "TLS reload: failed to read key file: {err}"
+                    );
+                    metrics().reload(self.scope, "io_error");
+                    return;
+                }
+            };
+            match build_certified_key(&cert_pem, &key_pem) {
+                Ok(new_ck) => {
+                    let fp = cert_fingerprint_short(&new_ck);
+                    self.inner.store(Arc::new(new_ck));
+                    tracing::info!(
+                        cert_path = %cert_path.display(),
+                        fingerprint = %fp,
+                        scope = self.scope.as_str(),
+                        "TLS reload: swapped server certificate"
+                    );
+                    metrics().reload(self.scope, "ok");
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        cert_path = %cert_path.display(),
+                        "TLS reload: rejected new material, keeping old: {err}"
+                    );
+                    metrics().reload(self.scope, "parse_error");
+                }
             }
-        };
-        let key_pem = match fs::read(key_path) {
-            Ok(b) => b,
-            Err(err) => {
-                tracing::warn!(
-                    path = %key_path.display(),
-                    "TLS reload: failed to read key file: {err}"
-                );
-                metrics().reload(self.scope, "io_error");
-                return;
-            }
-        };
-        match build_certified_key(&cert_pem, &key_pem) {
-            Ok(new_ck) => {
-                let fp = cert_fingerprint_short(&new_ck);
-                self.inner.store(Arc::new(new_ck));
-                tracing::info!(
-                    cert_path = %cert_path.display(),
-                    fingerprint = %fp,
-                    scope = self.scope.as_str(),
-                    "TLS reload: swapped server certificate"
-                );
-                metrics().reload(self.scope, "ok");
-            }
-            Err(err) => {
-                tracing::warn!(
-                    cert_path = %cert_path.display(),
-                    "TLS reload: rejected new material, keeping old: {err}"
-                );
-                metrics().reload(self.scope, "parse_error");
+        }
+
+        // ---- client CA (mTLS verifiers) ----
+        // Independent from the cert+key swap: a bad CA rotation must
+        // not affect the server cert, and vice versa. The strict and
+        // lax verifiers are rebuilt from the same CA bytes and stored
+        // back-to-back; rustls reads each independently per handshake,
+        // so a connection only ever sees one consistent verifier.
+        if let (Some(ca_path), Some(strict_swap), Some(lax_swap)) = (
+            &self.client_ca_path,
+            &self.verifier_swap,
+            &self.verifier_swap_lax,
+        ) {
+            let ca_pem = match fs::read(ca_path) {
+                Ok(b) => b,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %ca_path.display(),
+                        "TLS reload: failed to read client CA file: {err}"
+                    );
+                    metrics().reload(self.scope, "io_error");
+                    return;
+                }
+            };
+            let strict = build_client_verifier(&ca_pem, ClientVerifierKind::Strict);
+            let lax = build_client_verifier(&ca_pem, ClientVerifierKind::Lax);
+            match (strict, lax) {
+                (Ok(new_strict), Ok(new_lax)) => {
+                    strict_swap.store(Arc::new(new_strict));
+                    lax_swap.store(Arc::new(new_lax));
+                    tracing::info!(
+                        ca_path = %ca_path.display(),
+                        scope = self.scope.as_str(),
+                        "TLS reload: swapped client CA bundle"
+                    );
+                    metrics().reload(self.scope, "ok");
+                }
+                (Err(err), _) | (_, Err(err)) => {
+                    tracing::warn!(
+                        ca_path = %ca_path.display(),
+                        "TLS reload: rejected new client CA bundle, keeping old: {err}"
+                    );
+                    metrics().reload(self.scope, "parse_error");
+                }
             }
         }
     }
@@ -213,6 +362,149 @@ impl ReloadableServerCerts {
 impl ResolvesServerCert for ReloadableServerCerts {
     fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
         Some(self.inner.load_full())
+    }
+}
+
+impl ReloadableServerCerts {
+    /// Returns the *strict* [`ClientCertVerifier`] suitable for
+    /// [`ServerConfig::with_client_cert_verifier`] when this resolver was
+    /// built with a client CA configured. "Strict" means the rustls
+    /// handshake fails if the client does not present a cert. Used by
+    /// the Flight listener.
+    ///
+    /// The returned verifier is a thin shim that reads `verifier_swap`
+    /// on every handshake — so a CA rotation lands on the next
+    /// handshake without rebuilding the `ServerConfig`.
+    ///
+    /// `None` when the resolver was built without client-cert auth
+    /// (the caller should wire `with_no_client_auth()` instead).
+    #[must_use]
+    pub fn client_verifier(&self) -> Option<Arc<dyn ClientCertVerifier>> {
+        Some(shim_for(self.verifier_swap.as_ref()?))
+    }
+
+    /// Returns the *lax* [`ClientCertVerifier`] for the HTTP and
+    /// metrics listeners. "Lax" means a client that presents no cert
+    /// completes the handshake (and `peer_certificates()` is empty);
+    /// a client that presents an invalid / wrong-CA cert is still
+    /// rejected at the handshake. Per-route HTTP middleware enforces
+    /// presence for non-probe routes; `/health` and `/v1/ready` are
+    /// reachable without a cert by design for Kubernetes probes.
+    ///
+    /// `None` mirrors [`Self::client_verifier`].
+    #[must_use]
+    pub fn client_verifier_lax(&self) -> Option<Arc<dyn ClientCertVerifier>> {
+        Some(shim_for(self.verifier_swap_lax.as_ref()?))
+    }
+}
+
+fn shim_for(swap: &Arc<ArcSwap<Arc<dyn ClientCertVerifier>>>) -> Arc<dyn ClientCertVerifier> {
+    // Capture `root_hint_subjects` from the live verifier once,
+    // here, because `ClientCertVerifier::root_hint_subjects`
+    // returns `&[DistinguishedName]` — a borrow that cannot point
+    // into an `ArcSwap::load` result. This matches the design
+    // choice in `crate::cluster::pki::ClusterPkiBundle`: the set
+    // of advertised CA subjects is pinned at startup and a
+    // rotated CA file does **not** change the
+    // `CertificateRequest` hint list. Operators rotating a CA in
+    // a way that adds or removes subject DNs need to restart the
+    // process to re-advertise; in practice CA rotations swap the
+    // signing key under the same Subject, so the hint list stays
+    // valid.
+    let hint_subjects = swap.load_full().root_hint_subjects().to_vec();
+    Arc::new(ReloadableClientVerifier {
+        inner: Arc::clone(swap),
+        hint_subjects,
+    })
+}
+
+/// Thin shim that delegates every [`ClientCertVerifier`] call to the
+/// live verifier inside an [`ArcSwap`]. Reads happen on the rustls
+/// handshake hot path and are wait-free (`ArcSwap::load_full` is a
+/// single atomic read + clone of the inner `Arc`). The dispatcher
+/// thread is the only writer and only stores fully-validated
+/// verifiers, so no handshake can ever observe a torn / partially
+/// rebuilt verifier.
+///
+/// Methods other than `verify_client_cert` (TLS 1.2 / 1.3 signature
+/// verification, supported schemes) also delegate to the live verifier
+/// so a CA rotation that, for example, narrows the supported
+/// signature schemes is reflected immediately. `root_hint_subjects`
+/// is the exception — see the doc comment in
+/// [`ReloadableServerCerts::client_verifier`] for why it's pinned at
+/// startup.
+#[derive(Debug)]
+struct ReloadableClientVerifier {
+    inner: Arc<ArcSwap<Arc<dyn ClientCertVerifier>>>,
+    /// Subject DN list captured at construction time and returned
+    /// from every `root_hint_subjects` call. See the constructor for
+    /// the rotation trade-off.
+    hint_subjects: Vec<DistinguishedName>,
+}
+
+impl ReloadableClientVerifier {
+    fn live(&self) -> Arc<dyn ClientCertVerifier> {
+        // `inner` is an `Arc<ArcSwap<Arc<dyn ClientCertVerifier>>>`,
+        // so `load_full()` returns `Arc<Arc<dyn ClientCertVerifier>>`
+        // (the outer `Arc` is the snapshot guard, the inner is the
+        // verifier itself). Deref one layer and clone the inner Arc
+        // explicitly so the return type isn't relying on a subtle
+        // `Deref` coercion.
+        let snapshot = self.inner.load_full();
+        Arc::clone(&*snapshot)
+    }
+}
+
+impl ClientCertVerifier for ReloadableClientVerifier {
+    fn offer_client_auth(&self) -> bool {
+        self.live().offer_client_auth()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        // Forwarded from the live verifier so the
+        // strict-vs-`allow_unauthenticated` distinction baked into
+        // each underlying `WebPkiClientVerifier` actually reaches
+        // rustls. The default trait impl returns `true`, which would
+        // override `allow_unauthenticated()` on the lax verifier and
+        // make the handshake reject no-cert clients — not what we
+        // want for the HTTP listener that serves `/health`.
+        self.live().client_auth_mandatory()
+    }
+
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &self.hint_subjects
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        self.live()
+            .verify_client_cert(end_entity, intermediates, now)
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.live().verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.live().verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.live().supported_verify_schemes()
     }
 }
 
@@ -466,6 +758,50 @@ fn build_certified_key(cert_pem: &[u8], key_pem: &[u8]) -> Result<CertifiedKey, 
     Ok(CertifiedKey::new(cert_chain, signing_key))
 }
 
+/// Whether to build the strict (rejects no-cert at handshake) or lax
+/// (`allow_unauthenticated`) variant of the `WebPkiClientVerifier`.
+/// Both variants share the same trust roots; only the no-cert
+/// behavior differs.
+#[derive(Debug, Clone, Copy)]
+enum ClientVerifierKind {
+    Strict,
+    Lax,
+}
+
+/// Build a [`WebPkiClientVerifier`] from one or more PEM-encoded CA
+/// certificates. Used both at startup and on every CA-file rotation.
+///
+/// Treats an empty CA bundle as an error — a verifier with no roots
+/// would silently reject every client cert and operators would have a
+/// hard time figuring out why mTLS "stopped working".
+fn build_client_verifier(
+    ca_pem: &[u8],
+    kind: ClientVerifierKind,
+) -> Result<Arc<dyn ClientCertVerifier>, ReloadError> {
+    let mut roots = RootCertStore::empty();
+    let ca_certs = certs(&mut Cursor::new(ca_pem))
+        .collect::<io::Result<Vec<_>>>()
+        .map_err(|source| ReloadError::ParseCert { source })?;
+    if ca_certs.is_empty() {
+        return Err(ReloadError::EmptyClientCa);
+    }
+    for ca in ca_certs {
+        roots
+            .add(ca)
+            .map_err(|source| ReloadError::Rustls { source })?;
+    }
+    let builder = WebPkiClientVerifier::builder(Arc::new(roots));
+    let builder = match kind {
+        ClientVerifierKind::Strict => builder,
+        ClientVerifierKind::Lax => builder.allow_unauthenticated(),
+    };
+    builder
+        .build()
+        .map_err(|err| ReloadError::ClientVerifierBuild {
+            message: err.to_string(),
+        })
+}
+
 fn load_certs(pem: &[u8]) -> Result<Vec<CertificateDer<'static>>, ReloadError> {
     let mut cursor = Cursor::new(pem);
     certs(&mut cursor)
@@ -511,6 +847,10 @@ pub enum ReloadError {
     MissingKey,
     #[snafu(display("TLS PEM contained no certificates"))]
     EmptyCertChain,
+    #[snafu(display("client CA bundle contained no certificates"))]
+    EmptyClientCa,
+    #[snafu(display("failed to build rustls client cert verifier: {message}"))]
+    ClientVerifierBuild { message: String },
     #[snafu(display("rustls signing key error: {source}"))]
     Sign { source: rustls::Error },
     #[snafu(display("rustls error: {source}"))]

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -93,6 +93,7 @@ mod metadata;
 mod mongo;
 #[cfg(feature = "mssql")]
 mod mssql;
+mod mtls_public;
 #[cfg(feature = "mysql")]
 mod mysql;
 #[cfg(feature = "odbc")]

--- a/crates/runtime/tests/mtls_public/mod.rs
+++ b/crates/runtime/tests/mtls_public/mod.rs
@@ -1,0 +1,628 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! End-to-end tests for the public-facing mTLS surface (HTTP + Flight).
+//!
+//! Exercises:
+//!
+//! - `client_auth: required` accepts certs signed by the configured CA
+//!   on **both** the HTTP and Flight listeners.
+//! - `client_auth: required` admits no-cert HTTPS connections at the
+//!   transport (so Kubernetes liveness/readiness probes work) but the
+//!   HTTP route layer still 401s non-probe routes that arrived
+//!   without a verified client cert.
+//! - The metrics port (`/health`, `/metrics`) is always reachable over
+//!   TLS without a client cert when `client_auth: required` is set.
+//! - The Flight listener stays strict: no-cert and foreign-CA cert
+//!   handshakes are rejected at the TLS layer.
+//! - mTLS-as-identity mode ([`IdentitySource::Channel`]): a verified
+//!   peer cert is sufficient — no API key is required even when the
+//!   underlying servers have no `runtime.auth` configured.
+//!
+//! mTLS-as-channel mode (cert + API key) is covered indirectly by the
+//! existing API-key auth tests plus the unit tests on the per-protocol
+//! mTLS layers in `crates/runtime/src/{http,flight}/mtls.rs`.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use crate::{init_tracing, utils::test_request_context};
+use arrow_flight::{
+    FlightDescriptor,
+    flight_service_client::FlightServiceClient,
+    sql::{CommandStatementQuery, ProstMessageExt},
+};
+use prost::Message;
+use rand::RngExt;
+use rcgen::{
+    CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
+};
+use runtime::{Runtime, auth::EndpointAuth, config::Config, tls::TlsConfig};
+use runtime_auth::IdentitySource;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+fn install_crypto_provider() {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+}
+
+/// PKI bundle generated for one test: a CA, a server leaf signed by
+/// the CA, and a client leaf signed by the same CA.
+#[expect(
+    clippy::struct_field_names,
+    reason = "`_pem` postfix matches the rest of the test module's PEM-shaped vars"
+)]
+struct TestPki {
+    ca_pem: String,
+    server_cert_pem: String,
+    server_key_pem: String,
+    client_cert_pem: String,
+    client_key_pem: String,
+}
+
+fn generate_pki(tag: &str) -> TestPki {
+    // CA
+    let mut ca_dn = DistinguishedName::new();
+    ca_dn.push(DnType::CommonName, format!("Spice mTLS test CA {tag}"));
+    let mut ca_params = CertificateParams::default();
+    ca_params.distinguished_name = ca_dn;
+    ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ];
+    let ca_key = KeyPair::generate().expect("ca keypair");
+    let ca = ca_params.self_signed(&ca_key).expect("self-signed CA");
+    let ca_issuer = Issuer::new(ca_params, ca_key);
+
+    // Server leaf
+    let mut srv_dn = DistinguishedName::new();
+    srv_dn.push(DnType::CommonName, format!("spiced-server-{tag}"));
+    let mut srv_params = CertificateParams::default();
+    srv_params.distinguished_name = srv_dn;
+    srv_params
+        .subject_alt_names
+        .push(SanType::DnsName("localhost".try_into().expect("dns")));
+    srv_params
+        .subject_alt_names
+        .push(SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    let srv_key = KeyPair::generate().expect("srv keypair");
+    let srv = srv_params
+        .signed_by(&srv_key, &ca_issuer)
+        .expect("server signed by CA");
+
+    // Client leaf
+    let mut cli_dn = DistinguishedName::new();
+    cli_dn.push(DnType::CommonName, format!("spiced-client-{tag}"));
+    let mut cli_params = CertificateParams::default();
+    cli_params.distinguished_name = cli_dn;
+    let cli_key = KeyPair::generate().expect("cli keypair");
+    let cli = cli_params
+        .signed_by(&cli_key, &ca_issuer)
+        .expect("client signed by CA");
+
+    TestPki {
+        ca_pem: ca.pem(),
+        server_cert_pem: srv.pem(),
+        server_key_pem: srv_key.serialize_pem(),
+        client_cert_pem: cli.pem(),
+        client_key_pem: cli_key.serialize_pem(),
+    }
+}
+
+fn random_ports() -> (u16, u16, u16) {
+    let mut rng = rand::rng();
+    let http: u16 = rng.random_range(50000..60000);
+    (http, http + 1, http + 2)
+}
+
+/// Spin up a `Runtime` listening on the given ports with TLS +
+/// the given [`ClientAuthEnforcement`] configured against `pki`.
+async fn start_runtime_with_mtls(
+    http_port: u16,
+    flight_port: u16,
+    metrics_port: u16,
+    pki: &TestPki,
+    identity_source: IdentitySource,
+    enforcement: runtime::tls::ClientAuthEnforcement,
+) {
+    let api_config = Config::new()
+        .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port));
+
+    let tls_config = TlsConfig::try_new_with_client_auth_mode(
+        pki.server_cert_pem.as_bytes(),
+        pki.server_key_pem.as_bytes(),
+        Some(pki.ca_pem.as_bytes()),
+        enforcement,
+    )
+    .expect("valid TlsConfig with client auth");
+
+    let registry = prometheus::Registry::new();
+    let app = app::AppBuilder::new("test_app").build();
+
+    let rt = Arc::new(
+        Runtime::builder()
+            .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
+            .with_app(app)
+            .build()
+            .await,
+    );
+
+    let endpoint_auth = EndpointAuth::no_auth().with_identity_source(identity_source);
+    tokio::spawn(async move {
+        Box::pin(Arc::clone(&rt).start_servers(
+            api_config,
+            Some(Arc::new(tls_config)),
+            endpoint_auth,
+        ))
+        .await
+    });
+}
+
+/// Build a reqwest HTTPS client that trusts `ca_pem` and (optionally)
+/// presents a client cert/key. Concatenates cert + key into the single
+/// blob `reqwest::Identity::from_pem` expects.
+fn build_http_client(ca_pem: &str, client_pem_pair: Option<(&str, &str)>) -> reqwest::Client {
+    let ca = reqwest::tls::Certificate::from_pem(ca_pem.as_bytes()).expect("valid CA");
+    let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
+        .tls_built_in_root_certs(false)
+        .add_root_certificate(ca);
+    if let Some((cert_pem, key_pem)) = client_pem_pair {
+        let mut buf = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
+        buf.extend_from_slice(cert_pem.as_bytes());
+        buf.push(b'\n');
+        buf.extend_from_slice(key_pem.as_bytes());
+        let id = reqwest::Identity::from_pem(&buf).expect("valid client identity");
+        builder = builder.identity(id);
+    }
+    builder.build().expect("reqwest client")
+}
+
+async fn build_flight_client(
+    ca_pem: &str,
+    client_pem_pair: Option<(&str, &str)>,
+    flight_port: u16,
+) -> Result<FlightServiceClient<Channel>, tonic::transport::Error> {
+    let mut tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(ca_pem.as_bytes()))
+        .domain_name("localhost");
+    if let Some((cert_pem, key_pem)) = client_pem_pair {
+        tls = tls.identity(Identity::from_pem(cert_pem.as_bytes(), key_pem.as_bytes()));
+    }
+    let channel = Channel::from_shared(format!("https://localhost:{flight_port}"))
+        .expect("valid uri")
+        .tls_config(tls)?
+        .connect()
+        .await?;
+    Ok(FlightServiceClient::new(channel))
+}
+
+async fn flight_show_tables(
+    client: &mut FlightServiceClient<Channel>,
+) -> Result<(), tonic::Status> {
+    let cmd = CommandStatementQuery {
+        query: "show tables".to_string(),
+        transaction_id: None,
+    };
+    let req = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
+    let _ = client.get_flight_info(req).await?;
+    Ok(())
+}
+
+/// Wait for `f` to return `Ok(())`, retrying for up to `timeout`. Useful
+/// while the spawned `Runtime` boots its listeners.
+async fn wait_for_ok<F, Fut, E>(timeout: Duration, mut f: F) -> Result<(), E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), E>>,
+    E: std::fmt::Debug,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last_err: Option<E> = None;
+    while std::time::Instant::now() < deadline {
+        match f().await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(last_err.expect("at least one attempt was made"))
+}
+
+/// `client_auth: required` + `IdentitySource::Channel` (mTLS-as-identity):
+///
+/// - Plain HTTPS connection with no client cert → handshake fails.
+/// - Client cert signed by the trusted CA → HTTP `/health` returns 200
+///   AND a Flight `get_flight_info` succeeds, with no API key on the
+///   wire (the per-protocol mTLS layers must promote the cert to the
+///   request principal so the auth-layer short-circuit fires).
+/// - Client cert signed by an unrelated CA → handshake fails.
+#[tokio::test]
+async fn test_public_mtls_required_channel_mode() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    install_crypto_provider();
+
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_public_mtls_required_channel_mode");
+            let _span_guard = span.enter();
+
+            let pki = generate_pki("primary");
+            let foreign = generate_pki("foreign");
+            let (http_port, flight_port, metrics_port) = random_ports();
+            tracing::debug!(
+                "mTLS ports: http={http_port}, flight={flight_port}, metrics={metrics_port}"
+            );
+
+            start_runtime_with_mtls(
+                http_port,
+                flight_port,
+                metrics_port,
+                &pki,
+                IdentitySource::Channel,
+                runtime::tls::ClientAuthEnforcement::Required,
+            )
+            .await;
+
+            // 1. Wait for the HTTP listener to be up by repeatedly
+            //    trying with a *valid* client cert.
+            let valid_http = build_http_client(
+                &pki.ca_pem,
+                Some((&pki.client_cert_pem, &pki.client_key_pem)),
+            );
+            let url = format!("https://localhost:{http_port}/health");
+            wait_for_ok::<_, _, reqwest::Error>(Duration::from_secs(15), || async {
+                valid_http.get(&url).send().await.map(|_| ())
+            })
+            .await
+            .expect("HTTP listener never came up under valid client cert");
+            let resp = valid_http
+                .get(&url)
+                .send()
+                .await
+                .expect("HTTP /health under valid cert");
+            assert!(
+                resp.status().is_success(),
+                "valid client cert should reach HTTP /health, got {}",
+                resp.status()
+            );
+            tracing::info!("HTTP /health OK with valid client cert");
+
+            // 2. Same client, no client cert → /health bypasses the
+            //    route gate so probes succeed; /v1/sql is on the
+            //    authenticated router and 401s.
+            let no_cert_http = build_http_client(&pki.ca_pem, None);
+            let resp = no_cert_http
+                .get(&url)
+                .send()
+                .await
+                .expect("no-cert /health must complete the TLS handshake");
+            assert!(
+                resp.status().is_success(),
+                "no-cert /health must succeed under client_auth: required, got {}",
+                resp.status()
+            );
+            tracing::info!("no-cert HTTPS /health bypassed gate as expected");
+
+            let ready_resp = no_cert_http
+                .get(format!("https://localhost:{http_port}/v1/ready"))
+                .send()
+                .await
+                .expect("no-cert /v1/ready must complete the TLS handshake");
+            assert!(
+                ready_resp.status().is_success() || ready_resp.status().as_u16() == 503,
+                "no-cert /v1/ready must reach the route handler (200 or 503), got {}",
+                ready_resp.status()
+            );
+
+            let sql_resp = no_cert_http
+                .post(format!("https://localhost:{http_port}/v1/sql"))
+                .body("SELECT 1")
+                .send()
+                .await
+                .expect("no-cert /v1/sql must complete the TLS handshake");
+            assert_eq!(
+                sql_resp.status().as_u16(),
+                401,
+                "no-cert /v1/sql must be 401 under client_auth: required, got {}",
+                sql_resp.status()
+            );
+            tracing::info!("no-cert HTTPS /v1/sql correctly 401d by route gate");
+
+            // 3. Client cert signed by a *different* CA → handshake
+            //    fails on every route (the lax verifier still rejects
+            //    presented-but-untrusted certs at TLS).
+            let foreign_http = build_http_client(
+                &pki.ca_pem,
+                Some((&foreign.client_cert_pem, &foreign.client_key_pem)),
+            );
+            let err = foreign_http
+                .get(&url)
+                .send()
+                .await
+                .expect_err("foreign-CA cert HTTPS request must fail");
+            tracing::info!("foreign-CA HTTPS correctly rejected: {err}");
+
+            // 4. Flight: valid client cert succeeds.
+            let mut flight_client = build_flight_client(
+                &pki.ca_pem,
+                Some((&pki.client_cert_pem, &pki.client_key_pem)),
+                flight_port,
+            )
+            .await
+            .expect("flight connect with valid cert");
+            flight_show_tables(&mut flight_client)
+                .await
+                .expect("flight show tables under valid cert");
+            tracing::info!("Flight get_flight_info OK with valid client cert");
+
+            // 5. Flight: no client cert. tonic's `Channel::connect()`
+            //    may complete the TCP connect before the TLS
+            //    handshake actually rejects (the server-side rustls
+            //    `WebPkiClientVerifier` runs during handshake, but
+            //    detection at the client may surface only on the
+            //    first RPC). Either an error from `connect` OR an
+            //    error from the first `get_flight_info` is acceptable.
+            let no_cert_outcome: Result<(), tonic::Status> =
+                match build_flight_client(&pki.ca_pem, None, flight_port).await {
+                    Err(_) => Err(tonic::Status::unavailable("connect failed (no cert)")),
+                    Ok(mut c) => flight_show_tables(&mut c).await,
+                };
+            let err = no_cert_outcome
+                .expect_err("flight RPC without client cert must fail at connect or first call");
+            tracing::info!("Flight no-cert correctly rejected: {err}");
+
+            // 6. Flight: foreign-CA cert. Same caveat as #5.
+            let foreign_outcome: Result<(), tonic::Status> = match build_flight_client(
+                &pki.ca_pem,
+                Some((&foreign.client_cert_pem, &foreign.client_key_pem)),
+                flight_port,
+            )
+            .await
+            {
+                Err(_) => Err(tonic::Status::unavailable("connect failed (foreign cert)")),
+                Ok(mut c) => flight_show_tables(&mut c).await,
+            };
+            let err = foreign_outcome
+                .expect_err("flight RPC with foreign-CA cert must fail at connect or first call");
+            tracing::info!("Flight foreign-CA correctly rejected: {err}");
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+}
+
+/// `client_auth: required` + `IdentitySource::Anonymous` (the
+/// out-of-the-box default with no `runtime.auth` and no per-protocol
+/// promotion): a verified peer cert still passes the channel
+/// requirement, the request just runs as the anonymous principal.
+/// Verifies the validation surface is wired and a request can complete
+/// when only `client_auth` is required, regardless of the `IdentitySource`.
+#[tokio::test]
+async fn test_public_mtls_required_anonymous_mode() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    install_crypto_provider();
+
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_public_mtls_required_anonymous_mode");
+            let _span_guard = span.enter();
+
+            let pki = generate_pki("anon");
+            let (http_port, flight_port, metrics_port) = random_ports();
+
+            start_runtime_with_mtls(
+                http_port,
+                flight_port,
+                metrics_port,
+                &pki,
+                IdentitySource::Anonymous,
+                runtime::tls::ClientAuthEnforcement::Required,
+            )
+            .await;
+
+            let http = build_http_client(
+                &pki.ca_pem,
+                Some((&pki.client_cert_pem, &pki.client_key_pem)),
+            );
+            let url = format!("https://localhost:{http_port}/health");
+            wait_for_ok::<_, _, reqwest::Error>(Duration::from_secs(15), || async {
+                http.get(&url).send().await.map(|_| ())
+            })
+            .await
+            .expect("HTTP listener never came up");
+            let resp = http.get(&url).send().await.expect("HTTP /health");
+            assert!(
+                resp.status().is_success(),
+                "valid client cert in anonymous mode should reach /health, got {}",
+                resp.status()
+            );
+
+            // No-cert /health is now allowed (probes); /v1/sql is
+            // still 401d by the route gate even in anonymous mode.
+            let no_cert = build_http_client(&pki.ca_pem, None);
+            let resp = no_cert
+                .get(&url)
+                .send()
+                .await
+                .expect("no-cert /health must complete the handshake");
+            assert!(
+                resp.status().is_success(),
+                "no-cert /health in anonymous mode must succeed, got {}",
+                resp.status()
+            );
+            let sql_resp = no_cert
+                .post(format!("https://localhost:{http_port}/v1/sql"))
+                .body("SELECT 1")
+                .send()
+                .await
+                .expect("no-cert /v1/sql must complete the handshake");
+            assert_eq!(
+                sql_resp.status().as_u16(),
+                401,
+                "no-cert /v1/sql in anonymous mode must be 401, got {}",
+                sql_resp.status()
+            );
+            tracing::info!("anonymous-mode no-cert: /health 200, /v1/sql 401");
+
+            // The metrics port reuses the lax HTTP `ServerConfig` and
+            // has no application-layer client-auth gate, so /health
+            // and /metrics are reachable over TLS with no client cert.
+            let metrics_health = no_cert
+                .get(format!("https://localhost:{metrics_port}/health"))
+                .send()
+                .await
+                .expect("no-cert metrics /health");
+            assert!(
+                metrics_health.status().is_success(),
+                "no-cert metrics /health must succeed, got {}",
+                metrics_health.status()
+            );
+            let metrics_body = no_cert
+                .get(format!("https://localhost:{metrics_port}/metrics"))
+                .send()
+                .await
+                .expect("no-cert metrics /metrics");
+            assert!(
+                metrics_body.status().is_success(),
+                "no-cert metrics /metrics must succeed, got {}",
+                metrics_body.status()
+            );
+            tracing::info!("metrics endpoints reachable over TLS without client cert");
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+}
+
+/// `client_auth_mode: request` (optional mTLS): both HTTP and Flight
+/// listeners send `CertificateRequest` but accept no-cert
+/// handshakes. Presented certs must be signed by the configured CA.
+///
+/// - No-cert HTTPS `/v1/sql` succeeds (no app-layer gate). Probes
+///   continue to work.
+/// - Valid client cert reaches Flight `get_flight_info` (no app-layer
+///   gate either; the cert is promoted to the auth principal under
+///   `IdentitySource::Channel`).
+/// - A foreign-CA cert is rejected at the rustls handshake \u2014 the
+///   `allow_unauthenticated` verifier still validates *presented*
+///   certs against the trust roots.
+#[tokio::test]
+async fn test_public_mtls_request_mode() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    install_crypto_provider();
+
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_public_mtls_request_mode");
+            let _span_guard = span.enter();
+
+            let pki = generate_pki("request");
+            let foreign = generate_pki("foreign-req");
+            let (http_port, flight_port, metrics_port) = random_ports();
+
+            start_runtime_with_mtls(
+                http_port,
+                flight_port,
+                metrics_port,
+                &pki,
+                IdentitySource::Channel,
+                runtime::tls::ClientAuthEnforcement::Requested,
+            )
+            .await;
+
+            // 1. Wait for the HTTP listener to come up under a valid
+            //    client cert.
+            let valid_http = build_http_client(
+                &pki.ca_pem,
+                Some((&pki.client_cert_pem, &pki.client_key_pem)),
+            );
+            let health_url = format!("https://localhost:{http_port}/health");
+            wait_for_ok::<_, _, reqwest::Error>(Duration::from_secs(15), || async {
+                valid_http.get(&health_url).send().await.map(|_| ())
+            })
+            .await
+            .expect("HTTP listener never came up under request mode");
+
+            // 2. No-cert HTTPS reaches /v1/sql without a 401 (no gate
+            //    under Requested). We don't care about the *body*; we
+            //    care that the response was not 401 from the route
+            //    middleware. Returns 400 (bad SQL) or similar from
+            //    the handler is fine.
+            let no_cert_http = build_http_client(&pki.ca_pem, None);
+            let sql_resp = no_cert_http
+                .post(format!("https://localhost:{http_port}/v1/sql"))
+                .body("SELECT 1")
+                .send()
+                .await
+                .expect("no-cert /v1/sql must complete the handshake under request mode");
+            assert_ne!(
+                sql_resp.status().as_u16(),
+                401,
+                "request-mode no-cert /v1/sql must NOT be 401, got {}",
+                sql_resp.status()
+            );
+
+            // 3. Foreign-CA cert is still rejected at the handshake \u2014
+            //    presented certs are verified.
+            let foreign_http = build_http_client(
+                &pki.ca_pem,
+                Some((&foreign.client_cert_pem, &foreign.client_key_pem)),
+            );
+            let err = foreign_http
+                .get(&health_url)
+                .send()
+                .await
+                .expect_err("foreign-CA cert must be rejected at the handshake");
+            tracing::info!("request-mode foreign-CA rejected: {err}");
+
+            // 4. Flight: no-cert handshake succeeds under Requested
+            //    (lax verifier on Flight too).
+            let mut no_cert_flight = build_flight_client(&pki.ca_pem, None, flight_port)
+                .await
+                .expect("flight connect with no cert under request mode");
+            flight_show_tables(&mut no_cert_flight)
+                .await
+                .expect("flight show tables with no cert under request mode");
+
+            // 5. Flight: valid client cert succeeds.
+            let mut valid_flight = build_flight_client(
+                &pki.ca_pem,
+                Some((&pki.client_cert_pem, &pki.client_key_pem)),
+                flight_port,
+            )
+            .await
+            .expect("flight connect with valid cert under request mode");
+            flight_show_tables(&mut valid_flight)
+                .await
+                .expect("flight show tables with valid cert under request mode");
+
+            let _ = metrics_port; // metrics port behavior is covered by anonymous-mode test
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+}

--- a/crates/runtime/tests/tls_reload/mod.rs
+++ b/crates/runtime/tests/tls_reload/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! End-to-end tests for TLS certificate hot-reload (mTLS plan, milestone 1).
+//! End-to-end tests for TLS certificate hot-reload.
 //!
 //! Each test:
 //! 1. Generates a fresh CA + server cert/key into a tempdir.

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -168,6 +168,71 @@ pub struct TlsConfig {
 
     /// A PEM encoded private key
     pub key: Option<String>,
+
+    /// Filesystem path to a PEM-encoded CA bundle used to verify client
+    /// certificates when `client_auth_mode` is `request` or `required`.
+    /// Eligible for hot-reload via the same watcher that picks up server
+    /// cert / key rotations.
+    pub client_auth_ca_file: Option<String>,
+
+    /// Inline PEM (or `${ secrets:... }`) form of the client CA bundle.
+    /// Mutually exclusive with `client_auth_ca_file`. Inline material is
+    /// not hot-reloaded.
+    pub client_auth_ca: Option<String>,
+
+    /// How the runtime treats client certificates on the public TLS
+    /// endpoints. Defaults to `none`, which preserves today's behavior
+    /// (the server does not request a client cert during the TLS
+    /// handshake). See [`ClientAuthMode`] for the full mode table.
+    pub client_auth_mode: Option<ClientAuthMode>,
+}
+
+/// How the runtime treats client certificates on the public TLS
+/// endpoints (HTTP, Flight, Metrics).
+///
+/// `None` is the out-of-the-box default and disables client-cert
+/// authentication entirely — the server runs `with_no_client_auth()`
+/// at the rustls layer and does not send a `CertificateRequest`. A
+/// non-conforming client that nonetheless presents a cert is rejected
+/// by rustls as a protocol violation.
+///
+/// `Request` opts in to *optional* mTLS: the server sends
+/// `CertificateRequest` and accepts both no-cert and cert-bearing
+/// handshakes. Presented certs must be signed by
+/// `client_auth_ca` / `client_auth_ca_file` (an invalid cert is still
+/// rejected at the handshake). When a cert is presented it is
+/// promoted to the request's auth principal under
+/// `IdentitySource::Channel`; when absent the request runs as the
+/// anonymous principal. Useful for migration windows and for
+/// audit-only deployments where every cert seen should be recorded
+/// but not enforced.
+///
+/// `Required` enables strict mTLS: the server demands a valid client
+/// cert (verified against `client_auth_ca` / `client_auth_ca_file`)
+/// for every connection on the Flight listener; on the HTTP and
+/// metrics listeners the TLS handshake admits no-cert connections so
+/// Kubernetes liveness / readiness probes and Prometheus scrapes work
+/// without a client cert, but the HTTP route layer 401s any
+/// non-probe request whose connection has no verified client cert.
+///
+/// Whether a presented cert *also* becomes the request's auth
+/// principal is determined separately by whether `runtime.auth` is
+/// configured — see the `IdentitySource` enum at the binary
+/// entrypoint. Briefly:
+///
+/// - `client_auth_mode: required` and no `runtime.auth`
+///   → mTLS-as-identity (the cert is the principal).
+/// - `client_auth_mode: required` plus `runtime.auth`
+///   → mTLS-as-channel (the cert protects the channel; the
+///   API key / OIDC token is the principal).
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub enum ClientAuthMode {
+    #[default]
+    None,
+    Request,
+    Required,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2264,5 +2329,103 @@ mod tests {
         let mcp = runtime.mcp.expect("mcp section should be present");
         let hosts = mcp.allowed_hosts.expect("allowed_hosts should be set");
         assert_eq!(hosts, vec!["*"]);
+    }
+
+    #[test]
+    fn test_deserialize_tls_client_auth_default_none() {
+        // The bare TLS section omits `client_auth_mode` — it should
+        // deserialize to `None` and the default mode at use sites
+        // should be `ClientAuthMode::None`.
+        let yaml = r"
+            tls:
+              enabled: true
+              certificate_file: /etc/spice/tls/server.crt
+              key_file: /etc/spice/tls/server.key
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        let tls = runtime.tls.expect("tls section should be present");
+        assert!(tls.client_auth_mode.is_none());
+        assert!(tls.client_auth_ca_file.is_none());
+        assert!(tls.client_auth_ca.is_none());
+        // Sanity: the enum's `Default` is `None`.
+        assert_eq!(ClientAuthMode::default(), ClientAuthMode::None);
+    }
+
+    #[test]
+    fn test_deserialize_tls_client_auth_required_with_ca() {
+        let yaml = r"
+            tls:
+              enabled: true
+              certificate_file: /etc/spice/tls/server.crt
+              key_file: /etc/spice/tls/server.key
+              client_auth_mode: required
+              client_auth_ca_file: /etc/spice/tls/client-ca.crt
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        let tls = runtime.tls.expect("tls section should be present");
+        assert_eq!(tls.client_auth_mode, Some(ClientAuthMode::Required));
+        assert_eq!(
+            tls.client_auth_ca_file.as_deref(),
+            Some("/etc/spice/tls/client-ca.crt")
+        );
+    }
+
+    #[test]
+    fn test_deserialize_tls_client_auth_request_with_ca() {
+        let yaml = r"
+            tls:
+              enabled: true
+              certificate_file: /etc/spice/tls/server.crt
+              key_file: /etc/spice/tls/server.key
+              client_auth_mode: request
+              client_auth_ca_file: /etc/spice/tls/client-ca.crt
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        let tls = runtime.tls.expect("tls section should be present");
+        assert_eq!(tls.client_auth_mode, Some(ClientAuthMode::Request));
+    }
+
+    #[test]
+    fn test_deserialize_tls_client_auth_inline_ca() {
+        let yaml = r"
+            tls:
+              enabled: true
+              certificate_file: /etc/spice/tls/server.crt
+              key_file: /etc/spice/tls/server.key
+              client_auth_mode: required
+              client_auth_ca: |
+                -----BEGIN CERTIFICATE-----
+                MIIBhTCCASug...
+                -----END CERTIFICATE-----
+        ";
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        let tls = runtime.tls.expect("tls section should be present");
+        assert_eq!(tls.client_auth_mode, Some(ClientAuthMode::Required));
+        assert!(
+            tls.client_auth_ca
+                .as_deref()
+                .is_some_and(|ca| ca.contains("BEGIN CERTIFICATE"))
+        );
+        assert!(tls.client_auth_ca_file.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_tls_client_auth_unknown_mode_rejected() {
+        // Validates `#[serde(rename_all = "snake_case", deny_unknown_fields)]`
+        // by feeding a non-existent variant. This is the operator-typo
+        // guard that ensures `client_auth_mode: requuired` doesn't
+        // silently fall through to the default `none`.
+        let yaml = r"
+            tls:
+              enabled: true
+              certificate_file: /etc/spice/tls/server.crt
+              key_file: /etc/spice/tls/server.key
+              client_auth_mode: requuired
+        ";
+        let result: Result<Runtime, _> = yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "expected unknown client_auth_mode value to be rejected"
+        );
     }
 }


### PR DESCRIPTION
Adds per-protocol mTLS to the public HTTP and Flight listeners on top
of the existing TLS hot-reload foundation in #10727. **Default behavior
is unchanged**: `client_auth_mode: none` is the default and produces a
`with_no_client_auth` rustls server config — operators that don't opt
in see no change.

HTML version: https://public-data.spiceai.org/mtls.html

```yaml
version: v1
kind: Spicepod
name: my-app

runtime:
  tls:
    # Enable TLS on the public HTTP and Flight listeners.
    enabled: true

    # Server cert + key. Both file-backed paths are watched for
    # changes and atomically swapped on rotation.
    certificate_file: /etc/spice/tls/server.pem
    key_file: /etc/spice/tls/server.key

    # NEW: enable mTLS — three modes, see table below.
    client_auth_mode: required          # none | request | required
    client_auth_ca_file: /etc/spice/tls/clients-ca.pem

datasets:
  - from: file:data.csv
    name: hello
    params:
      file_format: csv
```

## The three modes

| mode | TLS handshake (HTTP & metrics) | TLS handshake (Flight) | App-layer route gate | Use case |
|---|---|---|---|---|
| `none` *(default)* | no client cert requested | no client cert requested | none | Classic one-way TLS |
| `request` | `CertificateRequest` sent; no-cert accepted; presented certs verified | same as HTTP | none — anonymous and cert-bearing requests both reach handlers; cert is promoted to auth principal when present | Migration / audit-only |
| `required` | `CertificateRequest` sent; no-cert accepted at TLS so probes work | strict — no-cert rejected at TLS | HTTP: 401 on non-probe routes when no verified client cert; `/health` and `/v1/ready` bypass. Flight: handshake already rejected no-cert. | Strict mTLS in production |

The metrics listener (`/health`, `/metrics`) always reuses the HTTP listener's `ServerConfig` and has no application-layer client-auth gate, so Kubernetes probes and Prometheus scrapes work without a client cert under all modes.

A presented-but-untrusted cert is always rejected at the rustls handshake, regardless of mode (the `allow_unauthenticated` flag only changes the no-cert path; presented certs are still verified against the configured CA bundle).

## What's in this PR

### Spicepod + CLI surface

- New `runtime.tls.client_auth_mode` enum (`none` | `request` | `required`).
- New `runtime.tls.client_auth_ca_file` (file path) and inline
  `runtime.tls.client_auth_ca` (PEM blob).
- Matching CLI flags: `--tls-client-auth-mode`, `--tls-client-auth-ca-file`,
  `--tls-client-auth-ca`.
- Validation: `request` and `required` require a CA; `none` must NOT
  have a CA (prevents a misconfiguration silently downgrading to no
  client auth). 6 unit tests cover the cross-product.
- Schema regenerated at `.schema/spicepod.schema.json`.

### Hot-reload-aware client trust roots, with split listener configs

- `ReloadableServerCerts` extended with **two** swappable
  `WebPkiClientVerifier`s built off the same CA bundle:
  - **Strict** verifier (no `allow_unauthenticated`) — used by the
    Flight listener under `required`.
  - **Lax** verifier (`allow_unauthenticated()`) — used by the HTTP
    and metrics listeners under `request` / `required`, and by the
    Flight listener under `request`.

  Both rotate atomically on a single dispatcher tick: one CA-file
  change → one re-read → both `ArcSwap`s stored back-to-back.
- `TlsConfig` exposes `flight_server_config: Arc<ServerConfig>` and
  `http_server_config: Arc<ServerConfig>`. Under `none`, both are
  identical `with_no_client_auth()` configs.
- New `ClientAuthEnforcement { Disabled, Requested, Required }` enum
  on `TlsConfig`, plumbed once at startup and copied into each
  connection's `PerConnTls` so the route gate observes it without
  any per-request branching on listener config.
- `ReloadableClientVerifier` shim forwards `offer_client_auth` and
  `client_auth_mandatory` to the live verifier so the strict-vs-lax
  distinction baked into each underlying `WebPkiClientVerifier`
  actually reaches the rustls handshake.
- New errors: `EmptyClientCa`, `ClientVerifierBuild`.
- New constructors: `TlsConfig::try_new_with_client_auth_mode`,
  `TlsConfig::try_new_from_paths_with_client_auth_mode`. The earlier
  `*_with_client_auth` constructors are kept and default to
  `Required` semantics when a CA is supplied.

### `runtime-auth` mTLS module

- `IdentitySource` enum (`Anonymous` | `Channel` | `RuntimeAuth`).
- `MtlsPrincipal` (auth principal in identity mode) and
  `ChannelIdentity` (always-on audit identity).
- `principal_from_cert` / `channel_identity_from_cert` from leaf DER.
- `stable_id` namespaces: `mtls:dn:` > `mtls:fp:`.
- HTTP and Flight `BasicAuthLayer` short-circuit when
  `AuthRequestContext::auth_principal()` is already set, so a verified
  cert in identity mode replaces a bearer token without rejecting the
  request.

### Per-protocol mTLS layers

- HTTP: `runtime::http::mtls::PerConnTls` snapshots the verified peer
  chain off the rustls connection into a per-connection extension; the
  per-request `mtls_request_layer` reads it, always inserts a
  `ChannelIdentity` for audit, and — in `Channel` mode only —
  promotes the cert to the request's auth principal.
- HTTP route gate: `mtls::require_channel_identity` middleware on the
  authenticated router only; 401s when
  `ClientAuthEnforcement::Required` and the connection has no
  `channel_identity`. `/health` and `/v1/ready` are on the
  unauthenticated router and bypass by construction. Under
  `Requested` the middleware is a no-op (still wired so the gate
  observes future config changes if rotation ever toggles the mode).
- Flight: `runtime::flight::mtls::MtlsLayer` does the same against
  tonic's `TlsConnectInfo` (the `tls-connect-info` feature was added
  to the workspace tonic dep).
- Layer ordering: `RequestContextLayer` (sets the
  `AuthRequestContext` extension) → `MtlsLayer` (sets the principal)
  → `BasicAuthLayer` (short-circuits when principal is set).

### IdentitySource resolution

`EndpointAuth` carries an `identity_source` field; `with_identity_source`
overrides what `EndpointAuth::new` decided. The spiced entrypoint
computes the effective mode from `(runtime.auth, client_auth_mode)`:

| `runtime.auth` | `client_auth_mode` | `IdentitySource` |
|----------------|--------------------|------------------|
| unset          | none               | `Anonymous`      |
| unset          | request            | `Channel`        |
| unset          | required           | `Channel`        |
| set            | none               | `RuntimeAuth`    |
| set            | request            | `RuntimeAuth`    |
| set            | required           | `RuntimeAuth` (mTLS-as-channel) |

## Tests

- 8 unit tests in `runtime_auth::mtls` (principal + stable-id,
  cert-rotation invariants).
- 5 spicepod parser tests (defaults, request + file CA, required +
  file CA, inline CA, unknown-mode rejection).
- 7 spiced validation tests covering the `(mode, CA presence)`
  cross-product.
- 2 unit tests on `runtime::http::mtls::PerConnTls::build`.
- 3 end-to-end integration tests in `tests/mtls_public/`:
  - `test_public_mtls_required_channel_mode`: CA-signed peer reaches
    `/health` and Flight `get_flight_info` with no Authorization
    header; no-cert peer reaches `/health` + `/v1/ready` (probe
    bypass) but is 401d on `/v1/sql`; foreign-CA peer is rejected at
    the handshake; Flight rejects no-cert and foreign-CA at the
    handshake.
  - `test_public_mtls_required_anonymous_mode`: same with
    `IdentitySource::Anonymous`. Also asserts the metrics port
    serves `/health` and `/metrics` over TLS without a client cert.
  - `test_public_mtls_request_mode` *(new)*: no-cert HTTPS reaches
    `/v1/sql` without a 401 (no app-layer gate); valid cert reaches
    Flight `get_flight_info`; foreign-CA cert is rejected at the
    handshake; no-cert Flight handshake also succeeds under
    `Requested`.
- All existing TLS / cluster-mTLS reload tests still pass.

## Out of scope (deferred)

- Per-cert authorization rules / trust-domain pinning.
- mTLS-as-channel API-key end-to-end test (covered indirectly by
  existing API-key auth tests + per-protocol mTLS unit tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
