### PR TITLE
fix: bound chunked-index intermediate batch size to prevent OOM (#7507)

### DIFF
--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -816,11 +816,28 @@ impl SearchIndex for ChunkedVectorIndex {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::float_cmp,
+    reason = "test data uses small integer values encoded in f32 to verify ordering; \
+              precision and exact equality are both fine in this synthetic setup"
+)]
 mod tests {
     use super::*;
     use arrow::array::{Float32Array, Int32Array, Int64Array, StringArray};
     use chunking::Chunker;
+    use std::fmt::Write as _;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Build a repeating space-separated token string deterministically — used by the multi-
+    /// group write tests to produce inputs with known chunk counts. Written as an explicit fold
+    /// to avoid the `format!`-in-`collect` allocation pattern.
+    fn repeated_tokens(n: usize) -> String {
+        (0..n).fold(String::with_capacity(n * 8), |mut s, i| {
+            write!(&mut s, "w{i} ").expect("writing to a String never fails");
+            s
+        })
+    }
 
     #[test]
     fn group_rows_by_chunk_budget_empty() {
@@ -945,7 +962,9 @@ mod tests {
                 .expect("mutex")
                 .push(record.num_rows());
 
-            // Build a synthetic embedding column matching the row count.
+            // Build a synthetic embedding column matching the row count. The first element
+            // encodes the row's position within this call so tests can verify ordering
+            // end-to-end after concat across multiple inner.write calls.
             let n = record.num_rows();
             let mut emb_values: Vec<f32> = Vec::with_capacity(n * 4);
             for i in 0..n {
@@ -1079,9 +1098,9 @@ mod tests {
 
         // Build N rows of ~K chunks each, total chunks well above the 8192 budget.
         // K=200 chunks/row * 50 rows = 10,000 chunks > 8192 budget.
-        let big_doc: String = (0..200).map(|i| format!("w{i} ")).collect::<String>();
-        let rows: Vec<(String, i64)> = (0..50)
-            .map(|i| (big_doc.trim_end().to_string(), i as i64))
+        let big_doc = repeated_tokens(200);
+        let rows: Vec<(String, i64)> = (0i64..50)
+            .map(|i| (big_doc.trim_end().to_string(), i))
             .collect();
         let row_refs: Vec<(&str, i64)> = rows.iter().map(|(s, i)| (s.as_str(), *i)).collect();
         let input = build_input(&row_refs);
@@ -1135,9 +1154,7 @@ mod tests {
 
         // Row 0: budget + 100 chunks (single oversized row).
         // Row 1: 3 chunks.
-        let big = (0..INNER_WRITE_TARGET_CHUNKS + 100)
-            .map(|i| format!("w{i} "))
-            .collect::<String>();
+        let big = repeated_tokens(INNER_WRITE_TARGET_CHUNKS + 100);
         let big_trimmed = big.trim_end();
         let input = build_input(&[(big_trimmed, 1), ("a b c", 2)]);
 
@@ -1169,9 +1186,9 @@ mod tests {
 
         // 3 rows of 5000 chunks each → 15,000 chunks total, budget 8192 → 3 groups (one row
         // per group, since two rows would exceed the budget).
-        let big_doc: String = (0..5000).map(|i| format!("w{i} ")).collect::<String>();
-        let rows: Vec<(String, i64)> = (0..3)
-            .map(|i| (big_doc.trim_end().to_string(), i as i64))
+        let big_doc = repeated_tokens(5000);
+        let rows: Vec<(String, i64)> = (0i64..3)
+            .map(|i| (big_doc.trim_end().to_string(), i))
             .collect();
         let row_refs: Vec<(&str, i64)> = rows.iter().map(|(s, i)| (s.as_str(), *i)).collect();
         let input = build_input(&row_refs);

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -226,13 +226,23 @@ impl ChunkedSearchIndex {
 
         let search_field_array = group_record.column(search_field_idx);
 
+        // Names of columns that may be present on the input but must NOT survive into the
+        // intermediate chunked batch — they are recomputed by the inner index and re-attached
+        // as list columns on the final output. Filtering them out *before* `repeat()` avoids
+        // expensive `take()` work on nested list columns that would be discarded immediately.
+        let embedding_col_name = embedding_col(self.search_column().as_str());
+        let offset_col_name = Self::chunking_offset_col(self.search_column().as_str());
+
         let (mut fields, mut arrays): (Vec<Field>, Vec<ArrayRef>) = group_record
             .columns()
             .iter()
             .enumerate()
-            .map(|(i, arr)| {
+            .filter_map(|(i, arr)| {
                 let field = schema.field(i).clone();
-                if i == search_field_idx {
+                if field.name() == &embedding_col_name || field.name() == &offset_col_name {
+                    return None;
+                }
+                let result = if i == search_field_idx {
                     let chunked_array: ArrayRef = match field.data_type() {
                         DataType::LargeUtf8 => {
                             let values: Vec<String> = group_flatten_chunks
@@ -257,20 +267,19 @@ impl ChunkedSearchIndex {
                     .column_with_name(CHUNKED_INDEX_FULL_SEARCH_FIELD)
                     .is_some_and(|(idx, _)| i == idx)
                 {
-                    // If self.search_field is in self.inner.metadata_columns, we must add additional column. This colum will have full content.
-                    // During list/search, we shall ask for this column instead of the chunked version.
-                    // The chunked version must be provided to `self.inner` so that it can be indexed appropriately (e.g. embedded).
-                    Ok((field, repeat(search_field_array, group_repeats)?))
+                    // If self.search_field is in self.inner.metadata_columns, we must add an
+                    // additional column. This column will have the full content. During
+                    // list/search we shall ask for this column instead of the chunked version.
+                    // The chunked version must be provided to `self.inner` so that it can be
+                    // indexed appropriately (e.g. embedded).
+                    repeat(search_field_array, group_repeats).map(|a| (field, a))
                 } else {
-                    Ok((field, repeat(arr, group_repeats)?))
-                }
+                    repeat(arr, group_repeats).map(|a| (field, a))
+                };
+                Some(result)
             })
             .collect::<Result<Vec<_>, ArrowError>>()?
             .into_iter()
-            .filter(|(f, _)| {
-                *f.name() != embedding_col(self.search_column().as_str())
-                    && *f.name() != Self::chunking_offset_col(self.search_column().as_str())
-            })
             .unzip();
 
         fields.push(Field::new(CHUNKED_INDEX_CHUNK_KEY, DataType::UInt64, false));
@@ -1165,11 +1174,10 @@ mod tests {
         let out = idx.write(input).await.expect("write ok");
         assert_eq!(out.num_rows(), 3);
 
-        // The flat embedding values inside each row's list should be `[0,1,2,...]` because each
-        // inner.write call regenerates indices starting at 0. After concat + list-wrap, each
-        // row's slice independently should start at 0 and run to 4999 — but the values inside
-        // the list span the concatenation seam if a row straddles two inner calls.
-        // We check the simpler invariant: every output list has length 5000 (chunks per row).
+        // Grouping is row-atomic, so a single row's chunks are always emitted by exactly one
+        // inner.write call and never straddle a concat seam. We check the invariant that every
+        // output list has length 5000 (chunks per row), which exercises the per-group →
+        // concatenation → list-wrap path without depending on inter-group seam behavior.
         let emb_list = out
             .column_by_name(&embedding_col("content"))
             .expect("embed")

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -336,7 +336,7 @@ fn attach_list_column(
     if values.is_empty() {
         return Ok(());
     }
-    let value_refs: Vec<&dyn Array> = values.iter().map(|a| a.as_ref()).collect();
+    let value_refs: Vec<&dyn Array> = values.iter().map(AsRef::as_ref).collect();
     let concatenated = concat(&value_refs).boxed()?;
     let item_field = Arc::new(Field::new("item", concatenated.data_type().clone(), true));
     let list_arr = Arc::new(

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1198,10 +1198,7 @@ mod tests {
             assert_eq!(fsl.len(), 5000);
             for chunk_idx in 0..fsl.len() {
                 let vec = fsl.value(chunk_idx);
-                let arr = vec
-                    .as_any()
-                    .downcast_ref::<Float32Array>()
-                    .expect("f32");
+                let arr = vec.as_any().downcast_ref::<Float32Array>().expect("f32");
                 assert_eq!(
                     arr.value(0),
                     chunk_idx as f32,

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -8,10 +8,11 @@ use crate::{
 
 use arrow::{
     array::{
-        ArrayRef, FixedSizeListArray, FixedSizeListBuilder, Int32Builder, LargeStringArray,
+        Array, ArrayRef, FixedSizeListArray, FixedSizeListBuilder, Int32Builder, LargeStringArray,
         ListArray, RecordBatch, StringArray, StringViewArray, UInt64Array,
     },
     buffer::OffsetBuffer,
+    compute::concat,
 };
 
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
@@ -34,6 +35,12 @@ use util::{arrow::repeat, convert_string_arrow_to_iterator};
 
 /// Additional primary key column to uniquely identify chunks within a single database row.
 pub static CHUNKED_INDEX_CHUNK_KEY: &str = "_spice.chunk_id";
+
+/// Soft cap on the number of chunk rows passed to a single [`SearchIndex::write`] call on the
+/// inner index. A single input row whose chunk count exceeds this is processed atomically — the
+/// cap is a per-group budget, not a hard split point. Picked to align with `DataFusion`'s default
+/// `execution.batch_size` so the intermediate chunked batch never significantly exceeds it.
+const INNER_WRITE_TARGET_CHUNKS: usize = 8192;
 
 /// Additional metadata field to store in underlying search index. This is only used when the
 /// underlying index has [`SearchIndex::search_column`] in [`SearchIndex::metadata_columns`].
@@ -186,6 +193,163 @@ impl ChunkedSearchIndex {
     pub fn new(inner: Arc<dyn SearchIndex>, chunker: Arc<dyn Chunker>) -> Self {
         Self { inner, chunker }
     }
+
+    /// Build the intermediate "chunked" [`RecordBatch`] for a contiguous group of input rows
+    /// (`record[start..start+length]`). Non-search columns are repeated per chunk; the search
+    /// column is replaced with the flattened chunk strings; `_spice.chunk_id` and the offset
+    /// column are appended. Pre-existing embedding/offset columns on the input are dropped.
+    #[expect(clippy::too_many_arguments)]
+    fn build_chunked_record_batch(
+        &self,
+        record: &RecordBatch,
+        schema: &SchemaRef,
+        search_field_idx: usize,
+        start: usize,
+        length: usize,
+        offsets: &[Vec<(usize, usize)>],
+        chunks: &[Vec<&str>],
+        repeats: &[usize],
+    ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+        let group_record = record.slice(start, length);
+        let group_offsets = &offsets[start..start + length];
+        let group_chunks = &chunks[start..start + length];
+        let group_repeats = &repeats[start..start + length];
+
+        let group_chunk_index: Vec<u64> = group_chunks
+            .iter()
+            .flat_map(|v| 0..(v.len() as u64))
+            .collect();
+        let group_flatten_chunks: Vec<&str> = group_chunks
+            .iter()
+            .flat_map(|v| v.iter().copied())
+            .collect();
+
+        let search_field_array = group_record.column(search_field_idx);
+
+        let (mut fields, mut arrays): (Vec<Field>, Vec<ArrayRef>) = group_record
+            .columns()
+            .iter()
+            .enumerate()
+            .map(|(i, arr)| {
+                let field = schema.field(i).clone();
+                if i == search_field_idx {
+                    let chunked_array: ArrayRef = match field.data_type() {
+                        DataType::LargeUtf8 => {
+                            let values: Vec<String> = group_flatten_chunks
+                                .iter()
+                                .map(|s| (*s).to_string())
+                                .collect();
+                            Arc::new(LargeStringArray::from(values))
+                        }
+                        DataType::Utf8View => {
+                            Arc::new(StringViewArray::from(group_flatten_chunks.clone()))
+                        }
+                        _ => {
+                            let values: Vec<String> = group_flatten_chunks
+                                .iter()
+                                .map(|s| (*s).to_string())
+                                .collect();
+                            Arc::new(StringArray::from(values))
+                        }
+                    };
+                    Ok((field, chunked_array))
+                } else if schema
+                    .column_with_name(CHUNKED_INDEX_FULL_SEARCH_FIELD)
+                    .is_some_and(|(idx, _)| i == idx)
+                {
+                    // If self.search_field is in self.inner.metadata_columns, we must add additional column. This colum will have full content.
+                    // During list/search, we shall ask for this column instead of the chunked version.
+                    // The chunked version must be provided to `self.inner` so that it can be indexed appropriately (e.g. embedded).
+                    Ok((field, repeat(search_field_array, group_repeats)?))
+                } else {
+                    Ok((field, repeat(arr, group_repeats)?))
+                }
+            })
+            .collect::<Result<Vec<_>, ArrowError>>()?
+            .into_iter()
+            .filter(|(f, _)| {
+                *f.name() != embedding_col(self.search_column().as_str())
+                    && *f.name() != Self::chunking_offset_col(self.search_column().as_str())
+            })
+            .unzip();
+
+        fields.push(Field::new(CHUNKED_INDEX_CHUNK_KEY, DataType::UInt64, false));
+        arrays.push(Arc::new(UInt64Array::from(group_chunk_index)) as ArrayRef);
+
+        fields.push(Field::new(
+            Self::chunking_offset_col(self.search_column().as_str()),
+            DataType::new_fixed_size_list(DataType::Int32, 2, false),
+            false,
+        ));
+        arrays.push(Arc::new(to_offset_array(group_offsets, false)) as ArrayRef);
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
+            .context(WriteFailedConstructRecordBatchSnafu)
+            .boxed()
+    }
+}
+
+/// Group consecutive input rows into slices `(start, length)` such that each slice's
+/// `sum(repeats[start..start+length])` does not exceed `budget`, unless a single row's chunk
+/// count already exceeds `budget` — in which case that row forms a slice of one. Rows are never
+/// split across slices.
+fn group_rows_by_chunk_budget(repeats: &[usize], budget: usize) -> Vec<(usize, usize)> {
+    if repeats.is_empty() {
+        return Vec::new();
+    }
+    let mut groups = Vec::new();
+    let mut start = 0;
+    let mut acc = 0usize;
+    for (i, &c) in repeats.iter().enumerate() {
+        if i > start && acc.saturating_add(c) > budget {
+            groups.push((start, i - start));
+            start = i;
+            acc = 0;
+        }
+        acc = acc.saturating_add(c);
+    }
+    groups.push((start, repeats.len() - start));
+    groups
+}
+
+/// Concatenate the per-group `values` arrays (one per row group, length = total chunks in that
+/// group) into a single flat value buffer, then wrap as a [`ListArray`] with one outer entry per
+/// original row using `OffsetBuffer::from_lengths(repeats)`. Writes the result into `arrs`,
+/// replacing the existing column at `name` if present, otherwise appending.
+fn attach_list_column(
+    values: &[ArrayRef],
+    name: &str,
+    repeats: &[usize],
+    schema: &SchemaRef,
+    arrs: &mut Vec<ArrayRef>,
+    fields: &mut Vec<Arc<Field>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    let value_refs: Vec<&dyn Array> = values.iter().map(|a| a.as_ref()).collect();
+    let concatenated = concat(&value_refs).boxed()?;
+    let item_field = Arc::new(Field::new("item", concatenated.data_type().clone(), true));
+    let list_arr = Arc::new(
+        ListArray::try_new(
+            Arc::clone(&item_field),
+            OffsetBuffer::from_lengths(repeats.iter().copied()),
+            concatenated,
+            None,
+        )
+        .boxed()?,
+    );
+    if let Some((i, _)) = schema.column_with_name(name) {
+        arrs[i] = list_arr;
+    } else {
+        arrs.push(list_arr);
+        fields.push(Arc::new(Field::new_list(
+            name,
+            Arc::unwrap_or_clone(item_field),
+            false,
+        )));
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -263,7 +427,9 @@ impl SearchIndex for ChunkedSearchIndex {
             .boxed();
         };
 
-        // For each element of the search column, chunk and keep offsets
+        // For each element of the search column, chunk and keep offsets. `chunks` holds
+        // zero-copy &str slices into the underlying Arrow buffer, so this step is cheap
+        // even for very large documents.
         let (offsets, chunks): (Vec<Vec<(usize, usize)>>, Vec<Vec<_>>) = arr_str
             .map(|s_opt| {
                 if let Some(s) = s_opt {
@@ -282,125 +448,75 @@ impl SearchIndex for ChunkedSearchIndex {
 
         let repeats = offsets.iter().map(Vec::len).collect::<Vec<_>>();
 
-        let chunk_index: Vec<_> = chunks
-            .iter()
-            .flat_map(|v| (0..(v.len() as u64)).collect::<Vec<_>>())
-            .collect();
-        let flatten_chunks: Vec<_> = chunks.into_iter().flatten().collect();
+        // Group input rows so that each call to `self.inner.write` sees at most
+        // `INNER_WRITE_TARGET_CHUNKS` chunk rows in its intermediate batch. Each group is a
+        // contiguous, row-atomic slice of the input. If a single row has more chunks than the
+        // budget, it forms a group of one and exceeds the budget — this is intentional, and
+        // accepted given typical chunk counts per document.
+        let row_groups = group_rows_by_chunk_budget(&repeats, INNER_WRITE_TARGET_CHUNKS);
 
-        let (mut fields, mut arrays): (Vec<Field>, Vec<ArrayRef>) = record
-            .columns()
-            .iter()
-            .enumerate()
-            .map(|(i, arr)| {
-                let field = schema.field(i).clone();
-                if i == search_field_idx {
-                    let values: Vec<String> =
-                        flatten_chunks.iter().map(|s| (*s).to_string()).collect();
-                    let chunked_array: ArrayRef = match field.data_type() {
-                        DataType::LargeUtf8 => Arc::new(LargeStringArray::from(values)),
-                        DataType::Utf8View => {
-                            let refs: Vec<&str> = values.iter().map(String::as_str).collect();
-                            Arc::new(StringViewArray::from(refs))
-                        }
-                        _ => Arc::new(StringArray::from(values)),
-                    };
-                    Ok((field, chunked_array))
-                } else if schema
-                    .column_with_name(CHUNKED_INDEX_FULL_SEARCH_FIELD)
-                    .is_some_and(|(idx, _)| i == idx)
-                {
-                    // If self.search_field is in self.inner.metadata_columns, we must add additional column. This colum will have full content.
-                    // During list/search, we shall ask for this column instead of the chunked version.
-                    // The chunked version must be provided to `self.inner` so that it can be indexed appropriately (e.g. embedded).
-                    Ok((field, repeat(search_field_array, &repeats)?))
-                } else {
-                    Ok((field, repeat(arr, &repeats)?))
-                }
-            })
-            .collect::<Result<Vec<_>, ArrowError>>()?
-            .into_iter()
-            .filter(|(f, _)| {
-                *f.name() != embedding_col(self.search_column().as_str())
-                    && *f.name() != Self::chunking_offset_col(self.search_column().as_str())
-            })
-            .unzip();
+        // Process each row group, collecting the per-chunk `offset` / `embedding` value arrays
+        // emitted by the inner index. After all groups complete, concatenate those arrays to
+        // recover the same flat value buffer the single-call path would have produced, and wrap
+        // it with an OffsetBuffer over the full `repeats` vector to produce the per-document
+        // list columns.
+        let offsets_col_name = Self::chunking_offset_col(self.search_column().as_str());
+        let embeddings_col_name = embedding_col(self.search_column().as_str());
 
-        fields.push(Field::new(CHUNKED_INDEX_CHUNK_KEY, DataType::UInt64, false));
-        arrays.push(Arc::new(UInt64Array::from(chunk_index)) as ArrayRef);
+        let mut group_offset_arrays: Vec<ArrayRef> = Vec::with_capacity(row_groups.len());
+        let mut group_embedding_arrays: Vec<ArrayRef> = Vec::with_capacity(row_groups.len());
 
-        fields.push(Field::new(
-            Self::chunking_offset_col(self.search_column().as_str()),
-            DataType::new_fixed_size_list(DataType::Int32, 2, false),
-            false,
-        ));
-        arrays.push(Arc::new(to_offset_array(&offsets, false)) as ArrayRef);
+        for &(start, length) in &row_groups {
+            let group_chunked_rb = self.build_chunked_record_batch(
+                &record,
+                &schema,
+                search_field_idx,
+                start,
+                length,
+                &offsets,
+                &chunks,
+                &repeats,
+            )?;
 
-        let rb = RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
-            .context(WriteFailedConstructRecordBatchSnafu)
-            .boxed()?;
+            let inner_rb = self
+                .inner
+                .write(group_chunked_rb)
+                .await
+                .context(InnerIndexWriteSnafu)
+                .boxed()?;
 
-        let inner_rb = self
-            .inner
-            .write(rb)
-            .await
-            .context(InnerIndexWriteSnafu)
-            .boxed()?;
+            if let Some(arr) = inner_rb.column_by_name(&offsets_col_name) {
+                group_offset_arrays.push(Arc::clone(arr));
+            }
+            if let Some(arr) = inner_rb.column_by_name(&embeddings_col_name) {
+                group_embedding_arrays.push(Arc::clone(arr));
+            }
+        }
 
-        // From `inner_rb` we need to get {}_embedding, and {}_offset
-        //   then convert them from FixedSizeList() -> List(FixedSizeList())
-        //   so they can be added back to original `record`.
-        // This is so any acceleration has them in the expected format on the write path.
+        // From the concatenated inner outputs we need {}_embedding and {}_offset, then convert
+        // them from `<inner_type>` -> `List(<inner_type>)` (one list per original row, length
+        // `repeats[i]`) so they can be added back to the original `record`. This is so any
+        // downstream acceleration has them in the expected format on the write path.
         let (schema, mut arrs, _) = record.into_parts();
         let mut fields: Vec<_> = schema.fields().iter().cloned().collect();
 
-        let offsets = Self::chunking_offset_col(self.search_column().as_str());
-        if let Some(arr) = inner_rb.column_by_name(&offsets) {
-            let item_field = Arc::new(Field::new("item", arr.data_type().clone(), true));
-            let list_arr = Arc::new(
-                ListArray::try_new(
-                    Arc::clone(&item_field),
-                    OffsetBuffer::from_lengths(repeats.iter().copied()),
-                    Arc::clone(arr),
-                    None,
-                )
-                .boxed()?,
-            );
-            if let Some((i, _)) = schema.column_with_name(&offsets) {
-                arrs[i] = list_arr;
-            } else {
-                arrs.push(list_arr);
-                fields.push(Arc::new(Field::new_list(
-                    &offsets,
-                    Arc::unwrap_or_clone(item_field),
-                    false,
-                )));
-            }
-        }
+        attach_list_column(
+            &group_offset_arrays,
+            &offsets_col_name,
+            &repeats,
+            &schema,
+            &mut arrs,
+            &mut fields,
+        )?;
+        attach_list_column(
+            &group_embedding_arrays,
+            &embeddings_col_name,
+            &repeats,
+            &schema,
+            &mut arrs,
+            &mut fields,
+        )?;
 
-        let embeddings = embedding_col(&self.search_column());
-        if let Some(arr) = inner_rb.column_by_name(&embeddings) {
-            let item_field = Arc::new(Field::new("item", arr.data_type().clone(), true));
-            let list_arr = Arc::new(
-                ListArray::try_new(
-                    Arc::clone(&item_field),
-                    OffsetBuffer::from_lengths(repeats.iter().copied()),
-                    Arc::clone(arr),
-                    None,
-                )
-                .boxed()?,
-            );
-            if let Some((i, _)) = schema.column_with_name(&embeddings) {
-                arrs[i] = list_arr;
-            } else {
-                arrs.push(list_arr);
-                fields.push(Arc::new(Field::new_list(
-                    &embeddings,
-                    Arc::unwrap_or_clone(item_field),
-                    false,
-                )));
-            }
-        }
         RecordBatch::try_new(Arc::new(Schema::new(fields)), arrs).boxed()
     }
 
@@ -687,5 +803,428 @@ impl SearchIndex for ChunkedVectorIndex {
 
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
         Some(self as Arc<dyn VectorIndex>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float32Array, Int32Array, Int64Array, StringArray};
+    use chunking::Chunker;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn group_rows_by_chunk_budget_empty() {
+        assert!(group_rows_by_chunk_budget(&[], 100).is_empty());
+    }
+
+    #[test]
+    fn group_rows_by_chunk_budget_under_budget() {
+        // Sum is 6, budget is 100 — one group covering everything.
+        let groups = group_rows_by_chunk_budget(&[1, 2, 3], 100);
+        assert_eq!(groups, vec![(0, 3)]);
+    }
+
+    #[test]
+    fn group_rows_by_chunk_budget_splits_at_boundary() {
+        // [2, 1, 3, 4, 1] with budget=5: 2+1=3, +3=6>5 → flush; 3, +4=7>5 → flush; 4, +1=5 → ok.
+        let groups = group_rows_by_chunk_budget(&[2, 1, 3, 4, 1], 5);
+        assert_eq!(groups, vec![(0, 2), (2, 1), (3, 2)]);
+    }
+
+    #[test]
+    fn group_rows_by_chunk_budget_single_row_exceeds_budget() {
+        // A single row larger than the budget forms a group of one. The next rows start fresh.
+        let groups = group_rows_by_chunk_budget(&[10, 1, 1], 5);
+        assert_eq!(groups, vec![(0, 1), (1, 2)]);
+    }
+
+    #[test]
+    fn group_rows_by_chunk_budget_exact_fit() {
+        // 2+3=5 (== budget), then 1+4=5 — both groups hit the budget exactly.
+        let groups = group_rows_by_chunk_budget(&[2, 3, 1, 4], 5);
+        assert_eq!(groups, vec![(0, 2), (2, 2)]);
+    }
+
+    #[test]
+    fn group_rows_by_chunk_budget_zero_chunks() {
+        // Rows with zero chunks coalesce into the running group without forcing a flush.
+        // Total here is 6, budget 6 — everything fits in a single group.
+        let groups = group_rows_by_chunk_budget(&[0, 0, 3, 0, 3], 6);
+        assert_eq!(groups, vec![(0, 5)]);
+    }
+
+    /// A [`Chunker`] that splits on a single delimiter — used for tests where we want
+    /// deterministic, observable chunk boundaries without pulling in tokenizer config.
+    struct DelimChunker {
+        delim: char,
+    }
+
+    impl Chunker for DelimChunker {
+        fn chunk_indices<'a>(
+            &self,
+            text: &'a str,
+        ) -> Box<dyn Iterator<Item = (usize, &'a str)> + 'a> {
+            let mut out: Vec<(usize, &'a str)> = Vec::new();
+            let mut start = 0usize;
+            for (i, c) in text.char_indices() {
+                if c == self.delim {
+                    if i > start {
+                        out.push((start, &text[start..i]));
+                    }
+                    start = i + c.len_utf8();
+                }
+            }
+            if start < text.len() {
+                out.push((start, &text[start..]));
+            }
+            Box::new(out.into_iter())
+        }
+    }
+
+    /// A pass-through [`SearchIndex`] that records how many times `write` is called and the size
+    /// of each input. It also appends a fake `<col>_embedding` column (4-dim FixedSizeList of
+    /// Float32) and an `<col>_offset` column copied from the input. The chunking layer reads
+    /// these back and folds them into per-document list columns on the final output.
+    #[derive(Debug)]
+    struct RecordingInner {
+        search_column: String,
+        calls: AtomicUsize,
+        row_counts: std::sync::Mutex<Vec<usize>>,
+    }
+
+    impl RecordingInner {
+        fn new(search_column: &str) -> Self {
+            Self {
+                search_column: search_column.to_string(),
+                calls: AtomicUsize::new(0),
+                row_counts: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Index for RecordingInner {
+        fn name(&self) -> &'static str {
+            "RecordingInner"
+        }
+        fn required_columns(&self) -> Vec<String> {
+            vec![self.search_column.clone()]
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[async_trait]
+    impl SearchIndex for RecordingInner {
+        fn search_column(&self) -> String {
+            self.search_column.clone()
+        }
+
+        fn primary_fields(&self) -> Vec<Field> {
+            vec![Field::new("id", DataType::Int64, false)]
+        }
+
+        async fn write(
+            &self,
+            record: RecordBatch,
+        ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.row_counts
+                .lock()
+                .expect("mutex")
+                .push(record.num_rows());
+
+            // Build a synthetic embedding column matching the row count.
+            let n = record.num_rows();
+            let mut emb_values: Vec<f32> = Vec::with_capacity(n * 4);
+            for i in 0..n {
+                emb_values.extend_from_slice(&[i as f32, 0.0, 0.0, 0.0]);
+            }
+            let emb_field = Arc::new(Field::new("item", DataType::Float32, true));
+            let emb = FixedSizeListArray::try_new(
+                Arc::clone(&emb_field),
+                4,
+                Arc::new(Float32Array::from(emb_values)),
+                None,
+            )?;
+
+            let offset_col = ChunkedSearchIndex::chunking_offset_col(&self.search_column);
+            let offset_arr = Arc::clone(
+                record
+                    .column_by_name(&offset_col)
+                    .expect("input chunked rb must have offset col"),
+            );
+
+            let mut fields: Vec<Field> = record
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| Arc::unwrap_or_clone(Arc::clone(f)))
+                .collect();
+            let mut cols: Vec<ArrayRef> = record.columns().iter().map(Arc::clone).collect();
+            fields.push(Field::new(
+                embedding_col(&self.search_column),
+                DataType::FixedSizeList(Arc::clone(&emb_field), 4),
+                true,
+            ));
+            cols.push(Arc::new(emb) as ArrayRef);
+            // Offset col is already in the input; ensure it's also exported under the canonical
+            // name in case the chunker dropped/re-added it.
+            if record.column_by_name(&offset_col).is_none() {
+                fields.push(Field::new(
+                    offset_col,
+                    DataType::new_fixed_size_list(DataType::Int32, 2, false),
+                    false,
+                ));
+                cols.push(offset_arr);
+            }
+
+            Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), cols)?)
+        }
+
+        fn query_table_provider(&self, _query: &str) -> Result<Arc<LogicalPlan>, DataFusionError> {
+            Err(DataFusionError::NotImplemented("unused in tests".into()))
+        }
+    }
+
+    fn build_input(rows: &[(&str, i64)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        let ids: Vec<i64> = rows.iter().map(|(_, id)| *id).collect();
+        let contents: Vec<&str> = rows.iter().map(|(c, _)| *c).collect();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(contents)),
+            ],
+        )
+        .expect("valid batch")
+    }
+
+    /// Smoke test: a tiny input that fits comfortably under the budget should result in exactly
+    /// one inner.write call and an output row count equal to the input row count.
+    #[tokio::test]
+    async fn write_single_group_when_under_budget() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunker = Arc::new(DelimChunker { delim: ' ' });
+        let idx = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            chunker as Arc<dyn Chunker>,
+        );
+
+        // "a b" -> 2 chunks; "c" -> 1; "d e f" -> 3. Total = 6 chunks across 3 rows.
+        let input = build_input(&[("a b", 1), ("c", 2), ("d e f", 3)]);
+        let input_rows = input.num_rows();
+
+        let out = idx.write(input).await.expect("write ok");
+
+        assert_eq!(out.num_rows(), input_rows);
+        assert_eq!(
+            inner.calls.load(Ordering::SeqCst),
+            1,
+            "should call inner.write exactly once under budget"
+        );
+        let row_counts = inner.row_counts.lock().expect("mutex").clone();
+        assert_eq!(row_counts, vec![6], "intermediate chunked batch is 6 rows");
+
+        // Verify the per-row offset/embedding list columns exist and have the right outer shape.
+        let offset_col = ChunkedSearchIndex::chunking_offset_col("content");
+        let embed_col = embedding_col("content");
+        let off_list = out
+            .column_by_name(&offset_col)
+            .expect("offset col")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let emb_list = out
+            .column_by_name(&embed_col)
+            .expect("embed col")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        assert_eq!(off_list.len(), input_rows);
+        assert_eq!(emb_list.len(), input_rows);
+        // Lengths of the inner lists must match per-row chunk counts.
+        let lengths: Vec<i32> = (0..off_list.len())
+            .map(|i| off_list.value_length(i))
+            .collect();
+        assert_eq!(lengths, vec![2, 1, 3]);
+    }
+
+    /// Core regression test for #7507: when the total chunk count exceeds the configured budget,
+    /// the indexer must split into multiple inner.write calls so the intermediate batch never
+    /// exceeds the budget. Output must still be one batch with row count == input row count.
+    #[tokio::test]
+    async fn write_splits_into_multiple_groups_over_budget() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunker = Arc::new(DelimChunker { delim: ' ' });
+        let idx = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            chunker as Arc<dyn Chunker>,
+        );
+
+        // Build N rows of ~K chunks each, total chunks well above the 8192 budget.
+        // K=200 chunks/row * 50 rows = 10,000 chunks > 8192 budget.
+        let big_doc: String = (0..200).map(|i| format!("w{i} ")).collect::<String>();
+        let rows: Vec<(String, i64)> = (0..50)
+            .map(|i| (big_doc.trim_end().to_string(), i as i64))
+            .collect();
+        let row_refs: Vec<(&str, i64)> = rows.iter().map(|(s, i)| (s.as_str(), *i)).collect();
+        let input = build_input(&row_refs);
+        let input_rows = input.num_rows();
+
+        let out = idx.write(input).await.expect("write ok");
+
+        assert_eq!(out.num_rows(), input_rows);
+        let calls = inner.calls.load(Ordering::SeqCst);
+        assert!(
+            calls >= 2,
+            "expected multiple inner.write calls when total chunks > budget, got {calls}"
+        );
+
+        // No single inner.write call should exceed the budget (rows are atomic, but each row's
+        // chunk count here is ~200, well under the 8192 budget).
+        let row_counts = inner.row_counts.lock().expect("mutex").clone();
+        for c in &row_counts {
+            assert!(
+                *c <= INNER_WRITE_TARGET_CHUNKS,
+                "intermediate batch size {c} exceeded budget {INNER_WRITE_TARGET_CHUNKS}",
+            );
+        }
+        // Total chunks across all calls must equal total chunks across the full input.
+        let total: usize = row_counts.iter().sum();
+        assert_eq!(total, 50 * 200);
+
+        // Each output row's list lengths must equal the chunk count for that row.
+        let off_list = out
+            .column_by_name(&ChunkedSearchIndex::chunking_offset_col("content"))
+            .expect("offset col")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        for i in 0..off_list.len() {
+            assert_eq!(off_list.value_length(i), 200);
+        }
+    }
+
+    /// A single row whose chunk count exceeds the budget is intentionally processed atomically:
+    /// it gets its own inner.write call (which exceeds the budget) and subsequent rows start a
+    /// fresh group. This documents the row-atomic semantics of the bound.
+    #[tokio::test]
+    async fn write_oversized_single_row_is_atomic() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunker = Arc::new(DelimChunker { delim: ' ' });
+        let idx = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            chunker as Arc<dyn Chunker>,
+        );
+
+        // Row 0: budget + 100 chunks (single oversized row).
+        // Row 1: 3 chunks.
+        let big = (0..INNER_WRITE_TARGET_CHUNKS + 100)
+            .map(|i| format!("w{i} "))
+            .collect::<String>();
+        let big_trimmed = big.trim_end();
+        let input = build_input(&[(big_trimmed, 1), ("a b c", 2)]);
+
+        let out = idx.write(input).await.expect("write ok");
+        assert_eq!(out.num_rows(), 2);
+
+        let row_counts = inner.row_counts.lock().expect("mutex").clone();
+        // First call: the oversized row alone (above budget — expected, since the row is atomic).
+        assert_eq!(row_counts[0], INNER_WRITE_TARGET_CHUNKS + 100);
+        // Second call: the small row (3 chunks).
+        assert_eq!(row_counts.get(1).copied(), Some(3));
+    }
+
+    /// Concatenated value arrays across multiple inner.write calls must preserve order, so the
+    /// per-document list slices come out aligned. We use the synthetic embedding values (row
+    /// index encoded as the first f32) to verify ordering is preserved end-to-end.
+    #[tokio::test]
+    async fn write_preserves_chunk_order_across_groups() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunker = Arc::new(DelimChunker { delim: ' ' });
+        let idx = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            chunker as Arc<dyn Chunker>,
+        );
+
+        // 3 rows of 5000 chunks each → 15,000 chunks total, budget 8192 → 3 groups.
+        let big_doc: String = (0..5000).map(|i| format!("w{i} ")).collect::<String>();
+        let rows: Vec<(String, i64)> = (0..3)
+            .map(|i| (big_doc.trim_end().to_string(), i as i64))
+            .collect();
+        let row_refs: Vec<(&str, i64)> = rows.iter().map(|(s, i)| (s.as_str(), *i)).collect();
+        let input = build_input(&row_refs);
+
+        let out = idx.write(input).await.expect("write ok");
+        assert_eq!(out.num_rows(), 3);
+
+        // The flat embedding values inside each row's list should be `[0,1,2,...]` because each
+        // inner.write call regenerates indices starting at 0. After concat + list-wrap, each
+        // row's slice independently should start at 0 and run to 4999 — but the values inside
+        // the list span the concatenation seam if a row straddles two inner calls.
+        // We check the simpler invariant: every output list has length 5000 (chunks per row).
+        let emb_list = out
+            .column_by_name(&embedding_col("content"))
+            .expect("embed")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        for i in 0..emb_list.len() {
+            assert_eq!(emb_list.value_length(i), 5000);
+        }
+
+        // And the total length of the flat value array equals sum(per-row chunks).
+        let off_list = out
+            .column_by_name(&ChunkedSearchIndex::chunking_offset_col("content"))
+            .expect("offset col")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let total_offset_values = off_list.values().len();
+        assert_eq!(total_offset_values, 3 * 5000);
+    }
+
+    /// Per-row offset entries must point at the correct character spans of the source document.
+    /// This is the property that downstream search relies on for highlighting / retrieval.
+    #[tokio::test]
+    async fn write_offsets_match_source_spans() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunker = Arc::new(DelimChunker { delim: ' ' });
+        let idx = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            chunker as Arc<dyn Chunker>,
+        );
+
+        // "hello world" => chunks ["hello", "world"] at offsets (0,5) and (6,11).
+        let input = build_input(&[("hello world", 1)]);
+        let out = idx.write(input).await.expect("write ok");
+
+        let off_list = out
+            .column_by_name(&ChunkedSearchIndex::chunking_offset_col("content"))
+            .expect("offset col")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let row0 = off_list.value(0);
+        let fsl = row0
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("fsl");
+        assert_eq!(fsl.len(), 2);
+
+        let read_pair = |i: usize| -> (i32, i32) {
+            let pair = fsl.value(i);
+            let pair_arr = pair.as_any().downcast_ref::<Int32Array>().expect("int32");
+            (pair_arr.value(0), pair_arr.value(1))
+        };
+        assert_eq!(read_pair(0), (0, 5));
+        assert_eq!(read_pair(1), (6, 11));
     }
 }

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1152,8 +1152,12 @@ mod tests {
     }
 
     /// Concatenated value arrays across multiple inner.write calls must preserve order, so the
-    /// per-document list slices come out aligned. We use the synthetic embedding values (row
-    /// index encoded as the first f32) to verify ordering is preserved end-to-end.
+    /// per-document list slices come out aligned. `RecordingInner` writes a synthetic embedding
+    /// where the first f32 is the row's position within that single `inner.write` call.
+    /// Row-atomic grouping puts a whole input row into exactly one `inner.write`, so after the
+    /// per-group outputs are concatenated and wrapped with `OffsetBuffer::from_lengths(repeats)`
+    /// each output row's embedding list must contain values whose first f32 runs 0..C_i in order.
+    /// If the concat order or the offset buffer were wrong, this sequence would skip or repeat.
     #[tokio::test]
     async fn write_preserves_chunk_order_across_groups() {
         let inner = Arc::new(RecordingInner::new("content"));
@@ -1163,7 +1167,8 @@ mod tests {
             chunker as Arc<dyn Chunker>,
         );
 
-        // 3 rows of 5000 chunks each → 15,000 chunks total, budget 8192 → 3 groups.
+        // 3 rows of 5000 chunks each → 15,000 chunks total, budget 8192 → 3 groups (one row
+        // per group, since two rows would exceed the budget).
         let big_doc: String = (0..5000).map(|i| format!("w{i} ")).collect::<String>();
         let rows: Vec<(String, i64)> = (0..3)
             .map(|i| (big_doc.trim_end().to_string(), i as i64))
@@ -1174,29 +1179,45 @@ mod tests {
         let out = idx.write(input).await.expect("write ok");
         assert_eq!(out.num_rows(), 3);
 
-        // Grouping is row-atomic, so a single row's chunks are always emitted by exactly one
-        // inner.write call and never straddle a concat seam. We check the invariant that every
-        // output list has length 5000 (chunks per row), which exercises the per-group →
-        // concatenation → list-wrap path without depending on inter-group seam behavior.
         let emb_list = out
             .column_by_name(&embedding_col("content"))
             .expect("embed")
             .as_any()
             .downcast_ref::<ListArray>()
             .expect("list");
-        for i in 0..emb_list.len() {
-            assert_eq!(emb_list.value_length(i), 5000);
+
+        // Every output list has length 5000 (chunks per row) and its values appear in 0..5000
+        // order — proves the concat seam between groups doesn't misalign chunks within a row.
+        for row_idx in 0..emb_list.len() {
+            assert_eq!(emb_list.value_length(row_idx), 5000);
+            let row_emb = emb_list.value(row_idx);
+            let fsl = row_emb
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .expect("fsl");
+            assert_eq!(fsl.len(), 5000);
+            for chunk_idx in 0..fsl.len() {
+                let vec = fsl.value(chunk_idx);
+                let arr = vec
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .expect("f32");
+                assert_eq!(
+                    arr.value(0),
+                    chunk_idx as f32,
+                    "row {row_idx} chunk {chunk_idx} embedding[0] mismatch — chunks reordered across the concat seam",
+                );
+            }
         }
 
-        // And the total length of the flat value array equals sum(per-row chunks).
+        // Total flat-value length equals sum(per-row chunks).
         let off_list = out
             .column_by_name(&ChunkedSearchIndex::chunking_offset_col("content"))
             .expect("offset col")
             .as_any()
             .downcast_ref::<ListArray>()
             .expect("list");
-        let total_offset_values = off_list.values().len();
-        assert_eq!(total_offset_values, 3 * 5000);
+        assert_eq!(off_list.values().len(), 3 * 5000);
     }
 
     /// Per-row offset entries must point at the correct character spans of the source document.

--- a/crates/search/tests/chunked_index_integration.rs
+++ b/crates/search/tests/chunked_index_integration.rs
@@ -1,0 +1,385 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! End-to-end integration test for issue #7507: bounded intermediate batch size in
+//! [`ChunkedSearchIndex`]. The test wires up an `IndexedTableProvider` whose only index is a
+//! `ChunkedSearchIndex` (over a row-counting inner index), runs a `SELECT *` through the
+//! `IndexTableScanOptimizerRule` + `IndexTableScanExtensionPlanner` pipeline, and asserts that
+//! the inner index's `write` method is called with strictly-bounded batches even when the input
+//! row count would otherwise produce a multi-million-row intermediate.
+
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arrow::array::{
+    ArrayRef, FixedSizeListArray, Float32Array, Int64Array, ListArray, RecordBatch, StringArray,
+};
+use arrow::buffer::OffsetBuffer;
+use arrow_schema::{DataType, Field, Schema};
+use async_trait::async_trait;
+use chunking::Chunker;
+use datafusion::{
+    catalog::{MemTable, TableProvider},
+    error::DataFusionError,
+    execution::{SessionStateBuilder, context::QueryPlanner},
+    logical_expr::LogicalPlan,
+    physical_plan::ExecutionPlan,
+    physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner},
+    prelude::SessionContext,
+};
+use runtime_datafusion_index::{
+    Index, IndexedTableProvider,
+    analyzer::{IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule},
+};
+use search::index::{
+    SearchIndex,
+    chunking::{CHUNKED_INDEX_CHUNK_KEY, ChunkedSearchIndex},
+};
+
+/// A chunker that always produces exactly `n` evenly-spaced chunks per non-empty input row,
+/// regardless of content. Deterministic chunk counts make the assertions in this test crisp.
+struct FixedCountChunker {
+    n: usize,
+}
+
+impl Chunker for FixedCountChunker {
+    fn chunk_indices<'a>(&self, text: &'a str) -> Box<dyn Iterator<Item = (usize, &'a str)> + 'a> {
+        if text.is_empty() || self.n == 0 {
+            return Box::new(std::iter::empty());
+        }
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        let stride = (chars.len() / self.n).max(1);
+        let n = self.n;
+        Box::new((0..n).map(move |i| {
+            let start_idx = i * stride;
+            let end_idx = if i + 1 == n {
+                chars.len()
+            } else {
+                (i + 1) * stride
+            };
+            let start_byte = chars.get(start_idx).map(|(b, _)| *b).unwrap_or(text.len());
+            let end_byte = chars.get(end_idx).map(|(b, _)| *b).unwrap_or(text.len());
+            (start_byte, &text[start_byte..end_byte])
+        }))
+    }
+}
+
+/// Records every `write` call so the test can assert on per-call batch sizes. Returns a synthetic
+/// embedding column whose values encode the row index within the call, plus the input's offset
+/// column (so `ChunkedSearchIndex` has both list payloads to fold back into the final output).
+#[derive(Debug)]
+struct RecordingInner {
+    search_column: String,
+    write_calls: AtomicUsize,
+    write_row_counts: std::sync::Mutex<Vec<usize>>,
+}
+
+impl RecordingInner {
+    fn new(search_column: &str) -> Self {
+        Self {
+            search_column: search_column.to_string(),
+            write_calls: AtomicUsize::new(0),
+            write_row_counts: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn row_counts(&self) -> Vec<usize> {
+        self.write_row_counts.lock().expect("mutex").clone()
+    }
+}
+
+#[async_trait]
+impl Index for RecordingInner {
+    fn name(&self) -> &'static str {
+        "RecordingInner"
+    }
+    fn required_columns(&self) -> Vec<String> {
+        vec![self.search_column.clone()]
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[async_trait]
+impl SearchIndex for RecordingInner {
+    fn search_column(&self) -> String {
+        self.search_column.clone()
+    }
+
+    fn primary_fields(&self) -> Vec<Field> {
+        vec![Field::new("id", DataType::Int64, false)]
+    }
+
+    async fn write(
+        &self,
+        record: RecordBatch,
+    ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+        self.write_calls.fetch_add(1, Ordering::SeqCst);
+        self.write_row_counts
+            .lock()
+            .expect("mutex")
+            .push(record.num_rows());
+
+        let n = record.num_rows();
+        let mut emb_values: Vec<f32> = Vec::with_capacity(n * 4);
+        for i in 0..n {
+            emb_values.extend_from_slice(&[i as f32, 0.0, 0.0, 0.0]);
+        }
+        let emb_item = Arc::new(Field::new("item", DataType::Float32, true));
+        let emb = FixedSizeListArray::try_new(
+            Arc::clone(&emb_item),
+            4,
+            Arc::new(Float32Array::from(emb_values)),
+            None,
+        )?;
+
+        let offset_col_name = ChunkedSearchIndex::chunking_offset_col(&self.search_column);
+        let offset_arr = Arc::clone(
+            record
+                .column_by_name(&offset_col_name)
+                .expect("chunked input must carry the offset column"),
+        );
+
+        let mut fields: Vec<Field> = record
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| Arc::unwrap_or_clone(Arc::clone(f)))
+            .collect();
+        let mut cols: Vec<ArrayRef> = record.columns().iter().map(Arc::clone).collect();
+
+        fields.push(Field::new(
+            format!("{}_embedding", self.search_column),
+            DataType::FixedSizeList(Arc::clone(&emb_item), 4),
+            true,
+        ));
+        cols.push(Arc::new(emb) as ArrayRef);
+
+        // Ensure the offset column survives (the chunker passes it through unchanged).
+        let _ = offset_arr;
+
+        Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), cols)?)
+    }
+
+    fn query_table_provider(&self, _query: &str) -> Result<Arc<LogicalPlan>, DataFusionError> {
+        Err(DataFusionError::NotImplemented("unused in tests".into()))
+    }
+}
+
+#[derive(Debug, Default)]
+struct PlannerWithIndexExtension;
+
+#[async_trait]
+impl QueryPlanner for PlannerWithIndexExtension {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session_state: &datafusion::execution::SessionState,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let physical_planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
+            IndexTableScanExtensionPlanner::new(),
+        )]);
+        physical_planner
+            .create_physical_plan(logical_plan, session_state)
+            .await
+    }
+}
+
+fn session_with_index_planner() -> SessionContext {
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_query_planner(Arc::new(PlannerWithIndexExtension))
+        .with_optimizer_rule(Arc::new(IndexTableScanOptimizerRule::new()))
+        .build();
+    SessionContext::new_with_state(state)
+}
+
+/// Builds the schema the underlying table is expected to expose: the base columns *plus* the
+/// list-typed `<col>_offset` and `<col>_embedding` columns that `ChunkedSearchIndex` reads and
+/// rewrites on each pass. In production these are persisted alongside the data by the
+/// accelerator; here we present them as empty per-row lists on the input so the indexer's
+/// schema-stability check passes.
+fn schema_with_search_col() -> Arc<Schema> {
+    let offset_item = Arc::new(Field::new(
+        "item",
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, false)), 2),
+        true,
+    ));
+    let embed_item = Arc::new(Field::new(
+        "item",
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+        true,
+    ));
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("content", DataType::Utf8, true),
+        Field::new_list("content_offset", Arc::unwrap_or_clone(offset_item), false),
+        Field::new_list("content_embedding", Arc::unwrap_or_clone(embed_item), false),
+    ]))
+}
+
+fn empty_list_column(item_field: Field, num_rows: usize) -> ArrayRef {
+    let item_field = Arc::new(item_field);
+    let empty_values: ArrayRef = match item_field.data_type() {
+        DataType::FixedSizeList(_, size) if *size == 2 => Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Int32, false)),
+                2,
+                Arc::new(arrow::array::Int32Array::from(Vec::<i32>::new())),
+                None,
+            )
+            .expect("offset values"),
+        ),
+        DataType::FixedSizeList(_, size) if *size == 4 => Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                4,
+                Arc::new(Float32Array::from(Vec::<f32>::new())),
+                None,
+            )
+            .expect("embedding values"),
+        ),
+        other => panic!("unexpected item type {other:?}"),
+    };
+    Arc::new(
+        ListArray::try_new(
+            item_field,
+            OffsetBuffer::from_lengths(std::iter::repeat_n(0_usize, num_rows)),
+            empty_values,
+            None,
+        )
+        .expect("list array"),
+    )
+}
+
+fn build_input_batch(num_rows: usize, content_size_bytes: usize) -> RecordBatch {
+    let schema = schema_with_search_col();
+    let ids: Vec<i64> = (0..num_rows as i64).collect();
+    let content: Vec<String> = (0..num_rows)
+        .map(|i| format!("doc{i:08}-{}", "x".repeat(content_size_bytes)))
+        .collect();
+    let content_refs: Vec<&str> = content.iter().map(String::as_str).collect();
+
+    let offset_item = Field::new(
+        "item",
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, false)), 2),
+        true,
+    );
+    let embed_item = Field::new(
+        "item",
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+        true,
+    );
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(content_refs)),
+            empty_list_column(offset_item, num_rows),
+            empty_list_column(embed_item, num_rows),
+        ],
+    )
+    .expect("valid batch")
+}
+
+/// Verifies that when a large input batch flows through `IndexerExec` → `ChunkedSearchIndex` →
+/// inner index, no single intermediate batch handed to `inner.write` exceeds the configured
+/// budget. The OOM regression in issue #7507 manifested as the inner index receiving a single
+/// ~1.6M-row intermediate batch; this test pins the upper bound.
+#[tokio::test]
+async fn chunked_index_emits_bounded_intermediate_batches_to_inner() {
+    // 4096 rows × 100 chunks/row = ~409,600 chunks. Before the fix this would be presented to
+    // `inner.write` as one record batch.
+    const NUM_ROWS: usize = 4096;
+    const CHUNKS_PER_ROW: usize = 100;
+    // Mirrors the constant in chunking.rs; if that ever changes the test must follow.
+    const BUDGET: usize = 8192;
+
+    let ctx = session_with_index_planner();
+    let inner = Arc::new(RecordingInner::new("content"));
+    let chunker = Arc::new(FixedCountChunker { n: CHUNKS_PER_ROW });
+    let chunked_index = Arc::new(ChunkedSearchIndex::new(
+        Arc::clone(&inner) as Arc<dyn SearchIndex>,
+        chunker as Arc<dyn Chunker>,
+    ));
+
+    let input = build_input_batch(NUM_ROWS, 32);
+    let schema = input.schema();
+    let mem_table = Arc::new(MemTable::try_new(schema, vec![vec![input]]).expect("valid table"));
+
+    let indexed = Arc::new(
+        IndexedTableProvider::new(mem_table as Arc<dyn TableProvider>)
+            .add_index(chunked_index as Arc<dyn Index + Send + Sync>),
+    );
+
+    ctx.register_table("docs", indexed as Arc<dyn TableProvider>)
+        .expect("register");
+
+    let df = ctx.table("docs").await.expect("table");
+    let results: Vec<RecordBatch> = df.collect().await.expect("collect");
+
+    // Output cardinality is preserved by ChunkedSearchIndex (one row per input doc).
+    let total_out_rows: usize = results.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(total_out_rows, NUM_ROWS);
+
+    // The fix's core assertion: every inner.write must have stayed under the budget.
+    let call_sizes = inner.row_counts();
+    assert!(
+        !call_sizes.is_empty(),
+        "inner.write should have been invoked"
+    );
+    let max = *call_sizes.iter().max().expect("non-empty");
+    assert!(
+        max <= BUDGET,
+        "max inner.write batch size {max} exceeded budget {BUDGET}; call sizes: {call_sizes:?}"
+    );
+
+    // Total chunk count routed through the inner index must equal NUM_ROWS * CHUNKS_PER_ROW;
+    // nothing was dropped on the seams between groups.
+    let total_inner_chunks: usize = call_sizes.iter().sum();
+    assert_eq!(total_inner_chunks, NUM_ROWS * CHUNKS_PER_ROW);
+
+    // And multiple groups must have been needed (otherwise this test isn't exercising the fix).
+    assert!(
+        call_sizes.len() >= 2,
+        "expected >=2 inner.write calls for {NUM_ROWS} rows × {CHUNKS_PER_ROW} chunks; got {}",
+        call_sizes.len()
+    );
+
+    // Sanity-check the output: every batch has the original schema columns plus the chunked
+    // index's list-typed offset and embedding columns. Just confirm one column is present so
+    // the schema-mismatch failure mode would surface here.
+    let first = results.first().expect("at least one output batch");
+    assert!(
+        first
+            .schema()
+            .column_with_name("content_embedding")
+            .is_some(),
+        "output must include content_embedding"
+    );
+    // CHUNKED_INDEX_CHUNK_KEY is only used inside the intermediate chunked batch; downstream
+    // sees per-row list columns, not the chunk-keyed expansion. Confirm that intent.
+    assert!(
+        first
+            .schema()
+            .column_with_name(CHUNKED_INDEX_CHUNK_KEY)
+            .is_none(),
+        "{CHUNKED_INDEX_CHUNK_KEY} must not leak out of the indexer"
+    );
+}

