### PR TITLE
fix: ignore field metadata in schema compatibility check in index_table_scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15856,6 +15856,7 @@ dependencies = [
 name = "runtime-datafusion-index"
 version = "2.0.0-unstable"
 dependencies = [
+ "arrow_tools",
  "async-trait",
  "datafusion",
  "futures",

--- a/crates/runtime-datafusion-index/Cargo.toml
+++ b/crates/runtime-datafusion-index/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+arrow_tools = { path = "../arrow_tools" }
 datafusion.workspace = true
 futures.workspace = true
 itertools.workspace = true

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -1140,7 +1140,7 @@ mod test {
 
     /// Regression test for #10223: a field-level metadata difference (e.g. FTS attaching
     /// metadata to indexed fields) must not trigger a false "unexpected schema" error.
-    /// Arrow's `Field` PartialEq includes field-level metadata, so the old `fields() != fields()`
+    /// Arrow's `Field` `PartialEq` includes field-level metadata, so the old `fields() != fields()`
     /// check would fail even when names, types, and nullability are identical.
     #[tokio::test]
     async fn pipeline_tolerates_field_level_metadata_difference() {

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -484,8 +484,13 @@ impl ExecutionPlan for IndexerExec {
                     let mut b = batch;
 
                     // Verify the incoming batch fields match the advertised schema.
-                    // Uses fields-only comparison to tolerate metadata differences.
-                    if b.schema().fields() != advertised_schema.fields() {
+                    // Use a metadata-ignoring comparison: Arrow's `Field` PartialEq includes
+                    // field-level metadata, so two schemas that are identical in name, type, and
+                    // nullability can still compare unequal if FTS (or another index) attaches
+                    // metadata to fields in the advertised schema but not in the incoming batch
+                    // (or vice versa). That would produce a confusing error where "Expected" and
+                    // "Got" look identical in the log. We only care about structural compatibility.
+                    if !fields_structurally_equal(b.schema().fields(), advertised_schema.fields()) {
                         let exp = schema_signature(advertised_schema.as_ref());
                         let got = schema_signature(b.schema().as_ref());
                         return Err(DataFusionError::Execution(format!(
@@ -511,7 +516,10 @@ impl ExecutionPlan for IndexerExec {
                                 b = out
                                     .pop()
                                     .unwrap_or_else(|| unreachable!("length is checked"));
-                                if b.schema().fields() != schema_before.fields() {
+                                if !fields_structurally_equal(
+                                    b.schema().fields(),
+                                    schema_before.fields(),
+                                ) {
                                     let exp = schema_signature(schema_before.as_ref());
                                     let got = schema_signature(b.schema().as_ref());
                                     return Err(DataFusionError::Execution(format!(
@@ -604,6 +612,22 @@ impl ExecutionPlan for IndexerExec {
 }
 
 /// Helper for better diagnostics when schema is mismatched.
+/// Returns `true` if two field lists are structurally compatible: same length, and every
+/// corresponding pair has the same name, data type, and nullability.
+///
+/// Arrow's [`Field`] `PartialEq` includes field-level metadata, which means two schemas that are
+/// visually identical can compare as unequal when one side carries index-attached metadata (e.g.
+/// FTS column markers) and the other does not. This function intentionally ignores metadata so
+/// that schema validation catches real structural mismatches without false positives.
+fn fields_structurally_equal(a: &arrow::datatypes::Fields, b: &arrow::datatypes::Fields) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(fa, fb)| {
+            fa.name() == fb.name()
+                && fa.data_type() == fb.data_type()
+                && fa.is_nullable() == fb.is_nullable()
+        })
+}
+
 fn schema_signature(s: &Schema) -> String {
     use std::fmt::Write;
     let mut buf = String::new();

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -484,16 +484,11 @@ impl ExecutionPlan for IndexerExec {
                     let mut b = batch;
 
                     // Verify the incoming batch fields match the advertised schema.
-                    // Use arrow_tools::verify_schema which compares fields by name and data type
-                    // only, ignoring field-level metadata. Arrow's `Field` PartialEq includes
-                    // field-level metadata, so two schemas that are identical in name, type, and
-                    // nullability can still compare unequal if FTS (or another index) attaches
-                    // metadata to fields in the advertised schema but not in the incoming batch
-                    // (or vice versa). That would produce a confusing error where "Expected" and
-                    // "Got" look identical in the log. We only care about structural compatibility.
-                    if let Err(e) =
-                        arrow_tools::verify_schema(advertised_schema.fields(), b.schema().fields())
-                    {
+                    // Ignore field and schema-level metadata.
+                    if let Err(e) = arrow_tools::schema::verify_schema(
+                        advertised_schema.fields(),
+                        b.schema().fields(),
+                    ) {
                         let exp = schema_signature(advertised_schema.as_ref());
                         let got = schema_signature(b.schema().as_ref());
                         return Err(DataFusionError::Execution(format!(

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -484,17 +484,20 @@ impl ExecutionPlan for IndexerExec {
                     let mut b = batch;
 
                     // Verify the incoming batch fields match the advertised schema.
-                    // Use a metadata-ignoring comparison: Arrow's `Field` PartialEq includes
+                    // Use arrow_tools::verify_schema which compares fields by name and data type
+                    // only, ignoring field-level metadata. Arrow's `Field` PartialEq includes
                     // field-level metadata, so two schemas that are identical in name, type, and
                     // nullability can still compare unequal if FTS (or another index) attaches
                     // metadata to fields in the advertised schema but not in the incoming batch
                     // (or vice versa). That would produce a confusing error where "Expected" and
                     // "Got" look identical in the log. We only care about structural compatibility.
-                    if !fields_structurally_equal(b.schema().fields(), advertised_schema.fields()) {
+                    if let Err(e) =
+                        arrow_tools::verify_schema(advertised_schema.fields(), b.schema().fields())
+                    {
                         let exp = schema_signature(advertised_schema.as_ref());
                         let got = schema_signature(b.schema().as_ref());
                         return Err(DataFusionError::Execution(format!(
-                            "Input stream produced batch with unexpected schema. \
+                            "Input stream produced batch with unexpected schema ({e}). \
                             Expected fields ({}): {} \
                             Got fields ({}): {}",
                             advertised_schema.fields().len(),
@@ -516,14 +519,14 @@ impl ExecutionPlan for IndexerExec {
                                 b = out
                                     .pop()
                                     .unwrap_or_else(|| unreachable!("length is checked"));
-                                if !fields_structurally_equal(
-                                    b.schema().fields(),
+                                if let Err(e) = arrow_tools::verify_schema(
                                     schema_before.fields(),
+                                    b.schema().fields(),
                                 ) {
                                     let exp = schema_signature(schema_before.as_ref());
                                     let got = schema_signature(b.schema().as_ref());
                                     return Err(DataFusionError::Execution(format!(
-                                        "Index {} changed schema. \
+                                        "Index {} changed schema ({e}). \
                                         Expected fields ({}): {} \
                                         Got fields ({}): {}",
                                         idx.name(),
@@ -611,23 +614,10 @@ impl ExecutionPlan for IndexerExec {
     }
 }
 
-/// Helper for better diagnostics when schema is mismatched.
-/// Returns `true` if two field lists are structurally compatible: same length, and every
-/// corresponding pair has the same name, data type, and nullability.
-///
-/// Arrow's [`Field`] `PartialEq` includes field-level metadata, which means two schemas that are
-/// visually identical can compare as unequal when one side carries index-attached metadata (e.g.
-/// FTS column markers) and the other does not. This function intentionally ignores metadata so
-/// that schema validation catches real structural mismatches without false positives.
-fn fields_structurally_equal(a: &arrow::datatypes::Fields, b: &arrow::datatypes::Fields) -> bool {
-    a.len() == b.len()
-        && a.iter().zip(b.iter()).all(|(fa, fb)| {
-            fa.name() == fb.name()
-                && fa.data_type() == fb.data_type()
-                && fa.is_nullable() == fb.is_nullable()
-        })
-}
-
+/// Returns a human-readable summary of schema fields for use in error messages.
+/// Intentionally omits field metadata so that the output reflects only the structural
+/// shape (name, type, nullability) — this keeps error messages readable and avoids
+/// exposing internal index metadata to users.
 fn schema_signature(s: &Schema) -> String {
     use std::fmt::Write;
     let mut buf = String::new();
@@ -1151,6 +1141,67 @@ mod test {
         assert!(msg.contains("extra: Int64"));
 
         assert_eq!(1, idx_add.compute_index_calls());
+    }
+
+    /// Regression test for #10223: a field-level metadata difference (e.g. FTS attaching
+    /// metadata to indexed fields) must not trigger a false "unexpected schema" error.
+    /// Arrow's `Field` PartialEq includes field-level metadata, so the old `fields() != fields()`
+    /// check would fail even when names, types, and nullability are identical.
+    #[tokio::test]
+    async fn pipeline_tolerates_field_level_metadata_difference() {
+        let ctx = get_ctx();
+
+        // Index callback that rebuilds the batch with extra field-level metadata on one field,
+        // simulating what FTS does when it marks indexed columns. The column data is identical;
+        // only the metadata attached to the Field differs.
+        let idx = Arc::new(TestIndex::new(
+            vec!["id".to_string()],
+            Some(|batches| {
+                let b = batches.into_iter().next().expect("one batch");
+                // Rebuild the schema with metadata added to the first field only.
+                let new_fields: Vec<Field> = b
+                    .schema()
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| {
+                        if i == 0 {
+                            let mut meta = f.metadata().clone();
+                            meta.insert("fts_index_marker".to_string(), "enabled".to_string());
+                            f.as_ref().clone().with_metadata(meta)
+                        } else {
+                            f.as_ref().clone()
+                        }
+                    })
+                    .collect();
+                let new_schema = Arc::new(Schema::new(new_fields));
+                let columns: Vec<ArrayRef> = (0..b.num_columns())
+                    .map(|i| Arc::clone(b.column(i)))
+                    .collect();
+                let out = RecordBatch::try_new(new_schema, columns)
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                Ok(vec![out])
+            }),
+        ));
+
+        let table = mem_table_from_batches(vec![one_row_batch()]);
+        let provider = IndexedTableProvider::new(table)
+            .add_index(Arc::clone(&idx) as Arc<dyn Index + Send + Sync>);
+
+        ctx.register_table(
+            "field_meta_diff_table",
+            Arc::new(provider) as Arc<dyn TableProvider>,
+        )
+        .expect("valid");
+
+        let df = ctx.table("field_meta_diff_table").await.expect("valid");
+        // Must succeed — field-level metadata differences are benign.
+        let results = df
+            .collect()
+            .await
+            .expect("field-level metadata difference should not error");
+        assert_eq!(results.len(), 1);
+        assert_eq!(1, idx.compute_index_calls());
     }
 
     /// Regression test for #10223: a metadata-only schema difference introduced

--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -514,7 +514,7 @@ impl ExecutionPlan for IndexerExec {
                                 b = out
                                     .pop()
                                     .unwrap_or_else(|| unreachable!("length is checked"));
-                                if let Err(e) = arrow_tools::verify_schema(
+                                if let Err(e) = arrow_tools::schema::verify_schema(
                                     schema_before.fields(),
                                     b.schema().fields(),
                                 ) {


### PR DESCRIPTION
## Problem

When Full-Text Search (FTS) is enabled on an accelerated dataset, the dataset refresh fails with:

```
Input stream produced batch with unexpected schema. Expected fields (89): ... Got fields (89): ...
```

The error is misleading — the Expected and Got schemas appear **identical** in the log. The root cause is that Arrow's `Field` `PartialEq` includes **field-level metadata**. When FTS is enabled, metadata is attached to the indexed fields in the advertised schema but not in the incoming record batch stream (or vice versa). The `fields() != fields()` comparison then fails even though the schemas are structurally identical.

The error display function (`schema_signature`) intentionally omits metadata, which is why both sides of the error look the same — the actual mismatch is invisible to the user.

Reported in #10223.

## Fix

Replace both `fields() != fields()` comparisons in `IndexTableScanExec::execute` with a new `fields_structurally_equal()` helper that compares only field **name**, **data type**, and **nullability**, ignoring metadata. This correctly catches real structural mismatches while tolerating metadata differences introduced by FTS and other index layers.

The existing comment claimed the comparison already tolerated metadata differences — that comment was incorrect and has been updated to explain the actual behaviour.

## Testing

This fixes a user-reported regression (#10223) where toggling FTS off and back on caused all subsequent dataset refreshes to fail. The fix can be validated by:
1. Configuring an accelerated dataset (e.g. ADBC/BigQuery + Cayenne) with FTS enabled on one or more columns
2. Restarting spiced and confirming the dataset loads successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->