### PR TITLE
Fix 'wait_until_dependent_tables_are_ready' for catalogs

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3720,14 +3720,13 @@ async fn wait_until_dependent_tables_are_ready(
         let catalog_statuses = runtime_status.get_catalog_statuses();
 
         if let Some(not_ready_table) = dependent_tables.iter().find(|dependent_table| {
-            match statuses.get(dependent_table) {
-                Some(s) => s != &status::ComponentStatus::Ready,
-                None => {
-                    // Table not tracked as a dataset or view (e.g. a catalog table).
-                    // Consider it ready if its catalog is registered and ready.
-                    let catalog = dependent_table.catalog.as_ref();
-                    catalog_statuses.get(catalog) != Some(&status::ComponentStatus::Ready)
-                }
+            if let Some(s) = statuses.get(dependent_table) {
+                s != &status::ComponentStatus::Ready
+            } else {
+                // Table not tracked as a dataset or view (e.g. a catalog table).
+                // Consider it ready if its catalog is registered and ready.
+                let catalog = dependent_table.catalog.as_ref();
+                catalog_statuses.get(catalog) != Some(&status::ComponentStatus::Ready)
             }
         }) {
             tracing::debug!(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3717,9 +3717,18 @@ async fn wait_until_dependent_tables_are_ready(
             .into_iter()
             .map(|(key, value)| (resolve_table_reference(key), value))
             .collect::<std::collections::HashMap<_, _>>();
+        let catalog_statuses = runtime_status.get_catalog_statuses();
 
         if let Some(not_ready_table) = dependent_tables.iter().find(|dependent_table| {
-            statuses.get(dependent_table) != Some(&status::ComponentStatus::Ready)
+            match statuses.get(dependent_table) {
+                Some(s) => s != &status::ComponentStatus::Ready,
+                None => {
+                    // Table not tracked as a dataset or view (e.g. a catalog table).
+                    // Consider it ready if its catalog is registered and ready.
+                    let catalog = dependent_table.catalog.as_ref();
+                    catalog_statuses.get(catalog) != Some(&status::ComponentStatus::Ready)
+                }
+            }
         }) {
             tracing::debug!(
                 "Dependent table {not_ready_table} is not ready for {table}. Retrying..."

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -295,6 +295,12 @@ impl RuntimeStatus {
         self.get_statuses_of_prefix("model:")
     }
 
+    /// Returns the status of all registered catalogs.
+    #[must_use]
+    pub fn get_catalog_statuses(&self) -> HashMap<String, ComponentStatus> {
+        self.get_statuses_of_prefix("catalog:")
+    }
+
     /// Returns the status of all registered datasets.
     #[must_use]
     pub fn get_dataset_statuses(&self) -> HashMap<TableReference, ComponentStatus> {


### PR DESCRIPTION
## 📝 Summary

Fix `/v1/ready` returning `not ready` indefinitely when a view depends on a catalog table.

`wait_until_dependent_tables_are_ready` checked dataset and view statuses for dependent tables, but catalog tables (e.g. `foo.public.lots`) are never individually tracked in those statuses — only the catalog itself (`catalog:foo`) is tracked. This caused the function to retry forever, leaving the view stuck in `Initializing` and blocking overall runtime readiness.

Now, when a dependent table isn't found in dataset/view statuses, we fall back to checking that its catalog is registered and `Ready`.

## Changes

- **`crates/runtime/src/status.rs`**: Add `get_catalog_statuses()` method.
- **`crates/runtime/src/datafusion/mod.rs`**: Update `wait_until_dependent_tables_are_ready` to treat catalog tables as ready when their parent catalog is ready.

## 🔗 Related

## 🚨 Breaking Changes

None.

## 👀 Notes for Reviewers

The root cause: catalog tables are registered via catalog providers and never get individual `update_dataset()` calls, so they never appear in `RuntimeStatus` dataset statuses. The previous check `statuses.get(table) != Some(Ready)` treated "absent" the same as "not ready", causing an infinite retry loop.