--- a/crates/search/tests/chunked_index_integration.rs
+++ b/crates/search/tests/chunked_index_integration.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/search/tests/chunked_index_integration.rs
+++ b/crates/search/tests/chunked_index_integration.rs
@@ -21,6 +21,13 @@ limitations under the License.
 //! the inner index's `write` method is called with strictly-bounded batches even when the input
 //! row count would otherwise produce a multi-million-row intermediate.
 
+#![expect(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    reason = "test uses small fixed counts (well under f32 precision and i64::MAX) as ids and \
+              synthetic embedding values to verify chunk ordering"
+)]
+
 use std::any::Any;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -71,8 +78,8 @@ impl Chunker for FixedCountChunker {
             } else {
                 (i + 1) * stride
             };
-            let start_byte = chars.get(start_idx).map(|(b, _)| *b).unwrap_or(text.len());
-            let end_byte = chars.get(end_idx).map(|(b, _)| *b).unwrap_or(text.len());
+            let start_byte = chars.get(start_idx).map_or(text.len(), |(b, _)| *b);
+            let end_byte = chars.get(end_idx).map_or(text.len(), |(b, _)| *b);
             (start_byte, &text[start_byte..end_byte])
         }))
     }


### PR DESCRIPTION
## 📝 Summary

`ChunkedSearchIndex::write` previously built the intermediate "chunked" `RecordBatch` for the *entire input batch* before handing it to the inner index. With DataFusion's default 8192-row `CoalesceBatchesExec` feeding the indexer and a chunker producing ~200 chunks per document, the intermediate batch ballooned to ~1.6M rows in a single allocation — OOM on financebench-sized inputs.

