### PR TITLE
Ensure we always resolve table names in distributed mode/metadata

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use ::datafusion::optimizer::AnalyzerRule;
 use ::datafusion::prelude::SessionConfig;
-use ::datafusion::sql::{ResolvedTableReference, TableReference};
+use ::datafusion::sql::ResolvedTableReference;
 use app::App;
 use ballista_core::config::ShuffleFormat as BallistaShuffleFormat;
 use ballista_core::extension::SessionConfigExt;

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use ::datafusion::optimizer::AnalyzerRule;
 use ::datafusion::prelude::SessionConfig;
-use ::datafusion::sql::TableReference;
+use ::datafusion::sql::{ResolvedTableReference, TableReference};
 use app::App;
 use ballista_core::config::ShuffleFormat as BallistaShuffleFormat;
 use ballista_core::extension::SessionConfigExt;
@@ -112,7 +112,7 @@ pub enum DistributedNode {
         ///
         /// This is populated during startup when the executor registers with the scheduler.
         /// It contains the list of partition filters (expressions) that this executor is responsible for.
-        partition_assignments: Arc<RwLock<HashMap<TableReference, Vec<Expr>>>>,
+        partition_assignments: Arc<RwLock<HashMap<ResolvedTableReference, Vec<Expr>>>>,
     },
 }
 

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -20,8 +20,9 @@ mod startup;
 
 use std::collections::HashMap;
 
-use datafusion::sql::TableReference;
+use datafusion::sql::{ResolvedTableReference, TableReference};
 use datafusion_expr::Expr;
+use runtime_datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use snafu::Snafu;
 
 // Re-export types that moved into the `runtime-cluster` crate so callers inside
@@ -98,10 +99,13 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Multiple assigned partitions are combined with OR (union semantics), then returned
 /// as a single-element `Vec<Expr>` so that applying them via `.filter()` is correct.
 /// Returns an empty `Vec` if no partitions are assigned.
