### PR TITLE
Allow Cayenne to use append_stream when available

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2398,15 +2398,15 @@ impl DataFusion {
             }
         }
 
-        // For append mode without time_column, check if source provides append_stream
-        // Skip this check for Cayenne which has its own validation (supports primary_key or time_column)
-        if refresh_mode == RefreshMode::Append
-            && dataset.time_column.is_none()
-            && acceleration_settings.engine != Engine::Cayenne
-        {
+        // For append mode without time_column, attach the source's append_stream
+        // when available (e.g. Kafka). This enables streaming append into any
+        // accelerator engine, including Cayenne. When the source does not
+        // provide an append_stream, Cayenne falls back to its own validation
+        // (supports primary_key); other engines require time_column.
+        if refresh_mode == RefreshMode::Append && dataset.time_column.is_none() {
             if let Some(append_stream) = source.append_stream(source_table_provider) {
                 accelerated_table_builder.append_stream(append_stream);
-            } else {
+            } else if acceleration_settings.engine != Engine::Cayenne {
                 return Err(Error::AppendRequiresTimeColumn {
                     from: dataset.from.clone(),
                 });


### PR DESCRIPTION
## 📝 Summary

This change modifies the append mode validation logic to allow Cayenne (and other accelerator engines) to utilize a source's `append_stream` when available, rather than skipping the check entirely for Cayenne. The validation now only fails when:
1. Append mode is used without a time_column, AND
2. The source doesn't provide an append_stream, AND
3. The engine is not Cayenne (which has its own fallback validation)

This enables streaming append capabilities for Cayenne when sources like Kafka provide an append_stream, while maintaining backward compatibility for engines that strictly require a time_column.

## 🔗 Related

<!-- Link to relevant issues if applicable -->

## 👀 Notes for Reviewers

The key behavioral change is in the error handling logic:
- **Before**: Cayenne was excluded from the append_stream check entirely
- **After**: Cayenne can now benefit from append_stream when available, with its own validation as a fallback

The comment has been updated to clarify that Cayenne's validation (supporting primary_key) is a fallback mechanism, not a reason to skip the append_stream attachment.

https://claude.ai/code/session_019Rh4JUYjzYpvoSUhZpJLg4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->