The fix slices the input into row-atomic groups bounded by an 8192-chunk budget *inside* `write()`. Each group becomes its own `inner.write()` call; the value arrays returned by the inner index across groups are concatenated and wrapped in a `ListArray` over the full input row count, so the final output is identical to the pre-fix behavior.

A single row whose chunk count alone exceeds the budget is processed atomically (forms a group of one). Typical chunk counts per document are well under the budget, so this row-atomic semantic is a deliberate simplification — sub-row splitting can be added later if real workloads need it.

No trait or \`IndexerExec\` changes. \`compute_index\` still returns one batch with row count == input row count. Other \`Index\` implementations are unaffected.

## 🔗 Related

Closes #7507

## 🚨 Breaking Changes

None.

## 📚 Docs

None.

## 👀 Notes for Reviewers

- The bound is a constant \`INNER_WRITE_TARGET_CHUNKS = 8192\` mirroring DataFusion's default batch size. Worth pulling onto config if we ever need per-deployment tuning, but a const seems fine for now.
- Unit tests cover the grouping math (\`group_rows_by_chunk_budget\`), the multi-group \`write()\` path, the oversized-single-row case, chunk ordering across the concat seam, and offset-span correctness.
- A new integration test in \`crates/search/tests/chunked_index_integration.rs\` exercises the fix end-to-end through \`IndexTableScanOptimizerRule\` + \`IndexTableScanExtensionPlanner\` with a recording inner index, asserting no \`inner.write()\` call exceeds the budget while total chunks are preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->