+///
+/// The lookup key is resolved against the default catalog/schema so that bare,
+/// partial, and fully-qualified references all match the same entry.
 #[expect(clippy::implicit_hasher)]
 pub fn get_partition_filter_exprs(
-    tbl: &TableReference,
-    assignments: &HashMap<TableReference, Vec<Expr>>,
+    tbl: &ResolvedTableReference,
+    assignments: &HashMap<ResolvedTableReference, Vec<Expr>>,
 ) -> Vec<Expr> {
     let partitions = assignments.get(tbl).cloned().unwrap_or_default();
     if partitions.is_empty() {

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -20,9 +20,8 @@ mod startup;
 
 use std::collections::HashMap;
 
-use datafusion::sql::{ResolvedTableReference, TableReference};
+use datafusion::sql::ResolvedTableReference;
 use datafusion_expr::Expr;
-use runtime_datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use snafu::Snafu;
 
 // Re-export types that moved into the `runtime-cluster` crate so callers inside
@@ -100,8 +99,10 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// as a single-element `Vec<Expr>` so that applying them via `.filter()` is correct.
 /// Returns an empty `Vec` if no partitions are assigned.
 ///
-/// The lookup key is resolved against the default catalog/schema so that bare,
-/// partial, and fully-qualified references all match the same entry.
+/// The caller is responsible for resolving the table reference to a
+/// `ResolvedTableReference` (e.g. against the default catalog/schema) before
+/// calling this function, so that bare, partial, and fully-qualified references
+/// all produce the same key and match correctly against the assignments map.
 #[expect(clippy::implicit_hasher)]
 pub fn get_partition_filter_exprs(
     tbl: &ResolvedTableReference,

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -18,7 +18,12 @@ use std::{collections::HashMap, sync::Arc};
 
 use app::App;
 
-use datafusion::{execution::FunctionRegistry, logical_expr::Expr, sql::TableReference};
+use datafusion::{
+    execution::FunctionRegistry,
+    logical_expr::Expr,
+    sql::{ResolvedTableReference, TableReference},
+};
+use runtime_datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use datafusion_proto::bytes::Serializeable;
 use runtime_proto::{
     AllocateInitialPartitionsRequest, cluster_service_client::ClusterServiceClient,
@@ -148,7 +153,7 @@ pub async fn executor_request_initial_partitions(
     mut client: ClusterServiceClient<Channel>,
     executor_url: String,
     registry: &(dyn FunctionRegistry + Send + Sync),
-) -> Result<HashMap<TableReference, Vec<Expr>>> {
+) -> Result<HashMap<ResolvedTableReference, Vec<Expr>>> {
     let response = client
         .allocate_initial_partitions(AllocateInitialPartitionsRequest { executor_url })
         .await
@@ -158,7 +163,8 @@ pub async fn executor_request_initial_partitions(
     let mut result = HashMap::new();
 
     for (table_name, partitions) in response.table_partitions {
-        let table_ref = TableReference::parse_str(&table_name);
+        let resolved = TableReference::parse_str(&table_name)
+            .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
         let mut exprs = Vec::new();
 
         for item in partitions.items {
@@ -167,7 +173,7 @@ pub async fn executor_request_initial_partitions(
             exprs.push(expr);
         }
 
-        result.insert(table_ref, exprs);
+        result.insert(resolved, exprs);
     }
 
     Ok(result)

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -23,8 +23,8 @@ use datafusion::{
     logical_expr::Expr,
     sql::{ResolvedTableReference, TableReference},
 };
-use runtime_datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use datafusion_proto::bytes::Serializeable;
+use runtime_datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use runtime_proto::{
     AllocateInitialPartitionsRequest, cluster_service_client::ClusterServiceClient,
 };

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1119,7 +1119,11 @@ impl Runtime {
             && let Some(assignments) = self.partition_assignments()
         {
             let assignments = assignments.read().await;
-            let partition_filters = get_partition_filter_exprs(&ds.name, &assignments);
+            let resolved = ds.name.clone().resolve(
+                crate::datafusion::SPICE_DEFAULT_CATALOG,
+                crate::datafusion::SPICE_DEFAULT_SCHEMA,
+            );
+            let partition_filters = get_partition_filter_exprs(&resolved, &assignments);
             if !partition_filters.is_empty() {
                 tracing::debug!(
                     "For table={}, extracted {} partition filter(s) for assigned partitions.",

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -803,9 +803,9 @@ impl Runtime {
             crate::cluster::partition::get_partition_filter_exprs(&table, assignments);
 
         let table_ref = TableReference::full(
-            table.catalog.clone(),
-            table.schema.clone(),
-            table.table.clone(),
+            Arc::<str>::clone(&table.catalog),
+            Arc::<str>::clone(&table.schema),
+            Arc::<str>::clone(&table.table),
         );
         if let Err(e) = self
             .datafusion()

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -40,11 +40,12 @@ use worker::WorkerRegistry;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::datafusion::DataFusion;
 use crate::datafusion::error::format_datafusion_error;
+use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 use crate::model::LLMResponsesModelStore;
 use crate::{auth::EndpointAuth, dataconnector::DataConnector};
 
 use ::datafusion::error::DataFusionError;
-use ::datafusion::sql::{TableReference, sqlparser};
+use ::datafusion::sql::{ResolvedTableReference, TableReference, sqlparser};
 use app::App;
 use datafusion_proto::bytes::Serializeable;
 
@@ -141,7 +142,8 @@ mod udtfs;
 mod view;
 mod worker;
 
-pub type PartitionAssignments = HashMap<TableReference, Vec<::datafusion::logical_expr::Expr>>;
+pub type PartitionAssignments =
+    HashMap<ResolvedTableReference, Vec<::datafusion::logical_expr::Expr>>;
 pub type SharedPartitionAssignments = Arc<RwLock<PartitionAssignments>>;
 
 #[derive(Debug, Snafu)]
@@ -722,7 +724,8 @@ impl Runtime {
 
             // Handle removed partitions
             for (table_name, partitions) in &removed_partitions {
-                let table_ref = TableReference::parse_str(table_name);
+                let table_ref = TableReference::parse_str(table_name)
+                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
                 if let Some(current_partitions) = guard.get_mut(&table_ref) {
                     for partition_bytes in partitions {
                         if let Ok(partition_expr) =
@@ -740,7 +743,8 @@ impl Runtime {
 
             // Handle new partitions
             for (table_name, partitions) in &new_partitions {
-                let table_ref = TableReference::parse_str(table_name);
+                let table_ref = TableReference::parse_str(table_name)
+                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
                 let current_partitions = guard.entry(table_ref.clone()).or_default();
                 for partition_bytes in partitions {
                     if let Ok(partition_expr) = ::datafusion_expr::Expr::from_bytes_with_registry(
@@ -773,10 +777,11 @@ impl Runtime {
 
             // Update all affected tables
             for table_name in affected_tables {
-                let table_ref = TableReference::parse_str(table_name);
+                let resolved = TableReference::parse_str(table_name)
+                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
 
                 if let Err(e) = self
-                    .update_partition_refresh_sql(table_ref.clone(), &assignments)
+                    .update_partition_refresh_sql(resolved.clone(), &assignments)
                     .await
                 {
                     tracing::warn!("Failed to update partition refresh SQL for {table_name}: {e}");
@@ -791,22 +796,27 @@ impl Runtime {
 
     pub(crate) async fn update_partition_refresh_sql(
         &self,
-        table: TableReference,
+        table: ResolvedTableReference,
         assignments: &PartitionAssignments,
     ) -> Result<()> {
         let partition_filters =
             crate::cluster::partition::get_partition_filter_exprs(&table, assignments);
 
+        let table_ref = TableReference::full(
+            table.catalog.clone(),
+            table.schema.clone(),
+            table.table.clone(),
+        );
         if let Err(e) = self
             .datafusion()
-            .update_partition_filters(table.clone(), partition_filters)
+            .update_partition_filters(table_ref.clone(), partition_filters)
             .await
         {
             tracing::error!("Failed to update partition filters for {table}: {e}");
         } else {
             tracing::info!("Updated partition assignments for {table}");
             // Trigger a refresh to load the data for the new partitions
-            if let Err(e) = self.datafusion().refresh_table(&table, None).await {
+            if let Err(e) = self.datafusion().refresh_table(&table_ref, None).await {
                 tracing::warn!(
                     "Failed to trigger refresh for {table} after updating partitions: {e}"
                 );


### PR DESCRIPTION
## 📝 Summary
  - Changes PartitionAssignments key type from TableReference to ResolvedTableReference, ensuring my_table, public.my_table, and spice.public.my_table all resolve to the same map entry
  - Resolves table references at protobuf deserialization boundaries (initial partition allocation and UpdatePartitions control stream messages)
  - Updates all lookup sites (get_partition_filter_exprs, dataset init) to resolve before querying the map

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->